### PR TITLE
feat(memory): add provenance-aware workspace recall system

### DIFF
--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -229,18 +229,21 @@ pub enum MemoryProfile {
 pub enum MemorySystemKind {
     #[default]
     Builtin,
+    WorkspaceRecall,
 }
 
 impl MemorySystemKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Builtin => "builtin",
+            Self::WorkspaceRecall => "workspace_recall",
         }
     }
 
     pub fn parse_id(raw: &str) -> Option<Self> {
         match raw.trim().to_ascii_lowercase().as_str() {
             "builtin" => Some(Self::Builtin),
+            "workspace_recall" => Some(Self::WorkspaceRecall),
             _ => None,
         }
     }
@@ -254,7 +257,7 @@ impl<'de> Deserialize<'de> for MemorySystemKind {
         let raw = String::deserialize(deserializer)?;
         Self::parse_id(&raw).ok_or_else(|| {
             serde::de::Error::custom(format!(
-                "unsupported memory.system `{}` (available: builtin)",
+                "unsupported memory.system `{}` (available: builtin, workspace_recall)",
                 raw.trim()
             ))
         })
@@ -519,6 +522,14 @@ mod tests {
         assert_eq!(config.system, MemorySystemKind::Builtin);
         assert_eq!(config.resolved_system(), MemorySystemKind::Builtin);
         assert_eq!(config.resolved_system().as_str(), DEFAULT_MEMORY_SYSTEM_ID);
+    }
+
+    #[test]
+    fn memory_system_accepts_workspace_recall_variant() {
+        assert_eq!(
+            MemorySystemKind::parse_id("workspace_recall"),
+            Some(MemorySystemKind::WorkspaceRecall)
+        );
     }
 
     #[test]

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -951,6 +951,77 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_engine_kernel_bound_workspace_recall_system_reorders_retrieved_memory() {
+        let capabilities = std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+            loongclaw_contracts::Capability::MemoryRead,
+        ]);
+        let harness = TurnTestHarness::with_capabilities(capabilities);
+        let session_id = "kernel-workspace-recall-session";
+        let sqlite_path = harness.temp_dir.join("memory.sqlite3");
+        let sqlite_path_text = sqlite_path.display().to_string();
+        let curated_memory_path = harness.temp_dir.join("MEMORY.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nPromote workspace recall above history.\n",
+        )
+        .expect("write durable recall");
+
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+        config.memory.sqlite_path = sqlite_path_text;
+        config.memory.system_id = Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
+
+        let memory_config =
+            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        memory::append_turn_direct(session_id, "user", "turn 1", &memory_config)
+            .expect("append turn 1 should succeed");
+        memory::append_turn_direct(session_id, "assistant", "turn 2", &memory_config)
+            .expect("append turn 2 should succeed");
+
+        let binding =
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let assembled = DefaultContextEngine
+            .assemble_context(&config, session_id, true, binding)
+            .await
+            .expect("assemble context");
+
+        assert!(
+            assembled.messages.len() >= 3,
+            "expected system prompt, retrieved memory, and history turns"
+        );
+        let retrieved_artifact = assembled
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_kind == ContextArtifactKind::RetrievedMemory)
+            .expect("retrieved memory artifact");
+        let retrieved_index = retrieved_artifact.message_index;
+        let retrieved_message = &assembled.messages[retrieved_index];
+
+        assert_eq!(retrieved_message["role"], "system");
+        assert!(
+            retrieved_message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("Promote workspace recall above history.")),
+            "expected a retrieved memory message containing workspace recall content"
+        );
+        let first_user_index = assembled
+            .messages
+            .iter()
+            .position(|message| message["role"] == "user")
+            .expect("first history message index");
+        assert!(
+            retrieved_index < first_user_index,
+            "retrieved memory (index {retrieved_index}) should precede history (index {first_user_index})"
+        );
+        assert_eq!(assembled.messages[first_user_index]["content"], "turn 1");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn default_engine_kernel_bound_messages_match_provider_governed_profile_projection() {
         let capabilities = std::collections::BTreeSet::from([
             loongclaw_contracts::Capability::InvokeTool,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -34,10 +34,6 @@ use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::{
-    MemorySystem, MemorySystemCapability, MemorySystemMetadata, register_memory_system,
-};
-#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
     NewSessionToolPolicyRecord, SessionKind, SessionRepository, SessionState,
@@ -105,25 +101,6 @@ enum FakeTurnResponse {
 }
 
 type CompactHook = Arc<dyn Fn(&str, &[Value]) -> Result<(), String> + Send + Sync>;
-
-#[cfg(feature = "memory-sqlite")]
-struct RegistryRetrieveOnlyConversationMemorySystem;
-
-#[cfg(feature = "memory-sqlite")]
-impl MemorySystem for RegistryRetrieveOnlyConversationMemorySystem {
-    fn id(&self) -> &'static str {
-        "registry-retrieve-only-conversation"
-    }
-
-    fn metadata(&self) -> MemorySystemMetadata {
-        MemorySystemMetadata::new(
-            "registry-retrieve-only-conversation",
-            [MemorySystemCapability::PromptHydration],
-            "Conversation test registry-selected memory system",
-        )
-        .with_supported_pre_assembly_stage_families([crate::memory::MemoryStageFamily::Retrieve])
-    }
-}
 
 struct TraitDefaultToolViewRuntime;
 struct NoopTurnMiddleware {
@@ -4006,21 +3983,31 @@ async fn default_runtime_kernel_build_context_preserves_profile_projection() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn default_runtime_build_context_with_registry_selected_system_skips_builtin_memory_projection()
- {
-    register_memory_system("registry-retrieve-only-conversation", || {
-        Box::new(RegistryRetrieveOnlyConversationMemorySystem)
-    })
-    .expect("register conversation registry-selected memory system");
-
+async fn default_runtime_build_context_with_workspace_recall_system_reorders_memory_projection() {
     let runtime = DefaultConversationRuntime::default();
-    let session_id = unique_acp_test_id("default-runtime-context", "registry-selected-system");
-    let sqlite_path = unique_memory_sqlite_path("registry-selected-system");
+    let session_id = unique_acp_test_id("default-runtime-context", "workspace-recall-system");
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let workspace_root = temp_dir.path();
+    let memory_dir = workspace_root.join("memory");
+    std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+    std::fs::write(
+        workspace_root.join("MEMORY.md"),
+        "# Durable Notes\n\nRemember the deploy freeze window.\n",
+    )
+    .expect("write curated durable memory");
+    std::fs::write(
+        memory_dir.join("2026-03-22.md"),
+        "## Durable Recall\n\nCustomer migration starts tomorrow.\n",
+    )
+    .expect("write daily durable memory");
+
+    let sqlite_path = unique_memory_sqlite_path("workspace-recall-system");
     let mut config = test_config();
-    config.memory.system_id = Some("registry-retrieve-only-conversation".to_owned());
+    config.memory.system = MemorySystemKind::WorkspaceRecall;
     config.memory.profile = MemoryProfile::WindowPlusSummary;
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(workspace_root.display().to_string());
 
     let runtime_config =
         crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
@@ -4059,13 +4046,43 @@ async fn default_runtime_build_context_with_registry_selected_system_skips_built
         ]
     );
     assert!(
+        assembled.messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("Remember the deploy freeze window."))
+        }),
+        "workspace recall system should project durable recall into the runtime context"
+    );
+    let durable_recall_index = assembled
+        .messages
+        .iter()
+        .position(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("Remember the deploy freeze window."))
+        })
+        .expect("workspace recall system message index");
+    let first_window_turn_index = assembled
+        .messages
+        .iter()
+        .position(|message| {
+            message["role"] == "assistant" && message["content"].as_str() == Some("turn 2")
+        })
+        .expect("first projected window turn index");
+    assert!(
+        durable_recall_index < first_window_turn_index,
+        "workspace recall should be ranked ahead of projected recent history"
+    );
+    assert!(
         !assembled.messages.iter().any(|message| {
             message["role"] == "system"
                 && message["content"]
                     .as_str()
                     .is_some_and(|content| content.contains("## Memory Summary"))
         }),
-        "registry-selected systems without executors should not reuse builtin summary projection"
+        "workspace recall system should suppress builtin summary projection after rank-stage reordering"
     );
 
     let _ = std::fs::remove_file(sqlite_path);
@@ -15012,6 +15029,14 @@ fn staged_memory_envelope_payload_from_window_turns(window_turns: &Value) -> Val
             kind: crate::memory::MemoryContextKind::Turn,
             role: turn.role.clone(),
             content: turn.content.clone(),
+            provenance: vec![crate::memory::MemoryContextProvenance::new(
+                "builtin",
+                crate::memory::MemoryProvenanceSourceKind::RecentWindowTurn,
+                Some("fixture-session".to_owned()),
+                None,
+                Some(crate::memory::MemoryScope::Session),
+                crate::memory::MemoryRecallMode::PromptAssembly,
+            )],
         })
         .collect::<Vec<_>>();
     let envelope = crate::memory::StageEnvelope {

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,14 +1,14 @@
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
-use crate::config::MemoryMode;
-use crate::config::MemoryProfile;
+use crate::config::{MemoryMode, MemoryProfile, MemorySystemKind};
 use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
 use super::sqlite;
 use super::{
-    MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, encode_stage_envelope_payload,
+    MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, MemoryContextProvenance,
+    MemoryProvenanceSourceKind, MemoryRecallMode, MemoryScope, encode_stage_envelope_payload,
     orchestrator::hydrate_stage_envelope_with_workspace_root,
     protocol::{MemoryContextEntry, MemoryContextKind},
     runtime_config::MemoryRuntimeConfig,
@@ -59,6 +59,31 @@ fn read_context_runtime_config(
 
         runtime_config.profile = profile;
         runtime_config.mode = mode;
+    }
+
+    if let Some(system_value) = payload.get("system") {
+        let system_text = system_value
+            .as_str()
+            .ok_or_else(|| "memory.read_context payload.system must be a string".to_owned())?;
+        let system = MemorySystemKind::parse_id(system_text).ok_or_else(|| {
+            format!("memory.read_context payload.system `{system_text}` is unsupported")
+        })?;
+
+        runtime_config.system = system;
+    }
+
+    if let Some(system_id_value) = payload.get("system_id") {
+        let normalized_system_id = match system_id_value {
+            Value::Null => None,
+            Value::String(raw_value) => super::normalize_system_id(raw_value.as_str()),
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+                return Err(
+                    "memory.read_context payload.system_id must be a string or null".to_owned(),
+                );
+            }
+        };
+
+        runtime_config.resolved_system_id = normalized_system_id;
     }
 
     if let Some(sliding_window_value) = payload.get("sliding_window") {
@@ -175,11 +200,11 @@ pub fn load_prompt_context(
     config: &MemoryRuntimeConfig,
 ) -> Result<Vec<MemoryContextEntry>, String> {
     let mut entries = Vec::new();
-
     let profile_entry = build_profile_entry(config);
     if let Some(profile_entry) = profile_entry {
         entries.push(profile_entry);
     }
+    let selected_system_id = super::selected_prompt_hydration_system_id(config);
 
     #[cfg(feature = "memory-sqlite")]
     {
@@ -194,6 +219,14 @@ pub fn load_prompt_context(
                 kind: MemoryContextKind::Summary,
                 role: "system".to_owned(),
                 content: summary,
+                provenance: vec![MemoryContextProvenance::new(
+                    selected_system_id.as_str(),
+                    MemoryProvenanceSourceKind::SummaryCheckpoint,
+                    Some(session_id.to_owned()),
+                    None,
+                    Some(MemoryScope::Session),
+                    MemoryRecallMode::PromptAssembly,
+                )],
             });
         }
         for turn in snapshot.window_turns {
@@ -201,6 +234,14 @@ pub fn load_prompt_context(
                 kind: MemoryContextKind::Turn,
                 role: turn.role,
                 content: turn.content,
+                provenance: vec![MemoryContextProvenance::new(
+                    selected_system_id.as_str(),
+                    MemoryProvenanceSourceKind::RecentWindowTurn,
+                    Some(session_id.to_owned()),
+                    None,
+                    Some(MemoryScope::Session),
+                    MemoryRecallMode::PromptAssembly,
+                )],
             });
         }
     }
@@ -228,6 +269,14 @@ pub(super) fn build_profile_entry(config: &MemoryRuntimeConfig) -> Option<Memory
         kind: MemoryContextKind::Profile,
         role: "system".to_owned(),
         content: profile_section,
+        provenance: vec![MemoryContextProvenance::new(
+            super::selected_prompt_hydration_system_id(config).as_str(),
+            MemoryProvenanceSourceKind::ProfileNote,
+            None,
+            None,
+            Some(MemoryScope::Session),
+            MemoryRecallMode::PromptAssembly,
+        )],
     })
 }
 
@@ -284,6 +333,28 @@ mod tests {
                 .any(|entry| entry.content.contains("turn 1")),
             "expected summary to mention older turns"
         );
+        let summary_entry = hydrated
+            .iter()
+            .find(|entry| entry.kind == MemoryContextKind::Summary)
+            .expect("summary entry");
+        assert_eq!(summary_entry.provenance.len(), 1);
+        assert_eq!(
+            summary_entry.provenance[0].source_kind,
+            MemoryProvenanceSourceKind::SummaryCheckpoint
+        );
+        assert_eq!(
+            summary_entry.provenance[0].scope,
+            Some(MemoryScope::Session)
+        );
+        let turn_entry = hydrated
+            .iter()
+            .find(|entry| entry.kind == MemoryContextKind::Turn)
+            .expect("turn entry");
+        assert_eq!(turn_entry.provenance.len(), 1);
+        assert_eq!(
+            turn_entry.provenance[0].source_kind,
+            MemoryProvenanceSourceKind::RecentWindowTurn
+        );
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
@@ -326,6 +397,19 @@ mod tests {
                 .iter()
                 .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
             "expected profile note content"
+        );
+        let profile_entry = hydrated
+            .iter()
+            .find(|entry| entry.kind == MemoryContextKind::Profile)
+            .expect("profile entry");
+        assert_eq!(profile_entry.provenance.len(), 1);
+        assert_eq!(
+            profile_entry.provenance[0].source_kind,
+            MemoryProvenanceSourceKind::ProfileNote
+        );
+        assert_eq!(
+            profile_entry.provenance[0].scope,
+            Some(MemoryScope::Session)
         );
 
         let _ = std::fs::remove_file(&db_path);
@@ -718,6 +802,35 @@ mod tests {
         assert!(
             has_durable_recall,
             "expected staged envelope payload to keep workspace durable recall"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn load_prompt_context_uses_selected_memory_system_id_in_provenance() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("selected-system.sqlite3");
+
+        let mut config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            profile: crate::config::MemoryProfile::WindowOnly,
+            mode: crate::config::MemoryMode::WindowOnly,
+            ..MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id =
+            Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
+
+        super::super::append_turn_direct("selected-system-session", "user", "hello", &config)
+            .expect("append turn should succeed");
+
+        let entries =
+            load_prompt_context("selected-system-session", &config).expect("load prompt context");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].provenance.len(), 1);
+        assert_eq!(
+            entries[0].provenance[0].memory_system_id,
+            crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID
         );
     }
 }

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -5,23 +5,27 @@ use std::path::Path;
 use crate::runtime_self_continuity;
 
 use super::{
-    MemoryContextEntry, MemoryContextKind, WorkspaceMemoryDocumentKind,
-    WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations,
-    runtime_config::MemoryRuntimeConfig,
+    MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind,
+    MemoryRecallMode, MemoryScope, WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
+    collect_workspace_memory_document_locations, runtime_config::MemoryRuntimeConfig,
 };
 
 const RECENT_DAILY_LOG_LIMIT: usize = 2;
 const DURABLE_RECALL_READ_SLACK_BYTES: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DurableRecallDocument {
-    label: String,
-    content: String,
+pub(crate) struct DurableRecallDocument {
+    pub label: String,
+    pub path: String,
+    pub scope: MemoryScope,
+    pub content: String,
 }
 
 pub(crate) fn load_durable_recall_entries(
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
 ) -> Result<Vec<MemoryContextEntry>, String> {
     let Some(workspace_root) = workspace_root else {
         return Ok(Vec::new());
@@ -35,16 +39,80 @@ pub(crate) fn load_durable_recall_entries(
     }
 
     let content = render_durable_recall_block(documents.as_slice());
+    let provenance = documents
+        .iter()
+        .map(|document| {
+            build_workspace_document_provenance(document, memory_system_id, recall_mode)
+        })
+        .collect::<Vec<_>>();
     let entry = MemoryContextEntry {
         kind: MemoryContextKind::RetrievedMemory,
         role: "system".to_owned(),
         content,
+        provenance,
     };
 
     Ok(vec![entry])
 }
 
-fn collect_durable_recall_documents(
+pub(crate) fn load_workspace_document_recall_entries(
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
+    scopes: &[MemoryScope],
+    max_documents: usize,
+) -> Result<Vec<MemoryContextEntry>, String> {
+    let Some(workspace_root) = workspace_root else {
+        return Ok(Vec::new());
+    };
+
+    let per_file_char_budget = config.summary_max_chars.max(256);
+    let documents = collect_durable_recall_documents(workspace_root, per_file_char_budget)?;
+    if documents.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let filtered_documents = filter_recall_documents_by_scope(documents, scopes);
+    let capped_documents = filtered_documents
+        .into_iter()
+        .take(max_documents)
+        .collect::<Vec<_>>();
+    let mut entries = Vec::new();
+
+    for document in capped_documents {
+        let heading = format!("## Advisory Durable Recall — {}", document.label);
+        let intro = runtime_self_continuity::runtime_durable_recall_intro().to_owned();
+        let content = [heading, intro, document.content.clone()].join("\n\n");
+        let provenance =
+            build_workspace_document_provenance(&document, memory_system_id, recall_mode);
+        let entry = MemoryContextEntry {
+            kind: MemoryContextKind::RetrievedMemory,
+            role: "system".to_owned(),
+            content,
+            provenance: vec![provenance],
+        };
+        entries.push(entry);
+    }
+
+    Ok(entries)
+}
+
+fn filter_recall_documents_by_scope(
+    documents: Vec<DurableRecallDocument>,
+    scopes: &[MemoryScope],
+) -> Vec<DurableRecallDocument> {
+    if scopes.is_empty() {
+        return documents;
+    }
+
+    documents
+        .into_iter()
+        .filter(|document| scopes.contains(&document.scope))
+        .collect()
+}
+
+pub(crate) fn collect_durable_recall_documents(
     workspace_root: &Path,
     per_file_char_budget: usize,
 ) -> Result<Vec<DurableRecallDocument>, String> {
@@ -89,9 +157,18 @@ fn load_document_from_location(
 
     let document = DurableRecallDocument {
         label: location.label.clone(),
+        path: location.path.display().to_string(),
+        scope: document_scope(location.kind),
         content,
     };
     Ok(Some(document))
+}
+
+fn document_scope(kind: WorkspaceMemoryDocumentKind) -> MemoryScope {
+    match kind {
+        WorkspaceMemoryDocumentKind::Curated => MemoryScope::Workspace,
+        WorkspaceMemoryDocumentKind::DailyLog => MemoryScope::Session,
+    }
 }
 
 fn load_trimmed_document_content(
@@ -162,7 +239,7 @@ fn truncate_chars(input: &str, max_chars: usize) -> String {
     }
 }
 
-fn render_durable_recall_block(documents: &[DurableRecallDocument]) -> String {
+pub(crate) fn render_durable_recall_block(documents: &[DurableRecallDocument]) -> String {
     let mut sections = Vec::new();
     sections.push("## Advisory Durable Recall".to_owned());
     sections.push(runtime_self_continuity::runtime_durable_recall_intro().to_owned());
@@ -174,6 +251,21 @@ fn render_durable_recall_block(documents: &[DurableRecallDocument]) -> String {
     }
 
     sections.join("\n\n")
+}
+
+fn build_workspace_document_provenance(
+    document: &DurableRecallDocument,
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
+) -> MemoryContextProvenance {
+    MemoryContextProvenance::new(
+        memory_system_id,
+        MemoryProvenanceSourceKind::WorkspaceDocument,
+        Some(document.label.clone()),
+        Some(document.path.clone()),
+        Some(document.scope),
+        recall_mode,
+    )
 }
 
 #[cfg(test)]
@@ -199,8 +291,11 @@ mod tests {
 
         assert_eq!(documents.len(), 3);
         assert_eq!(documents[0].label, "MEMORY.md");
+        assert_eq!(documents[0].scope, MemoryScope::Workspace);
         assert_eq!(documents[1].label, "memory/2026-03-22.md");
+        assert_eq!(documents[1].scope, MemoryScope::Session);
         assert_eq!(documents[2].label, "memory/2026-03-21.md");
+        assert_eq!(documents[2].scope, MemoryScope::Session);
     }
 
     #[test]
@@ -259,5 +354,75 @@ mod tests {
 
         assert_eq!(truncated_char_count, 8);
         assert!(!truncated.is_empty());
+    }
+
+    #[test]
+    fn load_durable_recall_entries_attach_source_path_and_scope_provenance() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(workspace_root.join("MEMORY.md"), "curated").expect("write curated file");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "daily").expect("write daily file");
+
+        let config = MemoryRuntimeConfig::default();
+        let expected_curated_path = workspace_root
+            .join("MEMORY.md")
+            .canonicalize()
+            .expect("canonical curated path")
+            .display()
+            .to_string();
+        let entries = load_durable_recall_entries(
+            Some(workspace_root),
+            &config,
+            "builtin",
+            MemoryRecallMode::PromptAssembly,
+        )
+        .expect("load durable recall entries");
+
+        let entry = entries.first().expect("retrieved entry");
+        assert_eq!(entry.provenance.len(), 2);
+
+        let curated_provenance = &entry.provenance[0];
+        assert_eq!(curated_provenance.memory_system_id, "builtin");
+        assert_eq!(
+            curated_provenance.source_path.as_deref(),
+            Some(expected_curated_path.as_str())
+        );
+        assert_eq!(curated_provenance.scope, Some(MemoryScope::Workspace));
+
+        let daily_provenance = &entry.provenance[1];
+        assert_eq!(daily_provenance.scope, Some(MemoryScope::Session));
+        assert_eq!(
+            daily_provenance.recall_mode,
+            MemoryRecallMode::PromptAssembly
+        );
+    }
+
+    #[test]
+    fn workspace_document_recall_entries_honor_requested_scopes() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(workspace_root.join("MEMORY.md"), "curated").expect("write curated file");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "daily").expect("write daily file");
+
+        let config = MemoryRuntimeConfig::default();
+        let entries = load_workspace_document_recall_entries(
+            Some(workspace_root),
+            &config,
+            "workspace_recall",
+            MemoryRecallMode::PromptAssembly,
+            &[MemoryScope::Workspace],
+            4,
+        )
+        .expect("load workspace document recall entries");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].provenance.len(), 1);
+        assert_eq!(entries[0].provenance[0].scope, Some(MemoryScope::Workspace));
     }
 }

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -37,7 +37,6 @@ pub use canonical::{
 pub use context::load_prompt_context;
 #[cfg(feature = "memory-sqlite")]
 pub(crate) use durable_flush::flush_pre_compaction_durable_memory;
-pub(crate) use durable_recall::load_durable_recall_entries;
 pub use kernel_adapter::MvpMemoryAdapter;
 pub(crate) use orchestrator::run_compact_stage;
 pub use orchestrator::{
@@ -60,12 +59,13 @@ pub(crate) use sqlite::CanonicalMemorySearchHit;
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
 pub use stage::{
-    DerivedMemoryKind, MemoryRetrievalRequest, MemoryStageFamily, StageDiagnostics, StageEnvelope,
-    StageOutcome, builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
+    DerivedMemoryKind, MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
+    MemoryRetrievalRequest, MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
+    builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
 };
 pub use system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
-    MemorySystemCapability, MemorySystemMetadata,
+    MemorySystemCapability, MemorySystemMetadata, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
 };
 pub use system_registry::{
     MEMORY_SYSTEM_ENV, MemorySystemPolicySnapshot, MemorySystemRuntimeSnapshot,
@@ -268,6 +268,7 @@ pub fn load_prompt_context_with_diagnostics(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<(Vec<MemoryContextEntry>, SqliteContextLoadDiagnostics), String> {
     let mut profile_entry = context::build_profile_entry(config);
+    let selected_system_id = selected_prompt_hydration_system_id(config);
 
     let (snapshot, diagnostics) =
         sqlite::load_context_snapshot_with_diagnostics(session_id, config)?;
@@ -289,6 +290,14 @@ pub fn load_prompt_context_with_diagnostics(
             kind: MemoryContextKind::Summary,
             role: "system".to_owned(),
             content: summary,
+            provenance: vec![MemoryContextProvenance::new(
+                selected_system_id.as_str(),
+                MemoryProvenanceSourceKind::SummaryCheckpoint,
+                Some(session_id.to_owned()),
+                None,
+                Some(MemoryScope::Session),
+                MemoryRecallMode::PromptAssembly,
+            )],
         });
     }
     for turn in snapshot.window_turns {
@@ -296,10 +305,27 @@ pub fn load_prompt_context_with_diagnostics(
             kind: MemoryContextKind::Turn,
             role: turn.role,
             content: turn.content,
+            provenance: vec![MemoryContextProvenance::new(
+                selected_system_id.as_str(),
+                MemoryProvenanceSourceKind::RecentWindowTurn,
+                Some(session_id.to_owned()),
+                None,
+                Some(MemoryScope::Session),
+                MemoryRecallMode::PromptAssembly,
+            )],
         });
     }
 
     Ok((entries, diagnostics))
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn selected_prompt_hydration_system_id(
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> String {
+    let selected_system_id = registered_memory_system_id(Some(config.selected_system_id()));
+
+    selected_system_id.unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned())
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -2,13 +2,11 @@ use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use crate::config::MemoryMode;
-
 use super::{
-    DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, MemoryContextEntry, MemoryRetrievalRequest,
-    MemoryScope, MemoryStageFamily, MemorySystemMetadata, StageDiagnostics, StageEnvelope,
-    StageOutcome, WindowTurn, builtin_pre_assembly_stage_families, describe_memory_system,
-    load_prompt_context, runtime_config::MemoryRuntimeConfig,
+    DEFAULT_MEMORY_SYSTEM_ID, MemoryContextEntry, MemoryRetrievalRequest, MemoryStageFamily,
+    MemorySystem, MemorySystemMetadata, StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn,
+    describe_memory_system, load_prompt_context, resolve_memory_system,
+    runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,27 +115,33 @@ impl BuiltinMemoryOrchestrator {
         session_id: &str,
         workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
+        system: &dyn MemorySystem,
         metadata: &MemorySystemMetadata,
     ) -> Result<StageEnvelope, String> {
         let recent_window = recent_window_records(session_id, config)?;
         let mut entries = load_prompt_context(session_id, config)?;
-        let retrieval_request = metadata
-            .supports_pre_assembly_stage_family(MemoryStageFamily::Retrieve)
-            .then(|| build_builtin_retrieval_request(session_id, config, &recent_window))
-            .flatten();
+        let retrieval_request =
+            system.build_retrieval_request(session_id, workspace_root, config, &recent_window);
 
         let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, metadata, config, || {
-            run_derivation_stage(session_id, config, &recent_window)
+            run_derivation_stage(system, session_id, config, &recent_window)
         })?;
         entries.extend(derive.records);
 
         let retrieve =
             run_pre_assembly_stage(MemoryStageFamily::Retrieve, metadata, config, || {
-                run_retrieval_stage(session_id, workspace_root, config, &recent_window)
+                run_retrieval_stage(
+                    system,
+                    session_id,
+                    retrieval_request.as_ref(),
+                    workspace_root,
+                    config,
+                    &recent_window,
+                )
             })?;
         entries.extend(retrieve.records);
 
-        let rank = run_rank_stage(entries, metadata);
+        let rank = run_rank_stage(system, entries, metadata, config)?;
         let diagnostics = vec![derive.diagnostics, retrieve.diagnostics, rank.diagnostics];
 
         Ok(StageEnvelope {
@@ -158,10 +162,11 @@ impl BuiltinMemoryOrchestrator {
         session_id: &str,
         workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
+        system: &dyn MemorySystem,
         metadata: &MemorySystemMetadata,
     ) -> Result<HydratedMemoryContext, String> {
         Ok(self
-            .hydrate_stage_envelope(session_id, workspace_root, config, metadata)?
+            .hydrate_stage_envelope(session_id, workspace_root, config, system, metadata)?
             .hydrated)
     }
 }
@@ -227,6 +232,13 @@ struct StageRunResult {
     diagnostics: StageDiagnostics,
 }
 
+fn missing_execution_adapter_message(family: MemoryStageFamily) -> String {
+    format!(
+        "memory system declares `{}` stage support but provides no execution adapter",
+        family.as_str()
+    )
+}
+
 fn run_pre_assembly_stage<F>(
     family: MemoryStageFamily,
     metadata: &MemorySystemMetadata,
@@ -234,7 +246,7 @@ fn run_pre_assembly_stage<F>(
     runner: F,
 ) -> Result<StageRunResult, String>
 where
-    F: FnOnce() -> Result<Vec<MemoryContextEntry>, String>,
+    F: FnOnce() -> Result<Option<Vec<MemoryContextEntry>>, String>,
 {
     if !metadata.supports_pre_assembly_stage_family(family) {
         return Ok(StageRunResult {
@@ -244,9 +256,16 @@ where
     }
 
     match runner() {
-        Ok(records) => Ok(StageRunResult {
+        Ok(Some(records)) => Ok(StageRunResult {
             records,
             diagnostics: StageDiagnostics::succeeded(family),
+        }),
+        Ok(None) => Ok(StageRunResult {
+            records: Vec::new(),
+            diagnostics: skipped_stage_diagnostics(
+                family,
+                Some(missing_execution_adapter_message(family)),
+            ),
         }),
         Err(error) if config.effective_fail_open() => Ok(StageRunResult {
             records: Vec::new(),
@@ -264,22 +283,52 @@ where
 }
 
 fn run_rank_stage(
+    system: &dyn MemorySystem,
     entries: Vec<MemoryContextEntry>,
     metadata: &MemorySystemMetadata,
-) -> StageRunResult {
+    config: &MemoryRuntimeConfig,
+) -> Result<StageRunResult, String> {
     if !metadata.supports_pre_assembly_stage_family(MemoryStageFamily::Rank) {
-        return StageRunResult {
+        return Ok(StageRunResult {
             records: entries,
             diagnostics: skipped_stage_diagnostics(MemoryStageFamily::Rank, None),
-        };
+        });
     }
 
-    // Slice 1 keeps ranking as an identity stage until compaction and external
-    // ranking hooks graduate beyond the built-in pipeline contract.
-    StageRunResult {
-        records: entries,
-        diagnostics: StageDiagnostics::succeeded(MemoryStageFamily::Rank),
-    }
+    let rank_family = MemoryStageFamily::Rank;
+    let pass_through_entries = entries.clone();
+    let (records, diagnostics) = match system.run_rank_stage(entries, config) {
+        Ok(Some(records)) => (records, StageDiagnostics::succeeded(rank_family)),
+        Ok(None) => (
+            pass_through_entries,
+            skipped_stage_diagnostics(
+                rank_family,
+                Some(missing_execution_adapter_message(rank_family)),
+            ),
+        ),
+        Err(error) if config.effective_fail_open() => (
+            pass_through_entries,
+            StageDiagnostics {
+                family: rank_family,
+                outcome: StageOutcome::Fallback,
+                budget_ms: None,
+                elapsed_ms: None,
+                fallback_activated: true,
+                message: Some(error),
+            },
+        ),
+        Err(error) => {
+            return Err(format!(
+                "memory {} stage failed: {error}",
+                rank_family.as_str()
+            ));
+        }
+    };
+
+    Ok(StageRunResult {
+        records,
+        diagnostics,
+    })
 }
 
 fn skipped_stage_diagnostics(
@@ -368,44 +417,7 @@ async fn run_builtin_compact_stage(
     }
 }
 
-fn build_builtin_retrieval_request(
-    session_id: &str,
-    config: &MemoryRuntimeConfig,
-    recent_window: &[WindowTurn],
-) -> Option<MemoryRetrievalRequest> {
-    if !matches!(config.mode, MemoryMode::WindowPlusSummary) {
-        return None;
-    }
-
-    let query = retrieval_query_from_recent_window(recent_window);
-
-    let budget_items = if recent_window.is_empty() {
-        6
-    } else {
-        config.sliding_window.min(6)
-    };
-
-    Some(MemoryRetrievalRequest {
-        session_id: session_id.to_owned(),
-        query,
-        scopes: vec![
-            MemoryScope::Session,
-            MemoryScope::Workspace,
-            MemoryScope::Agent,
-            MemoryScope::User,
-        ],
-        budget_items,
-        allowed_kinds: vec![
-            DerivedMemoryKind::Profile,
-            DerivedMemoryKind::Fact,
-            DerivedMemoryKind::Episode,
-            DerivedMemoryKind::Procedure,
-            DerivedMemoryKind::Overview,
-        ],
-    })
-}
-
-fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<String> {
+pub(super) fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<String> {
     recent_window.iter().rev().find_map(|turn| {
         if turn.role != "user" {
             return None;
@@ -421,7 +433,9 @@ fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<St
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn render_cross_session_recall_block(hits: &[super::sqlite::CanonicalMemorySearchHit]) -> String {
+pub(super) fn render_cross_session_recall_block(
+    hits: &[super::sqlite::CanonicalMemorySearchHit],
+) -> String {
     let mut sections = Vec::new();
     sections.push("## Advisory Cross-Session Recall".to_owned());
     sections.push(
@@ -466,7 +480,6 @@ fn truncate_recall_content(input: &str, max_chars: usize) -> String {
     let prefix = input.chars().take(max_chars - 3).collect::<String>();
     format!("{prefix}...")
 }
-
 fn stage_error_message(
     stage_diagnostics: &[StageDiagnostics],
     family: MemoryStageFamily,
@@ -481,10 +494,11 @@ fn stage_error_message(
 }
 
 fn run_derivation_stage(
+    system: &dyn MemorySystem,
     _session_id: &str,
     _config: &MemoryRuntimeConfig,
     _recent_window: &[WindowTurn],
-) -> Result<Vec<MemoryContextEntry>, String> {
+) -> Result<Option<Vec<MemoryContextEntry>>, String> {
     #[cfg(test)]
     if let Some(error) = matching_memory_orchestrator_test_faults(_session_id)
         .and_then(|faults| faults.derivation_error)
@@ -492,42 +506,29 @@ fn run_derivation_stage(
         return Err(error);
     }
 
-    Ok(Vec::new())
+    system.run_derive_stage(_session_id, _config, _recent_window)
 }
 
 fn run_retrieval_stage(
-    session_id: &str,
+    system: &dyn MemorySystem,
+    _session_id: &str,
+    retrieval_request: Option<&MemoryRetrievalRequest>,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
     recent_window: &[WindowTurn],
-) -> Result<Vec<MemoryContextEntry>, String> {
+) -> Result<Option<Vec<MemoryContextEntry>>, String> {
     #[cfg(test)]
-    if let Some(error) = matching_memory_orchestrator_test_faults(session_id)
+    if let Some(error) = matching_memory_orchestrator_test_faults(_session_id)
         .and_then(|faults| faults.retrieval_error)
     {
         return Err(error);
     }
 
-    let mut entries = super::load_durable_recall_entries(workspace_root, config)?;
+    let Some(retrieval_request) = retrieval_request else {
+        return Ok(None);
+    };
 
-    #[cfg(feature = "memory-sqlite")]
-    if let Some(query) = retrieval_query_from_recent_window(recent_window) {
-        let hits = super::sqlite::search_canonical_records_for_recall(
-            query.as_str(),
-            config.sliding_window.min(6),
-            Some(session_id),
-            config,
-        )?;
-        if !hits.is_empty() {
-            entries.push(MemoryContextEntry {
-                kind: super::MemoryContextKind::RetrievedMemory,
-                role: "system".to_owned(),
-                content: render_cross_session_recall_block(hits.as_slice()),
-            });
-        }
-    }
-
-    Ok(entries)
+    system.run_retrieve_stage(retrieval_request, workspace_root, config, recent_window)
 }
 
 pub fn hydrate_memory_context(
@@ -559,58 +560,16 @@ pub(crate) fn hydrate_stage_envelope_with_workspace_root(
 ) -> Result<StageEnvelope, String> {
     let selected_system_id = super::registered_memory_system_id(Some(config.selected_system_id()))
         .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
+    let system = resolve_memory_system(Some(selected_system_id.as_str()))?;
     let metadata = describe_memory_system(Some(selected_system_id.as_str()))?;
 
-    if metadata.id == DEFAULT_MEMORY_SYSTEM_ID {
-        return BuiltinMemoryOrchestrator.hydrate_stage_envelope(
-            session_id,
-            workspace_root,
-            config,
-            &metadata,
-        );
-    }
-
-    hydrate_stage_envelope_without_execution_adapter(session_id, config, &metadata)
-}
-
-fn hydrate_stage_envelope_without_execution_adapter(
-    session_id: &str,
-    config: &MemoryRuntimeConfig,
-    metadata: &MemorySystemMetadata,
-) -> Result<StageEnvelope, String> {
-    let recent_window = recent_window_records(session_id, config)?;
-    let entries = recent_window
-        .iter()
-        .map(|turn| MemoryContextEntry {
-            kind: super::MemoryContextKind::Turn,
-            role: turn.role.clone(),
-            content: turn.content.clone(),
-        })
-        .collect::<Vec<_>>();
-    let diagnostics = builtin_pre_assembly_stage_families()
-        .into_iter()
-        .map(|family| {
-            let message = metadata
-                .supports_pre_assembly_stage_family(family)
-                .then(|| {
-                    "memory system is registered but has no pre-assembly execution adapter yet"
-                        .to_owned()
-                });
-            skipped_stage_diagnostics(family, message)
-        })
-        .collect::<Vec<_>>();
-
-    Ok(StageEnvelope {
-        hydrated: HydratedMemoryContext::from_stage_parts(
-            entries,
-            recent_window,
-            &diagnostics,
-            metadata.id,
-            config,
-        ),
-        retrieval_request: None,
-        diagnostics,
-    })
+    BuiltinMemoryOrchestrator.hydrate_stage_envelope(
+        session_id,
+        workspace_root,
+        config,
+        system.as_ref(),
+        &metadata,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -643,9 +602,10 @@ mod tests {
     use super::*;
     use crate::config::{MemoryMode, MemoryProfile};
     use crate::memory::{
-        MemoryContextKind, MemoryStageFamily, MemorySystem, MemorySystemCapability,
-        MemorySystemMetadata, StageOutcome, append_turn_direct,
-        builtin_pre_assembly_stage_families, register_memory_system,
+        DerivedMemoryKind, MemoryContextKind, MemoryRecallMode, MemoryScope, MemoryStageFamily,
+        MemorySystem, MemorySystemCapability, MemorySystemMetadata, StageOutcome,
+        WORKSPACE_RECALL_MEMORY_SYSTEM_ID, append_turn_direct, builtin_pre_assembly_stage_families,
+        register_memory_system,
     };
 
     struct RegistryRetrieveOnlyMemorySystem;
@@ -666,7 +626,7 @@ mod tests {
     }
 
     fn hydrated_memory_temp_dir(prefix: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()))
+        crate::test_support::unique_temp_dir(prefix)
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -909,19 +869,13 @@ mod tests {
                 MemoryStageFamily::Rank,
             ]
         );
-        assert!(
-            envelope
-                .diagnostics
-                .iter()
-                .all(|diag| diag.outcome == StageOutcome::Succeeded)
-        );
-        assert_eq!(
-            envelope
-                .retrieval_request
-                .as_ref()
-                .map(|req| req.budget_items),
-            Some(config.sliding_window)
-        );
+        assert!(envelope.diagnostics[0].outcome == StageOutcome::Succeeded);
+        assert_eq!(envelope.diagnostics[1].outcome, StageOutcome::Succeeded);
+        assert_eq!(envelope.diagnostics[2].outcome, StageOutcome::Succeeded);
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("window-plus-summary should advertise retrieval request");
+        assert_eq!(retrieval_request.query.as_deref(), Some("turn 3"));
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
@@ -981,6 +935,15 @@ mod tests {
         let _ = std::fs::create_dir_all(&tmp);
         let db_path = tmp.join("window-plus-summary.sqlite3");
         let _ = std::fs::remove_file(&db_path);
+        let memory_dir = tmp.join("memory");
+        let _ = std::fs::create_dir_all(&memory_dir);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember this").expect("write memory file");
+        let memory_file_path_text = memory_file_path
+            .canonicalize()
+            .expect("canonical memory file path")
+            .display()
+            .to_string();
 
         let config = crate::memory::runtime_config::MemoryRuntimeConfig {
             profile: MemoryProfile::WindowPlusSummary,
@@ -990,31 +953,42 @@ mod tests {
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
 
-        let envelope = hydrate_stage_envelope("stage-window-plus-summary", &config)
-            .expect("hydrate staged envelope");
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-window-plus-summary",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
 
         let retrieval_request = envelope
             .retrieval_request
             .expect("window-plus-summary should advertise retrieval request");
-        assert_eq!(retrieval_request.budget_items, 6);
+        assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.recall_mode,
+            crate::memory::MemoryRecallMode::PromptAssembly
+        );
+        assert_eq!(retrieval_request.query, None);
+        assert_eq!(retrieval_request.budget_items, 1);
         assert_eq!(
             retrieval_request.allowed_kinds,
-            vec![
-                DerivedMemoryKind::Profile,
-                DerivedMemoryKind::Fact,
-                DerivedMemoryKind::Episode,
-                DerivedMemoryKind::Procedure,
-                DerivedMemoryKind::Overview,
-            ]
+            vec![DerivedMemoryKind::Reference]
         );
         assert_eq!(
             retrieval_request.scopes,
-            vec![
-                MemoryScope::Session,
-                MemoryScope::Workspace,
-                MemoryScope::Agent,
-                MemoryScope::User,
-            ]
+            vec![MemoryScope::Workspace, MemoryScope::Session]
+        );
+        assert_eq!(envelope.hydrated.entries.len(), 1);
+        assert_eq!(
+            envelope.hydrated.entries[0].kind,
+            crate::memory::MemoryContextKind::RetrievedMemory
+        );
+        assert_eq!(envelope.hydrated.entries[0].provenance.len(), 1);
+        assert_eq!(
+            envelope.hydrated.entries[0].provenance[0]
+                .source_path
+                .as_deref(),
+            Some(memory_file_path_text.as_str())
         );
 
         let _ = std::fs::remove_file(&db_path);
@@ -1110,6 +1084,31 @@ mod tests {
             retrieval_request.query.as_deref(),
             Some("Find the rollback checklist for database migration")
         );
+        assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.recall_mode,
+            crate::memory::MemoryRecallMode::PromptAssembly
+        );
+        assert_eq!(retrieval_request.budget_items, 4);
+        assert_eq!(
+            retrieval_request.scopes,
+            vec![
+                MemoryScope::Session,
+                MemoryScope::Workspace,
+                MemoryScope::Agent,
+                MemoryScope::User,
+            ]
+        );
+        assert_eq!(
+            retrieval_request.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Profile,
+                DerivedMemoryKind::Fact,
+                DerivedMemoryKind::Episode,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+            ]
+        );
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
@@ -1147,6 +1146,15 @@ mod tests {
         let _ = std::fs::create_dir_all(&tmp);
         let db_path = tmp.join("profile-plus-window.sqlite3");
         let _ = std::fs::remove_file(&db_path);
+        let memory_dir = tmp.join("memory");
+        let _ = std::fs::create_dir_all(&memory_dir);
+        let daily_log_path = memory_dir.join("2026-04-06.md");
+        std::fs::write(&daily_log_path, "recent durable note").expect("write daily log");
+        let daily_log_path_text = daily_log_path
+            .canonicalize()
+            .expect("canonical daily log path")
+            .display()
+            .to_string();
 
         let config = crate::memory::runtime_config::MemoryRuntimeConfig {
             profile: MemoryProfile::ProfilePlusWindow,
@@ -1157,12 +1165,44 @@ mod tests {
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
 
-        let envelope = hydrate_stage_envelope("stage-profile-plus-window", &config)
-            .expect("hydrate staged envelope");
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-profile-plus-window",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
 
-        assert_eq!(envelope.retrieval_request, None);
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("profile-plus-window should advertise retrieval request");
+        assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.scopes,
+            vec![MemoryScope::Workspace, MemoryScope::Session]
+        );
+        assert_eq!(
+            retrieval_request.allowed_kinds,
+            vec![DerivedMemoryKind::Reference]
+        );
+        let retrieved_entry = envelope
+            .hydrated
+            .entries
+            .iter()
+            .find(|entry| entry.kind == crate::memory::MemoryContextKind::RetrievedMemory)
+            .expect("retrieved entry");
+        assert_eq!(retrieved_entry.provenance.len(), 1);
+        assert_eq!(
+            retrieved_entry.provenance[0].scope,
+            Some(MemoryScope::Session)
+        );
+        assert_eq!(
+            retrieved_entry.provenance[0].source_path.as_deref(),
+            Some(daily_log_path_text.as_str())
+        );
 
         let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&daily_log_path);
+        let _ = std::fs::remove_dir(&memory_dir);
         let _ = std::fs::remove_dir(&tmp);
     }
 
@@ -1225,8 +1265,192 @@ mod tests {
                 .map(|family| (family, StageOutcome::Skipped))
                 .collect::<Vec<_>>()
         );
+        assert_eq!(
+            envelope.diagnostics[1].message.as_deref(),
+            Some(
+                "memory system declares `retrieve` stage support but provides no execution adapter"
+            )
+        );
 
         let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn workspace_recall_system_executes_retrieve_and_rank_stages() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-workspace-recall");
+        let memory_dir = tmp.join("memory");
+        let memory_file_path = tmp.join("MEMORY.md");
+        let _ = std::fs::create_dir_all(&memory_dir);
+        let _ = std::fs::write(
+            &memory_file_path,
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        );
+        let memory_file_path_text = memory_file_path
+            .canonicalize()
+            .expect("canonical memory file path")
+            .display()
+            .to_string();
+        let _ = std::fs::write(
+            memory_dir.join("2026-03-22.md"),
+            "## Durable Recall\n\nCustomer migration starts tomorrow.\n",
+        );
+
+        let db_path = tmp.join("workspace-recall.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id = Some(WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
+
+        append_turn_direct("workspace-recall", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("workspace-recall", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("workspace-recall", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "workspace-recall",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope for workspace-recall system");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .as_ref()
+            .expect("workspace recall should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.memory_system_id,
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+        );
+        assert_eq!(
+            retrieval_request.recall_mode,
+            MemoryRecallMode::PromptAssembly
+        );
+        assert_eq!(retrieval_request.budget_items, 2);
+
+        let entry_kinds = envelope
+            .hydrated
+            .entries
+            .iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>();
+        assert!(
+            entry_kinds.contains(&MemoryContextKind::RetrievedMemory),
+            "expected at least one retrieved-memory entry"
+        );
+        assert_eq!(
+            entry_kinds
+                .iter()
+                .filter(|kind| **kind == MemoryContextKind::Turn)
+                .count(),
+            2
+        );
+
+        let retrieved_entry = envelope
+            .hydrated
+            .entries
+            .iter()
+            .find(|entry| {
+                let first_provenance = entry.provenance.first();
+                let entry_label =
+                    first_provenance.and_then(|provenance| provenance.source_label.as_deref());
+                entry.kind == MemoryContextKind::RetrievedMemory && entry_label == Some("MEMORY.md")
+            })
+            .expect("curated retrieved memory entry");
+        let retrieved_provenance = retrieved_entry
+            .provenance
+            .first()
+            .expect("retrieved provenance");
+        assert_eq!(
+            retrieved_provenance.memory_system_id,
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+        );
+        assert_eq!(
+            retrieved_provenance.source_path.as_deref(),
+            Some(memory_file_path_text.as_str())
+        );
+
+        let diagnostics = envelope
+            .diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.family, diagnostic.outcome))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            diagnostics,
+            vec![
+                (MemoryStageFamily::Derive, StageOutcome::Skipped),
+                (MemoryStageFamily::Retrieve, StageOutcome::Succeeded),
+                (MemoryStageFamily::Rank, StageOutcome::Succeeded),
+            ]
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn workspace_recall_system_reorders_retrieved_entries_ahead_of_history_turns() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-workspace-recall");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("workspace-recall.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_dir = tmp.join("memory");
+        let _ = std::fs::create_dir_all(&memory_dir);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "curated workspace fact").expect("write memory file");
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id =
+            Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
+
+        append_turn_direct("workspace-recall", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("workspace-recall", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "workspace-recall",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope for workspace-recall");
+
+        assert_eq!(
+            envelope.hydrated.diagnostics.system_id,
+            crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+        );
+        assert_eq!(envelope.diagnostics[0].outcome, StageOutcome::Skipped);
+        assert_eq!(envelope.diagnostics[1].outcome, StageOutcome::Succeeded);
+        assert_eq!(envelope.diagnostics[2].outcome, StageOutcome::Succeeded);
+        assert_eq!(
+            envelope.hydrated.entries[0].kind,
+            MemoryContextKind::RetrievedMemory
+        );
+        assert_eq!(envelope.hydrated.entries[0].provenance.len(), 1);
+        assert_eq!(
+            envelope.hydrated.entries[0].provenance[0].memory_system_id,
+            crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&memory_dir);
         let _ = std::fs::remove_dir(&tmp);
     }
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -7,8 +7,9 @@ use serde_json::{Value, json};
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::{
-    DerivedMemoryKind, HydratedMemoryContext, MemoryDiagnostics, MemoryRetrievalRequest,
-    MemoryScope, MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
+    DerivedMemoryKind, HydratedMemoryContext, MemoryContextProvenance, MemoryDiagnostics,
+    MemoryRecallMode, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, StageDiagnostics,
+    StageEnvelope, StageOutcome,
 };
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
@@ -39,6 +40,8 @@ pub struct MemoryContextEntry {
     pub kind: MemoryContextKind,
     pub role: String,
     pub content: String,
+    #[serde(default)]
+    pub provenance: Vec<MemoryContextProvenance>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -83,7 +86,11 @@ struct HydratedMemoryContextPayload {
 struct MemoryRetrievalRequestPayload {
     session_id: String,
     #[serde(default)]
+    memory_system_id: Option<String>,
+    #[serde(default)]
     query: Option<String>,
+    #[serde(default)]
+    recall_mode: Option<MemoryRecallMode>,
     #[serde(default)]
     scopes: Vec<String>,
     #[serde(default)]
@@ -145,6 +152,8 @@ pub fn build_read_context_request(
         payload: json!({
             "session_id": session_id,
             "profile": config.profile.as_str(),
+            "system": config.system.as_str(),
+            "system_id": config.resolved_system_id.as_deref(),
             "sliding_window": config.sliding_window,
             "summary_max_chars": config.summary_max_chars,
             "profile_note": config.profile_note,
@@ -199,6 +208,11 @@ pub fn build_read_stage_envelope_request_with_workspace_root(
     }
 
     payload.insert("profile".to_owned(), json!(config.profile.as_str()));
+    payload.insert("system".to_owned(), json!(config.system.as_str()));
+    payload.insert(
+        "system_id".to_owned(),
+        json!(config.resolved_system_id.as_deref()),
+    );
     payload.insert("sliding_window".to_owned(), json!(config.sliding_window));
     payload.insert(
         "summary_max_chars".to_owned(),
@@ -313,7 +327,9 @@ impl From<&MemoryRetrievalRequest> for MemoryRetrievalRequestPayload {
     fn from(value: &MemoryRetrievalRequest) -> Self {
         Self {
             session_id: value.session_id.clone(),
+            memory_system_id: Some(value.memory_system_id.clone()),
             query: value.query.clone(),
+            recall_mode: Some(value.recall_mode),
             scopes: value
                 .scopes
                 .iter()
@@ -410,7 +426,11 @@ fn decode_memory_retrieval_request_payload(
 
     Some(MemoryRetrievalRequest {
         session_id: payload.session_id,
+        memory_system_id: payload
+            .memory_system_id
+            .unwrap_or_else(|| crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned()),
         query: payload.query,
+        recall_mode: payload.recall_mode.unwrap_or_default(),
         scopes: payload
             .scopes
             .into_iter()
@@ -518,7 +538,12 @@ mod tests {
             .retrieval_request
             .expect("retrieval request should decode");
         assert_eq!(retrieval_request.session_id, "session-123");
+        assert_eq!(retrieval_request.memory_system_id, "builtin");
         assert_eq!(retrieval_request.query, None);
+        assert_eq!(
+            retrieval_request.recall_mode,
+            MemoryRecallMode::PromptAssembly
+        );
         assert!(retrieval_request.scopes.is_empty());
         assert_eq!(retrieval_request.budget_items, 0);
         assert!(retrieval_request.allowed_kinds.is_empty());

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use super::{HydratedMemoryContext, MemoryScope};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +72,7 @@ pub enum DerivedMemoryKind {
     Episode,
     Procedure,
     Overview,
+    Reference,
 }
 
 impl DerivedMemoryKind {
@@ -82,6 +85,7 @@ impl DerivedMemoryKind {
             Self::Episode => "episode",
             Self::Procedure => "procedure",
             Self::Overview => "overview",
+            Self::Reference => "reference",
         }
     }
 
@@ -94,7 +98,94 @@ impl DerivedMemoryKind {
             "episode" => Some(Self::Episode),
             "procedure" => Some(Self::Procedure),
             "overview" => Some(Self::Overview),
+            "reference" => Some(Self::Reference),
             _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryRecallMode {
+    #[default]
+    PromptAssembly,
+    OperatorInspection,
+    EvaluationEvidence,
+    BackgroundDerivation,
+}
+
+impl MemoryRecallMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PromptAssembly => "prompt_assembly",
+            Self::OperatorInspection => "operator_inspection",
+            Self::EvaluationEvidence => "evaluation_evidence",
+            Self::BackgroundDerivation => "background_derivation",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "prompt_assembly" => Some(Self::PromptAssembly),
+            "operator_inspection" => Some(Self::OperatorInspection),
+            "evaluation_evidence" => Some(Self::EvaluationEvidence),
+            "background_derivation" => Some(Self::BackgroundDerivation),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryProvenanceSourceKind {
+    WorkspaceDocument,
+    ProfileNote,
+    SummaryCheckpoint,
+    RecentWindowTurn,
+    MemorySystem,
+}
+
+impl MemoryProvenanceSourceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkspaceDocument => "workspace_document",
+            Self::ProfileNote => "profile_note",
+            Self::SummaryCheckpoint => "summary_checkpoint",
+            Self::RecentWindowTurn => "recent_window_turn",
+            Self::MemorySystem => "memory_system",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryContextProvenance {
+    pub memory_system_id: String,
+    pub source_kind: MemoryProvenanceSourceKind,
+    pub source_label: Option<String>,
+    pub source_path: Option<String>,
+    pub scope: Option<MemoryScope>,
+    pub recall_mode: MemoryRecallMode,
+}
+
+impl MemoryContextProvenance {
+    pub fn new(
+        memory_system_id: &str,
+        source_kind: MemoryProvenanceSourceKind,
+        source_label: Option<String>,
+        source_path: Option<String>,
+        scope: Option<MemoryScope>,
+        recall_mode: MemoryRecallMode,
+    ) -> Self {
+        let normalized_system_id = super::normalize_system_id(memory_system_id)
+            .unwrap_or_else(|| memory_system_id.to_owned());
+
+        Self {
+            memory_system_id: normalized_system_id,
+            source_kind,
+            source_label,
+            source_path,
+            scope,
+            recall_mode,
         }
     }
 }
@@ -102,7 +193,9 @@ impl DerivedMemoryKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryRetrievalRequest {
     pub session_id: String,
+    pub memory_system_id: String,
     pub query: Option<String>,
+    pub recall_mode: MemoryRecallMode,
     pub scopes: Vec<MemoryScope>,
     pub budget_items: usize,
     pub allowed_kinds: Vec<DerivedMemoryKind>,
@@ -195,7 +288,9 @@ mod tests {
             },
             retrieval_request: Some(MemoryRetrievalRequest {
                 session_id: "session-123".to_owned(),
+                memory_system_id: "builtin".to_owned(),
                 query: None,
+                recall_mode: MemoryRecallMode::PromptAssembly,
                 scopes: vec![MemoryScope::Session],
                 budget_items: 8,
                 allowed_kinds: vec![DerivedMemoryKind::Summary],

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -1,9 +1,17 @@
+use std::path::Path;
+
 use std::collections::BTreeSet;
 
-use super::{MemoryStageFamily, builtin_pre_assembly_stage_families};
+use super::{
+    DerivedMemoryKind, MemoryContextEntry, MemoryContextKind, MemoryContextProvenance,
+    MemoryProvenanceSourceKind, MemoryRecallMode, MemoryRetrievalRequest, MemoryScope,
+    MemoryStageFamily, WindowTurn, builtin_pre_assembly_stage_families, durable_recall,
+    runtime_config::MemoryRuntimeConfig,
+};
 
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
 pub const DEFAULT_MEMORY_SYSTEM_ID: &str = "builtin";
+pub const WORKSPACE_RECALL_MEMORY_SYSTEM_ID: &str = "workspace_recall";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MemorySystemCapability {
@@ -11,6 +19,7 @@ pub enum MemorySystemCapability {
     PromptHydration,
     DeterministicSummary,
     ProfileNoteProjection,
+    RetrievalProvenance,
 }
 
 impl MemorySystemCapability {
@@ -20,6 +29,7 @@ impl MemorySystemCapability {
             Self::PromptHydration => "prompt_hydration",
             Self::DeterministicSummary => "deterministic_summary",
             Self::ProfileNoteProjection => "profile_note_projection",
+            Self::RetrievalProvenance => "retrieval_provenance",
         }
     }
 }
@@ -31,6 +41,7 @@ pub struct MemorySystemMetadata {
     pub capabilities: BTreeSet<MemorySystemCapability>,
     pub summary: &'static str,
     pub supported_pre_assembly_stage_families: Vec<MemoryStageFamily>,
+    pub supported_recall_modes: Vec<MemoryRecallMode>,
 }
 
 impl MemorySystemMetadata {
@@ -45,6 +56,7 @@ impl MemorySystemMetadata {
             capabilities: capabilities.into_iter().collect(),
             summary,
             supported_pre_assembly_stage_families: Vec::new(),
+            supported_recall_modes: Vec::new(),
         }
     }
 
@@ -53,6 +65,14 @@ impl MemorySystemMetadata {
         families: impl IntoIterator<Item = MemoryStageFamily>,
     ) -> Self {
         self.supported_pre_assembly_stage_families = families.into_iter().collect();
+        self
+    }
+
+    pub fn with_supported_recall_modes(
+        mut self,
+        recall_modes: impl IntoIterator<Item = MemoryRecallMode>,
+    ) -> Self {
+        self.supported_recall_modes = recall_modes.into_iter().collect();
         self
     }
 
@@ -76,6 +96,43 @@ pub trait MemorySystem: Send + Sync {
     fn id(&self) -> &'static str;
 
     fn metadata(&self) -> MemorySystemMetadata;
+
+    fn build_retrieval_request(
+        &self,
+        _session_id: &str,
+        _workspace_root: Option<&Path>,
+        _config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        None
+    }
+
+    fn run_derive_stage(
+        &self,
+        _session_id: &str,
+        _config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(None)
+    }
+
+    fn run_retrieve_stage(
+        &self,
+        _request: &MemoryRetrievalRequest,
+        _workspace_root: Option<&Path>,
+        _config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(None)
+    }
+
+    fn run_rank_stage(
+        &self,
+        _entries: Vec<MemoryContextEntry>,
+        _config: &MemoryRuntimeConfig,
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(None)
+    }
 }
 
 impl<T> MemorySystem for Box<T>
@@ -88,6 +145,46 @@ where
 
     fn metadata(&self) -> MemorySystemMetadata {
         self.as_ref().metadata()
+    }
+
+    fn build_retrieval_request(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        self.as_ref()
+            .build_retrieval_request(session_id, workspace_root, config, recent_window)
+    }
+
+    fn run_derive_stage(
+        &self,
+        session_id: &str,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        self.as_ref()
+            .run_derive_stage(session_id, config, recent_window)
+    }
+
+    fn run_retrieve_stage(
+        &self,
+        request: &MemoryRetrievalRequest,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        self.as_ref()
+            .run_retrieve_stage(request, workspace_root, config, recent_window)
+    }
+
+    fn run_rank_stage(
+        &self,
+        entries: Vec<MemoryContextEntry>,
+        config: &MemoryRuntimeConfig,
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        self.as_ref().run_rank_stage(entries, config)
     }
 }
 
@@ -107,10 +204,239 @@ impl MemorySystem for BuiltinMemorySystem {
                 MemorySystemCapability::PromptHydration,
                 MemorySystemCapability::DeterministicSummary,
                 MemorySystemCapability::ProfileNoteProjection,
+                MemorySystemCapability::RetrievalProvenance,
             ],
             "Built-in SQLite-backed canonical memory with deterministic prompt hydration.",
         )
         .with_supported_pre_assembly_stage_families(builtin_pre_assembly_stage_families())
+        .with_supported_recall_modes([MemoryRecallMode::PromptAssembly])
+    }
+
+    fn build_retrieval_request(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        let supports_query_recall =
+            matches!(config.mode, crate::config::MemoryMode::WindowPlusSummary);
+        let has_workspace_root = workspace_root.is_some();
+        let query = if supports_query_recall {
+            super::orchestrator::retrieval_query_from_recent_window(recent_window)
+        } else {
+            None
+        };
+        let has_query = query.is_some();
+        let has_retrieval_path = has_workspace_root || has_query;
+        if !has_retrieval_path {
+            return None;
+        }
+
+        let (scopes, allowed_kinds, budget_items) = if has_query {
+            let scopes = vec![
+                MemoryScope::Session,
+                MemoryScope::Workspace,
+                MemoryScope::Agent,
+                MemoryScope::User,
+            ];
+            let mut allowed_kinds = vec![
+                DerivedMemoryKind::Profile,
+                DerivedMemoryKind::Fact,
+                DerivedMemoryKind::Episode,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+            ];
+            if has_workspace_root {
+                allowed_kinds.push(DerivedMemoryKind::Reference);
+            }
+            let budget_items = if recent_window.is_empty() {
+                6
+            } else {
+                config.sliding_window.min(6)
+            };
+            (scopes, allowed_kinds, budget_items)
+        } else {
+            let scopes = vec![MemoryScope::Workspace, MemoryScope::Session];
+            let allowed_kinds = vec![DerivedMemoryKind::Reference];
+            let budget_items = 1;
+            (scopes, allowed_kinds, budget_items)
+        };
+
+        let retrieval_request = MemoryRetrievalRequest {
+            session_id: session_id.to_owned(),
+            memory_system_id: self.id().to_owned(),
+            query,
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes,
+            budget_items,
+            allowed_kinds,
+        };
+
+        Some(retrieval_request)
+    }
+
+    fn run_derive_stage(
+        &self,
+        _session_id: &str,
+        _config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(Some(Vec::new()))
+    }
+
+    fn run_retrieve_stage(
+        &self,
+        request: &MemoryRetrievalRequest,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        let mut entries = durable_recall::load_durable_recall_entries(
+            workspace_root,
+            config,
+            self.id(),
+            request.recall_mode,
+        )?;
+
+        #[cfg(feature = "memory-sqlite")]
+        if let Some(query) = request.query.as_deref() {
+            let hits = super::sqlite::search_canonical_records_for_recall(
+                query,
+                request.budget_items,
+                Some(request.session_id.as_str()),
+                config,
+            )?;
+            if !hits.is_empty() {
+                let content =
+                    super::orchestrator::render_cross_session_recall_block(hits.as_slice());
+                let provenance = MemoryContextProvenance::new(
+                    self.id(),
+                    MemoryProvenanceSourceKind::MemorySystem,
+                    Some("cross_session_recall".to_owned()),
+                    None,
+                    Some(MemoryScope::Session),
+                    request.recall_mode,
+                );
+                let entry = MemoryContextEntry {
+                    kind: MemoryContextKind::RetrievedMemory,
+                    role: "system".to_owned(),
+                    content,
+                    provenance: vec![provenance],
+                };
+                entries.push(entry);
+            }
+        }
+
+        Ok(Some(entries))
+    }
+
+    fn run_rank_stage(
+        &self,
+        entries: Vec<MemoryContextEntry>,
+        _config: &MemoryRuntimeConfig,
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(Some(entries))
+    }
+}
+
+#[derive(Default)]
+pub struct WorkspaceRecallMemorySystem;
+
+impl MemorySystem for WorkspaceRecallMemorySystem {
+    fn id(&self) -> &'static str {
+        WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+    }
+
+    fn metadata(&self) -> MemorySystemMetadata {
+        MemorySystemMetadata::new(
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+            [
+                MemorySystemCapability::PromptHydration,
+                MemorySystemCapability::RetrievalProvenance,
+            ],
+            "Workspace-document recall system with provenance-aware retrieval and rank-stage reordering.",
+        )
+        .with_supported_pre_assembly_stage_families([
+            MemoryStageFamily::Retrieve,
+            MemoryStageFamily::Rank,
+        ])
+        .with_supported_recall_modes([MemoryRecallMode::PromptAssembly])
+    }
+
+    fn build_retrieval_request(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        let has_workspace_root = workspace_root.is_some();
+        if !has_workspace_root {
+            return None;
+        }
+
+        let budget_items = config.sliding_window.min(4);
+        let normalized_budget_items = budget_items.max(1);
+
+        Some(MemoryRetrievalRequest {
+            session_id: session_id.to_owned(),
+            memory_system_id: self.id().to_owned(),
+            query: None,
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes: vec![crate::memory::MemoryScope::Workspace],
+            budget_items: normalized_budget_items,
+            allowed_kinds: vec![crate::memory::DerivedMemoryKind::Reference],
+        })
+    }
+
+    fn run_retrieve_stage(
+        &self,
+        request: &MemoryRetrievalRequest,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        let entries = durable_recall::load_workspace_document_recall_entries(
+            workspace_root,
+            config,
+            self.id(),
+            request.recall_mode,
+            request.scopes.as_slice(),
+            request.budget_items,
+        )?;
+        Ok(Some(entries))
+    }
+
+    fn run_rank_stage(
+        &self,
+        entries: Vec<MemoryContextEntry>,
+        _config: &MemoryRuntimeConfig,
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        let mut profile_entries = Vec::new();
+        let mut retrieved_entries = Vec::new();
+        let mut summary_entries = Vec::new();
+        let mut history_entries = Vec::new();
+
+        for entry in entries {
+            match entry.kind {
+                MemoryContextKind::Profile => profile_entries.push(entry),
+                MemoryContextKind::RetrievedMemory => retrieved_entries.push(entry),
+                MemoryContextKind::Summary => summary_entries.push(entry),
+                MemoryContextKind::Turn => history_entries.push(entry),
+            }
+        }
+
+        let has_retrieved_entries = !retrieved_entries.is_empty();
+        let mut ranked_entries = Vec::new();
+        ranked_entries.extend(profile_entries);
+        ranked_entries.extend(retrieved_entries);
+        if !has_retrieved_entries {
+            ranked_entries.extend(summary_entries);
+        }
+        ranked_entries.extend(history_entries);
+
+        Ok(Some(ranked_entries))
     }
 }
 
@@ -147,7 +473,12 @@ mod tests {
                 "deterministic_summary",
                 "profile_note_projection",
                 "prompt_hydration",
+                "retrieval_provenance",
             ]
+        );
+        assert_eq!(
+            metadata.supported_recall_modes,
+            vec![MemoryRecallMode::PromptAssembly]
         );
     }
 
@@ -168,6 +499,7 @@ mod tests {
             custom.supported_pre_assembly_stage_families,
             vec![MemoryStageFamily::Retrieve]
         );
+        assert!(custom.supported_recall_modes.is_empty());
     }
 
     #[test]
@@ -177,6 +509,29 @@ mod tests {
             metadata
                 .iter()
                 .any(|entry| entry.id == DEFAULT_MEMORY_SYSTEM_ID)
+        );
+        assert!(
+            metadata
+                .iter()
+                .any(|entry| entry.id == WORKSPACE_RECALL_MEMORY_SYSTEM_ID)
+        );
+    }
+
+    #[test]
+    fn workspace_recall_memory_system_metadata_is_stable() {
+        let metadata = WorkspaceRecallMemorySystem.metadata();
+        assert_eq!(metadata.id, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
+        assert_eq!(
+            metadata.capability_names(),
+            vec!["prompt_hydration", "retrieval_provenance"]
+        );
+        assert_eq!(
+            metadata.supported_pre_assembly_stage_families,
+            vec![MemoryStageFamily::Retrieve, MemoryStageFamily::Rank]
+        );
+        assert_eq!(
+            metadata.supported_recall_modes,
+            vec![MemoryRecallMode::PromptAssembly]
         );
     }
 
@@ -191,5 +546,87 @@ mod tests {
             crate::memory::MemorySystemSelectionSource::Default
         );
         assert_eq!(snapshot.selected_metadata.id, DEFAULT_MEMORY_SYSTEM_ID);
+    }
+
+    #[test]
+    fn workspace_recall_rank_stage_keeps_summary_without_retrieved_entries() {
+        let entries = vec![
+            MemoryContextEntry {
+                kind: MemoryContextKind::Profile,
+                role: "system".to_owned(),
+                content: "profile".to_owned(),
+                provenance: Vec::new(),
+            },
+            MemoryContextEntry {
+                kind: MemoryContextKind::Summary,
+                role: "system".to_owned(),
+                content: "summary".to_owned(),
+                provenance: Vec::new(),
+            },
+            MemoryContextEntry {
+                kind: MemoryContextKind::Turn,
+                role: "user".to_owned(),
+                content: "turn".to_owned(),
+                provenance: Vec::new(),
+            },
+        ];
+
+        let ranked_entries = WorkspaceRecallMemorySystem
+            .run_rank_stage(entries, &MemoryRuntimeConfig::default())
+            .expect("rank stage should succeed")
+            .expect("workspace recall rank stage should return entries");
+
+        let kinds = ranked_entries
+            .into_iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            kinds,
+            vec![
+                MemoryContextKind::Profile,
+                MemoryContextKind::Summary,
+                MemoryContextKind::Turn,
+            ]
+        );
+    }
+
+    #[test]
+    fn workspace_recall_rank_stage_drops_summary_when_retrieved_entries_exist() {
+        let entries = vec![
+            MemoryContextEntry {
+                kind: MemoryContextKind::Summary,
+                role: "system".to_owned(),
+                content: "summary".to_owned(),
+                provenance: Vec::new(),
+            },
+            MemoryContextEntry {
+                kind: MemoryContextKind::RetrievedMemory,
+                role: "system".to_owned(),
+                content: "retrieved".to_owned(),
+                provenance: Vec::new(),
+            },
+            MemoryContextEntry {
+                kind: MemoryContextKind::Turn,
+                role: "user".to_owned(),
+                content: "turn".to_owned(),
+                provenance: Vec::new(),
+            },
+        ];
+
+        let ranked_entries = WorkspaceRecallMemorySystem
+            .run_rank_stage(entries, &MemoryRuntimeConfig::default())
+            .expect("rank stage should succeed")
+            .expect("workspace recall rank stage should return entries");
+
+        let kinds = ranked_entries
+            .into_iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            kinds,
+            vec![MemoryContextKind::RetrievedMemory, MemoryContextKind::Turn]
+        );
     }
 }

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -12,6 +12,7 @@ use crate::config::{
 use super::runtime_config::MemoryRuntimeConfig;
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
+    WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
 };
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
@@ -87,6 +88,10 @@ fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
         map.insert(
             DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
             Arc::new(|| Box::new(BuiltinMemorySystem)),
+        );
+        map.insert(
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned(),
+            Arc::new(|| Box::new(WorkspaceRecallMemorySystem)),
         );
         RwLock::new(map)
     })
@@ -248,7 +253,7 @@ pub fn collect_memory_system_runtime_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
+    use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemoryRecallMode, MemorySystemCapability};
     use crate::test_support::ScopedEnv;
 
     fn clear_memory_runtime_env_overrides(env: &mut ScopedEnv) {
@@ -394,6 +399,25 @@ mod tests {
                 .capabilities
                 .contains(&MemorySystemCapability::CanonicalStore),
             "builtin metadata should include canonical-store capability"
+        );
+        assert_eq!(
+            builtin.supported_recall_modes,
+            vec![MemoryRecallMode::PromptAssembly]
+        );
+
+        let workspace_recall = metadata
+            .iter()
+            .find(|entry| entry.id == WORKSPACE_RECALL_MEMORY_SYSTEM_ID)
+            .expect("workspace_recall metadata entry");
+        assert!(
+            workspace_recall
+                .capabilities
+                .contains(&MemorySystemCapability::RetrievalProvenance),
+            "workspace_recall metadata should include retrieval provenance capability"
+        );
+        assert_eq!(
+            workspace_recall.supported_recall_modes,
+            vec![MemoryRecallMode::PromptAssembly]
         );
     }
 

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -340,6 +340,32 @@ fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_p
 
 #[cfg(feature = "memory-sqlite")]
 #[test]
+fn load_prompt_context_with_diagnostics_uses_selected_memory_system_id_in_provenance() {
+    let (root, mut config) = isolated_memory_workspace("loongclaw-selected-system-provenance");
+    let session_id = "selected-system-provenance-session";
+
+    config.resolved_system_id = Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
+
+    append_turn_direct(session_id, "user", "hello from selected system", &config)
+        .expect("append_turn_direct should succeed");
+
+    let (entries, _diagnostics) = load_prompt_context_with_diagnostics(session_id, &config)
+        .expect("load_prompt_context_with_diagnostics should succeed");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].provenance.len(), 1);
+    assert_eq!(
+        entries[0].provenance[0].memory_system_id,
+        crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID
+    );
+
+    let sqlite_path = config.sqlite_path.expect("sqlite path");
+    let _ = std::fs::remove_file(sqlite_path);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
 fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
     let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
     let _durable_flush_guard = durable_flush_lock.blocking_lock();

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -1377,6 +1377,94 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn message_builder_workspace_recall_system_suppresses_summary_and_prioritizes_recall_entries() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+        std::fs::write(
+            workspace_root.join("MEMORY.md"),
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        )
+        .expect("write curated memory");
+        std::fs::write(
+            memory_dir.join("2026-03-23.md"),
+            "## Durable Recall\n\nCustomer migration starts tomorrow.\n",
+        )
+        .expect("write daily durable memory");
+
+        let db_path = workspace_root.join("provider-workspace-recall.sqlite3");
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(workspace_root.display().to_string());
+        config.memory.system = crate::config::MemorySystemKind::WorkspaceRecall;
+        config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
+        config.memory.sliding_window = 2;
+        config.memory.sqlite_path = db_path.display().to_string();
+
+        let runtime_config =
+            crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct(
+            "provider-workspace-recall-session",
+            "user",
+            "turn 1",
+            &runtime_config,
+        )
+        .expect("append turn 1");
+        crate::memory::append_turn_direct(
+            "provider-workspace-recall-session",
+            "assistant",
+            "turn 2",
+            &runtime_config,
+        )
+        .expect("append turn 2");
+        crate::memory::append_turn_direct(
+            "provider-workspace-recall-session",
+            "user",
+            "turn 3",
+            &runtime_config,
+        )
+        .expect("append turn 3");
+
+        let messages =
+            build_messages_for_session(&config, "provider-workspace-recall-session", true)
+                .expect("build messages");
+
+        let has_summary_message = messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        });
+        assert!(
+            !has_summary_message,
+            "workspace recall system should suppress builtin summary projection"
+        );
+
+        let durable_recall_message_index = messages
+            .iter()
+            .position(|message| {
+                message["role"] == "system"
+                    && message["content"].as_str().is_some_and(|content| {
+                        content.contains("Remember the deploy freeze window.")
+                    })
+            })
+            .expect("durable recall system message");
+        let first_turn_message_index = messages
+            .iter()
+            .position(|message| {
+                message["role"] == "assistant" && message["content"].as_str() == Some("turn 2")
+            })
+            .expect("assistant turn 2 message");
+
+        assert!(
+            durable_recall_message_index < first_turn_message_index,
+            "workspace recall entries should be projected before recent conversation turns"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn message_builder_keeps_durable_recall_advisory_when_memory_files_look_like_identity() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
@@ -1509,6 +1597,7 @@ mod tests {
                 "- demote repeated summary headings",
             )
             .to_owned(),
+            provenance: Vec::new(),
         };
 
         append_advisory_memory_message(&mut messages, &mut artifacts, &entry);

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5887,6 +5887,12 @@ pub fn memory_system_metadata_json(
         .copied()
         .map(mvp::memory::MemoryStageFamily::as_str)
         .collect::<Vec<_>>();
+    let supported_recall_modes = metadata
+        .supported_recall_modes
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryRecallMode::as_str)
+        .collect::<Vec<_>>();
     let mut payload = serde_json::Map::new();
     payload.insert("id".to_owned(), json!(metadata.id));
     payload.insert("api_version".to_owned(), json!(metadata.api_version));
@@ -5897,6 +5903,10 @@ pub fn memory_system_metadata_json(
     payload.insert(
         "supported_pre_assembly_stage_families".to_owned(),
         json!(supported_pre_assembly_stage_families),
+    );
+    payload.insert(
+        "supported_recall_modes".to_owned(),
+        json!(supported_recall_modes),
     );
     payload.insert("summary".to_owned(), json!(metadata.summary));
     if let Some(source) = source {
@@ -5910,6 +5920,15 @@ fn format_memory_stage_family_names(families: &[mvp::memory::MemoryStageFamily])
         .iter()
         .copied()
         .map(mvp::memory::MemoryStageFamily::as_str)
+        .collect::<Vec<_>>();
+    render_string_list(names)
+}
+
+fn format_memory_recall_mode_names(recall_modes: &[mvp::memory::MemoryRecallMode]) -> String {
+    let names = recall_modes
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryRecallMode::as_str)
         .collect::<Vec<_>>();
     render_string_list(names)
 }
@@ -5956,15 +5975,18 @@ pub fn render_memory_system_snapshot_text(
             .selected_metadata
             .supported_pre_assembly_stage_families,
     );
+    let selected_recall_modes =
+        format_memory_recall_mode_names(&snapshot.selected_metadata.supported_recall_modes);
     let mut lines = vec![
         format!("config={config_path}"),
         format!(
-            "selected={} source={} api_version={} capabilities={} pre_assembly_stages={} summary={}",
+            "selected={} source={} api_version={} capabilities={} pre_assembly_stages={} recall_modes={} summary={}",
             snapshot.selected_metadata.id,
             snapshot.selected.source.as_str(),
             snapshot.selected_metadata.api_version,
             format_capability_names(&selected_capabilities),
             selected_pre_assembly_stages,
+            selected_recall_modes,
             snapshot.selected_metadata.summary
         ),
         format!(
@@ -5985,12 +6007,14 @@ pub fn render_memory_system_snapshot_text(
         let capabilities = metadata.capability_names();
         let pre_assembly_stages =
             format_memory_stage_family_names(&metadata.supported_pre_assembly_stage_families);
+        let recall_modes = format_memory_recall_mode_names(&metadata.supported_recall_modes);
         lines.push(format!(
-            "- {} api_version={} capabilities={} pre_assembly_stages={} summary={}",
+            "- {} api_version={} capabilities={} pre_assembly_stages={} recall_modes={} summary={}",
             metadata.id,
             metadata.api_version,
             format_capability_names(&capabilities),
             pre_assembly_stages,
+            recall_modes,
             metadata.summary
         ));
     }

--- a/crates/daemon/src/memory_context_benchmark.rs
+++ b/crates/daemon/src/memory_context_benchmark.rs
@@ -1490,16 +1490,19 @@ mod tests {
             kind: MemoryContextKind::RetrievedMemory,
             role: "system".to_owned(),
             content: "durable recall".to_owned(),
+            provenance: Vec::new(),
         };
         let summary_entry = MemoryContextEntry {
             kind: MemoryContextKind::Summary,
             role: "system".to_owned(),
             content: "summary block".to_owned(),
+            provenance: Vec::new(),
         };
         let turn_entry = MemoryContextEntry {
             kind: MemoryContextKind::Turn,
             role: "user".to_owned(),
             content: "hello".to_owned(),
+            provenance: Vec::new(),
         };
         let entries = vec![retrieved_entry, summary_entry, turn_entry];
         let retrieved_payload_chars = "system".len() + "durable recall".len();

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1424,6 +1424,10 @@ fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
         payload["supported_pre_assembly_stage_families"],
         json!(["derive", "retrieve", "rank"])
     );
+    assert_eq!(
+        payload["supported_recall_modes"],
+        json!(["prompt_assembly"])
+    );
 }
 
 #[test]
@@ -1448,6 +1452,10 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
     assert_eq!(
         payload["selected"]["supported_pre_assembly_stage_families"],
         json!(["derive", "retrieve", "rank"])
+    );
+    assert_eq!(
+        payload["selected"]["supported_recall_modes"],
+        json!(["prompt_assembly"])
     );
     assert_eq!(payload["policy"]["backend"], "sqlite");
     assert_eq!(payload["policy"]["profile"], "window_plus_summary");
@@ -1477,11 +1485,11 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains(
-        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration pre_assembly_stages=derive,retrieve,rank"
+        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
     ));
     assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
     assert!(rendered.contains(
-        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration pre_assembly_stages=derive,retrieve,rank"
+        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
     ));
 }
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T13:20:33Z
+- Generated at: 2026-04-06T13:57:29Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 381 | 650 | 269 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 7.0% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2795 | 2800 | 5 | 48 | 65 | 17 | 99.8% | TIGHT | 2698 | 3.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
@@ -24,12 +24,12 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10638 | 11200 | 562 | 94 | 120 | 26 | 95.0% | WATCH | 10831 | -1.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6464 | 6500 | 36 | 205 | 210 | 5 | 99.4% | TIGHT | 6324 | 2.2% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6488 | 6500 | 12 | 206 | 210 | 4 | 99.8% | TIGHT | 6324 | 2.6% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9746 | 9800 | 54 | 235 | 250 | 15 | 99.4% | TIGHT | 9519 | 2.4% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.0%), daemon_lib (99.4%), onboard_cli (99.4%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.0%), daemon_lib (99.8%), onboard_cli (99.4%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%), turn_coordinator (95.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -61,7 +61,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=381 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2795 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
@@ -70,7 +70,7 @@
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10638 functions=94 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6464 functions=205 -->
+<!-- arch-hotspot key=daemon_lib lines=6488 functions=206 -->
 <!-- arch-hotspot key=onboard_cli lines=9746 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - LoongClaw's memory seam could not express typed recall intent or structured provenance strongly enough for a governed memory-provider contract, and the operator-facing memory tools still lagged behind that contract.
- Why it matters:
  - Future memory systems and retrieval-heavy flows need runtime-visible recall modes, provenance-aware memory entries, and truthful operator-inspection outputs instead of inferring everything from prompt text or file paths alone.
- What changed:
  - Added a real `workspace_recall` memory system and extended memory contracts with recall modes plus structured provenance.
  - Populated provenance for built-in profile, summary, turn, and workspace recall entries.
  - Surfaced supported recall modes in memory-system metadata, daemon JSON/text snapshots, and related regression tests.
  - Added coverage showing workspace recall is ordered ahead of history and preserved through context assembly / provider message building.
  - Extended `memory_search` and `memory_get` so operator-inspection results now return structured recall metadata and workspace-document provenance.
  - Aligned builtin and `workspace_recall` metadata to advertise `operator_inspection` support where that inspection surface is real.
- What did not change (scope boundary):
  - No embeddings/vector retrieval landed.
  - No new public docs-only planning material was added.
  - No autonomous promotion or external memory provider plugin runtime was added.

## Linked Issues

- Closes #1023
- Closes #1037
- Related #421
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
PASS cargo fmt --all -- --check
PASS scripts/check_dep_graph.sh
PASS scripts/check_architecture_boundaries.sh
PASS diff CLAUDE.md AGENTS.md
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo clippy --workspace --all-targets --all-features -- -D warnings
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test -p loongclaw-app memory_search_tool_returns_structured_hits_from_workspace_memory_files -- --test-threads=1
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test -p loongclaw-app memory_get_tool_returns_bounded_line_window_from_memory_file -- --test-threads=1
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test -p loongclaw-app workspace_recall_system_executes_retrieve_and_rank_stages -- --test-threads=1
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test -p loongclaw-app default_runtime_build_context_with_workspace_recall_system_reorders_memory_projection -- --test-threads=1
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test -p loongclaw-daemon memory_system_ -- --test-threads=1
PASS CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test --workspace --locked -- --test-threads=1
FAIL CARGO_TARGET_DIR=/tmp/loongclaw-memory-provider-test cargo test --workspace --all-features --locked -- --test-threads=1
     - unrelated daemon/browser-companion baseline failures on this machine:
       * browser_companion_diagnostics::tests::collect_browser_companion_diagnostics_rejects_partial_expected_version_matches
       * doctor_cli::tests::browser_companion_doctor_checks_pass_when_runtime_gate_is_open
       * doctor_cli::tests::browser_companion_doctor_checks_warn_when_expected_version_mismatches
       * doctor_cli::tests::browser_companion_doctor_checks_warn_when_runtime_gate_is_closed
FAIL cargo deny check advisories bans licenses sources
     - pre-existing repo baseline failure: deny rejects 0BSD for quoted_printable via lettre
```

## User-visible / Operator-visible Changes

- `memory.system = "workspace_recall"` is now a real selectable memory system.
- Memory system snapshots now advertise both `prompt_assembly` and `operator_inspection` recall modes where supported.
- Workspace recall entries carry structured provenance and are ranked ahead of recent history when that system is selected.
- `memory_search` and `memory_get` now return structured operator-inspection provenance for workspace durable-memory documents.

## Failure Recovery

- Fast rollback or disable path:
  - revert commits `45e6ec64a` and `cd2de803`
  - or switch back to `memory.system = "builtin"`
- Observable failure symptoms reviewers should watch for:
  - retrieved memory missing provenance
  - workspace recall entries appearing after history turns
  - daemon memory-system snapshots missing recall-mode metadata
  - memory tool outputs missing structured provenance

## Reviewer Focus

- Check that provenance and recall-mode fields stay additive and backward-compatible in memory payloads and tool outputs.
- Check that `memory_search` / `memory_get` now reflect the same typed memory contract as prompt hydration.
- Check that `workspace_recall` does not regress builtin prompt hydration semantics.
- Check that the rank-stage ordering logic stays narrow and does not overreach beyond retrieved-memory prioritization.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a "workspace recall" memory system for projecting workspace documents into context.
  - Introduced recall mode support (Prompt Assembly exposure) and provenance tracking on memory entries.
  - Memory projections now rank durable workspace recall entries before recent turns and suppress the built-in summary when applicable.
  - CLI/config output now displays supported recall modes and recall-related metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->