### PR TITLE
refactor: centralize delegate recovery semantics

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -28,9 +28,7 @@ use crate::acp::{
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::operator::delegate_runtime::{
-    build_delegate_child_lifecycle_seed, next_delegate_child_depth,
-};
+use crate::operator::delegate_runtime::create_delegate_child_session;
 use crate::runtime_self_continuity;
 
 use super::super::config::LoongClawConfig;
@@ -135,7 +133,6 @@ use crate::session::repository::TransitionApprovalRequestIfCurrentRequest;
 use crate::session::repository::{
     ApprovalDecision, ApprovalRequestStatus, FinalizeSessionTerminalRequest, NewSessionEvent,
     NewSessionRecord, SessionKind, SessionRepository, SessionState,
-    TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -127,11 +127,8 @@ use super::turn_shared::{
 #[cfg(test)]
 use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
 use crate::config::ToolConsentMode;
-#[cfg(feature = "memory-sqlite")]
-use crate::session::recovery::{
-    RECOVERY_EVENT_KIND, build_async_spawn_failure_recovery_payload,
-    build_terminal_finalize_recovery_payload,
-};
+#[cfg(all(feature = "memory-sqlite", test))]
+use crate::session::recovery::RECOVERY_EVENT_KIND;
 #[cfg(all(test, feature = "memory-sqlite"))]
 use crate::session::repository::TransitionApprovalRequestIfCurrentRequest;
 #[cfg(feature = "memory-sqlite")]
@@ -4344,7 +4341,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
     }
 }
 
-#[cfg(feature = "memory-sqlite")]
+#[cfg(all(feature = "memory-sqlite", test))]
 fn finalize_async_delegate_spawn_failure(
     memory_config: &MemoryRuntimeConfig,
     child_session_id: &str,
@@ -4353,37 +4350,14 @@ fn finalize_async_delegate_spawn_failure(
     execution: &ConstrainedSubagentExecution,
     error: String,
 ) -> Result<(), String> {
-    let repo = SessionRepository::new(memory_config)?;
-    let subagent_contract = execution.contract_view();
-    let outcome = crate::tools::delegate::delegate_error_outcome(
-        child_session_id.to_owned(),
-        Some(parent_session_id.to_owned()),
-        label,
-        Some(&subagent_contract),
-        error.clone(),
-        0,
-    );
-    let request = FinalizeSessionTerminalRequest {
-        state: SessionState::Failed,
-        last_error: Some(error.clone()),
-        event_kind: "delegate_spawn_failed".to_owned(),
-        actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json: execution.terminal_payload(
-            ConstrainedSubagentTerminalReason::SpawnFailed,
-            0,
-            None,
-            Some(error.as_str()),
-        ),
-        outcome_status: outcome.status,
-        outcome_payload_json: outcome.payload,
-    };
-    finalize_terminal_if_current_allowing_stale_state(
-        &repo,
+    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure(
+        memory_config,
         child_session_id,
-        SessionState::Ready,
-        request,
-    )?;
-    Ok(())
+        parent_session_id,
+        label,
+        execution,
+        error,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4395,69 +4369,14 @@ fn finalize_async_delegate_spawn_failure_with_recovery(
     execution: &ConstrainedSubagentExecution,
     error: String,
 ) -> Result<(), String> {
-    let recovery_label = label.clone();
-    match finalize_async_delegate_spawn_failure(
+    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure_with_recovery(
         memory_config,
         child_session_id,
         parent_session_id,
         label,
         execution,
-        error.clone(),
-    ) {
-        Ok(()) => Ok(()),
-        Err(finalize_error) => {
-            let repo = SessionRepository::new(memory_config)?;
-            let recovery_error = format!(
-                "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
-            );
-            match repo.transition_session_with_event_if_current(
-                child_session_id,
-                TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: SessionState::Ready,
-                    next_state: SessionState::Failed,
-                    last_error: Some(recovery_error.clone()),
-                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: build_async_spawn_failure_recovery_payload(
-                        recovery_label.as_deref(),
-                        &error,
-                        &recovery_error,
-                    ),
-                },
-            ) {
-                Ok(Some(_)) => Ok(()),
-                Ok(None) => {
-                    let current_state = repo
-                        .load_session(child_session_id)?
-                        .map(|session| session.state.as_str().to_owned())
-                        .unwrap_or_else(|| "missing".to_owned());
-                    Err(format!(
-                        "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
-                    ))
-                }
-                Err(recovery_event_error) => match repo.update_session_state_if_current(
-                    child_session_id,
-                    SessionState::Ready,
-                    SessionState::Failed,
-                    Some(recovery_error.clone()),
-                ) {
-                    Ok(Some(_)) => Ok(()),
-                    Ok(None) => {
-                        let current_state = repo
-                            .load_session(child_session_id)?
-                            .map(|session| session.state.as_str().to_owned())
-                            .unwrap_or_else(|| "missing".to_owned());
-                        Err(format!(
-                            "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
-                        ))
-                    }
-                    Err(mark_error) => Err(format!(
-                        "{recovery_error}; delegate_async_spawn_recovery_failed: {mark_error}; delegate_async_spawn_recovery_event_failed: {recovery_event_error}"
-                    )),
-                },
-            }
-        }
-    }
+        error,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4593,89 +4512,11 @@ fn finalize_delegate_child_terminal_with_recovery(
     child_session_id: &str,
     request: FinalizeSessionTerminalRequest,
 ) -> Result<(), String> {
-    let recovery_request = request.clone();
-    match finalize_terminal_if_current_allowing_stale_state(
+    crate::operator::delegate_runtime::finalize_delegate_child_terminal_with_recovery(
         repo,
         child_session_id,
-        SessionState::Running,
         request,
-    ) {
-        Ok(()) => Ok(()),
-        Err(finalize_error) => {
-            let recovery_error = format!("delegate_terminal_finalize_failed: {finalize_error}");
-            match repo.transition_session_with_event_if_current(
-                child_session_id,
-                TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: SessionState::Running,
-                    next_state: SessionState::Failed,
-                    last_error: Some(recovery_error.clone()),
-                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
-                    actor_session_id: recovery_request.actor_session_id.clone(),
-                    event_payload_json: build_terminal_finalize_recovery_payload(
-                        &recovery_request,
-                        &recovery_error,
-                    ),
-                },
-            ) {
-                Ok(Some(_)) => Err(recovery_error),
-                Ok(None) => {
-                    delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
-                }
-                Err(recovery_event_error) => match repo.update_session_state_if_current(
-                    child_session_id,
-                    SessionState::Running,
-                    SessionState::Failed,
-                    Some(recovery_error.clone()),
-                ) {
-                    Ok(Some(_)) => Err(format!(
-                        "{recovery_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
-                    )),
-                    Ok(None) => delegate_terminal_recovery_skipped_error(
-                        repo,
-                        child_session_id,
-                        recovery_error,
-                    ),
-                    Err(mark_error) => Err(format!(
-                        "{recovery_error}; delegate_terminal_recovery_failed: {mark_error}"
-                    )),
-                },
-            }
-        }
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn finalize_terminal_if_current_allowing_stale_state(
-    repo: &SessionRepository,
-    session_id: &str,
-    expected_state: SessionState,
-    request: FinalizeSessionTerminalRequest,
-) -> Result<(), String> {
-    match repo.finalize_session_terminal_if_current(session_id, expected_state, request)? {
-        Some(_) => Ok(()),
-        None => {
-            if repo.load_session(session_id)?.is_some() {
-                Ok(())
-            } else {
-                Err(format!("session `{session_id}` not found"))
-            }
-        }
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn delegate_terminal_recovery_skipped_error(
-    repo: &SessionRepository,
-    child_session_id: &str,
-    recovery_error: String,
-) -> Result<(), String> {
-    let current_state = repo
-        .load_session(child_session_id)?
-        .map(|session| session.state.as_str().to_owned())
-        .unwrap_or_else(|| "missing".to_owned());
-    Err(format!(
-        "{recovery_error}; delegate_terminal_recovery_skipped_from_state: {current_state}"
-    ))
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -28,7 +28,9 @@ use crate::acp::{
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::operator::delegate_runtime::create_delegate_child_session;
+use crate::operator::delegate_runtime::{
+    build_delegate_child_lifecycle_seed, next_delegate_child_depth,
+};
 use crate::runtime_self_continuity;
 
 use super::super::config::LoongClawConfig;

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -3,11 +3,19 @@ use serde_json::Value;
 use crate::config::LoongClawConfig;
 use crate::conversation::{
     ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentIdentity,
-    ConstrainedSubagentMode, ConstrainedSubagentProfile, ConversationRuntimeBinding,
+    ConstrainedSubagentMode, ConstrainedSubagentProfile, ConstrainedSubagentTerminalReason,
+    ConversationRuntimeBinding,
 };
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity::RuntimeSelfContinuity;
+use crate::session::recovery::{
+    RECOVERY_EVENT_KIND, build_async_spawn_failure_recovery_payload,
+    build_terminal_finalize_recovery_payload,
+};
 use crate::session::repository::{
-    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    CreateSessionWithEventRequest, CreateSessionWithEventResult, FinalizeSessionTerminalRequest,
+    NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    TransitionSessionWithEventIfCurrentRequest,
 };
 use crate::trust::{
     delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
@@ -241,6 +249,233 @@ fn build_delegate_child_event_payload(
     }
 
     payload_with_trust
+}
+
+pub(crate) fn finalize_async_delegate_spawn_failure(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    execution: &ConstrainedSubagentExecution,
+    error: String,
+) -> Result<(), String> {
+    let repo = SessionRepository::new(memory_config)?;
+    let outcome = crate::tools::delegate::delegate_error_outcome(
+        child_session_id.to_owned(),
+        Some(parent_session_id.to_owned()),
+        label,
+        Some(&execution.contract_view()),
+        error.clone(),
+        0,
+    );
+    let request = FinalizeSessionTerminalRequest {
+        state: SessionState::Failed,
+        last_error: Some(error.clone()),
+        event_kind: "delegate_spawn_failed".to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json: execution.terminal_payload(
+            ConstrainedSubagentTerminalReason::SpawnFailed,
+            0,
+            None,
+            Some(error.as_str()),
+        ),
+        outcome_status: outcome.status,
+        outcome_payload_json: outcome.payload,
+    };
+    finalize_terminal_if_current_allowing_stale_state(
+        &repo,
+        child_session_id,
+        SessionState::Ready,
+        request,
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    execution: &ConstrainedSubagentExecution,
+    error: String,
+) -> Result<(), String> {
+    let recovery_label = label.clone();
+    let finalize_result = finalize_async_delegate_spawn_failure(
+        memory_config,
+        child_session_id,
+        parent_session_id,
+        label,
+        execution,
+        error.clone(),
+    );
+    match finalize_result {
+        Ok(()) => Ok(()),
+        Err(finalize_error) => {
+            let repo = SessionRepository::new(memory_config)?;
+            let recovery_error = format!(
+                "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
+            );
+            let transition_result = repo.transition_session_with_event_if_current(
+                child_session_id,
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Ready,
+                    next_state: SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: Some(parent_session_id.to_owned()),
+                    event_payload_json: build_async_spawn_failure_recovery_payload(
+                        recovery_label.as_deref(),
+                        &error,
+                        &recovery_error,
+                    ),
+                },
+            );
+            match transition_result {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => {
+                    let current_state = repo
+                        .load_session(child_session_id)?
+                        .map(|session| session.state.as_str().to_owned())
+                        .unwrap_or_else(|| "missing".to_owned());
+                    let message = format!(
+                        "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                    );
+                    Err(message)
+                }
+                Err(recovery_event_error) => {
+                    let state_result = repo.update_session_state_if_current(
+                        child_session_id,
+                        SessionState::Ready,
+                        SessionState::Failed,
+                        Some(recovery_error.clone()),
+                    );
+                    match state_result {
+                        Ok(Some(_)) => Ok(()),
+                        Ok(None) => {
+                            let current_state = repo
+                                .load_session(child_session_id)?
+                                .map(|session| session.state.as_str().to_owned())
+                                .unwrap_or_else(|| "missing".to_owned());
+                            let message = format!(
+                                "{recovery_error}; delegate_async_spawn_recovery_skipped_from_state: {current_state}"
+                            );
+                            Err(message)
+                        }
+                        Err(mark_error) => {
+                            let message = format!(
+                                "{recovery_error}; delegate_async_spawn_recovery_failed: {mark_error}; delegate_async_spawn_recovery_event_failed: {recovery_event_error}"
+                            );
+                            Err(message)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn finalize_delegate_child_terminal_with_recovery(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    request: FinalizeSessionTerminalRequest,
+) -> Result<(), String> {
+    let recovery_request = request.clone();
+    let finalize_result = finalize_terminal_if_current_allowing_stale_state(
+        repo,
+        child_session_id,
+        SessionState::Running,
+        request,
+    );
+    match finalize_result {
+        Ok(()) => Ok(()),
+        Err(finalize_error) => {
+            let recovery_error = format!("delegate_terminal_finalize_failed: {finalize_error}");
+            let transition_result = repo.transition_session_with_event_if_current(
+                child_session_id,
+                TransitionSessionWithEventIfCurrentRequest {
+                    expected_state: SessionState::Running,
+                    next_state: SessionState::Failed,
+                    last_error: Some(recovery_error.clone()),
+                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                    actor_session_id: recovery_request.actor_session_id.clone(),
+                    event_payload_json: build_terminal_finalize_recovery_payload(
+                        &recovery_request,
+                        &recovery_error,
+                    ),
+                },
+            );
+            match transition_result {
+                Ok(Some(_)) => Err(recovery_error),
+                Ok(None) => {
+                    delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
+                }
+                Err(recovery_event_error) => {
+                    let state_result = repo.update_session_state_if_current(
+                        child_session_id,
+                        SessionState::Running,
+                        SessionState::Failed,
+                        Some(recovery_error.clone()),
+                    );
+                    match state_result {
+                        Ok(Some(_)) => {
+                            let message = format!(
+                                "{recovery_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
+                            );
+                            Err(message)
+                        }
+                        Ok(None) => delegate_terminal_recovery_skipped_error(
+                            repo,
+                            child_session_id,
+                            recovery_error,
+                        ),
+                        Err(mark_error) => {
+                            let message = format!(
+                                "{recovery_error}; delegate_terminal_recovery_failed: {mark_error}"
+                            );
+                            Err(message)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn finalize_terminal_if_current_allowing_stale_state(
+    repo: &SessionRepository,
+    session_id: &str,
+    expected_state: SessionState,
+    request: FinalizeSessionTerminalRequest,
+) -> Result<(), String> {
+    let finalize_result =
+        repo.finalize_session_terminal_if_current(session_id, expected_state, request)?;
+    match finalize_result {
+        Some(_) => Ok(()),
+        None => {
+            let session = repo.load_session(session_id)?;
+            if session.is_some() {
+                return Ok(());
+            }
+
+            let message = format!("session `{session_id}` not found");
+            Err(message)
+        }
+    }
+}
+
+fn delegate_terminal_recovery_skipped_error(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    recovery_error: String,
+) -> Result<(), String> {
+    let current_state = repo
+        .load_session(child_session_id)?
+        .map(|session| session.state.as_str().to_owned())
+        .unwrap_or_else(|| "missing".to_owned());
+    let message =
+        format!("{recovery_error}; delegate_terminal_recovery_skipped_from_state: {current_state}");
+    Err(message)
 }
 
 #[cfg(test)]

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -20,6 +20,9 @@ use crate::session::repository::{
 use crate::trust::{
     delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
 };
+use crate::trust::{
+    delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
+};
 
 use super::session_graph::OperatorSessionGraph;
 
@@ -165,6 +168,135 @@ fn build_delegate_child_execution(
         identity,
         profile: Some(profile),
     }
+}
+
+fn build_delegate_child_request(
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    mode: ConstrainedSubagentMode,
+) -> CreateSessionWithEventRequest {
+    let session_state = delegate_child_session_state(mode);
+    let event_kind = delegate_child_event_kind(mode);
+    let source_surface = delegate_child_source_surface(mode);
+    let event_payload_json = build_delegate_child_event_payload(
+        parent_session_id,
+        child_session_id,
+        task,
+        child_label.as_deref(),
+        runtime_self_continuity,
+        execution,
+        source_surface,
+    );
+    let session = NewSessionRecord {
+        session_id: child_session_id.to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: child_label,
+        state: session_state,
+    };
+
+    CreateSessionWithEventRequest {
+        session,
+        event_kind: event_kind.to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json,
+    }
+}
+
+fn delegate_child_session_state(mode: ConstrainedSubagentMode) -> SessionState {
+    match mode {
+        ConstrainedSubagentMode::Inline => SessionState::Running,
+        ConstrainedSubagentMode::Async => SessionState::Ready,
+    }
+}
+
+fn delegate_child_event_kind(mode: ConstrainedSubagentMode) -> &'static str {
+    match mode {
+        ConstrainedSubagentMode::Inline => "delegate_started",
+        ConstrainedSubagentMode::Async => "delegate_queued",
+    }
+}
+
+fn delegate_child_source_surface(mode: ConstrainedSubagentMode) -> &'static str {
+    match mode {
+        ConstrainedSubagentMode::Inline => "delegate.inline",
+        ConstrainedSubagentMode::Async => "delegate.async",
+    }
+}
+
+fn build_delegate_child_event_payload(
+    parent_session_id: &str,
+    child_session_id: &str,
+    task: &str,
+    child_label: Option<&str>,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    source_surface: &str,
+) -> Value {
+    let trust_event =
+        delegate_child_trust_event(parent_session_id, child_session_id, source_surface);
+    let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
+        task,
+        child_label,
+        runtime_self_continuity,
+    );
+    let payload_with_trust =
+        embed_trust_event_payload(event_payload_json.clone(), trust_event.clone());
+    let extracted_trust_event = extract_trust_event_payload(&payload_with_trust);
+    if extracted_trust_event.as_ref() != Some(&trust_event) {
+        return event_payload_json;
+    }
+
+    payload_with_trust
+}
+
+pub(crate) fn create_delegate_child_session(
+    repo: &SessionRepository,
+    config: &LoongClawConfig,
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    child_identity: Option<ConstrainedSubagentIdentity>,
+    task: &str,
+    mode: ConstrainedSubagentMode,
+    timeout_seconds: u64,
+    binding: ConversationRuntimeBinding<'_>,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+) -> Result<(CreateSessionWithEventResult, ConstrainedSubagentExecution), String> {
+    let next_child_depth =
+        next_delegate_child_depth(repo, parent_session_id, config.tools.delegate.max_depth)?;
+    let max_active_children = config.tools.delegate.max_active_children;
+    let child_session_id = child_session_id.to_owned();
+    let parent_session_id = parent_session_id.to_owned();
+    let task = task.to_owned();
+
+    repo.create_delegate_child_session_with_event_if_within_limit(
+        &parent_session_id,
+        max_active_children,
+        |active_children| {
+            let child_label = child_label.clone();
+            let child_identity = child_identity.clone();
+            let seed = build_delegate_child_lifecycle_seed(
+                config,
+                binding,
+                mode,
+                timeout_seconds,
+                next_child_depth,
+                active_children,
+                &parent_session_id,
+                &child_session_id,
+                child_label,
+                &task,
+                runtime_self_continuity,
+                child_identity,
+            );
+            Ok((seed.request, seed.execution))
+        },
+    )
 }
 
 fn build_delegate_child_request(

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -13,12 +13,8 @@ use crate::session::recovery::{
     build_terminal_finalize_recovery_payload,
 };
 use crate::session::repository::{
-    CreateSessionWithEventRequest, CreateSessionWithEventResult, FinalizeSessionTerminalRequest,
-    NewSessionRecord, SessionKind, SessionRepository, SessionState,
-    TransitionSessionWithEventIfCurrentRequest,
-};
-use crate::trust::{
-    delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
+    CreateSessionWithEventRequest, FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind,
+    SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
 };
 use crate::trust::{
     delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
@@ -168,135 +164,6 @@ fn build_delegate_child_execution(
         identity,
         profile: Some(profile),
     }
-}
-
-fn build_delegate_child_request(
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_label: Option<String>,
-    task: &str,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-    mode: ConstrainedSubagentMode,
-) -> CreateSessionWithEventRequest {
-    let session_state = delegate_child_session_state(mode);
-    let event_kind = delegate_child_event_kind(mode);
-    let source_surface = delegate_child_source_surface(mode);
-    let event_payload_json = build_delegate_child_event_payload(
-        parent_session_id,
-        child_session_id,
-        task,
-        child_label.as_deref(),
-        runtime_self_continuity,
-        execution,
-        source_surface,
-    );
-    let session = NewSessionRecord {
-        session_id: child_session_id.to_owned(),
-        kind: SessionKind::DelegateChild,
-        parent_session_id: Some(parent_session_id.to_owned()),
-        label: child_label,
-        state: session_state,
-    };
-
-    CreateSessionWithEventRequest {
-        session,
-        event_kind: event_kind.to_owned(),
-        actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json,
-    }
-}
-
-fn delegate_child_session_state(mode: ConstrainedSubagentMode) -> SessionState {
-    match mode {
-        ConstrainedSubagentMode::Inline => SessionState::Running,
-        ConstrainedSubagentMode::Async => SessionState::Ready,
-    }
-}
-
-fn delegate_child_event_kind(mode: ConstrainedSubagentMode) -> &'static str {
-    match mode {
-        ConstrainedSubagentMode::Inline => "delegate_started",
-        ConstrainedSubagentMode::Async => "delegate_queued",
-    }
-}
-
-fn delegate_child_source_surface(mode: ConstrainedSubagentMode) -> &'static str {
-    match mode {
-        ConstrainedSubagentMode::Inline => "delegate.inline",
-        ConstrainedSubagentMode::Async => "delegate.async",
-    }
-}
-
-fn build_delegate_child_event_payload(
-    parent_session_id: &str,
-    child_session_id: &str,
-    task: &str,
-    child_label: Option<&str>,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-    execution: &ConstrainedSubagentExecution,
-    source_surface: &str,
-) -> Value {
-    let trust_event =
-        delegate_child_trust_event(parent_session_id, child_session_id, source_surface);
-    let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
-        task,
-        child_label,
-        runtime_self_continuity,
-    );
-    let payload_with_trust =
-        embed_trust_event_payload(event_payload_json.clone(), trust_event.clone());
-    let extracted_trust_event = extract_trust_event_payload(&payload_with_trust);
-    if extracted_trust_event.as_ref() != Some(&trust_event) {
-        return event_payload_json;
-    }
-
-    payload_with_trust
-}
-
-pub(crate) fn create_delegate_child_session(
-    repo: &SessionRepository,
-    config: &LoongClawConfig,
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_label: Option<String>,
-    child_identity: Option<ConstrainedSubagentIdentity>,
-    task: &str,
-    mode: ConstrainedSubagentMode,
-    timeout_seconds: u64,
-    binding: ConversationRuntimeBinding<'_>,
-    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
-) -> Result<(CreateSessionWithEventResult, ConstrainedSubagentExecution), String> {
-    let next_child_depth =
-        next_delegate_child_depth(repo, parent_session_id, config.tools.delegate.max_depth)?;
-    let max_active_children = config.tools.delegate.max_active_children;
-    let child_session_id = child_session_id.to_owned();
-    let parent_session_id = parent_session_id.to_owned();
-    let task = task.to_owned();
-
-    repo.create_delegate_child_session_with_event_if_within_limit(
-        &parent_session_id,
-        max_active_children,
-        |active_children| {
-            let child_label = child_label.clone();
-            let child_identity = child_identity.clone();
-            let seed = build_delegate_child_lifecycle_seed(
-                config,
-                binding,
-                mode,
-                timeout_seconds,
-                next_child_depth,
-                active_children,
-                &parent_session_id,
-                &child_session_id,
-                child_label,
-                &task,
-                runtime_self_continuity,
-                child_identity,
-            );
-            Ok((seed.request, seed.execution))
-        },
-    )
 }
 
 fn build_delegate_child_request(

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -12,10 +12,6 @@ impl<'a> OperatorSessionGraph<'a> {
         Self { repo }
     }
 
-    pub(crate) fn lineage_depth(&self, session_id: &str) -> Result<usize, String> {
-        self.repo.session_lineage_depth(session_id)
-    }
-
     pub(crate) fn lineage_root_session_id(
         &self,
         session_id: &str,
@@ -54,24 +50,6 @@ impl<'a> OperatorSessionGraph<'a> {
         }
 
         Ok(parent_session_id.to_owned())
-    }
-
-    pub(crate) fn next_delegate_child_depth(
-        &self,
-        session_id: &str,
-        max_depth: usize,
-    ) -> Result<usize, String> {
-        let current_depth = self.lineage_depth(session_id)?;
-        let next_child_depth = current_depth.saturating_add(1);
-
-        if next_child_depth > max_depth {
-            let error = format!(
-                "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {max_depth}"
-            );
-            return Err(error);
-        }
-
-        Ok(next_child_depth)
     }
 }
 
@@ -158,54 +136,6 @@ mod tests {
             .expect("compute lineage root");
 
         assert_eq!(lineage_root_session_id.as_deref(), Some("root-session"));
-    }
-
-    #[test]
-    fn operator_session_graph_computes_next_delegate_child_depth() {
-        let memory_config = isolated_memory_config("next-child-depth");
-        let repo = SessionRepository::new(&memory_config).expect("create session repository");
-
-        seed_session(&repo, "root-session", SessionKind::Root, None);
-        seed_session(
-            &repo,
-            "child-session",
-            SessionKind::DelegateChild,
-            Some("root-session"),
-        );
-
-        let session_graph = OperatorSessionGraph::new(&repo);
-        let root_child_depth = session_graph
-            .next_delegate_child_depth("root-session", 3)
-            .expect("compute root child depth");
-        let nested_child_depth = session_graph
-            .next_delegate_child_depth("child-session", 3)
-            .expect("compute nested child depth");
-
-        assert_eq!(root_child_depth, 1);
-        assert_eq!(nested_child_depth, 2);
-    }
-
-    #[test]
-    fn operator_session_graph_rejects_delegate_child_depth_over_limit() {
-        let memory_config = isolated_memory_config("depth-limit");
-        let repo = SessionRepository::new(&memory_config).expect("create session repository");
-
-        seed_session(&repo, "root-session", SessionKind::Root, None);
-        seed_session(
-            &repo,
-            "child-session",
-            SessionKind::DelegateChild,
-            Some("root-session"),
-        );
-
-        let session_graph = OperatorSessionGraph::new(&repo);
-        let result = session_graph.next_delegate_child_depth("child-session", 1);
-        let error = result.expect_err("depth overflow should fail");
-
-        assert!(
-            error.contains("delegate_depth_exceeded"),
-            "unexpected error: {error}"
-        );
     }
 
     #[test]

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -12,6 +12,10 @@ impl<'a> OperatorSessionGraph<'a> {
         Self { repo }
     }
 
+    pub(crate) fn lineage_depth(&self, session_id: &str) -> Result<usize, String> {
+        self.repo.session_lineage_depth(session_id)
+    }
+
     pub(crate) fn lineage_root_session_id(
         &self,
         session_id: &str,
@@ -50,6 +54,24 @@ impl<'a> OperatorSessionGraph<'a> {
         }
 
         Ok(parent_session_id.to_owned())
+    }
+
+    pub(crate) fn next_delegate_child_depth(
+        &self,
+        session_id: &str,
+        max_depth: usize,
+    ) -> Result<usize, String> {
+        let current_depth = self.lineage_depth(session_id)?;
+        let next_child_depth = current_depth.saturating_add(1);
+
+        if next_child_depth > max_depth {
+            let error = format!(
+                "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {max_depth}"
+            );
+            return Err(error);
+        }
+
+        Ok(next_child_depth)
     }
 }
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T10:02:41Z
+- Generated at: 2026-04-06T10:23:34Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10798 | 11200 | 402 | 96 | 120 | 24 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10638 | 11200 | 562 | 94 | 120 | 26 | 95.0% | WATCH | 10831 | -1.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6464 | 6500 | 36 | 205 | 210 | 5 | 99.4% | TIGHT | 6324 | 2.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (99.0%), daemon_lib (99.4%), onboard_cli (99.2%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.0%), daemon_lib (99.4%), onboard_cli (99.2%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%), turn_coordinator (95.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10798 functions=96 -->
+<!-- arch-hotspot key=turn_coordinator lines=10638 functions=94 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6464 functions=205 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->


### PR DESCRIPTION
## Summary

- Problem:
  `#770` centralized delegate-child admission, seed construction, and child contract/tool-view resolution, but terminal finalize fallback and async spawn failure recovery still lived as caller-local logic in `conversation::turn_coordinator`.
- Why it matters:
  That left delegate lifecycle ownership split exactly at the failure boundary. Async spawn failure, stale-state finalize fallback, and detached async cleanup still depended on local recovery logic instead of the private operator runtime owner.
- What changed:
  Extended `app::operator::delegate_runtime` to own delegate async spawn failure finalize/recovery semantics and delegate terminal finalize fallback semantics. `turn_coordinator` now routes those failure and stale-state paths through operator helpers instead of reconstructing them locally.
- What did not change (scope boundary):
  This PR does not add a new public crate, a new public SDK, a child messaging plane, or a session repository storage redesign.

## Linked Issues

- Closes #921
- Related #770

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This refactor moves more delegate lifecycle failure handling into the private operator module. The main risk is changing async spawn failure fallback or stale-state terminal finalize behavior in ways that diverge from existing recovery expectations.
- Rollout / guardrails:
  Keep the change private to `crates/app/src/operator/`, preserve the existing repository-facing recovery behavior, and keep regression coverage for spawn failure, missing child sessions, recovered stale states, and operator-triggered async cleanup paths.
- Rollback path:
  Revert commit `5eb0728447e7ee77e22ce766820f5e0969e317de` to restore the previous caller-local recovery logic.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo test -p loongclaw-app --all-features finalize_delegate_child_terminal_with_recovery_does_not_overwrite_recovered_failure -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo test -p loongclaw-app --all-features finalize_async_delegate_spawn_failure_with_recovery_errors_when_child_session_missing -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo test -p loongclaw-app --all-features handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recovers -- --test-threads=1
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo test --workspace --locked
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-921-targeted cargo test --workspace --all-features --locked -- --test-threads=1

All commands completed successfully on commit 5eb0728447e7ee77e22ce766820f5e0969e317de.
```

## User-visible / Operator-visible Changes

- None intended. This is a private runtime seam hardening step behind existing delegate-child behavior.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR commit and return delegate recovery ownership to the previous caller-local helpers.
- Observable failure symptoms reviewers should watch for:
  Async delegate spawn failures missing `delegate_spawn_failed` or recovery events, stale completed/failed child sessions getting overwritten, or missing-child recovery paths returning the wrong terminal error.

## Reviewer Focus

- Review `crates/app/src/operator/delegate_runtime.rs` for the new finalize/recovery owner boundary.
- Review `crates/app/src/conversation/turn_coordinator.rs` for the remaining thin wrappers and operator routing.
- Review the existing recovery tests in `crates/app/src/conversation/turn_coordinator.rs` to confirm behavior stayed stable while ownership moved.

Implementation note:
This PR is intentionally stacked on top of `#918`, which is itself stacked on `#907`. After the lower stacked PRs land, this PR should be retargeted to `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated delegate session error handling by centralizing finalization and recovery utilities. Improved organization of spawn failure handling and terminal state management logic across session operations.

* **Tests**
  * Removed test cases validating delegate session depth constraints and calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->