### PR TITLE
[Feature]: add shared MCP runtime inventory and operator surfaces

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
-#[cfg(test)]
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -467,7 +466,6 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
             .unwrap_or_else(|| ACPX_DEFAULT_COMMAND.to_owned());
         let expected_version = raw_profile.expected_version();
         let cwd = raw_profile.cwd();
-        let injectable_mcp_server_count = injectable_mcp_server_count(config)?;
         let mut diagnostics = BTreeMap::from([
             ("backend".to_owned(), self.id().to_owned()),
             ("command".to_owned(), command.clone()),
@@ -477,11 +475,21 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
                     .clone()
                     .unwrap_or_else(|| ACPX_VERSION_ANY.to_owned()),
             ),
-            (
-                "mcp_server_count".to_owned(),
-                injectable_mcp_server_count.to_string(),
-            ),
         ]);
+        let injectable_mcp_server_count = match injectable_mcp_server_count(config) {
+            Ok(count) => {
+                diagnostics.insert("mcp_server_count".to_owned(), count.to_string());
+                count
+            }
+            Err(error) => {
+                diagnostics.insert("status".to_owned(), "invalid_config".to_owned());
+                diagnostics.insert("error".to_owned(), error);
+                return Ok(Some(AcpDoctorReport {
+                    healthy: false,
+                    diagnostics,
+                }));
+            }
+        };
 
         if let Some(permission_mode) = raw_profile.permission_mode() {
             diagnostics.insert("permission_mode".to_owned(), permission_mode);
@@ -1590,6 +1598,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(unix)]
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use base64::Engine;
 
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1599,8 +1599,6 @@ mod tests {
     #[cfg(unix)]
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
-    use base64::Engine;
-
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};
     #[cfg(unix)]

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2152,13 +2152,11 @@ exit 0
 
         let command = build_mcp_proxy_agent_command("npx @zed-industries/codex-acp", &[server])
             .expect("proxy command");
-        let payload_marker = "--payload ";
+        let payload_marker = "--payload-file ";
         let payload_index = command.find(payload_marker).expect("payload marker");
-        let encoded_payload = &command[payload_index + payload_marker.len()..];
-        let decoded_payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(encoded_payload)
-            .expect("decode payload");
-        let payload: Value = serde_json::from_slice(&decoded_payload).expect("parse payload");
+        let payload_path = &command[payload_index + payload_marker.len()..];
+        let payload_bytes = std::fs::read(payload_path).expect("read payload file");
+        let payload: Value = serde_json::from_slice(&payload_bytes).expect("parse payload");
 
         assert_eq!(
             payload["mcpServers"][0]["cwd"],
@@ -2286,8 +2284,8 @@ exit 0
             "expected --agent proxy flag in log: {log}"
         );
         assert!(
-            log.contains("--payload"),
-            "expected MCP proxy payload flag in log: {log}"
+            log.contains("--payload-file"),
+            "expected MCP proxy payload file flag in log: {log}"
         );
         assert!(
             log.contains("sessions ensure --name session-proxy"),

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::OnceLock;
 
 use async_trait::async_trait;
+#[cfg(test)]
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -14,9 +14,14 @@ use tokio::time::{Duration, Instant, sleep, sleep_until, timeout};
 
 use crate::CliResult;
 use crate::config::LoongClawConfig;
-use crate::mcp::{McpRegistry, McpStdioServerLaunchSpec};
 use crate::process_launch::resolve_command_invocation;
 
+#[cfg(test)]
+use super::acpx_mcp::{AcpxMcpServerEntry, AcpxMcpServerEnvEntry, build_mcp_proxy_agent_command};
+use super::acpx_mcp::{
+    build_mcp_proxy_agent_command_for_selection, injectable_mcp_server_count,
+    probe_mcp_proxy_support, validate_requested_mcp_servers,
+};
 use super::backend::{
     AcpAbortSignal, AcpBackendMetadata, AcpCapability, AcpConfigPatch, AcpDoctorReport,
     AcpRuntimeBackend, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMode, AcpSessionState,
@@ -34,10 +39,6 @@ const ACPX_DEFAULT_QUEUE_OWNER_TTL_SECONDS: f64 = 0.1;
 const ACPX_PERMISSION_DENIED_EXIT_CODE: i32 = 5;
 const ACPX_SPAWN_RETRY_ATTEMPTS: usize = 5;
 const ACPX_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(25);
-const ACPX_MCP_PROXY_NODE_COMMAND: &str = "node";
-const ACPX_MCP_PROXY_SCRIPT_NAME: &str = "loongclaw-acpx-mcp-proxy.mjs";
-const ACPX_MCP_PROXY_SCRIPT_SOURCE: &str = include_str!("assets/acpx-mcp-proxy.mjs");
-static ACPX_MCP_PROXY_SCRIPT_PATH: OnceLock<Result<String, String>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct AcpxRuntimeHandleState {
@@ -77,22 +78,6 @@ struct AcpxIdentifiers {
     acpx_record_id: Option<String>,
     backend_session_id: Option<String>,
     agent_session_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct AcpxMcpServerEntry {
-    name: String,
-    command: String,
-    args: Vec<String>,
-    env: Vec<AcpxMcpServerEnvEntry>,
-    #[serde(default)]
-    cwd: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct AcpxMcpServerEnvEntry {
-    name: String,
-    value: String,
 }
 
 #[derive(Default)]
@@ -706,33 +691,6 @@ fn resolve_profile(config: &LoongClawConfig) -> CliResult<ResolvedAcpxProfile> {
     })
 }
 
-fn validate_requested_mcp_servers(
-    config: &LoongClawConfig,
-    request: &AcpSessionBootstrap,
-) -> CliResult<Vec<String>> {
-    if request.mcp_servers.is_empty() {
-        return Ok(Vec::new());
-    }
-    if !config.acp.allow_mcp_server_injection {
-        return Err(
-            "ACPX bootstrap requested MCP server injection but acp.allow_mcp_server_injection=false"
-                .to_owned(),
-        );
-    }
-
-    let registry = McpRegistry::from_config(config)?;
-    let selected = registry.resolve_selected_server_names(&request.mcp_servers)?;
-    let _launch_specs = registry.resolve_injectable_stdio_launch_specs(&selected)?;
-
-    Ok(selected)
-}
-
-fn injectable_mcp_server_count(config: &LoongClawConfig) -> CliResult<usize> {
-    let registry = McpRegistry::from_config(config)?;
-    let count = registry.injectable_stdio_server_count();
-    Ok(count)
-}
-
 async fn build_verb_args<I>(
     config: &LoongClawConfig,
     profile: &ResolvedAcpxProfile,
@@ -812,8 +770,11 @@ async fn resolve_raw_agent_command(
     }
 
     let target_command = resolve_acpx_agent_command(profile, timeout_ms, cwd, agent).await?;
-    let mcp_servers = resolve_selected_mcp_server_entries(config, selected_mcp_servers)?;
-    let proxy_command = build_mcp_proxy_agent_command(target_command.as_str(), &mcp_servers)?;
+    let proxy_command = build_mcp_proxy_agent_command_for_selection(
+        config,
+        target_command.as_str(),
+        selected_mcp_servers,
+    )?;
     Ok(Some(proxy_command))
 }
 
@@ -882,148 +843,6 @@ fn builtin_agent_command(agent: &str) -> Option<String> {
         _ => return None,
     };
     Some(command.to_owned())
-}
-
-fn resolve_selected_mcp_server_entries(
-    config: &LoongClawConfig,
-    selected_mcp_servers: &[String],
-) -> CliResult<Vec<AcpxMcpServerEntry>> {
-    let registry = McpRegistry::from_config(config)?;
-    let resolved_servers = registry.resolve_injectable_stdio_launch_specs(selected_mcp_servers)?;
-
-    let mut entries = Vec::new();
-    for server in resolved_servers {
-        let entry = acpx_mcp_server_entry_from_registry_server(server);
-        entries.push(entry);
-    }
-
-    Ok(entries)
-}
-
-fn acpx_mcp_server_entry_from_registry_server(
-    server: McpStdioServerLaunchSpec,
-) -> AcpxMcpServerEntry {
-    let mut env_entries = Vec::new();
-    for (name, value) in server.env {
-        let env_entry = AcpxMcpServerEnvEntry { name, value };
-        env_entries.push(env_entry);
-    }
-
-    AcpxMcpServerEntry {
-        name: server.name,
-        command: server.command,
-        args: server.args,
-        env: env_entries,
-        cwd: server.cwd,
-    }
-}
-
-fn build_mcp_proxy_agent_command(
-    target_command: &str,
-    mcp_servers: &[AcpxMcpServerEntry],
-) -> CliResult<String> {
-    let script_path = ensure_mcp_proxy_script_path()?;
-    let payload = serde_json::to_vec(&json!({
-        "targetCommand": target_command,
-        "mcpServers": mcp_servers,
-    }))
-    .map_err(|error| format!("serialize ACPX MCP proxy payload failed: {error}"))?;
-    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
-    Ok(join_command_line(&[
-        ACPX_MCP_PROXY_NODE_COMMAND.to_owned(),
-        script_path,
-        "--payload".to_owned(),
-        encoded,
-    ]))
-}
-
-fn ensure_mcp_proxy_script_path() -> CliResult<String> {
-    ACPX_MCP_PROXY_SCRIPT_PATH
-        .get_or_init(materialize_mcp_proxy_script)
-        .clone()
-}
-
-fn materialize_mcp_proxy_script() -> Result<String, String> {
-    let path = std::env::temp_dir()
-        .join("loongclaw")
-        .join(ACPX_MCP_PROXY_SCRIPT_NAME);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("create ACPX MCP proxy directory failed: {error}"))?;
-    }
-    std::fs::write(&path, ACPX_MCP_PROXY_SCRIPT_SOURCE)
-        .map_err(|error| format!("write ACPX MCP proxy script failed: {error}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let mut permissions = std::fs::metadata(&path)
-            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions)
-            .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
-    }
-    Ok(path.display().to_string())
-}
-
-async fn probe_mcp_proxy_support(cwd: Option<&str>) -> CliResult<(String, String)> {
-    let script_path = ensure_mcp_proxy_script_path()?;
-    let mut probe = Command::new(ACPX_MCP_PROXY_NODE_COMMAND);
-    probe.arg("--version");
-    if let Some(cwd) = cwd {
-        probe.current_dir(cwd);
-    }
-    let output = probe.output().await.map_err(|error| {
-        if error.kind() == ErrorKind::NotFound {
-            format!("embedded ACPX MCP proxy requires `{ACPX_MCP_PROXY_NODE_COMMAND}` on PATH")
-        } else {
-            format!("probe embedded ACPX MCP proxy runtime failed: {error}")
-        }
-    })?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let observed = match (stdout.is_empty(), stderr.is_empty()) {
-        (false, true) => stdout,
-        (true, false) => stderr,
-        (false, false) => format!("{stdout} | {stderr}"),
-        (true, true) => "(empty)".to_owned(),
-    };
-    if !output.status.success() {
-        return Err(format!(
-            "embedded ACPX MCP proxy runtime probe exited with code {}: {observed}",
-            output
-                .status
-                .code()
-                .map_or_else(|| "unknown".to_owned(), |code| code.to_string())
-        ));
-    }
-    Ok((script_path, observed))
-}
-
-fn join_command_line(parts: &[String]) -> String {
-    parts
-        .iter()
-        .map(|part| quote_command_part(part.as_str()))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn quote_command_part(value: &str) -> String {
-    if value.is_empty() {
-        return "\"\"".to_owned();
-    }
-    if value.chars().all(|ch| {
-        ch.is_ascii_alphanumeric()
-            || matches!(
-                ch,
-                '_' | '.' | '/' | ':' | '@' | '%' | '+' | '=' | ',' | '-'
-            )
-    }) {
-        return value.to_owned();
-    }
-    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("\"{escaped}\"")
 }
 
 fn resolve_effective_cwd(

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -13,7 +13,9 @@ use tokio::process::Command;
 use tokio::time::{Duration, Instant, sleep, sleep_until, timeout};
 
 use crate::CliResult;
-use crate::config::{AcpxMcpServerConfig, LoongClawConfig};
+use crate::config::LoongClawConfig;
+use crate::mcp::{McpRegistry, McpStdioServerLaunchSpec};
+use crate::process_launch::resolve_command_invocation;
 
 use super::backend::{
     AcpAbortSignal, AcpBackendMetadata, AcpCapability, AcpConfigPatch, AcpDoctorReport,
@@ -61,7 +63,6 @@ struct ResolvedAcpxProfile {
     non_interactive_permissions: String,
     timeout_seconds: Option<f64>,
     queue_owner_ttl_seconds: f64,
-    mcp_servers: BTreeMap<String, AcpxMcpServerConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -125,12 +126,13 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         request: &AcpSessionBootstrap,
     ) -> CliResult<AcpSessionHandle> {
         let profile = resolve_profile(config)?;
-        let selected_mcp_servers = validate_requested_mcp_servers(config, &profile, request)?;
+        let selected_mcp_servers = validate_requested_mcp_servers(config, request)?;
         let cwd =
             resolve_effective_cwd(request.working_directory.as_ref(), profile.cwd.as_deref())?;
         let agent = derive_agent_id(config, request.session_key.as_str(), &request.metadata)?;
 
         let ensure_args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             agent.as_str(),
@@ -158,6 +160,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
 
         if !identifiers.ready() {
             let new_args = build_verb_args(
+                config,
                 &profile,
                 config.acp.startup_timeout_ms(),
                 agent.as_str(),
@@ -238,6 +241,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let profile = resolve_profile(config)?;
         let state = resolve_handle_state(&profile, session)?;
         let prompt_args = build_prompt_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -271,6 +275,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let profile = resolve_profile(config)?;
         let state = resolve_handle_state(&profile, session)?;
         let args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -300,6 +305,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let profile = resolve_profile(config)?;
         let state = resolve_handle_state(&profile, session)?;
         let args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -333,6 +339,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let profile = resolve_profile(config)?;
         let state = resolve_handle_state(&profile, session)?;
         let args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -398,6 +405,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let profile = resolve_profile(config)?;
         let state = resolve_handle_state(&profile, session)?;
         let args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -437,6 +445,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         let value = normalized_non_empty(patch.value.as_str())
             .ok_or_else(|| "ACPX config option value must not be empty".to_owned())?;
         let args = build_verb_args(
+            config,
             &profile,
             config.acp.startup_timeout_ms(),
             state.agent.as_str(),
@@ -471,6 +480,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
             .unwrap_or_else(|| ACPX_DEFAULT_COMMAND.to_owned());
         let expected_version = raw_profile.expected_version();
         let cwd = raw_profile.cwd();
+        let injectable_mcp_server_count = injectable_mcp_server_count(config)?;
         let mut diagnostics = BTreeMap::from([
             ("backend".to_owned(), self.id().to_owned()),
             ("command".to_owned(), command.clone()),
@@ -482,7 +492,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
             ),
             (
                 "mcp_server_count".to_owned(),
-                raw_profile.mcp_servers.len().to_string(),
+                injectable_mcp_server_count.to_string(),
             ),
         ]);
 
@@ -523,10 +533,10 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
         }
 
         let mut mcp_proxy_ready = true;
-        if raw_profile.mcp_servers.is_empty() {
+        if injectable_mcp_server_count == 0 {
             diagnostics.insert(
                 "mcp_runtime_proxy".to_owned(),
-                "disabled_no_backend_mcp_servers".to_owned(),
+                "disabled_no_injectable_mcp_servers".to_owned(),
             );
         } else if !config.acp.allow_mcp_server_injection {
             diagnostics.insert(
@@ -685,13 +695,11 @@ fn resolve_profile(config: &LoongClawConfig) -> CliResult<ResolvedAcpxProfile> {
         non_interactive_permissions,
         timeout_seconds,
         queue_owner_ttl_seconds,
-        mcp_servers: profile.mcp_servers,
     })
 }
 
 fn validate_requested_mcp_servers(
     config: &LoongClawConfig,
-    profile: &ResolvedAcpxProfile,
     request: &AcpSessionBootstrap,
 ) -> CliResult<Vec<String>> {
     if request.mcp_servers.is_empty() {
@@ -704,33 +712,21 @@ fn validate_requested_mcp_servers(
         );
     }
 
-    let mut selected = Vec::new();
-    let mut seen = BTreeSet::new();
-    let mut missing = Vec::new();
-    for raw_name in &request.mcp_servers {
-        let Some(name) = normalized_non_empty(raw_name.as_str()) else {
-            return Err("ACPX bootstrap mcp_servers entries must not be empty".to_owned());
-        };
-        if !profile.mcp_servers.contains_key(&name) {
-            missing.push(name);
-            continue;
-        }
-        if seen.insert(name.clone()) {
-            selected.push(name);
-        }
-    }
+    let registry = McpRegistry::from_config(config)?;
+    let selected = registry.resolve_selected_server_names(&request.mcp_servers)?;
+    let _launch_specs = registry.resolve_injectable_stdio_launch_specs(&selected)?;
 
-    if missing.is_empty() {
-        Ok(selected)
-    } else {
-        Err(format!(
-            "ACPX requested mcp_servers are not configured under [acp.backends.acpx.mcp_servers]: {}",
-            missing.join(", ")
-        ))
-    }
+    Ok(selected)
+}
+
+fn injectable_mcp_server_count(config: &LoongClawConfig) -> CliResult<usize> {
+    let registry = McpRegistry::from_config(config)?;
+    let count = registry.injectable_stdio_server_count();
+    Ok(count)
 }
 
 async fn build_verb_args<I>(
+    config: &LoongClawConfig,
     profile: &ResolvedAcpxProfile,
     timeout_ms: u64,
     agent: &str,
@@ -742,8 +738,15 @@ async fn build_verb_args<I>(
 where
     I: IntoIterator<Item = String>,
 {
-    let raw_agent_command =
-        resolve_raw_agent_command(profile, timeout_ms, agent, cwd, selected_mcp_servers).await?;
+    let raw_agent_command = resolve_raw_agent_command(
+        config,
+        profile,
+        timeout_ms,
+        agent,
+        cwd,
+        selected_mcp_servers,
+    )
+    .await?;
     if let Some(agent_command) = raw_agent_command {
         prefix.extend(["--agent".to_owned(), agent_command]);
     } else {
@@ -754,6 +757,7 @@ where
 }
 
 async fn build_prompt_args(
+    config: &LoongClawConfig,
     profile: &ResolvedAcpxProfile,
     timeout_ms: u64,
     agent: &str,
@@ -775,6 +779,7 @@ async fn build_prompt_args(
     ]);
 
     build_verb_args(
+        config,
         profile,
         timeout_ms,
         agent,
@@ -787,6 +792,7 @@ async fn build_prompt_args(
 }
 
 async fn resolve_raw_agent_command(
+    config: &LoongClawConfig,
     profile: &ResolvedAcpxProfile,
     timeout_ms: u64,
     agent: &str,
@@ -798,7 +804,7 @@ async fn resolve_raw_agent_command(
     }
 
     let target_command = resolve_acpx_agent_command(profile, timeout_ms, cwd, agent).await?;
-    let mcp_servers = resolve_selected_mcp_server_entries(profile, selected_mcp_servers)?;
+    let mcp_servers = resolve_selected_mcp_server_entries(config, selected_mcp_servers)?;
     let proxy_command = build_mcp_proxy_agent_command(target_command.as_str(), &mcp_servers)?;
     Ok(Some(proxy_command))
 }
@@ -871,32 +877,36 @@ fn builtin_agent_command(agent: &str) -> Option<String> {
 }
 
 fn resolve_selected_mcp_server_entries(
-    profile: &ResolvedAcpxProfile,
+    config: &LoongClawConfig,
     selected_mcp_servers: &[String],
 ) -> CliResult<Vec<AcpxMcpServerEntry>> {
-    selected_mcp_servers
-        .iter()
-        .map(|name| {
-            let server = profile.mcp_servers.get(name).ok_or_else(|| {
-                format!(
-                    "ACPX requested mcp_servers are not configured under [acp.backends.acpx.mcp_servers]: {name}"
-                )
-            })?;
-            Ok(AcpxMcpServerEntry {
-                name: name.clone(),
-                command: server.command.clone(),
-                args: server.args.clone(),
-                env: server
-                    .env
-                    .iter()
-                    .map(|(key, value)| AcpxMcpServerEnvEntry {
-                        name: key.clone(),
-                        value: value.clone(),
-                    })
-                    .collect(),
-            })
-        })
-        .collect()
+    let registry = McpRegistry::from_config(config)?;
+    let resolved_servers = registry.resolve_injectable_stdio_launch_specs(selected_mcp_servers)?;
+
+    let mut entries = Vec::new();
+    for server in resolved_servers {
+        let entry = acpx_mcp_server_entry_from_registry_server(server);
+        entries.push(entry);
+    }
+
+    Ok(entries)
+}
+
+fn acpx_mcp_server_entry_from_registry_server(
+    server: McpStdioServerLaunchSpec,
+) -> AcpxMcpServerEntry {
+    let mut env_entries = Vec::new();
+    for (name, value) in server.env {
+        let env_entry = AcpxMcpServerEnvEntry { name, value };
+        env_entries.push(env_entry);
+    }
+
+    AcpxMcpServerEntry {
+        name: server.name,
+        command: server.command,
+        args: server.args,
+        env: env_entries,
+    }
 }
 
 fn build_mcp_proxy_agent_command(
@@ -1317,6 +1327,18 @@ async fn run_prompt_process(
     if exit_status.code().is_some_and(|code| code != 0) {
         return Err(format_exit_message(stderr.as_str(), exit_status.code()));
     }
+    if abort.as_ref().is_some_and(AcpAbortSignal::is_aborted) && !saw_done && !saw_error {
+        let done = synthetic_done_event(Some(AcpTurnStopReason::Cancelled));
+        emit_turn_event(sink, &done)?;
+        events.push(done);
+        return Ok(AcpTurnResult {
+            output_text: collect_output_text(&events),
+            state: AcpSessionState::Ready,
+            usage: collect_usage_update(&events),
+            stop_reason: Some(AcpTurnStopReason::Cancelled),
+            events,
+        });
+    }
     if !saw_done && !saw_error {
         let done = synthetic_done_event(Some(AcpTurnStopReason::Completed));
         emit_turn_event(sink, &done)?;
@@ -1448,9 +1470,10 @@ async fn spawn_acpx_child(
     pipe_stdin: bool,
 ) -> CliResult<tokio::process::Child> {
     retry_executable_file_busy(|| {
-        let mut process = Command::new(command);
+        let invocation = resolve_command_invocation(command, args.iter().map(String::as_str));
+        let mut process = Command::new(&invocation.program);
         process
-            .args(args)
+            .args(&invocation.args)
             .current_dir(cwd)
             .stdin(if pipe_stdin {
                 Stdio::piped()
@@ -1727,6 +1750,7 @@ fn now_ms() -> u64 {
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use std::collections::BTreeMap;
     #[cfg(unix)]
@@ -1736,6 +1760,8 @@ mod tests {
     #[cfg(unix)]
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    #[cfg(unix)]
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};
@@ -1757,6 +1783,15 @@ mod tests {
         ));
         std::fs::create_dir_all(&temp_dir).expect("create temp dir");
         temp_dir
+    }
+
+    #[cfg(unix)]
+    fn acpx_test_lock() -> MutexGuard<'static, ()> {
+        static ACPX_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ACPX_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     #[cfg(unix)]
@@ -2144,6 +2179,7 @@ exit 0
     #[tokio::test]
     #[cfg(unix)]
     async fn doctor_accepts_fake_version_command() {
+        let _guard = acpx_test_lock();
         let temp_dir = unique_temp_dir("loongclaw-acpx-probe");
         let script_path = temp_dir.join("fake-acpx");
         write_executable_script_atomically(&script_path, "#!/bin/sh\necho 'acpx 0.1.16'\n")
@@ -2267,9 +2303,12 @@ exit 0
             non_interactive_permissions: Some("fail".to_owned()),
             timeout_seconds: Some(12.5),
             queue_owner_ttl_seconds: Some(0.25),
-            mcp_servers: BTreeMap::from([(
-                "filesystem".to_owned(),
-                crate::config::AcpxMcpServerConfig {
+            ..AcpxBackendConfig::default()
+        });
+        config.mcp.servers = BTreeMap::from([(
+            "filesystem".to_owned(),
+            crate::mcp::McpServerConfig {
+                transport: crate::mcp::McpServerTransportConfig::Stdio {
                     command: "npx".to_owned(),
                     args: vec![
                         "-y".to_owned(),
@@ -2277,10 +2316,16 @@ exit 0
                         temp_dir.display().to_string(),
                     ],
                     env: BTreeMap::from([("ROOT".to_owned(), temp_dir.display().to_string())]),
+                    cwd: None,
                 },
-            )]),
-            ..AcpxBackendConfig::default()
-        });
+                enabled: true,
+                required: false,
+                startup_timeout_ms: None,
+                tool_timeout_ms: None,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+            },
+        )]);
 
         let backend = AcpxCliProbeBackend;
         let bootstrap = AcpSessionBootstrap {
@@ -2343,6 +2388,7 @@ exit 0
     #[tokio::test]
     #[cfg(unix)]
     async fn ensure_session_rejects_unknown_requested_mcp_server_names() {
+        let _guard = acpx_test_lock();
         let temp_dir = unique_temp_dir("loongclaw-acpx-mcp-unknown");
         let log_path = temp_dir.join("calls.log");
         let script_path = write_fake_acpx_script(
@@ -2353,17 +2399,23 @@ exit 0
         );
         let mut config = fake_acpx_config(&script_path, &temp_dir);
         config.acp.allow_mcp_server_injection = true;
-        config.acp.backends.acpx = Some(AcpxBackendConfig {
-            mcp_servers: BTreeMap::from([(
-                "filesystem".to_owned(),
-                crate::config::AcpxMcpServerConfig {
+        config.mcp.servers = BTreeMap::from([(
+            "filesystem".to_owned(),
+            crate::mcp::McpServerConfig {
+                transport: crate::mcp::McpServerTransportConfig::Stdio {
                     command: "npx".to_owned(),
                     args: vec!["@modelcontextprotocol/server-filesystem".to_owned()],
                     env: BTreeMap::new(),
+                    cwd: None,
                 },
-            )]),
-            ..AcpxBackendConfig::default()
-        });
+                enabled: true,
+                required: false,
+                startup_timeout_ms: None,
+                tool_timeout_ms: None,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+            },
+        )]);
 
         let backend = AcpxCliProbeBackend;
         let error = backend
@@ -2384,8 +2436,64 @@ exit 0
             .expect_err("unknown MCP server should fail");
 
         assert!(
-            error.contains("missing") && error.contains("mcp_servers"),
+            error.contains("missing") && error.contains("shared MCP registry"),
             "expected missing MCP server validation error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_session_rejects_streamable_http_requested_mcp_server() {
+        let _guard = acpx_test_lock();
+        let temp_dir = unique_temp_dir("loongclaw-acpx-mcp-http");
+        let log_path = temp_dir.join("calls.log");
+        let script_path = write_fake_acpx_script(
+            &temp_dir,
+            "fake-acpx",
+            &log_path,
+            "echo '{\"acpxSessionId\":\"unused\"}'\n",
+        );
+        let mut config = fake_acpx_config(&script_path, &temp_dir);
+        config.acp.allow_mcp_server_injection = true;
+        config.mcp.servers = BTreeMap::from([(
+            "remote".to_owned(),
+            crate::mcp::McpServerConfig {
+                transport: crate::mcp::McpServerTransportConfig::StreamableHttp {
+                    url: "https://mcp.example.com".to_owned(),
+                    bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                    http_headers: BTreeMap::new(),
+                    env_http_headers: BTreeMap::new(),
+                },
+                enabled: true,
+                required: false,
+                startup_timeout_ms: None,
+                tool_timeout_ms: None,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+            },
+        )]);
+
+        let backend = AcpxCliProbeBackend;
+        let error = backend
+            .ensure_session(
+                &config,
+                &AcpSessionBootstrap {
+                    session_key: "session-http-mcp".to_owned(),
+                    conversation_id: None,
+                    binding: None,
+                    working_directory: Some(temp_dir),
+                    initial_prompt: None,
+                    mode: Some(AcpSessionMode::Interactive),
+                    mcp_servers: vec!["remote".to_owned()],
+                    metadata: BTreeMap::new(),
+                },
+            )
+            .await
+            .expect_err("streamable_http MCP server should fail ACPX injection");
+
+        assert!(
+            error.contains("streamable_http") && error.contains("remote"),
+            "expected unsupported transport error, got: {error}"
         );
     }
 

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -85,6 +85,8 @@ struct AcpxMcpServerEntry {
     command: String,
     args: Vec<String>,
     env: Vec<AcpxMcpServerEnvEntry>,
+    #[serde(default)]
+    cwd: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -575,16 +577,21 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
             }));
         }
 
-        let mut probe = Command::new(&command);
-        probe.arg("--version");
-        if let Some(cwd) = cwd {
-            probe.current_dir(cwd);
-        }
+        let probe_cwd = resolve_effective_cwd(None, cwd.as_deref())?;
+        let version_args = vec!["--version".to_owned()];
+        let version_probe = run_process(
+            command.as_str(),
+            &version_args,
+            probe_cwd.as_str(),
+            config.acp.startup_timeout_ms(),
+            None,
+        )
+        .await;
 
-        match probe.output().await {
+        match version_probe {
             Ok(output) => {
-                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+                let stdout = output.stdout.trim().to_owned();
+                let stderr = output.stderr.trim().to_owned();
                 let observed = match (stdout.is_empty(), stderr.is_empty()) {
                     (false, true) => stdout,
                     (true, false) => stderr,
@@ -595,8 +602,7 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
                 diagnostics.insert(
                     "exit_status".to_owned(),
                     output
-                        .status
-                        .code()
+                        .exit_code
                         .map_or_else(|| "signal".to_owned(), |code| code.to_string()),
                 );
 
@@ -606,14 +612,15 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
                         value.eq_ignore_ascii_case(ACPX_VERSION_ANY) || observed.contains(value)
                     })
                     .unwrap_or(true);
-                let healthy = output.status.success() && version_matches && mcp_proxy_ready;
+                let exited_successfully = output.exit_code == Some(0);
+                let healthy = exited_successfully && version_matches && mcp_proxy_ready;
                 diagnostics.insert(
                     "status".to_owned(),
                     if !mcp_proxy_ready {
                         "mcp_proxy_unavailable".to_owned()
                     } else if healthy {
                         "ready".to_owned()
-                    } else if !output.status.success() {
+                    } else if !exited_successfully {
                         "execution_failed".to_owned()
                     } else {
                         "version_mismatch".to_owned()
@@ -625,15 +632,16 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
                 }))
             }
             Err(error) => {
+                let is_missing_command = error.starts_with("acpx command not found:");
                 diagnostics.insert(
                     "status".to_owned(),
-                    if error.kind() == ErrorKind::NotFound {
+                    if is_missing_command {
                         "missing_command".to_owned()
                     } else {
                         "spawn_failed".to_owned()
                     },
                 );
-                diagnostics.insert("error".to_owned(), error.to_string());
+                diagnostics.insert("error".to_owned(), error);
                 Ok(Some(AcpDoctorReport {
                     healthy: false,
                     diagnostics,
@@ -906,6 +914,7 @@ fn acpx_mcp_server_entry_from_registry_server(
         command: server.command,
         args: server.args,
         env: env_entries,
+        cwd: server.cwd,
     }
 }
 
@@ -1765,6 +1774,8 @@ mod tests {
 
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};
+    #[cfg(unix)]
+    use crate::test_support::ScopedEnv;
 
     #[cfg(unix)]
     const ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS: u64 = 60_000;
@@ -2246,6 +2257,84 @@ exit 0
 
         let _ = std::fs::remove_file(&script_path);
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn doctor_accepts_path_discovered_fake_version_command() {
+        let _guard = acpx_test_lock();
+        let temp_dir = unique_temp_dir("loongclaw-acpx-probe-path");
+        let bin_dir = temp_dir.join("bin");
+        let script_path = bin_dir.join("fake-acpx");
+        std::fs::create_dir_all(&bin_dir).expect("create bin dir");
+        write_executable_script_atomically(&script_path, "#!/bin/sh\necho 'acpx 0.1.16'\n")
+            .expect("write fake acpx script");
+
+        let mut env = ScopedEnv::new();
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let original_entries = std::env::split_paths(&original_path);
+        let mut path_entries = vec![bin_dir.clone()];
+        path_entries.extend(original_entries);
+        let joined_path = std::env::join_paths(path_entries).expect("join PATH");
+        env.set("PATH", joined_path);
+
+        let backend = AcpxCliProbeBackend;
+        let config = LoongClawConfig {
+            acp: AcpConfig {
+                backends: AcpBackendProfilesConfig {
+                    acpx: Some(AcpxBackendConfig {
+                        command: Some("fake-acpx".to_owned()),
+                        expected_version: Some("0.1.16".to_owned()),
+                        cwd: Some(temp_dir.display().to_string()),
+                        ..AcpxBackendConfig::default()
+                    }),
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let report = backend
+            .doctor(&config)
+            .await
+            .expect("doctor should not fail")
+            .expect("doctor report");
+
+        assert!(report.healthy, "doctor should use launcher path");
+        assert_eq!(
+            report.diagnostics.get("command"),
+            Some(&"fake-acpx".to_owned())
+        );
+        assert_eq!(report.diagnostics.get("status"), Some(&"ready".to_owned()));
+    }
+
+    #[test]
+    fn build_mcp_proxy_agent_command_preserves_server_cwd() {
+        let server = AcpxMcpServerEntry {
+            name: "docs".to_owned(),
+            command: "uvx".to_owned(),
+            args: vec!["context7-mcp".to_owned()],
+            env: vec![AcpxMcpServerEnvEntry {
+                name: "API_TOKEN".to_owned(),
+                value: "secret".to_owned(),
+            }],
+            cwd: Some("/workspace/docs".to_owned()),
+        };
+
+        let command = build_mcp_proxy_agent_command("npx @zed-industries/codex-acp", &[server])
+            .expect("proxy command");
+        let payload_marker = "--payload ";
+        let payload_index = command.find(payload_marker).expect("payload marker");
+        let encoded_payload = &command[payload_index + payload_marker.len()..];
+        let decoded_payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded_payload)
+            .expect("decode payload");
+        let payload: Value = serde_json::from_slice(&decoded_payload).expect("parse payload");
+
+        assert_eq!(
+            payload["mcpServers"][0]["cwd"],
+            Value::String("/workspace/docs".to_owned())
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/acp/acpx_doctor_tests.rs
+++ b/crates/app/src/acp/acpx_doctor_tests.rs
@@ -1,0 +1,55 @@
+use std::collections::BTreeMap;
+
+use super::acpx::AcpxCliProbeBackend;
+use super::backend::AcpRuntimeBackend;
+use crate::config::AcpConfig;
+use crate::config::LoongClawConfig;
+
+#[tokio::test]
+async fn doctor_reports_invalid_mcp_registry_config() {
+    let backend = AcpxCliProbeBackend;
+    let config = LoongClawConfig {
+        acp: AcpConfig {
+            allow_mcp_server_injection: true,
+            ..AcpConfig::default()
+        },
+        mcp: crate::mcp::McpConfig {
+            servers: BTreeMap::from([(
+                "".to_owned(),
+                crate::mcp::McpServerConfig {
+                    transport: crate::mcp::McpServerTransportConfig::Stdio {
+                        command: "uvx".to_owned(),
+                        args: vec!["context7-mcp".to_owned()],
+                        env: BTreeMap::new(),
+                        cwd: None,
+                    },
+                    enabled: true,
+                    required: false,
+                    startup_timeout_ms: None,
+                    tool_timeout_ms: None,
+                    enabled_tools: Vec::new(),
+                    disabled_tools: Vec::new(),
+                },
+            )]),
+        },
+        ..LoongClawConfig::default()
+    };
+
+    let report = backend
+        .doctor(&config)
+        .await
+        .expect("doctor should not error")
+        .expect("doctor report");
+
+    assert!(!report.healthy);
+    assert_eq!(
+        report.diagnostics.get("status"),
+        Some(&"invalid_config".to_owned())
+    );
+    assert!(
+        report
+            .diagnostics
+            .get("error")
+            .is_some_and(|error| error.contains("must not be empty"))
+    );
+}

--- a/crates/app/src/acp/acpx_mcp.rs
+++ b/crates/app/src/acp/acpx_mcp.rs
@@ -1,7 +1,7 @@
 use std::io::ErrorKind;
 use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::process::Command;
@@ -79,18 +79,19 @@ pub(crate) fn build_mcp_proxy_agent_command(
         "mcpServers": mcp_servers,
     }))
     .map_err(|error| format!("serialize ACPX MCP proxy payload failed: {error}"))?;
-    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+    let payload_path = materialize_mcp_proxy_payload_path(payload.as_slice())?;
     Ok(join_command_line(&[
         ACPX_MCP_PROXY_NODE_COMMAND.to_owned(),
         script_path,
-        "--payload".to_owned(),
-        encoded,
+        "--payload-file".to_owned(),
+        payload_path,
     ]))
 }
 
 pub(crate) async fn probe_mcp_proxy_support(cwd: Option<&str>) -> CliResult<(String, String)> {
     let script_path = ensure_mcp_proxy_script_path()?;
     let mut probe = Command::new(ACPX_MCP_PROXY_NODE_COMMAND);
+    probe.arg(script_path.as_str());
     probe.arg("--version");
     if let Some(cwd) = cwd {
         probe.current_dir(cwd);
@@ -184,6 +185,39 @@ fn materialize_mcp_proxy_script() -> Result<String, String> {
             .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
     }
     Ok(path.display().to_string())
+}
+
+fn materialize_mcp_proxy_payload_path(payload: &[u8]) -> CliResult<String> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("read system time for ACPX MCP payload failed: {error}"))?;
+    let payload_file_name = format!(
+        "acpx-mcp-payload-{}-{}.json",
+        std::process::id(),
+        timestamp.as_nanos()
+    );
+    let payload_path = std::env::temp_dir()
+        .join("loongclaw")
+        .join("acpx-mcp-payloads")
+        .join(payload_file_name);
+    if let Some(parent) = payload_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create ACPX MCP payload directory failed: {error}"))?;
+    }
+    std::fs::write(&payload_path, payload)
+        .map_err(|error| format!("write ACPX MCP payload failed: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(&payload_path)
+            .map_err(|error| format!("stat ACPX MCP payload failed: {error}"))?
+            .permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(&payload_path, permissions)
+            .map_err(|error| format!("chmod ACPX MCP payload failed: {error}"))?;
+    }
+    Ok(payload_path.display().to_string())
 }
 
 fn join_command_line(parts: &[String]) -> String {

--- a/crates/app/src/acp/acpx_mcp.rs
+++ b/crates/app/src/acp/acpx_mcp.rs
@@ -1,0 +1,210 @@
+use std::io::ErrorKind;
+use std::sync::OnceLock;
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::process::Command;
+
+use crate::CliResult;
+use crate::config::LoongClawConfig;
+use crate::mcp::{McpRegistry, McpStdioServerLaunchSpec};
+
+use super::backend::AcpSessionBootstrap;
+
+const ACPX_MCP_PROXY_NODE_COMMAND: &str = "node";
+const ACPX_MCP_PROXY_SCRIPT_NAME: &str = "loongclaw-acpx-mcp-proxy.mjs";
+const ACPX_MCP_PROXY_SCRIPT_SOURCE: &str = include_str!("assets/acpx-mcp-proxy.mjs");
+static ACPX_MCP_PROXY_SCRIPT_PATH: OnceLock<Result<String, String>> = OnceLock::new();
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcpxMcpServerEntry {
+    pub(crate) name: String,
+    pub(crate) command: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) env: Vec<AcpxMcpServerEnvEntry>,
+    #[serde(default)]
+    pub(crate) cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcpxMcpServerEnvEntry {
+    pub(crate) name: String,
+    pub(crate) value: String,
+}
+
+pub(crate) fn validate_requested_mcp_servers(
+    config: &LoongClawConfig,
+    request: &AcpSessionBootstrap,
+) -> CliResult<Vec<String>> {
+    if request.mcp_servers.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !config.acp.allow_mcp_server_injection {
+        return Err(
+            "ACPX bootstrap requested MCP server injection but acp.allow_mcp_server_injection=false"
+                .to_owned(),
+        );
+    }
+
+    let registry = McpRegistry::from_config(config)?;
+    let selected = registry.resolve_selected_server_names(&request.mcp_servers)?;
+    let _launch_specs = registry.resolve_injectable_stdio_launch_specs(&selected)?;
+
+    Ok(selected)
+}
+
+pub(crate) fn injectable_mcp_server_count(config: &LoongClawConfig) -> CliResult<usize> {
+    let registry = McpRegistry::from_config(config)?;
+    let count = registry.injectable_stdio_server_count();
+    Ok(count)
+}
+
+pub(crate) fn build_mcp_proxy_agent_command_for_selection(
+    config: &LoongClawConfig,
+    target_command: &str,
+    selected_mcp_servers: &[String],
+) -> CliResult<String> {
+    let mcp_servers = resolve_selected_mcp_server_entries(config, selected_mcp_servers)?;
+    build_mcp_proxy_agent_command(target_command, &mcp_servers)
+}
+
+pub(crate) fn build_mcp_proxy_agent_command(
+    target_command: &str,
+    mcp_servers: &[AcpxMcpServerEntry],
+) -> CliResult<String> {
+    let script_path = ensure_mcp_proxy_script_path()?;
+    let payload = serde_json::to_vec(&json!({
+        "targetCommand": target_command,
+        "mcpServers": mcp_servers,
+    }))
+    .map_err(|error| format!("serialize ACPX MCP proxy payload failed: {error}"))?;
+    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+    Ok(join_command_line(&[
+        ACPX_MCP_PROXY_NODE_COMMAND.to_owned(),
+        script_path,
+        "--payload".to_owned(),
+        encoded,
+    ]))
+}
+
+pub(crate) async fn probe_mcp_proxy_support(cwd: Option<&str>) -> CliResult<(String, String)> {
+    let script_path = ensure_mcp_proxy_script_path()?;
+    let mut probe = Command::new(ACPX_MCP_PROXY_NODE_COMMAND);
+    probe.arg("--version");
+    if let Some(cwd) = cwd {
+        probe.current_dir(cwd);
+    }
+    let output = probe.output().await.map_err(|error| {
+        if error.kind() == ErrorKind::NotFound {
+            format!("embedded ACPX MCP proxy requires `{ACPX_MCP_PROXY_NODE_COMMAND}` on PATH")
+        } else {
+            format!("probe embedded ACPX MCP proxy runtime failed: {error}")
+        }
+    })?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let observed = match (stdout.is_empty(), stderr.is_empty()) {
+        (false, true) => stdout,
+        (true, false) => stderr,
+        (false, false) => format!("{stdout} | {stderr}"),
+        (true, true) => "(empty)".to_owned(),
+    };
+    if !output.status.success() {
+        return Err(format!(
+            "embedded ACPX MCP proxy runtime probe exited with code {}: {observed}",
+            output
+                .status
+                .code()
+                .map_or_else(|| "unknown".to_owned(), |code| code.to_string())
+        ));
+    }
+    Ok((script_path, observed))
+}
+
+fn resolve_selected_mcp_server_entries(
+    config: &LoongClawConfig,
+    selected_mcp_servers: &[String],
+) -> CliResult<Vec<AcpxMcpServerEntry>> {
+    let registry = McpRegistry::from_config(config)?;
+    let resolved_servers = registry.resolve_injectable_stdio_launch_specs(selected_mcp_servers)?;
+
+    let mut entries = Vec::new();
+    for server in resolved_servers {
+        let entry = acpx_mcp_server_entry_from_registry_server(server);
+        entries.push(entry);
+    }
+
+    Ok(entries)
+}
+
+fn acpx_mcp_server_entry_from_registry_server(
+    server: McpStdioServerLaunchSpec,
+) -> AcpxMcpServerEntry {
+    let mut env_entries = Vec::new();
+    for (name, value) in server.env {
+        let env_entry = AcpxMcpServerEnvEntry { name, value };
+        env_entries.push(env_entry);
+    }
+
+    AcpxMcpServerEntry {
+        name: server.name,
+        command: server.command,
+        args: server.args,
+        env: env_entries,
+        cwd: server.cwd,
+    }
+}
+
+fn ensure_mcp_proxy_script_path() -> CliResult<String> {
+    ACPX_MCP_PROXY_SCRIPT_PATH
+        .get_or_init(materialize_mcp_proxy_script)
+        .clone()
+}
+
+fn materialize_mcp_proxy_script() -> Result<String, String> {
+    let path = std::env::temp_dir()
+        .join("loongclaw")
+        .join(ACPX_MCP_PROXY_SCRIPT_NAME);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create ACPX MCP proxy directory failed: {error}"))?;
+    }
+    std::fs::write(&path, ACPX_MCP_PROXY_SCRIPT_SOURCE)
+        .map_err(|error| format!("write ACPX MCP proxy script failed: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(&path)
+            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions)
+            .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
+    }
+    Ok(path.display().to_string())
+}
+
+fn join_command_line(parts: &[String]) -> String {
+    parts
+        .iter()
+        .map(|part| quote_command_part(part.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_command_part(value: &str) -> String {
+    if value.is_empty() {
+        return "\"\"".to_owned();
+    }
+    if value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || "-_./:@".contains(character))
+    {
+        return value.to_owned();
+    }
+
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}

--- a/crates/app/src/acp/assets/acpx-mcp-proxy.mjs
+++ b/crates/app/src/acp/assets/acpx-mcp-proxy.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import fs from "node:fs";
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 
@@ -60,9 +61,30 @@ function splitCommandLine(value) {
 }
 
 function decodePayload(argv) {
+  const payloadFileIndex = argv.indexOf("--payload-file");
+  if (payloadFileIndex >= 0) {
+    const payloadFilePath = argv[payloadFileIndex + 1];
+    if (!payloadFilePath) {
+      throw new Error("Missing MCP proxy payload file path");
+    }
+    const payloadSource = fs.readFileSync(payloadFilePath, "utf8");
+    fs.rmSync(payloadFilePath, { force: true });
+    const parsed = JSON.parse(payloadSource);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Invalid MCP proxy payload");
+    }
+    if (typeof parsed.targetCommand !== "string" || parsed.targetCommand.trim() === "") {
+      throw new Error("MCP proxy payload missing targetCommand");
+    }
+    const mcpServers = Array.isArray(parsed.mcpServers) ? parsed.mcpServers : [];
+    return {
+      targetCommand: parsed.targetCommand,
+      mcpServers,
+    };
+  }
   const payloadIndex = argv.indexOf("--payload");
   if (payloadIndex < 0) {
-    throw new Error("Missing --payload");
+    throw new Error("Missing MCP proxy payload");
   }
   const encoded = argv[payloadIndex + 1];
   if (!encoded) {
@@ -114,6 +136,11 @@ function rewriteLine(line, mcpServers) {
   } catch {
     return line;
   }
+}
+
+if (process.argv.includes("--version")) {
+  process.stdout.write("loongclaw-acpx-mcp-proxy 1\n");
+  process.exit(0);
 }
 
 const { targetCommand, mcpServers } = decodePayload(process.argv.slice(2));

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -1,4 +1,5 @@
 mod acpx;
+mod acpx_mcp;
 mod analytics;
 mod backend;
 mod binding;

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -1,4 +1,6 @@
 mod acpx;
+#[cfg(test)]
+mod acpx_doctor_tests;
 mod acpx_mcp;
 mod analytics;
 mod backend;

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -188,6 +188,7 @@ pub struct AcpRuntimeSnapshot {
     pub selected_metadata: AcpBackendMetadata,
     pub available: Vec<AcpBackendMetadata>,
     pub control_plane: AcpControlPlaneSnapshot,
+    pub mcp: crate::mcp::McpRuntimeSnapshot,
 }
 
 pub fn resolve_acp_backend_selection(config: &LoongClawConfig) -> AcpBackendSelection {
@@ -215,6 +216,7 @@ pub fn collect_acp_runtime_snapshot(config: &LoongClawConfig) -> CliResult<AcpRu
     let selected = resolve_acp_backend_selection(config);
     let selected_metadata = describe_acp_backend(Some(selected.id.as_str()))?;
     let available = list_acp_backend_metadata()?;
+    let mcp = crate::mcp::collect_mcp_runtime_snapshot(config)?;
     let default_agent = config.acp.resolved_default_agent()?;
     let allowed_agents = config.acp.allowed_agent_ids()?;
     let allowed_channels = config.acp.dispatch.allowed_channel_ids()?;
@@ -251,6 +253,7 @@ pub fn collect_acp_runtime_snapshot(config: &LoongClawConfig) -> CliResult<AcpRu
         selected_metadata,
         available,
         control_plane,
+        mcp,
     })
 }
 
@@ -896,6 +899,8 @@ mod tests {
             vec!["codex".to_owned(), "claude".to_owned()]
         );
         assert_eq!(snapshot.selected.id, DEFAULT_ACP_BACKEND_ID);
+        assert!(snapshot.mcp.servers.is_empty());
+        assert!(snapshot.mcp.missing_selected_servers.is_empty());
     }
 
     #[test]
@@ -999,6 +1004,11 @@ mod tests {
         assert_eq!(
             snapshot.control_plane.working_directory.as_deref(),
             Some("/workspace/dispatch")
+        );
+        assert!(snapshot.mcp.servers.is_empty());
+        assert_eq!(
+            snapshot.mcp.missing_selected_servers,
+            vec!["filesystem".to_owned(), "search".to_owned()]
         );
     }
 

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -10,6 +10,7 @@ mod runtime;
 mod shared;
 mod tools;
 
+pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
 pub use audit::{AuditConfig, AuditMode};
 #[allow(unused_imports)]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -8,6 +8,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::CliResult;
+use crate::mcp::McpConfig;
 
 use super::{
     OnebotChannelConfig, QqbotChannelConfig, WeixinChannelConfig,
@@ -149,6 +150,8 @@ pub struct LoongClawConfig {
     pub tools: ToolConfig,
     #[serde(default)]
     pub external_skills: ExternalSkillsConfig,
+    #[serde(default)]
+    pub mcp: McpConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
     #[serde(default)]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2748,13 +2748,17 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         ingress,
     )
     .await;
-    emit_runtime_binding_trust_event_if_needed(
-        runtime,
-        session_id,
-        &lane_execution.turn_result,
-        binding,
-    )
-    .await;
+    let should_emit_binding_trust_event =
+        !matches!(lane, ExecutionLane::Safe) || config.conversation.safe_lane_emit_runtime_events;
+    if should_emit_binding_trust_event {
+        emit_runtime_binding_trust_event_if_needed(
+            runtime,
+            session_id,
+            &lane_execution.turn_result,
+            binding,
+        )
+        .await;
+    }
     observe_provider_turn_tool_batch_terminal(observer, &lane_execution.tool_events);
     let loop_verdict = turn_loop_state.observe_turn(turn_loop_policy, &turn);
     let followup_config =

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod context;
 pub mod conversation;
 pub mod crypto;
+pub mod mcp;
 pub mod memory;
 pub mod migration;
 pub(crate) mod observability;
@@ -24,6 +25,8 @@ pub(crate) mod trust;
 pub mod tui_surface;
 
 mod process_env;
+#[doc(hidden)]
+pub mod process_launch;
 #[allow(
     clippy::expect_used,
     clippy::panic,

--- a/crates/app/src/mcp/config.rs
+++ b/crates/app/src/mcp/config.rs
@@ -1,0 +1,128 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct McpConfig {
+    #[serde(default)]
+    pub servers: BTreeMap<String, McpServerConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerConfig {
+    #[serde(flatten)]
+    pub transport: McpServerTransportConfig,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub startup_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub tool_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub enabled_tools: Vec<String>,
+    #[serde(default)]
+    pub disabled_tools: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged, deny_unknown_fields, rename_all = "snake_case")]
+pub enum McpServerTransportConfig {
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+        #[serde(default)]
+        cwd: Option<PathBuf>,
+    },
+    StreamableHttp {
+        url: String,
+        #[serde(default)]
+        bearer_token_env_var: Option<String>,
+        #[serde(default)]
+        http_headers: BTreeMap<String, String>,
+        #[serde(default)]
+        env_http_headers: BTreeMap<String, String>,
+    },
+}
+
+const fn default_enabled() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_config_defaults_to_empty_registry() {
+        let config = McpConfig::default();
+        assert!(config.servers.is_empty());
+    }
+
+    #[test]
+    fn deserialize_stdio_mcp_server_config() {
+        let raw = r#"
+        {
+          "command": "uvx",
+          "args": ["context7-mcp"],
+          "env": {"API_TOKEN": "secret"},
+          "cwd": "/workspace/repo",
+          "enabled": true,
+          "required": false,
+          "startup_timeout_ms": 15000,
+          "tool_timeout_ms": 120000
+        }
+        "#;
+        let parsed: McpServerConfig = serde_json::from_str(raw).expect("parse stdio MCP config");
+
+        assert_eq!(
+            parsed.transport,
+            McpServerTransportConfig::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["context7-mcp".to_owned()],
+                env: BTreeMap::from([("API_TOKEN".to_owned(), "secret".to_owned())]),
+                cwd: Some(PathBuf::from("/workspace/repo")),
+            }
+        );
+        assert!(parsed.enabled);
+        assert!(!parsed.required);
+        assert_eq!(parsed.startup_timeout_ms, Some(15_000));
+        assert_eq!(parsed.tool_timeout_ms, Some(120_000));
+    }
+
+    #[test]
+    fn deserialize_streamable_http_mcp_server_config() {
+        let raw = r#"
+        {
+          "url": "https://mcp.example.com",
+          "bearer_token_env_var": "MCP_TOKEN",
+          "http_headers": {"X-Test": "ok"},
+          "env_http_headers": {"Authorization": "MCP_AUTH_HEADER"},
+          "enabled_tools": ["search"],
+          "disabled_tools": ["write"]
+        }
+        "#;
+        let parsed: McpServerConfig =
+            serde_json::from_str(raw).expect("parse streamable HTTP MCP config");
+
+        assert_eq!(
+            parsed.transport,
+            McpServerTransportConfig::StreamableHttp {
+                url: "https://mcp.example.com".to_owned(),
+                bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                http_headers: BTreeMap::from([("X-Test".to_owned(), "ok".to_owned())]),
+                env_http_headers: BTreeMap::from([(
+                    "Authorization".to_owned(),
+                    "MCP_AUTH_HEADER".to_owned(),
+                )]),
+            }
+        );
+        assert_eq!(parsed.enabled_tools, vec!["search".to_owned()]);
+        assert_eq!(parsed.disabled_tools, vec!["write".to_owned()]);
+    }
+}

--- a/crates/app/src/mcp/mod.rs
+++ b/crates/app/src/mcp/mod.rs
@@ -1,0 +1,11 @@
+pub mod config;
+mod registry;
+mod types;
+
+pub use config::{McpConfig, McpServerConfig, McpServerTransportConfig};
+pub use registry::{McpRegistry, collect_mcp_runtime_snapshot};
+pub use types::{
+    McpAuthStatus, McpRuntimeServerSnapshot, McpRuntimeSnapshot, McpServerOrigin,
+    McpServerOriginKind, McpServerStatus, McpServerStatusKind, McpStdioServerLaunchSpec,
+    McpTransportSnapshot,
+};

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -261,8 +261,8 @@ fn registry_entry_from_acpx_profile(
     server: &AcpxMcpServerConfig,
 ) -> McpRegistryEntry {
     let transport = McpTransportSnapshot::Stdio {
-        command: server.command.clone(),
-        args: server.args.clone(),
+        command: redact_stdio_command(server.command.as_str()),
+        args: redact_stdio_args(&server.args),
         cwd: None,
         env_var_names: server.env.keys().cloned().collect(),
     };
@@ -670,6 +670,59 @@ mod tests {
 
         assert!(has_acpx_origin);
         assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_redacts_acpx_profile_servers() {
+        let config = LoongClawConfig {
+            acp: AcpConfig {
+                backends: crate::config::AcpBackendProfilesConfig {
+                    acpx: Some(crate::config::AcpxBackendConfig {
+                        mcp_servers: BTreeMap::from([(
+                            "filesystem".to_owned(),
+                            AcpxMcpServerConfig {
+                                command: "npx".to_owned(),
+                                args: vec![
+                                    "--apiKey=secret".to_owned(),
+                                    "-H".to_owned(),
+                                    "Authorization: Bearer secret".to_owned(),
+                                    "https://mcp.example.com?token=secret".to_owned(),
+                                ],
+                                env: BTreeMap::from([(
+                                    "NODE_ENV".to_owned(),
+                                    "production".to_owned(),
+                                )]),
+                            },
+                        )]),
+                        ..crate::config::AcpxBackendConfig::default()
+                    }),
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot
+            .servers
+            .iter()
+            .find(|server| server.name == "filesystem")
+            .expect("filesystem server");
+
+        assert_eq!(
+            server.transport,
+            McpTransportSnapshot::Stdio {
+                command: "npx".to_owned(),
+                args: vec![
+                    "--apiKey=<redacted>".to_owned(),
+                    "-H".to_owned(),
+                    "<redacted>".to_owned(),
+                    "https://mcp.example.com/?token=%3Credacted%3E".to_owned(),
+                ],
+                cwd: None,
+                env_var_names: vec!["NODE_ENV".to_owned()],
+            }
+        );
     }
 
     #[test]

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -1053,7 +1053,7 @@ mod tests {
     #[test]
     fn transport_snapshot_redacts_invalid_http_urls() {
         let transport = McpServerTransportConfig::StreamableHttp {
-            url: "https://mcp.example.com/path?token=secret%ZZ".to_owned(),
+            url: "https:// bad.example/path?token=secret".to_owned(),
             bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
             http_headers: BTreeMap::new(),
             env_http_headers: BTreeMap::new(),

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -402,34 +402,71 @@ fn split_flag_assignment(argument: &str) -> Option<(&str, &str)> {
     argument.split_once('=')
 }
 
+fn normalized_argument_key(argument: &str) -> String {
+    let trimmed = argument.trim_start_matches('-');
+    let mut normalized = String::new();
+
+    for (index, character) in trimmed.chars().enumerate() {
+        let is_separator = matches!(character, '_' | '.');
+        if is_separator {
+            normalized.push('-');
+            continue;
+        }
+
+        let is_uppercase = character.is_ascii_uppercase();
+        let should_insert_separator = is_uppercase && index > 0;
+        if should_insert_separator {
+            normalized.push('-');
+        }
+
+        let lowercased = character.to_ascii_lowercase();
+        normalized.push(lowercased);
+    }
+
+    normalized
+}
+
 fn argument_key_looks_sensitive(argument: &str) -> bool {
     if !argument.starts_with('-') {
         return false;
     }
 
-    let trimmed = argument.trim_start_matches('-');
-    let normalized = trimmed.replace(['_', '.'], "-").to_ascii_lowercase();
+    let normalized = normalized_argument_key(argument);
+    let is_header_flag = matches!(normalized.as_str(), "h" | "header" | "headers");
+    if is_header_flag {
+        return true;
+    }
+
+    let compact = normalized.replace('-', "");
+    let sensitive_keywords = [
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "authorization",
+        "cookie",
+        "bearer",
+    ];
+    let contains_sensitive_keyword = sensitive_keywords
+        .iter()
+        .any(|keyword| compact.contains(keyword));
+    if contains_sensitive_keyword {
+        return true;
+    }
+
     let parts = normalized
         .split('-')
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>();
-
-    let contains_secret_label = parts.iter().any(|part| {
-        matches!(
-            *part,
-            "token" | "secret" | "password" | "passwd" | "authorization" | "cookie" | "bearer"
-        )
-    });
-    if contains_secret_label {
+    if parts.contains(&"auth") {
         return true;
     }
 
-    let contains_key = parts.contains(&"key");
-    let contains_sensitive_scope = parts
-        .iter()
-        .any(|part| matches!(*part, "api" | "access" | "client" | "private" | "session"));
+    let key_scopes = ["api", "access", "client", "private", "session", "auth"];
+    let contains_key = compact.contains("key");
+    let contains_key_scope = key_scopes.iter().any(|scope| compact.contains(scope));
 
-    contains_key && contains_sensitive_scope
+    contains_key && contains_key_scope
 }
 
 fn redact_transport_value(value: &str) -> String {
@@ -444,7 +481,7 @@ fn redact_transport_value(value: &str) -> String {
 fn redact_transport_url(raw: &str) -> String {
     let parsed = reqwest::Url::parse(raw);
     let Ok(mut parsed) = parsed else {
-        return raw.to_owned();
+        return "<redacted-invalid-url>".to_owned();
     };
 
     let has_username = !parsed.username().is_empty();
@@ -881,6 +918,64 @@ mod tests {
     }
 
     #[test]
+    fn transport_snapshot_redacts_camel_case_and_header_stdio_arguments() {
+        let transport = McpServerTransportConfig::Stdio {
+            command: "uvx".to_owned(),
+            args: vec![
+                "--apiKey=secret".to_owned(),
+                "--accessToken".to_owned(),
+                "token-value".to_owned(),
+                "-H".to_owned(),
+                "Authorization: Bearer secret".to_owned(),
+                "--header=Cookie: session=secret".to_owned(),
+            ],
+            env: BTreeMap::new(),
+            cwd: Some(PathBuf::from("/workspace/repo")),
+        };
+
+        let snapshot = transport_snapshot(&transport);
+
+        assert_eq!(
+            snapshot,
+            McpTransportSnapshot::Stdio {
+                command: "uvx".to_owned(),
+                args: vec![
+                    "--apiKey=<redacted>".to_owned(),
+                    "--accessToken".to_owned(),
+                    "<redacted>".to_owned(),
+                    "-H".to_owned(),
+                    "<redacted>".to_owned(),
+                    "--header=<redacted>".to_owned(),
+                ],
+                cwd: Some("/workspace/repo".to_owned()),
+                env_var_names: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn transport_snapshot_preserves_non_sensitive_author_argument() {
+        let transport = McpServerTransportConfig::Stdio {
+            command: "uvx".to_owned(),
+            args: vec!["--author=alice".to_owned()],
+            env: BTreeMap::new(),
+            cwd: None,
+        };
+
+        let snapshot = transport_snapshot(&transport);
+
+        assert_eq!(
+            snapshot,
+            McpTransportSnapshot::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["--author=alice".to_owned()],
+                cwd: None,
+                env_var_names: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
     fn transport_snapshot_redacts_sensitive_http_url_components() {
         let transport = McpServerTransportConfig::StreamableHttp {
             url: "https://alice:secret@mcp.example.com/path?token=secret&mode=read#frag".to_owned(),
@@ -895,6 +990,28 @@ mod tests {
             snapshot,
             McpTransportSnapshot::StreamableHttp {
                 url: "https://%3Credacted%3E:%3Credacted%3E@mcp.example.com/path?token=%3Credacted%3E&mode=%3Credacted%3E#%3Credacted%3E".to_owned(),
+                bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                http_header_names: Vec::new(),
+                env_http_header_names: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn transport_snapshot_redacts_invalid_http_urls() {
+        let transport = McpServerTransportConfig::StreamableHttp {
+            url: "https://mcp.example.com/path?token=secret%ZZ".to_owned(),
+            bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+            http_headers: BTreeMap::new(),
+            env_http_headers: BTreeMap::new(),
+        };
+
+        let snapshot = transport_snapshot(&transport);
+
+        assert_eq!(
+            snapshot,
+            McpTransportSnapshot::StreamableHttp {
+                url: "<redacted-invalid-url>".to_owned(),
                 bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
                 http_header_names: Vec::new(),
                 env_http_header_names: Vec::new(),

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -200,12 +200,9 @@ impl McpRegistry {
             for origin in next.snapshot.origins.drain(..) {
                 push_origin(&mut existing.snapshot.origins, origin);
             }
-
-            let should_adopt_stdio_launch_spec = existing.stdio_launch_spec.is_none();
-
-            if should_adopt_stdio_launch_spec {
-                existing.stdio_launch_spec = next.stdio_launch_spec;
-            }
+            // Keep the first-seen transport authoritative for a given canonical
+            // server name so the runtime snapshot and injectable launch spec
+            // cannot drift to different transports.
 
             return;
         }
@@ -335,8 +332,8 @@ fn transport_snapshot(transport: &McpServerTransportConfig) -> McpTransportSnaps
             env,
             cwd,
         } => McpTransportSnapshot::Stdio {
-            command: command.clone(),
-            args: args.clone(),
+            command: redact_stdio_command(command),
+            args: redact_stdio_args(args),
             cwd: cwd.as_ref().map(|value| value.display().to_string()),
             env_var_names: env.keys().cloned().collect(),
         },
@@ -346,12 +343,139 @@ fn transport_snapshot(transport: &McpServerTransportConfig) -> McpTransportSnaps
             http_headers,
             env_http_headers,
         } => McpTransportSnapshot::StreamableHttp {
-            url: url.clone(),
+            url: redact_transport_url(url),
             bearer_token_env_var: bearer_token_env_var.clone(),
             http_header_names: http_headers.keys().cloned().collect(),
             env_http_header_names: env_http_headers.keys().cloned().collect(),
         },
     }
+}
+
+fn redact_stdio_command(command: &str) -> String {
+    redact_transport_value(command)
+}
+
+fn redact_stdio_args(args: &[String]) -> Vec<String> {
+    let mut redacted_args = Vec::new();
+    let mut redact_next_value = false;
+
+    for argument in args {
+        if redact_next_value {
+            let redacted_value = "<redacted>".to_owned();
+            redacted_args.push(redacted_value);
+            redact_next_value = false;
+            continue;
+        }
+
+        let maybe_assignment = split_flag_assignment(argument);
+        if let Some((flag, value)) = maybe_assignment {
+            let is_sensitive = argument_key_looks_sensitive(flag);
+            let rendered_value = if is_sensitive {
+                "<redacted>".to_owned()
+            } else {
+                redact_transport_value(value)
+            };
+            let rendered_argument = format!("{flag}={rendered_value}");
+            redacted_args.push(rendered_argument);
+            continue;
+        }
+
+        let is_sensitive_flag = argument_key_looks_sensitive(argument);
+        if is_sensitive_flag {
+            redacted_args.push(argument.clone());
+            redact_next_value = true;
+            continue;
+        }
+
+        let redacted_argument = redact_transport_value(argument);
+        redacted_args.push(redacted_argument);
+    }
+
+    redacted_args
+}
+
+fn split_flag_assignment(argument: &str) -> Option<(&str, &str)> {
+    if !argument.starts_with('-') {
+        return None;
+    }
+
+    argument.split_once('=')
+}
+
+fn argument_key_looks_sensitive(argument: &str) -> bool {
+    if !argument.starts_with('-') {
+        return false;
+    }
+
+    let trimmed = argument.trim_start_matches('-');
+    let normalized = trimmed.replace(['_', '.'], "-").to_ascii_lowercase();
+    let parts = normalized
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+
+    let contains_secret_label = parts.iter().any(|part| {
+        matches!(
+            *part,
+            "token" | "secret" | "password" | "passwd" | "authorization" | "cookie" | "bearer"
+        )
+    });
+    if contains_secret_label {
+        return true;
+    }
+
+    let contains_key = parts.contains(&"key");
+    let contains_sensitive_scope = parts
+        .iter()
+        .any(|part| matches!(*part, "api" | "access" | "client" | "private" | "session"));
+
+    contains_key && contains_sensitive_scope
+}
+
+fn redact_transport_value(value: &str) -> String {
+    let looks_like_url = value.contains("://");
+    if looks_like_url {
+        return redact_transport_url(value);
+    }
+
+    value.to_owned()
+}
+
+fn redact_transport_url(raw: &str) -> String {
+    let parsed = reqwest::Url::parse(raw);
+    let Ok(mut parsed) = parsed else {
+        return raw.to_owned();
+    };
+
+    let has_username = !parsed.username().is_empty();
+    if has_username {
+        let _ = parsed.set_username("<redacted>");
+    }
+
+    let has_password = parsed.password().is_some();
+    if has_password {
+        let _ = parsed.set_password(Some("<redacted>"));
+    }
+
+    let query_keys = parsed
+        .query_pairs()
+        .map(|(name, _value)| name.into_owned())
+        .collect::<Vec<_>>();
+    if !query_keys.is_empty() {
+        parsed.set_query(None);
+        let mut query_pairs = parsed.query_pairs_mut();
+        for query_key in query_keys {
+            query_pairs.append_pair(query_key.as_str(), "<redacted>");
+        }
+        drop(query_pairs);
+    }
+
+    let has_fragment = parsed.fragment().is_some();
+    if has_fragment {
+        parsed.set_fragment(Some("<redacted>"));
+    }
+
+    parsed.to_string()
 }
 
 fn transport_kind_label(transport: &McpTransportSnapshot) -> &'static str {
@@ -574,6 +698,66 @@ mod tests {
     }
 
     #[test]
+    fn registry_keeps_config_transport_authoritative_for_same_name_conflicts() {
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([(
+                    "shared".to_owned(),
+                    McpServerConfig {
+                        transport: McpServerTransportConfig::StreamableHttp {
+                            url: "https://mcp.example.com".to_owned(),
+                            bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                            http_headers: BTreeMap::new(),
+                            env_http_headers: BTreeMap::new(),
+                        },
+                        enabled: true,
+                        required: false,
+                        startup_timeout_ms: None,
+                        tool_timeout_ms: None,
+                        enabled_tools: Vec::new(),
+                        disabled_tools: Vec::new(),
+                    },
+                )]),
+            },
+            acp: AcpConfig {
+                backends: crate::config::AcpBackendProfilesConfig {
+                    acpx: Some(crate::config::AcpxBackendConfig {
+                        mcp_servers: BTreeMap::from([(
+                            "shared".to_owned(),
+                            AcpxMcpServerConfig {
+                                command: "npx".to_owned(),
+                                args: vec!["@modelcontextprotocol/server-filesystem".to_owned()],
+                                env: BTreeMap::new(),
+                            },
+                        )]),
+                        ..crate::config::AcpxBackendConfig::default()
+                    }),
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let registry = McpRegistry::from_config(&config).expect("registry");
+        let snapshot = registry.snapshot();
+        let server = snapshot
+            .servers
+            .iter()
+            .find(|server| server.name == "shared")
+            .expect("shared server");
+        let selected_names = vec!["shared".to_owned()];
+        let error = registry
+            .resolve_injectable_stdio_launch_specs(&selected_names)
+            .expect_err("config transport should remain authoritative");
+
+        assert!(matches!(
+            server.transport,
+            McpTransportSnapshot::StreamableHttp { .. }
+        ));
+        assert!(error.contains("streamable_http"), "error={error}");
+    }
+
+    #[test]
     fn registry_resolves_injectable_stdio_launch_specs_from_shared_mcp_config() {
         let config = LoongClawConfig {
             mcp: McpConfig {
@@ -662,5 +846,59 @@ mod tests {
             .expect_err("http server must be rejected for ACPX injection");
 
         assert!(error.contains("streamable_http"), "error={error}");
+    }
+
+    #[test]
+    fn transport_snapshot_redacts_sensitive_stdio_arguments() {
+        let transport = McpServerTransportConfig::Stdio {
+            command: "uvx".to_owned(),
+            args: vec![
+                "--api-key=secret".to_owned(),
+                "--token".to_owned(),
+                "token-value".to_owned(),
+                "https://mcp.example.com?access_token=secret".to_owned(),
+            ],
+            env: BTreeMap::new(),
+            cwd: Some(PathBuf::from("/workspace/repo")),
+        };
+
+        let snapshot = transport_snapshot(&transport);
+
+        assert_eq!(
+            snapshot,
+            McpTransportSnapshot::Stdio {
+                command: "uvx".to_owned(),
+                args: vec![
+                    "--api-key=<redacted>".to_owned(),
+                    "--token".to_owned(),
+                    "<redacted>".to_owned(),
+                    "https://mcp.example.com/?access_token=%3Credacted%3E".to_owned(),
+                ],
+                cwd: Some("/workspace/repo".to_owned()),
+                env_var_names: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn transport_snapshot_redacts_sensitive_http_url_components() {
+        let transport = McpServerTransportConfig::StreamableHttp {
+            url: "https://alice:secret@mcp.example.com/path?token=secret&mode=read#frag".to_owned(),
+            bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+            http_headers: BTreeMap::new(),
+            env_http_headers: BTreeMap::new(),
+        };
+
+        let snapshot = transport_snapshot(&transport);
+
+        assert_eq!(
+            snapshot,
+            McpTransportSnapshot::StreamableHttp {
+                url: "https://%3Credacted%3E:%3Credacted%3E@mcp.example.com/path?token=%3Credacted%3E&mode=%3Credacted%3E#%3Credacted%3E".to_owned(),
+                bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                http_header_names: Vec::new(),
+                env_http_header_names: Vec::new(),
+            }
+        );
     }
 }

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -1,0 +1,666 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::CliResult;
+use crate::config::{AcpxBackendConfig, AcpxMcpServerConfig, LoongClawConfig};
+
+use super::config::{McpServerConfig, McpServerTransportConfig};
+use super::types::{
+    McpAuthStatus, McpRuntimeServerSnapshot, McpRuntimeSnapshot, McpServerOrigin,
+    McpServerOriginKind, McpServerStatus, McpServerStatusKind, McpStdioServerLaunchSpec,
+    McpTransportSnapshot,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct McpRegistryEntry {
+    snapshot: McpRuntimeServerSnapshot,
+    stdio_launch_spec: Option<McpStdioServerLaunchSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct McpRegistry {
+    servers: BTreeMap<String, McpRegistryEntry>,
+    missing_selected_servers: Vec<String>,
+}
+
+impl McpRegistry {
+    pub fn from_config(config: &LoongClawConfig) -> CliResult<Self> {
+        let mut registry = Self::default();
+
+        for (raw_name, server) in &config.mcp.servers {
+            let name = canonical_server_name(raw_name)?;
+            let origin = McpServerOrigin {
+                kind: McpServerOriginKind::Config,
+                source_id: None,
+            };
+
+            registry.upsert_server_config(name, server, origin);
+        }
+
+        if let Some(profile) = config.acp.acpx_profile() {
+            registry.ingest_acpx_profile(profile)?;
+        }
+
+        let bootstrap_names = config.acp.dispatch.bootstrap_mcp_server_names()?;
+
+        for selected_name in bootstrap_names {
+            let maybe_server = registry.servers.get_mut(&selected_name);
+
+            if let Some(server) = maybe_server {
+                server.snapshot.selected_for_acp_bootstrap = true;
+
+                let origin = McpServerOrigin {
+                    kind: McpServerOriginKind::AcpBootstrapSelection,
+                    source_id: None,
+                };
+
+                push_origin(&mut server.snapshot.origins, origin);
+                continue;
+            }
+
+            registry.missing_selected_servers.push(selected_name);
+        }
+
+        Ok(registry)
+    }
+
+    pub fn snapshot(&self) -> McpRuntimeSnapshot {
+        let servers = self
+            .servers
+            .values()
+            .map(|entry| entry.snapshot.clone())
+            .collect();
+
+        McpRuntimeSnapshot {
+            servers,
+            missing_selected_servers: self.missing_selected_servers.clone(),
+        }
+    }
+
+    pub fn injectable_stdio_server_count(&self) -> usize {
+        let mut count = 0;
+
+        for entry in self.servers.values() {
+            let is_stdio = entry.stdio_launch_spec.is_some();
+            let is_enabled = entry.snapshot.enabled;
+
+            if is_stdio && is_enabled {
+                count += 1;
+            }
+        }
+
+        count
+    }
+
+    pub fn resolve_selected_server_names(
+        &self,
+        requested_names: &[String],
+    ) -> CliResult<Vec<String>> {
+        let mut selected_names = Vec::new();
+        let mut seen_names = BTreeSet::new();
+        let mut missing_names = Vec::new();
+
+        for raw_name in requested_names {
+            let normalized_name = canonical_server_name(raw_name)?;
+            let inserted = seen_names.insert(normalized_name.clone());
+
+            if !inserted {
+                continue;
+            }
+
+            let contains_server = self.servers.contains_key(&normalized_name);
+
+            if contains_server {
+                selected_names.push(normalized_name);
+                continue;
+            }
+
+            missing_names.push(normalized_name);
+        }
+
+        if missing_names.is_empty() {
+            return Ok(selected_names);
+        }
+
+        let rendered_names = missing_names.join(", ");
+        let message = format!(
+            "ACPX requested mcp_servers are not configured in the shared MCP registry ([mcp.servers] or [acp.backends.acpx.mcp_servers]): {rendered_names}"
+        );
+
+        Err(message)
+    }
+
+    pub fn resolve_injectable_stdio_launch_specs(
+        &self,
+        selected_names: &[String],
+    ) -> CliResult<Vec<McpStdioServerLaunchSpec>> {
+        let mut launch_specs = Vec::new();
+
+        for name in selected_names {
+            let maybe_entry = self.servers.get(name);
+
+            let Some(entry) = maybe_entry else {
+                let message = format!(
+                    "ACPX requested mcp_servers are not configured in the shared MCP registry ([mcp.servers] or [acp.backends.acpx.mcp_servers]): {name}"
+                );
+
+                return Err(message);
+            };
+
+            let is_enabled = entry.snapshot.enabled;
+
+            if !is_enabled {
+                let message = format!(
+                    "ACPX requested mcp_server `{name}` exists, but it is disabled in the shared MCP registry"
+                );
+
+                return Err(message);
+            }
+
+            let maybe_launch_spec = entry.stdio_launch_spec.clone();
+
+            let Some(launch_spec) = maybe_launch_spec else {
+                let transport_kind = transport_kind_label(&entry.snapshot.transport);
+                let message = format!(
+                    "ACPX requested mcp_server `{name}` exists, but its transport `{transport_kind}` is not compatible with ACPX injection; only stdio MCP servers can be proxied"
+                );
+
+                return Err(message);
+            };
+
+            launch_specs.push(launch_spec);
+        }
+
+        Ok(launch_specs)
+    }
+
+    fn ingest_acpx_profile(&mut self, profile: &AcpxBackendConfig) -> CliResult<()> {
+        for (raw_name, server) in &profile.mcp_servers {
+            let name = canonical_server_name(raw_name)?;
+            let entry = registry_entry_from_acpx_profile(name, server);
+            self.merge_or_insert(entry);
+        }
+
+        Ok(())
+    }
+
+    fn upsert_server_config(
+        &mut self,
+        name: String,
+        server: &McpServerConfig,
+        origin: McpServerOrigin,
+    ) {
+        let entry = registry_entry_from_config(name, server, origin);
+        self.merge_or_insert(entry);
+    }
+
+    fn merge_or_insert(&mut self, mut next: McpRegistryEntry) {
+        let maybe_existing = self.servers.get_mut(&next.snapshot.name);
+
+        if let Some(existing) = maybe_existing {
+            for origin in next.snapshot.origins.drain(..) {
+                push_origin(&mut existing.snapshot.origins, origin);
+            }
+
+            let should_adopt_stdio_launch_spec = existing.stdio_launch_spec.is_none();
+
+            if should_adopt_stdio_launch_spec {
+                existing.stdio_launch_spec = next.stdio_launch_spec;
+            }
+
+            return;
+        }
+
+        let name = next.snapshot.name.clone();
+        self.servers.insert(name, next);
+    }
+}
+
+pub fn collect_mcp_runtime_snapshot(config: &LoongClawConfig) -> CliResult<McpRuntimeSnapshot> {
+    let registry = McpRegistry::from_config(config)?;
+    let snapshot = registry.snapshot();
+    Ok(snapshot)
+}
+
+fn registry_entry_from_config(
+    name: String,
+    server: &McpServerConfig,
+    origin: McpServerOrigin,
+) -> McpRegistryEntry {
+    let transport = transport_snapshot(&server.transport);
+    let status_kind = if server.enabled {
+        McpServerStatusKind::Pending
+    } else {
+        McpServerStatusKind::Disabled
+    };
+
+    let snapshot = McpRuntimeServerSnapshot {
+        name,
+        enabled: server.enabled,
+        required: server.required,
+        selected_for_acp_bootstrap: false,
+        origins: vec![origin],
+        status: McpServerStatus {
+            kind: status_kind,
+            auth: McpAuthStatus::Unknown,
+            last_error: None,
+        },
+        transport,
+        enabled_tools: server.enabled_tools.clone(),
+        disabled_tools: server.disabled_tools.clone(),
+        startup_timeout_ms: server.startup_timeout_ms,
+        tool_timeout_ms: server.tool_timeout_ms,
+    };
+
+    let stdio_launch_spec = stdio_launch_spec_from_config(&snapshot, &server.transport);
+
+    McpRegistryEntry {
+        snapshot,
+        stdio_launch_spec,
+    }
+}
+
+fn registry_entry_from_acpx_profile(
+    name: String,
+    server: &AcpxMcpServerConfig,
+) -> McpRegistryEntry {
+    let transport = McpTransportSnapshot::Stdio {
+        command: server.command.clone(),
+        args: server.args.clone(),
+        cwd: None,
+        env_var_names: server.env.keys().cloned().collect(),
+    };
+
+    let snapshot = McpRuntimeServerSnapshot {
+        name: name.clone(),
+        enabled: true,
+        required: false,
+        selected_for_acp_bootstrap: false,
+        origins: vec![McpServerOrigin {
+            kind: McpServerOriginKind::AcpBackendProfile,
+            source_id: Some("acpx".to_owned()),
+        }],
+        status: McpServerStatus {
+            kind: McpServerStatusKind::Pending,
+            auth: McpAuthStatus::Unknown,
+            last_error: None,
+        },
+        transport,
+        enabled_tools: Vec::new(),
+        disabled_tools: Vec::new(),
+        startup_timeout_ms: None,
+        tool_timeout_ms: None,
+    };
+
+    let stdio_launch_spec = McpStdioServerLaunchSpec {
+        name,
+        command: server.command.clone(),
+        args: server.args.clone(),
+        env: server.env.clone(),
+        cwd: None,
+        startup_timeout_ms: None,
+        tool_timeout_ms: None,
+    };
+
+    McpRegistryEntry {
+        snapshot,
+        stdio_launch_spec: Some(stdio_launch_spec),
+    }
+}
+
+fn canonical_server_name(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+
+    if normalized.is_empty() {
+        return Err("MCP server names must not be empty".to_owned());
+    }
+
+    Ok(normalized)
+}
+
+fn push_origin(origins: &mut Vec<McpServerOrigin>, candidate: McpServerOrigin) {
+    let already_present = origins.iter().any(|origin| origin == &candidate);
+
+    if already_present {
+        return;
+    }
+
+    origins.push(candidate);
+}
+
+fn transport_snapshot(transport: &McpServerTransportConfig) -> McpTransportSnapshot {
+    match transport {
+        McpServerTransportConfig::Stdio {
+            command,
+            args,
+            env,
+            cwd,
+        } => McpTransportSnapshot::Stdio {
+            command: command.clone(),
+            args: args.clone(),
+            cwd: cwd.as_ref().map(|value| value.display().to_string()),
+            env_var_names: env.keys().cloned().collect(),
+        },
+        McpServerTransportConfig::StreamableHttp {
+            url,
+            bearer_token_env_var,
+            http_headers,
+            env_http_headers,
+        } => McpTransportSnapshot::StreamableHttp {
+            url: url.clone(),
+            bearer_token_env_var: bearer_token_env_var.clone(),
+            http_header_names: http_headers.keys().cloned().collect(),
+            env_http_header_names: env_http_headers.keys().cloned().collect(),
+        },
+    }
+}
+
+fn transport_kind_label(transport: &McpTransportSnapshot) -> &'static str {
+    match transport {
+        McpTransportSnapshot::Stdio { .. } => "stdio",
+        McpTransportSnapshot::StreamableHttp { .. } => "streamable_http",
+    }
+}
+
+fn stdio_launch_spec_from_config(
+    snapshot: &McpRuntimeServerSnapshot,
+    transport: &McpServerTransportConfig,
+) -> Option<McpStdioServerLaunchSpec> {
+    let McpServerTransportConfig::Stdio {
+        command,
+        args,
+        env,
+        cwd,
+    } = transport
+    else {
+        return None;
+    };
+
+    let cwd_string = cwd.as_ref().map(|value| value.display().to_string());
+
+    let launch_spec = McpStdioServerLaunchSpec {
+        name: snapshot.name.clone(),
+        command: command.clone(),
+        args: args.clone(),
+        env: env.clone(),
+        cwd: cwd_string,
+        startup_timeout_ms: snapshot.startup_timeout_ms,
+        tool_timeout_ms: snapshot.tool_timeout_ms,
+    };
+
+    Some(launch_spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::config::{AcpConfig, AcpxMcpServerConfig};
+
+    use super::*;
+    use crate::mcp::config::{McpConfig, McpServerConfig, McpServerTransportConfig};
+
+    fn configured_stdio_server() -> McpServerConfig {
+        McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["context7-mcp".to_owned()],
+                env: BTreeMap::from([("API_TOKEN".to_owned(), "secret".to_owned())]),
+                cwd: Some(PathBuf::from("/workspace/repo")),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: Some(15_000),
+            tool_timeout_ms: Some(120_000),
+            enabled_tools: vec!["search".to_owned()],
+            disabled_tools: vec!["write".to_owned()],
+        }
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_includes_config_servers_and_bootstrap_selection() {
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("Docs".to_owned(), configured_stdio_server())]),
+            },
+            acp: AcpConfig {
+                dispatch: crate::config::AcpDispatchConfig {
+                    bootstrap_mcp_servers: vec![" docs ".to_owned()],
+                    ..crate::config::AcpDispatchConfig::default()
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+
+        assert!(snapshot.missing_selected_servers.is_empty());
+        assert_eq!(snapshot.servers.len(), 1);
+
+        let server = &snapshot.servers[0];
+
+        assert_eq!(server.name, "docs");
+        assert!(server.selected_for_acp_bootstrap);
+        assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.enabled_tools, vec!["search".to_owned()]);
+        assert_eq!(server.disabled_tools, vec!["write".to_owned()]);
+
+        let has_config_origin = server
+            .origins
+            .iter()
+            .any(|origin| origin.kind == McpServerOriginKind::Config && origin.source_id.is_none());
+        let has_bootstrap_origin = server.origins.iter().any(|origin| {
+            origin.kind == McpServerOriginKind::AcpBootstrapSelection && origin.source_id.is_none()
+        });
+
+        assert!(has_config_origin);
+        assert!(has_bootstrap_origin);
+        assert_eq!(
+            server.transport,
+            McpTransportSnapshot::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["context7-mcp".to_owned()],
+                cwd: Some("/workspace/repo".to_owned()),
+                env_var_names: vec!["API_TOKEN".to_owned()],
+            }
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_includes_acpx_profile_servers() {
+        let config = LoongClawConfig {
+            acp: AcpConfig {
+                backends: crate::config::AcpBackendProfilesConfig {
+                    acpx: Some(crate::config::AcpxBackendConfig {
+                        mcp_servers: BTreeMap::from([(
+                            "filesystem".to_owned(),
+                            AcpxMcpServerConfig {
+                                command: "npx".to_owned(),
+                                args: vec![
+                                    "-y".to_owned(),
+                                    "@modelcontextprotocol/server-filesystem".to_owned(),
+                                ],
+                                env: BTreeMap::from([(
+                                    "NODE_ENV".to_owned(),
+                                    "production".to_owned(),
+                                )]),
+                            },
+                        )]),
+                        ..crate::config::AcpxBackendConfig::default()
+                    }),
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+
+        assert_eq!(snapshot.servers.len(), 1);
+
+        let server = &snapshot.servers[0];
+
+        assert_eq!(server.name, "filesystem");
+
+        let has_acpx_origin = server.origins.iter().any(|origin| {
+            origin.kind == McpServerOriginKind::AcpBackendProfile
+                && origin.source_id.as_deref() == Some("acpx")
+        });
+
+        assert!(has_acpx_origin);
+        assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_reports_missing_bootstrap_names() {
+        let config = LoongClawConfig {
+            acp: AcpConfig {
+                dispatch: crate::config::AcpDispatchConfig {
+                    bootstrap_mcp_servers: vec!["missing".to_owned()],
+                    ..crate::config::AcpDispatchConfig::default()
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+
+        assert!(snapshot.servers.is_empty());
+        assert_eq!(
+            snapshot.missing_selected_servers,
+            vec!["missing".to_owned()]
+        );
+    }
+
+    #[test]
+    fn registry_merges_same_server_across_config_and_acpx_profile() {
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("filesystem".to_owned(), configured_stdio_server())]),
+            },
+            acp: AcpConfig {
+                backends: crate::config::AcpBackendProfilesConfig {
+                    acpx: Some(crate::config::AcpxBackendConfig {
+                        mcp_servers: BTreeMap::from([(
+                            "filesystem".to_owned(),
+                            AcpxMcpServerConfig {
+                                command: "npx".to_owned(),
+                                args: Vec::new(),
+                                env: BTreeMap::new(),
+                            },
+                        )]),
+                        ..crate::config::AcpxBackendConfig::default()
+                    }),
+                },
+                dispatch: crate::config::AcpDispatchConfig {
+                    bootstrap_mcp_servers: vec!["filesystem".to_owned()],
+                    ..crate::config::AcpDispatchConfig::default()
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+
+        assert_eq!(snapshot.servers.len(), 1);
+
+        let server = &snapshot.servers[0];
+
+        assert_eq!(server.name, "filesystem");
+        assert_eq!(server.origins.len(), 3);
+        assert!(server.selected_for_acp_bootstrap);
+    }
+
+    #[test]
+    fn registry_resolves_injectable_stdio_launch_specs_from_shared_mcp_config() {
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("Docs".to_owned(), configured_stdio_server())]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let registry = McpRegistry::from_config(&config).expect("registry");
+        let requested_names = vec![" docs ".to_owned(), "docs".to_owned()];
+        let selected_names = registry
+            .resolve_selected_server_names(&requested_names)
+            .expect("selected names");
+        let launch_specs = registry
+            .resolve_injectable_stdio_launch_specs(&selected_names)
+            .expect("launch specs");
+
+        assert_eq!(selected_names, vec!["docs".to_owned()]);
+        assert_eq!(launch_specs.len(), 1);
+        assert_eq!(launch_specs[0].name, "docs");
+        assert_eq!(launch_specs[0].command, "uvx");
+        assert_eq!(launch_specs[0].args, vec!["context7-mcp".to_owned()]);
+        assert_eq!(
+            launch_specs[0].env,
+            BTreeMap::from([("API_TOKEN".to_owned(), "secret".to_owned())])
+        );
+    }
+
+    #[test]
+    fn registry_rejects_disabled_servers_for_acpx_injection() {
+        let disabled_server = McpServerConfig {
+            enabled: false,
+            ..configured_stdio_server()
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), disabled_server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let registry = McpRegistry::from_config(&config).expect("registry");
+        let requested_names = vec!["docs".to_owned()];
+        let selected_names = registry
+            .resolve_selected_server_names(&requested_names)
+            .expect("selected names");
+        let error = registry
+            .resolve_injectable_stdio_launch_specs(&selected_names)
+            .expect_err("disabled server must be rejected for ACPX injection");
+
+        assert!(error.contains("disabled"), "error={error}");
+    }
+
+    #[test]
+    fn registry_rejects_non_stdio_servers_for_acpx_injection() {
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([(
+                    "remote".to_owned(),
+                    McpServerConfig {
+                        transport: McpServerTransportConfig::StreamableHttp {
+                            url: "https://mcp.example.com".to_owned(),
+                            bearer_token_env_var: Some("MCP_TOKEN".to_owned()),
+                            http_headers: BTreeMap::new(),
+                            env_http_headers: BTreeMap::new(),
+                        },
+                        enabled: true,
+                        required: false,
+                        startup_timeout_ms: None,
+                        tool_timeout_ms: None,
+                        enabled_tools: Vec::new(),
+                        disabled_tools: Vec::new(),
+                    },
+                )]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let registry = McpRegistry::from_config(&config).expect("registry");
+        let requested_names = vec!["remote".to_owned()];
+        let selected_names = registry
+            .resolve_selected_server_names(&requested_names)
+            .expect("selected names");
+        let error = registry
+            .resolve_injectable_stdio_launch_specs(&selected_names)
+            .expect_err("http server must be rejected for ACPX injection");
+
+        assert!(error.contains("streamable_http"), "error={error}");
+    }
+}

--- a/crates/app/src/mcp/types.rs
+++ b/crates/app/src/mcp/types.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerOriginKind {
+    Config,
+    Plugin,
+    Managed,
+    AcpBackendProfile,
+    AcpBootstrapSelection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerOrigin {
+    pub kind: McpServerOriginKind,
+    pub source_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAuthStatus {
+    #[default]
+    Unknown,
+    Unsupported,
+    NotLoggedIn,
+    BearerToken,
+    OAuth,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerStatusKind {
+    Pending,
+    Connected,
+    NeedsAuth,
+    Failed,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerStatus {
+    pub kind: McpServerStatusKind,
+    pub auth: McpAuthStatus,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "transport", rename_all = "snake_case")]
+pub enum McpTransportSnapshot {
+    Stdio {
+        command: String,
+        args: Vec<String>,
+        cwd: Option<String>,
+        env_var_names: Vec<String>,
+    },
+    StreamableHttp {
+        url: String,
+        bearer_token_env_var: Option<String>,
+        http_header_names: Vec<String>,
+        env_http_header_names: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpRuntimeServerSnapshot {
+    pub name: String,
+    pub enabled: bool,
+    pub required: bool,
+    pub selected_for_acp_bootstrap: bool,
+    pub origins: Vec<McpServerOrigin>,
+    pub status: McpServerStatus,
+    pub transport: McpTransportSnapshot,
+    pub enabled_tools: Vec<String>,
+    pub disabled_tools: Vec<String>,
+    pub startup_timeout_ms: Option<u64>,
+    pub tool_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpStdioServerLaunchSpec {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub cwd: Option<String>,
+    pub startup_timeout_ms: Option<u64>,
+    pub tool_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct McpRuntimeSnapshot {
+    pub servers: Vec<McpRuntimeServerSnapshot>,
+    pub missing_selected_servers: Vec<String>,
+}

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -40,9 +40,20 @@ fn resolve_shebang_invocation(
 ) -> Option<ResolvedCommandInvocation> {
     let script_path = resolve_existing_command_path(command)?;
     let shebang = read_shebang(script_path.as_path())?;
-    let mut parts = shebang.split_whitespace();
-    let interpreter = parts.next()?;
-    let mut resolved_args = parts.map(OsString::from).collect::<Vec<_>>();
+    let trimmed_shebang = shebang.trim();
+    let separator_index = trimmed_shebang.find(char::is_whitespace);
+    let interpreter = match separator_index {
+        Some(index) => trimmed_shebang.get(..index)?,
+        None => trimmed_shebang,
+    };
+    let mut resolved_args = Vec::new();
+    let remainder = separator_index.and_then(|index| trimmed_shebang.get(index..));
+    let remainder = remainder.map(str::trim_start);
+    if let Some(remainder) = remainder
+        && !remainder.is_empty()
+    {
+        resolved_args.push(OsString::from(remainder));
+    }
     let script_arg = script_path.into_os_string();
     resolved_args.push(script_arg);
     for argument in collected_args {
@@ -152,6 +163,33 @@ mod tests {
             resolved.args,
             vec![
                 std::ffi::OsString::from("python3"),
+                PathBuf::from(&script_path).into_os_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_preserves_env_split_arguments_as_one_argument() {
+        let root = crate::test_support::unique_temp_dir("loongclaw-process-launch-env-s");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let script_path = root.join("script.py");
+        crate::test_support::write_executable_script_atomically(
+            &script_path,
+            "#!/usr/bin/env -S python3 -u\nprint('ok')\n",
+        )
+        .expect("write script");
+
+        let resolved = resolve_command_invocation(
+            script_path.to_string_lossy().as_ref(),
+            Vec::<String>::new(),
+        );
+
+        assert_eq!(resolved.program, std::ffi::OsString::from("/usr/bin/env"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                std::ffi::OsString::from("-S python3 -u"),
                 PathBuf::from(&script_path).into_os_string(),
             ]
         );

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -1,0 +1,150 @@
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct ResolvedCommandInvocation {
+    pub program: OsString,
+    pub args: Vec<OsString>,
+}
+
+#[doc(hidden)]
+pub fn resolve_command_invocation<I, S>(command: &str, args: I) -> ResolvedCommandInvocation
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let collected_args = args
+        .into_iter()
+        .map(|value| OsString::from(value.as_ref()))
+        .collect::<Vec<_>>();
+
+    #[cfg(unix)]
+    if let Some((interpreter, shebang_args)) = resolve_shebang_invocation(command) {
+        let mut resolved_args = shebang_args;
+        resolved_args.push(OsString::from(command));
+        resolved_args.extend(collected_args);
+        return ResolvedCommandInvocation {
+            program: interpreter,
+            args: resolved_args,
+        };
+    }
+
+    ResolvedCommandInvocation {
+        program: OsString::from(command),
+        args: collected_args,
+    }
+}
+
+#[cfg(unix)]
+fn resolve_shebang_invocation(command: &str) -> Option<(OsString, Vec<OsString>)> {
+    let script_path = resolve_existing_command_path(command)?;
+    let shebang = read_shebang(script_path.as_path())?;
+    let mut parts = shebang.split_whitespace();
+    let interpreter = parts.next()?;
+    let args = parts.map(OsString::from).collect::<Vec<_>>();
+    Some((OsString::from(interpreter), args))
+}
+
+#[cfg(unix)]
+fn resolve_existing_command_path(command: &str) -> Option<PathBuf> {
+    let direct_path = Path::new(command);
+    if direct_path.is_file() {
+        return Some(direct_path.to_path_buf());
+    }
+
+    which::which(command).ok()
+}
+
+#[cfg(unix)]
+fn read_shebang(path: &Path) -> Option<String> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buffer = [0_u8; 256];
+    let count = file.read(&mut buffer).ok()?;
+    let prefix = buffer.get(..2)?;
+    if count < 2 || prefix != b"#!" {
+        return None;
+    }
+
+    let header = buffer.get(..count)?;
+    let line_end = header
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .unwrap_or(count);
+    let line = std::str::from_utf8(buffer.get(2..line_end)?).ok()?;
+    let trimmed = line.trim().trim_end_matches('\r');
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::path::PathBuf;
+
+    use super::resolve_command_invocation;
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_wraps_shebang_script_with_interpreter() {
+        let root = crate::test_support::unique_temp_dir("loongclaw-process-launch-sh");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let script_path = root.join("script.sh");
+        crate::test_support::write_executable_script_atomically(
+            &script_path,
+            "#!/bin/sh\nexit 0\n",
+        )
+        .expect("write script");
+
+        let resolved =
+            resolve_command_invocation(script_path.to_string_lossy().as_ref(), ["--flag", "value"]);
+
+        assert_eq!(resolved.program, std::ffi::OsString::from("/bin/sh"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                script_path.into_os_string(),
+                std::ffi::OsString::from("--flag"),
+                std::ffi::OsString::from("value"),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_preserves_non_script_program() {
+        let resolved = resolve_command_invocation("/bin/echo", ["hello"]);
+
+        assert_eq!(resolved.program, std::ffi::OsString::from("/bin/echo"));
+        assert_eq!(resolved.args, vec![std::ffi::OsString::from("hello")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_supports_env_shebang_arguments() {
+        let root = crate::test_support::unique_temp_dir("loongclaw-process-launch-env");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let script_path = root.join("script.py");
+        crate::test_support::write_executable_script_atomically(
+            &script_path,
+            "#!/usr/bin/env python3\nprint('ok')\n",
+        )
+        .expect("write script");
+
+        let resolved = resolve_command_invocation(
+            script_path.to_string_lossy().as_ref(),
+            Vec::<String>::new(),
+        );
+
+        assert_eq!(resolved.program, std::ffi::OsString::from("/usr/bin/env"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                std::ffi::OsString::from("python3"),
+                PathBuf::from(&script_path).into_os_string(),
+            ]
+        );
+    }
+}

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -23,14 +23,8 @@ where
         .collect::<Vec<_>>();
 
     #[cfg(unix)]
-    if let Some((interpreter, shebang_args)) = resolve_shebang_invocation(command) {
-        let mut resolved_args = shebang_args;
-        resolved_args.push(OsString::from(command));
-        resolved_args.extend(collected_args);
-        return ResolvedCommandInvocation {
-            program: interpreter,
-            args: resolved_args,
-        };
+    if let Some(invocation) = resolve_shebang_invocation(command, &collected_args) {
+        return invocation;
     }
 
     ResolvedCommandInvocation {
@@ -40,13 +34,26 @@ where
 }
 
 #[cfg(unix)]
-fn resolve_shebang_invocation(command: &str) -> Option<(OsString, Vec<OsString>)> {
+fn resolve_shebang_invocation(
+    command: &str,
+    collected_args: &[OsString],
+) -> Option<ResolvedCommandInvocation> {
     let script_path = resolve_existing_command_path(command)?;
     let shebang = read_shebang(script_path.as_path())?;
     let mut parts = shebang.split_whitespace();
     let interpreter = parts.next()?;
-    let args = parts.map(OsString::from).collect::<Vec<_>>();
-    Some((OsString::from(interpreter), args))
+    let mut resolved_args = parts.map(OsString::from).collect::<Vec<_>>();
+    let script_arg = script_path.into_os_string();
+    resolved_args.push(script_arg);
+    for argument in collected_args {
+        let cloned_argument = argument.clone();
+        resolved_args.push(cloned_argument);
+    }
+
+    Some(ResolvedCommandInvocation {
+        program: OsString::from(interpreter),
+        args: resolved_args,
+    })
 }
 
 #[cfg(unix)]
@@ -81,6 +88,8 @@ fn read_shebang(path: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::path::Path;
     #[cfg(unix)]
     use std::path::PathBuf;
 
@@ -144,6 +153,38 @@ mod tests {
             vec![
                 std::ffi::OsString::from("python3"),
                 PathBuf::from(&script_path).into_os_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_uses_resolved_path_for_path_discovered_scripts() {
+        let root = crate::test_support::unique_temp_dir("loongclaw-process-launch-path");
+        let bin_dir = root.join("bin");
+        let script_path = bin_dir.join("path-script");
+        std::fs::create_dir_all(&bin_dir).expect("create bin dir");
+        crate::test_support::write_executable_script_atomically(
+            &script_path,
+            "#!/bin/sh\nexit 0\n",
+        )
+        .expect("write path-discovered script");
+
+        let mut env = crate::test_support::ScopedEnv::new();
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut path_entries = vec![PathBuf::from(&bin_dir)];
+        path_entries.extend(std::env::split_paths(Path::new(&original_path)).collect::<Vec<_>>());
+        let joined_path = std::env::join_paths(path_entries).expect("join PATH");
+        env.set("PATH", joined_path);
+
+        let resolved = resolve_command_invocation("path-script", ["--flag"]);
+
+        assert_eq!(resolved.program, std::ffi::OsString::from("/bin/sh"));
+        assert_eq!(
+            resolved.args,
+            vec![
+                script_path.into_os_string(),
+                std::ffi::OsString::from("--flag"),
             ]
         );
     }

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -54,6 +54,8 @@ impl<'a> ProviderRuntimeBinding<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::context::bootstrap_test_kernel_context;
+
     use super::ProviderRuntimeBinding;
 
     #[test]

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -60,9 +60,8 @@ mod tests {
 
     #[test]
     fn provider_runtime_binding_labels_are_stable() {
-        let kernel_context =
-            crate::context::bootstrap_test_kernel_context("runtime-binding-test", 60)
-                .expect("kernel context should bootstrap");
+        let kernel_context = bootstrap_test_kernel_context("runtime-binding-test", 60)
+            .expect("kernel context should bootstrap");
         let binding = ProviderRuntimeBinding::kernel(&kernel_context);
 
         assert_eq!(ProviderRuntimeBinding::direct().as_str(), "advisory_only");

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use wait_timeout::ChildExt;
 
+use crate::process_launch::resolve_command_invocation;
+
 const DEFAULT_BROWSER_COMPANION_SCOPE_ID: &str = "__global";
 const BROWSER_COMPANION_PROTOCOL: &str = "loongclaw.browser_companion.v1";
 const BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS: usize = 20;
@@ -129,8 +131,10 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
         let encoded = serde_json::to_vec(request)
             .map_err(|error| format!("browser_companion_request_encode_failed: {error}"))?;
         let mut child = retry_executable_file_busy(|| {
-            let mut process = Command::new(command);
+            let invocation = resolve_command_invocation(command, std::iter::empty::<&str>());
+            let mut process = Command::new(&invocation.program);
             process
+                .args(&invocation.args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -697,6 +697,8 @@ pub fn execute_tool_core_with_config(
             );
         }
     }
+
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -697,7 +697,6 @@ pub fn execute_tool_core_with_config(
             );
         }
     }
-    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,13 +1,10 @@
 use std::io::ErrorKind;
-use std::process::Output;
-use std::process::Stdio;
+use std::process::{Command as BlockingCommand, Output, Stdio};
 use std::time::Duration;
 
 use loongclaw_app as mvp;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
-use tokio::time::timeout;
+use wait_timeout::ChildExt;
+use mvp::process_launch::resolve_command_invocation;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
@@ -19,15 +16,6 @@ const TEST_BROWSER_COMPANION_VERSION_PREFIX: &str = "loongclaw-test-browser-comp
 
 fn browser_companion_probe_timeout_seconds(timeout_seconds: u64) -> u64 {
     timeout_seconds.max(1)
-}
-
-fn browser_companion_probe_timeout_duration(timeout_seconds: u64) -> Duration {
-    let normalized_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
-    let base_duration = Duration::from_secs(normalized_seconds);
-    let slack_millis = normalized_seconds.saturating_mul(100);
-    let bounded_slack_millis = slack_millis.min(500);
-    let slack_duration = Duration::from_millis(bounded_slack_millis);
-    base_duration.saturating_add(slack_duration)
 }
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
@@ -250,76 +238,90 @@ async fn probe_browser_companion_version(
     command: &str,
     timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
-    let timeout_duration = browser_companion_probe_timeout_duration(timeout_seconds);
-
     #[cfg(test)]
     if let Some(version) = command.strip_prefix(TEST_BROWSER_COMPANION_VERSION_PREFIX) {
         return Ok(format!("loongclaw-browser-companion {version}"));
     }
 
-    for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
-        let mut probe = Command::new(command);
-        probe.arg(BROWSER_COMPANION_VERSION_ARG);
-        probe.kill_on_drop(true);
-        probe.stdout(Stdio::piped());
-        probe.stderr(Stdio::piped());
-
-        let mut child = match probe.spawn() {
-            Ok(child) => child,
-            Err(error) => {
-                if error.kind() == ErrorKind::NotFound {
-                    return Err(BrowserCompanionProbeError::MissingBinary);
+    let command = command.to_owned();
+    let join_result = tokio::task::spawn_blocking(move || {
+        for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
+            let probe_result =
+                probe_browser_companion_version_once(command.as_str(), timeout_seconds);
+            match probe_result {
+                Err(BrowserCompanionProbeError::TimedOut) => {}
+                result => {
+                    return result;
                 }
-
-                let error_message = error.to_string();
-                return Err(BrowserCompanionProbeError::SpawnFailed(error_message));
-            }
-        };
-        let probe_result = timeout(timeout_duration, child.wait()).await;
-        match probe_result {
-            Ok(Ok(status)) => {
-                let stdout = read_probe_pipe(&mut child.stdout).await?;
-                let stderr = read_probe_pipe(&mut child.stderr).await?;
-                let output = Output {
-                    status,
-                    stdout,
-                    stderr,
-                };
-                return interpret_browser_companion_probe_output(output);
-            }
-            Ok(Err(error)) => {
-                if error.kind() == ErrorKind::NotFound {
-                    return Err(BrowserCompanionProbeError::MissingBinary);
-                }
-
-                let error_message = error.to_string();
-                return Err(BrowserCompanionProbeError::SpawnFailed(error_message));
-            }
-            Err(_) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
             }
         }
-    }
 
-    Err(BrowserCompanionProbeError::TimedOut)
+        Err(BrowserCompanionProbeError::TimedOut)
+    })
+    .await;
+
+    match join_result {
+        Ok(result) => result,
+        Err(error) => Err(BrowserCompanionProbeError::SpawnFailed(error.to_string())),
+    }
 }
 
-async fn read_probe_pipe<R>(pipe: &mut Option<R>) -> Result<Vec<u8>, BrowserCompanionProbeError>
-where
-    R: AsyncRead + Unpin,
-{
-    let Some(reader) = pipe.as_mut() else {
-        return Ok(Vec::new());
-    };
+fn probe_browser_companion_version_once(
+    command: &str,
+    timeout_seconds: u64,
+) -> Result<String, BrowserCompanionProbeError> {
+    let child = spawn_browser_companion_probe_process(command)?;
+    let output = wait_for_browser_companion_probe_output(child, timeout_seconds)?;
+    interpret_browser_companion_probe_output(output)
+}
 
-    let mut bytes = Vec::new();
-    reader
-        .read_to_end(&mut bytes)
-        .await
-        .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?;
+fn spawn_browser_companion_probe_process(
+    command: &str,
+) -> Result<std::process::Child, BrowserCompanionProbeError> {
+    let invocation = resolve_command_invocation(command, [BROWSER_COMPANION_VERSION_ARG]);
+    let mut process = BlockingCommand::new(&invocation.program);
+    process.args(&invocation.args);
+    process.stdin(Stdio::null());
+    process.stdout(Stdio::piped());
+    process.stderr(Stdio::piped());
 
-    Ok(bytes)
+    let spawn_result = process.spawn();
+    match spawn_result {
+        Ok(child) => Ok(child),
+        Err(error) => {
+            if error.kind() == ErrorKind::NotFound {
+                return Err(BrowserCompanionProbeError::MissingBinary);
+            }
+
+            let error_message = error.to_string();
+            Err(BrowserCompanionProbeError::SpawnFailed(error_message))
+        }
+    }
+}
+
+fn wait_for_browser_companion_probe_output(
+    mut child: std::process::Child,
+    timeout_seconds: u64,
+) -> Result<Output, BrowserCompanionProbeError> {
+    let timeout_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
+    let timeout_duration = Duration::from_secs(timeout_seconds);
+    let wait_result = child.wait_timeout(timeout_duration);
+    let status_option = wait_result.map_err(|error| {
+        let error_message = error.to_string();
+        BrowserCompanionProbeError::SpawnFailed(error_message)
+    })?;
+
+    if status_option.is_some() {
+        let output_result = child.wait_with_output();
+        return output_result.map_err(|error| {
+            let error_message = error.to_string();
+            BrowserCompanionProbeError::SpawnFailed(error_message)
+        });
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(BrowserCompanionProbeError::TimedOut)
 }
 
 fn interpret_browser_companion_probe_output(
@@ -606,12 +608,5 @@ mod tests {
             "loongclaw-browser-companion 11.5.0",
             "1.5.0"
         ));
-    }
-
-    #[test]
-    fn browser_companion_probe_timeout_duration_saturates() {
-        let timeout_duration = browser_companion_probe_timeout_duration(u64::MAX);
-
-        assert_eq!(timeout_duration, Duration::MAX);
     }
 }

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -3,8 +3,8 @@ use std::process::{Command as BlockingCommand, Output, Stdio};
 use std::time::Duration;
 
 use loongclaw_app as mvp;
-use wait_timeout::ChildExt;
 use mvp::process_launch::resolve_command_invocation;
+use wait_timeout::ChildExt;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";

--- a/crates/daemon/src/cli_json.rs
+++ b/crates/daemon/src/cli_json.rs
@@ -1,0 +1,16 @@
+use serde_json::Value;
+
+use crate::{CliResult, RuntimeSnapshotCliState, gateway};
+
+pub(crate) fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {
+    serde_json::from_str(raw).map_err(|error| format!("invalid JSON for {context}: {error}"))
+}
+
+pub(crate) fn build_runtime_snapshot_cli_json_payload(
+    snapshot: &RuntimeSnapshotCliState,
+) -> CliResult<Value> {
+    let read_model = gateway::read_models::build_runtime_snapshot_read_model(snapshot);
+    let payload = serde_json::to_value(read_model)
+        .map_err(|error| format!("serialize runtime snapshot read model failed: {error}"))?;
+    Ok(payload)
+}

--- a/crates/daemon/src/cli_json.rs
+++ b/crates/daemon/src/cli_json.rs
@@ -6,7 +6,7 @@ pub(crate) fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {
     serde_json::from_str(raw).map_err(|error| format!("invalid JSON for {context}: {error}"))
 }
 
-pub(crate) fn build_runtime_snapshot_cli_json_payload(
+pub fn build_runtime_snapshot_cli_json_payload(
     snapshot: &RuntimeSnapshotCliState,
 ) -> CliResult<Value> {
     let read_model = gateway::read_models::build_runtime_snapshot_read_model(snapshot);

--- a/crates/daemon/src/command_kind_tests.rs
+++ b/crates/daemon/src/command_kind_tests.rs
@@ -13,6 +13,23 @@ fn command_kind_for_logging_uses_stable_variant_names() {
         "run_task"
     );
     assert_eq!(
+        Commands::ListMcpServers {
+            config: None,
+            json: false,
+        }
+        .command_kind_for_logging(),
+        "list_mcp_servers"
+    );
+    assert_eq!(
+        Commands::ShowMcpServer {
+            config: None,
+            name: "test".to_owned(),
+            json: false,
+        }
+        .command_kind_for_logging(),
+        "show_mcp_server"
+    );
+    assert_eq!(
         Commands::WhatsappServe {
             config: None,
             account: None,

--- a/crates/daemon/src/command_kind_tests.rs
+++ b/crates/daemon/src/command_kind_tests.rs
@@ -1,0 +1,25 @@
+use super::Commands;
+
+#[test]
+fn command_kind_for_logging_uses_stable_variant_names() {
+    assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
+    assert_eq!(Commands::AuditDemo.command_kind_for_logging(), "audit_demo");
+    assert_eq!(
+        Commands::RunTask {
+            objective: "test".to_owned(),
+            payload: "{}".to_owned(),
+        }
+        .command_kind_for_logging(),
+        "run_task"
+    );
+    assert_eq!(
+        Commands::WhatsappServe {
+            config: None,
+            account: None,
+            bind: None,
+            path: None,
+        }
+        .command_kind_for_logging(),
+        "whatsapp_serve"
+    );
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -32,6 +32,7 @@ pub use loongclaw_spec::{CliResult, DEFAULT_AGENT_ID, DEFAULT_PACK_ID, kernel_bo
 pub use self::channel_send_target_kind::{
     default_twitch_send_target_kind, parse_twitch_send_target_kind,
 };
+pub use self::cli_json::build_runtime_snapshot_cli_json_payload;
 pub use self::mcp_cli::{
     build_mcp_server_detail_cli_json_payload, build_mcp_servers_cli_json_payload,
     run_list_mcp_servers_cli, run_show_mcp_server_cli,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -32,6 +32,10 @@ pub use loongclaw_spec::{CliResult, DEFAULT_AGENT_ID, DEFAULT_PACK_ID, kernel_bo
 pub use self::channel_send_target_kind::{
     default_twitch_send_target_kind, parse_twitch_send_target_kind,
 };
+pub use self::mcp_cli::{
+    build_mcp_server_detail_cli_json_payload, build_mcp_servers_cli_json_payload,
+    run_list_mcp_servers_cli, run_show_mcp_server_cli,
+};
 pub use loongclaw_bench::{
     run_programmatic_pressure_baseline_lint_cli, run_programmatic_pressure_benchmark_cli,
     run_wasm_cache_benchmark_cli,
@@ -82,6 +86,9 @@ mod channel_bridge_render;
 mod channel_send_cli_tests;
 mod channel_send_target_kind;
 mod cli_handoff;
+mod cli_json;
+#[cfg(test)]
+mod command_kind_tests;
 pub mod completions_cli;
 pub mod doctor_cli;
 pub mod doctor_security_cli;
@@ -90,6 +97,7 @@ pub mod feishu_cli;
 pub mod feishu_support;
 pub mod gateway;
 pub mod import_cli;
+mod mcp_cli;
 #[cfg(any(feature = "memory-sqlite", feature = "mvp"))]
 mod memory_context_benchmark;
 pub mod migrate_cli;
@@ -1408,25 +1416,6 @@ impl Commands {
     }
 }
 
-#[cfg(test)]
-mod command_kind_tests {
-    use super::Commands;
-
-    #[test]
-    fn command_kind_for_logging_uses_stable_variant_names() {
-        assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
-        assert_eq!(Commands::AuditDemo.command_kind_for_logging(), "audit_demo");
-        assert_eq!(
-            Commands::RunTask {
-                objective: "test".to_owned(),
-                payload: "{}".to_owned(),
-            }
-            .command_kind_for_logging(),
-            "run_task"
-        );
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ValidateConfigOutput {
     Text,
@@ -1778,7 +1767,7 @@ mod first_run_entry_tests {
 }
 
 pub async fn invoke_connector_cli(operation: &str, payload_raw: &str) -> CliResult<()> {
-    let payload = parse_json_payload(payload_raw, "invoke-connector payload")?;
+    let payload = cli_json::parse_json_payload(payload_raw, "invoke-connector payload")?;
 
     let kernel = kernel_bootstrap::KernelBuilder::default().build();
     let token = kernel
@@ -3394,7 +3383,7 @@ pub fn build_runtime_snapshot_artifact_json_payload(
     snapshot: &RuntimeSnapshotCliState,
     metadata: &RuntimeSnapshotArtifactMetadata,
 ) -> CliResult<Value> {
-    let base_payload = build_runtime_snapshot_cli_json_payload(snapshot)?;
+    let base_payload = cli_json::build_runtime_snapshot_cli_json_payload(snapshot)?;
     let lineage = runtime_snapshot_artifact_lineage(snapshot, metadata)?;
     let document = RuntimeSnapshotArtifactDocument {
         config: snapshot.config.clone(),
@@ -3792,58 +3781,6 @@ pub fn run_list_memory_systems_cli(config_path: Option<&str>, as_json: bool) -> 
         "{}",
         render_memory_system_snapshot_text(&resolved_path.display().to_string(), &snapshot)
     );
-    Ok(())
-}
-
-pub fn run_list_mcp_servers_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
-    let (resolved_path, config) = mvp::config::load(config_path)?;
-    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
-
-    if as_json {
-        let payload =
-            build_mcp_servers_cli_json_payload(&resolved_path.display().to_string(), &snapshot);
-        let pretty = serde_json::to_string_pretty(&payload)
-            .map_err(|error| format!("serialize MCP server output failed: {error}"))?;
-        println!("{pretty}");
-        return Ok(());
-    }
-
-    println!(
-        "{}",
-        render_mcp_servers_snapshot_text(&resolved_path.display().to_string(), &snapshot)
-    );
-    Ok(())
-}
-
-pub fn run_show_mcp_server_cli(
-    config_path: Option<&str>,
-    server_name: &str,
-    as_json: bool,
-) -> CliResult<()> {
-    let (resolved_path, config) = mvp::config::load(config_path)?;
-    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
-    let normalized_name = normalize_mcp_server_name(server_name)?;
-    let maybe_server = snapshot
-        .servers
-        .iter()
-        .find(|server| server.name == normalized_name);
-    let Some(server) = maybe_server else {
-        return Err(format!(
-            "MCP server `{normalized_name}` was not found in the runtime snapshot"
-        ));
-    };
-
-    if as_json {
-        let payload =
-            build_mcp_server_detail_cli_json_payload(&resolved_path.display().to_string(), server);
-        let pretty = serde_json::to_string_pretty(&payload)
-            .map_err(|error| format!("serialize MCP server detail output failed: {error}"))?;
-        println!("{pretty}");
-        return Ok(());
-    }
-
-    let rendered = render_mcp_server_detail_text(&resolved_path.display().to_string(), server);
-    println!("{rendered}");
     Ok(())
 }
 
@@ -5415,19 +5352,6 @@ pub async fn run_multi_channel_serve_cli(
     .await
 }
 
-pub fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {
-    serde_json::from_str(raw).map_err(|error| format!("invalid JSON for {context}: {error}"))
-}
-
-pub fn build_runtime_snapshot_cli_json_payload(
-    snapshot: &RuntimeSnapshotCliState,
-) -> CliResult<Value> {
-    let read_model = gateway::read_models::build_runtime_snapshot_read_model(snapshot);
-    let payload = serde_json::to_value(read_model)
-        .map_err(|error| format!("serialize runtime snapshot read model failed: {error}"))?;
-    Ok(payload)
-}
-
 pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> String {
     let mut lines = vec![
         format!("config={}", snapshot.config),
@@ -5553,7 +5477,7 @@ pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> Strin
             .as_deref()
             .unwrap_or("-")
     ));
-    append_mcp_runtime_snapshot_lines(&mut lines, &snapshot.acp.mcp);
+    mcp_cli::append_mcp_runtime_snapshot_lines(&mut lines, &snapshot.acp.mcp);
     lines.push(format!(
         "channels enabled={} service_enabled={} configured_accounts={} surfaces={}",
         render_string_list(snapshot.enabled_channel_ids.iter().map(String::as_str)),
@@ -5785,331 +5709,8 @@ fn runtime_snapshot_acp_json(snapshot: &mvp::acp::AcpRuntimeSnapshot) -> Value {
             .map(|metadata| acp_backend_metadata_json(metadata, None))
             .collect::<Vec<_>>(),
         "control_plane": acp_control_plane_json(&snapshot.control_plane),
-        "mcp": mcp_runtime_snapshot_json(&snapshot.mcp),
+        "mcp": mcp_cli::mcp_runtime_snapshot_json(&snapshot.mcp),
     })
-}
-
-pub fn build_mcp_servers_cli_json_payload(
-    config_path: &str,
-    snapshot: &mvp::mcp::McpRuntimeSnapshot,
-) -> Value {
-    json!({
-        "config": config_path,
-        "server_count": snapshot.servers.len(),
-        "servers": snapshot.servers.iter().map(mcp_runtime_server_json).collect::<Vec<_>>(),
-        "missing_selected_servers": snapshot.missing_selected_servers,
-    })
-}
-
-pub fn build_mcp_server_detail_cli_json_payload(
-    config_path: &str,
-    server: &mvp::mcp::McpRuntimeServerSnapshot,
-) -> Value {
-    let server_json = mcp_runtime_server_json(server);
-    json!({
-        "config": config_path,
-        "server": server_json,
-    })
-}
-
-fn mcp_runtime_snapshot_json(snapshot: &mvp::mcp::McpRuntimeSnapshot) -> Value {
-    json!({
-        "servers": snapshot
-            .servers
-            .iter()
-            .map(mcp_runtime_server_json)
-            .collect::<Vec<_>>(),
-        "missing_selected_servers": snapshot.missing_selected_servers,
-    })
-}
-
-fn mcp_runtime_server_json(server: &mvp::mcp::McpRuntimeServerSnapshot) -> Value {
-    let origins = server
-        .origins
-        .iter()
-        .map(|origin| {
-            json!({
-                "kind": mcp_origin_kind_str(origin.kind),
-                "source_id": origin.source_id,
-            })
-        })
-        .collect::<Vec<_>>();
-    let status_kind = mcp_server_status_kind_str(server.status.kind);
-    let auth_kind = mcp_auth_status_str(server.status.auth);
-
-    json!({
-        "name": server.name,
-        "enabled": server.enabled,
-        "required": server.required,
-        "selected_for_acp_bootstrap": server.selected_for_acp_bootstrap,
-        "origins": origins,
-        "status": {
-            "kind": status_kind,
-            "auth": auth_kind,
-            "last_error": server.status.last_error,
-        },
-        "transport": match &server.transport {
-            mvp::mcp::McpTransportSnapshot::Stdio {
-                command,
-                args,
-                cwd,
-                env_var_names,
-            } => json!({
-                "transport": "stdio",
-                "command": command,
-                "args": args,
-                "cwd": cwd,
-                "env_var_names": env_var_names,
-            }),
-            mvp::mcp::McpTransportSnapshot::StreamableHttp {
-                url,
-                bearer_token_env_var,
-                http_header_names,
-                env_http_header_names,
-            } => json!({
-                "transport": "streamable_http",
-                "url": url,
-                "bearer_token_env_var": bearer_token_env_var,
-                "http_header_names": http_header_names,
-                "env_http_header_names": env_http_header_names,
-            }),
-        },
-        "enabled_tools": server.enabled_tools,
-        "disabled_tools": server.disabled_tools,
-        "startup_timeout_ms": server.startup_timeout_ms,
-        "tool_timeout_ms": server.tool_timeout_ms,
-    })
-}
-
-fn render_mcp_servers_snapshot_text(
-    config_path: &str,
-    snapshot: &mvp::mcp::McpRuntimeSnapshot,
-) -> String {
-    let mut lines = vec![format!("config={config_path}")];
-    if snapshot.servers.is_empty() {
-        lines.push("mcp_servers=none".to_owned());
-    } else {
-        lines.push(format!("mcp_servers={}", snapshot.servers.len()));
-        for server in &snapshot.servers {
-            let origins = server
-                .origins
-                .iter()
-                .map(render_mcp_origin_label)
-                .collect::<Vec<_>>()
-                .join(",");
-            let transport = match &server.transport {
-                mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => {
-                    format!("stdio:{command}")
-                }
-                mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
-                    format!("streamable_http:{url}")
-                }
-            };
-            lines.push(format!(
-                "- {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
-                server.name,
-                mcp_server_status_kind_str(server.status.kind),
-                mcp_auth_status_str(server.status.auth),
-                server.selected_for_acp_bootstrap,
-                origins,
-                transport
-            ));
-        }
-    }
-    if !snapshot.missing_selected_servers.is_empty() {
-        lines.push(format!(
-            "missing_selected_servers={}",
-            snapshot.missing_selected_servers.join(",")
-        ));
-    }
-    lines.join("\n")
-}
-
-fn render_mcp_server_detail_text(
-    config_path: &str,
-    server: &mvp::mcp::McpRuntimeServerSnapshot,
-) -> String {
-    let mut lines = Vec::new();
-    lines.push(format!("config={config_path}"));
-    lines.push(format!("name={}", server.name));
-    lines.push(format!("enabled={}", server.enabled));
-    lines.push(format!("required={}", server.required));
-    lines.push(format!(
-        "selected_for_acp_bootstrap={}",
-        server.selected_for_acp_bootstrap
-    ));
-    lines.push(format!(
-        "status={}",
-        mcp_server_status_kind_str(server.status.kind)
-    ));
-    lines.push(format!("auth={}", mcp_auth_status_str(server.status.auth)));
-    append_mcp_origin_detail_lines(&mut lines, &server.origins);
-    append_mcp_transport_detail_lines(&mut lines, &server.transport);
-    if !server.enabled_tools.is_empty() {
-        let enabled_tools = server.enabled_tools.join(",");
-        lines.push(format!("enabled_tools={enabled_tools}"));
-    }
-    if !server.disabled_tools.is_empty() {
-        let disabled_tools = server.disabled_tools.join(",");
-        lines.push(format!("disabled_tools={disabled_tools}"));
-    }
-    if let Some(last_error) = &server.status.last_error {
-        lines.push(format!("last_error={last_error}"));
-    }
-    if let Some(startup_timeout_ms) = server.startup_timeout_ms {
-        lines.push(format!("startup_timeout_ms={startup_timeout_ms}"));
-    }
-    if let Some(tool_timeout_ms) = server.tool_timeout_ms {
-        lines.push(format!("tool_timeout_ms={tool_timeout_ms}"));
-    }
-    lines.join("\n")
-}
-
-fn append_mcp_runtime_snapshot_lines(
-    lines: &mut Vec<String>,
-    snapshot: &mvp::mcp::McpRuntimeSnapshot,
-) {
-    if snapshot.servers.is_empty() {
-        lines.push("acp mcp_servers=none".to_owned());
-    } else {
-        lines.push(format!("acp mcp_servers={}", snapshot.servers.len()));
-        for server in &snapshot.servers {
-            let origins = server
-                .origins
-                .iter()
-                .map(render_mcp_origin_label)
-                .collect::<Vec<_>>()
-                .join(",");
-            let transport = match &server.transport {
-                mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => {
-                    format!("stdio:{command}")
-                }
-                mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
-                    format!("streamable_http:{url}")
-                }
-            };
-            lines.push(format!(
-                "  acp_mcp {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
-                server.name,
-                mcp_server_status_kind_str(server.status.kind),
-                mcp_auth_status_str(server.status.auth),
-                server.selected_for_acp_bootstrap,
-                origins,
-                transport
-            ));
-        }
-    }
-
-    if !snapshot.missing_selected_servers.is_empty() {
-        let missing = snapshot.missing_selected_servers.join(",");
-        lines.push(format!("acp missing_selected_mcp_servers={missing}"));
-    }
-}
-
-fn append_mcp_origin_detail_lines(lines: &mut Vec<String>, origins: &[mvp::mcp::McpServerOrigin]) {
-    let labels = origins
-        .iter()
-        .map(render_mcp_origin_label)
-        .collect::<Vec<_>>()
-        .join(",");
-    lines.push(format!("origins={labels}"));
-}
-
-fn append_mcp_transport_detail_lines(
-    lines: &mut Vec<String>,
-    transport: &mvp::mcp::McpTransportSnapshot,
-) {
-    match transport {
-        mvp::mcp::McpTransportSnapshot::Stdio {
-            command,
-            args,
-            cwd,
-            env_var_names,
-        } => {
-            lines.push(format!("transport=stdio:{command}"));
-            if !args.is_empty() {
-                let rendered_args = render_string_list(args.iter().map(String::as_str));
-                lines.push(format!("transport_args={rendered_args}"));
-            }
-            if let Some(cwd) = cwd {
-                lines.push(format!("transport_cwd={cwd}"));
-            }
-            if !env_var_names.is_empty() {
-                let rendered_names = render_string_list(env_var_names.iter().map(String::as_str));
-                lines.push(format!("transport_env_var_names={rendered_names}"));
-            }
-        }
-        mvp::mcp::McpTransportSnapshot::StreamableHttp {
-            url,
-            bearer_token_env_var,
-            http_header_names,
-            env_http_header_names,
-        } => {
-            lines.push(format!("transport=streamable_http:{url}"));
-            if let Some(bearer_token_env_var) = bearer_token_env_var {
-                lines.push(format!(
-                    "transport_bearer_token_env_var={bearer_token_env_var}"
-                ));
-            }
-            if !http_header_names.is_empty() {
-                let rendered_names =
-                    render_string_list(http_header_names.iter().map(String::as_str));
-                lines.push(format!("transport_http_header_names={rendered_names}"));
-            }
-            if !env_http_header_names.is_empty() {
-                let rendered_names =
-                    render_string_list(env_http_header_names.iter().map(String::as_str));
-                lines.push(format!("transport_env_http_header_names={rendered_names}"));
-            }
-        }
-    }
-}
-
-fn render_mcp_origin_label(origin: &mvp::mcp::McpServerOrigin) -> String {
-    let kind = mcp_origin_kind_str(origin.kind);
-    let maybe_source_id = origin.source_id.as_deref();
-    let Some(source_id) = maybe_source_id else {
-        return kind.to_owned();
-    };
-    format!("{kind}:{source_id}")
-}
-
-fn mcp_origin_kind_str(kind: mvp::mcp::McpServerOriginKind) -> &'static str {
-    match kind {
-        mvp::mcp::McpServerOriginKind::Config => "config",
-        mvp::mcp::McpServerOriginKind::Plugin => "plugin",
-        mvp::mcp::McpServerOriginKind::Managed => "managed",
-        mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
-        mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
-    }
-}
-
-fn mcp_server_status_kind_str(kind: mvp::mcp::McpServerStatusKind) -> &'static str {
-    match kind {
-        mvp::mcp::McpServerStatusKind::Pending => "pending",
-        mvp::mcp::McpServerStatusKind::Connected => "connected",
-        mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
-        mvp::mcp::McpServerStatusKind::Failed => "failed",
-        mvp::mcp::McpServerStatusKind::Disabled => "disabled",
-    }
-}
-
-fn mcp_auth_status_str(auth: mvp::mcp::McpAuthStatus) -> &'static str {
-    match auth {
-        mvp::mcp::McpAuthStatus::Unknown => "unknown",
-        mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
-        mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
-        mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
-        mvp::mcp::McpAuthStatus::OAuth => "oauth",
-    }
-}
-
-fn normalize_mcp_server_name(raw: &str) -> CliResult<String> {
-    let normalized = raw.trim().to_ascii_lowercase();
-    if normalized.is_empty() {
-        return Err("MCP server name must not be empty".to_owned());
-    }
-    Ok(normalized)
 }
 
 fn runtime_snapshot_tool_runtime_json(
@@ -6186,7 +5787,7 @@ fn shell_policy_default_str(
     }
 }
 
-fn render_string_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
+pub(crate) fn render_string_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
     let rendered = values
         .into_iter()
         .filter(|value| !value.is_empty())

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5551,6 +5551,7 @@ pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> Strin
             .as_deref()
             .unwrap_or("-")
     ));
+    append_mcp_runtime_snapshot_lines(&mut lines, &snapshot.acp.mcp);
     lines.push(format!(
         "channels enabled={} service_enabled={} configured_accounts={} surfaces={}",
         render_string_list(snapshot.enabled_channel_ids.iter().map(String::as_str)),
@@ -5821,38 +5822,28 @@ fn mcp_runtime_snapshot_json(snapshot: &mvp::mcp::McpRuntimeSnapshot) -> Value {
 }
 
 fn mcp_runtime_server_json(server: &mvp::mcp::McpRuntimeServerSnapshot) -> Value {
+    let origins = server
+        .origins
+        .iter()
+        .map(|origin| {
+            json!({
+                "kind": mcp_origin_kind_str(origin.kind),
+                "source_id": origin.source_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    let status_kind = mcp_server_status_kind_str(server.status.kind);
+    let auth_kind = mcp_auth_status_str(server.status.auth);
+
     json!({
         "name": server.name,
         "enabled": server.enabled,
         "required": server.required,
         "selected_for_acp_bootstrap": server.selected_for_acp_bootstrap,
-        "origins": server.origins.iter().map(|origin| {
-            json!({
-                "kind": match origin.kind {
-                    mvp::mcp::McpServerOriginKind::Config => "config",
-                    mvp::mcp::McpServerOriginKind::Plugin => "plugin",
-                    mvp::mcp::McpServerOriginKind::Managed => "managed",
-                    mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
-                    mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
-                },
-                "source_id": origin.source_id,
-            })
-        }).collect::<Vec<_>>(),
+        "origins": origins,
         "status": {
-            "kind": match server.status.kind {
-                mvp::mcp::McpServerStatusKind::Pending => "pending",
-                mvp::mcp::McpServerStatusKind::Connected => "connected",
-                mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
-                mvp::mcp::McpServerStatusKind::Failed => "failed",
-                mvp::mcp::McpServerStatusKind::Disabled => "disabled",
-            },
-            "auth": match server.status.auth {
-                mvp::mcp::McpAuthStatus::Unknown => "unknown",
-                mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
-                mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
-                mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
-                mvp::mcp::McpAuthStatus::OAuth => "oauth",
-            },
+            "kind": status_kind,
+            "auth": auth_kind,
             "last_error": server.status.last_error,
         },
         "transport": match &server.transport {
@@ -5898,32 +5889,10 @@ fn render_mcp_servers_snapshot_text(
     } else {
         lines.push(format!("mcp_servers={}", snapshot.servers.len()));
         for server in &snapshot.servers {
-            let status = match server.status.kind {
-                mvp::mcp::McpServerStatusKind::Pending => "pending",
-                mvp::mcp::McpServerStatusKind::Connected => "connected",
-                mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
-                mvp::mcp::McpServerStatusKind::Failed => "failed",
-                mvp::mcp::McpServerStatusKind::Disabled => "disabled",
-            };
-            let auth = match server.status.auth {
-                mvp::mcp::McpAuthStatus::Unknown => "unknown",
-                mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
-                mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
-                mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
-                mvp::mcp::McpAuthStatus::OAuth => "oauth",
-            };
             let origins = server
                 .origins
                 .iter()
-                .map(|origin| match origin.kind {
-                    mvp::mcp::McpServerOriginKind::Config => "config",
-                    mvp::mcp::McpServerOriginKind::Plugin => "plugin",
-                    mvp::mcp::McpServerOriginKind::Managed => "managed",
-                    mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
-                    mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => {
-                        "acp_bootstrap_selection"
-                    }
-                })
+                .map(render_mcp_origin_label)
                 .collect::<Vec<_>>()
                 .join(",");
             let transport = match &server.transport {
@@ -5936,7 +5905,12 @@ fn render_mcp_servers_snapshot_text(
             };
             lines.push(format!(
                 "- {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
-                server.name, status, auth, server.selected_for_acp_bootstrap, origins, transport
+                server.name,
+                mcp_server_status_kind_str(server.status.kind),
+                mcp_auth_status_str(server.status.auth),
+                server.selected_for_acp_bootstrap,
+                origins,
+                transport
             ));
         }
     }
@@ -5953,38 +5927,6 @@ fn render_mcp_server_detail_text(
     config_path: &str,
     server: &mvp::mcp::McpRuntimeServerSnapshot,
 ) -> String {
-    let status = match server.status.kind {
-        mvp::mcp::McpServerStatusKind::Pending => "pending",
-        mvp::mcp::McpServerStatusKind::Connected => "connected",
-        mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
-        mvp::mcp::McpServerStatusKind::Failed => "failed",
-        mvp::mcp::McpServerStatusKind::Disabled => "disabled",
-    };
-    let auth = match server.status.auth {
-        mvp::mcp::McpAuthStatus::Unknown => "unknown",
-        mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
-        mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
-        mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
-        mvp::mcp::McpAuthStatus::OAuth => "oauth",
-    };
-    let transport = match &server.transport {
-        mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => format!("stdio:{command}"),
-        mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
-            format!("streamable_http:{url}")
-        }
-    };
-    let origin_labels = server
-        .origins
-        .iter()
-        .map(|origin| match origin.kind {
-            mvp::mcp::McpServerOriginKind::Config => "config",
-            mvp::mcp::McpServerOriginKind::Plugin => "plugin",
-            mvp::mcp::McpServerOriginKind::Managed => "managed",
-            mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
-            mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
-        })
-        .collect::<Vec<_>>()
-        .join(",");
     let mut lines = Vec::new();
     lines.push(format!("config={config_path}"));
     lines.push(format!("name={}", server.name));
@@ -5994,10 +5936,13 @@ fn render_mcp_server_detail_text(
         "selected_for_acp_bootstrap={}",
         server.selected_for_acp_bootstrap
     ));
-    lines.push(format!("status={status}"));
-    lines.push(format!("auth={auth}"));
-    lines.push(format!("transport={transport}"));
-    lines.push(format!("origins={origin_labels}"));
+    lines.push(format!(
+        "status={}",
+        mcp_server_status_kind_str(server.status.kind)
+    ));
+    lines.push(format!("auth={}", mcp_auth_status_str(server.status.auth)));
+    append_mcp_origin_detail_lines(&mut lines, &server.origins);
+    append_mcp_transport_detail_lines(&mut lines, &server.transport);
     if !server.enabled_tools.is_empty() {
         let enabled_tools = server.enabled_tools.join(",");
         lines.push(format!("enabled_tools={enabled_tools}"));
@@ -6009,7 +5954,152 @@ fn render_mcp_server_detail_text(
     if let Some(last_error) = &server.status.last_error {
         lines.push(format!("last_error={last_error}"));
     }
+    if let Some(startup_timeout_ms) = server.startup_timeout_ms {
+        lines.push(format!("startup_timeout_ms={startup_timeout_ms}"));
+    }
+    if let Some(tool_timeout_ms) = server.tool_timeout_ms {
+        lines.push(format!("tool_timeout_ms={tool_timeout_ms}"));
+    }
     lines.join("\n")
+}
+
+fn append_mcp_runtime_snapshot_lines(
+    lines: &mut Vec<String>,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) {
+    if snapshot.servers.is_empty() {
+        lines.push("acp mcp_servers=none".to_owned());
+    } else {
+        lines.push(format!("acp mcp_servers={}", snapshot.servers.len()));
+        for server in &snapshot.servers {
+            let origins = server
+                .origins
+                .iter()
+                .map(render_mcp_origin_label)
+                .collect::<Vec<_>>()
+                .join(",");
+            let transport = match &server.transport {
+                mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => {
+                    format!("stdio:{command}")
+                }
+                mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
+                    format!("streamable_http:{url}")
+                }
+            };
+            lines.push(format!(
+                "  acp_mcp {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
+                server.name,
+                mcp_server_status_kind_str(server.status.kind),
+                mcp_auth_status_str(server.status.auth),
+                server.selected_for_acp_bootstrap,
+                origins,
+                transport
+            ));
+        }
+    }
+
+    if !snapshot.missing_selected_servers.is_empty() {
+        let missing = snapshot.missing_selected_servers.join(",");
+        lines.push(format!("acp missing_selected_mcp_servers={missing}"));
+    }
+}
+
+fn append_mcp_origin_detail_lines(lines: &mut Vec<String>, origins: &[mvp::mcp::McpServerOrigin]) {
+    let labels = origins
+        .iter()
+        .map(render_mcp_origin_label)
+        .collect::<Vec<_>>()
+        .join(",");
+    lines.push(format!("origins={labels}"));
+}
+
+fn append_mcp_transport_detail_lines(
+    lines: &mut Vec<String>,
+    transport: &mvp::mcp::McpTransportSnapshot,
+) {
+    match transport {
+        mvp::mcp::McpTransportSnapshot::Stdio {
+            command,
+            args,
+            cwd,
+            env_var_names,
+        } => {
+            lines.push(format!("transport=stdio:{command}"));
+            if !args.is_empty() {
+                let rendered_args = render_string_list(args.iter().map(String::as_str));
+                lines.push(format!("transport_args={rendered_args}"));
+            }
+            if let Some(cwd) = cwd {
+                lines.push(format!("transport_cwd={cwd}"));
+            }
+            if !env_var_names.is_empty() {
+                let rendered_names = render_string_list(env_var_names.iter().map(String::as_str));
+                lines.push(format!("transport_env_var_names={rendered_names}"));
+            }
+        }
+        mvp::mcp::McpTransportSnapshot::StreamableHttp {
+            url,
+            bearer_token_env_var,
+            http_header_names,
+            env_http_header_names,
+        } => {
+            lines.push(format!("transport=streamable_http:{url}"));
+            if let Some(bearer_token_env_var) = bearer_token_env_var {
+                lines.push(format!(
+                    "transport_bearer_token_env_var={bearer_token_env_var}"
+                ));
+            }
+            if !http_header_names.is_empty() {
+                let rendered_names =
+                    render_string_list(http_header_names.iter().map(String::as_str));
+                lines.push(format!("transport_http_header_names={rendered_names}"));
+            }
+            if !env_http_header_names.is_empty() {
+                let rendered_names =
+                    render_string_list(env_http_header_names.iter().map(String::as_str));
+                lines.push(format!("transport_env_http_header_names={rendered_names}"));
+            }
+        }
+    }
+}
+
+fn render_mcp_origin_label(origin: &mvp::mcp::McpServerOrigin) -> String {
+    let kind = mcp_origin_kind_str(origin.kind);
+    let maybe_source_id = origin.source_id.as_deref();
+    let Some(source_id) = maybe_source_id else {
+        return kind.to_owned();
+    };
+    format!("{kind}:{source_id}")
+}
+
+fn mcp_origin_kind_str(kind: mvp::mcp::McpServerOriginKind) -> &'static str {
+    match kind {
+        mvp::mcp::McpServerOriginKind::Config => "config",
+        mvp::mcp::McpServerOriginKind::Plugin => "plugin",
+        mvp::mcp::McpServerOriginKind::Managed => "managed",
+        mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
+        mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
+    }
+}
+
+fn mcp_server_status_kind_str(kind: mvp::mcp::McpServerStatusKind) -> &'static str {
+    match kind {
+        mvp::mcp::McpServerStatusKind::Pending => "pending",
+        mvp::mcp::McpServerStatusKind::Connected => "connected",
+        mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
+        mvp::mcp::McpServerStatusKind::Failed => "failed",
+        mvp::mcp::McpServerStatusKind::Disabled => "disabled",
+    }
+}
+
+fn mcp_auth_status_str(auth: mvp::mcp::McpAuthStatus) -> &'static str {
+    match auth {
+        mvp::mcp::McpAuthStatus::Unknown => "unknown",
+        mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
+        mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
+        mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
+        mvp::mcp::McpAuthStatus::OAuth => "oauth",
+    }
 }
 
 fn normalize_mcp_server_name(raw: &str) -> CliResult<String> {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1361,6 +1361,8 @@ impl Commands {
             Self::RuntimeCapability { .. } => "runtime_capability",
             Self::ListContextEngines { .. } => "list_context_engines",
             Self::ListMemorySystems { .. } => "list_memory_systems",
+            Self::ListMcpServers { .. } => "list_mcp_servers",
+            Self::ShowMcpServer { .. } => "show_mcp_server",
             Self::ListAcpBackends { .. } => "list_acp_backends",
             Self::ListAcpSessions { .. } => "list_acp_sessions",
             Self::AcpStatus { .. } => "acp_status",

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -728,6 +728,22 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// List configured MCP servers and their runtime-visible inventory state
+    ListMcpServers {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Show one configured MCP server and its runtime-visible inventory state
+    ShowMcpServer {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        name: String,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// List available ACP runtime backends and current control-plane selection
     ListAcpBackends {
         #[arg(long)]
@@ -3777,6 +3793,58 @@ pub fn run_list_memory_systems_cli(config_path: Option<&str>, as_json: bool) -> 
     Ok(())
 }
 
+pub fn run_list_mcp_servers_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
+
+    if as_json {
+        let payload =
+            build_mcp_servers_cli_json_payload(&resolved_path.display().to_string(), &snapshot);
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize MCP server output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        render_mcp_servers_snapshot_text(&resolved_path.display().to_string(), &snapshot)
+    );
+    Ok(())
+}
+
+pub fn run_show_mcp_server_cli(
+    config_path: Option<&str>,
+    server_name: &str,
+    as_json: bool,
+) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
+    let normalized_name = normalize_mcp_server_name(server_name)?;
+    let maybe_server = snapshot
+        .servers
+        .iter()
+        .find(|server| server.name == normalized_name);
+    let Some(server) = maybe_server else {
+        return Err(format!(
+            "MCP server `{normalized_name}` was not found in the runtime snapshot"
+        ));
+    };
+
+    if as_json {
+        let payload =
+            build_mcp_server_detail_cli_json_payload(&resolved_path.display().to_string(), server);
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize MCP server detail output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_mcp_server_detail_text(&resolved_path.display().to_string(), server);
+    println!("{rendered}");
+    Ok(())
+}
+
 pub fn run_list_acp_backends_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
     let (resolved_path, config) = mvp::config::load(config_path)?;
     let snapshot = mvp::acp::collect_acp_runtime_snapshot(&config)?;
@@ -5714,7 +5782,242 @@ fn runtime_snapshot_acp_json(snapshot: &mvp::acp::AcpRuntimeSnapshot) -> Value {
             .map(|metadata| acp_backend_metadata_json(metadata, None))
             .collect::<Vec<_>>(),
         "control_plane": acp_control_plane_json(&snapshot.control_plane),
+        "mcp": mcp_runtime_snapshot_json(&snapshot.mcp),
     })
+}
+
+pub fn build_mcp_servers_cli_json_payload(
+    config_path: &str,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) -> Value {
+    json!({
+        "config": config_path,
+        "server_count": snapshot.servers.len(),
+        "servers": snapshot.servers.iter().map(mcp_runtime_server_json).collect::<Vec<_>>(),
+        "missing_selected_servers": snapshot.missing_selected_servers,
+    })
+}
+
+pub fn build_mcp_server_detail_cli_json_payload(
+    config_path: &str,
+    server: &mvp::mcp::McpRuntimeServerSnapshot,
+) -> Value {
+    let server_json = mcp_runtime_server_json(server);
+    json!({
+        "config": config_path,
+        "server": server_json,
+    })
+}
+
+fn mcp_runtime_snapshot_json(snapshot: &mvp::mcp::McpRuntimeSnapshot) -> Value {
+    json!({
+        "servers": snapshot
+            .servers
+            .iter()
+            .map(mcp_runtime_server_json)
+            .collect::<Vec<_>>(),
+        "missing_selected_servers": snapshot.missing_selected_servers,
+    })
+}
+
+fn mcp_runtime_server_json(server: &mvp::mcp::McpRuntimeServerSnapshot) -> Value {
+    json!({
+        "name": server.name,
+        "enabled": server.enabled,
+        "required": server.required,
+        "selected_for_acp_bootstrap": server.selected_for_acp_bootstrap,
+        "origins": server.origins.iter().map(|origin| {
+            json!({
+                "kind": match origin.kind {
+                    mvp::mcp::McpServerOriginKind::Config => "config",
+                    mvp::mcp::McpServerOriginKind::Plugin => "plugin",
+                    mvp::mcp::McpServerOriginKind::Managed => "managed",
+                    mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
+                    mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
+                },
+                "source_id": origin.source_id,
+            })
+        }).collect::<Vec<_>>(),
+        "status": {
+            "kind": match server.status.kind {
+                mvp::mcp::McpServerStatusKind::Pending => "pending",
+                mvp::mcp::McpServerStatusKind::Connected => "connected",
+                mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
+                mvp::mcp::McpServerStatusKind::Failed => "failed",
+                mvp::mcp::McpServerStatusKind::Disabled => "disabled",
+            },
+            "auth": match server.status.auth {
+                mvp::mcp::McpAuthStatus::Unknown => "unknown",
+                mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
+                mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
+                mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
+                mvp::mcp::McpAuthStatus::OAuth => "oauth",
+            },
+            "last_error": server.status.last_error,
+        },
+        "transport": match &server.transport {
+            mvp::mcp::McpTransportSnapshot::Stdio {
+                command,
+                args,
+                cwd,
+                env_var_names,
+            } => json!({
+                "transport": "stdio",
+                "command": command,
+                "args": args,
+                "cwd": cwd,
+                "env_var_names": env_var_names,
+            }),
+            mvp::mcp::McpTransportSnapshot::StreamableHttp {
+                url,
+                bearer_token_env_var,
+                http_header_names,
+                env_http_header_names,
+            } => json!({
+                "transport": "streamable_http",
+                "url": url,
+                "bearer_token_env_var": bearer_token_env_var,
+                "http_header_names": http_header_names,
+                "env_http_header_names": env_http_header_names,
+            }),
+        },
+        "enabled_tools": server.enabled_tools,
+        "disabled_tools": server.disabled_tools,
+        "startup_timeout_ms": server.startup_timeout_ms,
+        "tool_timeout_ms": server.tool_timeout_ms,
+    })
+}
+
+fn render_mcp_servers_snapshot_text(
+    config_path: &str,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) -> String {
+    let mut lines = vec![format!("config={config_path}")];
+    if snapshot.servers.is_empty() {
+        lines.push("mcp_servers=none".to_owned());
+    } else {
+        lines.push(format!("mcp_servers={}", snapshot.servers.len()));
+        for server in &snapshot.servers {
+            let status = match server.status.kind {
+                mvp::mcp::McpServerStatusKind::Pending => "pending",
+                mvp::mcp::McpServerStatusKind::Connected => "connected",
+                mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
+                mvp::mcp::McpServerStatusKind::Failed => "failed",
+                mvp::mcp::McpServerStatusKind::Disabled => "disabled",
+            };
+            let auth = match server.status.auth {
+                mvp::mcp::McpAuthStatus::Unknown => "unknown",
+                mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
+                mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
+                mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
+                mvp::mcp::McpAuthStatus::OAuth => "oauth",
+            };
+            let origins = server
+                .origins
+                .iter()
+                .map(|origin| match origin.kind {
+                    mvp::mcp::McpServerOriginKind::Config => "config",
+                    mvp::mcp::McpServerOriginKind::Plugin => "plugin",
+                    mvp::mcp::McpServerOriginKind::Managed => "managed",
+                    mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
+                    mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => {
+                        "acp_bootstrap_selection"
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            let transport = match &server.transport {
+                mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => {
+                    format!("stdio:{command}")
+                }
+                mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
+                    format!("streamable_http:{url}")
+                }
+            };
+            lines.push(format!(
+                "- {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
+                server.name, status, auth, server.selected_for_acp_bootstrap, origins, transport
+            ));
+        }
+    }
+    if !snapshot.missing_selected_servers.is_empty() {
+        lines.push(format!(
+            "missing_selected_servers={}",
+            snapshot.missing_selected_servers.join(",")
+        ));
+    }
+    lines.join("\n")
+}
+
+fn render_mcp_server_detail_text(
+    config_path: &str,
+    server: &mvp::mcp::McpRuntimeServerSnapshot,
+) -> String {
+    let status = match server.status.kind {
+        mvp::mcp::McpServerStatusKind::Pending => "pending",
+        mvp::mcp::McpServerStatusKind::Connected => "connected",
+        mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
+        mvp::mcp::McpServerStatusKind::Failed => "failed",
+        mvp::mcp::McpServerStatusKind::Disabled => "disabled",
+    };
+    let auth = match server.status.auth {
+        mvp::mcp::McpAuthStatus::Unknown => "unknown",
+        mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
+        mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
+        mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
+        mvp::mcp::McpAuthStatus::OAuth => "oauth",
+    };
+    let transport = match &server.transport {
+        mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => format!("stdio:{command}"),
+        mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
+            format!("streamable_http:{url}")
+        }
+    };
+    let origin_labels = server
+        .origins
+        .iter()
+        .map(|origin| match origin.kind {
+            mvp::mcp::McpServerOriginKind::Config => "config",
+            mvp::mcp::McpServerOriginKind::Plugin => "plugin",
+            mvp::mcp::McpServerOriginKind::Managed => "managed",
+            mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
+            mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut lines = Vec::new();
+    lines.push(format!("config={config_path}"));
+    lines.push(format!("name={}", server.name));
+    lines.push(format!("enabled={}", server.enabled));
+    lines.push(format!("required={}", server.required));
+    lines.push(format!(
+        "selected_for_acp_bootstrap={}",
+        server.selected_for_acp_bootstrap
+    ));
+    lines.push(format!("status={status}"));
+    lines.push(format!("auth={auth}"));
+    lines.push(format!("transport={transport}"));
+    lines.push(format!("origins={origin_labels}"));
+    if !server.enabled_tools.is_empty() {
+        let enabled_tools = server.enabled_tools.join(",");
+        lines.push(format!("enabled_tools={enabled_tools}"));
+    }
+    if !server.disabled_tools.is_empty() {
+        let disabled_tools = server.disabled_tools.join(",");
+        lines.push(format!("disabled_tools={disabled_tools}"));
+    }
+    if let Some(last_error) = &server.status.last_error {
+        lines.push(format!("last_error={last_error}"));
+    }
+    lines.join("\n")
+}
+
+fn normalize_mcp_server_name(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err("MCP server name must not be empty".to_owned());
+    }
+    Ok(normalized)
 }
 
 fn runtime_snapshot_tool_runtime_json(

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -355,6 +355,12 @@ async fn main() {
         Commands::ListMemorySystems { config, json } => {
             run_list_memory_systems_cli(config.as_deref(), json)
         }
+        Commands::ListMcpServers { config, json } => {
+            run_list_mcp_servers_cli(config.as_deref(), json)
+        }
+        Commands::ShowMcpServer { config, name, json } => {
+            run_show_mcp_server_cli(config.as_deref(), name.as_str(), json)
+        }
         Commands::ListAcpBackends { config, json } => {
             run_list_acp_backends_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/mcp_cli.rs
+++ b/crates/daemon/src/mcp_cli.rs
@@ -1,0 +1,379 @@
+use serde_json::{Value, json};
+
+use crate::{CliResult, mvp, render_string_list};
+
+pub fn run_list_mcp_servers_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
+
+    if as_json {
+        let payload =
+            build_mcp_servers_cli_json_payload(&resolved_path.display().to_string(), &snapshot);
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize MCP server output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        render_mcp_servers_snapshot_text(&resolved_path.display().to_string(), &snapshot)
+    );
+    Ok(())
+}
+
+pub fn run_show_mcp_server_cli(
+    config_path: Option<&str>,
+    server_name: &str,
+    as_json: bool,
+) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let snapshot = mvp::mcp::collect_mcp_runtime_snapshot(&config)?;
+    let normalized_name = normalize_mcp_server_name(server_name)?;
+    let maybe_server = snapshot
+        .servers
+        .iter()
+        .find(|server| server.name == normalized_name);
+    let Some(server) = maybe_server else {
+        return Err(format!(
+            "MCP server `{normalized_name}` was not found in the runtime snapshot"
+        ));
+    };
+
+    if as_json {
+        let payload =
+            build_mcp_server_detail_cli_json_payload(&resolved_path.display().to_string(), server);
+        let pretty = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize MCP server detail output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_mcp_server_detail_text(&resolved_path.display().to_string(), server);
+    println!("{rendered}");
+    Ok(())
+}
+
+pub fn build_mcp_servers_cli_json_payload(
+    config_path: &str,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) -> Value {
+    json!({
+        "config": config_path,
+        "server_count": snapshot.servers.len(),
+        "servers": snapshot
+            .servers
+            .iter()
+            .map(mcp_runtime_server_json)
+            .collect::<Vec<_>>(),
+        "missing_selected_servers": snapshot.missing_selected_servers,
+    })
+}
+
+pub fn build_mcp_server_detail_cli_json_payload(
+    config_path: &str,
+    server: &mvp::mcp::McpRuntimeServerSnapshot,
+) -> Value {
+    let server_json = mcp_runtime_server_json(server);
+    json!({
+        "config": config_path,
+        "server": server_json,
+    })
+}
+
+pub(crate) fn mcp_runtime_snapshot_json(snapshot: &mvp::mcp::McpRuntimeSnapshot) -> Value {
+    json!({
+        "servers": snapshot
+            .servers
+            .iter()
+            .map(mcp_runtime_server_json)
+            .collect::<Vec<_>>(),
+        "missing_selected_servers": snapshot.missing_selected_servers,
+    })
+}
+
+fn mcp_runtime_server_json(server: &mvp::mcp::McpRuntimeServerSnapshot) -> Value {
+    let origins = server
+        .origins
+        .iter()
+        .map(|origin| {
+            json!({
+                "kind": mcp_origin_kind_str(origin.kind),
+                "source_id": origin.source_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    let status_kind = mcp_server_status_kind_str(server.status.kind);
+    let auth_kind = mcp_auth_status_str(server.status.auth);
+
+    json!({
+        "name": server.name,
+        "enabled": server.enabled,
+        "required": server.required,
+        "selected_for_acp_bootstrap": server.selected_for_acp_bootstrap,
+        "origins": origins,
+        "status": {
+            "kind": status_kind,
+            "auth": auth_kind,
+            "last_error": server.status.last_error,
+        },
+        "transport": match &server.transport {
+            mvp::mcp::McpTransportSnapshot::Stdio {
+                command,
+                args,
+                cwd,
+                env_var_names,
+            } => json!({
+                "transport": "stdio",
+                "command": command,
+                "args": args,
+                "cwd": cwd,
+                "env_var_names": env_var_names,
+            }),
+            mvp::mcp::McpTransportSnapshot::StreamableHttp {
+                url,
+                bearer_token_env_var,
+                http_header_names,
+                env_http_header_names,
+            } => json!({
+                "transport": "streamable_http",
+                "url": url,
+                "bearer_token_env_var": bearer_token_env_var,
+                "http_header_names": http_header_names,
+                "env_http_header_names": env_http_header_names,
+            }),
+        },
+        "enabled_tools": server.enabled_tools,
+        "disabled_tools": server.disabled_tools,
+        "startup_timeout_ms": server.startup_timeout_ms,
+        "tool_timeout_ms": server.tool_timeout_ms,
+    })
+}
+
+pub(crate) fn render_mcp_servers_snapshot_text(
+    config_path: &str,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) -> String {
+    let mut lines = vec![format!("config={config_path}")];
+    if snapshot.servers.is_empty() {
+        lines.push("mcp_servers=none".to_owned());
+    } else {
+        lines.push(format!("mcp_servers={}", snapshot.servers.len()));
+        for server in &snapshot.servers {
+            let origins = server
+                .origins
+                .iter()
+                .map(render_mcp_origin_label)
+                .collect::<Vec<_>>()
+                .join(",");
+            let transport = render_mcp_transport_summary(&server.transport);
+            lines.push(format!(
+                "- {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
+                server.name,
+                mcp_server_status_kind_str(server.status.kind),
+                mcp_auth_status_str(server.status.auth),
+                server.selected_for_acp_bootstrap,
+                origins,
+                transport
+            ));
+        }
+    }
+    if !snapshot.missing_selected_servers.is_empty() {
+        lines.push(format!(
+            "missing_selected_servers={}",
+            snapshot.missing_selected_servers.join(",")
+        ));
+    }
+    lines.join("\n")
+}
+
+pub(crate) fn render_mcp_server_detail_text(
+    config_path: &str,
+    server: &mvp::mcp::McpRuntimeServerSnapshot,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("config={config_path}"));
+    lines.push(format!("name={}", server.name));
+    lines.push(format!("enabled={}", server.enabled));
+    lines.push(format!("required={}", server.required));
+    lines.push(format!(
+        "selected_for_acp_bootstrap={}",
+        server.selected_for_acp_bootstrap
+    ));
+    lines.push(format!(
+        "status={}",
+        mcp_server_status_kind_str(server.status.kind)
+    ));
+    lines.push(format!("auth={}", mcp_auth_status_str(server.status.auth)));
+    append_mcp_origin_detail_lines(&mut lines, &server.origins);
+    append_mcp_transport_detail_lines(&mut lines, &server.transport);
+    if !server.enabled_tools.is_empty() {
+        let enabled_tools = server.enabled_tools.join(",");
+        lines.push(format!("enabled_tools={enabled_tools}"));
+    }
+    if !server.disabled_tools.is_empty() {
+        let disabled_tools = server.disabled_tools.join(",");
+        lines.push(format!("disabled_tools={disabled_tools}"));
+    }
+    if let Some(last_error) = &server.status.last_error {
+        lines.push(format!("last_error={last_error}"));
+    }
+    if let Some(startup_timeout_ms) = server.startup_timeout_ms {
+        lines.push(format!("startup_timeout_ms={startup_timeout_ms}"));
+    }
+    if let Some(tool_timeout_ms) = server.tool_timeout_ms {
+        lines.push(format!("tool_timeout_ms={tool_timeout_ms}"));
+    }
+    lines.join("\n")
+}
+
+pub(crate) fn append_mcp_runtime_snapshot_lines(
+    lines: &mut Vec<String>,
+    snapshot: &mvp::mcp::McpRuntimeSnapshot,
+) {
+    if snapshot.servers.is_empty() {
+        lines.push("acp mcp_servers=none".to_owned());
+    } else {
+        lines.push(format!("acp mcp_servers={}", snapshot.servers.len()));
+        for server in &snapshot.servers {
+            let origins = server
+                .origins
+                .iter()
+                .map(render_mcp_origin_label)
+                .collect::<Vec<_>>()
+                .join(",");
+            let transport = render_mcp_transport_summary(&server.transport);
+            lines.push(format!(
+                "  acp_mcp {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
+                server.name,
+                mcp_server_status_kind_str(server.status.kind),
+                mcp_auth_status_str(server.status.auth),
+                server.selected_for_acp_bootstrap,
+                origins,
+                transport
+            ));
+        }
+    }
+
+    if !snapshot.missing_selected_servers.is_empty() {
+        let missing = snapshot.missing_selected_servers.join(",");
+        lines.push(format!("acp missing_selected_mcp_servers={missing}"));
+    }
+}
+
+fn append_mcp_origin_detail_lines(lines: &mut Vec<String>, origins: &[mvp::mcp::McpServerOrigin]) {
+    let labels = origins
+        .iter()
+        .map(render_mcp_origin_label)
+        .collect::<Vec<_>>()
+        .join(",");
+    lines.push(format!("origins={labels}"));
+}
+
+fn append_mcp_transport_detail_lines(
+    lines: &mut Vec<String>,
+    transport: &mvp::mcp::McpTransportSnapshot,
+) {
+    match transport {
+        mvp::mcp::McpTransportSnapshot::Stdio {
+            command,
+            args,
+            cwd,
+            env_var_names,
+        } => {
+            lines.push(format!("transport=stdio:{command}"));
+            if !args.is_empty() {
+                let rendered_args = render_string_list(args.iter().map(String::as_str));
+                lines.push(format!("transport_args={rendered_args}"));
+            }
+            if let Some(cwd) = cwd {
+                lines.push(format!("transport_cwd={cwd}"));
+            }
+            if !env_var_names.is_empty() {
+                let rendered_names = render_string_list(env_var_names.iter().map(String::as_str));
+                lines.push(format!("transport_env_var_names={rendered_names}"));
+            }
+        }
+        mvp::mcp::McpTransportSnapshot::StreamableHttp {
+            url,
+            bearer_token_env_var,
+            http_header_names,
+            env_http_header_names,
+        } => {
+            lines.push(format!("transport=streamable_http:{url}"));
+            if let Some(bearer_token_env_var) = bearer_token_env_var {
+                lines.push(format!(
+                    "transport_bearer_token_env_var={bearer_token_env_var}"
+                ));
+            }
+            if !http_header_names.is_empty() {
+                let rendered_names =
+                    render_string_list(http_header_names.iter().map(String::as_str));
+                lines.push(format!("transport_http_header_names={rendered_names}"));
+            }
+            if !env_http_header_names.is_empty() {
+                let rendered_names =
+                    render_string_list(env_http_header_names.iter().map(String::as_str));
+                lines.push(format!("transport_env_http_header_names={rendered_names}"));
+            }
+        }
+    }
+}
+
+fn render_mcp_transport_summary(transport: &mvp::mcp::McpTransportSnapshot) -> String {
+    match transport {
+        mvp::mcp::McpTransportSnapshot::Stdio { command, .. } => {
+            format!("stdio:{command}")
+        }
+        mvp::mcp::McpTransportSnapshot::StreamableHttp { url, .. } => {
+            format!("streamable_http:{url}")
+        }
+    }
+}
+
+fn render_mcp_origin_label(origin: &mvp::mcp::McpServerOrigin) -> String {
+    let kind = mcp_origin_kind_str(origin.kind);
+    let maybe_source_id = origin.source_id.as_deref();
+    let Some(source_id) = maybe_source_id else {
+        return kind.to_owned();
+    };
+    format!("{kind}:{source_id}")
+}
+
+fn mcp_origin_kind_str(kind: mvp::mcp::McpServerOriginKind) -> &'static str {
+    match kind {
+        mvp::mcp::McpServerOriginKind::Config => "config",
+        mvp::mcp::McpServerOriginKind::Plugin => "plugin",
+        mvp::mcp::McpServerOriginKind::Managed => "managed",
+        mvp::mcp::McpServerOriginKind::AcpBackendProfile => "acp_backend_profile",
+        mvp::mcp::McpServerOriginKind::AcpBootstrapSelection => "acp_bootstrap_selection",
+    }
+}
+
+fn mcp_server_status_kind_str(kind: mvp::mcp::McpServerStatusKind) -> &'static str {
+    match kind {
+        mvp::mcp::McpServerStatusKind::Pending => "pending",
+        mvp::mcp::McpServerStatusKind::Connected => "connected",
+        mvp::mcp::McpServerStatusKind::NeedsAuth => "needs_auth",
+        mvp::mcp::McpServerStatusKind::Failed => "failed",
+        mvp::mcp::McpServerStatusKind::Disabled => "disabled",
+    }
+}
+
+fn mcp_auth_status_str(auth: mvp::mcp::McpAuthStatus) -> &'static str {
+    match auth {
+        mvp::mcp::McpAuthStatus::Unknown => "unknown",
+        mvp::mcp::McpAuthStatus::Unsupported => "unsupported",
+        mvp::mcp::McpAuthStatus::NotLoggedIn => "not_logged_in",
+        mvp::mcp::McpAuthStatus::BearerToken => "bearer_token",
+        mvp::mcp::McpAuthStatus::OAuth => "oauth",
+    }
+}
+
+pub(crate) fn normalize_mcp_server_name(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err("MCP server name must not be empty".to_owned());
+    }
+    Ok(normalized)
+}

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -102,7 +102,7 @@ pub async fn run_demo() -> CliResult<()> {
 }
 
 pub async fn run_task_cli(objective: &str, payload_raw: &str) -> CliResult<()> {
-    let payload = crate::parse_json_payload(payload_raw, "run-task payload")?;
+    let payload = crate::cli_json::parse_json_payload(payload_raw, "run-task payload")?;
 
     let kernel = kernel_bootstrap::KernelBuilder::default().build();
     let token = kernel

--- a/crates/daemon/tests/integration/mcp.rs
+++ b/crates/daemon/tests/integration/mcp.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+#[test]
+fn list_mcp_servers_cli_parses_json_flag() {
+    let cli = try_parse_cli(["loongclaw", "list-mcp-servers", "--json"])
+        .expect("`list-mcp-servers --json` should parse");
+
+    match cli.command {
+        Some(Commands::ListMcpServers { config, json }) => {
+            assert_eq!(config, None);
+            assert!(json);
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn show_mcp_server_cli_parses_name_and_json_flag() {
+    let cli = try_parse_cli(["loongclaw", "show-mcp-server", "--name", "docs", "--json"])
+        .expect("`show-mcp-server --name docs --json` should parse");
+
+    match cli.command {
+        Some(Commands::ShowMcpServer { config, name, json }) => {
+            assert_eq!(config, None);
+            assert_eq!(name, "docs");
+            assert!(json);
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn build_mcp_servers_cli_json_payload_includes_server_status_and_missing_selection() {
+    let snapshot = mvp::mcp::McpRuntimeSnapshot {
+        servers: vec![mvp::mcp::McpRuntimeServerSnapshot {
+            name: "docs".to_owned(),
+            enabled: true,
+            required: false,
+            selected_for_acp_bootstrap: true,
+            origins: vec![
+                mvp::mcp::McpServerOrigin {
+                    kind: mvp::mcp::McpServerOriginKind::Config,
+                    source_id: None,
+                },
+                mvp::mcp::McpServerOrigin {
+                    kind: mvp::mcp::McpServerOriginKind::AcpBootstrapSelection,
+                    source_id: None,
+                },
+            ],
+            status: mvp::mcp::McpServerStatus {
+                kind: mvp::mcp::McpServerStatusKind::Pending,
+                auth: mvp::mcp::McpAuthStatus::Unknown,
+                last_error: None,
+            },
+            transport: mvp::mcp::McpTransportSnapshot::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["context7-mcp".to_owned()],
+                cwd: Some("/workspace/repo".to_owned()),
+                env_var_names: vec!["API_TOKEN".to_owned()],
+            },
+            enabled_tools: vec!["search".to_owned()],
+            disabled_tools: vec!["write".to_owned()],
+            startup_timeout_ms: Some(15_000),
+            tool_timeout_ms: Some(120_000),
+        }],
+        missing_selected_servers: vec!["missing".to_owned()],
+    };
+
+    let payload = build_mcp_servers_cli_json_payload("/tmp/loongclaw.toml", &snapshot);
+
+    assert_eq!(payload["config"], "/tmp/loongclaw.toml");
+    assert_eq!(payload["server_count"], 1);
+    assert_eq!(payload["missing_selected_servers"][0], "missing");
+    assert_eq!(payload["servers"][0]["name"], "docs");
+    assert_eq!(payload["servers"][0]["selected_for_acp_bootstrap"], true);
+    assert_eq!(payload["servers"][0]["status"]["kind"], "pending");
+    assert_eq!(payload["servers"][0]["transport"]["transport"], "stdio");
+    assert_eq!(payload["servers"][0]["transport"]["command"], "uvx");
+    assert_eq!(payload["servers"][0]["enabled_tools"][0], "search");
+    assert_eq!(payload["servers"][0]["disabled_tools"][0], "write");
+    assert_eq!(payload["servers"][0]["origins"][0]["kind"], "config");
+    assert_eq!(
+        payload["servers"][0]["origins"][1]["kind"],
+        "acp_bootstrap_selection"
+    );
+}
+
+#[test]
+fn build_mcp_server_detail_cli_json_payload_wraps_single_server() {
+    let server = mvp::mcp::McpRuntimeServerSnapshot {
+        name: "docs".to_owned(),
+        enabled: true,
+        required: false,
+        selected_for_acp_bootstrap: true,
+        origins: vec![mvp::mcp::McpServerOrigin {
+            kind: mvp::mcp::McpServerOriginKind::Config,
+            source_id: None,
+        }],
+        status: mvp::mcp::McpServerStatus {
+            kind: mvp::mcp::McpServerStatusKind::Pending,
+            auth: mvp::mcp::McpAuthStatus::Unknown,
+            last_error: None,
+        },
+        transport: mvp::mcp::McpTransportSnapshot::Stdio {
+            command: "uvx".to_owned(),
+            args: vec!["context7-mcp".to_owned()],
+            cwd: Some("/workspace/repo".to_owned()),
+            env_var_names: vec!["API_TOKEN".to_owned()],
+        },
+        enabled_tools: vec!["search".to_owned()],
+        disabled_tools: vec!["write".to_owned()],
+        startup_timeout_ms: Some(15_000),
+        tool_timeout_ms: Some(120_000),
+    };
+
+    let payload = build_mcp_server_detail_cli_json_payload("/tmp/loongclaw.toml", &server);
+
+    assert_eq!(payload["config"], "/tmp/loongclaw.toml");
+    assert_eq!(payload["server"]["name"], "docs");
+    assert_eq!(payload["server"]["status"]["kind"], "pending");
+    assert_eq!(payload["server"]["transport"]["transport"], "stdio");
+    assert_eq!(payload["server"]["enabled_tools"][0], "search");
+}

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -121,6 +121,7 @@ mod latest_selector_process_support;
 mod logging;
 mod managed_bridge_fixtures;
 mod managed_bridge_parity;
+mod mcp;
 mod memory_context_benchmark_cli;
 mod migrate_cli;
 mod migration;

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -119,6 +119,26 @@ fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongCla
     config.acp.dispatch.enabled = true;
     config.acp.default_agent = Some("codex".to_owned());
     config.acp.allowed_agents = vec!["codex".to_owned(), "planner".to_owned()];
+    config.mcp.servers.insert(
+        "docs".to_owned(),
+        mvp::mcp::McpServerConfig {
+            transport: mvp::mcp::McpServerTransportConfig::Stdio {
+                command: "uvx".to_owned(),
+                args: vec!["context7-mcp".to_owned()],
+                env: std::collections::BTreeMap::from([(
+                    "API_TOKEN".to_owned(),
+                    "secret".to_owned(),
+                )]),
+                cwd: Some(root.join("workspace")),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: Some(15_000),
+            tool_timeout_ms: Some(120_000),
+            enabled_tools: vec!["search".to_owned()],
+            disabled_tools: vec!["write".to_owned()],
+        },
+    );
     config.providers.insert(
         "openai-main".to_owned(),
         mvp::config::ProviderProfileConfig {
@@ -498,6 +518,8 @@ fn runtime_snapshot_text_highlights_experiment_relevant_sections() {
     assert!(rendered.contains("context_engine selected="));
     assert!(rendered.contains("memory selected="));
     assert!(rendered.contains("acp enabled=true"));
+    assert!(rendered.contains("acp mcp_servers=1"));
+    assert!(rendered.contains("acp_mcp docs status=pending"));
     assert!(rendered.contains("tools visible_count="));
     assert!(rendered.contains("external_skills inventory_status=ok override_active=false"));
     assert!(rendered.contains("demo-skill"));

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:20:30Z
+- Generated at: 2026-04-05T13:21:07Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2765 | 2800 | 35 | 48 | 65 | 17 | 98.8% | TIGHT | 2698 | 2.5% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2775 | 2800 | 25 | 48 | 65 | 17 | 99.1% | TIGHT | 2698 | 2.9% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (98.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.1%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2765 functions=48 -->
+<!-- arch-hotspot key=acpx_runtime lines=2775 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:01:09Z
+- Generated at: 2026-04-05T13:19:24Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,19 +17,19 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2749 | 2800 | 51 | 56 | 65 | 9 | 98.2% | TIGHT | 2698 | 1.9% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2946 | 2800 | -146 | 58 | 65 | 7 | 105.2% | BREACH | 2698 | 9.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10829 | 11200 | 371 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | -0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14809 | 15000 | 191 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6411 | 6500 | 89 | 208 | 210 | 2 | 99.0% | TIGHT | 6324 | 1.4% | PASS | 210 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14810 | 15000 | 190 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6806 | 6500 | -306 | 224 | 210 | -14 | 106.7% | BREACH | 6324 | 7.6% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (98.2%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (99.0%), onboard_cli (99.2%)
+- BREACH hotspots (>100% of any tracked budget): acpx_runtime (105.2%), daemon_lib (106.7%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,14 +63,14 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2749 functions=56 -->
+<!-- arch-hotspot key=acpx_runtime lines=2946 functions=58 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10829 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14809 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6411 functions=208 -->
+<!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
+<!-- arch-hotspot key=tools_mod lines=14810 functions=53 -->
+<!-- arch-hotspot key=daemon_lib lines=6806 functions=224 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:19:24Z
+- Generated at: 2026-04-05T13:20:30Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,19 +17,19 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2946 | 2800 | -146 | 58 | 65 | 7 | 105.2% | BREACH | 2698 | 9.2% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2765 | 2800 | 35 | 48 | 65 | 17 | 98.8% | TIGHT | 2698 | 2.5% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14810 | 15000 | 190 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6806 | 6500 | -306 | 224 | 210 | -14 | 106.7% | BREACH | 6324 | 7.6% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6407 | 6500 | 93 | 205 | 210 | 5 | 98.6% | TIGHT | 6324 | 1.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): acpx_runtime (105.2%), daemon_lib (106.7%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), onboard_cli (99.2%)
+- BREACH hotspots (>100% of any tracked budget): none
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (98.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,14 +63,14 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2946 functions=58 -->
+<!-- arch-hotspot key=acpx_runtime lines=2765 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14810 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6806 functions=224 -->
+<!-- arch-hotspot key=daemon_lib lines=6407 functions=205 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:21:07Z
+- Generated at: 2026-04-05T13:21:51Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,19 +17,19 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2775 | 2800 | 25 | 48 | 65 | 17 | 99.1% | TIGHT | 2698 | 2.9% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2773 | 2800 | 27 | 48 | 65 | 17 | 99.0% | TIGHT | 2698 | 2.8% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14810 | 15000 | 190 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6407 | 6500 | 93 | 205 | 210 | 5 | 98.6% | TIGHT | 6324 | 1.3% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6408 | 6500 | 92 | 205 | 210 | 5 | 98.6% | TIGHT | 6324 | 1.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.1%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.0%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,14 +63,14 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2775 functions=48 -->
+<!-- arch-hotspot key=acpx_runtime lines=2773 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14810 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6407 functions=205 -->
+<!-- arch-hotspot key=daemon_lib lines=6408 functions=205 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:21:51Z
+- Generated at: 2026-04-05T13:22:24Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2773 | 2800 | 27 | 48 | 65 | 17 | 99.0% | TIGHT | 2698 | 2.8% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2771 | 2800 | 29 | 48 | 65 | 17 | 99.0% | TIGHT | 2698 | 2.7% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2773 functions=48 -->
+<!-- arch-hotspot key=acpx_runtime lines=2771 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->


### PR DESCRIPTION
## Summary

- Problem:
  MCP existed as partial ACPX plumbing and config seams, but not as a shared runtime inventory with stable operator surfaces. Script-backed ACPX and browser companion commands also showed platform-specific launch instability.
- Why it matters:
  Without a shared MCP registry, ACPX, runtime snapshots, and daemon inspection drift apart. Without deterministic script launching, operator-visible health and runtime execution can disagree on the same command.
- What changed:
  Added a first-class `app::mcp` subsystem, routed ACPX MCP selection and proxy payload generation through the shared registry, added shebang-aware command launching for script-backed commands, added daemon MCP inventory/detail CLI surfaces, exposed MCP inventory in runtime-snapshot text output, and redacted sensitive MCP transport snapshot values in operator-visible surfaces.
- What did not change (scope boundary):
  This PR does not add a live MCP manager, reconnect lifecycle state machine, or exported MCP server lane. It stays on typed inventory, registry truth, ACPX integration, launcher correctness, and operator-visible inspection.

## Linked Issues

- Closes #919
- Related #221
- Related #897

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-mcp-runtime-followup cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-mcp-runtime-followup cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-mcp-runtime-followup cargo test --workspace --all-features -- --test-threads=1
```

Additional focused evidence:

```text
/tmp/loongclaw-mcp-runtime-followup/debug/deps/loongclaw_app-2deb999a9c13ec18 mcp::registry::tests::transport_snapshot_redacts_sensitive_stdio_arguments --exact --nocapture
/tmp/loongclaw-mcp-runtime-followup/debug/deps/loongclaw_app-2deb999a9c13ec18 mcp::registry::tests::transport_snapshot_redacts_sensitive_http_url_components --exact --nocapture
/tmp/loongclaw-mcp-runtime-followup/debug/deps/loongclaw_app-2deb999a9c13ec18 process_launch::tests::resolve_command_invocation_uses_resolved_path_for_path_discovered_scripts --exact --nocapture
/tmp/loongclaw-mcp-runtime-followup/debug/deps/loongclaw_app-2deb999a9c13ec18 acp::acpx::tests::doctor_accepts_path_discovered_fake_version_command --exact --nocapture
/tmp/loongclaw-mcp-runtime-followup/debug/deps/integration-d91de24894bea23f integration::runtime_snapshot_cli::runtime_snapshot_text_highlights_experiment_relevant_sections --exact --nocapture
```

Environment note:

- A temporary `/tmp` clean worktree was used to keep this scope isolated from unrelated local work.

## User-visible / Operator-visible Changes

- `LoongClawConfig` now has a first-class `mcp` config surface for shared MCP server inventory.
- ACP runtime snapshots now expose MCP inventory directly.
- ACPX MCP bootstrap selection now validates against the shared MCP registry rather than an ACPX-only private config map.
- Script-backed ACPX and browser companion commands launch deterministically through a shared shebang-aware command runner.
- Daemon CLI now supports `list-mcp-servers` plus `show-mcp-server --name <server>` for operator inspection.
- Runtime snapshot text output now includes MCP inventory, and operator-visible MCP transport snapshots redact sensitive URL/query and secret-flag argument values.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR commit range or stop using MCP bootstrap selections and the new daemon MCP inspection commands. The default runtime path without requested MCP injection remains unchanged.
- Observable failure symptoms reviewers should watch for:
  Wrong MCP registry names in ACPX bootstrap selection, runtime-snapshot text omitting MCP inventory, daemon MCP detail output missing transport metadata, or script-backed ACPX/browser companion commands failing before producing output.

## Reviewer Focus

- Shared MCP truth source and precedence rules in `crates/app/src/mcp/registry.rs`
- ACPX registry-backed MCP selection, proxy payload `cwd`, and doctor launcher parity in `crates/app/src/acp/acpx.rs`
- Shared script-launch contract in `crates/app/src/process_launch.rs`
- Unified tool validation observability in `crates/app/src/tools/mod.rs`
- Browser companion / doctor parity in `crates/app/src/tools/browser_companion.rs` and `crates/daemon/src/browser_companion_diagnostics.rs`
- Operator-visible MCP CLI and runtime-snapshot text surfaces in `crates/daemon/src/lib.rs` and `crates/daemon/tests/integration/runtime_snapshot_cli.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add MCP configuration, in-memory registry, and CLI commands to list/show MCP servers; runtime snapshots and diagnostics now include per-server MCP details.

* **Improvements**
  * More robust command invocation (shebang/launcher resolution) and preservation of per-server working directories in proxy payloads.
  * Better MCP selection/injection handling and clearer error messages; sensitive values redacted in MCP outputs.

* **Bug Fixes**
  * Emit a cancelled completion event for aborted child processes to avoid missing turn outcomes.

* **Tests**
  * Expanded unit and integration tests covering MCP configs, registry behavior, redaction, and CLI JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->