### PR TITLE
test: isolate remaining onboarding shortcut sqlite bootstrap paths

### DIFF
--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -339,6 +339,55 @@ fn observed_version_matches_expected(observed_version: &str, expected_version: &
 }
 
 #[cfg(test)]
+pub(crate) fn fake_browser_companion_version_command(version: &str) -> String {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_FAKE_COMMAND_SEED: AtomicU64 = AtomicU64::new(1);
+
+    let seed = NEXT_FAKE_COMMAND_SEED.fetch_add(1, Ordering::Relaxed);
+    let temp_dir = std::env::temp_dir().join(format!(
+        "loongclaw-browser-companion-fake-{}-{seed}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create fake browser companion temp dir");
+
+    if cfg!(windows) {
+        let script_path = temp_dir.join("browser-companion.cmd");
+        let mut file =
+            std::fs::File::create(&script_path).expect("create fake browser companion cmd");
+        writeln!(file, "@echo off").expect("write fake browser companion cmd header");
+        writeln!(file, "echo loongclaw-browser-companion {version}")
+            .expect("write fake browser companion cmd body");
+        file.sync_all().expect("sync fake browser companion cmd");
+        script_path.display().to_string()
+    } else {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let script_path = temp_dir.join("browser-companion");
+            let mut file =
+                std::fs::File::create(&script_path).expect("create fake browser companion script");
+            writeln!(file, "#!/bin/sh").expect("write fake browser companion shebang");
+            writeln!(file, "echo 'loongclaw-browser-companion {version}'")
+                .expect("write fake browser companion body");
+            file.sync_all().expect("sync fake browser companion script");
+            let mut permissions = std::fs::metadata(&script_path)
+                .expect("fake browser companion metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script_path, permissions)
+                .expect("chmod fake browser companion script");
+            return script_path.display().to_string();
+        }
+
+        #[allow(unreachable_code)]
+        temp_dir.join("browser-companion").display().to_string()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     #[cfg(unix)]

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -6282,6 +6282,7 @@ fn detected_setup_write_confirmation_screen_uses_quick_review_progress_copy() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_current_setup_shortcut_flow_skips_detailed_edit_screens() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let workspace_root = unique_temp_path("current-shortcut-workspace");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
     std::fs::write(workspace_root.join("AGENTS.md"), "# local guidance\n")
@@ -6363,6 +6364,7 @@ async fn onboard_current_setup_shortcut_flow_skips_detailed_edit_screens() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_current_setup_shortcut_can_install_selected_bundled_skills() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let output_path = unique_temp_path("current-shortcut-preinstall-config.toml");
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.model = "gpt-4.1".to_owned();
@@ -6432,6 +6434,7 @@ async fn onboard_current_setup_shortcut_can_install_selected_bundled_skills() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_current_setup_shortcut_can_install_minimax_office_pack() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let output_path = unique_temp_path("current-shortcut-minimax-office-config.toml");
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.model = "gpt-4.1".to_owned();
@@ -6487,6 +6490,7 @@ async fn onboard_current_setup_shortcut_can_install_minimax_office_pack() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_detected_setup_shortcut_flow_skips_detailed_edit_screens() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let workspace_root = unique_temp_path("detected-shortcut-workspace");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
     std::fs::write(workspace_root.join("AGENTS.md"), "# local guidance\n")

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:22:24Z
+- Generated at: 2026-04-05T15:55:50Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14810 | 15000 | 190 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6408 | 6500 | 92 | 205 | 210 | 5 | 98.6% | TIGHT | 6324 | 1.3% | PASS | 210 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14858 | 15000 | 142 | 54 | 70 | 16 | 99.1% | TIGHT | 14472 | 2.7% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6442 | 6500 | 58 | 206 | 210 | 4 | 99.1% | TIGHT | 6324 | 1.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.0%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (98.6%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.0%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.1%), daemon_lib (99.1%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,8 +69,8 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14810 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6408 functions=205 -->
+<!-- arch-hotspot key=tools_mod lines=14858 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=6442 functions=206 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- isolate the remaining onboarding shortcut integration flows from the host runtime sqlite path
- keep the existing detected-environment guard active for those shortcut tests so sqlite bootstrap always uses a temp test home
- close the post-merge CI regression tracked in `#929`

## Why

The merged control-plane work exposed a latent daemon integration-test leak: several onboarding shortcut tests still bootstrapped sqlite memory through the process default runtime path instead of a per-test isolated path. That let them pick up host-local sqlite state and fail with malformed-db errors.

## Validation

- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration integration::onboard_cli::non_interactive_personality_and_memory_profile_are_persisted`
- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration integration::onboard_cli::onboard_current_setup_shortcut_can_install_minimax_office_pack`
- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration onboard_current_setup_shortcut`
- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration integration::onboard_cli::onboard_detected_setup_shortcut_flow_skips_detailed_edit_screens`
- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration integration::import_cli::import_cli_apply_recommended_import_retains_multiple_same_kind_provider_profiles`
- `env CARGO_TARGET_DIR=/tmp/loongclaw-dev-fix-check cargo test --test integration integration::import_cli::import_cli_apply_supplements_existing_provider_profiles_without_replacing_active_provider`

Closes #929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved isolation in several integration tests to suppress ambient detected-environment state during execution.
  * Added a test helper to simulate the browser companion tool/version for diagnostics tests.
* **Documentation**
  * Updated architecture drift report: refreshed timestamp and adjusted hotspot metrics and classifications to reflect recent measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->