### PR TITLE
refactor: centralize delegate child runtime ownership

### DIFF
--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -7,6 +7,10 @@ use serde_json::Value;
 
 use crate::CliResult;
 use crate::KernelContext;
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::delegate_runtime::{
+    derive_subagent_profile_from_lineage, load_delegate_execution, resolve_delegate_child_contract,
+};
 use crate::runtime_self_continuity::{self, RuntimeSelfContinuity};
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::tools::{ToolView, delegate_child_tool_view_for_runtime_config_and_contract};
@@ -286,49 +290,6 @@ fn normalize_session_id(session_id: String) -> String {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn load_delegate_execution(
-    repo: &SessionRepository,
-    session_id: &str,
-) -> Result<Option<ConstrainedSubagentExecution>, String> {
-    let events = repo.list_delegate_lifecycle_events(session_id)?;
-    Ok(events.into_iter().rev().find_map(|event| {
-        matches!(
-            event.event_kind.as_str(),
-            "delegate_queued" | "delegate_started"
-        )
-        .then(|| {
-            super::subagent::ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
-        })
-        .flatten()
-    }))
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn derive_subagent_profile_from_lineage(
-    repo: &SessionRepository,
-    session_id: &str,
-    max_depth: usize,
-) -> Result<Option<ConstrainedSubagentProfile>, String> {
-    let depth = match repo.session_lineage_depth(session_id) {
-        Ok(depth) => depth,
-        Err(error)
-            if error.starts_with("session_lineage_broken:")
-                || error.starts_with("session_lineage_cycle_detected:") =>
-        {
-            return Ok(None);
-        }
-        Err(error) => {
-            return Err(format!(
-                "compute session lineage depth for subagent profile failed: {error}"
-            ));
-        }
-    };
-    Ok(Some(ConstrainedSubagentProfile::for_child_depth(
-        depth, max_depth,
-    )))
-}
-
-#[cfg(feature = "memory-sqlite")]
 fn load_session_tool_policy(
     repo: &SessionRepository,
     session_id: &str,
@@ -485,33 +446,10 @@ fn build_base_tool_view_from_snapshot(
         ));
     };
 
-    if snapshot.parent_session_id.is_some() {
-        let derived_contract = match snapshot.subagent_execution.as_ref() {
-            Some(subagent_execution) => Some(subagent_execution.contract_view()),
-            None => derive_subagent_profile_from_lineage(
-                repo,
-                session_id,
-                config.tools.delegate.max_depth,
-            )?
-            .map(ConstrainedSubagentContractView::from_profile),
-        };
-        return Ok(delegate_child_tool_view_for_runtime_config_and_contract(
-            &config.tools,
-            &tool_runtime_config,
-            derived_contract.as_ref(),
-        ));
-    }
-
-    if snapshot.is_delegate_child {
-        let derived_contract = match snapshot.subagent_execution.as_ref() {
-            Some(subagent_execution) => Some(subagent_execution.contract_view()),
-            None => derive_subagent_profile_from_lineage(
-                repo,
-                session_id,
-                config.tools.delegate.max_depth,
-            )?
-            .map(ConstrainedSubagentContractView::from_profile),
-        };
+    let is_delegate_child = snapshot.parent_session_id.is_some() || snapshot.is_delegate_child;
+    if is_delegate_child {
+        let derived_contract =
+            resolve_delegate_child_contract(repo, session_id, config.tools.delegate.max_depth)?;
         return Ok(delegate_child_tool_view_for_runtime_config_and_contract(
             &config.tools,
             &tool_runtime_config,

--- a/crates/app/src/conversation/trust_projection.rs
+++ b/crates/app/src/conversation/trust_projection.rs
@@ -1,23 +1,15 @@
 use serde_json::{Value, json};
 
 use crate::provider::parse_provider_failover_snapshot_payload;
-#[cfg(feature = "memory-sqlite")]
-use crate::runtime_self_continuity::RuntimeSelfContinuity;
-#[cfg(feature = "memory-sqlite")]
-use crate::session::repository::{
-    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionState,
-};
 use crate::trust::{
-    delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
-    provider_failover_trust_event, runtime_binding_missing_trust_event,
+    embed_trust_event_payload, extract_trust_event_payload, provider_failover_trust_event,
+    runtime_binding_missing_trust_event,
 };
 
 use super::super::config::LoongClawConfig;
 use super::persistence::persist_conversation_event;
 use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
-#[cfg(feature = "memory-sqlite")]
-use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::TurnResult;
 
 pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRuntime + ?Sized>(
@@ -150,112 +142,4 @@ pub(super) async fn emit_provider_failover_trust_event_if_needed<
             "failed to persist trust event"
         );
     }
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(super) fn build_delegate_started_child_session_request(
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_label: Option<String>,
-    task: &str,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-) -> CreateSessionWithEventRequest {
-    build_delegate_child_session_request(
-        parent_session_id,
-        child_session_id,
-        child_label,
-        task,
-        runtime_self_continuity,
-        execution,
-        SessionState::Running,
-        "delegate_started",
-        "delegate.inline",
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(super) fn build_delegate_queued_child_session_request(
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_label: Option<String>,
-    task: &str,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-) -> CreateSessionWithEventRequest {
-    build_delegate_child_session_request(
-        parent_session_id,
-        child_session_id,
-        child_label,
-        task,
-        runtime_self_continuity,
-        execution,
-        SessionState::Ready,
-        "delegate_queued",
-        "delegate.async",
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn build_delegate_child_session_request(
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_label: Option<String>,
-    task: &str,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-    session_state: SessionState,
-    event_kind: &str,
-    source_surface: &str,
-) -> CreateSessionWithEventRequest {
-    let event_payload_json = build_delegate_child_event_payload(
-        parent_session_id,
-        child_session_id,
-        task,
-        child_label.as_deref(),
-        runtime_self_continuity,
-        execution,
-        source_surface,
-    );
-    let session = NewSessionRecord {
-        session_id: child_session_id.to_owned(),
-        kind: SessionKind::DelegateChild,
-        parent_session_id: Some(parent_session_id.to_owned()),
-        label: child_label,
-        state: session_state,
-    };
-
-    CreateSessionWithEventRequest {
-        session,
-        event_kind: event_kind.to_owned(),
-        actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json,
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn build_delegate_child_event_payload(
-    parent_session_id: &str,
-    child_session_id: &str,
-    task: &str,
-    child_label: Option<&str>,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-    source_surface: &str,
-) -> Value {
-    let trust_event =
-        delegate_child_trust_event(parent_session_id, child_session_id, source_surface);
-    let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
-        task,
-        child_label,
-        runtime_self_continuity,
-    );
-    let payload_with_trust =
-        embed_trust_event_payload(event_payload_json.clone(), trust_event.clone());
-    let extracted_trust_event = extract_trust_event_payload(&payload_with_trust);
-    if extracted_trust_event.as_ref() != Some(&trust_event) {
-        return event_payload_json;
-    }
-
-    payload_with_trust
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -28,7 +28,9 @@ use crate::acp::{
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::operator::session_graph::OperatorSessionGraph;
+use crate::operator::delegate_runtime::{
+    build_delegate_child_lifecycle_seed, next_delegate_child_depth,
+};
 use crate::runtime_self_continuity;
 
 use super::super::config::LoongClawConfig;
@@ -75,12 +77,10 @@ use super::session_history::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::subagent::{
-    ConstrainedSubagentExecution, ConstrainedSubagentIdentity, ConstrainedSubagentMode,
-    ConstrainedSubagentProfile, ConstrainedSubagentTerminalReason,
+    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
 };
 use super::tool_discovery_state::{TOOL_DISCOVERY_REFRESHED_EVENT_NAME, ToolDiscoveryState};
 use super::trust_projection::{
-    build_delegate_queued_child_session_request, build_delegate_started_child_session_request,
     emit_provider_failover_trust_event_if_needed, emit_runtime_binding_trust_event_if_needed,
 };
 use super::turn_budget::{
@@ -3989,24 +3989,21 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                 &session_context.session_id,
                 config.tools.delegate.max_active_children,
                 |active_children| {
-                    let execution = constrained_subagent_execution_for_delegate(
+                    let seed = build_delegate_child_lifecycle_seed(
                         config,
                         binding,
-                        subagent_identity.clone(),
                         ConstrainedSubagentMode::Inline,
                         delegate_request.timeout_seconds,
                         next_child_depth,
                         active_children,
-                    );
-                    let request = build_delegate_started_child_session_request(
                         &session_context.session_id,
                         &child_session_id,
                         child_label.clone(),
                         &delegate_request.task,
                         runtime_self_continuity.as_ref(),
-                        &execution,
+                        subagent_identity.clone(),
                     );
-                    Ok((request, execution))
+                    Ok((seed.request, seed.execution))
                 },
             )?;
 
@@ -4060,24 +4057,21 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         &session_context.session_id,
         config.tools.delegate.max_active_children,
         |active_children| {
-            let execution = constrained_subagent_execution_for_delegate(
+            let seed = build_delegate_child_lifecycle_seed(
                 config,
                 binding,
-                subagent_identity.clone(),
                 ConstrainedSubagentMode::Async,
                 delegate_request.timeout_seconds,
                 next_child_depth,
                 active_children,
-            );
-            let request = build_delegate_queued_child_session_request(
                 &session_context.session_id,
                 &child_session_id,
                 child_label.clone(),
                 &delegate_request.task,
                 runtime_self_continuity.as_ref(),
-                &execution,
+                subagent_identity.clone(),
             );
-            Ok((request, execution))
+            Ok((seed.request, seed.execution))
         },
     )?;
 
@@ -4512,45 +4506,16 @@ fn spawn_async_delegate_detached(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn constrained_subagent_execution_for_delegate(
-    config: &LoongClawConfig,
-    binding: ConversationRuntimeBinding<'_>,
-    subagent_identity: Option<ConstrainedSubagentIdentity>,
-    mode: ConstrainedSubagentMode,
-    timeout_seconds: u64,
-    next_child_depth: usize,
-    active_children: usize,
-) -> ConstrainedSubagentExecution {
-    let subagent_profile = ConstrainedSubagentProfile::for_child_depth(
-        next_child_depth,
-        config.tools.delegate.max_depth,
-    );
-
-    ConstrainedSubagentExecution {
-        mode,
-        depth: next_child_depth,
-        max_depth: config.tools.delegate.max_depth,
-        active_children,
-        max_active_children: config.tools.delegate.max_active_children,
-        timeout_seconds,
-        allow_shell_in_child: config.tools.delegate.allow_shell_in_child,
-        child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
-        runtime_narrowing: config.tools.delegate.child_runtime.runtime_narrowing(),
-        kernel_bound: binding.is_kernel_bound(),
-        identity: subagent_identity,
-        profile: Some(subagent_profile),
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
 fn next_delegate_child_depth_for_delegate(
     config: &LoongClawConfig,
     repo: &SessionRepository,
     session_context: &SessionContext,
 ) -> Result<usize, String> {
-    let session_graph = OperatorSessionGraph::new(repo);
-    session_graph
-        .next_delegate_child_depth(&session_context.session_id, config.tools.delegate.max_depth)
+    next_delegate_child_depth(
+        repo,
+        &session_context.session_id,
+        config.tools.delegate.max_depth,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -20,6 +20,8 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::approval_runtime::{GovernedToolApprovalRequest, OperatorApprovalRuntime};
 #[cfg(feature = "memory-sqlite")]
+use crate::operator::delegate_runtime::resolve_delegate_child_contract;
+#[cfg(feature = "memory-sqlite")]
 use crate::operator::session_graph::OperatorSessionGraph;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
@@ -652,34 +654,11 @@ impl DefaultAppToolDispatcher {
             if session.parent_session_id.is_some() {
                 let subagent_contract = match session_context.resolved_subagent_contract() {
                     Some(subagent_contract) => Some(subagent_contract),
-                    None => {
-                        let session_graph = OperatorSessionGraph::new(&repo);
-                        match session_graph.lineage_depth(&session_context.session_id) {
-                            Ok(depth) => {
-                                let subagent_profile =
-                                    crate::conversation::ConstrainedSubagentProfile::for_child_depth(
-                                        depth,
-                                        self.tool_config.delegate.max_depth,
-                                    );
-                                Some(
-                                    crate::conversation::ConstrainedSubagentContractView::from_profile(
-                                        subagent_profile,
-                                    ),
-                                )
-                            }
-                            Err(error)
-                                if error.starts_with("session_lineage_broken:")
-                                    || error.starts_with("session_lineage_cycle_detected:") =>
-                            {
-                                None
-                            }
-                            Err(error) => {
-                                return Err(format!(
-                                    "compute session lineage depth for dispatcher tool view failed: {error}"
-                                ));
-                            }
-                        }
-                    }
+                    None => resolve_delegate_child_contract(
+                        &repo,
+                        &session_context.session_id,
+                        self.tool_config.delegate.max_depth,
+                    )?,
                 };
                 return Ok(with_runtime_ready_browser_companion_tools(
                     delegate_child_tool_view_for_contract(
@@ -698,32 +677,11 @@ impl DefaultAppToolDispatcher {
             .load_session_summary_with_legacy_fallback(&session_context.session_id)?
             .is_some_and(|session| session.kind == SessionKind::DelegateChild)
         {
-            let session_graph = OperatorSessionGraph::new(&repo);
-            let subagent_contract = match session_graph.lineage_depth(&session_context.session_id) {
-                Ok(depth) => {
-                    let subagent_profile =
-                        crate::conversation::ConstrainedSubagentProfile::for_child_depth(
-                            depth,
-                            self.tool_config.delegate.max_depth,
-                        );
-                    Some(
-                        crate::conversation::ConstrainedSubagentContractView::from_profile(
-                            subagent_profile,
-                        ),
-                    )
-                }
-                Err(error)
-                    if error.starts_with("session_lineage_broken:")
-                        || error.starts_with("session_lineage_cycle_detected:") =>
-                {
-                    None
-                }
-                Err(error) => {
-                    return Err(format!(
-                        "compute session lineage depth for dispatcher tool view failed: {error}"
-                    ));
-                }
-            };
+            let subagent_contract = resolve_delegate_child_contract(
+                &repo,
+                &session_context.session_id,
+                self.tool_config.delegate.max_depth,
+            )?;
             return Ok(with_runtime_ready_browser_companion_tools(
                 delegate_child_tool_view_for_contract(
                     &self.tool_config,

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -1,0 +1,403 @@
+use serde_json::Value;
+
+use crate::config::LoongClawConfig;
+use crate::conversation::{
+    ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentIdentity,
+    ConstrainedSubagentMode, ConstrainedSubagentProfile, ConversationRuntimeBinding,
+};
+use crate::runtime_self_continuity::RuntimeSelfContinuity;
+use crate::session::repository::{
+    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+};
+use crate::trust::{
+    delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
+};
+
+use super::session_graph::OperatorSessionGraph;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DelegateChildLifecycleSeed {
+    pub execution: ConstrainedSubagentExecution,
+    pub request: CreateSessionWithEventRequest,
+}
+
+pub(crate) fn load_delegate_execution(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<ConstrainedSubagentExecution>, String> {
+    let events = repo.list_delegate_lifecycle_events(session_id)?;
+    let execution = events.into_iter().rev().find_map(|event| {
+        let event_kind = event.event_kind.as_str();
+        let is_delegate_lifecycle_event =
+            matches!(event_kind, "delegate_queued" | "delegate_started");
+        if !is_delegate_lifecycle_event {
+            return None;
+        }
+
+        ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+    });
+    Ok(execution)
+}
+
+pub(crate) fn derive_subagent_profile_from_lineage(
+    repo: &SessionRepository,
+    session_id: &str,
+    max_depth: usize,
+) -> Result<Option<ConstrainedSubagentProfile>, String> {
+    let session_graph = OperatorSessionGraph::new(repo);
+    let depth_result = session_graph.lineage_depth(session_id);
+    let depth = match depth_result {
+        Ok(depth) => depth,
+        Err(error)
+            if error.starts_with("session_lineage_broken:")
+                || error.starts_with("session_lineage_cycle_detected:") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => {
+            let message = format!(
+                "compute session lineage depth for delegate runtime contract failed: {error}"
+            );
+            return Err(message);
+        }
+    };
+
+    let profile = ConstrainedSubagentProfile::for_child_depth(depth, max_depth);
+    Ok(Some(profile))
+}
+
+pub(crate) fn resolve_delegate_child_contract(
+    repo: &SessionRepository,
+    session_id: &str,
+    max_depth: usize,
+) -> Result<Option<ConstrainedSubagentContractView>, String> {
+    let execution = load_delegate_execution(repo, session_id)?;
+    if let Some(execution) = execution {
+        let contract = execution.contract_view();
+        return Ok(Some(contract));
+    }
+
+    let profile = derive_subagent_profile_from_lineage(repo, session_id, max_depth)?;
+    let contract = profile.map(ConstrainedSubagentContractView::from_profile);
+    Ok(contract)
+}
+
+pub(crate) fn next_delegate_child_depth(
+    repo: &SessionRepository,
+    session_id: &str,
+    max_depth: usize,
+) -> Result<usize, String> {
+    let session_graph = OperatorSessionGraph::new(repo);
+    session_graph.next_delegate_child_depth(session_id, max_depth)
+}
+
+pub(crate) fn build_delegate_child_lifecycle_seed(
+    config: &LoongClawConfig,
+    binding: ConversationRuntimeBinding<'_>,
+    mode: ConstrainedSubagentMode,
+    timeout_seconds: u64,
+    next_child_depth: usize,
+    active_children: usize,
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    identity: Option<ConstrainedSubagentIdentity>,
+) -> DelegateChildLifecycleSeed {
+    let execution = build_delegate_child_execution(
+        config,
+        binding,
+        mode,
+        timeout_seconds,
+        next_child_depth,
+        active_children,
+        identity,
+    );
+    let request = build_delegate_child_request(
+        parent_session_id,
+        child_session_id,
+        child_label,
+        task,
+        runtime_self_continuity,
+        &execution,
+        mode,
+    );
+
+    DelegateChildLifecycleSeed { execution, request }
+}
+
+fn build_delegate_child_execution(
+    config: &LoongClawConfig,
+    binding: ConversationRuntimeBinding<'_>,
+    mode: ConstrainedSubagentMode,
+    timeout_seconds: u64,
+    next_child_depth: usize,
+    active_children: usize,
+    identity: Option<ConstrainedSubagentIdentity>,
+) -> ConstrainedSubagentExecution {
+    let runtime_narrowing = config.tools.delegate.child_runtime.runtime_narrowing();
+    let kernel_bound = binding.is_kernel_bound();
+    let profile = ConstrainedSubagentProfile::for_child_depth(
+        next_child_depth,
+        config.tools.delegate.max_depth,
+    );
+
+    ConstrainedSubagentExecution {
+        mode,
+        depth: next_child_depth,
+        max_depth: config.tools.delegate.max_depth,
+        active_children,
+        max_active_children: config.tools.delegate.max_active_children,
+        timeout_seconds,
+        allow_shell_in_child: config.tools.delegate.allow_shell_in_child,
+        child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
+        runtime_narrowing,
+        kernel_bound,
+        identity,
+        profile: Some(profile),
+    }
+}
+
+fn build_delegate_child_request(
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    mode: ConstrainedSubagentMode,
+) -> CreateSessionWithEventRequest {
+    let session_state = delegate_child_session_state(mode);
+    let event_kind = delegate_child_event_kind(mode);
+    let source_surface = delegate_child_source_surface(mode);
+    let event_payload_json = build_delegate_child_event_payload(
+        parent_session_id,
+        child_session_id,
+        task,
+        child_label.as_deref(),
+        runtime_self_continuity,
+        execution,
+        source_surface,
+    );
+    let session = NewSessionRecord {
+        session_id: child_session_id.to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: child_label,
+        state: session_state,
+    };
+
+    CreateSessionWithEventRequest {
+        session,
+        event_kind: event_kind.to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json,
+    }
+}
+
+fn delegate_child_session_state(mode: ConstrainedSubagentMode) -> SessionState {
+    match mode {
+        ConstrainedSubagentMode::Inline => SessionState::Running,
+        ConstrainedSubagentMode::Async => SessionState::Ready,
+    }
+}
+
+fn delegate_child_event_kind(mode: ConstrainedSubagentMode) -> &'static str {
+    match mode {
+        ConstrainedSubagentMode::Inline => "delegate_started",
+        ConstrainedSubagentMode::Async => "delegate_queued",
+    }
+}
+
+fn delegate_child_source_surface(mode: ConstrainedSubagentMode) -> &'static str {
+    match mode {
+        ConstrainedSubagentMode::Inline => "delegate.inline",
+        ConstrainedSubagentMode::Async => "delegate.async",
+    }
+}
+
+fn build_delegate_child_event_payload(
+    parent_session_id: &str,
+    child_session_id: &str,
+    task: &str,
+    child_label: Option<&str>,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    source_surface: &str,
+) -> Value {
+    let trust_event =
+        delegate_child_trust_event(parent_session_id, child_session_id, source_surface);
+    let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
+        task,
+        child_label,
+        runtime_self_continuity,
+    );
+    let payload_with_trust =
+        embed_trust_event_payload(event_payload_json.clone(), trust_event.clone());
+    let extracted_trust_event = extract_trust_event_payload(&payload_with_trust);
+    if extracted_trust_event.as_ref() != Some(&trust_event) {
+        return event_payload_json;
+    }
+
+    payload_with_trust
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::config::LoongClawConfig;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{NewSessionEvent, NewSessionRecord};
+    use crate::trust::extract_trust_event_payload;
+
+    fn isolated_repo(test_name: &str) -> SessionRepository {
+        let sqlite_path = std::env::temp_dir().join(format!(
+            "loongclaw-operator-delegate-runtime-{test_name}-{}.sqlite3",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&sqlite_path);
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(sqlite_path),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        SessionRepository::new(&config).expect("session repository")
+    }
+
+    #[test]
+    fn resolve_delegate_child_contract_falls_back_to_lineage_profile() {
+        let repo = isolated_repo("lineage-fallback");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: None,
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: None,
+            state: SessionState::Ready,
+        })
+        .expect("create child session");
+
+        let contract =
+            resolve_delegate_child_contract(&repo, "child-session", 2).expect("resolve contract");
+        let profile = contract.and_then(|contract| contract.profile);
+
+        assert_eq!(
+            profile,
+            Some(ConstrainedSubagentProfile::for_child_depth(1, 2))
+        );
+    }
+
+    #[test]
+    fn resolve_delegate_child_contract_prefers_persisted_execution() {
+        let repo = isolated_repo("persisted-execution");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: None,
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: None,
+            state: SessionState::Ready,
+        })
+        .expect("create child session");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "execution": {
+                    "mode": "inline",
+                    "depth": 1,
+                    "max_depth": 3,
+                    "active_children": 0,
+                    "max_active_children": 2,
+                    "timeout_seconds": 60,
+                    "allow_shell_in_child": false,
+                    "child_tool_allowlist": ["file.read"],
+                    "kernel_bound": false,
+                    "runtime_narrowing": {
+                        "browser": {
+                            "max_sessions": 1
+                        }
+                    }
+                }
+            }),
+        })
+        .expect("append event");
+
+        let contract =
+            resolve_delegate_child_contract(&repo, "child-session", 3).expect("resolve contract");
+        let contract = contract.expect("resolved contract");
+        let profile = contract.profile;
+
+        assert_eq!(
+            profile,
+            Some(ConstrainedSubagentProfile::for_child_depth(1, 3))
+        );
+        assert_eq!(contract.runtime_narrowing.browser.max_sessions, Some(1));
+    }
+
+    #[test]
+    fn build_delegate_child_lifecycle_seed_uses_mode_specific_state_and_event_kind() {
+        let config = LoongClawConfig::default();
+        let seed = build_delegate_child_lifecycle_seed(
+            &config,
+            ConversationRuntimeBinding::direct(),
+            ConstrainedSubagentMode::Async,
+            42,
+            1,
+            0,
+            "parent-session",
+            "child-session",
+            Some("worker".to_owned()),
+            "research",
+            None,
+            None,
+        );
+
+        assert_eq!(seed.request.session.state, SessionState::Ready);
+        assert_eq!(seed.request.event_kind, "delegate_queued");
+        assert_eq!(seed.execution.mode, ConstrainedSubagentMode::Async);
+        assert_eq!(seed.execution.depth, 1);
+        assert_eq!(seed.execution.timeout_seconds, 42);
+    }
+
+    #[test]
+    fn build_delegate_child_lifecycle_seed_embeds_delegate_trust_event() {
+        let config = LoongClawConfig::default();
+        let seed = build_delegate_child_lifecycle_seed(
+            &config,
+            ConversationRuntimeBinding::direct(),
+            ConstrainedSubagentMode::Inline,
+            60,
+            1,
+            0,
+            "parent-session",
+            "child-session",
+            Some("worker".to_owned()),
+            "research",
+            None,
+            None,
+        );
+
+        let trust_event = extract_trust_event_payload(&seed.request.event_payload_json);
+        assert!(trust_event.is_some(), "expected trust event payload");
+    }
+}

--- a/crates/app/src/operator/mod.rs
+++ b/crates/app/src/operator/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod approval_runtime;
+pub(crate) mod delegate_runtime;
 pub(crate) mod session_graph;

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,9 +1,10 @@
 use std::io::ErrorKind;
-use std::process::Command as StdCommand;
 use std::process::Stdio;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use loongclaw_app as mvp;
+use tokio::process::Command as TokioCommand;
+use tokio::time::timeout;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
@@ -223,26 +224,13 @@ async fn probe_browser_companion_version(
 
 async fn probe_browser_companion_version_with_policy(
     command: &str,
-    timeout: Duration,
-    max_attempts: usize,
-) -> Result<String, BrowserCompanionProbeError> {
-    tokio::task::spawn_blocking({
-        let command = command.to_owned();
-        move || probe_browser_companion_version_blocking(command, timeout, max_attempts)
-    })
-    .await
-    .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?
-}
-
-fn probe_browser_companion_version_blocking(
-    command: String,
-    timeout: Duration,
+    timeout_duration: Duration,
     max_attempts: usize,
 ) -> Result<String, BrowserCompanionProbeError> {
     let effective_attempts = max_attempts.max(1);
     let mut attempt_index = 0usize;
     loop {
-        let probe_result = run_browser_companion_probe_once(&command, timeout);
+        let probe_result = run_browser_companion_probe_once(command, timeout_duration).await;
         match probe_result {
             Ok(observed_version) => {
                 return Ok(observed_version);
@@ -263,60 +251,39 @@ fn probe_browser_companion_version_blocking(
 }
 
 #[allow(clippy::disallowed_methods)]
-fn run_browser_companion_probe_once(
+async fn run_browser_companion_probe_once(
     command: &str,
-    timeout: Duration,
+    timeout_duration: Duration,
 ) -> Result<String, BrowserCompanionProbeError> {
-    let mut probe = StdCommand::new(command);
-    probe.arg(BROWSER_COMPANION_VERSION_ARG);
+    let invocation =
+        mvp::process_launch::resolve_command_invocation(command, [BROWSER_COMPANION_VERSION_ARG]);
+    let mut probe = TokioCommand::new(&invocation.program);
+    probe.args(&invocation.args);
     probe.stdin(Stdio::null());
     probe.stdout(Stdio::piped());
     probe.stderr(Stdio::piped());
+    probe.kill_on_drop(true);
 
-    let mut child = match probe.spawn() {
-        Ok(child) => child,
-        Err(error) => {
-            return if error.kind() == ErrorKind::NotFound {
+    match timeout(timeout_duration, probe.output()).await {
+        Ok(Ok(output)) => {
+            let observed = observed_output(&output.stdout, &output.stderr);
+            if output.status.success() {
+                return Ok(observed);
+            }
+
+            Err(BrowserCompanionProbeError::Exited {
+                observed,
+                exit_status: output.status.code(),
+            })
+        }
+        Ok(Err(error)) => {
+            if error.kind() == ErrorKind::NotFound {
                 Err(BrowserCompanionProbeError::MissingBinary)
             } else {
                 Err(BrowserCompanionProbeError::SpawnFailed(error.to_string()))
-            };
-        }
-    };
-
-    let started_at = Instant::now();
-    loop {
-        let try_wait_result = child.try_wait();
-        match try_wait_result {
-            Ok(Some(_status)) => {
-                let output_result = child.wait_with_output();
-                let output = output_result
-                    .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?;
-                let observed = observed_output(&output.stdout, &output.stderr);
-                if output.status.success() {
-                    return Ok(observed);
-                }
-                return Err(BrowserCompanionProbeError::Exited {
-                    observed,
-                    exit_status: output.status.code(),
-                });
-            }
-            Ok(None) => {
-                let elapsed = started_at.elapsed();
-                let timed_out = elapsed >= timeout;
-                if timed_out {
-                    let kill_result = child.kill();
-                    let _ = kill_result;
-                    let wait_result = child.wait();
-                    let _ = wait_result;
-                    return Err(BrowserCompanionProbeError::TimedOut);
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(error) => {
-                return Err(BrowserCompanionProbeError::SpawnFailed(error.to_string()));
             }
         }
+        Err(_) => Err(BrowserCompanionProbeError::TimedOut),
     }
 }
 

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -7,8 +7,10 @@
 use super::*;
 use serde_json::Value;
 use std::{
+    ffi::OsString,
     fs,
     path::{Path, PathBuf},
+    sync::MutexGuard,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -36,6 +38,57 @@ fn artifact_path_suffix(path: &Path) -> String {
     let suffix_parts = normalized_path.rsplit('/').take(2).collect::<Vec<_>>();
     let ordered_suffix_parts = suffix_parts.into_iter().rev().collect::<Vec<_>>();
     ordered_suffix_parts.join("/")
+}
+
+struct RuntimeCapabilityEnvironmentGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
+}
+
+impl RuntimeCapabilityEnvironmentGuard {
+    fn set(root: &Path) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        let home = root.join("home");
+        let loongclaw_home = home.join(".loongclaw");
+        fs::create_dir_all(&loongclaw_home).expect("create isolated loongclaw home");
+        let home_text = home.to_string_lossy().into_owned();
+        let loongclaw_home_text = loongclaw_home.to_string_lossy().into_owned();
+
+        let pairs = [
+            ("HOME", Some(home_text.as_str())),
+            ("LOONGCLAW_HOME", Some(loongclaw_home_text.as_str())),
+            ("LOONGCLAW_BROWSER_COMPANION_READY", None),
+        ];
+        let mut saved = Vec::new();
+        for (key, value) in pairs {
+            saved.push((key.to_owned(), std::env::var_os(key)));
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(key);
+                },
+            }
+        }
+
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for RuntimeCapabilityEnvironmentGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(&key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(&key);
+                },
+            }
+        }
+    }
 }
 
 fn write_runtime_capability_config(root: &Path) -> PathBuf {
@@ -232,6 +285,7 @@ fn finish_runtime_experiment(
     PathBuf,
     loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
 ) {
+    let _env_guard = RuntimeCapabilityEnvironmentGuard::set(root);
     let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
         root,
         config_path,
@@ -283,6 +337,7 @@ fn finish_runtime_experiment_with_compare_delta(
     PathBuf,
     loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
 ) {
+    let _env_guard = RuntimeCapabilityEnvironmentGuard::set(root);
     let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
         root,
         config_path,
@@ -406,6 +461,7 @@ fn finish_runtime_experiment_variant_with_memory_compare_delta(
     PathBuf,
     loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
 ) {
+    let _env_guard = RuntimeCapabilityEnvironmentGuard::set(root);
     let config_path = write_runtime_capability_config(root);
     let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
         root,
@@ -467,6 +523,7 @@ fn finish_runtime_experiment_variant(
     PathBuf,
     loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
 ) {
+    let _env_guard = RuntimeCapabilityEnvironmentGuard::set(root);
     let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
         root,
         config_path,

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T08:54:53Z
+- Generated at: 2026-04-06T10:02:41Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10798 | 11200 | 402 | 96 | 120 | 24 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6464 | 6500 | 36 | 205 | 210 | 5 | 99.4% | TIGHT | 6324 | 2.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.0%), daemon_lib (99.4%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (99.0%), daemon_lib (99.4%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
+<!-- arch-hotspot key=turn_coordinator lines=10798 functions=96 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6464 functions=205 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->


### PR DESCRIPTION
## Summary

- Problem:
  Delegate-child lifecycle semantics were still split across `conversation::turn_coordinator`, `conversation::runtime`, and `conversation::turn_engine`. Child admission, child execution seed construction, restored child contract lookup, and effective child tool-view decisions still depended on caller-local coordination instead of one private host-owned runtime owner.
- Why it matters:
  That duplication kept delegate runtime behavior harder to evolve safely and left the host runtime closer to call-site coordination than to one internal lifecycle authority.
- What changed:
  Added and expanded a private `app::operator::delegate_runtime` module, then routed delegate-child admission, child lifecycle seed construction, child session creation, restored child contract lookup, and effective child tool-view resolution through it. `turn_coordinator`, `runtime`, and `turn_engine` now rely on the same operator helper layer instead of reconstructing host rules independently.
- What did not change (scope boundary):
  This PR does not add a new public crate, a new public SDK, a child messaging plane, or any ACP/provider/channel redesign beyond the delegate runtime call sites.

## Linked Issues

- Closes #770
- Related #906

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This refactor moves more delegate-child lifecycle ownership into a private operator module. The main risk is changing inline or async child admission semantics, or creating drift between restored child contracts, child tool views, and newly created child sessions.
- Rollout / guardrails:
  Keep the change private to `crates/app/src/operator/`, route both inline and async delegate creation through the same helper, and keep regression coverage for legacy child restoration, child tool-view shaping, runtime narrowing inheritance, nested depth fail-closed behavior, and async spawn failure recovery.
- Rollback path:
  Revert commits `bc76845a43cf613af32de3853428c8f42c5bf1ca` and `3df87d3c0f3e34060e80ba796d82632b1fb467cf` to restore the previous caller-local delegate lifecycle logic.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features resolve_delegate_child_contract_falls_back_to_lineage_profile -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features resolve_delegate_child_contract_prefers_persisted_execution -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features build_delegate_child_lifecycle_seed_uses_mode_specific_state_and_event_kind -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features resolve_delegate_child_tool_view_respects_nested_depth_budget -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features create_delegate_child_session_centralizes_async_lifecycle_metadata -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features default_runtime_session_context_derives_subagent_profile_for_legacy_child_without_lifecycle_event -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features default_runtime_tool_view_denies_delegate_for_broken_lineage_child -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_after_queueing -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features handle_turn_with_runtime_kernel_delegate_async_spawn_failure_closes_lifecycle -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test -p loongclaw-app --all-features handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recovers -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-770-targeted cargo test --workspace --all-features --locked -- --test-threads=1

All commands completed successfully on commit 3df87d3c0f3e34060e80ba796d82632b1fb467cf.
```

## User-visible / Operator-visible Changes

- None intended. This is a private runtime seam hardening step behind existing delegate-child behavior.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR commits and return delegate-child lifecycle ownership to the previous caller-local logic.
- Observable failure symptoms reviewers should watch for:
  Inline delegate children starting in the wrong session state, async delegate children queuing with mismatched lifecycle payloads, or restored child tool-view/contract behavior drifting from newly created child sessions.

## Reviewer Focus

- Review `crates/app/src/operator/delegate_runtime.rs` for the new private owner boundary and the session creation/tool-view helpers.
- Review `crates/app/src/conversation/turn_coordinator.rs` for inline and async child creation routing changes.
- Review `crates/app/src/conversation/runtime.rs` and `crates/app/src/conversation/turn_engine.rs` for restored child contract/tool-view derivation using the operator helper.

Implementation note:
This PR is intentionally stacked on top of `#907` because it depends on the typed subagent contract surface introduced there. After `#907` lands, this PR should be retargeted to `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser companion version probe now fully async for improved responsiveness.

* **Refactor**
  * Consolidated delegate-child contract resolution into a shared runtime module.
  * Simplified delegate-child session creation and lifecycle handling across the app.

* **Tests**
  * Added isolated runtime environment support for integration tests to improve reliability.

* **Documentation**
  * Updated architecture drift report timestamp and hotspot metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->