### PR TITLE
fix: saturate browser companion probe timeout helper

### DIFF
--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -23,6 +23,9 @@ fn browser_companion_probe_timeout_seconds(timeout_seconds: u64) -> u64 {
 
 fn browser_companion_probe_timeout_duration(timeout_seconds: u64) -> Duration {
     let normalized_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
+    if normalized_seconds == u64::MAX {
+        return Duration::MAX;
+    }
     let base_duration = Duration::from_secs(normalized_seconds);
     let slack_millis = normalized_seconds.saturating_mul(100);
     let bounded_slack_millis = slack_millis.min(500);


### PR DESCRIPTION
## Summary

- fix the browser companion timeout helper so the saturation case returns `Duration::MAX`
- keep the existing bounded slack behavior for ordinary timeout values
- restore the daemon CI unit test that failed after `#907` landed

## Linked Issues

- Closes #925

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p loongclaw --all-features --lib browser_companion_probe_timeout_duration_saturates -- --nocapture`
- `cargo test -p loongclaw --lib browser_companion_probe_timeout_duration_saturates -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of timeout duration handling to prevent potential issues when timeout values reach maximum thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->