### PR TITLE
Tool concurrency classification (is_mutating)

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -246,6 +246,7 @@ pub struct ToolDescriptor {
     pub visibility_gate: ToolVisibilityGate,
     capability_action_class: CapabilityActionClass,
     policy: ToolPolicyDescriptor,
+    concurrency_class: ToolConcurrencyClass,
     provider_definition_builder: fn(&ToolDescriptor) -> Value,
 }
 
@@ -295,10 +296,7 @@ impl ToolDescriptor {
     }
 
     pub fn concurrency_class(&self) -> ToolConcurrencyClass {
-        match self.scheduling_class() {
-            ToolSchedulingClass::ParallelSafe => ToolConcurrencyClass::ReadOnly,
-            ToolSchedulingClass::SerialOnly => ToolConcurrencyClass::Unknown,
-        }
+        self.concurrency_class
     }
 
     pub fn governance_profile(&self) -> ToolGovernanceProfile {
@@ -447,6 +445,69 @@ impl ToolCatalog {
     }
 }
 
+fn declared_concurrency_class(tool_name: &str) -> ToolConcurrencyClass {
+    match tool_name {
+        "tool.search"
+        | "external_skills.resolve"
+        | "external_skills.search"
+        | "external_skills.recommend"
+        | "external_skills.source_search"
+        | "external_skills.inspect"
+        | "external_skills.list"
+        | "approval_request_status"
+        | "approval_requests_list"
+        | "session_events"
+        | "session_tool_policy_status"
+        | "session_search"
+        | "session_status"
+        | "session_wait"
+        | "sessions_history"
+        | "sessions_list"
+        | "file.read"
+        | "memory_search"
+        | "memory_get"
+        | "browser.companion.snapshot"
+        | "browser.companion.wait"
+        | "browser.extract"
+        | "web.fetch"
+        | "web.search" => ToolConcurrencyClass::ReadOnly,
+        "config.import"
+        | "external_skills.fetch"
+        | "external_skills.install"
+        | "external_skills.invoke"
+        | "external_skills.policy"
+        | "external_skills.remove"
+        | "provider.switch"
+        | "approval_request_resolve"
+        | "delegate"
+        | "delegate_async"
+        | "session_archive"
+        | "session_cancel"
+        | "session_tool_policy_set"
+        | "session_tool_policy_clear"
+        | "session_recover"
+        | "sessions_send"
+        | "file.write"
+        | "file.edit"
+        | "shell.exec"
+        | "bash.exec"
+        | "browser.click"
+        | "browser.companion.click"
+        | "browser.companion.navigate"
+        | "browser.companion.session.start"
+        | "browser.companion.session.stop"
+        | "browser.companion.type"
+        | "browser.open" => ToolConcurrencyClass::Mutating,
+        _ => ToolConcurrencyClass::Unknown,
+    }
+}
+
+fn annotate_tool_concurrency_classes(descriptors: &mut [ToolDescriptor]) {
+    for descriptor in descriptors {
+        descriptor.concurrency_class = declared_concurrency_class(descriptor.name);
+    }
+}
+
 fn build_tool_catalog() -> ToolCatalog {
     let mut descriptors = vec![
         ToolDescriptor {
@@ -460,6 +521,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::Discover,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: tool_search_definition,
         },
         ToolDescriptor {
@@ -473,6 +535,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: tool_invoke_definition,
         },
         ToolDescriptor {
@@ -486,6 +549,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: config_import_definition,
         },
         ToolDescriptor {
@@ -499,6 +563,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::CapabilityFetch,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_fetch_definition,
         },
         ToolDescriptor {
@@ -512,6 +577,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_resolve_definition,
         },
         ToolDescriptor {
@@ -525,6 +591,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_search_definition,
         },
         ToolDescriptor {
@@ -538,6 +605,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_recommend_definition,
         },
         ToolDescriptor {
@@ -551,6 +619,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_source_search_definition,
         },
         ToolDescriptor {
@@ -564,6 +633,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_inspect_definition,
         },
         ToolDescriptor {
@@ -577,6 +647,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::CapabilityInstall,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_install_definition,
         },
         ToolDescriptor {
@@ -590,6 +661,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::CapabilityLoad,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_invoke_definition,
         },
         ToolDescriptor {
@@ -603,6 +675,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_list_definition,
         },
         ToolDescriptor {
@@ -616,6 +689,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_policy_definition,
         },
         ToolDescriptor {
@@ -629,6 +703,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: external_skills_remove_definition,
         },
         ToolDescriptor {
@@ -642,6 +717,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::RuntimeSwitch,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: provider_switch_definition,
         },
         ToolDescriptor {
@@ -655,6 +731,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: approval_request_resolve_definition,
         },
         ToolDescriptor {
@@ -668,6 +745,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: approval_request_status_definition,
         },
         ToolDescriptor {
@@ -681,6 +759,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: approval_requests_list_definition,
         },
         ToolDescriptor {
@@ -694,6 +773,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Delegate,
             capability_action_class: CapabilityActionClass::TopologyExpand,
             policy: TOPOLOGY_MUTATION_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: delegate_definition,
         },
         ToolDescriptor {
@@ -707,6 +787,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Delegate,
             capability_action_class: CapabilityActionClass::TopologyExpand,
             policy: TOPOLOGY_MUTATION_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: delegate_async_definition,
         },
         ToolDescriptor {
@@ -720,6 +801,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::SessionMutation,
             capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_archive_definition,
         },
         ToolDescriptor {
@@ -733,6 +815,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::SessionMutation,
             capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_cancel_definition,
         },
         ToolDescriptor {
@@ -746,6 +829,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_events_definition,
         },
         ToolDescriptor {
@@ -759,6 +843,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_tool_policy_status_definition,
         },
         ToolDescriptor {
@@ -772,6 +857,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::SessionMutation,
             capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_tool_policy_set_definition,
         },
         ToolDescriptor {
@@ -785,6 +871,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::SessionMutation,
             capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_tool_policy_clear_definition,
         },
         ToolDescriptor {
@@ -798,6 +885,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_search_definition,
         },
         ToolDescriptor {
@@ -811,6 +899,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::SessionMutation,
             capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_recover_definition,
         },
         ToolDescriptor {
@@ -824,6 +913,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_status_definition,
         },
         ToolDescriptor {
@@ -837,6 +927,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: session_wait_definition,
         },
         ToolDescriptor {
@@ -850,6 +941,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: sessions_history_definition,
         },
         ToolDescriptor {
@@ -863,6 +955,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Sessions,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: sessions_list_definition,
         },
         ToolDescriptor {
@@ -876,6 +969,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Messages,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: sessions_send_definition,
         },
     ];
@@ -1157,6 +1251,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: file_read_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1170,6 +1265,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::MemorySearchCorpus,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: memory_search_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1183,6 +1279,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::MemoryFileRoot,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: memory_get_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1196,6 +1293,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: file_write_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1209,6 +1307,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: file_edit_definition,
         });
     }
@@ -1226,6 +1325,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: shell_exec_definition,
         });
     }
@@ -1243,6 +1343,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BashRuntime,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: bash_exec_definition,
         });
     }
@@ -1260,6 +1361,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Browser,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_click_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1273,6 +1375,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_click_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1286,6 +1389,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_navigate_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1299,6 +1403,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_session_start_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1312,6 +1417,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_session_stop_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1325,6 +1431,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_snapshot_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1338,6 +1445,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_type_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1351,6 +1459,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_companion_wait_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1364,6 +1473,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Browser,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_extract_definition,
         });
         descriptors.push(ToolDescriptor {
@@ -1378,6 +1488,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Browser,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_open_definition,
         });
     }
@@ -1395,6 +1506,7 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::WebFetch,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: web_fetch_definition,
         });
     }
@@ -1413,10 +1525,12 @@ fn build_tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::WebSearch,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: web_search_definition,
         });
     }
 
+    annotate_tool_concurrency_classes(&mut descriptors);
     descriptors.sort_by(|left, right| left.name.cmp(right.name));
     ToolCatalog { descriptors }
 }
@@ -3493,6 +3607,7 @@ fn push_feishu_tool_descriptor(
         visibility_gate: ToolVisibilityGate::Feishu,
         capability_action_class: CapabilityActionClass::ExecuteExisting,
         policy,
+        concurrency_class: ToolConcurrencyClass::Unknown,
         provider_definition_builder: feishu_definition,
     });
 }
@@ -4739,10 +4854,24 @@ mod tests {
         assert_eq!(invoke.scheduling_class, ToolSchedulingClass::SerialOnly);
         assert_eq!(invoke.concurrency_class, ToolConcurrencyClass::Unknown);
 
-        let status =
-            find_tool_catalog_entry("session_status").expect("session_status catalog entry");
-        assert_eq!(status.scheduling_class, ToolSchedulingClass::SerialOnly);
-        assert_eq!(status.concurrency_class, ToolConcurrencyClass::Unknown);
+        let delegate_async =
+            find_tool_catalog_entry("delegate_async").expect("delegate_async catalog entry");
+        assert_eq!(
+            delegate_async.scheduling_class,
+            ToolSchedulingClass::SerialOnly
+        );
+        assert_eq!(
+            delegate_async.concurrency_class,
+            ToolConcurrencyClass::Mutating
+        );
+
+        let file_write = find_tool_catalog_entry("file.write").expect("file.write catalog entry");
+        assert_eq!(file_write.scheduling_class, ToolSchedulingClass::SerialOnly);
+        assert_eq!(file_write.concurrency_class, ToolConcurrencyClass::Mutating);
+
+        let bash_exec = find_tool_catalog_entry("bash.exec").expect("bash.exec catalog entry");
+        assert_eq!(bash_exec.scheduling_class, ToolSchedulingClass::SerialOnly);
+        assert_eq!(bash_exec.concurrency_class, ToolConcurrencyClass::Mutating);
     }
 
     #[test]
@@ -4933,6 +5062,9 @@ mod tests {
         let search = find_tool_catalog_entry("tool.search").expect("tool.search catalog entry");
         let search_value =
             serde_json::to_value(search).expect("serialize tool.search catalog entry");
+        let invoke = find_tool_catalog_entry("tool.invoke").expect("tool.invoke catalog entry");
+        let invoke_value =
+            serde_json::to_value(invoke).expect("serialize tool.invoke catalog entry");
 
         assert_eq!(
             delegate_async.capability_action_class,
@@ -4942,8 +5074,9 @@ mod tests {
             delegate_async_value["capability_action_class"],
             "topology_expand"
         );
-        assert_eq!(delegate_async_value["concurrency_class"], "unknown");
+        assert_eq!(delegate_async_value["concurrency_class"], "mutating");
         assert_eq!(search_value["concurrency_class"], "read_only");
+        assert_eq!(invoke_value["concurrency_class"], "unknown");
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::OnceLock;
 
+use loongclaw_kernel::ToolConcurrencyClass;
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -293,6 +294,13 @@ impl ToolDescriptor {
         self.policy.scheduling_class
     }
 
+    pub fn concurrency_class(&self) -> ToolConcurrencyClass {
+        match self.scheduling_class() {
+            ToolSchedulingClass::ParallelSafe => ToolConcurrencyClass::ReadOnly,
+            ToolSchedulingClass::SerialOnly => ToolConcurrencyClass::Mutating,
+        }
+    }
+
     pub fn governance_profile(&self) -> ToolGovernanceProfile {
         self.policy.governance_profile
     }
@@ -320,6 +328,7 @@ pub struct ToolCatalogEntry {
     pub availability: ToolAvailability,
     pub capability_action_class: CapabilityActionClass,
     pub scheduling_class: ToolSchedulingClass,
+    pub concurrency_class: ToolConcurrencyClass,
 }
 
 impl ToolCatalogEntry {
@@ -1664,6 +1673,7 @@ fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
         availability: descriptor.availability,
         capability_action_class: descriptor.capability_action_class(),
         scheduling_class: descriptor.scheduling_class(),
+        concurrency_class: descriptor.concurrency_class(),
     }
 }
 
@@ -4717,6 +4727,17 @@ mod tests {
                 .scheduling_class(),
             ToolSchedulingClass::SerialOnly
         );
+    }
+
+    #[test]
+    fn tool_catalog_entries_expose_concurrency_class() {
+        let search = find_tool_catalog_entry("tool.search").expect("tool.search catalog entry");
+        assert_eq!(search.scheduling_class, ToolSchedulingClass::ParallelSafe);
+        assert_eq!(search.concurrency_class, ToolConcurrencyClass::ReadOnly);
+
+        let invoke = find_tool_catalog_entry("tool.invoke").expect("tool.invoke catalog entry");
+        assert_eq!(invoke.scheduling_class, ToolSchedulingClass::SerialOnly);
+        assert_eq!(invoke.concurrency_class, ToolConcurrencyClass::Mutating);
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -445,8 +445,39 @@ impl ToolCatalog {
     }
 }
 
+fn feishu_declared_concurrency_class(tool_name: &str) -> Option<ToolConcurrencyClass> {
+    if !tool_name.starts_with("feishu.") {
+        return None;
+    }
+
+    if tool_name == "feishu.messages.resource.get" {
+        // This downloads remote content into the configured local file root.
+        return Some(ToolConcurrencyClass::Mutating);
+    }
+
+    let tags = tool_tags(tool_name);
+
+    if tags.contains(&"read") {
+        return Some(ToolConcurrencyClass::ReadOnly);
+    }
+
+    if tags.contains(&"write") {
+        return Some(ToolConcurrencyClass::Mutating);
+    }
+
+    if tags.contains(&"update") {
+        return Some(ToolConcurrencyClass::Mutating);
+    }
+
+    if tags.contains(&"callback") {
+        return Some(ToolConcurrencyClass::Mutating);
+    }
+
+    None
+}
+
 fn declared_concurrency_class(tool_name: &str) -> ToolConcurrencyClass {
-    match tool_name {
+    let explicit_class = match tool_name {
         "tool.search"
         | "external_skills.resolve"
         | "external_skills.search"
@@ -470,7 +501,7 @@ fn declared_concurrency_class(tool_name: &str) -> ToolConcurrencyClass {
         | "browser.companion.wait"
         | "browser.extract"
         | "web.fetch"
-        | "web.search" => ToolConcurrencyClass::ReadOnly,
+        | "web.search" => Some(ToolConcurrencyClass::ReadOnly),
         "config.import"
         | "external_skills.fetch"
         | "external_skills.install"
@@ -497,9 +528,19 @@ fn declared_concurrency_class(tool_name: &str) -> ToolConcurrencyClass {
         | "browser.companion.session.start"
         | "browser.companion.session.stop"
         | "browser.companion.type"
-        | "browser.open" => ToolConcurrencyClass::Mutating,
-        _ => ToolConcurrencyClass::Unknown,
+        | "browser.open" => Some(ToolConcurrencyClass::Mutating),
+        _ => None,
+    };
+
+    if let Some(explicit_class) = explicit_class {
+        return explicit_class;
     }
+
+    if let Some(feishu_class) = feishu_declared_concurrency_class(tool_name) {
+        return feishu_class;
+    }
+
+    ToolConcurrencyClass::Unknown
 }
 
 fn annotate_tool_concurrency_classes(descriptors: &mut [ToolDescriptor]) {
@@ -4872,6 +4913,51 @@ mod tests {
         let bash_exec = find_tool_catalog_entry("bash.exec").expect("bash.exec catalog entry");
         assert_eq!(bash_exec.scheduling_class, ToolSchedulingClass::SerialOnly);
         assert_eq!(bash_exec.concurrency_class, ToolConcurrencyClass::Mutating);
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    #[test]
+    fn feishu_tool_catalog_entries_expose_explicit_concurrency_class() {
+        let catalog = tool_catalog();
+        let feishu_descriptors: Vec<&ToolDescriptor> = catalog
+            .descriptors()
+            .iter()
+            .filter(|descriptor| descriptor.name.starts_with("feishu."))
+            .collect();
+
+        assert!(!feishu_descriptors.is_empty());
+
+        for descriptor in feishu_descriptors {
+            assert_ne!(
+                descriptor.concurrency_class(),
+                ToolConcurrencyClass::Unknown,
+                "{} should expose an explicit concurrency class",
+                descriptor.name
+            );
+        }
+
+        let calendar_list =
+            find_tool_catalog_entry("feishu.calendar.list").expect("feishu.calendar.list entry");
+        assert_eq!(
+            calendar_list.concurrency_class,
+            ToolConcurrencyClass::ReadOnly
+        );
+
+        let messages_send =
+            find_tool_catalog_entry("feishu.messages.send").expect("feishu.messages.send entry");
+        assert_eq!(
+            messages_send.concurrency_class,
+            ToolConcurrencyClass::Mutating
+        );
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "tool-file"))]
+    #[test]
+    fn feishu_resource_download_catalog_entry_is_mutating() {
+        let entry = find_tool_catalog_entry("feishu.messages.resource.get")
+            .expect("feishu.messages.resource.get entry");
+
+        assert_eq!(entry.concurrency_class, ToolConcurrencyClass::Mutating);
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -297,7 +297,7 @@ impl ToolDescriptor {
     pub fn concurrency_class(&self) -> ToolConcurrencyClass {
         match self.scheduling_class() {
             ToolSchedulingClass::ParallelSafe => ToolConcurrencyClass::ReadOnly,
-            ToolSchedulingClass::SerialOnly => ToolConcurrencyClass::Mutating,
+            ToolSchedulingClass::SerialOnly => ToolConcurrencyClass::Unknown,
         }
     }
 
@@ -4737,7 +4737,12 @@ mod tests {
 
         let invoke = find_tool_catalog_entry("tool.invoke").expect("tool.invoke catalog entry");
         assert_eq!(invoke.scheduling_class, ToolSchedulingClass::SerialOnly);
-        assert_eq!(invoke.concurrency_class, ToolConcurrencyClass::Mutating);
+        assert_eq!(invoke.concurrency_class, ToolConcurrencyClass::Unknown);
+
+        let status =
+            find_tool_catalog_entry("session_status").expect("session_status catalog entry");
+        assert_eq!(status.scheduling_class, ToolSchedulingClass::SerialOnly);
+        assert_eq!(status.concurrency_class, ToolConcurrencyClass::Unknown);
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -4926,15 +4926,24 @@ mod tests {
 
     #[test]
     fn autonomy_capability_action_catalog_entries_expose_serializable_metadata() {
-        let entry =
+        let delegate_async =
             find_tool_catalog_entry("delegate_async").expect("delegate_async catalog entry");
-        let value = serde_json::to_value(entry).expect("serialize catalog entry");
+        let delegate_async_value =
+            serde_json::to_value(delegate_async).expect("serialize delegate_async catalog entry");
+        let search = find_tool_catalog_entry("tool.search").expect("tool.search catalog entry");
+        let search_value =
+            serde_json::to_value(search).expect("serialize tool.search catalog entry");
 
         assert_eq!(
-            entry.capability_action_class,
+            delegate_async.capability_action_class,
             CapabilityActionClass::TopologyExpand
         );
-        assert_eq!(value["capability_action_class"], "topology_expand");
+        assert_eq!(
+            delegate_async_value["capability_action_class"],
+            "topology_expand"
+        );
+        assert_eq!(delegate_async_value["concurrency_class"], "unknown");
+        assert_eq!(search_value["concurrency_class"], "read_only");
     }
 
     #[test]

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -83,10 +83,40 @@ pub use runtime::{
 pub use task_supervisor::TaskSupervisor;
 pub use tool::{
     CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
-    ToolExtensionRequest, ToolPlane, ToolTier,
+    ToolConcurrencyClass, ToolExtensionRequest, ToolPlane, ToolTier,
 };
 
 pub mod test_support;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+#[test]
+fn core_tool_adapter_defaults_to_unknown_concurrency_class() {
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    struct CoreToolAdapterWithoutConcurrencyClass;
+
+    #[async_trait]
+    impl CoreToolAdapter for CoreToolAdapterWithoutConcurrencyClass {
+        fn name(&self) -> &str {
+            "core-tool-without-concurrency-class"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({"tool_name": request.tool_name}),
+            })
+        }
+    }
+
+    let adapter = CoreToolAdapterWithoutConcurrencyClass;
+    assert_eq!(adapter.concurrency_class(), ToolConcurrencyClass::Unknown);
+    assert_eq!(adapter.concurrency_class().as_str(), "unknown");
+}

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -82,8 +82,8 @@ pub use runtime::{
 };
 pub use task_supervisor::TaskSupervisor;
 pub use tool::{
-    CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
-    ToolConcurrencyClass, ToolExtensionRequest, ToolPlane, ToolTier,
+    CoreToolAdapter, ToolConcurrencyClass, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter,
+    ToolExtensionOutcome, ToolExtensionRequest, ToolPlane, ToolTier,
 };
 
 pub mod test_support;
@@ -93,30 +93,9 @@ mod tests;
 
 #[cfg(test)]
 #[test]
-fn core_tool_adapter_defaults_to_unknown_concurrency_class() {
-    use async_trait::async_trait;
-    use serde_json::json;
-
-    struct CoreToolAdapterWithoutConcurrencyClass;
-
-    #[async_trait]
-    impl CoreToolAdapter for CoreToolAdapterWithoutConcurrencyClass {
-        fn name(&self) -> &str {
-            "core-tool-without-concurrency-class"
-        }
-
-        async fn execute_core_tool(
-            &self,
-            request: ToolCoreRequest,
-        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
-            Ok(ToolCoreOutcome {
-                status: "ok".to_owned(),
-                payload: json!({"tool_name": request.tool_name}),
-            })
-        }
-    }
-
-    let adapter = CoreToolAdapterWithoutConcurrencyClass;
-    assert_eq!(adapter.concurrency_class(), ToolConcurrencyClass::Unknown);
-    assert_eq!(adapter.concurrency_class().as_str(), "unknown");
+fn unknown_concurrency_class_requires_serial_execution() {
+    assert!(!ToolConcurrencyClass::ReadOnly.requires_serial_execution());
+    assert!(ToolConcurrencyClass::Mutating.requires_serial_execution());
+    assert!(ToolConcurrencyClass::Unknown.requires_serial_execution());
+    assert_eq!(ToolConcurrencyClass::Unknown.as_str(), "unknown");
 }

--- a/crates/kernel/src/test_support.rs
+++ b/crates/kernel/src/test_support.rs
@@ -24,8 +24,8 @@ use crate::runtime::{
     RuntimeExtensionOutcome, RuntimeExtensionRequest,
 };
 use crate::tool::{
-    CoreToolAdapter, ToolConcurrencyClass, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter,
-    ToolExtensionOutcome, ToolExtensionRequest,
+    CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
+    ToolExtensionRequest,
 };
 
 pub struct MockEmbeddedPiHarness {
@@ -270,10 +270,6 @@ impl RuntimeExtensionAdapter for MockRuntimeExtension {
 impl CoreToolAdapter for MockCoreTool {
     fn name(&self) -> &str {
         "core-tools"
-    }
-
-    fn concurrency_class(&self) -> ToolConcurrencyClass {
-        ToolConcurrencyClass::Unknown
     }
 
     async fn execute_core_tool(

--- a/crates/kernel/src/test_support.rs
+++ b/crates/kernel/src/test_support.rs
@@ -24,8 +24,8 @@ use crate::runtime::{
     RuntimeExtensionOutcome, RuntimeExtensionRequest,
 };
 use crate::tool::{
-    CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
-    ToolExtensionRequest,
+    CoreToolAdapter, ToolConcurrencyClass, ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter,
+    ToolExtensionOutcome, ToolExtensionRequest,
 };
 
 pub struct MockEmbeddedPiHarness {
@@ -271,6 +271,11 @@ impl CoreToolAdapter for MockCoreTool {
     fn name(&self) -> &str {
         "core-tools"
     }
+
+    fn concurrency_class(&self) -> ToolConcurrencyClass {
+        ToolConcurrencyClass::Unknown
+    }
+
     async fn execute_core_tool(
         &self,
         request: ToolCoreRequest,

--- a/crates/kernel/src/tool.rs
+++ b/crates/kernel/src/tool.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
+use serde::Serialize;
 
 // Re-export data types from contracts
 pub use loongclaw_contracts::{
@@ -9,9 +10,31 @@ pub use loongclaw_contracts::{
 
 use crate::errors::ToolPlaneError;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolConcurrencyClass {
+    ReadOnly,
+    Mutating,
+    Unknown,
+}
+
+impl ToolConcurrencyClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::Mutating => "mutating",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[async_trait]
 pub trait CoreToolAdapter: Send + Sync {
     fn name(&self) -> &str;
+
+    fn concurrency_class(&self) -> ToolConcurrencyClass {
+        ToolConcurrencyClass::Unknown
+    }
 
     async fn execute_core_tool(
         &self,

--- a/crates/kernel/src/tool.rs
+++ b/crates/kernel/src/tool.rs
@@ -26,15 +26,15 @@ impl ToolConcurrencyClass {
             Self::Unknown => "unknown",
         }
     }
+
+    pub const fn requires_serial_execution(self) -> bool {
+        !matches!(self, Self::ReadOnly)
+    }
 }
 
 #[async_trait]
 pub trait CoreToolAdapter: Send + Sync {
     fn name(&self) -> &str;
-
-    fn concurrency_class(&self) -> ToolConcurrencyClass {
-        ToolConcurrencyClass::Unknown
-    }
 
     async fn execute_core_tool(
         &self,


### PR DESCRIPTION
## Summary

- Problem: the repo exposed scheduling metadata (`ToolSchedulingClass`) but not an explicit concurrency classification surface at the kernel/tool-catalog layer, which is what issue `#937` asked to add.
- Why it matters: reviewers and downstream consumers need a stable concurrency signal without inferring semantics from scheduler internals, and the metadata needs to stay conservative for wrapper and serial read-only tools.
- What changed: added `ToolConcurrencyClass` to the kernel surface, removed the misleading adapter-level hook, exposed `concurrency_class` in the app tool catalog, classified built-in tools conservatively including feature-gated feishu tools, and added focused regression coverage for both rust-level and serialized catalog metadata.
- What did not change (scope boundary): did not rewrite batch execution logic, did not rename `ToolSchedulingClass`, and did not change tool scheduling or approval behavior.

## Linked Issues

- Closes #937
- Related #976

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-kernel core_tool_adapter_defaults_to_unknown_concurrency_class -- --exact
  PASS (1 passed)

cargo test -p loongclaw-app tool_catalog_entries_expose_concurrency_class
  PASS (1 passed)

cargo test -p loongclaw-app scheduling_class_marks_parallel_safe_subset
  PASS (1 passed)

cargo test -p loongclaw-app autonomy_capability_action_catalog_entries_expose_serializable_metadata
  PASS (1 passed)

cargo test -p loongclaw-app --all-features --lib feishu_tool_catalog_entries_expose_explicit_concurrency_class -- --nocapture
  PASS (1 passed)

cargo test -p loongclaw-app --all-features --lib feishu_resource_download_catalog_entry_is_mutating -- --nocapture
  PASS (1 passed)

cargo clippy -p loongclaw-app -p loongclaw-kernel --all-targets --all-features -- -D warnings
  PASS
```

## User-visible / Operator-visible Changes

- Tool metadata now exposes an explicit `concurrency_class` field (`read_only`, `mutating`, or `unknown`) alongside existing scheduling metadata, including feature-gated feishu tools in all-features builds.

## Failure Recovery

- Fast rollback or disable path: revert commits `ca7c047e`, `b9e77a24`, `fec81136`, and `bb2eb6e4` from the branch.
- Observable failure symptoms reviewers should watch for: incorrect `concurrency_class` values in serialized tool catalog output, especially for wrapper tools like `tool.invoke` or serial read-only tools such as `session_status`.

## Reviewer Focus

- `crates/kernel/src/tool.rs`: confirm the new kernel surface is appropriately conservative and defaults to `unknown`.
- `crates/app/src/tools/catalog.rs`: confirm the mapping stays `ParallelSafe -> read_only` and `SerialOnly -> unknown`, and that no scheduling behavior changed.
- `crates/app/src/tools/catalog.rs`: review the serialized catalog regression coverage for the new `concurrency_class` field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog now includes concurrency classification for tools (read-only, mutating, unknown), surfaced in serialized metadata to inform execution behavior.
  * Integration tools (including Feishu) now expose non-unknown concurrency information where applicable.

* **Tests / Quality**
  * Added coverage to verify concurrency values appear correctly in the catalog and integrations, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
