### PR TITLE
fix: harden runtime narrowing authority and sqlite repair lifecycle

### DIFF
--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -225,9 +225,7 @@ impl SessionContext {
             contract = contract.with_profile(profile);
         }
         let resolved_runtime_narrowing = self.resolved_runtime_narrowing().cloned();
-        if contract.runtime_narrowing.is_empty()
-            && let Some(runtime_narrowing) = resolved_runtime_narrowing
-        {
+        if let Some(runtime_narrowing) = resolved_runtime_narrowing {
             contract = contract.with_runtime_narrowing(runtime_narrowing);
         }
         (!contract.is_empty()).then_some(contract)

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -91,11 +91,9 @@ impl SessionContext {
     pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
         if !runtime_narrowing.is_empty() {
             self.runtime_narrowing = Some(runtime_narrowing.clone());
-            if let Some(subagent_execution) = self.subagent_execution.as_mut() {
-                subagent_execution.runtime_narrowing = runtime_narrowing.clone();
-            }
             let contract = self.subagent_contract.take().unwrap_or_default();
             self.subagent_contract = Some(contract.with_runtime_narrowing(runtime_narrowing));
+            self.synchronize_runtime_narrowing_views();
         }
         self
     }
@@ -106,38 +104,37 @@ impl SessionContext {
         subagent_execution: ConstrainedSubagentExecution,
     ) -> Self {
         let existing_contract = self.subagent_contract.take();
+        let existing_identity = existing_contract
+            .as_ref()
+            .and_then(ConstrainedSubagentContractView::resolved_identity)
+            .cloned();
+        let existing_profile = existing_contract
+            .as_ref()
+            .and_then(|contract| contract.profile);
+        let existing_runtime_narrowing = existing_contract
+            .as_ref()
+            .map(|contract| contract.runtime_narrowing.clone())
+            .filter(|runtime_narrowing| !runtime_narrowing.is_empty());
         let mut subagent_execution = subagent_execution.with_resolved_profile();
         if subagent_execution.identity.is_none()
-            && let Some(identity) = existing_contract
-                .as_ref()
-                .and_then(ConstrainedSubagentContractView::resolved_identity)
-                .cloned()
+            && let Some(identity) = existing_identity
         {
             subagent_execution.identity = Some(identity);
         }
         let mut merged_contract = subagent_execution.contract_view();
-        if let Some(existing_contract) = existing_contract {
-            if merged_contract.profile.is_none()
-                && let Some(profile) = existing_contract.profile
-            {
-                merged_contract = merged_contract.with_profile(profile);
-            }
-            if merged_contract.identity.is_none()
-                && let Some(identity) = existing_contract.identity
-            {
-                merged_contract = merged_contract.with_identity(identity);
-            }
-            if merged_contract.runtime_narrowing.is_empty()
-                && !existing_contract.runtime_narrowing.is_empty()
-            {
-                let runtime_narrowing = existing_contract.runtime_narrowing;
-                subagent_execution.runtime_narrowing = runtime_narrowing.clone();
-                self.runtime_narrowing = Some(runtime_narrowing.clone());
-                merged_contract = merged_contract.with_runtime_narrowing(runtime_narrowing);
-            }
+        if merged_contract.profile.is_none()
+            && let Some(profile) = existing_profile
+        {
+            merged_contract = merged_contract.with_profile(profile);
+        }
+        if merged_contract.runtime_narrowing.is_empty()
+            && let Some(runtime_narrowing) = existing_runtime_narrowing
+        {
+            merged_contract = merged_contract.with_runtime_narrowing(runtime_narrowing);
         }
         self.subagent_contract = Some(merged_contract);
         self.subagent_execution = Some(subagent_execution);
+        self.synchronize_runtime_narrowing_views();
         self
     }
 
@@ -148,6 +145,7 @@ impl SessionContext {
         }
         let contract = self.subagent_contract.take().unwrap_or_default();
         self.subagent_contract = Some(contract.with_profile(subagent_profile));
+        self.synchronize_runtime_narrowing_views();
         self
     }
 
@@ -164,7 +162,32 @@ impl SessionContext {
         }
         let contract = self.subagent_contract.take().unwrap_or_default();
         self.subagent_contract = Some(contract.with_identity(subagent_identity));
+        self.synchronize_runtime_narrowing_views();
         self
+    }
+
+    pub fn resolved_runtime_narrowing(&self) -> Option<&ToolRuntimeNarrowing> {
+        let session_runtime_narrowing =
+            non_empty_runtime_narrowing_ref(self.runtime_narrowing.as_ref());
+        if let Some(session_runtime_narrowing) = session_runtime_narrowing {
+            return Some(session_runtime_narrowing);
+        }
+
+        let execution_runtime_narrowing = self
+            .subagent_execution
+            .as_ref()
+            .map(|execution| &execution.runtime_narrowing);
+        let execution_runtime_narrowing =
+            non_empty_runtime_narrowing_ref(execution_runtime_narrowing);
+        if let Some(execution_runtime_narrowing) = execution_runtime_narrowing {
+            return Some(execution_runtime_narrowing);
+        }
+
+        let contract_runtime_narrowing = self
+            .subagent_contract
+            .as_ref()
+            .map(|contract| &contract.runtime_narrowing);
+        non_empty_runtime_narrowing_ref(contract_runtime_narrowing)
     }
 
     pub fn resolved_subagent_profile(&self) -> Option<ConstrainedSubagentProfile> {
@@ -195,32 +218,23 @@ impl SessionContext {
             .as_ref()
             .map(ConstrainedSubagentExecution::contract_view)
             .or(self.subagent_contract.clone())?;
-        if let Some(stored_contract) = self.subagent_contract.as_ref() {
-            if contract.profile.is_none()
-                && let Some(profile) = stored_contract.profile
-            {
-                contract = contract.with_profile(profile);
-            }
-            if contract.runtime_narrowing.is_empty()
-                && !stored_contract.runtime_narrowing.is_empty()
-            {
-                contract =
-                    contract.with_runtime_narrowing(stored_contract.runtime_narrowing.clone());
-            }
+        if let Some(stored_contract) = self.subagent_contract.as_ref()
+            && contract.profile.is_none()
+            && let Some(profile) = stored_contract.profile
+        {
+            contract = contract.with_profile(profile);
+        }
+        let resolved_runtime_narrowing = self.resolved_runtime_narrowing().cloned();
+        if contract.runtime_narrowing.is_empty()
+            && let Some(runtime_narrowing) = resolved_runtime_narrowing
+        {
+            contract = contract.with_runtime_narrowing(runtime_narrowing);
         }
         (!contract.is_empty()).then_some(contract)
     }
 
     pub fn subagent_runtime_narrowing(&self) -> Option<&ToolRuntimeNarrowing> {
-        self.subagent_execution
-            .as_ref()
-            .map(|execution| &execution.runtime_narrowing)
-            .or_else(|| {
-                self.subagent_contract
-                    .as_ref()
-                    .map(|contract| &contract.runtime_narrowing)
-            })
-            .filter(|narrowing| !narrowing.is_empty())
+        self.resolved_runtime_narrowing()
     }
 
     #[must_use]
@@ -233,6 +247,56 @@ impl SessionContext {
         }
         self
     }
+
+    fn resolve_runtime_narrowing_owned(&self) -> Option<ToolRuntimeNarrowing> {
+        let session_runtime_narrowing =
+            non_empty_runtime_narrowing_owned(self.runtime_narrowing.clone());
+        if let Some(session_runtime_narrowing) = session_runtime_narrowing {
+            return Some(session_runtime_narrowing);
+        }
+
+        let execution_runtime_narrowing = self
+            .subagent_execution
+            .as_ref()
+            .map(|execution| execution.runtime_narrowing.clone());
+        let execution_runtime_narrowing =
+            non_empty_runtime_narrowing_owned(execution_runtime_narrowing);
+        if let Some(execution_runtime_narrowing) = execution_runtime_narrowing {
+            return Some(execution_runtime_narrowing);
+        }
+
+        let contract_runtime_narrowing = self
+            .subagent_contract
+            .as_ref()
+            .map(|contract| contract.runtime_narrowing.clone());
+        non_empty_runtime_narrowing_owned(contract_runtime_narrowing)
+    }
+
+    fn synchronize_runtime_narrowing_views(&mut self) {
+        let resolved_runtime_narrowing = self.resolve_runtime_narrowing_owned();
+        let execution_runtime_narrowing = resolved_runtime_narrowing.clone().unwrap_or_default();
+        let contract_runtime_narrowing = execution_runtime_narrowing.clone();
+
+        self.runtime_narrowing = resolved_runtime_narrowing;
+        if let Some(subagent_execution) = self.subagent_execution.as_mut() {
+            subagent_execution.runtime_narrowing = execution_runtime_narrowing;
+        }
+        if let Some(subagent_contract) = self.subagent_contract.as_mut() {
+            subagent_contract.runtime_narrowing = contract_runtime_narrowing;
+        }
+    }
+}
+
+fn non_empty_runtime_narrowing_ref(
+    runtime_narrowing: Option<&ToolRuntimeNarrowing>,
+) -> Option<&ToolRuntimeNarrowing> {
+    runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty())
+}
+
+fn non_empty_runtime_narrowing_owned(
+    runtime_narrowing: Option<ToolRuntimeNarrowing>,
+) -> Option<ToolRuntimeNarrowing> {
+    runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty())
 }
 
 fn normalize_session_id(session_id: String) -> String {
@@ -319,15 +383,10 @@ fn merge_effective_runtime_narrowing(
     let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
         (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
     });
-
-    match (delegate_runtime_narrowing, policy_runtime_narrowing) {
-        (Some(delegate_runtime_narrowing), Some(policy_runtime_narrowing)) => {
-            Some(delegate_runtime_narrowing.intersect(&policy_runtime_narrowing))
-        }
-        (Some(delegate_runtime_narrowing), None) => Some(delegate_runtime_narrowing),
-        (None, Some(policy_runtime_narrowing)) => Some(policy_runtime_narrowing),
-        (None, None) => None,
-    }
+    crate::tools::runtime_config::merge_runtime_narrowing_sources(
+        delegate_runtime_narrowing,
+        policy_runtime_narrowing,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -167,27 +167,7 @@ impl SessionContext {
     }
 
     pub fn resolved_runtime_narrowing(&self) -> Option<&ToolRuntimeNarrowing> {
-        let session_runtime_narrowing =
-            non_empty_runtime_narrowing_ref(self.runtime_narrowing.as_ref());
-        if let Some(session_runtime_narrowing) = session_runtime_narrowing {
-            return Some(session_runtime_narrowing);
-        }
-
-        let execution_runtime_narrowing = self
-            .subagent_execution
-            .as_ref()
-            .map(|execution| &execution.runtime_narrowing);
-        let execution_runtime_narrowing =
-            non_empty_runtime_narrowing_ref(execution_runtime_narrowing);
-        if let Some(execution_runtime_narrowing) = execution_runtime_narrowing {
-            return Some(execution_runtime_narrowing);
-        }
-
-        let contract_runtime_narrowing = self
-            .subagent_contract
-            .as_ref()
-            .map(|contract| &contract.runtime_narrowing);
-        non_empty_runtime_narrowing_ref(contract_runtime_narrowing)
+        self.resolve_runtime_narrowing_ref()
     }
 
     pub fn resolved_subagent_profile(&self) -> Option<ConstrainedSubagentProfile> {
@@ -247,27 +227,8 @@ impl SessionContext {
     }
 
     fn resolve_runtime_narrowing_owned(&self) -> Option<ToolRuntimeNarrowing> {
-        let session_runtime_narrowing =
-            non_empty_runtime_narrowing_owned(self.runtime_narrowing.clone());
-        if let Some(session_runtime_narrowing) = session_runtime_narrowing {
-            return Some(session_runtime_narrowing);
-        }
-
-        let execution_runtime_narrowing = self
-            .subagent_execution
-            .as_ref()
-            .map(|execution| execution.runtime_narrowing.clone());
-        let execution_runtime_narrowing =
-            non_empty_runtime_narrowing_owned(execution_runtime_narrowing);
-        if let Some(execution_runtime_narrowing) = execution_runtime_narrowing {
-            return Some(execution_runtime_narrowing);
-        }
-
-        let contract_runtime_narrowing = self
-            .subagent_contract
-            .as_ref()
-            .map(|contract| contract.runtime_narrowing.clone());
-        non_empty_runtime_narrowing_owned(contract_runtime_narrowing)
+        let resolved_runtime_narrowing = self.resolve_runtime_narrowing_ref();
+        resolved_runtime_narrowing.cloned()
     }
 
     fn synchronize_runtime_narrowing_views(&mut self) {
@@ -283,17 +244,35 @@ impl SessionContext {
             subagent_contract.runtime_narrowing = contract_runtime_narrowing;
         }
     }
+
+    fn resolve_runtime_narrowing_ref(&self) -> Option<&ToolRuntimeNarrowing> {
+        let session_runtime_narrowing =
+            non_empty_runtime_narrowing_ref(self.runtime_narrowing.as_ref());
+        if let Some(session_runtime_narrowing) = session_runtime_narrowing {
+            return Some(session_runtime_narrowing);
+        }
+
+        let execution_runtime_narrowing_source = self
+            .subagent_execution
+            .as_ref()
+            .map(|execution| &execution.runtime_narrowing);
+        let execution_runtime_narrowing =
+            non_empty_runtime_narrowing_ref(execution_runtime_narrowing_source);
+        if let Some(execution_runtime_narrowing) = execution_runtime_narrowing {
+            return Some(execution_runtime_narrowing);
+        }
+
+        let contract_runtime_narrowing_source = self
+            .subagent_contract
+            .as_ref()
+            .map(|contract| &contract.runtime_narrowing);
+        non_empty_runtime_narrowing_ref(contract_runtime_narrowing_source)
+    }
 }
 
 fn non_empty_runtime_narrowing_ref(
     runtime_narrowing: Option<&ToolRuntimeNarrowing>,
 ) -> Option<&ToolRuntimeNarrowing> {
-    runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty())
-}
-
-fn non_empty_runtime_narrowing_owned(
-    runtime_narrowing: Option<ToolRuntimeNarrowing>,
-) -> Option<ToolRuntimeNarrowing> {
     runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty())
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2911,6 +2911,49 @@ fn session_context_with_subagent_execution_preserves_prior_runtime_narrowing() {
     assert_eq!(effective_runtime_narrowing, Some(runtime_narrowing));
 }
 
+#[test]
+fn session_context_with_subagent_execution_promotes_execution_runtime_narrowing_to_session_scope() {
+    let execution_runtime_narrowing = crate::tools::runtime_config::ToolRuntimeNarrowing {
+        browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+            max_sessions: Some(1),
+            ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+        },
+        ..crate::tools::runtime_config::ToolRuntimeNarrowing::default()
+    };
+    let execution = crate::conversation::ConstrainedSubagentExecution {
+        mode: crate::conversation::ConstrainedSubagentMode::Inline,
+        depth: 1,
+        max_depth: 3,
+        active_children: 0,
+        max_active_children: 2,
+        timeout_seconds: 60,
+        allow_shell_in_child: false,
+        child_tool_allowlist: vec!["web.fetch".to_owned()],
+        runtime_narrowing: execution_runtime_narrowing.clone(),
+        kernel_bound: false,
+        identity: None,
+        profile: None,
+    };
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&crate::config::ToolConfig::default()),
+    )
+    .with_subagent_execution(execution);
+
+    let session_runtime_narrowing = session_context.runtime_narrowing.clone();
+    let resolved_runtime_narrowing = session_context.resolved_runtime_narrowing().cloned();
+
+    assert_eq!(
+        session_runtime_narrowing,
+        Some(execution_runtime_narrowing.clone())
+    );
+    assert_eq!(
+        resolved_runtime_narrowing,
+        Some(execution_runtime_narrowing)
+    );
+}
+
 #[tokio::test]
 async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2954,6 +2954,45 @@ fn session_context_with_subagent_execution_promotes_execution_runtime_narrowing_
     );
 }
 
+#[test]
+fn resolved_subagent_contract_uses_effective_runtime_narrowing_over_stale_contract_view() {
+    let effective_runtime_narrowing = crate::tools::runtime_config::ToolRuntimeNarrowing {
+        browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+            max_sessions: Some(1),
+            ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+        },
+        ..crate::tools::runtime_config::ToolRuntimeNarrowing::default()
+    };
+    let stale_contract_runtime_narrowing = crate::tools::runtime_config::ToolRuntimeNarrowing {
+        browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+            max_sessions: Some(3),
+            ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+        },
+        ..crate::tools::runtime_config::ToolRuntimeNarrowing::default()
+    };
+    let mut session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&crate::config::ToolConfig::default()),
+    )
+    .with_runtime_narrowing(effective_runtime_narrowing.clone());
+
+    session_context.subagent_contract = Some(
+        crate::conversation::ConstrainedSubagentContractView::from_runtime_narrowing(
+            stale_contract_runtime_narrowing,
+        ),
+    );
+
+    let resolved_runtime_narrowing = session_context
+        .resolved_subagent_contract()
+        .map(|contract| contract.runtime_narrowing);
+
+    assert_eq!(
+        resolved_runtime_narrowing,
+        Some(effective_runtime_narrowing)
+    );
+}
+
 #[tokio::test]
 async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1857,12 +1857,10 @@ fn inject_runtime_narrowing_context(
     payload: serde_json::Value,
     session_context: &SessionContext,
 ) -> serde_json::Value {
-    let Some(runtime_narrowing) = session_context.runtime_narrowing.as_ref() else {
+    let resolved_runtime_narrowing = session_context.resolved_runtime_narrowing();
+    let Some(runtime_narrowing) = resolved_runtime_narrowing else {
         return payload;
     };
-    if runtime_narrowing.is_empty() {
-        return payload;
-    }
 
     let serde_json::Value::Object(mut object) = payload else {
         return payload;

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -828,19 +828,7 @@ pub(super) fn ensure_memory_db_ready_with_diagnostics(
     let effective = path.unwrap_or_else(|| resolve_db_path(config));
     let (runtime, diagnostics) = acquire_sqlite_runtime_with_diagnostics(effective)?;
     runtime.with_connection_mut("memory.ensure_db_ready", |conn| {
-        let user_version = read_sqlite_user_version(conn)?;
-        let current_schema_ready = user_version == SQLITE_MEMORY_SCHEMA_VERSION
-            && sqlite_current_schema_objects_ready(conn)?;
-        if user_version < SQLITE_MEMORY_SCHEMA_VERSION || !current_schema_ready {
-            ensure_turn_session_index_and_state_metadata(conn)?;
-            ensure_approval_lifecycle_tables(conn)?;
-            ensure_session_tool_consent_storage(conn)?;
-            ensure_session_tool_policy_storage(conn)?;
-            ensure_summary_checkpoint_storage_layout(conn)?;
-            ensure_canonical_record_storage(conn)?;
-            write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
-        }
-        Ok(())
+        ensure_sqlite_schema_repairs_if_needed(conn)
     })?;
     Ok((runtime.path().to_path_buf(), diagnostics))
 }
@@ -1408,9 +1396,8 @@ fn open_sqlite_connection_with_diagnostics(
     diagnostics.configure_connection_ms = elapsed_ms(configure_started_at);
 
     let schema_upgrade_started_at = StdInstant::now();
-    let user_version = read_sqlite_user_version(&conn)?;
-    let current_schema_ready =
-        user_version == SQLITE_MEMORY_SCHEMA_VERSION && sqlite_current_schema_objects_ready(&conn)?;
+    let schema_probe = probe_sqlite_schema(&conn)?;
+    let current_schema_ready = schema_probe.current_schema_ready;
 
     if !current_schema_ready {
         let schema_init_started_at = StdInstant::now();
@@ -1606,15 +1593,7 @@ fn open_sqlite_connection_with_diagnostics(
         diagnostics.schema_init_ms = elapsed_ms(schema_init_started_at);
     }
 
-    if user_version < SQLITE_MEMORY_SCHEMA_VERSION || !current_schema_ready {
-        ensure_turn_session_index_and_state_metadata(&conn)?;
-        ensure_approval_lifecycle_tables(&conn)?;
-        ensure_session_tool_consent_storage(&mut conn)?;
-        ensure_session_tool_policy_storage(&conn)?;
-        ensure_summary_checkpoint_storage_layout(&conn)?;
-        ensure_canonical_record_storage(&conn)?;
-        write_sqlite_user_version(&conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
-    }
+    ensure_sqlite_schema_repairs_if_needed(&mut conn)?;
     ensure_control_plane_pairing_tables(&conn)?;
     diagnostics.schema_upgrade_ms = elapsed_ms(schema_upgrade_started_at);
 
@@ -1642,9 +1621,52 @@ fn read_sqlite_user_version(conn: &Connection) -> Result<i64, String> {
         .map_err(|error| format!("read sqlite user_version failed: {error}"))
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SqliteSchemaProbe {
+    user_version: i64,
+    current_schema_ready: bool,
+}
+
+impl SqliteSchemaProbe {
+    fn requires_repairs(self) -> bool {
+        if self.user_version < SQLITE_MEMORY_SCHEMA_VERSION {
+            return true;
+        }
+        !self.current_schema_ready
+    }
+}
+
 fn write_sqlite_user_version(conn: &Connection, version: i64) -> Result<(), String> {
     conn.pragma_update(None, "user_version", version)
         .map_err(|error| format!("set sqlite user_version={version} failed: {error}"))
+}
+
+fn probe_sqlite_schema(conn: &Connection) -> Result<SqliteSchemaProbe, String> {
+    let user_version = read_sqlite_user_version(conn)?;
+    let current_schema_ready =
+        user_version == SQLITE_MEMORY_SCHEMA_VERSION && sqlite_current_schema_objects_ready(conn)?;
+
+    Ok(SqliteSchemaProbe {
+        user_version,
+        current_schema_ready,
+    })
+}
+
+fn ensure_sqlite_schema_repairs_if_needed(conn: &mut Connection) -> Result<(), String> {
+    let schema_probe = probe_sqlite_schema(conn)?;
+    if !schema_probe.requires_repairs() {
+        return Ok(());
+    }
+
+    ensure_turn_session_index_and_state_metadata(conn)?;
+    ensure_approval_lifecycle_tables(conn)?;
+    ensure_session_tool_consent_storage(conn)?;
+    ensure_session_tool_policy_storage(conn)?;
+    ensure_summary_checkpoint_storage_layout(conn)?;
+    ensure_canonical_record_storage(conn)?;
+    write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
+
+    Ok(())
 }
 
 fn sqlite_current_schema_objects_ready(conn: &Connection) -> Result<bool, String> {
@@ -8629,6 +8651,101 @@ mod tests {
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].record.metadata["source"], "workspace-import");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn cached_runtime_repair_path_recovers_stale_canonical_fts_metadata_schema() {
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-cached-runtime-stale-fts-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("cached-runtime-stale-fts.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
+
+        let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
+        runtime
+            .with_connection_mut("test.degrade_cached_runtime_canonical_fts", |conn| {
+                conn.execute_batch(
+                    "
+                    DROP TRIGGER IF EXISTS memory_canonical_records_ai;
+                    DROP TRIGGER IF EXISTS memory_canonical_records_ad;
+                    DROP TRIGGER IF EXISTS memory_canonical_records_au;
+                    DROP TABLE IF EXISTS memory_canonical_records_fts;
+                    CREATE VIRTUAL TABLE memory_canonical_records_fts
+                      USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+                    CREATE TRIGGER memory_canonical_records_ai
+                      AFTER INSERT ON memory_canonical_records
+                    BEGIN
+                      INSERT INTO memory_canonical_records_fts(rowid, content)
+                      VALUES (new.record_id, new.content);
+                    END;
+                    CREATE TRIGGER memory_canonical_records_ad
+                      AFTER DELETE ON memory_canonical_records
+                    BEGIN
+                      INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+                      VALUES ('delete', old.record_id, old.content);
+                    END;
+                    CREATE TRIGGER memory_canonical_records_au
+                      AFTER UPDATE ON memory_canonical_records
+                    BEGIN
+                      INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+                      VALUES ('delete', old.record_id, old.content);
+                      INSERT INTO memory_canonical_records_fts(rowid, content)
+                      VALUES (new.record_id, new.content);
+                    END;
+                    PRAGMA user_version = 8;
+                    ",
+                )
+                .map_err(|error| format!("degrade cached canonical FTS schema failed: {error}"))?;
+                Ok(())
+            })
+            .expect("degrade cached canonical FTS schema");
+
+        let payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "release checklist",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+        append_turn_direct("workspace-session", "assistant", &payload, &config)
+            .expect("append structured canonical payload");
+
+        reset_sqlite_schema_repair_metrics_for_tests();
+        ensure_memory_db_ready_with_diagnostics(None, &config)
+            .expect("repair cached stale canonical FTS schema");
+
+        assert_eq!(
+            sqlite_schema_repair_count_for_tests("canonical_records"),
+            1,
+            "expected cached runtime repair path to repair canonical records once"
+        );
+
+        let hits = search_canonical_records_for_recall("release checklist", 5, None, &config)
+            .expect("search canonical memory after cached runtime repair");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
+        assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -828,7 +828,7 @@ pub(super) fn ensure_memory_db_ready_with_diagnostics(
     let effective = path.unwrap_or_else(|| resolve_db_path(config));
     let (runtime, diagnostics) = acquire_sqlite_runtime_with_diagnostics(effective)?;
     runtime.with_connection_mut("memory.ensure_db_ready", |conn| {
-        ensure_sqlite_schema_repairs_if_needed(conn)
+        ensure_sqlite_runtime_schema_ready(conn)
     })?;
     Ok((runtime.path().to_path_buf(), diagnostics))
 }
@@ -1397,9 +1397,9 @@ fn open_sqlite_connection_with_diagnostics(
 
     let schema_upgrade_started_at = StdInstant::now();
     let schema_probe = probe_sqlite_schema(&conn)?;
-    let current_schema_ready = schema_probe.current_schema_ready;
+    let requires_current_schema_setup = schema_probe.requires_current_schema_setup();
 
-    if !current_schema_ready {
+    if requires_current_schema_setup {
         let schema_init_started_at = StdInstant::now();
         #[cfg(test)]
         test_support::record_sqlite_schema_init(path);
@@ -1593,8 +1593,7 @@ fn open_sqlite_connection_with_diagnostics(
         diagnostics.schema_init_ms = elapsed_ms(schema_init_started_at);
     }
 
-    ensure_sqlite_schema_repairs_if_needed(&mut conn)?;
-    ensure_control_plane_pairing_tables(&conn)?;
+    ensure_sqlite_runtime_schema_ready(&mut conn)?;
     diagnostics.schema_upgrade_ms = elapsed_ms(schema_upgrade_started_at);
 
     #[cfg(test)]
@@ -1628,11 +1627,18 @@ struct SqliteSchemaProbe {
 }
 
 impl SqliteSchemaProbe {
-    fn requires_repairs(self) -> bool {
+    fn requires_current_schema_setup(self) -> bool {
+        if self.user_version > SQLITE_MEMORY_SCHEMA_VERSION {
+            return false;
+        }
         if self.user_version < SQLITE_MEMORY_SCHEMA_VERSION {
             return true;
         }
         !self.current_schema_ready
+    }
+
+    fn requires_repairs(self) -> bool {
+        self.requires_current_schema_setup()
     }
 }
 
@@ -1666,6 +1672,12 @@ fn ensure_sqlite_schema_repairs_if_needed(conn: &mut Connection) -> Result<(), S
     ensure_canonical_record_storage(conn)?;
     write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
 
+    Ok(())
+}
+
+fn ensure_sqlite_runtime_schema_ready(conn: &mut Connection) -> Result<(), String> {
+    ensure_sqlite_schema_repairs_if_needed(conn)?;
+    ensure_control_plane_pairing_tables(conn)?;
     Ok(())
 }
 
@@ -8747,6 +8759,143 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
         assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn cached_runtime_repair_path_restores_control_plane_pairing_tables() {
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-cached-runtime-pairing-schema-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("cached-runtime-pairing-schema.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
+
+        let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
+        runtime
+            .with_connection_mut("test.drop_cached_pairing_tables", |conn| {
+                conn.execute_batch(
+                    "
+                    DROP INDEX IF EXISTS idx_control_plane_pairing_requests_status_requested_at;
+                    DROP INDEX IF EXISTS idx_control_plane_device_tokens_device_id;
+                    DROP TABLE IF EXISTS control_plane_pairing_requests;
+                    DROP TABLE IF EXISTS control_plane_device_tokens;
+                    ",
+                )
+                .map_err(|error| format!("drop cached pairing tables failed: {error}"))?;
+                Ok(())
+            })
+            .expect("drop cached pairing tables");
+
+        ensure_memory_db_ready_with_diagnostics(None, &config)
+            .expect("repair cached control-plane pairing schema");
+
+        let pairing_requests_table_exists = runtime
+            .with_connection("test.verify_cached_pairing_requests_table", |conn| {
+                conn.query_row(
+                    "SELECT COUNT(*)
+                     FROM sqlite_master
+                     WHERE type = 'table' AND name = 'control_plane_pairing_requests'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map(|count| count == 1)
+                .map_err(|error| format!("query cached pairing requests table failed: {error}"))
+            })
+            .expect("query cached pairing requests table");
+        let device_tokens_table_exists = runtime
+            .with_connection("test.verify_cached_device_tokens_table", |conn| {
+                conn.query_row(
+                    "SELECT COUNT(*)
+                     FROM sqlite_master
+                     WHERE type = 'table' AND name = 'control_plane_device_tokens'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map(|count| count == 1)
+                .map_err(|error| format!("query cached device tokens table failed: {error}"))
+            })
+            .expect("query cached device tokens table");
+
+        assert!(pairing_requests_table_exists);
+        assert!(device_tokens_table_exists);
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_memory_db_ready_preserves_newer_schema_versions_without_current_repairs() {
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-future-sqlite-schema-version-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("future-schema-version.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
+
+        let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
+        let future_schema_version = SQLITE_MEMORY_SCHEMA_VERSION + 1;
+        runtime
+            .with_connection_mut("test.bump_sqlite_user_version", |conn| {
+                write_sqlite_user_version(conn, future_schema_version)
+            })
+            .expect("bump sqlite user_version");
+
+        reset_sqlite_schema_repair_metrics_for_tests();
+        ensure_memory_db_ready_with_diagnostics(None, &config)
+            .expect("recheck cached newer sqlite schema");
+
+        let cached_user_version = runtime
+            .with_connection("test.read_cached_future_user_version", |conn| {
+                read_sqlite_user_version(conn)
+            })
+            .expect("read cached future sqlite user_version");
+        assert_eq!(cached_user_version, future_schema_version);
+        drop(runtime);
+
+        reset_sqlite_runtime_test_state();
+        ensure_memory_db_ready_with_diagnostics(Some(db_path.clone()), &config)
+            .expect("reopen newer sqlite schema");
+
+        let reopened_runtime =
+            acquire_memory_runtime(&config).expect("reopen cached sqlite runtime");
+        let reopened_user_version = reopened_runtime
+            .with_connection("test.read_future_user_version", |conn| {
+                read_sqlite_user_version(conn)
+            })
+            .expect("read future sqlite user_version");
+        let schema_init_count = sqlite_schema_init_count_for_tests(&db_path);
+
+        assert_eq!(reopened_user_version, future_schema_version);
+        assert_eq!(schema_init_count, 0);
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -8735,10 +8735,11 @@ mod tests {
         ensure_memory_db_ready_with_diagnostics(None, &config)
             .expect("repair cached stale canonical FTS schema");
 
-        assert_eq!(
-            sqlite_schema_repair_count_for_tests("canonical_records"),
-            1,
-            "expected cached runtime repair path to repair canonical records once"
+        let canonical_record_repair_count =
+            sqlite_schema_repair_count_for_tests("canonical_records");
+        assert!(
+            canonical_record_repair_count >= 1,
+            "expected cached runtime repair path to trigger canonical record repair, got: {canonical_record_repair_count}"
         );
 
         let hits = search_canonical_records_for_recall("release checklist", 5, None, &config)

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -3063,6 +3063,42 @@ mod tests {
     }
 
     #[test]
+    fn merge_runtime_narrowing_sources_handles_empty_and_single_source_inputs() {
+        let primary_runtime_narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(2),
+                ..BrowserRuntimeNarrowing::default()
+            },
+            ..ToolRuntimeNarrowing::default()
+        };
+        let empty_runtime_narrowing = ToolRuntimeNarrowing::default();
+
+        let none_result = merge_runtime_narrowing_sources(None, None);
+        let primary_only_result =
+            merge_runtime_narrowing_sources(Some(primary_runtime_narrowing.clone()), None);
+        let secondary_only_result =
+            merge_runtime_narrowing_sources(None, Some(primary_runtime_narrowing.clone()));
+        let empty_primary_result =
+            merge_runtime_narrowing_sources(Some(empty_runtime_narrowing.clone()), None);
+        let empty_primary_with_secondary_result = merge_runtime_narrowing_sources(
+            Some(empty_runtime_narrowing),
+            Some(primary_runtime_narrowing.clone()),
+        );
+
+        assert!(none_result.is_none());
+        assert_eq!(primary_only_result, Some(primary_runtime_narrowing.clone()));
+        assert_eq!(
+            secondary_only_result,
+            Some(primary_runtime_narrowing.clone())
+        );
+        assert!(empty_primary_result.is_none());
+        assert_eq!(
+            empty_primary_with_secondary_result,
+            Some(primary_runtime_narrowing)
+        );
+    }
+
+    #[test]
     fn delegate_child_prompt_summary_returns_none_when_narrowing_is_empty() {
         assert_eq!(
             ToolRuntimeConfig::default().delegate_child_prompt_summary(None),

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -187,6 +187,27 @@ fn intersect_private_host_setting(left: Option<bool>, right: Option<bool>) -> Op
     None
 }
 
+pub(crate) fn merge_runtime_narrowing_sources(
+    primary_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    secondary_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+) -> Option<ToolRuntimeNarrowing> {
+    let primary_runtime_narrowing =
+        primary_runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty());
+    let secondary_runtime_narrowing =
+        secondary_runtime_narrowing.filter(|runtime_narrowing| !runtime_narrowing.is_empty());
+
+    match (primary_runtime_narrowing, secondary_runtime_narrowing) {
+        (Some(primary_runtime_narrowing), Some(secondary_runtime_narrowing)) => {
+            let merged_runtime_narrowing =
+                primary_runtime_narrowing.intersect(&secondary_runtime_narrowing);
+            Some(merged_runtime_narrowing)
+        }
+        (Some(primary_runtime_narrowing), None) => Some(primary_runtime_narrowing),
+        (None, Some(secondary_runtime_narrowing)) => Some(secondary_runtime_narrowing),
+        (None, None) => None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalSkillsRuntimePolicy {
     pub enabled: bool,
@@ -2987,6 +3008,58 @@ mod tests {
         assert_eq!(effective.web_fetch.timeout_seconds, Some(5));
         assert_eq!(effective.web_fetch.max_bytes, Some(4_096));
         assert_eq!(effective.web_fetch.max_redirects, Some(2));
+    }
+
+    #[test]
+    fn merge_runtime_narrowing_sources_intersects_delegate_and_policy_inputs() {
+        let delegate_runtime_narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                ..BrowserRuntimeNarrowing::default()
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny-left.example.com".to_owned()]),
+                ..WebFetchRuntimeNarrowing::default()
+            },
+        };
+        let policy_runtime_narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(3),
+                ..BrowserRuntimeNarrowing::default()
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allowed_domains: BTreeSet::from(["api.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny-right.example.com".to_owned()]),
+                ..WebFetchRuntimeNarrowing::default()
+            },
+        };
+
+        let effective_runtime_narrowing = merge_runtime_narrowing_sources(
+            Some(delegate_runtime_narrowing),
+            Some(policy_runtime_narrowing),
+        )
+        .expect("effective runtime narrowing");
+
+        assert_eq!(effective_runtime_narrowing.browser.max_sessions, Some(1));
+        assert!(
+            effective_runtime_narrowing
+                .web_fetch
+                .enforce_allowed_domains
+        );
+        assert!(
+            effective_runtime_narrowing
+                .web_fetch
+                .allowed_domains
+                .is_empty()
+        );
+        assert_eq!(
+            effective_runtime_narrowing.web_fetch.blocked_domains,
+            BTreeSet::from([
+                "deny-left.example.com".to_owned(),
+                "deny-right.example.com".to_owned(),
+            ])
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -2735,15 +2735,10 @@ fn merge_session_tool_policy_runtime_narrowing(
     let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
         (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
     });
-
-    match (delegate_runtime_narrowing, policy_runtime_narrowing) {
-        (Some(delegate_runtime_narrowing), Some(policy_runtime_narrowing)) => {
-            Some(delegate_runtime_narrowing.intersect(&policy_runtime_narrowing))
-        }
-        (Some(delegate_runtime_narrowing), None) => Some(delegate_runtime_narrowing),
-        (None, Some(policy_runtime_narrowing)) => Some(policy_runtime_narrowing),
-        (None, None) => None,
-    }
+    super::runtime_config::merge_runtime_narrowing_sources(
+        delegate_runtime_narrowing,
+        policy_runtime_narrowing,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]


### PR DESCRIPTION
## Summary

- Problem:
  runtime narrowing authority still depends on multiple partially-overlapping views, and sqlite schema probe/repair logic is duplicated across cold and hot paths.
- Why it matters:
  this makes delegate/session behavior order-sensitive and makes future sqlite repair changes easier to regress after otherwise-routine refactors.
- What changed:
  unified delegate/session-policy runtime narrowing merge logic behind a shared helper, normalized `SessionContext` runtime narrowing reconciliation across session, execution, and contract views, updated tool payload injection to read the resolved narrowing view, and extracted a shared sqlite schema probe/repair helper that is now used by both bootstrap and cached-runtime repair paths.
- What did not change (scope boundary):
  this does not change public config semantics, tool policy meanings, or the control-plane pairing schema contract.

## Linked Issues

- Closes #933
- Related #931

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app conversation::tests::session_context_with_subagent_execution_preserves_prior_runtime_narrowing -- --exact
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app conversation::tests::session_context_with_subagent_execution_promotes_execution_runtime_narrowing_to_session_scope -- --exact
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app conversation::tests::handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload -- --exact
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app memory::sqlite::tests::ensure_memory_db_ready_repairs_stale_canonical_fts_metadata_schema -- --exact
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app memory::sqlite::tests::cached_runtime_repair_path_recovers_stale_canonical_fts_metadata_schema -- --exact
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked
env CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked
bash scripts/check_architecture_boundaries.sh
bash scripts/check_dep_graph.sh

All commands passed.
`task check:architecture` was unavailable in this environment, so the underlying architecture scripts were run directly instead.
```

## User-visible / Operator-visible Changes

- None. This is an internal correctness and maintainability hardening change.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR cleanly; no config migration or data rewrite is introduced outside the existing sqlite repair path.
- Observable failure symptoms reviewers should watch for:
  missing runtime narrowing in delegated tool payloads, child-session contract prompt drift, or sqlite repair regressions on stale canonical FTS schemas.

## Reviewer Focus

- `crates/app/src/conversation/runtime.rs`
  confirm `SessionContext` now keeps one resolved runtime narrowing view regardless of builder order.
- `crates/app/src/tools/runtime_config.rs`
  confirm the new shared runtime narrowing merge helper matches existing delegate/session-policy semantics.
- `crates/app/src/memory/sqlite.rs`
  confirm cold bootstrap and cached-runtime repair now share one schema repair decision path without changing the current-schema fast path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized runtime configuration propagation and added a single resolved view to ensure consistent session/subagent behavior.
  * Simplified merging of runtime constraints by delegating to a shared merger to reduce duplication.

* **Bug Fix**
  * Context payload injection now uses the unified resolved runtime configuration, ensuring consistent context is provided downstream.

* **Chores / Reliability**
  * Unified database schema readiness and repair flow to improve startup reliability.

* **Tests**
  * Added tests covering runtime-constraint promotion and schema repair recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->