### PR TITLE
refactor(channel): extract command orchestration foundation

### DIFF
--- a/crates/app/src/channel/commands/context.rs
+++ b/crates/app/src/channel/commands/context.rs
@@ -1,0 +1,100 @@
+use std::path::PathBuf;
+
+use crate::config::ChannelResolvedAccountRoute;
+use crate::config::LoongClawConfig;
+#[cfg(feature = "channel-feishu")]
+use crate::config::ResolvedFeishuChannelConfig;
+#[cfg(feature = "channel-matrix")]
+use crate::config::ResolvedMatrixChannelConfig;
+#[cfg(feature = "channel-telegram")]
+use crate::config::ResolvedTelegramChannelConfig;
+#[cfg(feature = "channel-wecom")]
+use crate::config::ResolvedWecomChannelConfig;
+
+use super::super::http;
+
+#[derive(Debug, Clone)]
+pub(in crate::channel) struct ChannelCommandContext<R> {
+    pub(in crate::channel) resolved_path: PathBuf,
+    pub(in crate::channel) config: LoongClawConfig,
+    pub(in crate::channel) resolved: R,
+    pub(in crate::channel) route: ChannelResolvedAccountRoute,
+}
+
+impl<R> ChannelCommandContext<R> {
+    pub(in crate::channel) fn emit_route_notice(&self, channel_id: &str) {
+        if let Some(notice) = render_channel_route_notice(channel_id, &self.route) {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("warning: {notice}");
+            }
+        }
+    }
+
+    pub(in crate::channel) fn outbound_http_policy(&self) -> http::ChannelOutboundHttpPolicy {
+        http::outbound_http_policy_from_config(&self.config)
+    }
+}
+
+pub(in crate::channel) trait ChannelResolvedRuntimeAccount {
+    fn runtime_account_id(&self) -> &str;
+    fn runtime_account_label(&self) -> &str;
+}
+
+#[cfg(feature = "channel-telegram")]
+impl ChannelResolvedRuntimeAccount for ResolvedTelegramChannelConfig {
+    fn runtime_account_id(&self) -> &str {
+        self.account.id.as_str()
+    }
+
+    fn runtime_account_label(&self) -> &str {
+        self.account.label.as_str()
+    }
+}
+
+#[cfg(feature = "channel-feishu")]
+impl ChannelResolvedRuntimeAccount for ResolvedFeishuChannelConfig {
+    fn runtime_account_id(&self) -> &str {
+        self.account.id.as_str()
+    }
+
+    fn runtime_account_label(&self) -> &str {
+        self.account.label.as_str()
+    }
+}
+
+#[cfg(feature = "channel-matrix")]
+impl ChannelResolvedRuntimeAccount for ResolvedMatrixChannelConfig {
+    fn runtime_account_id(&self) -> &str {
+        self.account.id.as_str()
+    }
+
+    fn runtime_account_label(&self) -> &str {
+        self.account.label.as_str()
+    }
+}
+
+#[cfg(feature = "channel-wecom")]
+impl ChannelResolvedRuntimeAccount for ResolvedWecomChannelConfig {
+    fn runtime_account_id(&self) -> &str {
+        self.account.id.as_str()
+    }
+
+    fn runtime_account_label(&self) -> &str {
+        self.account.label.as_str()
+    }
+}
+
+pub(in crate::channel) fn render_channel_route_notice(
+    channel_id: &str,
+    route: &ChannelResolvedAccountRoute,
+) -> Option<String> {
+    if !route.uses_implicit_fallback_default() {
+        return None;
+    }
+    let config_key = channel_id.replace('-', "_");
+    Some(format!(
+        "{} omitted --account and routed to configured account `{}` via fallback default selection; set {}.default_account or pass --account to avoid routing surprises",
+        channel_id, route.selected_configured_account_id, config_key
+    ))
+}

--- a/crates/app/src/channel/commands/mod.rs
+++ b/crates/app/src/channel/commands/mod.rs
@@ -1,0 +1,7 @@
+pub(in crate::channel) mod context;
+mod send;
+mod serve;
+
+pub(super) use context::{ChannelCommandContext, ChannelResolvedRuntimeAccount};
+pub(super) use send::{ChannelSendCommandSpec, run_channel_send_command};
+pub(super) use serve::run_channel_serve_command_with_stop;

--- a/crates/app/src/channel/commands/send.rs
+++ b/crates/app/src/channel/commands/send.rs
@@ -1,0 +1,33 @@
+use crate::CliResult;
+
+use super::super::types::ChannelCommandFuture;
+use super::context::ChannelCommandContext;
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::channel) struct ChannelSendCommandSpec {
+    pub(in crate::channel) channel_id: &'static str,
+}
+
+pub(in crate::channel) async fn run_channel_send_command<R, F, G>(
+    context: ChannelCommandContext<R>,
+    spec: ChannelSendCommandSpec,
+    send: F,
+    render_success: G,
+) -> CliResult<()>
+where
+    F: for<'a> FnOnce(&'a ChannelCommandContext<R>) -> ChannelCommandFuture<'a>,
+    G: FnOnce(&ChannelCommandContext<R>) -> String,
+{
+    crate::runtime_env::initialize_runtime_environment(
+        &context.config,
+        Some(context.resolved_path.as_path()),
+    );
+    context.emit_route_notice(spec.channel_id);
+    send(&context).await?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("{}", render_success(&context));
+    }
+    Ok(())
+}

--- a/crates/app/src/channel/commands/serve.rs
+++ b/crates/app/src/channel/commands/serve.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use crate::CliResult;
+use crate::KernelContext;
+use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
+
+use super::super::runtime_state::ChannelOperationRuntimeTracker;
+use super::super::serve_runtime::{
+    ChannelServeCommandSpec, ChannelServeRuntimeSpec, ChannelServeStopHandle,
+    with_channel_serve_runtime_with_stop,
+};
+use super::super::types::ChannelCommandFuture;
+use super::context::{ChannelCommandContext, ChannelResolvedRuntimeAccount};
+
+pub(in crate::channel) async fn run_channel_serve_command_with_stop<R, V, F>(
+    context: ChannelCommandContext<R>,
+    spec: ChannelServeCommandSpec,
+    validate: V,
+    stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
+    run: F,
+) -> CliResult<()>
+where
+    R: ChannelResolvedRuntimeAccount,
+    V: FnOnce(&R) -> CliResult<()>,
+    F: for<'a> FnOnce(
+        &'a ChannelCommandContext<R>,
+        KernelContext,
+        Arc<ChannelOperationRuntimeTracker>,
+        ChannelServeStopHandle,
+    ) -> ChannelCommandFuture<'a>,
+{
+    validate(&context.resolved)?;
+    if initialize_runtime_environment {
+        crate::runtime_env::initialize_runtime_environment(
+            &context.config,
+            Some(context.resolved_path.as_path()),
+        );
+    }
+    let kernel_ctx = bootstrap_kernel_context_with_config(
+        spec.family.runtime.serve_bootstrap_agent_id,
+        DEFAULT_TOKEN_TTL_S,
+        &context.config,
+    )?;
+    let runtime_account_id = context.resolved.runtime_account_id().to_owned();
+    let runtime_account_label = context.resolved.runtime_account_label().to_owned();
+
+    with_channel_serve_runtime_with_stop(
+        ChannelServeRuntimeSpec {
+            platform: spec.family.runtime.platform,
+            operation_id: spec.family.serve().id,
+            account_id: runtime_account_id.as_str(),
+            account_label: runtime_account_label.as_str(),
+        },
+        stop,
+        move |runtime, stop| async move {
+            let channel_id = spec.family.channel_id();
+            context.emit_route_notice(channel_id);
+            run(&context, kernel_ctx, runtime, stop).await
+        },
+    )
+    .await
+}

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -101,7 +101,6 @@ use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
     feature = "channel-imessage",
     feature = "channel-nostr",
 ))]
-use crate::config::ChannelResolvedAccountRoute;
 #[cfg(feature = "channel-dingtalk")]
 use crate::config::ResolvedDingtalkChannelConfig;
 #[cfg(feature = "channel-discord")]
@@ -163,6 +162,10 @@ use crate::conversation::{
 ))]
 use crate::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
+pub(super) use super::commands::{
+    ChannelCommandContext, ChannelResolvedRuntimeAccount, ChannelSendCommandSpec,
+    run_channel_send_command, run_channel_serve_command_with_stop,
+};
 #[cfg(feature = "channel-dingtalk")]
 use super::dingtalk;
 #[cfg(feature = "channel-discord")]
@@ -173,7 +176,6 @@ use super::email;
 use super::feishu;
 #[cfg(feature = "channel-google-chat")]
 use super::google_chat;
-use super::http;
 #[cfg(feature = "channel-imessage")]
 use super::imessage;
 #[cfg(feature = "channel-irc")]
@@ -193,7 +195,6 @@ use super::registry::{
     WECOM_COMMAND_FAMILY_DESCRIPTOR,
 };
 use super::runtime_state;
-use super::runtime_state::ChannelOperationRuntimeTracker;
 use super::serve_runtime::{
     ChannelServeCommandSpec, ChannelServeRuntimeSpec, ChannelServeStopHandle,
     with_channel_serve_runtime_with_stop,
@@ -247,181 +248,9 @@ use super::types::{
     feature = "channel-whatsapp",
 ))]
 use super::types::{
-    ChannelCommandFuture, ChannelResolvedAcpTurnHints, KnownChannelSessionSendTarget,
+    ChannelResolvedAcpTurnHints, KnownChannelSessionSendTarget,
     parse_known_channel_session_send_target, process_channel_batch,
 };
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-discord",
-    feature = "channel-dingtalk",
-    feature = "channel-email",
-    feature = "channel-feishu",
-    feature = "channel-google-chat",
-    feature = "channel-webhook",
-    feature = "channel-line",
-    feature = "channel-matrix",
-    feature = "channel-mattermost",
-    feature = "channel-nextcloud-talk",
-    feature = "channel-signal",
-    feature = "channel-slack",
-    feature = "channel-synology-chat",
-    feature = "channel-irc",
-    feature = "channel-twitch",
-    feature = "channel-teams",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-imessage",
-    feature = "channel-nostr"
-))]
-#[derive(Debug, Clone)]
-pub(super) struct ChannelCommandContext<R> {
-    pub(super) resolved_path: PathBuf,
-    pub(super) config: LoongClawConfig,
-    pub(super) resolved: R,
-    pub(super) route: ChannelResolvedAccountRoute,
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-discord",
-    feature = "channel-dingtalk",
-    feature = "channel-email",
-    feature = "channel-feishu",
-    feature = "channel-google-chat",
-    feature = "channel-webhook",
-    feature = "channel-line",
-    feature = "channel-matrix",
-    feature = "channel-mattermost",
-    feature = "channel-nextcloud-talk",
-    feature = "channel-signal",
-    feature = "channel-slack",
-    feature = "channel-synology-chat",
-    feature = "channel-irc",
-    feature = "channel-twitch",
-    feature = "channel-teams",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-imessage",
-    feature = "channel-nostr"
-))]
-impl<R> ChannelCommandContext<R> {
-    fn emit_route_notice(&self, channel_id: &str) {
-        if let Some(notice) = render_channel_route_notice(channel_id, &self.route) {
-            #[allow(clippy::print_stderr)]
-            {
-                eprintln!("warning: {notice}");
-            }
-        }
-    }
-
-    fn outbound_http_policy(&self) -> http::ChannelOutboundHttpPolicy {
-        http::outbound_http_policy_from_config(&self.config)
-    }
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-))]
-pub(super) trait ChannelResolvedRuntimeAccount {
-    fn runtime_account_id(&self) -> &str;
-    fn runtime_account_label(&self) -> &str;
-}
-
-#[cfg(feature = "channel-telegram")]
-impl ChannelResolvedRuntimeAccount for ResolvedTelegramChannelConfig {
-    fn runtime_account_id(&self) -> &str {
-        self.account.id.as_str()
-    }
-
-    fn runtime_account_label(&self) -> &str {
-        self.account.label.as_str()
-    }
-}
-
-#[cfg(feature = "channel-feishu")]
-impl ChannelResolvedRuntimeAccount for ResolvedFeishuChannelConfig {
-    fn runtime_account_id(&self) -> &str {
-        self.account.id.as_str()
-    }
-
-    fn runtime_account_label(&self) -> &str {
-        self.account.label.as_str()
-    }
-}
-
-#[cfg(feature = "channel-matrix")]
-impl ChannelResolvedRuntimeAccount for ResolvedMatrixChannelConfig {
-    fn runtime_account_id(&self) -> &str {
-        self.account.id.as_str()
-    }
-
-    fn runtime_account_label(&self) -> &str {
-        self.account.label.as_str()
-    }
-}
-
-#[cfg(feature = "channel-wecom")]
-impl ChannelResolvedRuntimeAccount for ResolvedWecomChannelConfig {
-    fn runtime_account_id(&self) -> &str {
-        self.account.id.as_str()
-    }
-
-    fn runtime_account_label(&self) -> &str {
-        self.account.label.as_str()
-    }
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-discord",
-    feature = "channel-dingtalk",
-    feature = "channel-email",
-    feature = "channel-feishu",
-    feature = "channel-google-chat",
-    feature = "channel-webhook",
-    feature = "channel-line",
-    feature = "channel-matrix",
-    feature = "channel-mattermost",
-    feature = "channel-nextcloud-talk",
-    feature = "channel-signal",
-    feature = "channel-slack",
-    feature = "channel-twitch",
-    feature = "channel-irc",
-    feature = "channel-synology-chat",
-    feature = "channel-teams",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-imessage",
-    feature = "channel-nostr"
-))]
-pub(super) async fn run_channel_send_command<R, F, G>(
-    context: ChannelCommandContext<R>,
-    spec: ChannelSendCommandSpec,
-    send: F,
-    render_success: G,
-) -> CliResult<()>
-where
-    F: for<'a> FnOnce(&'a ChannelCommandContext<R>) -> ChannelCommandFuture<'a>,
-    G: FnOnce(&ChannelCommandContext<R>) -> String,
-{
-    crate::runtime_env::initialize_runtime_environment(
-        &context.config,
-        Some(context.resolved_path.as_path()),
-    );
-    context.emit_route_notice(spec.channel_id);
-    send(&context).await?;
-
-    #[allow(clippy::print_stdout)]
-    {
-        println!("{}", render_success(&context));
-    }
-    Ok(())
-}
 
 #[cfg(any(
     feature = "channel-dingtalk",
@@ -1116,91 +945,6 @@ fn build_nostr_command_context(
         resolved,
         route,
     })
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-discord",
-    feature = "channel-dingtalk",
-    feature = "channel-email",
-    feature = "channel-feishu",
-    feature = "channel-google-chat",
-    feature = "channel-webhook",
-    feature = "channel-line",
-    feature = "channel-matrix",
-    feature = "channel-mattermost",
-    feature = "channel-nextcloud-talk",
-    feature = "channel-signal",
-    feature = "channel-slack",
-    feature = "channel-irc",
-    feature = "channel-synology-chat",
-    feature = "channel-twitch",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-teams",
-    feature = "channel-imessage",
-    feature = "channel-nostr"
-))]
-#[derive(Debug, Clone, Copy)]
-pub(super) struct ChannelSendCommandSpec {
-    pub(super) channel_id: &'static str,
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-))]
-pub(super) async fn run_channel_serve_command_with_stop<R, V, F>(
-    context: ChannelCommandContext<R>,
-    spec: ChannelServeCommandSpec,
-    validate: V,
-    stop: ChannelServeStopHandle,
-    initialize_runtime_environment: bool,
-    run: F,
-) -> CliResult<()>
-where
-    R: ChannelResolvedRuntimeAccount,
-    V: FnOnce(&R) -> CliResult<()>,
-    F: for<'a> FnOnce(
-        &'a ChannelCommandContext<R>,
-        KernelContext,
-        Arc<ChannelOperationRuntimeTracker>,
-        ChannelServeStopHandle,
-    ) -> ChannelCommandFuture<'a>,
-{
-    validate(&context.resolved)?;
-    if initialize_runtime_environment {
-        crate::runtime_env::initialize_runtime_environment(
-            &context.config,
-            Some(context.resolved_path.as_path()),
-        );
-    }
-    let kernel_ctx = bootstrap_kernel_context_with_config(
-        spec.family.runtime.serve_bootstrap_agent_id,
-        DEFAULT_TOKEN_TTL_S,
-        &context.config,
-    )?;
-    let runtime_account_id = context.resolved.runtime_account_id().to_owned();
-    let runtime_account_label = context.resolved.runtime_account_label().to_owned();
-
-    with_channel_serve_runtime_with_stop(
-        ChannelServeRuntimeSpec {
-            platform: spec.family.runtime.platform,
-            operation_id: spec.family.serve().id,
-            account_id: runtime_account_id.as_str(),
-            account_label: runtime_account_label.as_str(),
-        },
-        stop,
-        move |runtime, stop| async move {
-            let channel_id = spec.family.channel_id();
-            context.emit_route_notice(channel_id);
-            run(&context, kernel_ctx, runtime, stop).await
-        },
-    )
-    .await
 }
 
 #[cfg(feature = "channel-telegram")]
@@ -3592,42 +3336,6 @@ fn normalized_feishu_callback_context(
         return None;
     }
     Some(normalized)
-}
-
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-discord",
-    feature = "channel-feishu",
-    feature = "channel-dingtalk",
-    feature = "channel-email",
-    feature = "channel-matrix",
-    feature = "channel-google-chat",
-    feature = "channel-webhook",
-    feature = "channel-line",
-    feature = "channel-mattermost",
-    feature = "channel-nextcloud-talk",
-    feature = "channel-signal",
-    feature = "channel-slack",
-    feature = "channel-synology-chat",
-    feature = "channel-twitch",
-    feature = "channel-teams",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-imessage",
-    feature = "channel-nostr"
-))]
-pub(super) fn render_channel_route_notice(
-    channel_id: &str,
-    route: &ChannelResolvedAccountRoute,
-) -> Option<String> {
-    if !route.uses_implicit_fallback_default() {
-        return None;
-    }
-    let config_key = channel_id.replace('-', "_");
-    Some(format!(
-        "{} omitted --account and routed to configured account `{}` via fallback default selection; set {}.default_account or pass --account to avoid routing surprises",
-        channel_id, route.selected_configured_account_id, config_key
-    ))
 }
 
 #[cfg(feature = "channel-telegram")]

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1,6 +1,7 @@
 use crate::config::LoongClawConfig;
 
 mod catalog;
+mod commands;
 #[cfg(feature = "channel-dingtalk")]
 mod dingtalk;
 #[cfg(feature = "channel-discord")]
@@ -139,6 +140,8 @@ mod dispatch;
 use crate::CliResult;
 #[cfg(test)]
 use crate::conversation::ConversationIngressPrivateContext;
+#[cfg(test)]
+use commands::context::render_channel_route_notice;
 #[cfg(any(
     feature = "channel-telegram",
     feature = "channel-feishu",
@@ -171,7 +174,7 @@ use dispatch::{ChannelCommandContext, ChannelSendCommandSpec, run_channel_send_c
 use dispatch::{
     build_feishu_command_context, build_telegram_command_context, channel_message_ingress_context,
     process_inbound_with_runtime_and_feedback, reload_channel_turn_config,
-    render_channel_route_notice, validate_feishu_security_config, validate_matrix_security_config,
+    validate_feishu_security_config, validate_matrix_security_config,
     validate_telegram_security_config,
 };
 pub use dispatch::{

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -21,7 +21,7 @@
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10638 | 11200 | 562 | 94 | 120 | 26 | 95.0% | WATCH | 10831 | -1.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6464 | 6500 | 36 | 205 | 210 | 5 | 99.4% | TIGHT | 6324 | 2.2% | PASS | 210 |
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
-<!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
+<!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10638 functions=94 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6464 functions=205 -->


### PR DESCRIPTION
## Summary

- Extract command orchestration foundation from `dispatch.rs` into `channel/commands/`
- Move `ChannelCommandContext`, `ChannelResolvedRuntimeAccount`, `ChannelSendCommandSpec` and related functions
- Follows issue #892 PR slice 2 decomposition plan

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features`
- [x] `cargo test --all-features`
- [x] `cargo fmt -- --check`

## Related issue

#892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized channel command handling into a dedicated commands submodule and consolidated send/serve flows for more consistent behavior.
  * Centralized command context and runtime-account resolution, leading to consistent route-warning emission and outbound HTTP policy handling.
* **Documentation**
  * Updated architecture drift report metrics for the channel module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->