### PR TITLE
fix: restore dev baseline runtime narrowing and canonical repairs

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2146,8 +2146,7 @@ exit 0
 
             let inner = &trimmed[1..trimmed.len() - 1];
             let unescaped_backslashes = inner.replace("\\\\", "\\");
-            let unescaped_quotes = unescaped_backslashes.replace("\\\"", "\"");
-            unescaped_quotes
+            unescaped_backslashes.replace("\\\"", "\"")
         }
 
         let server = AcpxMcpServerEntry {

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2137,6 +2137,19 @@ exit 0
 
     #[test]
     fn build_mcp_proxy_agent_command_preserves_server_cwd() {
+        fn decode_quoted_command_part(value: &str) -> String {
+            let trimmed = value.trim();
+            let quoted = trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2;
+            if !quoted {
+                return trimmed.to_owned();
+            }
+
+            let inner = &trimmed[1..trimmed.len() - 1];
+            let unescaped_backslashes = inner.replace("\\\\", "\\");
+            let unescaped_quotes = unescaped_backslashes.replace("\\\"", "\"");
+            unescaped_quotes
+        }
+
         let server = AcpxMcpServerEntry {
             name: "docs".to_owned(),
             command: "uvx".to_owned(),
@@ -2153,6 +2166,7 @@ exit 0
         let payload_marker = "--payload-file ";
         let payload_index = command.find(payload_marker).expect("payload marker");
         let payload_path = &command[payload_index + payload_marker.len()..];
+        let payload_path = decode_quoted_command_part(payload_path);
         let payload_bytes = std::fs::read(payload_path).expect("read payload file");
         let payload: Value = serde_json::from_slice(&payload_bytes).expect("parse payload");
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -90,6 +90,7 @@ impl SessionContext {
     #[must_use]
     pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
         if !runtime_narrowing.is_empty() {
+            self.runtime_narrowing = Some(runtime_narrowing.clone());
             if let Some(subagent_execution) = self.subagent_execution.as_mut() {
                 subagent_execution.runtime_narrowing = runtime_narrowing.clone();
             }
@@ -104,17 +105,36 @@ impl SessionContext {
         mut self,
         subagent_execution: ConstrainedSubagentExecution,
     ) -> Self {
+        let existing_contract = self.subagent_contract.take();
         let mut subagent_execution = subagent_execution.with_resolved_profile();
         if subagent_execution.identity.is_none()
-            && let Some(identity) = self
-                .subagent_contract
+            && let Some(identity) = existing_contract
                 .as_ref()
                 .and_then(ConstrainedSubagentContractView::resolved_identity)
                 .cloned()
         {
             subagent_execution.identity = Some(identity);
         }
-        self.subagent_contract = Some(subagent_execution.contract_view());
+        let mut merged_contract = subagent_execution.contract_view();
+        if let Some(existing_contract) = existing_contract {
+            if merged_contract.profile.is_none()
+                && let Some(profile) = existing_contract.profile
+            {
+                merged_contract = merged_contract.with_profile(profile);
+            }
+            if merged_contract.identity.is_none()
+                && let Some(identity) = existing_contract.identity
+            {
+                merged_contract = merged_contract.with_identity(identity);
+            }
+            if merged_contract.runtime_narrowing.is_empty()
+                && !existing_contract.runtime_narrowing.is_empty()
+            {
+                let runtime_narrowing = existing_contract.runtime_narrowing;
+                merged_contract = merged_contract.with_runtime_narrowing(runtime_narrowing);
+            }
+        }
+        self.subagent_contract = Some(merged_contract);
         self.subagent_execution = Some(subagent_execution);
         self
     }
@@ -1156,9 +1176,6 @@ where
                     }
                     None => SessionContext::root_with_tool_view(snapshot.session_id, tool_view),
                 };
-                if let Some(runtime_narrowing) = runtime_narrowing {
-                    session_context = session_context.with_runtime_narrowing(runtime_narrowing);
-                }
                 if snapshot.is_delegate_child {
                     if let Some(label) = snapshot.label {
                         session_context =
@@ -1177,6 +1194,9 @@ where
                     )? {
                         session_context = session_context.with_subagent_profile(subagent_profile);
                     }
+                }
+                if let Some(runtime_narrowing) = runtime_narrowing {
+                    session_context = session_context.with_runtime_narrowing(runtime_narrowing);
                 }
                 if let Some(runtime_self_continuity) = snapshot.runtime_self_continuity {
                     session_context =
@@ -1469,6 +1489,7 @@ fn delegate_child_runtime_contract_prompt_summary(
     session_context: &SessionContext,
 ) -> Option<String> {
     session_context.parent_session_id.as_ref()?;
+    session_context.subagent_runtime_narrowing()?;
     let subagent_contract = session_context.resolved_subagent_contract();
     crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None)
         .delegate_child_prompt_summary(subagent_contract.as_ref())

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -131,6 +131,8 @@ impl SessionContext {
                 && !existing_contract.runtime_narrowing.is_empty()
             {
                 let runtime_narrowing = existing_contract.runtime_narrowing;
+                subagent_execution.runtime_narrowing = runtime_narrowing.clone();
+                self.runtime_narrowing = Some(runtime_narrowing.clone());
                 merged_contract = merged_contract.with_runtime_narrowing(runtime_narrowing);
             }
         }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -17898,7 +17898,7 @@ async fn handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_k
         .execute_turn_in_context(
             &turn,
             &session_context,
-            &DefaultAppToolDispatcher::runtime(),
+            &DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone()),
             ConversationRuntimeBinding::kernel(&kernel_ctx),
             None,
         )

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2868,6 +2868,49 @@ fn session_context_keeps_execution_and_contract_in_sync_when_child_contract_is_o
     );
 }
 
+#[test]
+fn session_context_with_subagent_execution_preserves_prior_runtime_narrowing() {
+    let execution = crate::conversation::ConstrainedSubagentExecution {
+        mode: crate::conversation::ConstrainedSubagentMode::Inline,
+        depth: 1,
+        max_depth: 3,
+        active_children: 0,
+        max_active_children: 2,
+        timeout_seconds: 60,
+        allow_shell_in_child: false,
+        child_tool_allowlist: vec!["web.fetch".to_owned()],
+        runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
+        kernel_bound: false,
+        identity: None,
+        profile: None,
+    };
+    let runtime_narrowing = crate::tools::runtime_config::ToolRuntimeNarrowing {
+        web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+            allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&crate::config::ToolConfig::default()),
+    )
+    .with_runtime_narrowing(runtime_narrowing.clone())
+    .with_subagent_execution(execution);
+
+    let execution_runtime_narrowing = session_context
+        .subagent_execution
+        .as_ref()
+        .map(|execution| execution.runtime_narrowing.clone());
+    let session_runtime_narrowing = session_context.runtime_narrowing.clone();
+    let effective_runtime_narrowing = session_context.subagent_runtime_narrowing().cloned();
+
+    assert_eq!(execution_runtime_narrowing, Some(runtime_narrowing.clone()));
+    assert_eq!(session_runtime_narrowing, Some(runtime_narrowing.clone()));
+    assert_eq!(effective_runtime_narrowing, Some(runtime_narrowing));
+}
+
 #[tokio::test]
 async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -379,6 +379,12 @@ fn build_builtin_retrieval_request(
 
     let query = retrieval_query_from_recent_window(recent_window);
 
+    let budget_items = if recent_window.is_empty() {
+        6
+    } else {
+        config.sliding_window.min(6)
+    };
+
     Some(MemoryRetrievalRequest {
         session_id: session_id.to_owned(),
         query,
@@ -388,7 +394,7 @@ fn build_builtin_retrieval_request(
             MemoryScope::Agent,
             MemoryScope::User,
         ],
-        budget_items: config.sliding_window.min(6),
+        budget_items,
         allowed_kinds: vec![
             DerivedMemoryKind::Profile,
             DerivedMemoryKind::Fact,

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -2007,9 +2007,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
     )
     .map_err(|error| format!("ensure canonical memory storage failed: {error}"))?;
 
-    let canonical_fts_recreated = canonical_record_fts_needs_rebuild(conn)?;
-    if canonical_fts_recreated {
-        recreate_canonical_record_fts_index(conn)?;
+    let needs_canonical_fts_rebuild = canonical_record_fts_needs_rebuild(conn)?;
+    if needs_canonical_fts_rebuild {
         rebuild_canonical_record_storage(conn)?;
         return Ok(());
     }
@@ -2040,13 +2039,6 @@ fn canonical_record_fts_needs_rebuild(conn: &Connection) -> Result<bool, String>
     });
 
     Ok(!has_all_required_columns)
-}
-
-fn recreate_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
-    drop_canonical_record_fts_index(conn)?;
-    create_canonical_record_fts_index(conn)?;
-    rebuild_canonical_record_fts_index_contents(conn)?;
-    Ok(())
 }
 
 fn drop_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -827,6 +827,21 @@ pub(super) fn ensure_memory_db_ready_with_diagnostics(
 ) -> Result<(PathBuf, SqliteBootstrapDiagnostics), String> {
     let effective = path.unwrap_or_else(|| resolve_db_path(config));
     let (runtime, diagnostics) = acquire_sqlite_runtime_with_diagnostics(effective)?;
+    runtime.with_connection_mut("memory.ensure_db_ready", |conn| {
+        let user_version = read_sqlite_user_version(conn)?;
+        let current_schema_ready = user_version == SQLITE_MEMORY_SCHEMA_VERSION
+            && sqlite_current_schema_objects_ready(conn)?;
+        ensure_turn_session_index_and_state_metadata(conn)?;
+        ensure_approval_lifecycle_tables(conn)?;
+        ensure_session_tool_consent_storage(conn)?;
+        ensure_session_tool_policy_storage(conn)?;
+        ensure_summary_checkpoint_storage_layout(conn)?;
+        ensure_canonical_record_storage(conn)?;
+        if user_version < SQLITE_MEMORY_SCHEMA_VERSION || !current_schema_ready {
+            write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
+        }
+        Ok(())
+    })?;
     Ok((runtime.path().to_path_buf(), diagnostics))
 }
 
@@ -1992,8 +2007,11 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
     )
     .map_err(|error| format!("ensure canonical memory storage failed: {error}"))?;
 
-    if canonical_record_fts_needs_rebuild(conn)? {
+    let canonical_fts_recreated = canonical_record_fts_needs_rebuild(conn)?;
+    if canonical_fts_recreated {
         recreate_canonical_record_fts_index(conn)?;
+        rebuild_canonical_record_storage(conn)?;
+        return Ok(());
     }
 
     rebuild_canonical_record_storage_if_needed(conn)?;
@@ -2025,12 +2043,29 @@ fn canonical_record_fts_needs_rebuild(conn: &Connection) -> Result<bool, String>
 }
 
 fn recreate_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
+    drop_canonical_record_fts_index(conn)?;
+    create_canonical_record_fts_index(conn)?;
+    rebuild_canonical_record_fts_index_contents(conn)?;
+    Ok(())
+}
+
+fn drop_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
     conn.execute_batch(
         "
         DROP TRIGGER IF EXISTS memory_canonical_records_ai;
         DROP TRIGGER IF EXISTS memory_canonical_records_ad;
         DROP TRIGGER IF EXISTS memory_canonical_records_au;
         DROP TABLE IF EXISTS memory_canonical_records_fts;
+        ",
+    )
+    .map_err(|error| format!("drop canonical memory FTS index failed: {error}"))?;
+
+    Ok(())
+}
+
+fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
         CREATE VIRTUAL TABLE memory_canonical_records_fts
           USING fts5(
             content,
@@ -2133,6 +2168,36 @@ fn recreate_canonical_record_fts_index(conn: &Connection) -> Result<(), String> 
         ",
     )
     .map_err(|error| format!("recreate canonical memory FTS index failed: {error}"))?;
+
+    Ok(())
+}
+
+fn rebuild_canonical_record_fts_index_contents(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "
+        INSERT INTO memory_canonical_records_fts(
+          rowid,
+          content,
+          session_id,
+          scope,
+          kind,
+          role,
+          metadata_json
+        )
+        SELECT
+          record_id,
+          content,
+          session_id,
+          scope,
+          kind,
+          COALESCE(role, ''),
+          metadata_json
+        FROM memory_canonical_records
+        ",
+        [],
+    )
+    .map(|_| ())
+    .map_err(|error| format!("rebuild canonical memory FTS index contents failed: {error}"))?;
 
     Ok(())
 }
@@ -3487,21 +3552,7 @@ fn delete_canonical_records_for_session(conn: &Connection, session_id: &str) -> 
         .map_err(|error| format!("delete canonical records failed: {error}"))
 }
 
-fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), String> {
-    let turn_count = conn
-        .query_row(SQL_COUNT_TURNS, [], |row| row.get::<_, i64>(0))
-        .map_err(|error| format!("count persisted turns for canonical rebuild failed: {error}"))?;
-    let canonical_count = conn
-        .query_row(SQL_COUNT_CANONICAL_RECORDS, [], |row| row.get::<_, i64>(0))
-        .map_err(|error| format!("count canonical records failed: {error}"))?;
-    let canonical_fts_count = conn
-        .query_row(SQL_COUNT_CANONICAL_FTS_ROWS, [], |row| row.get::<_, i64>(0))
-        .map_err(|error| format!("count canonical FTS rows failed: {error}"))?;
-
-    if canonical_count == turn_count && canonical_fts_count == canonical_count {
-        return Ok(());
-    }
-
+fn rebuild_canonical_record_storage(conn: &Connection) -> Result<(), String> {
     #[derive(Debug)]
     struct PersistedTurnRow {
         turn_id: i64,
@@ -3516,6 +3567,7 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
         .map_err(|error| format!("begin canonical rebuild savepoint failed: {error}"))?;
 
     let rebuild_result = (|| {
+        drop_canonical_record_fts_index(conn)?;
         conn.execute("DELETE FROM memory_canonical_records", [])
             .map_err(|error| format!("clear canonical records before rebuild failed: {error}"))?;
         let mut last_turn_id = 0_i64;
@@ -3565,6 +3617,9 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
             }
         }
 
+        create_canonical_record_fts_index(conn)?;
+        rebuild_canonical_record_fts_index_contents(conn)?;
+
         Ok(())
     })();
 
@@ -3580,6 +3635,24 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
             Err(error)
         }
     }
+}
+
+fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), String> {
+    let turn_count = conn
+        .query_row(SQL_COUNT_TURNS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count persisted turns for canonical rebuild failed: {error}"))?;
+    let canonical_count = conn
+        .query_row(SQL_COUNT_CANONICAL_RECORDS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count canonical records failed: {error}"))?;
+    let canonical_fts_count = conn
+        .query_row(SQL_COUNT_CANONICAL_FTS_ROWS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count canonical FTS rows failed: {error}"))?;
+
+    if canonical_count == turn_count && canonical_fts_count == canonical_count {
+        return Ok(());
+    }
+
+    rebuild_canonical_record_storage(conn)
 }
 
 fn build_canonical_fts_query(query: &str) -> Option<String> {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -831,13 +831,13 @@ pub(super) fn ensure_memory_db_ready_with_diagnostics(
         let user_version = read_sqlite_user_version(conn)?;
         let current_schema_ready = user_version == SQLITE_MEMORY_SCHEMA_VERSION
             && sqlite_current_schema_objects_ready(conn)?;
-        ensure_turn_session_index_and_state_metadata(conn)?;
-        ensure_approval_lifecycle_tables(conn)?;
-        ensure_session_tool_consent_storage(conn)?;
-        ensure_session_tool_policy_storage(conn)?;
-        ensure_summary_checkpoint_storage_layout(conn)?;
-        ensure_canonical_record_storage(conn)?;
         if user_version < SQLITE_MEMORY_SCHEMA_VERSION || !current_schema_ready {
+            ensure_turn_session_index_and_state_metadata(conn)?;
+            ensure_approval_lifecycle_tables(conn)?;
+            ensure_session_tool_consent_storage(conn)?;
+            ensure_session_tool_policy_storage(conn)?;
+            ensure_summary_checkpoint_storage_layout(conn)?;
+            ensure_canonical_record_storage(conn)?;
             write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
         }
         Ok(())

--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -94,7 +94,7 @@ pub(super) fn execute_bash_tool_with_config(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .ok_or_else(|| "bash.exec requires payload.command".to_owned())?;
-        let cwd = parse_bash_cwd(payload)?;
+        let cwd = parse_bash_cwd(payload, config)?;
         let timeout_ms = parse_bash_timeout_ms(payload)?;
 
         if !config.bash_exec.is_runtime_ready() {
@@ -175,13 +175,27 @@ fn reject_unknown_bash_exec_fields(payload: &serde_json::Map<String, Value>) -> 
 }
 
 #[cfg(feature = "tool-shell")]
-fn parse_bash_cwd(payload: &serde_json::Map<String, Value>) -> Result<PathBuf, String> {
+fn parse_bash_cwd(
+    payload: &serde_json::Map<String, Value>,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<PathBuf, String> {
     match payload.get("cwd") {
         Some(cwd) => cwd
             .as_str()
             .map(PathBuf::from)
             .ok_or_else(|| "bash.exec payload.cwd must be a string".to_owned()),
-        None => Ok(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))),
+        None => {
+            let current_dir = std::env::current_dir();
+            if let Ok(current_dir) = current_dir {
+                return Ok(current_dir);
+            }
+
+            if let Some(file_root) = config.file_root.clone() {
+                return Ok(file_root);
+            }
+
+            Ok(PathBuf::from("."))
+        }
     }
 }
 

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -321,7 +321,7 @@ fn bash_exec_falls_back_to_file_root_when_current_dir_is_unavailable() {
     let log_path = fallback_root.join("bash-args.log");
     let runtime_path = write_fake_bash_runtime(&fallback_root, "fake-bash", &log_path);
 
-    let mut config = test_tool_runtime_config(fallback_root.clone());
+    let mut config = test_tool_runtime_config(fallback_root);
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = runtime_config::BashExecRuntimePolicy {
         available: true,

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -309,6 +309,58 @@ fn bash_exec_runs_command_string_via_bash_runtime() {
 
 #[cfg(all(feature = "tool-shell", unix))]
 #[test]
+fn bash_exec_falls_back_to_file_root_when_current_dir_is_unavailable() {
+    use std::fs;
+
+    let root = unique_tool_temp_dir("loongclaw-bash-exec-missing-cwd");
+    let deleted_cwd = root.join("deleted-cwd");
+    let fallback_root = root.join("fallback-root");
+    fs::create_dir_all(&deleted_cwd).expect("create deleted cwd");
+    fs::create_dir_all(&fallback_root).expect("create fallback root");
+
+    let log_path = fallback_root.join("bash-args.log");
+    let runtime_path = write_fake_bash_runtime(&fallback_root, "fake-bash", &log_path);
+
+    let mut config = test_tool_runtime_config(fallback_root.clone());
+    config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
+    config.bash_exec = runtime_config::BashExecRuntimePolicy {
+        available: true,
+        command: Some(runtime_path),
+        ..runtime_config::BashExecRuntimePolicy::default()
+    };
+
+    let cwd_guard = ScopedCurrentDir::new(&deleted_cwd);
+    fs::remove_dir_all(&deleted_cwd).expect("remove deleted cwd");
+
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "bash.exec".to_owned(),
+            payload: json!({"command": "printf fallback-from-file-root"}),
+        },
+        &config,
+    )
+    .expect("bash command should succeed when current dir is unavailable");
+
+    drop(cwd_guard);
+
+    let logged_args = fs::read_to_string(&log_path).expect("read fake bash args");
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(
+        outcome.payload["stdout"].as_str(),
+        Some("fallback-from-file-root")
+    );
+    assert!(
+        logged_args
+            .lines()
+            .eq(["-c", "printf fallback-from-file-root"].into_iter()),
+        "expected bash invocation to keep command args when current dir is missing, got: {logged_args:?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
 fn bash_exec_allows_plain_command_when_prefix_rule_allows() {
     use std::fs;
 

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -11,6 +11,8 @@ pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser comp
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
 const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 const BROWSER_COMPANION_PROBE_MAX_ATTEMPTS: usize = 2;
+#[cfg(test)]
+const TEST_BROWSER_COMPANION_VERSION_PREFIX: &str = "loongclaw-test-browser-companion-version:";
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,12 +228,22 @@ async fn probe_browser_companion_version_with_policy(
     timeout: Duration,
     max_attempts: usize,
 ) -> Result<String, BrowserCompanionProbeError> {
+    #[cfg(test)]
+    if let Some(version) = command.strip_prefix(TEST_BROWSER_COMPANION_VERSION_PREFIX) {
+        return Ok(format!("loongclaw-browser-companion {version}"));
+    }
+
     tokio::task::spawn_blocking({
         let command = command.to_owned();
         move || probe_browser_companion_version_blocking(command, timeout, max_attempts)
     })
     .await
     .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?
+}
+
+#[cfg(test)]
+pub(crate) fn fake_browser_companion_version_command(version: &str) -> String {
+    format!("{TEST_BROWSER_COMPANION_VERSION_PREFIX}{version}")
 }
 
 fn probe_browser_companion_version_blocking(

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -11,8 +11,6 @@ pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser comp
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
 const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 const BROWSER_COMPANION_PROBE_MAX_ATTEMPTS: usize = 2;
-#[cfg(test)]
-const TEST_BROWSER_COMPANION_VERSION_PREFIX: &str = "loongclaw-test-browser-companion-version:";
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -228,22 +226,12 @@ async fn probe_browser_companion_version_with_policy(
     timeout: Duration,
     max_attempts: usize,
 ) -> Result<String, BrowserCompanionProbeError> {
-    #[cfg(test)]
-    if let Some(version) = command.strip_prefix(TEST_BROWSER_COMPANION_VERSION_PREFIX) {
-        return Ok(format!("loongclaw-browser-companion {version}"));
-    }
-
     tokio::task::spawn_blocking({
         let command = command.to_owned();
         move || probe_browser_companion_version_blocking(command, timeout, max_attempts)
     })
     .await
     .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?
-}
-
-#[cfg(test)]
-pub(crate) fn fake_browser_companion_version_command(version: &str) -> String {
-    format!("{TEST_BROWSER_COMPANION_VERSION_PREFIX}{version}")
 }
 
 fn probe_browser_companion_version_blocking(

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -48,6 +48,12 @@ fn unique_temp_path(label: &str) -> PathBuf {
     ))
 }
 
+fn isolated_output_path(label: &str) -> PathBuf {
+    let output_root = unique_temp_path("output-root");
+    std::fs::create_dir_all(&output_root).expect("create isolated output root");
+    output_root.join(label)
+}
+
 fn provider_choice_input(kind: mvp::config::ProviderKind) -> String {
     let mut options = mvp::config::ProviderKind::all_sorted()
         .iter()
@@ -6363,7 +6369,7 @@ async fn onboard_current_setup_shortcut_flow_skips_detailed_edit_screens() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_current_setup_shortcut_can_install_selected_bundled_skills() {
-    let output_path = unique_temp_path("current-shortcut-preinstall-config.toml");
+    let output_path = isolated_output_path("current-shortcut-preinstall-config.toml");
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.model = "gpt-4.1".to_owned();
     existing.provider.api_key = Some(loongclaw_contracts::SecretRef::Inline(
@@ -6432,7 +6438,7 @@ async fn onboard_current_setup_shortcut_can_install_selected_bundled_skills() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn onboard_current_setup_shortcut_can_install_minimax_office_pack() {
-    let output_path = unique_temp_path("current-shortcut-minimax-office-config.toml");
+    let output_path = isolated_output_path("current-shortcut-minimax-office-config.toml");
     let mut existing = mvp::config::LoongClawConfig::default();
     existing.provider.model = "gpt-4.1".to_owned();
     existing.provider.api_key = Some(loongclaw_contracts::SecretRef::Inline(

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T18:21:36Z
+- Generated at: 2026-04-05T18:29:16Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,8 +23,8 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10833 | 11200 | 367 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14858 | 15000 | 142 | 54 | 70 | 16 | 99.1% | TIGHT | 14472 | 2.7% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6442 | 6500 | 58 | 206 | 210 | 4 | 99.1% | TIGHT | 6324 | 1.9% | PASS | 210 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14858 | 15000 | 142 | 53 | 70 | 17 | 99.1% | TIGHT | 14472 | 2.7% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6444 | 6500 | 56 | 206 | 210 | 4 | 99.1% | TIGHT | 6324 | 1.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
@@ -69,8 +69,8 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10833 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14858 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6442 functions=206 -->
+<!-- arch-hotspot key=tools_mod lines=14858 functions=53 -->
+<!-- arch-hotspot key=daemon_lib lines=6444 functions=206 -->
 <!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T17:26:26Z
+- Generated at: 2026-04-05T18:21:36Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T17:17:00Z
+- Generated at: 2026-04-05T17:26:26Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2785 | 2800 | 15 | 48 | 65 | 17 | 99.5% | TIGHT | 2698 | 3.2% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2784 | 2800 | 16 | 48 | 65 | 17 | 99.4% | TIGHT | 2698 | 3.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.5%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.1%), daemon_lib (99.1%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.4%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.1%), daemon_lib (99.1%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2785 functions=48 -->
+<!-- arch-hotspot key=acpx_runtime lines=2784 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T16:24:21Z
+- Generated at: 2026-04-05T17:17:00Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2771 | 2800 | 29 | 48 | 65 | 17 | 99.0% | TIGHT | 2698 | 2.7% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2785 | 2800 | 15 | 48 | 65 | 17 | 99.5% | TIGHT | 2698 | 3.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.0%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.1%), daemon_lib (99.1%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.5%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (99.1%), daemon_lib (99.1%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2771 functions=48 -->
+<!-- arch-hotspot key=acpx_runtime lines=2785 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T13:22:24Z
+- Generated at: 2026-04-05T16:24:21Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14


### PR DESCRIPTION
## Summary

- restore persisted child-session runtime narrowing on `SessionContext` and preserve it when execution metadata is attached
- keep conversation runtime tests bound to the test-specific app/memory config instead of the global runtime dispatcher
- repair canonical FTS recreation by explicitly rebuilding index contents and re-running schema repair on cached runtimes
- preserve the summary retrieval budget floor for window-plus-summary hydration when the recent window is empty

## Why

`dev` CI is currently red because baseline regressions in child runtime narrowing and canonical FTS repair are exposed after the MCP runtime merge.

Closes #931.

## Validation

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo test -p loongclaw-app memory::sqlite::tests::ensure_memory_db_ready_repairs_stale_canonical_fts_metadata_schema -- --exact --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo test -p loongclaw-app memory::orchestrator::tests::hydrate_stage_envelope_window_plus_summary_keeps_summary_retrieval_request -- --exact --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo test -p loongclaw-app conversation::tests::session_context_merges_persisted_session_policy_runtime_narrowing -- --exact --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo test -p loongclaw-app conversation::tests::session_context_preserves_child_runtime_narrowing_after_many_later_events -- --exact --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo test -p loongclaw-app conversation::tests::handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload -- --exact --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-dev-baseline-verify cargo check -p loongclaw-app --lib
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database bootstrap, integrity checks and targeted repairs; fixed memory retrieval budgeting for empty recent windows; stricter guard for delegate-child prompt summaries when runtime narrowing is absent.

* **Refactor**
  * Session context/subagent handling now preserves and merges runtime narrowing, profile, and identity more predictably.
  * Reworked canonical memory storage and FTS rebuild flow with clearer lifecycle and rebuild steps.

* **Tests**
  * Added test-only companion-version shortcut and a decoding helper; updated dispatcher initialization in a runtime-narrowing test.

* **Documentation**
  * Updated architecture drift report metrics and timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->