### PR TITLE
feat: productize continuity-aware CLI chat status and compaction surfaces

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-#[cfg(feature = "memory-sqlite")]
-use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex as StdMutex;
@@ -9,15 +7,10 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-#[cfg(feature = "memory-sqlite")]
-use loongclaw_contracts::Capability;
 use tokio::sync::Notify;
 
 use crate::CliResult;
-use crate::acp::{
-    AcpConversationTurnOptions, AcpTurnEventSink, JsonlAcpTurnEventSink,
-    resolve_acp_backend_selection,
-};
+use crate::acp::{AcpConversationTurnOptions, AcpTurnEventSink, JsonlAcpTurnEventSink};
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 mod cli_input;
@@ -27,9 +20,50 @@ mod latest_session_selector_tests;
 mod operator_surfaces;
 
 use self::cli_input::ConcurrentCliInputReader;
+#[cfg(test)]
+use self::operator_surfaces::CliChatStartupSummary;
+#[cfg(test)]
+use self::operator_surfaces::ManualCompactionResult;
+#[cfg(test)]
+use self::operator_surfaces::ManualCompactionStatus;
+#[cfg(test)]
+use self::operator_surfaces::build_cli_chat_startup_summary;
+use self::operator_surfaces::is_cli_chat_status_command;
+use self::operator_surfaces::is_manual_compaction_command;
+use self::operator_surfaces::is_turn_checkpoint_repair_command;
+#[cfg(test)]
+use self::operator_surfaces::load_history_lines;
+#[cfg(test)]
+use self::operator_surfaces::load_manual_compaction_result;
+#[cfg(test)]
+use self::operator_surfaces::manual_compaction_status_from_report;
+use self::operator_surfaces::parse_exact_chat_command;
+use self::operator_surfaces::parse_fast_lane_summary_limit;
+use self::operator_surfaces::parse_safe_lane_summary_limit;
+#[cfg(test)]
+use self::operator_surfaces::parse_summary_limit;
+use self::operator_surfaces::parse_turn_checkpoint_summary_limit;
+use self::operator_surfaces::print_cli_chat_startup;
+use self::operator_surfaces::print_cli_chat_status;
+use self::operator_surfaces::print_help;
+use self::operator_surfaces::print_history;
+use self::operator_surfaces::print_manual_compaction;
+#[cfg(test)]
+use self::operator_surfaces::render_cli_chat_help_lines_with_width;
+#[cfg(test)]
+use self::operator_surfaces::render_cli_chat_history_lines_with_width;
+use self::operator_surfaces::render_cli_chat_missing_config_decline_lines_with_width;
+use self::operator_surfaces::render_cli_chat_missing_config_lines_with_width;
+#[cfg(test)]
+use self::operator_surfaces::render_cli_chat_startup_lines_with_width;
+#[cfg(test)]
+use self::operator_surfaces::render_cli_chat_status_lines_with_width;
+#[cfg(test)]
+use self::operator_surfaces::render_manual_compaction_lines_with_width;
+use self::operator_surfaces::should_run_missing_config_onboard;
 
 use super::config::{self, ConversationConfig, LoongClawConfig};
-#[cfg(any(test, feature = "memory-sqlite"))]
+#[cfg(test)]
 use super::conversation::ContextCompactionReport;
 #[cfg(test)]
 use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
@@ -62,9 +96,9 @@ use super::session::LATEST_SESSION_SELECTOR;
 #[cfg(feature = "memory-sqlite")]
 use super::session::latest_resumable_root_session_id;
 use super::tui_surface::{
-    TuiActionSpec, TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec,
-    TuiHeaderStyle, TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec,
-    render_tui_message_spec, render_tui_screen_spec,
+    TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec, TuiHeaderStyle,
+    TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec, render_tui_message_spec,
+    render_tui_screen_spec,
 };
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
@@ -235,30 +269,6 @@ enum CliChatLoopControl {
     AssistantText(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CliChatStartupSummary {
-    config_path: String,
-    memory_label: String,
-    session_id: String,
-    context_engine_id: String,
-    context_engine_source: String,
-    compaction_enabled: bool,
-    compaction_min_messages: Option<usize>,
-    compaction_trigger_estimated_tokens: Option<usize>,
-    compaction_preserve_recent_turns: usize,
-    compaction_fail_open: bool,
-    acp_enabled: bool,
-    dispatch_enabled: bool,
-    conversation_routing: String,
-    allowed_channels: Vec<String>,
-    acp_backend_id: String,
-    acp_backend_source: String,
-    explicit_acp_request: bool,
-    event_stream_enabled: bool,
-    bootstrap_mcp_servers: Vec<String>,
-    working_directory: Option<String>,
-}
-
 type CliChatLiveSurfaceSink = Arc<dyn Fn(Vec<String>) + Send + Sync>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -312,31 +322,6 @@ struct CliChatLiveSurfaceObserver {
     render_width: usize,
     render_sink: CliChatLiveSurfaceSink,
     state: StdMutex<CliChatLiveSurfaceState>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ManualCompactionResult {
-    status: ManualCompactionStatus,
-    before_turns: usize,
-    after_turns: usize,
-    estimated_tokens_before: Option<usize>,
-    estimated_tokens_after: Option<usize>,
-    summary_headline: Option<String>,
-    detail: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ManualCompactionStatus {
-    Applied,
-    NoChange,
-    FailedOpen,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ManualCompactionWindowSnapshot {
-    turns: Vec<memory::WindowTurn>,
-    turn_count: Option<usize>,
 }
 
 #[allow(clippy::print_stdout)] // CLI REPL output
@@ -797,147 +782,6 @@ async fn process_cli_chat_input(
     ))
 }
 
-#[allow(clippy::print_stdout)] // CLI output
-fn print_cli_chat_startup(runtime: &CliTurnRuntime, options: &CliChatOptions) -> CliResult<()> {
-    let summary = build_cli_chat_startup_summary(runtime, options)?;
-    for line in render_cli_chat_startup_lines(&summary) {
-        println!("{line}");
-    }
-    Ok(())
-}
-
-#[allow(clippy::print_stdout)] // CLI output
-async fn print_cli_chat_status(
-    runtime: &CliTurnRuntime,
-    options: &CliChatOptions,
-) -> CliResult<()> {
-    operator_surfaces::print_cli_chat_status(runtime, options).await
-}
-
-fn build_cli_chat_startup_summary(
-    runtime: &CliTurnRuntime,
-    options: &CliChatOptions,
-) -> CliResult<CliChatStartupSummary> {
-    operator_surfaces::build_cli_chat_startup_summary(runtime, options)
-}
-
-fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
-    operator_surfaces::render_cli_chat_startup_lines(summary)
-}
-
-fn should_run_missing_config_onboard(read: usize, input: &str) -> bool {
-    if read == 0 {
-        return false;
-    }
-
-    let normalized_input = input.trim().to_ascii_lowercase();
-
-    if normalized_input.is_empty() {
-        return true;
-    }
-
-    matches!(normalized_input.as_str(), "y" | "yes")
-}
-
-fn render_cli_chat_missing_config_lines_with_width(
-    onboard_hint: &str,
-    width: usize,
-) -> Vec<String> {
-    let screen_spec = build_cli_chat_missing_config_screen_spec(onboard_hint);
-    render_tui_screen_spec(&screen_spec, width, false)
-}
-
-fn build_cli_chat_missing_config_screen_spec(onboard_hint: &str) -> TuiScreenSpec {
-    let intro_lines = vec![
-        format!("Welcome to {}!", config::PRODUCT_DISPLAY_NAME),
-        "No configuration found for interactive chat.".to_owned(),
-    ];
-    let sections = vec![TuiSectionSpec::ActionGroup {
-        title: Some("setup command".to_owned()),
-        inline_title_when_wide: true,
-        items: vec![TuiActionSpec {
-            label: "start setup".to_owned(),
-            command: onboard_hint.to_owned(),
-        }],
-    }];
-    let choices = vec![
-        TuiChoiceSpec {
-            key: "y".to_owned(),
-            label: "run setup wizard".to_owned(),
-            detail_lines: vec!["Create a config now and return to interactive chat.".to_owned()],
-            recommended: true,
-        },
-        TuiChoiceSpec {
-            key: "n".to_owned(),
-            label: "skip for now".to_owned(),
-            detail_lines: vec!["Exit chat now and keep the setup command for later.".to_owned()],
-            recommended: false,
-        },
-    ];
-    let footer_lines = vec!["Press Enter to accept y.".to_owned()];
-
-    TuiScreenSpec {
-        header_style: TuiHeaderStyle::Compact,
-        subtitle: Some("interactive chat".to_owned()),
-        title: Some("setup required".to_owned()),
-        progress_line: None,
-        intro_lines,
-        sections,
-        choices,
-        footer_lines,
-    }
-}
-
-fn render_cli_chat_missing_config_decline_lines_with_width(
-    onboard_hint: &str,
-    width: usize,
-) -> Vec<String> {
-    let message_spec = build_cli_chat_missing_config_decline_message_spec(onboard_hint);
-    render_tui_message_spec(&message_spec, width)
-}
-
-fn build_cli_chat_missing_config_decline_message_spec(onboard_hint: &str) -> TuiMessageSpec {
-    let setup_hint = format!("You can run '{onboard_hint}' later to get started.");
-    let sections = vec![
-        TuiSectionSpec::Callout {
-            tone: TuiCalloutTone::Info,
-            title: Some("setup skipped".to_owned()),
-            lines: vec![setup_hint],
-        },
-        TuiSectionSpec::ActionGroup {
-            title: Some("start later".to_owned()),
-            inline_title_when_wide: true,
-            items: vec![TuiActionSpec {
-                label: "setup command".to_owned(),
-                command: onboard_hint.to_owned(),
-            }],
-        },
-    ];
-
-    TuiMessageSpec {
-        role: "chat".to_owned(),
-        caption: Some("setup required".to_owned()),
-        sections,
-        footer_lines: Vec::new(),
-    }
-}
-
-#[cfg(test)]
-fn render_cli_chat_startup_lines_with_width(
-    summary: &CliChatStartupSummary,
-    width: usize,
-) -> Vec<String> {
-    operator_surfaces::render_cli_chat_startup_lines_with_width(summary, width)
-}
-
-#[cfg(test)]
-fn render_cli_chat_status_lines_with_width(
-    summary: &CliChatStartupSummary,
-    width: usize,
-) -> Vec<String> {
-    operator_surfaces::render_cli_chat_status_lines_with_width(summary, width)
-}
-
 fn detect_cli_chat_render_width() -> usize {
     crate::presentation::detect_render_width()
 }
@@ -947,50 +791,6 @@ fn print_rendered_cli_chat_lines(lines: &[String]) {
     for line in lines {
         println!("{line}");
     }
-}
-
-fn render_cli_chat_history_lines_with_width(
-    session_id: &str,
-    limit: usize,
-    history_lines: &[String],
-    width: usize,
-) -> Vec<String> {
-    let message_spec = build_cli_chat_history_message_spec(session_id, limit, history_lines);
-    render_tui_message_spec(&message_spec, width)
-}
-
-#[cfg(test)]
-fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
-    operator_surfaces::render_cli_chat_help_lines_with_width(width)
-}
-
-fn build_cli_chat_history_message_spec(
-    session_id: &str,
-    limit: usize,
-    history_lines: &[String],
-) -> TuiMessageSpec {
-    let caption = format!("session={session_id} limit={limit}");
-    let history_section = TuiSectionSpec::Narrative {
-        title: Some("sliding window".to_owned()),
-        lines: history_lines.to_vec(),
-    };
-
-    TuiMessageSpec {
-        role: "history".to_owned(),
-        caption: Some(caption),
-        sections: vec![history_section],
-        footer_lines: Vec::new(),
-    }
-}
-
-#[cfg(test)]
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn render_manual_compaction_lines_with_width(
-    session_id: &str,
-    result: &ManualCompactionResult,
-    width: usize,
-) -> Vec<String> {
-    operator_surfaces::render_manual_compaction_lines_with_width(session_id, result, width)
 }
 
 fn render_cli_chat_assistant_lines_with_width(assistant_text: &str, width: usize) -> Vec<String> {
@@ -2243,239 +2043,6 @@ fn is_exit_command(config: &LoongClawConfig, input: &str) -> bool {
         .iter()
         .map(|value| value.trim().to_ascii_lowercase())
         .any(|value| !value.is_empty() && value == lower)
-}
-
-#[allow(clippy::print_stdout)] // CLI output
-fn print_help() {
-    operator_surfaces::print_help();
-}
-
-#[allow(clippy::print_stdout)] // CLI output
-async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
-    operator_surfaces::print_manual_compaction(runtime).await
-}
-
-#[allow(clippy::print_stdout)] // CLI output
-async fn print_history(
-    session_id: &str,
-    limit: usize,
-    binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
-) -> CliResult<()> {
-    #[cfg(feature = "memory-sqlite")]
-    {
-        let history_lines = load_history_lines(session_id, limit, binding, memory_config).await?;
-        let render_width = detect_cli_chat_render_width();
-        let rendered_lines = render_cli_chat_history_lines_with_width(
-            session_id,
-            limit,
-            &history_lines,
-            render_width,
-        );
-        print_rendered_cli_chat_lines(&rendered_lines);
-        Ok(())
-    }
-
-    #[cfg(not(feature = "memory-sqlite"))]
-    {
-        let _ = (session_id, limit, binding);
-        let render_width = detect_cli_chat_render_width();
-        let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
-            "history",
-            "history unavailable: memory-sqlite feature disabled",
-            render_width,
-        );
-
-        print_rendered_cli_chat_lines(&rendered_lines);
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "memory-sqlite")]
-async fn load_manual_compaction_result(
-    config: &LoongClawConfig,
-    session_id: &str,
-    turn_coordinator: &ConversationTurnCoordinator,
-    binding: ConversationRuntimeBinding<'_>,
-    _memory_config: &MemoryRuntimeConfig,
-) -> CliResult<ManualCompactionResult> {
-    operator_surfaces::load_manual_compaction_result(
-        config,
-        session_id,
-        turn_coordinator,
-        binding,
-        _memory_config,
-    )
-    .await
-}
-
-#[cfg(test)]
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn manual_compaction_status_from_report(
-    report: &ContextCompactionReport,
-) -> CliResult<ManualCompactionStatus> {
-    operator_surfaces::manual_compaction_status_from_report(report)
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn format_window_history_lines(turns: &[memory::WindowTurn]) -> Vec<String> {
-    if turns.is_empty() {
-        return vec!["(no history yet)".to_owned()];
-    }
-
-    turns
-        .iter()
-        .map(|turn| {
-            format!(
-                "[{}] {}: {}",
-                turn.ts.unwrap_or_default(),
-                turn.role,
-                turn.content
-            )
-        })
-        .collect()
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn format_prompt_context_history_lines(entries: &[memory::MemoryContextEntry]) -> Vec<String> {
-    if entries.is_empty() {
-        return vec!["(no history yet)".to_owned()];
-    }
-
-    let mut lines = Vec::new();
-    for entry in entries {
-        match entry.kind {
-            memory::MemoryContextKind::Profile => {
-                lines.push("[profile]".to_owned());
-                lines.push(entry.content.clone());
-            }
-            memory::MemoryContextKind::Summary => {
-                lines.push("[summary]".to_owned());
-                lines.push(entry.content.clone());
-            }
-            memory::MemoryContextKind::RetrievedMemory => {
-                lines.push("[retrieved_memory]".to_owned());
-                lines.push(entry.content.clone());
-            }
-            memory::MemoryContextKind::Turn => {
-                lines.push(format!("{}: {}", entry.role, entry.content));
-            }
-        }
-    }
-    lines
-}
-
-#[cfg(feature = "memory-sqlite")]
-async fn load_history_lines(
-    session_id: &str,
-    limit: usize,
-    binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
-) -> CliResult<Vec<String>> {
-    if let Some(ctx) = binding.kernel_context() {
-        let request = memory::build_window_request(session_id, limit);
-        let caps = BTreeSet::from([Capability::MemoryRead]);
-        let outcome = ctx
-            .kernel
-            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-            .await
-            .map_err(|error| format!("load history via kernel failed: {error}"))?;
-        if outcome.status != "ok" {
-            return Err(format!(
-                "load history via kernel returned non-ok status: {}",
-                outcome.status
-            ));
-        }
-        let turns = memory::decode_window_turns(&outcome.payload);
-        return Ok(format_window_history_lines(&turns));
-    }
-
-    let entries = memory::load_prompt_context(session_id, memory_config)
-        .map_err(|error| format!("load history failed: {error}"))?;
-    Ok(format_prompt_context_history_lines(&entries))
-}
-
-fn parse_safe_lane_summary_limit(input: &str, default_window: usize) -> CliResult<Option<usize>> {
-    parse_summary_limit(
-        input,
-        default_window,
-        &["/safe_lane_summary", "/safe-lane-summary"],
-    )
-}
-
-fn parse_fast_lane_summary_limit(input: &str, default_window: usize) -> CliResult<Option<usize>> {
-    parse_summary_limit(
-        input,
-        default_window,
-        &["/fast_lane_summary", "/fast-lane-summary"],
-    )
-}
-
-fn parse_summary_limit(
-    input: &str,
-    default_window: usize,
-    aliases: &[&str],
-) -> CliResult<Option<usize>> {
-    let Some(primary_alias) = aliases.first().copied() else {
-        return Ok(None);
-    };
-
-    let mut tokens = input.split_whitespace();
-    let Some(command) = tokens.next() else {
-        return Ok(None);
-    };
-    if !aliases.contains(&command) {
-        return Ok(None);
-    }
-
-    let usage = format!("usage: {primary_alias} [limit]");
-    let default_limit = default_window.saturating_mul(4).max(64);
-    let limit = match tokens.next() {
-        Some(raw) => raw
-            .parse::<usize>()
-            .map_err(|error| format!("invalid {primary_alias} limit `{raw}`: {error}; {usage}"))?,
-        None => default_limit,
-    };
-    if limit == 0 {
-        return Err(format!("invalid {primary_alias} limit `0`; {usage}"));
-    }
-    if tokens.next().is_some() {
-        return Err(usage);
-    }
-    Ok(Some(limit))
-}
-
-fn parse_turn_checkpoint_summary_limit(
-    input: &str,
-    default_window: usize,
-) -> CliResult<Option<usize>> {
-    parse_summary_limit(
-        input,
-        default_window,
-        &["/turn_checkpoint_summary", "/turn-checkpoint-summary"],
-    )
-}
-
-fn parse_exact_chat_command(input: &str, aliases: &[&str], usage: &str) -> CliResult<bool> {
-    operator_surfaces::parse_exact_chat_command(input, aliases, usage)
-}
-
-fn is_manual_compaction_command(input: &str) -> CliResult<bool> {
-    operator_surfaces::is_manual_compaction_command(input)
-}
-
-fn is_cli_chat_status_command(input: &str) -> CliResult<bool> {
-    operator_surfaces::is_cli_chat_status_command(input)
-}
-
-fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
-    let aliases = [
-        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND,
-        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS,
-    ];
-    let usage = "usage: /turn_checkpoint_repair";
-    parse_exact_chat_command(input, &aliases, usage)
 }
 
 #[allow(clippy::print_stdout)] // CLI output

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -11,7 +11,6 @@ use std::sync::{
 
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
-use serde_json::json;
 use tokio::sync::Notify;
 
 use crate::CliResult;
@@ -25,6 +24,7 @@ mod cli_input;
 #[cfg(all(test, feature = "memory-sqlite"))]
 #[allow(clippy::expect_used)]
 mod latest_session_selector_tests;
+mod operator_surfaces;
 
 use self::cli_input::ConcurrentCliInputReader;
 
@@ -37,8 +37,7 @@ use super::conversation::{
     ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
     ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,
-    ExecutionLane, ProviderErrorMode, collect_context_engine_runtime_snapshot,
-    parse_approval_prompt_view, resolve_context_engine_selection,
+    ExecutionLane, ProviderErrorMode, parse_approval_prompt_view,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -58,7 +57,6 @@ use super::conversation::{load_fast_lane_tool_batch_event_summary, load_safe_lan
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
-use super::runtime_self_continuity;
 #[cfg(feature = "memory-sqlite")]
 use super::session::LATEST_SESSION_SELECTOR;
 #[cfg(feature = "memory-sqlite")]
@@ -619,38 +617,7 @@ fn resolve_cli_runtime_session_id(
 
 #[allow(clippy::print_stdout)] // CLI output
 async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
-    #[cfg(feature = "memory-sqlite")]
-    let render_width = detect_cli_chat_render_width();
-
-    #[cfg(feature = "memory-sqlite")]
-    match runtime
-        .turn_coordinator
-        .load_turn_checkpoint_diagnostics(
-            &runtime.config,
-            &runtime.session_id,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await
-    {
-        Ok(diagnostics) => {
-            if let Some(rendered_lines) = render_turn_checkpoint_startup_health_lines_with_width(
-                &runtime.session_id,
-                &diagnostics,
-                render_width,
-            ) {
-                print_rendered_cli_chat_lines(&rendered_lines);
-            }
-        }
-        Err(error) => {
-            let rendered_lines = render_turn_checkpoint_health_error_lines_with_width(
-                &runtime.session_id,
-                &error,
-                render_width,
-            );
-
-            print_rendered_cli_chat_lines(&rendered_lines);
-        }
-    }
+    operator_surfaces::print_turn_checkpoint_startup_health(runtime).await;
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -720,7 +687,7 @@ async fn process_cli_chat_input(
     if is_exit_command(&runtime.config, input) {
         return Ok(CliChatLoopControl::Exit);
     }
-    if input == CLI_CHAT_HELP_COMMAND {
+    if parse_exact_chat_command(input, &[CLI_CHAT_HELP_COMMAND], "usage: /help")? {
         print_help();
         return Ok(CliChatLoopControl::Continue);
     }
@@ -732,7 +699,7 @@ async fn process_cli_chat_input(
         print_manual_compaction(runtime).await?;
         return Ok(CliChatLoopControl::Continue);
     }
-    if input == CLI_CHAT_HISTORY_COMMAND {
+    if parse_exact_chat_command(input, &[CLI_CHAT_HISTORY_COMMAND], "usage: /history")? {
         #[cfg(feature = "memory-sqlite")]
         print_history(
             &runtime.session_id,
@@ -844,61 +811,18 @@ async fn print_cli_chat_status(
     runtime: &CliTurnRuntime,
     options: &CliChatOptions,
 ) -> CliResult<()> {
-    let render_width = detect_cli_chat_render_width();
-    let summary = build_cli_chat_startup_summary(runtime, options)?;
-    let rendered_lines = render_cli_chat_status_lines_with_width(&summary, render_width);
-    print_rendered_cli_chat_lines(&rendered_lines);
-    print_turn_checkpoint_startup_health(runtime).await;
-    Ok(())
+    operator_surfaces::print_cli_chat_status(runtime, options).await
 }
 
 fn build_cli_chat_startup_summary(
     runtime: &CliTurnRuntime,
     options: &CliChatOptions,
 ) -> CliResult<CliChatStartupSummary> {
-    let context_engine_selection = resolve_context_engine_selection(&runtime.config);
-    let context_engine_runtime = collect_context_engine_runtime_snapshot(&runtime.config)?;
-    let compaction = context_engine_runtime.compaction;
-    let acp_selection = resolve_acp_backend_selection(&runtime.config);
-    Ok(CliChatStartupSummary {
-        config_path: runtime.resolved_path.display().to_string(),
-        memory_label: runtime.memory_label.clone(),
-        session_id: runtime.session_id.clone(),
-        context_engine_id: context_engine_selection.id.to_owned(),
-        context_engine_source: context_engine_selection.source.as_str().to_owned(),
-        compaction_enabled: compaction.enabled,
-        compaction_min_messages: compaction.min_messages,
-        compaction_trigger_estimated_tokens: compaction.trigger_estimated_tokens,
-        compaction_preserve_recent_turns: runtime
-            .config
-            .conversation
-            .compact_preserve_recent_turns(),
-        compaction_fail_open: compaction.fail_open,
-        acp_enabled: runtime.config.acp.enabled,
-        dispatch_enabled: runtime.config.acp.dispatch_enabled(),
-        conversation_routing: runtime
-            .config
-            .acp
-            .dispatch
-            .conversation_routing
-            .as_str()
-            .to_owned(),
-        allowed_channels: runtime.config.acp.dispatch.allowed_channel_ids()?,
-        acp_backend_id: acp_selection.id.to_owned(),
-        acp_backend_source: acp_selection.source.as_str().to_owned(),
-        explicit_acp_request: runtime.explicit_acp_request,
-        event_stream_enabled: options.acp_event_stream,
-        bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
-        working_directory: runtime
-            .effective_working_directory
-            .as_ref()
-            .map(|path| path.display().to_string()),
-    })
+    operator_surfaces::build_cli_chat_startup_summary(runtime, options)
 }
 
 fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
-    let render_width = detect_cli_chat_render_width();
-    render_cli_chat_startup_lines_with_width(summary, render_width)
+    operator_surfaces::render_cli_chat_startup_lines(summary)
 }
 
 fn should_run_missing_config_onboard(read: usize, input: &str) -> bool {
@@ -998,20 +922,20 @@ fn build_cli_chat_missing_config_decline_message_spec(onboard_hint: &str) -> Tui
     }
 }
 
+#[cfg(test)]
 fn render_cli_chat_startup_lines_with_width(
     summary: &CliChatStartupSummary,
     width: usize,
 ) -> Vec<String> {
-    let screen_spec = build_cli_chat_startup_screen_spec(summary);
-    render_tui_screen_spec(&screen_spec, width, false)
+    operator_surfaces::render_cli_chat_startup_lines_with_width(summary, width)
 }
 
+#[cfg(test)]
 fn render_cli_chat_status_lines_with_width(
     summary: &CliChatStartupSummary,
     width: usize,
 ) -> Vec<String> {
-    let message_spec = build_cli_chat_status_message_spec(summary);
-    render_tui_message_spec(&message_spec, width)
+    operator_surfaces::render_cli_chat_status_lines_with_width(summary, width)
 }
 
 fn detect_cli_chat_render_width() -> usize {
@@ -1025,237 +949,6 @@ fn print_rendered_cli_chat_lines(lines: &[String]) {
     }
 }
 
-fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScreenSpec {
-    let mut sections = vec![
-        TuiSectionSpec::ActionGroup {
-            title: Some("start here".to_owned()),
-            inline_title_when_wide: true,
-            items: vec![TuiActionSpec {
-                label: "first prompt".to_owned(),
-                command: DEFAULT_FIRST_PROMPT.to_owned(),
-            }],
-        },
-        TuiSectionSpec::Narrative {
-            title: None,
-            lines: vec!["- type your request, or use /help for commands".to_owned()],
-        },
-    ];
-    let runtime_sections = build_cli_chat_runtime_sections(summary);
-    sections.extend(runtime_sections);
-
-    TuiScreenSpec {
-        header_style: TuiHeaderStyle::Compact,
-        subtitle: Some("interactive chat".to_owned()),
-        title: Some("chat ready".to_owned()),
-        progress_line: None,
-        intro_lines: Vec::new(),
-        sections,
-        choices: Vec::new(),
-        footer_lines: Vec::new(),
-    }
-}
-
-fn build_cli_chat_status_message_spec(summary: &CliChatStartupSummary) -> TuiMessageSpec {
-    let caption = format!("session={}", summary.session_id);
-    let mut sections = build_cli_chat_runtime_sections(summary);
-    let operator_callout = TuiSectionSpec::Callout {
-        tone: TuiCalloutTone::Info,
-        title: Some("operator controls".to_owned()),
-        lines: vec![format!(
-            "Use {CLI_CHAT_COMPACT_COMMAND} to checkpoint the active session window on demand."
-        )],
-    };
-    sections.push(operator_callout);
-
-    TuiMessageSpec {
-        role: "status".to_owned(),
-        caption: Some(caption),
-        sections,
-        footer_lines: Vec::new(),
-    }
-}
-
-fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSectionSpec> {
-    let allowed_channels = if summary.allowed_channels.is_empty() {
-        "-".to_owned()
-    } else {
-        summary.allowed_channels.join(",")
-    };
-    let compaction_min_messages = summary
-        .compaction_min_messages
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "-".to_owned());
-    let compaction_trigger_estimated_tokens = summary
-        .compaction_trigger_estimated_tokens
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "-".to_owned());
-    let runtime_line = format!(
-        "ACP enabled={} dispatch_enabled={} routing={} backend={} ({}) allowed_channels={allowed_channels}",
-        summary.acp_enabled,
-        summary.dispatch_enabled,
-        summary.conversation_routing,
-        summary.acp_backend_id,
-        summary.acp_backend_source,
-    );
-    let session_items = vec![
-        TuiKeyValueSpec::Plain {
-            key: "session".to_owned(),
-            value: summary.session_id.clone(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "config".to_owned(),
-            value: summary.config_path.clone(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "memory".to_owned(),
-            value: summary.memory_label.clone(),
-        },
-    ];
-    let context_engine_value = format!(
-        "{} ({})",
-        summary.context_engine_id, summary.context_engine_source
-    );
-    let runtime_items = vec![
-        TuiKeyValueSpec::Plain {
-            key: "context engine".to_owned(),
-            value: context_engine_value,
-        },
-        TuiKeyValueSpec::Plain {
-            key: "acp".to_owned(),
-            value: runtime_line,
-        },
-    ];
-    let session_section = TuiSectionSpec::KeyValues {
-        title: Some("session details".to_owned()),
-        items: session_items,
-    };
-    let runtime_section = TuiSectionSpec::KeyValues {
-        title: Some("runtime details".to_owned()),
-        items: runtime_items,
-    };
-    let continuity_section = TuiSectionSpec::KeyValues {
-        title: Some("continuity maintenance".to_owned()),
-        items: vec![
-            TuiKeyValueSpec::Plain {
-                key: "compaction".to_owned(),
-                value: summary.compaction_enabled.to_string(),
-            },
-            TuiKeyValueSpec::Plain {
-                key: "min messages".to_owned(),
-                value: compaction_min_messages,
-            },
-            TuiKeyValueSpec::Plain {
-                key: "trigger tokens".to_owned(),
-                value: compaction_trigger_estimated_tokens,
-            },
-            TuiKeyValueSpec::Plain {
-                key: "preserve recent".to_owned(),
-                value: summary.compaction_preserve_recent_turns.to_string(),
-            },
-            TuiKeyValueSpec::Plain {
-                key: "fail open".to_owned(),
-                value: summary.compaction_fail_open.to_string(),
-            },
-        ],
-    };
-    let mut sections = vec![session_section, runtime_section, continuity_section];
-
-    if summary.explicit_acp_request
-        || summary.event_stream_enabled
-        || !summary.bootstrap_mcp_servers.is_empty()
-        || summary.working_directory.is_some()
-    {
-        let bootstrap_label = if summary.bootstrap_mcp_servers.is_empty() {
-            "-".to_owned()
-        } else {
-            summary.bootstrap_mcp_servers.join(",")
-        };
-        let cwd_label = summary.working_directory.as_deref().unwrap_or("-");
-        let override_lines = vec![
-            format!("explicit request: {}", summary.explicit_acp_request),
-            format!("event stream: {}", summary.event_stream_enabled),
-            format!("bootstrap MCP servers: {bootstrap_label}"),
-            format!("working directory: {cwd_label}"),
-        ];
-        sections.push(TuiSectionSpec::Callout {
-            tone: TuiCalloutTone::Info,
-            title: Some("acp overrides".to_owned()),
-            lines: override_lines,
-        });
-    }
-
-    sections
-}
-
-fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
-    let message_spec = build_cli_chat_help_message_spec();
-    render_tui_message_spec(&message_spec, width)
-}
-
-fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
-    let command_items = vec![
-        TuiKeyValueSpec::Plain {
-            key: CLI_CHAT_HELP_COMMAND.to_owned(),
-            value: "show chat commands".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: CLI_CHAT_COMPACT_COMMAND.to_owned(),
-            value: "write a continuity-safe checkpoint into the active window".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: CLI_CHAT_STATUS_COMMAND.to_owned(),
-            value: "show session, runtime, compaction, and durability status".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: CLI_CHAT_HISTORY_COMMAND.to_owned(),
-            value: "print the current session sliding window".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "/fast_lane_summary [limit]".to_owned(),
-            value: "summarize fast-lane batch execution events".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "/safe_lane_summary [limit]".to_owned(),
-            value: "summarize safe-lane runtime events".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "/turn_checkpoint_summary [limit]".to_owned(),
-            value: "summarize durable turn finalization state".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND.to_owned(),
-            value: "repair durable turn finalization tail when safe".to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "/exit".to_owned(),
-            value: "quit chat".to_owned(),
-        },
-    ];
-    let note_lines = vec![
-        "Type any non-command text to send a normal assistant turn.".to_owned(),
-        "Use /status to inspect runtime maintenance settings without sending a turn.".to_owned(),
-        "Use /history to inspect the active memory window when a reply feels off.".to_owned(),
-        "Use /compact to checkpoint the active session before the next turn.".to_owned(),
-    ];
-
-    TuiMessageSpec {
-        role: "chat".to_owned(),
-        caption: Some("commands".to_owned()),
-        sections: vec![
-            TuiSectionSpec::KeyValues {
-                title: Some("slash commands".to_owned()),
-                items: command_items,
-            },
-            TuiSectionSpec::Callout {
-                tone: TuiCalloutTone::Info,
-                title: Some("usage notes".to_owned()),
-                lines: note_lines,
-            },
-        ],
-        footer_lines: Vec::new(),
-    }
-}
-
 fn render_cli_chat_history_lines_with_width(
     session_id: &str,
     limit: usize,
@@ -1264,6 +957,11 @@ fn render_cli_chat_history_lines_with_width(
 ) -> Vec<String> {
     let message_spec = build_cli_chat_history_message_spec(session_id, limit, history_lines);
     render_tui_message_spec(&message_spec, width)
+}
+
+#[cfg(test)]
+fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
+    operator_surfaces::render_cli_chat_help_lines_with_width(width)
 }
 
 fn build_cli_chat_history_message_spec(
@@ -1285,83 +983,14 @@ fn build_cli_chat_history_message_spec(
     }
 }
 
+#[cfg(test)]
 #[cfg(any(test, feature = "memory-sqlite"))]
 fn render_manual_compaction_lines_with_width(
     session_id: &str,
     result: &ManualCompactionResult,
     width: usize,
 ) -> Vec<String> {
-    let message_spec = build_manual_compaction_message_spec(session_id, result);
-    render_tui_message_spec(&message_spec, width)
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn build_manual_compaction_message_spec(
-    session_id: &str,
-    result: &ManualCompactionResult,
-) -> TuiMessageSpec {
-    let caption = format!("session={session_id}");
-    let status = format_manual_compaction_status(result.status).to_owned();
-    let estimated_tokens_before = format_manual_compaction_tokens(result.estimated_tokens_before);
-    let estimated_tokens_after = format_manual_compaction_tokens(result.estimated_tokens_after);
-    let tone = manual_compaction_tone(result.status);
-
-    let result_section = TuiSectionSpec::KeyValues {
-        title: Some("compaction result".to_owned()),
-        items: vec![
-            tui_plain_item("status", status),
-            tui_plain_item("before turns", result.before_turns.to_string()),
-            tui_plain_item("after turns", result.after_turns.to_string()),
-            tui_plain_item("tokens before", estimated_tokens_before),
-            tui_plain_item("tokens after", estimated_tokens_after),
-            tui_plain_item(
-                "summary",
-                result
-                    .summary_headline
-                    .clone()
-                    .unwrap_or_else(|| "-".to_owned()),
-            ),
-        ],
-    };
-
-    let detail_section = TuiSectionSpec::Callout {
-        tone,
-        title: Some("details".to_owned()),
-        lines: vec![result.detail.clone()],
-    };
-
-    TuiMessageSpec {
-        role: "compact".to_owned(),
-        caption: Some(caption),
-        sections: vec![result_section, detail_section],
-        footer_lines: Vec::new(),
-    }
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn format_manual_compaction_status(status: ManualCompactionStatus) -> &'static str {
-    match status {
-        ManualCompactionStatus::Applied => "applied",
-        ManualCompactionStatus::NoChange => "no_change",
-        ManualCompactionStatus::FailedOpen => "failed_open",
-    }
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn format_manual_compaction_tokens(value: Option<usize>) -> String {
-    let Some(value) = value else {
-        return "-".to_owned();
-    };
-    value.to_string()
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn manual_compaction_tone(status: ManualCompactionStatus) -> TuiCalloutTone {
-    match status {
-        ManualCompactionStatus::Applied => TuiCalloutTone::Success,
-        ManualCompactionStatus::NoChange => TuiCalloutTone::Info,
-        ManualCompactionStatus::FailedOpen => TuiCalloutTone::Warning,
-    }
+    operator_surfaces::render_manual_compaction_lines_with_width(session_id, result, width)
 }
 
 fn render_cli_chat_assistant_lines_with_width(assistant_text: &str, width: usize) -> Vec<String> {
@@ -2618,43 +2247,12 @@ fn is_exit_command(config: &LoongClawConfig, input: &str) -> bool {
 
 #[allow(clippy::print_stdout)] // CLI output
 fn print_help() {
-    let render_width = detect_cli_chat_render_width();
-    let rendered_lines = render_cli_chat_help_lines_with_width(render_width);
-    print_rendered_cli_chat_lines(&rendered_lines);
+    operator_surfaces::print_help();
 }
 
 #[allow(clippy::print_stdout)] // CLI output
 async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
-    #[cfg(feature = "memory-sqlite")]
-    {
-        let binding = ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
-        let result = load_manual_compaction_result(
-            &runtime.config,
-            &runtime.session_id,
-            &runtime.turn_coordinator,
-            binding,
-            &runtime.memory_config,
-        )
-        .await?;
-        let render_width = detect_cli_chat_render_width();
-        let rendered_lines =
-            render_manual_compaction_lines_with_width(&runtime.session_id, &result, render_width);
-        print_rendered_cli_chat_lines(&rendered_lines);
-        Ok(())
-    }
-
-    #[cfg(not(feature = "memory-sqlite"))]
-    {
-        let _ = runtime;
-        let render_width = detect_cli_chat_render_width();
-        let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
-            "compact",
-            "manual compaction unavailable: memory-sqlite feature disabled",
-            render_width,
-        );
-        print_rendered_cli_chat_lines(&rendered_lines);
-        Ok(())
-    }
+    operator_surfaces::print_manual_compaction(runtime).await
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -2693,6 +2291,7 @@ async fn print_history(
     }
 }
 
+#[cfg(test)]
 #[cfg(feature = "memory-sqlite")]
 async fn load_manual_compaction_result(
     config: &LoongClawConfig,
@@ -2701,137 +2300,22 @@ async fn load_manual_compaction_result(
     binding: ConversationRuntimeBinding<'_>,
     _memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<ManualCompactionResult> {
-    let before_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
-    let before_turns = resolve_manual_compaction_turn_count(&before_snapshot);
-    let report = turn_coordinator
-        .compact_session(config, session_id, binding)
-        .await?;
-    let after_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
-    let after_turns = resolve_manual_compaction_turn_count(&after_snapshot);
-    let summary_headline = extract_manual_compaction_summary_headline(&after_snapshot);
-    let status = manual_compaction_status_from_report(&report)?;
-    let detail = build_manual_compaction_detail(status, &summary_headline);
-
-    Ok(ManualCompactionResult {
-        status,
-        before_turns,
-        after_turns,
-        estimated_tokens_before: report.estimated_tokens_before,
-        estimated_tokens_after: report.estimated_tokens_after,
-        summary_headline,
-        detail,
-    })
+    operator_surfaces::load_manual_compaction_result(
+        config,
+        session_id,
+        turn_coordinator,
+        binding,
+        _memory_config,
+    )
+    .await
 }
 
-#[cfg(feature = "memory-sqlite")]
-async fn load_manual_compaction_window_snapshot(
-    session_id: &str,
-    binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<ManualCompactionWindowSnapshot> {
-    const MAX_MANUAL_COMPACTION_WINDOW_TURNS: usize = 512;
-
-    let kernel_ctx = binding
-        .kernel_context()
-        .ok_or_else(|| "manual compaction requires a kernel-bound session".to_owned())?;
-    let caps = BTreeSet::from([Capability::MemoryRead]);
-    let request = loongclaw_contracts::MemoryCoreRequest {
-        operation: memory::MEMORY_OP_WINDOW.to_owned(),
-        payload: json!({
-            "session_id": session_id,
-            "limit": MAX_MANUAL_COMPACTION_WINDOW_TURNS,
-            "allow_extended_limit": true,
-        }),
-    };
-    let outcome = kernel_ctx
-        .kernel
-        .execute_memory_core(
-            kernel_ctx.pack_id(),
-            &kernel_ctx.token,
-            &caps,
-            None,
-            request,
-        )
-        .await
-        .map_err(|error| format!("load compaction window via kernel failed: {error}"))?;
-
-    if outcome.status != "ok" {
-        let status = outcome.status;
-        let message = format!("load compaction window via kernel returned non-ok status: {status}");
-        return Err(message);
-    }
-
-    let turns = memory::decode_window_turns(&outcome.payload);
-    let turn_count = memory::decode_window_turn_count(&outcome.payload);
-
-    Ok(ManualCompactionWindowSnapshot { turns, turn_count })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn resolve_manual_compaction_turn_count(snapshot: &ManualCompactionWindowSnapshot) -> usize {
-    snapshot.turn_count.unwrap_or(snapshot.turns.len())
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn extract_manual_compaction_summary_headline(
-    snapshot: &ManualCompactionWindowSnapshot,
-) -> Option<String> {
-    let first_turn = snapshot.turns.first()?;
-    let content = first_turn.content.trim();
-    if !content.starts_with("Compacted ") {
-        return None;
-    }
-
-    let headline = content.lines().next()?.trim();
-    Some(headline.to_owned())
-}
-
+#[cfg(test)]
 #[cfg(any(test, feature = "memory-sqlite"))]
 fn manual_compaction_status_from_report(
     report: &ContextCompactionReport,
 ) -> CliResult<ManualCompactionStatus> {
-    if report.was_applied() {
-        return Ok(ManualCompactionStatus::Applied);
-    }
-
-    if report.was_skipped() {
-        return Ok(ManualCompactionStatus::NoChange);
-    }
-
-    if report.was_failed_open() {
-        return Ok(ManualCompactionStatus::FailedOpen);
-    }
-
-    let status_label = report.status_label();
-    let message = format!("manual compaction returned unexpected status: {status_label}");
-    Err(message)
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn build_manual_compaction_detail(
-    status: ManualCompactionStatus,
-    summary_headline: &Option<String>,
-) -> String {
-    let continuity_note = runtime_self_continuity::compaction_summary_scope_note();
-    match status {
-        ManualCompactionStatus::Applied => match summary_headline {
-            Some(headline) => {
-                format!("{headline}. {continuity_note}")
-            }
-            None => {
-                format!(
-                    "Compaction completed and the active session window was rewritten. {continuity_note}"
-                )
-            }
-        },
-        ManualCompactionStatus::NoChange => {
-            "No compaction change applied. The active session was already summarized or already compact enough."
-                .to_owned()
-        }
-        ManualCompactionStatus::FailedOpen => {
-            "Compaction failed open and left the current history unchanged. Inspect /status and /history before continuing."
-                .to_owned()
-        }
-    }
+    operator_surfaces::manual_compaction_status_from_report(report)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -2974,36 +2458,15 @@ fn parse_turn_checkpoint_summary_limit(
 }
 
 fn parse_exact_chat_command(input: &str, aliases: &[&str], usage: &str) -> CliResult<bool> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        return Ok(false);
-    }
-
-    let mut tokens = trimmed.split_whitespace();
-    let Some(command) = tokens.next() else {
-        return Ok(false);
-    };
-    if !aliases.contains(&command) {
-        return Ok(false);
-    }
-
-    if tokens.next().is_some() {
-        return Err(usage.to_owned());
-    }
-
-    Ok(true)
+    operator_surfaces::parse_exact_chat_command(input, aliases, usage)
 }
 
 fn is_manual_compaction_command(input: &str) -> CliResult<bool> {
-    let aliases = [CLI_CHAT_COMPACT_COMMAND];
-    let usage = "usage: /compact";
-    parse_exact_chat_command(input, &aliases, usage)
+    operator_surfaces::is_manual_compaction_command(input)
 }
 
 fn is_cli_chat_status_command(input: &str) -> CliResult<bool> {
-    let aliases = [CLI_CHAT_STATUS_COMMAND];
-    let usage = "usage: /status";
-    parse_exact_chat_command(input, &aliases, usage)
+    operator_surfaces::is_cli_chat_status_command(input)
 }
 
 fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
@@ -3286,115 +2749,18 @@ fn build_turn_checkpoint_health_error_message_spec(
     }
 }
 
+#[cfg(test)]
 #[cfg(any(test, feature = "memory-sqlite"))]
 fn render_turn_checkpoint_startup_health_lines_with_width(
     session_id: &str,
     diagnostics: &TurnCheckpointDiagnostics,
     width: usize,
 ) -> Option<Vec<String>> {
-    let message_spec = build_turn_checkpoint_startup_health_message_spec(session_id, diagnostics)?;
-    let rendered_lines = render_tui_message_spec(&message_spec, width);
-
-    Some(rendered_lines)
-}
-
-#[cfg(any(test, feature = "memory-sqlite"))]
-fn build_turn_checkpoint_startup_health_message_spec(
-    session_id: &str,
-    diagnostics: &TurnCheckpointDiagnostics,
-) -> Option<TuiMessageSpec> {
-    let summary = diagnostics.summary();
-    if !summary.checkpoint_durable {
-        return None;
-    }
-
-    let render_labels = TurnCheckpointSummaryRenderLabels::from_summary(summary);
-    let durability_labels = TurnCheckpointDurabilityRenderLabels::from_summary(summary);
-    let recovery_labels =
-        TurnCheckpointRecoveryRenderLabels::from_assessment(diagnostics.recovery());
-    let failure_step = format_turn_checkpoint_failure_step(summary.latest_failure_step);
-    let recovery_needed = bool_yes_no_value(summary.requires_recovery);
-    let reply_durable = bool_yes_no_value(summary.reply_durable);
-    let checkpoint_durable = bool_yes_no_value(summary.checkpoint_durable);
-    let recovery_tone = recovery_callout_tone(summary.requires_recovery);
-    let caption = format!("session={session_id}");
-    let recovery_reason = recovery_labels.reason.to_owned();
-
-    let mut sections = vec![
-        TuiSectionSpec::KeyValues {
-            title: Some("durability status".to_owned()),
-            items: vec![
-                tui_plain_item("state", render_labels.session_state.to_owned()),
-                tui_plain_item("durability", durability_labels.durability.to_owned()),
-                tui_plain_item("reply durable", reply_durable),
-                tui_plain_item("checkpoint durable", checkpoint_durable),
-            ],
-        },
-        TuiSectionSpec::Callout {
-            tone: recovery_tone,
-            title: Some("recovery".to_owned()),
-            lines: vec![
-                format!("recovery needed: {recovery_needed}"),
-                format!("action: {}", recovery_labels.action),
-                format!("source: {}", recovery_labels.source),
-                format!("reason: {recovery_reason}"),
-            ],
-        },
-        TuiSectionSpec::KeyValues {
-            title: Some("latest turn".to_owned()),
-            items: vec![
-                tui_plain_item("stage", render_labels.stage.to_owned()),
-                tui_plain_item("after turn", render_labels.after_turn.to_owned()),
-                tui_plain_item("compaction", render_labels.compaction.to_owned()),
-                tui_plain_item("lane", render_labels.lane.to_owned()),
-                tui_plain_item("result kind", render_labels.result_kind.to_owned()),
-                tui_plain_item(
-                    "persistence mode",
-                    render_labels.persistence_mode.to_owned(),
-                ),
-                tui_plain_item("identity", render_labels.identity.to_owned()),
-                tui_plain_item("failure step", failure_step.to_owned()),
-            ],
-        },
-    ];
-
-    if render_labels.safe_lane_route_decision != "-"
-        || render_labels.safe_lane_route_reason != "-"
-        || render_labels.safe_lane_route_source != "-"
-    {
-        sections.push(TuiSectionSpec::KeyValues {
-            title: Some("safe-lane route".to_owned()),
-            items: vec![
-                tui_plain_item(
-                    "decision",
-                    render_labels.safe_lane_route_decision.to_owned(),
-                ),
-                tui_plain_item("reason", render_labels.safe_lane_route_reason.to_owned()),
-                tui_plain_item("source", render_labels.safe_lane_route_source.to_owned()),
-            ],
-        });
-    }
-
-    if let Some(probe) = diagnostics.runtime_probe() {
-        let probe_lines = vec![
-            format!("action: {}", probe.action().as_str()),
-            format!("source: {}", probe.source().as_str()),
-            format!("reason: {}", probe.reason().as_str()),
-        ];
-
-        sections.push(TuiSectionSpec::Callout {
-            tone: TuiCalloutTone::Info,
-            title: Some("runtime probe".to_owned()),
-            lines: probe_lines,
-        });
-    }
-
-    Some(TuiMessageSpec {
-        role: "checkpoint".to_owned(),
-        caption: Some(caption),
-        sections,
-        footer_lines: Vec::new(),
-    })
+    operator_surfaces::render_turn_checkpoint_startup_health_lines_with_width(
+        session_id,
+        diagnostics,
+        width,
+    )
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -4930,6 +4296,7 @@ fn format_average(sum: u64, samples: u32) -> String {
 mod tests {
     use super::*;
     use crate::conversation::ConversationRuntimeBinding;
+    use serde_json::json;
     use std::ffi::OsStr;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -4949,7 +4316,7 @@ mod tests {
         MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
     };
     #[cfg(feature = "memory-sqlite")]
-    use serde_json::{Value, json};
+    use serde_json::Value;
 
     #[cfg(feature = "memory-sqlite")]
     fn test_config() -> LoongClawConfig {
@@ -6138,6 +5505,56 @@ mod tests {
     }
 
     #[test]
+    fn render_turn_checkpoint_startup_health_lines_skip_non_durable_sessions() {
+        let summary = TurnCheckpointEventSummary {
+            session_state: TurnCheckpointSessionState::NotDurable,
+            checkpoint_durable: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+
+        let lines = render_turn_checkpoint_startup_health_lines_with_width(
+            "session-health",
+            &diagnostics,
+            80,
+        );
+
+        assert!(
+            lines.is_none(),
+            "startup health should stay quiet until a durable checkpoint exists"
+        );
+    }
+
+    #[test]
+    fn render_turn_checkpoint_status_health_lines_surface_non_durable_sessions() {
+        let summary = TurnCheckpointEventSummary {
+            session_state: TurnCheckpointSessionState::NotDurable,
+            checkpoint_durable: false,
+            reply_durable: false,
+            ..TurnCheckpointEventSummary::default()
+        };
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+        let lines = operator_surfaces::render_turn_checkpoint_status_health_lines_with_width(
+            "session-health",
+            &diagnostics,
+            80,
+        );
+
+        assert_eq!(lines[0], "checkpoint: session=session-health");
+        assert!(
+            lines.iter().any(|line| line.contains("state: not_durable")),
+            "status health should surface non-durable sessions explicitly: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("checkpoint durable: no")),
+            "status health should surface checkpoint durability explicitly: {lines:#?}"
+        );
+    }
+
+    #[test]
     fn render_fast_lane_summary_lines_surface_aggregates_and_segments() {
         let mut summary = FastLaneToolBatchEventSummary {
             batch_events: 2,
@@ -7109,6 +6526,22 @@ allowed_decisions: yes / auto / full / esc";
         let error = is_manual_compaction_command("/compact now")
             .expect_err("extra args should be rejected");
         assert_eq!(error, "usage: /compact");
+    }
+
+    #[test]
+    fn help_and_history_commands_reject_extra_args() {
+        let help_error =
+            parse_exact_chat_command("/help now", &[CLI_CHAT_HELP_COMMAND], "usage: /help")
+                .expect_err("help should reject extra args");
+        assert_eq!(help_error, "usage: /help");
+
+        let history_error = parse_exact_chat_command(
+            "/history now",
+            &[CLI_CHAT_HISTORY_COMMAND],
+            "usage: /history",
+        )
+        .expect_err("history should reject extra args");
+        assert_eq!(history_error, "usage: /history");
     }
 
     #[test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -6156,15 +6156,9 @@ allowed_decisions: yes / auto / full / esc";
 
         let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
         let turn_coordinator = ConversationTurnCoordinator::new();
-        let result = load_manual_compaction_result(
-            &config,
-            session_id,
-            &turn_coordinator,
-            binding,
-            &memory_config,
-        )
-        .await
-        .expect("manual compaction should succeed");
+        let result = load_manual_compaction_result(&config, session_id, &turn_coordinator, binding)
+            .await
+            .expect("manual compaction should succeed");
 
         assert_eq!(result.status, ManualCompactionStatus::Applied);
         assert_eq!(result.before_turns, 8);

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -11,6 +11,7 @@ use std::sync::{
 
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
+use serde_json::json;
 use tokio::sync::Notify;
 
 use crate::CliResult;
@@ -28,13 +29,16 @@ mod latest_session_selector_tests;
 use self::cli_input::ConcurrentCliInputReader;
 
 use super::config::{self, ConversationConfig, LoongClawConfig};
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::conversation::ContextCompactionReport;
 #[cfg(test)]
 use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
 use super::conversation::{
     ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
     ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,
-    ExecutionLane, ProviderErrorMode, parse_approval_prompt_view, resolve_context_engine_selection,
+    ExecutionLane, ProviderErrorMode, collect_context_engine_runtime_snapshot,
+    parse_approval_prompt_view, resolve_context_engine_selection,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -54,6 +58,7 @@ use super::conversation::{load_fast_lane_tool_batch_event_summary, load_safe_lan
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
+use super::runtime_self_continuity;
 #[cfg(feature = "memory-sqlite")]
 use super::session::LATEST_SESSION_SELECTOR;
 #[cfg(feature = "memory-sqlite")]
@@ -72,6 +77,12 @@ const CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS: usize = 320;
 const CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS: usize = 4096;
 const CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS: usize = 160;
 const CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS: usize = 1024;
+const CLI_CHAT_HELP_COMMAND: &str = "/help";
+const CLI_CHAT_COMPACT_COMMAND: &str = "/compact";
+const CLI_CHAT_STATUS_COMMAND: &str = "/status";
+const CLI_CHAT_HISTORY_COMMAND: &str = "/history";
+const CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND: &str = "/turn_checkpoint_repair";
+const CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS: &str = "/turn-checkpoint-repair";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CliChatOptions {
@@ -233,6 +244,11 @@ struct CliChatStartupSummary {
     session_id: String,
     context_engine_id: String,
     context_engine_source: String,
+    compaction_enabled: bool,
+    compaction_min_messages: Option<usize>,
+    compaction_trigger_estimated_tokens: Option<usize>,
+    compaction_preserve_recent_turns: usize,
+    compaction_fail_open: bool,
     acp_enabled: bool,
     dispatch_enabled: bool,
     conversation_routing: String,
@@ -298,6 +314,31 @@ struct CliChatLiveSurfaceObserver {
     render_width: usize,
     render_sink: CliChatLiveSurfaceSink,
     state: StdMutex<CliChatLiveSurfaceState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManualCompactionResult {
+    status: ManualCompactionStatus,
+    before_turns: usize,
+    after_turns: usize,
+    estimated_tokens_before: Option<usize>,
+    estimated_tokens_after: Option<usize>,
+    summary_headline: Option<String>,
+    detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManualCompactionStatus {
+    Applied,
+    NoChange,
+    FailedOpen,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManualCompactionWindowSnapshot {
+    turns: Vec<memory::WindowTurn>,
+    turn_count: Option<usize>,
 }
 
 #[allow(clippy::print_stdout)] // CLI REPL output
@@ -670,7 +711,7 @@ async fn run_concurrent_cli_host_loop(
 async fn process_cli_chat_input(
     runtime: &CliTurnRuntime,
     input: &str,
-    _options: &CliChatOptions,
+    options: &CliChatOptions,
     event_sink: Option<&dyn AcpTurnEventSink>,
 ) -> CliResult<CliChatLoopControl> {
     if input.is_empty() {
@@ -679,11 +720,19 @@ async fn process_cli_chat_input(
     if is_exit_command(&runtime.config, input) {
         return Ok(CliChatLoopControl::Exit);
     }
-    if input == "/help" {
+    if input == CLI_CHAT_HELP_COMMAND {
         print_help();
         return Ok(CliChatLoopControl::Continue);
     }
-    if input == "/history" {
+    if is_cli_chat_status_command(input)? {
+        print_cli_chat_status(runtime, options).await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if is_manual_compaction_command(input)? {
+        print_manual_compaction(runtime).await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if input == CLI_CHAT_HISTORY_COMMAND {
         #[cfg(feature = "memory-sqlite")]
         print_history(
             &runtime.session_id,
@@ -790,11 +839,26 @@ fn print_cli_chat_startup(runtime: &CliTurnRuntime, options: &CliChatOptions) ->
     Ok(())
 }
 
+#[allow(clippy::print_stdout)] // CLI output
+async fn print_cli_chat_status(
+    runtime: &CliTurnRuntime,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let render_width = detect_cli_chat_render_width();
+    let summary = build_cli_chat_startup_summary(runtime, options)?;
+    let rendered_lines = render_cli_chat_status_lines_with_width(&summary, render_width);
+    print_rendered_cli_chat_lines(&rendered_lines);
+    print_turn_checkpoint_startup_health(runtime).await;
+    Ok(())
+}
+
 fn build_cli_chat_startup_summary(
     runtime: &CliTurnRuntime,
     options: &CliChatOptions,
 ) -> CliResult<CliChatStartupSummary> {
     let context_engine_selection = resolve_context_engine_selection(&runtime.config);
+    let context_engine_runtime = collect_context_engine_runtime_snapshot(&runtime.config)?;
+    let compaction = context_engine_runtime.compaction;
     let acp_selection = resolve_acp_backend_selection(&runtime.config);
     Ok(CliChatStartupSummary {
         config_path: runtime.resolved_path.display().to_string(),
@@ -802,6 +866,14 @@ fn build_cli_chat_startup_summary(
         session_id: runtime.session_id.clone(),
         context_engine_id: context_engine_selection.id.to_owned(),
         context_engine_source: context_engine_selection.source.as_str().to_owned(),
+        compaction_enabled: compaction.enabled,
+        compaction_min_messages: compaction.min_messages,
+        compaction_trigger_estimated_tokens: compaction.trigger_estimated_tokens,
+        compaction_preserve_recent_turns: runtime
+            .config
+            .conversation
+            .compact_preserve_recent_turns(),
+        compaction_fail_open: compaction.fail_open,
         acp_enabled: runtime.config.acp.enabled,
         dispatch_enabled: runtime.config.acp.dispatch_enabled(),
         conversation_routing: runtime
@@ -934,6 +1006,14 @@ fn render_cli_chat_startup_lines_with_width(
     render_tui_screen_spec(&screen_spec, width, false)
 }
 
+fn render_cli_chat_status_lines_with_width(
+    summary: &CliChatStartupSummary,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_status_message_spec(summary);
+    render_tui_message_spec(&message_spec, width)
+}
+
 fn detect_cli_chat_render_width() -> usize {
     crate::presentation::detect_render_width()
 }
@@ -946,19 +1026,6 @@ fn print_rendered_cli_chat_lines(lines: &[String]) {
 }
 
 fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScreenSpec {
-    let allowed_channels = if summary.allowed_channels.is_empty() {
-        "-".to_owned()
-    } else {
-        summary.allowed_channels.join(",")
-    };
-    let runtime_line = format!(
-        "ACP enabled={} dispatch_enabled={} routing={} backend={} ({}) allowed_channels={allowed_channels}",
-        summary.acp_enabled,
-        summary.dispatch_enabled,
-        summary.conversation_routing,
-        summary.acp_backend_id,
-        summary.acp_backend_source,
-    );
     let mut sections = vec![
         TuiSectionSpec::ActionGroup {
             title: Some("start here".to_owned()),
@@ -972,40 +1039,126 @@ fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScr
             title: None,
             lines: vec!["- type your request, or use /help for commands".to_owned()],
         },
-        TuiSectionSpec::KeyValues {
-            title: Some("session details".to_owned()),
-            items: vec![
-                TuiKeyValueSpec::Plain {
-                    key: "session".to_owned(),
-                    value: summary.session_id.clone(),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "config".to_owned(),
-                    value: summary.config_path.clone(),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "memory".to_owned(),
-                    value: summary.memory_label.clone(),
-                },
-            ],
+    ];
+    let runtime_sections = build_cli_chat_runtime_sections(summary);
+    sections.extend(runtime_sections);
+
+    TuiScreenSpec {
+        header_style: TuiHeaderStyle::Compact,
+        subtitle: Some("interactive chat".to_owned()),
+        title: Some("chat ready".to_owned()),
+        progress_line: None,
+        intro_lines: Vec::new(),
+        sections,
+        choices: Vec::new(),
+        footer_lines: Vec::new(),
+    }
+}
+
+fn build_cli_chat_status_message_spec(summary: &CliChatStartupSummary) -> TuiMessageSpec {
+    let caption = format!("session={}", summary.session_id);
+    let mut sections = build_cli_chat_runtime_sections(summary);
+    let operator_callout = TuiSectionSpec::Callout {
+        tone: TuiCalloutTone::Info,
+        title: Some("operator controls".to_owned()),
+        lines: vec![format!(
+            "Use {CLI_CHAT_COMPACT_COMMAND} to checkpoint the active session window on demand."
+        )],
+    };
+    sections.push(operator_callout);
+
+    TuiMessageSpec {
+        role: "status".to_owned(),
+        caption: Some(caption),
+        sections,
+        footer_lines: Vec::new(),
+    }
+}
+
+fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSectionSpec> {
+    let allowed_channels = if summary.allowed_channels.is_empty() {
+        "-".to_owned()
+    } else {
+        summary.allowed_channels.join(",")
+    };
+    let compaction_min_messages = summary
+        .compaction_min_messages
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let compaction_trigger_estimated_tokens = summary
+        .compaction_trigger_estimated_tokens
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let runtime_line = format!(
+        "ACP enabled={} dispatch_enabled={} routing={} backend={} ({}) allowed_channels={allowed_channels}",
+        summary.acp_enabled,
+        summary.dispatch_enabled,
+        summary.conversation_routing,
+        summary.acp_backend_id,
+        summary.acp_backend_source,
+    );
+    let session_items = vec![
+        TuiKeyValueSpec::Plain {
+            key: "session".to_owned(),
+            value: summary.session_id.clone(),
         },
-        TuiSectionSpec::KeyValues {
-            title: Some("runtime details".to_owned()),
-            items: vec![
-                TuiKeyValueSpec::Plain {
-                    key: "context engine".to_owned(),
-                    value: format!(
-                        "{} ({})",
-                        summary.context_engine_id, summary.context_engine_source
-                    ),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "acp".to_owned(),
-                    value: runtime_line,
-                },
-            ],
+        TuiKeyValueSpec::Plain {
+            key: "config".to_owned(),
+            value: summary.config_path.clone(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "memory".to_owned(),
+            value: summary.memory_label.clone(),
         },
     ];
+    let context_engine_value = format!(
+        "{} ({})",
+        summary.context_engine_id, summary.context_engine_source
+    );
+    let runtime_items = vec![
+        TuiKeyValueSpec::Plain {
+            key: "context engine".to_owned(),
+            value: context_engine_value,
+        },
+        TuiKeyValueSpec::Plain {
+            key: "acp".to_owned(),
+            value: runtime_line,
+        },
+    ];
+    let session_section = TuiSectionSpec::KeyValues {
+        title: Some("session details".to_owned()),
+        items: session_items,
+    };
+    let runtime_section = TuiSectionSpec::KeyValues {
+        title: Some("runtime details".to_owned()),
+        items: runtime_items,
+    };
+    let continuity_section = TuiSectionSpec::KeyValues {
+        title: Some("continuity maintenance".to_owned()),
+        items: vec![
+            TuiKeyValueSpec::Plain {
+                key: "compaction".to_owned(),
+                value: summary.compaction_enabled.to_string(),
+            },
+            TuiKeyValueSpec::Plain {
+                key: "min messages".to_owned(),
+                value: compaction_min_messages,
+            },
+            TuiKeyValueSpec::Plain {
+                key: "trigger tokens".to_owned(),
+                value: compaction_trigger_estimated_tokens,
+            },
+            TuiKeyValueSpec::Plain {
+                key: "preserve recent".to_owned(),
+                value: summary.compaction_preserve_recent_turns.to_string(),
+            },
+            TuiKeyValueSpec::Plain {
+                key: "fail open".to_owned(),
+                value: summary.compaction_fail_open.to_string(),
+            },
+        ],
+    };
+    let mut sections = vec![session_section, runtime_section, continuity_section];
 
     if summary.explicit_acp_request
         || summary.event_stream_enabled
@@ -1031,16 +1184,7 @@ fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScr
         });
     }
 
-    TuiScreenSpec {
-        header_style: TuiHeaderStyle::Compact,
-        subtitle: Some("interactive chat".to_owned()),
-        title: Some("chat ready".to_owned()),
-        progress_line: None,
-        intro_lines: Vec::new(),
-        sections,
-        choices: Vec::new(),
-        footer_lines: Vec::new(),
-    }
+    sections
 }
 
 fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
@@ -1051,11 +1195,19 @@ fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
 fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
     let command_items = vec![
         TuiKeyValueSpec::Plain {
-            key: "/help".to_owned(),
+            key: CLI_CHAT_HELP_COMMAND.to_owned(),
             value: "show chat commands".to_owned(),
         },
         TuiKeyValueSpec::Plain {
-            key: "/history".to_owned(),
+            key: CLI_CHAT_COMPACT_COMMAND.to_owned(),
+            value: "write a continuity-safe checkpoint into the active window".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_STATUS_COMMAND.to_owned(),
+            value: "show session, runtime, compaction, and durability status".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_HISTORY_COMMAND.to_owned(),
             value: "print the current session sliding window".to_owned(),
         },
         TuiKeyValueSpec::Plain {
@@ -1071,7 +1223,7 @@ fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
             value: "summarize durable turn finalization state".to_owned(),
         },
         TuiKeyValueSpec::Plain {
-            key: "/turn_checkpoint_repair".to_owned(),
+            key: CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND.to_owned(),
             value: "repair durable turn finalization tail when safe".to_owned(),
         },
         TuiKeyValueSpec::Plain {
@@ -1081,7 +1233,9 @@ fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
     ];
     let note_lines = vec![
         "Type any non-command text to send a normal assistant turn.".to_owned(),
+        "Use /status to inspect runtime maintenance settings without sending a turn.".to_owned(),
         "Use /history to inspect the active memory window when a reply feels off.".to_owned(),
+        "Use /compact to checkpoint the active session before the next turn.".to_owned(),
     ];
 
     TuiMessageSpec {
@@ -1128,6 +1282,85 @@ fn build_cli_chat_history_message_spec(
         caption: Some(caption),
         sections: vec![history_section],
         footer_lines: Vec::new(),
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn render_manual_compaction_lines_with_width(
+    session_id: &str,
+    result: &ManualCompactionResult,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_manual_compaction_message_spec(session_id, result);
+    render_tui_message_spec(&message_spec, width)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_manual_compaction_message_spec(
+    session_id: &str,
+    result: &ManualCompactionResult,
+) -> TuiMessageSpec {
+    let caption = format!("session={session_id}");
+    let status = format_manual_compaction_status(result.status).to_owned();
+    let estimated_tokens_before = format_manual_compaction_tokens(result.estimated_tokens_before);
+    let estimated_tokens_after = format_manual_compaction_tokens(result.estimated_tokens_after);
+    let tone = manual_compaction_tone(result.status);
+
+    let result_section = TuiSectionSpec::KeyValues {
+        title: Some("compaction result".to_owned()),
+        items: vec![
+            tui_plain_item("status", status),
+            tui_plain_item("before turns", result.before_turns.to_string()),
+            tui_plain_item("after turns", result.after_turns.to_string()),
+            tui_plain_item("tokens before", estimated_tokens_before),
+            tui_plain_item("tokens after", estimated_tokens_after),
+            tui_plain_item(
+                "summary",
+                result
+                    .summary_headline
+                    .clone()
+                    .unwrap_or_else(|| "-".to_owned()),
+            ),
+        ],
+    };
+
+    let detail_section = TuiSectionSpec::Callout {
+        tone,
+        title: Some("details".to_owned()),
+        lines: vec![result.detail.clone()],
+    };
+
+    TuiMessageSpec {
+        role: "compact".to_owned(),
+        caption: Some(caption),
+        sections: vec![result_section, detail_section],
+        footer_lines: Vec::new(),
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_manual_compaction_status(status: ManualCompactionStatus) -> &'static str {
+    match status {
+        ManualCompactionStatus::Applied => "applied",
+        ManualCompactionStatus::NoChange => "no_change",
+        ManualCompactionStatus::FailedOpen => "failed_open",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_manual_compaction_tokens(value: Option<usize>) -> String {
+    let Some(value) = value else {
+        return "-".to_owned();
+    };
+    value.to_string()
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn manual_compaction_tone(status: ManualCompactionStatus) -> TuiCalloutTone {
+    match status {
+        ManualCompactionStatus::Applied => TuiCalloutTone::Success,
+        ManualCompactionStatus::NoChange => TuiCalloutTone::Info,
+        ManualCompactionStatus::FailedOpen => TuiCalloutTone::Warning,
     }
 }
 
@@ -2391,6 +2624,40 @@ fn print_help() {
 }
 
 #[allow(clippy::print_stdout)] // CLI output
+async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let binding = ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
+        let result = load_manual_compaction_result(
+            &runtime.config,
+            &runtime.session_id,
+            &runtime.turn_coordinator,
+            binding,
+            &runtime.memory_config,
+        )
+        .await?;
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines =
+            render_manual_compaction_lines_with_width(&runtime.session_id, &result, render_width);
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = runtime;
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
+            "compact",
+            "manual compaction unavailable: memory-sqlite feature disabled",
+            render_width,
+        );
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)] // CLI output
 async fn print_history(
     session_id: &str,
     limit: usize,
@@ -2423,6 +2690,147 @@ async fn print_history(
 
         print_rendered_cli_chat_lines(&rendered_lines);
         Ok(())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_manual_compaction_result(
+    config: &LoongClawConfig,
+    session_id: &str,
+    turn_coordinator: &ConversationTurnCoordinator,
+    binding: ConversationRuntimeBinding<'_>,
+    _memory_config: &MemoryRuntimeConfig,
+) -> CliResult<ManualCompactionResult> {
+    let before_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
+    let before_turns = resolve_manual_compaction_turn_count(&before_snapshot);
+    let report = turn_coordinator
+        .compact_session(config, session_id, binding)
+        .await?;
+    let after_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
+    let after_turns = resolve_manual_compaction_turn_count(&after_snapshot);
+    let summary_headline = extract_manual_compaction_summary_headline(&after_snapshot);
+    let status = manual_compaction_status_from_report(&report)?;
+    let detail = build_manual_compaction_detail(status, &summary_headline);
+
+    Ok(ManualCompactionResult {
+        status,
+        before_turns,
+        after_turns,
+        estimated_tokens_before: report.estimated_tokens_before,
+        estimated_tokens_after: report.estimated_tokens_after,
+        summary_headline,
+        detail,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_manual_compaction_window_snapshot(
+    session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<ManualCompactionWindowSnapshot> {
+    const MAX_MANUAL_COMPACTION_WINDOW_TURNS: usize = 512;
+
+    let kernel_ctx = binding
+        .kernel_context()
+        .ok_or_else(|| "manual compaction requires a kernel-bound session".to_owned())?;
+    let caps = BTreeSet::from([Capability::MemoryRead]);
+    let request = loongclaw_contracts::MemoryCoreRequest {
+        operation: memory::MEMORY_OP_WINDOW.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "limit": MAX_MANUAL_COMPACTION_WINDOW_TURNS,
+            "allow_extended_limit": true,
+        }),
+    };
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| format!("load compaction window via kernel failed: {error}"))?;
+
+    if outcome.status != "ok" {
+        let status = outcome.status;
+        let message = format!("load compaction window via kernel returned non-ok status: {status}");
+        return Err(message);
+    }
+
+    let turns = memory::decode_window_turns(&outcome.payload);
+    let turn_count = memory::decode_window_turn_count(&outcome.payload);
+
+    Ok(ManualCompactionWindowSnapshot { turns, turn_count })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_manual_compaction_turn_count(snapshot: &ManualCompactionWindowSnapshot) -> usize {
+    snapshot.turn_count.unwrap_or(snapshot.turns.len())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn extract_manual_compaction_summary_headline(
+    snapshot: &ManualCompactionWindowSnapshot,
+) -> Option<String> {
+    let first_turn = snapshot.turns.first()?;
+    let content = first_turn.content.trim();
+    if !content.starts_with("Compacted ") {
+        return None;
+    }
+
+    let headline = content.lines().next()?.trim();
+    Some(headline.to_owned())
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn manual_compaction_status_from_report(
+    report: &ContextCompactionReport,
+) -> CliResult<ManualCompactionStatus> {
+    if report.was_applied() {
+        return Ok(ManualCompactionStatus::Applied);
+    }
+
+    if report.was_skipped() {
+        return Ok(ManualCompactionStatus::NoChange);
+    }
+
+    if report.was_failed_open() {
+        return Ok(ManualCompactionStatus::FailedOpen);
+    }
+
+    let status_label = report.status_label();
+    let message = format!("manual compaction returned unexpected status: {status_label}");
+    Err(message)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_manual_compaction_detail(
+    status: ManualCompactionStatus,
+    summary_headline: &Option<String>,
+) -> String {
+    let continuity_note = runtime_self_continuity::compaction_summary_scope_note();
+    match status {
+        ManualCompactionStatus::Applied => match summary_headline {
+            Some(headline) => {
+                format!("{headline}. {continuity_note}")
+            }
+            None => {
+                format!(
+                    "Compaction completed and the active session window was rewritten. {continuity_note}"
+                )
+            }
+        },
+        ManualCompactionStatus::NoChange => {
+            "No compaction change applied. The active session was already summarized or already compact enough."
+                .to_owned()
+        }
+        ManualCompactionStatus::FailedOpen => {
+            "Compaction failed open and left the current history unchanged. Inspect /status and /history before continuing."
+                .to_owned()
+        }
     }
 }
 
@@ -2565,18 +2973,46 @@ fn parse_turn_checkpoint_summary_limit(
     )
 }
 
-fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
-    let mut tokens = input.split_whitespace();
+fn parse_exact_chat_command(input: &str, aliases: &[&str], usage: &str) -> CliResult<bool> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(false);
+    }
+
+    let mut tokens = trimmed.split_whitespace();
     let Some(command) = tokens.next() else {
         return Ok(false);
     };
-    if command != "/turn_checkpoint_repair" && command != "/turn-checkpoint-repair" {
+    if !aliases.contains(&command) {
         return Ok(false);
     }
+
     if tokens.next().is_some() {
-        return Err("usage: /turn_checkpoint_repair".to_owned());
+        return Err(usage.to_owned());
     }
+
     Ok(true)
+}
+
+fn is_manual_compaction_command(input: &str) -> CliResult<bool> {
+    let aliases = [CLI_CHAT_COMPACT_COMMAND];
+    let usage = "usage: /compact";
+    parse_exact_chat_command(input, &aliases, usage)
+}
+
+fn is_cli_chat_status_command(input: &str) -> CliResult<bool> {
+    let aliases = [CLI_CHAT_STATUS_COMMAND];
+    let usage = "usage: /status";
+    parse_exact_chat_command(input, &aliases, usage)
+}
+
+fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
+    let aliases = [
+        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND,
+        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS,
+    ];
+    let usage = "usage: /turn_checkpoint_repair";
+    parse_exact_chat_command(input, &aliases, usage)
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -4514,6 +4950,69 @@ mod tests {
     };
     #[cfg(feature = "memory-sqlite")]
     use serde_json::{Value, json};
+
+    #[cfg(feature = "memory-sqlite")]
+    fn test_config() -> LoongClawConfig {
+        let mut config = LoongClawConfig::default();
+        config.provider = crate::config::ProviderConfig::default();
+        config.audit.mode = crate::config::AuditMode::InMemory;
+        config
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn unique_memory_sqlite_path(suffix: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let file_name = format!("loongclaw-chat-{suffix}-{nanos}.sqlite");
+        let path = std::env::temp_dir().join(file_name);
+        path.display().to_string()
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn test_kernel_context_with_memory(
+        agent_id: &str,
+        memory_config: &MemoryRuntimeConfig,
+    ) -> crate::KernelContext {
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+        let pack = VerticalPackManifest {
+            pack_id: "test-pack-memory".to_owned(),
+            domain: "testing".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: None,
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::MemoryRead, Capability::MemoryWrite]),
+            metadata: BTreeMap::new(),
+        };
+
+        kernel
+            .register_pack(pack)
+            .expect("register memory test pack");
+
+        let adapter = crate::memory::MvpMemoryAdapter::with_config(memory_config.clone());
+        kernel.register_core_memory_adapter(adapter);
+
+        kernel
+            .set_default_core_memory_adapter("mvp-memory")
+            .expect("set memory test adapter");
+
+        let token = kernel
+            .issue_token("test-pack-memory", agent_id, 60)
+            .expect("issue memory test token");
+
+        crate::KernelContext {
+            kernel: Arc::new(kernel),
+            token,
+        }
+    }
+
     #[test]
     fn cli_chat_options_detect_explicit_acp_requests() {
         assert!(
@@ -5383,6 +5882,11 @@ mod tests {
                 session_id: "default".to_owned(),
                 context_engine_id: "threaded".to_owned(),
                 context_engine_source: "config".to_owned(),
+                compaction_enabled: true,
+                compaction_min_messages: Some(6),
+                compaction_trigger_estimated_tokens: Some(120),
+                compaction_preserve_recent_turns: 4,
+                compaction_fail_open: false,
                 acp_enabled: true,
                 dispatch_enabled: true,
                 conversation_routing: "automatic".to_owned(),
@@ -5424,8 +5928,16 @@ mod tests {
             "chat startup should still preserve runtime context in a compact secondary section: {lines:#?}"
         );
         assert!(
+            lines.iter().any(|line| line == "continuity maintenance"),
+            "chat startup should show compaction maintenance settings in a dedicated section: {lines:#?}"
+        );
+        assert!(
             lines.iter().any(|line| line == "- session: default"),
             "chat startup should continue to show session identity after the handoff block: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "- compaction: true"),
+            "chat startup should show whether automatic compaction is enabled: {lines:#?}"
         );
     }
 
@@ -5438,6 +5950,11 @@ mod tests {
                 session_id: "thread-42".to_owned(),
                 context_engine_id: "threaded".to_owned(),
                 context_engine_source: "env".to_owned(),
+                compaction_enabled: true,
+                compaction_min_messages: Some(6),
+                compaction_trigger_estimated_tokens: Some(120),
+                compaction_preserve_recent_turns: 4,
+                compaction_fail_open: false,
                 acp_enabled: true,
                 dispatch_enabled: true,
                 conversation_routing: "manual".to_owned(),
@@ -5467,6 +5984,57 @@ mod tests {
                 .iter()
                 .any(|line| line == "- working directory: /workspace/project"),
             "chat startup should still surface the working directory override: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn render_cli_chat_status_lines_focus_on_runtime_state_without_start_here() {
+        let lines = render_cli_chat_status_lines_with_width(
+            &CliChatStartupSummary {
+                config_path: "/tmp/loongclaw.toml".to_owned(),
+                memory_label: "/tmp/loongclaw.db".to_owned(),
+                session_id: "default".to_owned(),
+                context_engine_id: "threaded".to_owned(),
+                context_engine_source: "config".to_owned(),
+                compaction_enabled: true,
+                compaction_min_messages: Some(6),
+                compaction_trigger_estimated_tokens: Some(120),
+                compaction_preserve_recent_turns: 4,
+                compaction_fail_open: false,
+                acp_enabled: true,
+                dispatch_enabled: true,
+                conversation_routing: "automatic".to_owned(),
+                allowed_channels: vec!["cli".to_owned()],
+                acp_backend_id: "builtin".to_owned(),
+                acp_backend_source: "default".to_owned(),
+                explicit_acp_request: false,
+                event_stream_enabled: false,
+                bootstrap_mcp_servers: Vec::new(),
+                working_directory: None,
+            },
+            80,
+        );
+
+        assert_eq!(lines[0], "status: session=default");
+        assert!(
+            lines.iter().any(|line| line == "session details"),
+            "status output should keep session facts grouped under a section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "runtime details"),
+            "status output should keep runtime facts grouped under a section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "continuity maintenance"),
+            "status output should surface compaction maintenance settings: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "note: operator controls"),
+            "status output should include the operator control callout: {lines:#?}"
+        );
+        assert!(
+            !lines.iter().any(|line| line.starts_with("start here:")),
+            "status output should not re-render the first-turn guidance block: {lines:#?}"
         );
     }
 
@@ -5774,12 +6342,111 @@ mod tests {
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- /history: print the current session sliding window"),
+                .any(|line| line.contains("/history: print the current session sliding window")),
             "help output should render slash commands as readable key-value rows: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line
+                .contains("/status: show session, runtime, compaction, and durability status")),
+            "help output should surface the status command: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line
+                .contains("/compact: write a continuity-safe checkpoint into the active window")),
+            "help output should surface the manual compaction command: {lines:#?}"
         );
         assert!(
             lines.iter().any(|line| line == "note: usage notes"),
             "help output should preserve operator guidance as a callout: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn render_cli_chat_status_lines_surface_runtime_and_compaction_controls() {
+        let summary = CliChatStartupSummary {
+            config_path: "/tmp/loongclaw.toml".to_owned(),
+            memory_label: "window_plus_summary".to_owned(),
+            session_id: "session-status".to_owned(),
+            context_engine_id: "default".to_owned(),
+            context_engine_source: "config".to_owned(),
+            compaction_enabled: true,
+            compaction_min_messages: Some(6),
+            compaction_trigger_estimated_tokens: Some(12_000),
+            compaction_preserve_recent_turns: 4,
+            compaction_fail_open: true,
+            acp_enabled: true,
+            dispatch_enabled: true,
+            conversation_routing: "auto".to_owned(),
+            allowed_channels: vec!["cli".to_owned()],
+            acp_backend_id: "builtin".to_owned(),
+            acp_backend_source: "config".to_owned(),
+            explicit_acp_request: false,
+            event_stream_enabled: false,
+            bootstrap_mcp_servers: Vec::new(),
+            working_directory: None,
+        };
+
+        let lines = render_cli_chat_status_lines_with_width(&summary, 80);
+
+        assert_eq!(lines[0], "status: session=session-status");
+        assert!(
+            lines.iter().any(|line| line == "continuity maintenance"),
+            "status output should expose compaction settings as a dedicated section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("compaction: true")),
+            "status output should expose compaction enablement: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("trigger tokens: 12000")),
+            "status output should surface the compaction token trigger: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "note: operator controls"),
+            "status output should append the operator controls callout: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("checkpoint the active session window on demand")),
+            "status output should direct operators toward manual compaction: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn render_manual_compaction_lines_surface_structured_result() {
+        let result = ManualCompactionResult {
+            status: ManualCompactionStatus::Applied,
+            before_turns: 8,
+            after_turns: 3,
+            estimated_tokens_before: Some(1200),
+            estimated_tokens_after: Some(420),
+            summary_headline: Some("Compacted 6 earlier turns".to_owned()),
+            detail: "Compacted 6 earlier turns. Session-local recall only. It does not replace Runtime Self Context.".to_owned(),
+        };
+
+        let lines = render_manual_compaction_lines_with_width("session-compact", &result, 80);
+
+        assert_eq!(lines[0], "compact: session=session-compact");
+        assert!(
+            lines.iter().any(|line| line == "compaction result"),
+            "manual compaction should render a dedicated result section: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("status: applied")),
+            "manual compaction should surface the applied status: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("tokens after: 420")),
+            "manual compaction should surface token estimates: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Runtime Self Context")),
+            "manual compaction should preserve the continuity boundary detail: {lines:#?}"
         );
     }
 
@@ -6422,6 +7089,115 @@ allowed_decisions: yes / auto / full / esc";
         let error = is_turn_checkpoint_repair_command("/turn_checkpoint_repair now")
             .expect_err("extra args should be rejected");
         assert!(error.contains("usage"));
+    }
+
+    #[test]
+    fn is_cli_chat_status_command_accepts_exact_match_and_rejects_extra_args() {
+        assert!(is_cli_chat_status_command("/status").expect("parse"));
+        assert!(!is_cli_chat_status_command("/history").expect("parse"));
+
+        let error =
+            is_cli_chat_status_command("/status now").expect_err("extra args should be rejected");
+        assert_eq!(error, "usage: /status");
+    }
+
+    #[test]
+    fn is_manual_compaction_command_accepts_exact_match_and_rejects_extra_args() {
+        assert!(is_manual_compaction_command("/compact").expect("parse"));
+        assert!(!is_manual_compaction_command("/history").expect("parse"));
+
+        let error = is_manual_compaction_command("/compact now")
+            .expect_err("extra args should be rejected");
+        assert_eq!(error, "usage: /compact");
+    }
+
+    #[test]
+    fn manual_compaction_status_from_report_maps_failed_open() {
+        let report = ContextCompactionReport {
+            status: TurnCheckpointProgressStatus::FailedOpen,
+            estimated_tokens_before: Some(420),
+            estimated_tokens_after: Some(420),
+        };
+
+        let status =
+            manual_compaction_status_from_report(&report).expect("failed_open should map cleanly");
+
+        assert_eq!(status, ManualCompactionStatus::FailedOpen);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn manual_compaction_result_applies_and_surfaces_continuity_checkpoint() {
+        let mut config = test_config();
+        let db_path = unique_memory_sqlite_path("chat-manual-compaction");
+        let _ = std::fs::remove_file(&db_path);
+        config.memory.sqlite_path = db_path.clone();
+        config.memory.sliding_window = 32;
+        config.conversation.compact_enabled = false;
+        config.conversation.compact_preserve_recent_turns = 2;
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let kernel_ctx = test_kernel_context_with_memory("chat-manual-compaction", &memory_config);
+        let session_id = "chat-manual-compaction";
+
+        for (role, content) in [
+            ("user", "ask 1"),
+            ("assistant", "reply 1"),
+            ("user", "ask 2"),
+            ("assistant", "reply 2"),
+            ("user", "ask 3"),
+            ("assistant", "reply 3"),
+            ("user", "recent ask"),
+            ("assistant", "recent reply"),
+        ] {
+            crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+                .expect("seed turns should succeed");
+        }
+
+        let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+        let turn_coordinator = ConversationTurnCoordinator::new();
+        let result = load_manual_compaction_result(
+            &config,
+            session_id,
+            &turn_coordinator,
+            binding,
+            &memory_config,
+        )
+        .await
+        .expect("manual compaction should succeed");
+
+        assert_eq!(result.status, ManualCompactionStatus::Applied);
+        assert_eq!(result.before_turns, 8);
+        assert_eq!(result.after_turns, 3);
+        assert!(
+            result.estimated_tokens_before.is_some(),
+            "manual compaction should surface a before-token estimate"
+        );
+        assert!(
+            result.estimated_tokens_after.is_some(),
+            "manual compaction should surface an after-token estimate"
+        );
+        assert!(
+            result
+                .summary_headline
+                .as_deref()
+                .is_some_and(|headline| headline.contains("Compacted 6 earlier turns"))
+        );
+        assert!(
+            result.detail.contains("Runtime Self Context"),
+            "manual compaction detail should reuse the continuity boundary note"
+        );
+
+        let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+            .expect("window load should succeed");
+        assert!(
+            turns[0]
+                .content
+                .contains("Does not replace Runtime Self Context"),
+            "manual compaction should persist the continuity-aware checkpoint"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
     }
 
     fn test_turn_checkpoint_diagnostics(

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -672,35 +672,75 @@ async fn process_cli_chat_input(
     if is_exit_command(&runtime.config, input) {
         return Ok(CliChatLoopControl::Exit);
     }
-    if parse_exact_chat_command(input, &[CLI_CHAT_HELP_COMMAND], "usage: /help")? {
-        print_help();
-        return Ok(CliChatLoopControl::Continue);
+    match classify_chat_command_match_result(parse_exact_chat_command(
+        input,
+        &[CLI_CHAT_HELP_COMMAND],
+        "usage: /help",
+    ))? {
+        ChatCommandMatchResult::Matched => {
+            print_help();
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::UsageError(usage) => {
+            let usage_lines = vec![usage];
+            print_rendered_cli_chat_lines(&usage_lines);
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::NotMatched => {}
     }
-    if is_cli_chat_status_command(input)? {
-        print_cli_chat_status(runtime, options).await?;
-        return Ok(CliChatLoopControl::Continue);
+    match classify_chat_command_match_result(is_cli_chat_status_command(input))? {
+        ChatCommandMatchResult::Matched => {
+            print_cli_chat_status(runtime, options).await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::UsageError(usage) => {
+            let usage_lines = vec![usage];
+            print_rendered_cli_chat_lines(&usage_lines);
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::NotMatched => {}
     }
-    if is_manual_compaction_command(input)? {
-        print_manual_compaction(runtime).await?;
-        return Ok(CliChatLoopControl::Continue);
+    match classify_chat_command_match_result(is_manual_compaction_command(input))? {
+        ChatCommandMatchResult::Matched => {
+            print_manual_compaction(runtime).await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::UsageError(usage) => {
+            let usage_lines = vec![usage];
+            print_rendered_cli_chat_lines(&usage_lines);
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::NotMatched => {}
     }
-    if parse_exact_chat_command(input, &[CLI_CHAT_HISTORY_COMMAND], "usage: /history")? {
-        #[cfg(feature = "memory-sqlite")]
-        print_history(
-            &runtime.session_id,
-            runtime.config.memory.sliding_window,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            &runtime.memory_config,
-        )
-        .await?;
-        #[cfg(not(feature = "memory-sqlite"))]
-        print_history(
-            &runtime.session_id,
-            runtime.config.memory.sliding_window,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await?;
-        return Ok(CliChatLoopControl::Continue);
+    match classify_chat_command_match_result(parse_exact_chat_command(
+        input,
+        &[CLI_CHAT_HISTORY_COMMAND],
+        "usage: /history",
+    ))? {
+        ChatCommandMatchResult::Matched => {
+            #[cfg(feature = "memory-sqlite")]
+            print_history(
+                &runtime.session_id,
+                runtime.config.memory.sliding_window,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                &runtime.memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_history(
+                &runtime.session_id,
+                runtime.config.memory.sliding_window,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            )
+            .await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::UsageError(usage) => {
+            let usage_lines = vec![usage];
+            print_rendered_cli_chat_lines(&usage_lines);
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::NotMatched => {}
     }
     if let Some(limit) = parse_fast_lane_summary_limit(input, runtime.config.memory.sliding_window)?
     {
@@ -780,6 +820,24 @@ async fn process_cli_chat_input(
     Ok(CliChatLoopControl::AssistantText(
         run_cli_turn(runtime, input, event_sink, true).await?,
     ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChatCommandMatchResult {
+    Matched,
+    NotMatched,
+    UsageError(String),
+}
+
+fn classify_chat_command_match_result(
+    result: CliResult<bool>,
+) -> CliResult<ChatCommandMatchResult> {
+    match result {
+        Ok(true) => Ok(ChatCommandMatchResult::Matched),
+        Ok(false) => Ok(ChatCommandMatchResult::NotMatched),
+        Err(error) if error.starts_with("usage:") => Ok(ChatCommandMatchResult::UsageError(error)),
+        Err(error) => Err(error),
+    }
 }
 
 fn detect_cli_chat_render_width() -> usize {
@@ -3894,17 +3952,6 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn unique_memory_sqlite_path(suffix: &str) -> String {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let file_name = format!("loongclaw-chat-{suffix}-{nanos}.sqlite");
-        let path = std::env::temp_dir().join(file_name);
-        path.display().to_string()
-    }
-
-    #[cfg(feature = "memory-sqlite")]
     fn test_kernel_context_with_memory(
         agent_id: &str,
         memory_config: &MemoryRuntimeConfig,
@@ -5094,6 +5141,32 @@ mod tests {
     }
 
     #[test]
+    fn render_turn_checkpoint_startup_health_lines_surface_non_durable_recovery() {
+        let summary = TurnCheckpointEventSummary {
+            session_state: TurnCheckpointSessionState::NotDurable,
+            checkpoint_durable: false,
+            reply_durable: false,
+            requires_recovery: true,
+            ..TurnCheckpointEventSummary::default()
+        };
+        let diagnostics = test_turn_checkpoint_diagnostics(summary, None);
+
+        let lines = render_turn_checkpoint_startup_health_lines_with_width(
+            "session-health",
+            &diagnostics,
+            80,
+        )
+        .expect("non-durable recovery should still render");
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("recovery needed: yes")),
+            "startup health should surface non-durable recovery cases: {lines:#?}"
+        );
+    }
+
+    #[test]
     fn render_turn_checkpoint_status_health_lines_surface_non_durable_sessions() {
         let summary = TurnCheckpointEventSummary {
             session_state: TurnCheckpointSessionState::NotDurable,
@@ -6112,6 +6185,24 @@ allowed_decisions: yes / auto / full / esc";
     }
 
     #[test]
+    fn classify_chat_command_match_result_treats_usage_as_non_fatal() {
+        let usage_result =
+            classify_chat_command_match_result(Err("usage: /help".to_owned())).expect("classify");
+        assert_eq!(
+            usage_result,
+            ChatCommandMatchResult::UsageError("usage: /help".to_owned())
+        );
+
+        let matched_result =
+            classify_chat_command_match_result(Ok(true)).expect("classify matched");
+        assert_eq!(matched_result, ChatCommandMatchResult::Matched);
+
+        let not_matched_result =
+            classify_chat_command_match_result(Ok(false)).expect("classify non-match");
+        assert_eq!(not_matched_result, ChatCommandMatchResult::NotMatched);
+    }
+
+    #[test]
     fn manual_compaction_status_from_report_maps_failed_open() {
         let report = ContextCompactionReport {
             status: TurnCheckpointProgressStatus::FailedOpen,
@@ -6129,9 +6220,9 @@ allowed_decisions: yes / auto / full / esc";
     #[tokio::test]
     async fn manual_compaction_result_applies_and_surfaces_continuity_checkpoint() {
         let mut config = test_config();
-        let db_path = unique_memory_sqlite_path("chat-manual-compaction");
-        let _ = std::fs::remove_file(&db_path);
-        config.memory.sqlite_path = db_path.clone();
+        let sqlite_path = unique_chat_sqlite_path("chat-manual-compaction");
+        cleanup_chat_test_memory(&sqlite_path);
+        config.memory.sqlite_path = sqlite_path.display().to_string();
         config.memory.sliding_window = 32;
         config.conversation.compact_enabled = false;
         config.conversation.compact_preserve_recent_turns = 2;
@@ -6191,7 +6282,7 @@ allowed_decisions: yes / auto / full / esc";
             "manual compaction should persist the continuity-aware checkpoint"
         );
 
-        let _ = std::fs::remove_file(&db_path);
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     fn test_turn_checkpoint_diagnostics(

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -1,0 +1,843 @@
+use super::*;
+
+#[cfg(feature = "memory-sqlite")]
+use std::collections::BTreeSet;
+
+#[cfg(feature = "memory-sqlite")]
+use loongclaw_contracts::Capability;
+#[cfg(feature = "memory-sqlite")]
+use serde_json::json;
+
+use crate::conversation::{
+    collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
+};
+use crate::runtime_self_continuity;
+
+pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
+    #[cfg(feature = "memory-sqlite")]
+    let render_width = detect_cli_chat_render_width();
+
+    #[cfg(feature = "memory-sqlite")]
+    match runtime
+        .turn_coordinator
+        .load_turn_checkpoint_diagnostics(
+            &runtime.config,
+            &runtime.session_id,
+            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await
+    {
+        Ok(diagnostics) => {
+            if let Some(rendered_lines) = render_turn_checkpoint_startup_health_lines_with_width(
+                &runtime.session_id,
+                &diagnostics,
+                render_width,
+            ) {
+                print_rendered_cli_chat_lines(&rendered_lines);
+            }
+        }
+        Err(error) => {
+            let rendered_lines = render_turn_checkpoint_health_error_lines_with_width(
+                &runtime.session_id,
+                &error,
+                render_width,
+            );
+
+            print_rendered_cli_chat_lines(&rendered_lines);
+        }
+    }
+}
+
+pub(super) async fn print_cli_chat_status(
+    runtime: &CliTurnRuntime,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let render_width = detect_cli_chat_render_width();
+    let summary = build_cli_chat_startup_summary(runtime, options)?;
+    let rendered_lines = render_cli_chat_status_lines_with_width(&summary, render_width);
+    print_rendered_cli_chat_lines(&rendered_lines);
+    print_turn_checkpoint_status_health(runtime).await;
+    Ok(())
+}
+
+async fn print_turn_checkpoint_status_health(runtime: &CliTurnRuntime) {
+    #[cfg(feature = "memory-sqlite")]
+    let render_width = detect_cli_chat_render_width();
+
+    #[cfg(feature = "memory-sqlite")]
+    match runtime
+        .turn_coordinator
+        .load_turn_checkpoint_diagnostics(
+            &runtime.config,
+            &runtime.session_id,
+            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await
+    {
+        Ok(diagnostics) => {
+            let rendered_lines = render_turn_checkpoint_status_health_lines_with_width(
+                &runtime.session_id,
+                &diagnostics,
+                render_width,
+            );
+
+            print_rendered_cli_chat_lines(&rendered_lines);
+        }
+        Err(error) => {
+            let rendered_lines = render_turn_checkpoint_health_error_lines_with_width(
+                &runtime.session_id,
+                &error,
+                render_width,
+            );
+
+            print_rendered_cli_chat_lines(&rendered_lines);
+        }
+    }
+}
+
+pub(super) fn build_cli_chat_startup_summary(
+    runtime: &CliTurnRuntime,
+    options: &CliChatOptions,
+) -> CliResult<CliChatStartupSummary> {
+    let context_engine_selection = resolve_context_engine_selection(&runtime.config);
+    let context_engine_runtime = collect_context_engine_runtime_snapshot(&runtime.config)?;
+    let compaction = context_engine_runtime.compaction;
+    let acp_selection = resolve_acp_backend_selection(&runtime.config);
+
+    Ok(CliChatStartupSummary {
+        config_path: runtime.resolved_path.display().to_string(),
+        memory_label: runtime.memory_label.clone(),
+        session_id: runtime.session_id.clone(),
+        context_engine_id: context_engine_selection.id.to_owned(),
+        context_engine_source: context_engine_selection.source.as_str().to_owned(),
+        compaction_enabled: compaction.enabled,
+        compaction_min_messages: compaction.min_messages,
+        compaction_trigger_estimated_tokens: compaction.trigger_estimated_tokens,
+        compaction_preserve_recent_turns: runtime
+            .config
+            .conversation
+            .compact_preserve_recent_turns(),
+        compaction_fail_open: compaction.fail_open,
+        acp_enabled: runtime.config.acp.enabled,
+        dispatch_enabled: runtime.config.acp.dispatch_enabled(),
+        conversation_routing: runtime
+            .config
+            .acp
+            .dispatch
+            .conversation_routing
+            .as_str()
+            .to_owned(),
+        allowed_channels: runtime.config.acp.dispatch.allowed_channel_ids()?,
+        acp_backend_id: acp_selection.id.to_owned(),
+        acp_backend_source: acp_selection.source.as_str().to_owned(),
+        explicit_acp_request: runtime.explicit_acp_request,
+        event_stream_enabled: options.acp_event_stream,
+        bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
+        working_directory: runtime
+            .effective_working_directory
+            .as_ref()
+            .map(|path| path.display().to_string()),
+    })
+}
+
+pub(super) fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
+    let render_width = detect_cli_chat_render_width();
+    render_cli_chat_startup_lines_with_width(summary, render_width)
+}
+
+pub(super) fn render_cli_chat_startup_lines_with_width(
+    summary: &CliChatStartupSummary,
+    width: usize,
+) -> Vec<String> {
+    let screen_spec = build_cli_chat_startup_screen_spec(summary);
+    render_tui_screen_spec(&screen_spec, width, false)
+}
+
+pub(super) fn render_cli_chat_status_lines_with_width(
+    summary: &CliChatStartupSummary,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_status_message_spec(summary);
+    render_tui_message_spec(&message_spec, width)
+}
+
+fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScreenSpec {
+    let mut sections = vec![
+        TuiSectionSpec::ActionGroup {
+            title: Some("start here".to_owned()),
+            inline_title_when_wide: true,
+            items: vec![TuiActionSpec {
+                label: "first prompt".to_owned(),
+                command: DEFAULT_FIRST_PROMPT.to_owned(),
+            }],
+        },
+        TuiSectionSpec::Narrative {
+            title: None,
+            lines: vec!["- type your request, or use /help for commands".to_owned()],
+        },
+    ];
+    let runtime_sections = build_cli_chat_runtime_sections(summary);
+    sections.extend(runtime_sections);
+
+    TuiScreenSpec {
+        header_style: TuiHeaderStyle::Compact,
+        subtitle: Some("interactive chat".to_owned()),
+        title: Some("chat ready".to_owned()),
+        progress_line: None,
+        intro_lines: Vec::new(),
+        sections,
+        choices: Vec::new(),
+        footer_lines: Vec::new(),
+    }
+}
+
+fn build_cli_chat_status_message_spec(summary: &CliChatStartupSummary) -> TuiMessageSpec {
+    let caption = format!("session={}", summary.session_id);
+    let mut sections = build_cli_chat_runtime_sections(summary);
+    let operator_callout = TuiSectionSpec::Callout {
+        tone: TuiCalloutTone::Info,
+        title: Some("operator controls".to_owned()),
+        lines: vec![format!(
+            "Use {CLI_CHAT_COMPACT_COMMAND} to checkpoint the active session window on demand."
+        )],
+    };
+    sections.push(operator_callout);
+
+    TuiMessageSpec {
+        role: "status".to_owned(),
+        caption: Some(caption),
+        sections,
+        footer_lines: Vec::new(),
+    }
+}
+
+fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSectionSpec> {
+    let allowed_channels = if summary.allowed_channels.is_empty() {
+        "-".to_owned()
+    } else {
+        summary.allowed_channels.join(",")
+    };
+    let compaction_min_messages = summary
+        .compaction_min_messages
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let compaction_trigger_estimated_tokens = summary
+        .compaction_trigger_estimated_tokens
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let runtime_line = format!(
+        "ACP enabled={} dispatch_enabled={} routing={} backend={} ({}) allowed_channels={allowed_channels}",
+        summary.acp_enabled,
+        summary.dispatch_enabled,
+        summary.conversation_routing,
+        summary.acp_backend_id,
+        summary.acp_backend_source,
+    );
+    let session_items = vec![
+        TuiKeyValueSpec::Plain {
+            key: "session".to_owned(),
+            value: summary.session_id.clone(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "config".to_owned(),
+            value: summary.config_path.clone(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "memory".to_owned(),
+            value: summary.memory_label.clone(),
+        },
+    ];
+    let context_engine_value = format!(
+        "{} ({})",
+        summary.context_engine_id, summary.context_engine_source
+    );
+    let runtime_items = vec![
+        TuiKeyValueSpec::Plain {
+            key: "context engine".to_owned(),
+            value: context_engine_value,
+        },
+        TuiKeyValueSpec::Plain {
+            key: "acp".to_owned(),
+            value: runtime_line,
+        },
+    ];
+    let session_section = TuiSectionSpec::KeyValues {
+        title: Some("session details".to_owned()),
+        items: session_items,
+    };
+    let runtime_section = TuiSectionSpec::KeyValues {
+        title: Some("runtime details".to_owned()),
+        items: runtime_items,
+    };
+    let continuity_section = TuiSectionSpec::KeyValues {
+        title: Some("continuity maintenance".to_owned()),
+        items: vec![
+            TuiKeyValueSpec::Plain {
+                key: "compaction".to_owned(),
+                value: summary.compaction_enabled.to_string(),
+            },
+            TuiKeyValueSpec::Plain {
+                key: "min messages".to_owned(),
+                value: compaction_min_messages,
+            },
+            TuiKeyValueSpec::Plain {
+                key: "trigger tokens".to_owned(),
+                value: compaction_trigger_estimated_tokens,
+            },
+            TuiKeyValueSpec::Plain {
+                key: "preserve recent".to_owned(),
+                value: summary.compaction_preserve_recent_turns.to_string(),
+            },
+            TuiKeyValueSpec::Plain {
+                key: "fail open".to_owned(),
+                value: summary.compaction_fail_open.to_string(),
+            },
+        ],
+    };
+    let mut sections = vec![session_section, runtime_section, continuity_section];
+
+    if summary.explicit_acp_request
+        || summary.event_stream_enabled
+        || !summary.bootstrap_mcp_servers.is_empty()
+        || summary.working_directory.is_some()
+    {
+        let bootstrap_label = if summary.bootstrap_mcp_servers.is_empty() {
+            "-".to_owned()
+        } else {
+            summary.bootstrap_mcp_servers.join(",")
+        };
+        let cwd_label = summary.working_directory.as_deref().unwrap_or("-");
+        let override_lines = vec![
+            format!("explicit request: {}", summary.explicit_acp_request),
+            format!("event stream: {}", summary.event_stream_enabled),
+            format!("bootstrap MCP servers: {bootstrap_label}"),
+            format!("working directory: {cwd_label}"),
+        ];
+        sections.push(TuiSectionSpec::Callout {
+            tone: TuiCalloutTone::Info,
+            title: Some("acp overrides".to_owned()),
+            lines: override_lines,
+        });
+    }
+
+    sections
+}
+
+pub(super) fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
+    let message_spec = build_cli_chat_help_message_spec();
+    render_tui_message_spec(&message_spec, width)
+}
+
+fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
+    let command_items = vec![
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_HELP_COMMAND.to_owned(),
+            value: "show chat commands".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_COMPACT_COMMAND.to_owned(),
+            value: "write a continuity-safe checkpoint into the active window".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_STATUS_COMMAND.to_owned(),
+            value: "show session, runtime, compaction, and durability status".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_HISTORY_COMMAND.to_owned(),
+            value: "print the current session sliding window".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "/fast_lane_summary [limit]".to_owned(),
+            value: "summarize fast-lane batch execution events".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "/safe_lane_summary [limit]".to_owned(),
+            value: "summarize safe-lane runtime events".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "/turn_checkpoint_summary [limit]".to_owned(),
+            value: "summarize durable turn finalization state".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND.to_owned(),
+            value: "repair durable turn finalization tail when safe".to_owned(),
+        },
+        TuiKeyValueSpec::Plain {
+            key: "/exit".to_owned(),
+            value: "quit chat".to_owned(),
+        },
+    ];
+    let note_lines = vec![
+        "Type any non-command text to send a normal assistant turn.".to_owned(),
+        "Use /status to inspect runtime maintenance settings without sending a turn.".to_owned(),
+        "Use /history to inspect the active memory window when a reply feels off.".to_owned(),
+        "Use /compact to checkpoint the active session before the next turn.".to_owned(),
+    ];
+
+    TuiMessageSpec {
+        role: "chat".to_owned(),
+        caption: Some("commands".to_owned()),
+        sections: vec![
+            TuiSectionSpec::KeyValues {
+                title: Some("slash commands".to_owned()),
+                items: command_items,
+            },
+            TuiSectionSpec::Callout {
+                tone: TuiCalloutTone::Info,
+                title: Some("usage notes".to_owned()),
+                lines: note_lines,
+            },
+        ],
+        footer_lines: Vec::new(),
+    }
+}
+
+pub(super) fn print_help() {
+    let render_width = detect_cli_chat_render_width();
+    let rendered_lines = render_cli_chat_help_lines_with_width(render_width);
+    print_rendered_cli_chat_lines(&rendered_lines);
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+pub(super) fn render_manual_compaction_lines_with_width(
+    session_id: &str,
+    result: &ManualCompactionResult,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_manual_compaction_message_spec(session_id, result);
+    render_tui_message_spec(&message_spec, width)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_manual_compaction_message_spec(
+    session_id: &str,
+    result: &ManualCompactionResult,
+) -> TuiMessageSpec {
+    let caption = format!("session={session_id}");
+    let status = format_manual_compaction_status(result.status).to_owned();
+    let estimated_tokens_before = format_manual_compaction_tokens(result.estimated_tokens_before);
+    let estimated_tokens_after = format_manual_compaction_tokens(result.estimated_tokens_after);
+    let tone = manual_compaction_tone(result.status);
+
+    let result_section = TuiSectionSpec::KeyValues {
+        title: Some("compaction result".to_owned()),
+        items: vec![
+            tui_plain_item("status", status),
+            tui_plain_item("before turns", result.before_turns.to_string()),
+            tui_plain_item("after turns", result.after_turns.to_string()),
+            tui_plain_item("tokens before", estimated_tokens_before),
+            tui_plain_item("tokens after", estimated_tokens_after),
+            tui_plain_item(
+                "summary",
+                result
+                    .summary_headline
+                    .clone()
+                    .unwrap_or_else(|| "-".to_owned()),
+            ),
+        ],
+    };
+
+    let detail_section = TuiSectionSpec::Callout {
+        tone,
+        title: Some("details".to_owned()),
+        lines: vec![result.detail.clone()],
+    };
+
+    TuiMessageSpec {
+        role: "compact".to_owned(),
+        caption: Some(caption),
+        sections: vec![result_section, detail_section],
+        footer_lines: Vec::new(),
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_manual_compaction_status(status: ManualCompactionStatus) -> &'static str {
+    match status {
+        ManualCompactionStatus::Applied => "applied",
+        ManualCompactionStatus::NoChange => "no_change",
+        ManualCompactionStatus::FailedOpen => "failed_open",
+    }
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_manual_compaction_tokens(value: Option<usize>) -> String {
+    let Some(value) = value else {
+        return "-".to_owned();
+    };
+
+    value.to_string()
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn manual_compaction_tone(status: ManualCompactionStatus) -> TuiCalloutTone {
+    match status {
+        ManualCompactionStatus::Applied => TuiCalloutTone::Success,
+        ManualCompactionStatus::NoChange => TuiCalloutTone::Info,
+        ManualCompactionStatus::FailedOpen => TuiCalloutTone::Warning,
+    }
+}
+
+pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let binding = ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
+        let result = load_manual_compaction_result(
+            &runtime.config,
+            &runtime.session_id,
+            &runtime.turn_coordinator,
+            binding,
+            &runtime.memory_config,
+        )
+        .await?;
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines =
+            render_manual_compaction_lines_with_width(&runtime.session_id, &result, render_width);
+
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = runtime;
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
+            "compact",
+            "manual compaction unavailable: memory-sqlite feature disabled",
+            render_width,
+        );
+
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) async fn load_manual_compaction_result(
+    config: &LoongClawConfig,
+    session_id: &str,
+    turn_coordinator: &ConversationTurnCoordinator,
+    binding: ConversationRuntimeBinding<'_>,
+    _memory_config: &MemoryRuntimeConfig,
+) -> CliResult<ManualCompactionResult> {
+    let before_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
+    let before_turns = resolve_manual_compaction_turn_count(&before_snapshot);
+    let report = turn_coordinator
+        .compact_session(config, session_id, binding)
+        .await?;
+    let after_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
+    let after_turns = resolve_manual_compaction_turn_count(&after_snapshot);
+    let summary_headline = extract_manual_compaction_summary_headline(&after_snapshot);
+    let status = manual_compaction_status_from_report(&report)?;
+    let detail = build_manual_compaction_detail(status, &summary_headline);
+
+    Ok(ManualCompactionResult {
+        status,
+        before_turns,
+        after_turns,
+        estimated_tokens_before: report.estimated_tokens_before,
+        estimated_tokens_after: report.estimated_tokens_after,
+        summary_headline,
+        detail,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_manual_compaction_window_snapshot(
+    session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<ManualCompactionWindowSnapshot> {
+    const MAX_MANUAL_COMPACTION_WINDOW_TURNS: usize = 512;
+
+    let kernel_ctx = binding
+        .kernel_context()
+        .ok_or_else(|| "manual compaction requires a kernel-bound session".to_owned())?;
+    let caps = BTreeSet::from([Capability::MemoryRead]);
+    let request = loongclaw_contracts::MemoryCoreRequest {
+        operation: memory::MEMORY_OP_WINDOW.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "limit": MAX_MANUAL_COMPACTION_WINDOW_TURNS,
+            "allow_extended_limit": true,
+        }),
+    };
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| format!("load compaction window via kernel failed: {error}"))?;
+
+    if outcome.status != "ok" {
+        let status = outcome.status;
+        let message = format!("load compaction window via kernel returned non-ok status: {status}");
+        return Err(message);
+    }
+
+    let turns = memory::decode_window_turns(&outcome.payload);
+    let turn_count = memory::decode_window_turn_count(&outcome.payload);
+
+    Ok(ManualCompactionWindowSnapshot { turns, turn_count })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_manual_compaction_turn_count(snapshot: &ManualCompactionWindowSnapshot) -> usize {
+    snapshot.turn_count.unwrap_or(snapshot.turns.len())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn extract_manual_compaction_summary_headline(
+    snapshot: &ManualCompactionWindowSnapshot,
+) -> Option<String> {
+    let first_turn = snapshot.turns.first()?;
+    let content = first_turn.content.trim();
+    if !content.starts_with("Compacted ") {
+        return None;
+    }
+
+    let headline = content.lines().next()?.trim();
+    Some(headline.to_owned())
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+pub(super) fn manual_compaction_status_from_report(
+    report: &ContextCompactionReport,
+) -> CliResult<ManualCompactionStatus> {
+    if report.was_applied() {
+        return Ok(ManualCompactionStatus::Applied);
+    }
+
+    if report.was_skipped() {
+        return Ok(ManualCompactionStatus::NoChange);
+    }
+
+    if report.was_failed_open() {
+        return Ok(ManualCompactionStatus::FailedOpen);
+    }
+
+    let status_label = report.status_label();
+    let message = format!("manual compaction returned unexpected status: {status_label}");
+    Err(message)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_manual_compaction_detail(
+    status: ManualCompactionStatus,
+    summary_headline: &Option<String>,
+) -> String {
+    let continuity_note = runtime_self_continuity::compaction_summary_scope_note();
+    match status {
+        ManualCompactionStatus::Applied => match summary_headline {
+            Some(headline) => {
+                format!("{headline}. {continuity_note}")
+            }
+            None => {
+                format!(
+                    "Compaction completed and the active session window was rewritten. {continuity_note}"
+                )
+            }
+        },
+        ManualCompactionStatus::NoChange => {
+            "No compaction change applied. The active session was already summarized or already compact enough."
+                .to_owned()
+        }
+        ManualCompactionStatus::FailedOpen => {
+            "Compaction failed open and left the current history unchanged. Inspect /status and /history before continuing."
+                .to_owned()
+        }
+    }
+}
+
+pub(super) fn parse_exact_chat_command(
+    input: &str,
+    aliases: &[&str],
+    usage: &str,
+) -> CliResult<bool> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(false);
+    }
+
+    let mut tokens = trimmed.split_whitespace();
+    let Some(command) = tokens.next() else {
+        return Ok(false);
+    };
+    if !aliases.contains(&command) {
+        return Ok(false);
+    }
+
+    if tokens.next().is_some() {
+        return Err(usage.to_owned());
+    }
+
+    Ok(true)
+}
+
+pub(super) fn is_manual_compaction_command(input: &str) -> CliResult<bool> {
+    let aliases = [CLI_CHAT_COMPACT_COMMAND];
+    let usage = "usage: /compact";
+    parse_exact_chat_command(input, &aliases, usage)
+}
+
+pub(super) fn is_cli_chat_status_command(input: &str) -> CliResult<bool> {
+    let aliases = [CLI_CHAT_STATUS_COMMAND];
+    let usage = "usage: /status";
+    parse_exact_chat_command(input, &aliases, usage)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+pub(super) fn render_turn_checkpoint_startup_health_lines_with_width(
+    session_id: &str,
+    diagnostics: &TurnCheckpointDiagnostics,
+    width: usize,
+) -> Option<Vec<String>> {
+    let message_spec = build_turn_checkpoint_health_message_spec(
+        session_id,
+        diagnostics,
+        /*always_emit*/ false,
+    )?;
+    let rendered_lines = render_tui_message_spec(&message_spec, width);
+
+    Some(rendered_lines)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+pub(super) fn render_turn_checkpoint_status_health_lines_with_width(
+    session_id: &str,
+    diagnostics: &TurnCheckpointDiagnostics,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_turn_checkpoint_health_message_spec(
+        session_id,
+        diagnostics,
+        /*always_emit*/ true,
+    );
+    let message_spec = match message_spec {
+        Some(message_spec) => message_spec,
+        None => {
+            let caption = format!("session={session_id}");
+            let detail_line = "checkpoint diagnostics unavailable".to_owned();
+            return render_tui_message_spec(
+                &TuiMessageSpec {
+                    role: "checkpoint".to_owned(),
+                    caption: Some(caption),
+                    sections: vec![TuiSectionSpec::Callout {
+                        tone: TuiCalloutTone::Info,
+                        title: Some("durability status".to_owned()),
+                        lines: vec![detail_line],
+                    }],
+                    footer_lines: Vec::new(),
+                },
+                width,
+            );
+        }
+    };
+
+    render_tui_message_spec(&message_spec, width)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_turn_checkpoint_health_message_spec(
+    session_id: &str,
+    diagnostics: &TurnCheckpointDiagnostics,
+    always_emit: bool,
+) -> Option<TuiMessageSpec> {
+    let summary = diagnostics.summary();
+    if !always_emit && !summary.checkpoint_durable {
+        return None;
+    }
+
+    let render_labels = TurnCheckpointSummaryRenderLabels::from_summary(summary);
+    let durability_labels = TurnCheckpointDurabilityRenderLabels::from_summary(summary);
+    let recovery_labels =
+        TurnCheckpointRecoveryRenderLabels::from_assessment(diagnostics.recovery());
+    let failure_step = format_turn_checkpoint_failure_step(summary.latest_failure_step);
+    let recovery_needed = bool_yes_no_value(summary.requires_recovery);
+    let reply_durable = bool_yes_no_value(summary.reply_durable);
+    let checkpoint_durable = bool_yes_no_value(summary.checkpoint_durable);
+    let recovery_tone = recovery_callout_tone(summary.requires_recovery);
+    let caption = format!("session={session_id}");
+    let recovery_reason = recovery_labels.reason.to_owned();
+
+    let mut sections = vec![
+        TuiSectionSpec::KeyValues {
+            title: Some("durability status".to_owned()),
+            items: vec![
+                tui_plain_item("state", render_labels.session_state.to_owned()),
+                tui_plain_item("durability", durability_labels.durability.to_owned()),
+                tui_plain_item("reply durable", reply_durable),
+                tui_plain_item("checkpoint durable", checkpoint_durable),
+            ],
+        },
+        TuiSectionSpec::Callout {
+            tone: recovery_tone,
+            title: Some("recovery".to_owned()),
+            lines: vec![
+                format!("recovery needed: {recovery_needed}"),
+                format!("action: {}", recovery_labels.action),
+                format!("source: {}", recovery_labels.source),
+                format!("reason: {recovery_reason}"),
+            ],
+        },
+        TuiSectionSpec::KeyValues {
+            title: Some("latest turn".to_owned()),
+            items: vec![
+                tui_plain_item("stage", render_labels.stage.to_owned()),
+                tui_plain_item("after turn", render_labels.after_turn.to_owned()),
+                tui_plain_item("compaction", render_labels.compaction.to_owned()),
+                tui_plain_item("lane", render_labels.lane.to_owned()),
+                tui_plain_item("result kind", render_labels.result_kind.to_owned()),
+                tui_plain_item(
+                    "persistence mode",
+                    render_labels.persistence_mode.to_owned(),
+                ),
+                tui_plain_item("identity", render_labels.identity.to_owned()),
+                tui_plain_item("failure step", failure_step.to_owned()),
+            ],
+        },
+    ];
+
+    if render_labels.safe_lane_route_decision != "-"
+        || render_labels.safe_lane_route_reason != "-"
+        || render_labels.safe_lane_route_source != "-"
+    {
+        sections.push(TuiSectionSpec::KeyValues {
+            title: Some("safe-lane route".to_owned()),
+            items: vec![
+                tui_plain_item(
+                    "decision",
+                    render_labels.safe_lane_route_decision.to_owned(),
+                ),
+                tui_plain_item("reason", render_labels.safe_lane_route_reason.to_owned()),
+                tui_plain_item("source", render_labels.safe_lane_route_source.to_owned()),
+            ],
+        });
+    }
+
+    if let Some(probe) = diagnostics.runtime_probe() {
+        let probe_lines = vec![
+            format!("action: {}", probe.action().as_str()),
+            format!("source: {}", probe.source().as_str()),
+            format!("reason: {}", probe.reason().as_str()),
+        ];
+
+        sections.push(TuiSectionSpec::Callout {
+            tone: TuiCalloutTone::Info,
+            title: Some("runtime probe".to_owned()),
+            lines: probe_lines,
+        });
+    }
+
+    Some(TuiMessageSpec {
+        role: "checkpoint".to_owned(),
+        caption: Some(caption),
+        sections,
+        footer_lines: Vec::new(),
+    })
+}

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 #[cfg(feature = "memory-sqlite")]
 use std::collections::BTreeSet;
 
@@ -8,11 +6,126 @@ use loongclaw_contracts::Capability;
 #[cfg(feature = "memory-sqlite")]
 use serde_json::json;
 
-use crate::conversation::{
-    collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
-};
+use crate::CliResult;
+use crate::acp::resolve_acp_backend_selection;
+use crate::config;
+use crate::config::LoongClawConfig;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use crate::conversation::ContextCompactionReport;
+use crate::conversation::ConversationRuntimeBinding;
+use crate::conversation::ConversationTurnCoordinator;
+use crate::conversation::collect_context_engine_runtime_snapshot;
+use crate::conversation::resolve_context_engine_selection;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use crate::memory;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(any(test, feature = "memory-sqlite"))]
 use crate::runtime_self_continuity;
+use crate::tui_surface::TuiActionSpec;
+use crate::tui_surface::TuiCalloutTone;
+use crate::tui_surface::TuiChoiceSpec;
+use crate::tui_surface::TuiHeaderStyle;
+use crate::tui_surface::TuiKeyValueSpec;
+use crate::tui_surface::TuiMessageSpec;
+use crate::tui_surface::TuiScreenSpec;
+use crate::tui_surface::TuiSectionSpec;
+use crate::tui_surface::render_tui_message_spec;
+use crate::tui_surface::render_tui_screen_spec;
 
+use super::CLI_CHAT_COMPACT_COMMAND;
+use super::CLI_CHAT_HELP_COMMAND;
+use super::CLI_CHAT_HISTORY_COMMAND;
+use super::CLI_CHAT_STATUS_COMMAND;
+use super::CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND;
+use super::CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS;
+use super::CliChatOptions;
+use super::CliTurnRuntime;
+use super::DEFAULT_FIRST_PROMPT;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::TurnCheckpointDiagnostics;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::TurnCheckpointDurabilityRenderLabels;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::TurnCheckpointRecoveryRenderLabels;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::TurnCheckpointSummaryRenderLabels;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::bool_yes_no_value;
+use super::detect_cli_chat_render_width;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::format_turn_checkpoint_failure_step;
+use super::print_rendered_cli_chat_lines;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::recovery_callout_tone;
+#[cfg(not(feature = "memory-sqlite"))]
+use super::render_cli_chat_feature_unavailable_lines_with_width;
+#[cfg(any(test, feature = "memory-sqlite"))]
+use super::render_turn_checkpoint_health_error_lines_with_width;
+use super::tui_plain_item;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatStartupSummary {
+    pub(super) config_path: String,
+    pub(super) memory_label: String,
+    pub(super) session_id: String,
+    pub(super) context_engine_id: String,
+    pub(super) context_engine_source: String,
+    pub(super) compaction_enabled: bool,
+    pub(super) compaction_min_messages: Option<usize>,
+    pub(super) compaction_trigger_estimated_tokens: Option<usize>,
+    pub(super) compaction_preserve_recent_turns: usize,
+    pub(super) compaction_fail_open: bool,
+    pub(super) acp_enabled: bool,
+    pub(super) dispatch_enabled: bool,
+    pub(super) conversation_routing: String,
+    pub(super) allowed_channels: Vec<String>,
+    pub(super) acp_backend_id: String,
+    pub(super) acp_backend_source: String,
+    pub(super) explicit_acp_request: bool,
+    pub(super) event_stream_enabled: bool,
+    pub(super) bootstrap_mcp_servers: Vec<String>,
+    pub(super) working_directory: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ManualCompactionResult {
+    pub(super) status: ManualCompactionStatus,
+    pub(super) before_turns: usize,
+    pub(super) after_turns: usize,
+    pub(super) estimated_tokens_before: Option<usize>,
+    pub(super) estimated_tokens_after: Option<usize>,
+    pub(super) summary_headline: Option<String>,
+    pub(super) detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ManualCompactionStatus {
+    Applied,
+    NoChange,
+    FailedOpen,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManualCompactionWindowSnapshot {
+    turns: Vec<memory::WindowTurn>,
+    turn_count: Option<usize>,
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+pub(super) fn print_cli_chat_startup(
+    runtime: &CliTurnRuntime,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let summary = build_cli_chat_startup_summary(runtime, options)?;
+    for line in render_cli_chat_startup_lines(&summary) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+#[allow(clippy::print_stdout)] // CLI output
 pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
     #[cfg(feature = "memory-sqlite")]
     let render_width = detect_cli_chat_render_width();
@@ -103,7 +216,6 @@ pub(super) fn build_cli_chat_startup_summary(
     let context_engine_runtime = collect_context_engine_runtime_snapshot(&runtime.config)?;
     let compaction = context_engine_runtime.compaction;
     let acp_selection = resolve_acp_backend_selection(&runtime.config);
-
     Ok(CliChatStartupSummary {
         config_path: runtime.resolved_path.display().to_string(),
         memory_label: runtime.memory_label.clone(),
@@ -140,9 +252,106 @@ pub(super) fn build_cli_chat_startup_summary(
     })
 }
 
-pub(super) fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
+fn render_cli_chat_startup_lines(summary: &CliChatStartupSummary) -> Vec<String> {
     let render_width = detect_cli_chat_render_width();
     render_cli_chat_startup_lines_with_width(summary, render_width)
+}
+
+pub(super) fn should_run_missing_config_onboard(read: usize, input: &str) -> bool {
+    if read == 0 {
+        return false;
+    }
+
+    let normalized_input = input.trim().to_ascii_lowercase();
+
+    if normalized_input.is_empty() {
+        return true;
+    }
+
+    matches!(normalized_input.as_str(), "y" | "yes")
+}
+
+pub(super) fn render_cli_chat_missing_config_lines_with_width(
+    onboard_hint: &str,
+    width: usize,
+) -> Vec<String> {
+    let screen_spec = build_cli_chat_missing_config_screen_spec(onboard_hint);
+    render_tui_screen_spec(&screen_spec, width, false)
+}
+
+fn build_cli_chat_missing_config_screen_spec(onboard_hint: &str) -> TuiScreenSpec {
+    let intro_lines = vec![
+        format!("Welcome to {}!", config::PRODUCT_DISPLAY_NAME),
+        "No configuration found for interactive chat.".to_owned(),
+    ];
+    let sections = vec![TuiSectionSpec::ActionGroup {
+        title: Some("setup command".to_owned()),
+        inline_title_when_wide: true,
+        items: vec![TuiActionSpec {
+            label: "start setup".to_owned(),
+            command: onboard_hint.to_owned(),
+        }],
+    }];
+    let choices = vec![
+        TuiChoiceSpec {
+            key: "y".to_owned(),
+            label: "run setup wizard".to_owned(),
+            detail_lines: vec!["Create a config now and return to interactive chat.".to_owned()],
+            recommended: true,
+        },
+        TuiChoiceSpec {
+            key: "n".to_owned(),
+            label: "skip for now".to_owned(),
+            detail_lines: vec!["Exit chat now and keep the setup command for later.".to_owned()],
+            recommended: false,
+        },
+    ];
+    let footer_lines = vec!["Press Enter to accept y.".to_owned()];
+
+    TuiScreenSpec {
+        header_style: TuiHeaderStyle::Compact,
+        subtitle: Some("interactive chat".to_owned()),
+        title: Some("setup required".to_owned()),
+        progress_line: None,
+        intro_lines,
+        sections,
+        choices,
+        footer_lines,
+    }
+}
+
+pub(super) fn render_cli_chat_missing_config_decline_lines_with_width(
+    onboard_hint: &str,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_missing_config_decline_message_spec(onboard_hint);
+    render_tui_message_spec(&message_spec, width)
+}
+
+fn build_cli_chat_missing_config_decline_message_spec(onboard_hint: &str) -> TuiMessageSpec {
+    let setup_hint = format!("You can run '{onboard_hint}' later to get started.");
+    let sections = vec![
+        TuiSectionSpec::Callout {
+            tone: TuiCalloutTone::Info,
+            title: Some("setup skipped".to_owned()),
+            lines: vec![setup_hint],
+        },
+        TuiSectionSpec::ActionGroup {
+            title: Some("start later".to_owned()),
+            inline_title_when_wide: true,
+            items: vec![TuiActionSpec {
+                label: "setup command".to_owned(),
+                command: onboard_hint.to_owned(),
+            }],
+        },
+    ];
+
+    TuiMessageSpec {
+        role: "chat".to_owned(),
+        caption: Some("setup required".to_owned()),
+        sections,
+        footer_lines: Vec::new(),
+    }
 }
 
 pub(super) fn render_cli_chat_startup_lines_with_width(
@@ -162,21 +371,21 @@ pub(super) fn render_cli_chat_status_lines_with_width(
 }
 
 fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScreenSpec {
-    let mut sections = vec![
-        TuiSectionSpec::ActionGroup {
-            title: Some("start here".to_owned()),
-            inline_title_when_wide: true,
-            items: vec![TuiActionSpec {
-                label: "first prompt".to_owned(),
-                command: DEFAULT_FIRST_PROMPT.to_owned(),
-            }],
-        },
-        TuiSectionSpec::Narrative {
-            title: None,
-            lines: vec!["- type your request, or use /help for commands".to_owned()],
-        },
-    ];
+    let first_prompt_action = TuiActionSpec {
+        label: "first prompt".to_owned(),
+        command: DEFAULT_FIRST_PROMPT.to_owned(),
+    };
+    let start_here_section = TuiSectionSpec::ActionGroup {
+        title: Some("start here".to_owned()),
+        inline_title_when_wide: true,
+        items: vec![first_prompt_action],
+    };
+    let narrative_section = TuiSectionSpec::Narrative {
+        title: None,
+        lines: vec!["- type your request, or use /help for commands".to_owned()],
+    };
     let runtime_sections = build_cli_chat_runtime_sections(summary);
+    let mut sections = vec![start_here_section, narrative_section];
     sections.extend(runtime_sections);
 
     TuiScreenSpec {
@@ -225,7 +434,7 @@ fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSe
         .compaction_trigger_estimated_tokens
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_owned());
-    let runtime_line = format!(
+    let runtime_value = format!(
         "ACP enabled={} dispatch_enabled={} routing={} backend={} ({}) allowed_channels={allowed_channels}",
         summary.acp_enabled,
         summary.dispatch_enabled,
@@ -233,65 +442,36 @@ fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSe
         summary.acp_backend_id,
         summary.acp_backend_source,
     );
-    let session_items = vec![
-        TuiKeyValueSpec::Plain {
-            key: "session".to_owned(),
-            value: summary.session_id.clone(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "config".to_owned(),
-            value: summary.config_path.clone(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "memory".to_owned(),
-            value: summary.memory_label.clone(),
-        },
-    ];
     let context_engine_value = format!(
         "{} ({})",
         summary.context_engine_id, summary.context_engine_source
     );
-    let runtime_items = vec![
-        TuiKeyValueSpec::Plain {
-            key: "context engine".to_owned(),
-            value: context_engine_value,
-        },
-        TuiKeyValueSpec::Plain {
-            key: "acp".to_owned(),
-            value: runtime_line,
-        },
-    ];
     let session_section = TuiSectionSpec::KeyValues {
         title: Some("session details".to_owned()),
-        items: session_items,
+        items: vec![
+            tui_plain_item("session", summary.session_id.clone()),
+            tui_plain_item("config", summary.config_path.clone()),
+            tui_plain_item("memory", summary.memory_label.clone()),
+        ],
     };
     let runtime_section = TuiSectionSpec::KeyValues {
         title: Some("runtime details".to_owned()),
-        items: runtime_items,
+        items: vec![
+            tui_plain_item("context engine", context_engine_value),
+            tui_plain_item("acp", runtime_value),
+        ],
     };
     let continuity_section = TuiSectionSpec::KeyValues {
         title: Some("continuity maintenance".to_owned()),
         items: vec![
-            TuiKeyValueSpec::Plain {
-                key: "compaction".to_owned(),
-                value: summary.compaction_enabled.to_string(),
-            },
-            TuiKeyValueSpec::Plain {
-                key: "min messages".to_owned(),
-                value: compaction_min_messages,
-            },
-            TuiKeyValueSpec::Plain {
-                key: "trigger tokens".to_owned(),
-                value: compaction_trigger_estimated_tokens,
-            },
-            TuiKeyValueSpec::Plain {
-                key: "preserve recent".to_owned(),
-                value: summary.compaction_preserve_recent_turns.to_string(),
-            },
-            TuiKeyValueSpec::Plain {
-                key: "fail open".to_owned(),
-                value: summary.compaction_fail_open.to_string(),
-            },
+            tui_plain_item("compaction", summary.compaction_enabled.to_string()),
+            tui_plain_item("min messages", compaction_min_messages),
+            tui_plain_item("trigger tokens", compaction_trigger_estimated_tokens),
+            tui_plain_item(
+                "preserve recent",
+                summary.compaction_preserve_recent_turns.to_string(),
+            ),
+            tui_plain_item("fail open", summary.compaction_fail_open.to_string()),
         ],
     };
     let mut sections = vec![session_section, runtime_section, continuity_section];
@@ -306,18 +486,19 @@ fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSe
         } else {
             summary.bootstrap_mcp_servers.join(",")
         };
-        let cwd_label = summary.working_directory.as_deref().unwrap_or("-");
+        let working_directory = summary.working_directory.as_deref().unwrap_or("-");
         let override_lines = vec![
             format!("explicit request: {}", summary.explicit_acp_request),
             format!("event stream: {}", summary.event_stream_enabled),
             format!("bootstrap MCP servers: {bootstrap_label}"),
-            format!("working directory: {cwd_label}"),
+            format!("working directory: {working_directory}"),
         ];
-        sections.push(TuiSectionSpec::Callout {
+        let override_callout = TuiSectionSpec::Callout {
             tone: TuiCalloutTone::Info,
             title: Some("acp overrides".to_owned()),
             lines: override_lines,
-        });
+        };
+        sections.push(override_callout);
     }
 
     sections
@@ -367,38 +548,59 @@ fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
             value: "quit chat".to_owned(),
         },
     ];
-    let note_lines = vec![
-        "Type any non-command text to send a normal assistant turn.".to_owned(),
-        "Use /status to inspect runtime maintenance settings without sending a turn.".to_owned(),
-        "Use /history to inspect the active memory window when a reply feels off.".to_owned(),
-        "Use /compact to checkpoint the active session before the next turn.".to_owned(),
-    ];
+    let usage_section = TuiSectionSpec::Callout {
+        tone: TuiCalloutTone::Info,
+        title: Some("usage notes".to_owned()),
+        lines: vec![
+            "Type any non-command text to send a normal assistant turn.".to_owned(),
+            "Use /status to inspect runtime maintenance settings without sending a turn."
+                .to_owned(),
+            "Use /history to inspect the active memory window when a reply feels off.".to_owned(),
+            "Use /compact to checkpoint the active session before the next turn.".to_owned(),
+        ],
+    };
+    let command_section = TuiSectionSpec::KeyValues {
+        title: Some("slash commands".to_owned()),
+        items: command_items,
+    };
 
     TuiMessageSpec {
         role: "chat".to_owned(),
         caption: Some("commands".to_owned()),
-        sections: vec![
-            TuiSectionSpec::KeyValues {
-                title: Some("slash commands".to_owned()),
-                items: command_items,
-            },
-            TuiSectionSpec::Callout {
-                tone: TuiCalloutTone::Info,
-                title: Some("usage notes".to_owned()),
-                lines: note_lines,
-            },
-        ],
+        sections: vec![command_section, usage_section],
         footer_lines: Vec::new(),
     }
 }
 
-pub(super) fn print_help() {
-    let render_width = detect_cli_chat_render_width();
-    let rendered_lines = render_cli_chat_help_lines_with_width(render_width);
-    print_rendered_cli_chat_lines(&rendered_lines);
+pub(super) fn render_cli_chat_history_lines_with_width(
+    session_id: &str,
+    limit: usize,
+    history_lines: &[String],
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_history_message_spec(session_id, limit, history_lines);
+    render_tui_message_spec(&message_spec, width)
 }
 
-#[cfg(any(test, feature = "memory-sqlite"))]
+fn build_cli_chat_history_message_spec(
+    session_id: &str,
+    limit: usize,
+    history_lines: &[String],
+) -> TuiMessageSpec {
+    let caption = format!("session={session_id} limit={limit}");
+    let history_section = TuiSectionSpec::Narrative {
+        title: Some("sliding window".to_owned()),
+        lines: history_lines.to_vec(),
+    };
+
+    TuiMessageSpec {
+        role: "history".to_owned(),
+        caption: Some(caption),
+        sections: vec![history_section],
+        footer_lines: Vec::new(),
+    }
+}
+
 pub(super) fn render_manual_compaction_lines_with_width(
     session_id: &str,
     result: &ManualCompactionResult,
@@ -408,7 +610,6 @@ pub(super) fn render_manual_compaction_lines_with_width(
     render_tui_message_spec(&message_spec, width)
 }
 
-#[cfg(any(test, feature = "memory-sqlite"))]
 fn build_manual_compaction_message_spec(
     session_id: &str,
     result: &ManualCompactionResult,
@@ -418,7 +619,6 @@ fn build_manual_compaction_message_spec(
     let estimated_tokens_before = format_manual_compaction_tokens(result.estimated_tokens_before);
     let estimated_tokens_after = format_manual_compaction_tokens(result.estimated_tokens_after);
     let tone = manual_compaction_tone(result.status);
-
     let result_section = TuiSectionSpec::KeyValues {
         title: Some("compaction result".to_owned()),
         items: vec![
@@ -436,7 +636,6 @@ fn build_manual_compaction_message_spec(
             ),
         ],
     };
-
     let detail_section = TuiSectionSpec::Callout {
         tone,
         title: Some("details".to_owned()),
@@ -451,7 +650,6 @@ fn build_manual_compaction_message_spec(
     }
 }
 
-#[cfg(any(test, feature = "memory-sqlite"))]
 fn format_manual_compaction_status(status: ManualCompactionStatus) -> &'static str {
     match status {
         ManualCompactionStatus::Applied => "applied",
@@ -460,16 +658,13 @@ fn format_manual_compaction_status(status: ManualCompactionStatus) -> &'static s
     }
 }
 
-#[cfg(any(test, feature = "memory-sqlite"))]
 fn format_manual_compaction_tokens(value: Option<usize>) -> String {
     let Some(value) = value else {
         return "-".to_owned();
     };
-
     value.to_string()
 }
 
-#[cfg(any(test, feature = "memory-sqlite"))]
 fn manual_compaction_tone(status: ManualCompactionStatus) -> TuiCalloutTone {
     match status {
         ManualCompactionStatus::Applied => TuiCalloutTone::Success,
@@ -478,6 +673,14 @@ fn manual_compaction_tone(status: ManualCompactionStatus) -> TuiCalloutTone {
     }
 }
 
+#[allow(clippy::print_stdout)] // CLI output
+pub(super) fn print_help() {
+    let render_width = detect_cli_chat_render_width();
+    let rendered_lines = render_cli_chat_help_lines_with_width(render_width);
+    print_rendered_cli_chat_lines(&rendered_lines);
+}
+
+#[allow(clippy::print_stdout)] // CLI output
 pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -493,7 +696,6 @@ pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResu
         let render_width = detect_cli_chat_render_width();
         let rendered_lines =
             render_manual_compaction_lines_with_width(&runtime.session_id, &result, render_width);
-
         print_rendered_cli_chat_lines(&rendered_lines);
         Ok(())
     }
@@ -505,6 +707,41 @@ pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResu
         let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
             "compact",
             "manual compaction unavailable: memory-sqlite feature disabled",
+            render_width,
+        );
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+pub(super) async fn print_history(
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<()> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let history_lines = load_history_lines(session_id, limit, binding, memory_config).await?;
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines = render_cli_chat_history_lines_with_width(
+            session_id,
+            limit,
+            &history_lines,
+            render_width,
+        );
+        print_rendered_cli_chat_lines(&rendered_lines);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, limit, binding);
+        let render_width = detect_cli_chat_render_width();
+        let rendered_lines = render_cli_chat_feature_unavailable_lines_with_width(
+            "history",
+            "history unavailable: memory-sqlite feature disabled",
             render_width,
         );
 
@@ -654,6 +891,151 @@ fn build_manual_compaction_detail(
     }
 }
 
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_window_history_lines(turns: &[memory::WindowTurn]) -> Vec<String> {
+    if turns.is_empty() {
+        return vec!["(no history yet)".to_owned()];
+    }
+
+    turns
+        .iter()
+        .map(|turn| {
+            format!(
+                "[{}] {}: {}",
+                turn.ts.unwrap_or_default(),
+                turn.role,
+                turn.content
+            )
+        })
+        .collect()
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_prompt_context_history_lines(entries: &[memory::MemoryContextEntry]) -> Vec<String> {
+    if entries.is_empty() {
+        return vec!["(no history yet)".to_owned()];
+    }
+
+    let mut lines = Vec::new();
+    for entry in entries {
+        match entry.kind {
+            memory::MemoryContextKind::Profile => {
+                lines.push("[profile]".to_owned());
+                lines.push(entry.content.clone());
+            }
+            memory::MemoryContextKind::Summary => {
+                lines.push("[summary]".to_owned());
+                lines.push(entry.content.clone());
+            }
+            memory::MemoryContextKind::RetrievedMemory => {
+                lines.push("[retrieved_memory]".to_owned());
+                lines.push(entry.content.clone());
+            }
+            memory::MemoryContextKind::Turn => {
+                lines.push(format!("{}: {}", entry.role, entry.content));
+            }
+        }
+    }
+    lines
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) async fn load_history_lines(
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<Vec<String>> {
+    if let Some(ctx) = binding.kernel_context() {
+        let request = memory::build_window_request(session_id, limit);
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        let outcome = ctx
+            .kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await
+            .map_err(|error| format!("load history via kernel failed: {error}"))?;
+        if outcome.status != "ok" {
+            return Err(format!(
+                "load history via kernel returned non-ok status: {}",
+                outcome.status
+            ));
+        }
+        let turns = memory::decode_window_turns(&outcome.payload);
+        return Ok(format_window_history_lines(&turns));
+    }
+
+    let entries = memory::load_prompt_context(session_id, memory_config)
+        .map_err(|error| format!("load history failed: {error}"))?;
+    Ok(format_prompt_context_history_lines(&entries))
+}
+
+pub(super) fn parse_safe_lane_summary_limit(
+    input: &str,
+    default_window: usize,
+) -> CliResult<Option<usize>> {
+    parse_summary_limit(
+        input,
+        default_window,
+        &["/safe_lane_summary", "/safe-lane-summary"],
+    )
+}
+
+pub(super) fn parse_fast_lane_summary_limit(
+    input: &str,
+    default_window: usize,
+) -> CliResult<Option<usize>> {
+    parse_summary_limit(
+        input,
+        default_window,
+        &["/fast_lane_summary", "/fast-lane-summary"],
+    )
+}
+
+pub(super) fn parse_summary_limit(
+    input: &str,
+    default_window: usize,
+    aliases: &[&str],
+) -> CliResult<Option<usize>> {
+    let Some(primary_alias) = aliases.first().copied() else {
+        return Ok(None);
+    };
+
+    let mut tokens = input.split_whitespace();
+    let Some(command) = tokens.next() else {
+        return Ok(None);
+    };
+    if !aliases.contains(&command) {
+        return Ok(None);
+    }
+
+    let usage = format!("usage: {primary_alias} [limit]");
+    let default_limit = default_window.saturating_mul(4).max(64);
+    let limit = match tokens.next() {
+        Some(raw) => raw
+            .parse::<usize>()
+            .map_err(|error| format!("invalid {primary_alias} limit `{raw}`: {error}; {usage}"))?,
+        None => default_limit,
+    };
+    if limit == 0 {
+        return Err(format!("invalid {primary_alias} limit `0`; {usage}"));
+    }
+    if tokens.next().is_some() {
+        return Err(usage);
+    }
+    Ok(Some(limit))
+}
+
+pub(super) fn parse_turn_checkpoint_summary_limit(
+    input: &str,
+    default_window: usize,
+) -> CliResult<Option<usize>> {
+    parse_summary_limit(
+        input,
+        default_window,
+        &["/turn_checkpoint_summary", "/turn-checkpoint-summary"],
+    )
+}
+
 pub(super) fn parse_exact_chat_command(
     input: &str,
     aliases: &[&str],
@@ -688,6 +1070,15 @@ pub(super) fn is_manual_compaction_command(input: &str) -> CliResult<bool> {
 pub(super) fn is_cli_chat_status_command(input: &str) -> CliResult<bool> {
     let aliases = [CLI_CHAT_STATUS_COMMAND];
     let usage = "usage: /status";
+    parse_exact_chat_command(input, &aliases, usage)
+}
+
+pub(super) fn is_turn_checkpoint_repair_command(input: &str) -> CliResult<bool> {
+    let aliases = [
+        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND,
+        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS,
+    ];
+    let usage = "usage: /turn_checkpoint_repair";
     parse_exact_chat_command(input, &aliases, usage)
 }
 

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -127,6 +127,9 @@ pub(super) fn print_cli_chat_startup(
 
 #[allow(clippy::print_stdout)] // CLI output
 pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
+    #[cfg(not(feature = "memory-sqlite"))]
+    let _ = runtime;
+
     #[cfg(feature = "memory-sqlite")]
     let render_width = detect_cli_chat_render_width();
 
@@ -174,6 +177,9 @@ pub(super) async fn print_cli_chat_status(
 }
 
 async fn print_turn_checkpoint_status_health(runtime: &CliTurnRuntime) {
+    #[cfg(not(feature = "memory-sqlite"))]
+    let _ = runtime;
+
     #[cfg(feature = "memory-sqlite")]
     let render_width = detect_cli_chat_render_width();
 
@@ -832,7 +838,7 @@ fn extract_manual_compaction_summary_headline(
 ) -> Option<String> {
     let first_turn = snapshot.turns.first()?;
     let content = first_turn.content.trim();
-    if !content.starts_with("Compacted ") {
+    if !crate::conversation::is_compacted_summary_content(content) {
         return None;
     }
 
@@ -1138,7 +1144,7 @@ fn build_turn_checkpoint_health_message_spec(
     always_emit: bool,
 ) -> Option<TuiMessageSpec> {
     let summary = diagnostics.summary();
-    if !always_emit && !summary.checkpoint_durable {
+    if !always_emit && !summary.checkpoint_durable && !summary.requires_recovery {
         return None;
     }
 

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -690,7 +690,6 @@ pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResu
             &runtime.session_id,
             &runtime.turn_coordinator,
             binding,
-            &runtime.memory_config,
         )
         .await?;
         let render_width = detect_cli_chat_render_width();
@@ -756,7 +755,6 @@ pub(super) async fn load_manual_compaction_result(
     session_id: &str,
     turn_coordinator: &ConversationTurnCoordinator,
     binding: ConversationRuntimeBinding<'_>,
-    _memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<ManualCompactionResult> {
     let before_snapshot = load_manual_compaction_window_snapshot(session_id, binding).await?;
     let before_turns = resolve_manual_compaction_turn_count(&before_snapshot);

--- a/crates/app/src/conversation/compaction.rs
+++ b/crates/app/src/conversation/compaction.rs
@@ -78,8 +78,8 @@ fn render_summary(turns: &[WindowTurn]) -> String {
         .into_iter()
         .filter_map(|idx| all_lines.get(idx).cloned())
         .collect::<Vec<_>>();
-    let omitted_turns = all_lines.len().saturating_sub(selected_lines.len());
-    render_structured_summary(&selected_lines, omitted_turns)
+    let omitted_lines = all_lines.len().saturating_sub(selected_lines.len());
+    render_structured_summary(&selected_lines, omitted_lines)
 }
 
 fn extend_summary_indices(
@@ -181,7 +181,7 @@ struct RenderedSummaryLine {
     is_user: bool,
 }
 
-fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_turns: usize) -> String {
+fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_lines: usize) -> String {
     let mut sections = Vec::new();
     let scope_note = runtime_self_continuity::compaction_summary_scope_note();
     sections.push(scope_note.to_owned());
@@ -192,9 +192,9 @@ fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_turns: usize
     let assistant_lines = collect_summary_group(lines, false);
     append_summary_section(&mut sections, ASSISTANT_PROGRESS_HEADING, &assistant_lines);
 
-    if omitted_turns > 0 {
+    if omitted_lines > 0 {
         let omitted_line =
-            format!("{OMITTED_CONTEXT_PREFIX} {omitted_turns} earlier turns omitted.");
+            format!("{OMITTED_CONTEXT_PREFIX} {omitted_lines} earlier turns omitted.");
         sections.push(omitted_line);
     }
 
@@ -362,15 +362,12 @@ fn trim_to_chars(value: &str, max_chars: usize) -> String {
     let remaining_chars = max_chars - 3;
     let head_chars = remaining_chars / 2;
     let tail_chars = remaining_chars - head_chars;
+    let char_count = value.chars().count();
 
     let prefix = value.chars().take(head_chars).collect::<String>();
     let suffix = value
         .chars()
-        .rev()
-        .take(tail_chars)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
+        .skip(char_count.saturating_sub(tail_chars))
         .collect::<String>();
 
     format!("{prefix}...{suffix}")

--- a/crates/app/src/conversation/compaction.rs
+++ b/crates/app/src/conversation/compaction.rs
@@ -1,8 +1,15 @@
 use crate::memory::WindowTurn;
+use crate::runtime_self_continuity;
 
-const SUMMARY_MAX_RENDERED_TURNS: usize = 4;
+const SUMMARY_MAX_RENDERED_TURNS: usize = 3;
+const SUMMARY_PREFERRED_USER_TURNS: usize = 3;
+const SUMMARY_PREFERRED_ASSISTANT_TURNS: usize = 0;
 const SUMMARY_TURN_EXCERPT_CHARS: usize = 96;
+const SUMMARY_TOTAL_CHARS_MAX: usize = 480;
 const PRIOR_COMPACTED_SUMMARY_PLACEHOLDER: &str = "[prior compacted summary]";
+const USER_CONTEXT_HEADING: &str = "User context:";
+const ASSISTANT_PROGRESS_HEADING: &str = "Assistant progress:";
+const OMITTED_CONTEXT_PREFIX: &str = "More omitted context:";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompactPolicy {
@@ -50,39 +57,170 @@ fn render_summary(turns: &[WindowTurn]) -> String {
         .iter()
         .flat_map(render_summary_lines)
         .collect::<Vec<_>>();
-    let mut selected_indices = all_lines
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, line)| line.is_user.then_some(idx))
-        .take(SUMMARY_MAX_RENDERED_TURNS)
-        .collect::<Vec<_>>();
-    if selected_indices.len() < SUMMARY_MAX_RENDERED_TURNS {
-        let remaining = SUMMARY_MAX_RENDERED_TURNS - selected_indices.len();
-        selected_indices.extend(
-            all_lines
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, line)| (!line.is_user).then_some(idx))
-                .take(remaining),
-        );
-    }
+    let mut selected_indices = Vec::new();
+    extend_summary_indices(
+        &mut selected_indices,
+        &all_lines,
+        /*want_user*/ true,
+        SUMMARY_PREFERRED_USER_TURNS,
+    );
+    extend_summary_indices(
+        &mut selected_indices,
+        &all_lines,
+        /*want_user*/ false,
+        SUMMARY_PREFERRED_ASSISTANT_TURNS,
+    );
+    let remaining = SUMMARY_MAX_RENDERED_TURNS.saturating_sub(selected_indices.len());
+    extend_remaining_summary_indices(&mut selected_indices, &all_lines, remaining);
     selected_indices.sort_unstable();
 
-    let mut lines = selected_indices
+    let selected_lines = selected_indices
         .into_iter()
-        .filter_map(|idx| all_lines.get(idx).map(|line| line.text.clone()))
+        .filter_map(|idx| all_lines.get(idx).cloned())
         .collect::<Vec<_>>();
-    let omitted_turns = all_lines.len().saturating_sub(lines.len());
-    if omitted_turns > 0 {
-        lines.push(format!("... {} earlier turns omitted", omitted_turns));
+    let omitted_turns = all_lines.len().saturating_sub(selected_lines.len());
+    render_structured_summary(&selected_lines, omitted_turns)
+}
+
+fn extend_summary_indices(
+    selected_indices: &mut Vec<usize>,
+    all_lines: &[RenderedSummaryLine],
+    want_user: bool,
+    limit: usize,
+) {
+    if limit == 0 {
+        return;
     }
-    lines.join("\n")
+
+    let matching_indices = all_lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (line.is_user == want_user).then_some(index));
+    let matching_indices = matching_indices.collect::<Vec<_>>();
+    let balanced_indices = select_balanced_indices(&matching_indices, limit);
+
+    for index in balanced_indices {
+        if selected_indices.len() >= SUMMARY_MAX_RENDERED_TURNS {
+            return;
+        }
+
+        if selected_indices.contains(&index) {
+            continue;
+        }
+
+        selected_indices.push(index);
+    }
+}
+
+fn extend_remaining_summary_indices(
+    selected_indices: &mut Vec<usize>,
+    all_lines: &[RenderedSummaryLine],
+    remaining: usize,
+) {
+    if remaining == 0 {
+        return;
+    }
+
+    let all_indices = all_lines.iter().enumerate().map(|(index, _line)| index);
+    for index in all_indices {
+        if selected_indices.len() >= SUMMARY_MAX_RENDERED_TURNS {
+            return;
+        }
+
+        if selected_indices.contains(&index) {
+            continue;
+        }
+
+        selected_indices.push(index);
+    }
+}
+
+fn select_balanced_indices(indices: &[usize], limit: usize) -> Vec<usize> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    if indices.len() <= limit {
+        return indices.to_vec();
+    }
+
+    let leading_count = limit / 2;
+    let trailing_count = limit.saturating_sub(leading_count);
+    let trailing_start = indices.len().saturating_sub(trailing_count);
+
+    let mut selected = Vec::with_capacity(limit);
+    let leading_indices = indices.iter().take(leading_count).copied();
+    selected.extend(leading_indices);
+    let trailing_indices = indices.iter().skip(trailing_start).copied();
+    selected.extend(trailing_indices);
+    selected.sort_unstable();
+    selected.dedup();
+
+    if selected.len() >= limit {
+        return selected;
+    }
+
+    for index in indices {
+        if selected.contains(index) {
+            continue;
+        }
+
+        selected.push(*index);
+
+        if selected.len() == limit {
+            break;
+        }
+    }
+
+    selected.sort_unstable();
+    selected
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RenderedSummaryLine {
     text: String,
     is_user: bool,
+}
+
+fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_turns: usize) -> String {
+    let mut sections = Vec::new();
+    let scope_note = runtime_self_continuity::compaction_summary_scope_note();
+    sections.push(scope_note.to_owned());
+
+    let user_lines = collect_summary_group(lines, true);
+    append_summary_section(&mut sections, USER_CONTEXT_HEADING, &user_lines);
+
+    let assistant_lines = collect_summary_group(lines, false);
+    append_summary_section(&mut sections, ASSISTANT_PROGRESS_HEADING, &assistant_lines);
+
+    if omitted_turns > 0 {
+        let omitted_line =
+            format!("{OMITTED_CONTEXT_PREFIX} {omitted_turns} earlier turns omitted.");
+        sections.push(omitted_line);
+    }
+
+    let rendered = sections.join("\n");
+    trim_to_chars(&rendered, SUMMARY_TOTAL_CHARS_MAX)
+}
+
+fn collect_summary_group(lines: &[RenderedSummaryLine], is_user: bool) -> Vec<String> {
+    lines
+        .iter()
+        .filter(|line| line.is_user == is_user)
+        .map(|line| line.text.clone())
+        .collect::<Vec<_>>()
+}
+
+fn append_summary_section(sections: &mut Vec<String>, heading: &str, lines: &[String]) {
+    if lines.is_empty() {
+        return;
+    }
+
+    sections.push(heading.to_owned());
+
+    for line in lines {
+        let bullet_line = format!("- {line}");
+        sections.push(bullet_line);
+    }
 }
 
 fn render_summary_lines(turn: &WindowTurn) -> Vec<RenderedSummaryLine> {
@@ -143,11 +281,16 @@ fn extract_prior_summary_lines(content: &str) -> Vec<RenderedSummaryLine> {
 
 fn normalize_prior_summary_line(line: &str) -> Option<RenderedSummaryLine> {
     let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed.starts_with("... ") {
+    if trimmed.is_empty() {
         return None;
     }
 
-    let (role, content) = strip_repeated_summary_role_prefixes(trimmed);
+    let bullet_trimmed = trimmed.strip_prefix("- ").unwrap_or(trimmed);
+    if is_summary_metadata_line(bullet_trimmed) {
+        return None;
+    }
+
+    let (role, content) = strip_repeated_summary_role_prefixes(bullet_trimmed);
     if role == "assistant" && is_internal_assistant_summary_content(content) {
         return None;
     }
@@ -159,6 +302,23 @@ fn normalize_prior_summary_line(line: &str) -> Option<RenderedSummaryLine> {
         ),
         is_user: role == "user",
     })
+}
+
+fn is_summary_metadata_line(line: &str) -> bool {
+    let scope_note = runtime_self_continuity::compaction_summary_scope_note();
+    if line == scope_note {
+        return true;
+    }
+    if line == USER_CONTEXT_HEADING {
+        return true;
+    }
+    if line == ASSISTANT_PROGRESS_HEADING {
+        return true;
+    }
+    if line.starts_with(OMITTED_CONTEXT_PREFIX) {
+        return true;
+    }
+    false
 }
 
 fn strip_repeated_summary_role_prefixes(mut line: &str) -> (&str, &str) {
@@ -199,7 +359,19 @@ fn trim_to_chars(value: &str, max_chars: usize) -> String {
         return value.chars().take(max_chars).collect();
     }
 
-    let mut trimmed = value.chars().take(max_chars - 3).collect::<String>();
-    trimmed.push_str("...");
-    trimmed
+    let remaining_chars = max_chars - 3;
+    let head_chars = remaining_chars / 2;
+    let tail_chars = remaining_chars - head_chars;
+
+    let prefix = value.chars().take(head_chars).collect::<String>();
+    let suffix = value
+        .chars()
+        .rev()
+        .take(tail_chars)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+
+    format!("{prefix}...{suffix}")
 }

--- a/crates/app/src/conversation/compaction.rs
+++ b/crates/app/src/conversation/compaction.rs
@@ -1,6 +1,7 @@
 use crate::memory::WindowTurn;
 use crate::runtime_self_continuity;
 
+pub(crate) const COMPACTED_SUMMARY_PREFIX: &str = "Compacted ";
 const SUMMARY_MAX_RENDERED_TURNS: usize = 4;
 const SUMMARY_PREFERRED_USER_TURNS: usize = 3;
 const SUMMARY_PREFERRED_ASSISTANT_TURNS: usize = 1;
@@ -39,7 +40,7 @@ pub fn compact_window(turns: &[WindowTurn], policy: CompactPolicy) -> Option<Vec
     let summary = WindowTurn {
         role: "user".to_owned(),
         content: format!(
-            "Compacted {} earlier turns\n{}",
+            "{COMPACTED_SUMMARY_PREFIX}{} earlier turns\n{}",
             older.len(),
             render_summary(older)
         ),
@@ -78,8 +79,7 @@ fn render_summary(turns: &[WindowTurn]) -> String {
         .into_iter()
         .filter_map(|idx| all_lines.get(idx).cloned())
         .collect::<Vec<_>>();
-    let omitted_lines = all_lines.len().saturating_sub(selected_lines.len());
-    render_structured_summary(&selected_lines, omitted_lines)
+    render_structured_summary(&selected_lines, all_lines.len())
 }
 
 fn extend_summary_indices(
@@ -181,42 +181,43 @@ struct RenderedSummaryLine {
     is_user: bool,
 }
 
-fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_lines: usize) -> String {
+fn render_structured_summary(lines: &[RenderedSummaryLine], total_line_count: usize) -> String {
     let scope_note = runtime_self_continuity::compaction_summary_scope_note();
-    let omitted_line = if omitted_lines > 0 {
-        Some(format!(
-            "{OMITTED_CONTEXT_PREFIX} {omitted_lines} earlier turns omitted."
-        ))
-    } else {
-        None
-    };
-    let reserved_chars = omitted_line
-        .as_ref()
-        .map(|line| line.chars().count() + 1)
-        .unwrap_or(0);
+    let max_omitted_count_width = total_line_count.to_string().chars().count();
+    let omitted_line = format!(
+        "{OMITTED_CONTEXT_PREFIX} {} earlier turns omitted.",
+        "9".repeat(max_omitted_count_width.max(1))
+    );
+    let reserved_chars = omitted_line.chars().count().saturating_add(1);
     let content_budget_limit = SUMMARY_TOTAL_CHARS_MAX.saturating_sub(reserved_chars);
     let mut budget = SummaryCharBudget::new(content_budget_limit);
     let mut sections = Vec::new();
+    let mut rendered_selected_lines = 0usize;
 
     push_summary_line(&mut sections, &mut budget, scope_note);
 
     let user_lines = collect_summary_group(lines, true);
-    append_summary_section(
+    let user_rendered_lines = append_summary_section(
         &mut sections,
         &mut budget,
         USER_CONTEXT_HEADING,
         &user_lines,
     );
+    rendered_selected_lines += user_rendered_lines;
 
     let assistant_lines = collect_summary_group(lines, false);
-    append_summary_section(
+    let assistant_rendered_lines = append_summary_section(
         &mut sections,
         &mut budget,
         ASSISTANT_PROGRESS_HEADING,
         &assistant_lines,
     );
+    rendered_selected_lines += assistant_rendered_lines;
 
-    if let Some(omitted_line) = omitted_line {
+    let omitted_lines = total_line_count.saturating_sub(rendered_selected_lines);
+    if omitted_lines > 0 {
+        let omitted_line =
+            format!("{OMITTED_CONTEXT_PREFIX} {omitted_lines} earlier turns omitted.");
         sections.push(omitted_line);
     }
 
@@ -236,21 +237,24 @@ fn append_summary_section(
     budget: &mut SummaryCharBudget,
     heading: &str,
     lines: &[String],
-) {
+) -> usize {
     if lines.is_empty() {
-        return;
+        return 0;
     }
 
     if !push_summary_line(sections, budget, heading) {
-        return;
+        return 0;
     }
 
+    let mut rendered_lines = 0usize;
     for line in lines {
         let bullet_line = format!("- {line}");
         if !push_summary_line(sections, budget, &bullet_line) {
-            return;
+            return rendered_lines;
         }
+        rendered_lines += 1;
     }
+    rendered_lines
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -300,7 +304,7 @@ fn render_summary_lines(turn: &WindowTurn) -> Vec<RenderedSummaryLine> {
         return Vec::new();
     }
 
-    if turn.content.trim_start().starts_with("Compacted ") {
+    if is_compacted_summary_content(&turn.content) {
         let lines = extract_prior_summary_lines(&turn.content);
         if !lines.is_empty() {
             return lines;
@@ -318,7 +322,11 @@ fn render_summary_lines(turn: &WindowTurn) -> Vec<RenderedSummaryLine> {
 }
 
 fn is_compacted_summary_turn(turn: &WindowTurn) -> bool {
-    turn.content.trim_start().starts_with("Compacted ")
+    is_compacted_summary_content(&turn.content)
+}
+
+pub(crate) fn is_compacted_summary_content(content: &str) -> bool {
+    content.trim_start().starts_with(COMPACTED_SUMMARY_PREFIX)
 }
 
 fn is_internal_assistant_event_turn(turn: &WindowTurn) -> bool {

--- a/crates/app/src/conversation/compaction.rs
+++ b/crates/app/src/conversation/compaction.rs
@@ -1,9 +1,9 @@
 use crate::memory::WindowTurn;
 use crate::runtime_self_continuity;
 
-const SUMMARY_MAX_RENDERED_TURNS: usize = 3;
+const SUMMARY_MAX_RENDERED_TURNS: usize = 4;
 const SUMMARY_PREFERRED_USER_TURNS: usize = 3;
-const SUMMARY_PREFERRED_ASSISTANT_TURNS: usize = 0;
+const SUMMARY_PREFERRED_ASSISTANT_TURNS: usize = 1;
 const SUMMARY_TURN_EXCERPT_CHARS: usize = 96;
 const SUMMARY_TOTAL_CHARS_MAX: usize = 480;
 const PRIOR_COMPACTED_SUMMARY_PLACEHOLDER: &str = "[prior compacted summary]";
@@ -182,24 +182,45 @@ struct RenderedSummaryLine {
 }
 
 fn render_structured_summary(lines: &[RenderedSummaryLine], omitted_lines: usize) -> String {
-    let mut sections = Vec::new();
     let scope_note = runtime_self_continuity::compaction_summary_scope_note();
-    sections.push(scope_note.to_owned());
+    let omitted_line = if omitted_lines > 0 {
+        Some(format!(
+            "{OMITTED_CONTEXT_PREFIX} {omitted_lines} earlier turns omitted."
+        ))
+    } else {
+        None
+    };
+    let reserved_chars = omitted_line
+        .as_ref()
+        .map(|line| line.chars().count() + 1)
+        .unwrap_or(0);
+    let content_budget_limit = SUMMARY_TOTAL_CHARS_MAX.saturating_sub(reserved_chars);
+    let mut budget = SummaryCharBudget::new(content_budget_limit);
+    let mut sections = Vec::new();
+
+    push_summary_line(&mut sections, &mut budget, scope_note);
 
     let user_lines = collect_summary_group(lines, true);
-    append_summary_section(&mut sections, USER_CONTEXT_HEADING, &user_lines);
+    append_summary_section(
+        &mut sections,
+        &mut budget,
+        USER_CONTEXT_HEADING,
+        &user_lines,
+    );
 
     let assistant_lines = collect_summary_group(lines, false);
-    append_summary_section(&mut sections, ASSISTANT_PROGRESS_HEADING, &assistant_lines);
+    append_summary_section(
+        &mut sections,
+        &mut budget,
+        ASSISTANT_PROGRESS_HEADING,
+        &assistant_lines,
+    );
 
-    if omitted_lines > 0 {
-        let omitted_line =
-            format!("{OMITTED_CONTEXT_PREFIX} {omitted_lines} earlier turns omitted.");
+    if let Some(omitted_line) = omitted_line {
         sections.push(omitted_line);
     }
 
-    let rendered = sections.join("\n");
-    trim_to_chars(&rendered, SUMMARY_TOTAL_CHARS_MAX)
+    sections.join("\n")
 }
 
 fn collect_summary_group(lines: &[RenderedSummaryLine], is_user: bool) -> Vec<String> {
@@ -210,17 +231,68 @@ fn collect_summary_group(lines: &[RenderedSummaryLine], is_user: bool) -> Vec<St
         .collect::<Vec<_>>()
 }
 
-fn append_summary_section(sections: &mut Vec<String>, heading: &str, lines: &[String]) {
+fn append_summary_section(
+    sections: &mut Vec<String>,
+    budget: &mut SummaryCharBudget,
+    heading: &str,
+    lines: &[String],
+) {
     if lines.is_empty() {
         return;
     }
 
-    sections.push(heading.to_owned());
+    if !push_summary_line(sections, budget, heading) {
+        return;
+    }
 
     for line in lines {
         let bullet_line = format!("- {line}");
-        sections.push(bullet_line);
+        if !push_summary_line(sections, budget, &bullet_line) {
+            return;
+        }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SummaryCharBudget {
+    remaining: usize,
+    has_lines: bool,
+}
+
+impl SummaryCharBudget {
+    fn new(limit: usize) -> Self {
+        Self {
+            remaining: limit,
+            has_lines: false,
+        }
+    }
+}
+
+fn push_summary_line(
+    sections: &mut Vec<String>,
+    budget: &mut SummaryCharBudget,
+    line: &str,
+) -> bool {
+    if budget.remaining == 0 {
+        return false;
+    }
+
+    let separator_chars = if budget.has_lines { 1 } else { 0 };
+    if budget.remaining <= separator_chars {
+        return false;
+    }
+
+    let available_chars = budget.remaining - separator_chars;
+    let rendered_line = trim_to_chars(line, available_chars);
+    let rendered_chars = rendered_line.chars().count();
+    if rendered_chars == 0 {
+        return false;
+    }
+
+    sections.push(rendered_line);
+    budget.remaining -= separator_chars + rendered_chars;
+    budget.has_lines = true;
+    true
 }
 
 fn render_summary_lines(turn: &WindowTurn) -> Vec<RenderedSummaryLine> {
@@ -318,7 +390,25 @@ fn is_summary_metadata_line(line: &str) -> bool {
     if line.starts_with(OMITTED_CONTEXT_PREFIX) {
         return true;
     }
+    if is_legacy_omitted_turns_marker(line) {
+        return true;
+    }
     false
+}
+
+fn is_legacy_omitted_turns_marker(line: &str) -> bool {
+    let Some(stripped_line) = line.strip_prefix("... ") else {
+        return false;
+    };
+
+    let Some((count, suffix)) = stripped_line.split_once(' ') else {
+        return false;
+    };
+    if count.parse::<usize>().is_err() {
+        return false;
+    }
+
+    suffix == "earlier turns omitted"
 }
 
 fn strip_repeated_summary_role_prefixes(mut line: &str) -> (&str, &str) {

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -377,19 +377,8 @@ impl ConversationContextEngine for DefaultContextEngine {
         #[cfg(feature = "memory-sqlite")]
         {
             const MAX_COMPACTION_CONFLICT_RETRIES: usize = 3;
-            let memory_config =
-                memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
 
             for _ in 0..MAX_COMPACTION_CONFLICT_RETRIES {
-                let context_entries =
-                    load_memory_context_entries(&memory_config, session_id, kernel_ctx).await?;
-                let has_summary_checkpoint = context_entries
-                    .into_iter()
-                    .any(|entry| entry.kind == memory::MemoryContextKind::Summary);
-                if has_summary_checkpoint {
-                    return Ok(());
-                }
-
                 let snapshot = load_memory_window_snapshot(config, session_id, kernel_ctx).await?;
                 if !snapshot.is_complete_session_snapshot() {
                     return Ok(());
@@ -557,36 +546,6 @@ async fn load_memory_window_snapshot(
         turns: memory::decode_window_turns(&outcome.payload),
         turn_count: memory::decode_window_turn_count(&outcome.payload),
     })
-}
-
-#[cfg(feature = "memory-sqlite")]
-async fn load_memory_context_entries(
-    config: &memory::runtime_config::MemoryRuntimeConfig,
-    session_id: &str,
-    kernel_ctx: &KernelContext,
-) -> CliResult<Vec<memory::MemoryContextEntry>> {
-    let request = memory::build_read_context_request(session_id, config);
-    let caps = BTreeSet::from([Capability::MemoryRead]);
-    let outcome = kernel_ctx
-        .kernel
-        .execute_memory_core(
-            kernel_ctx.pack_id(),
-            &kernel_ctx.token,
-            &caps,
-            None,
-            request,
-        )
-        .await
-        .map_err(|error| format!("load memory context via kernel failed: {error}"))?;
-
-    if outcome.status != "ok" {
-        return Err(format!(
-            "load memory context via kernel returned non-ok status: {}",
-            outcome.status
-        ));
-    }
-
-    Ok(memory::decode_memory_context_entries(&outcome.payload))
 }
 
 async fn persist_memory_window(

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -42,6 +42,7 @@ pub use analytics::{
     summarize_fast_lane_tool_batch_events, summarize_safe_lane_events,
     summarize_turn_checkpoint_events,
 };
+pub(crate) use compaction::is_compacted_summary_content;
 pub use context_engine::{
     AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextArtifactDescriptor,
     ContextArtifactKind, ContextEngineBootstrapResult, ContextEngineCapability,

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -105,7 +105,9 @@ pub use turn_checkpoint::{
     TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
     TurnCheckpointTailRepairStatus,
 };
-pub use turn_coordinator::{ConversationTurnCoordinator, spawn_background_delegate_with_runtime};
+pub use turn_coordinator::{
+    ContextCompactionReport, ConversationTurnCoordinator, spawn_background_delegate_with_runtime,
+};
 pub use turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, NoopAppToolDispatcher, ProviderTurn, ToolDecision,
     ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23865,7 +23865,7 @@ fn compact_window_bounds_summary_content_and_prior_summaries() {
 fn compact_window_retains_prior_summary_details_across_repeated_compaction() {
     use super::compaction::{CompactPolicy, compact_window};
 
-    let prior_summary = "Compacted 1 earlier turns\nuser: For this test, remember these facts exactly: - codename: NIMBUS-17 - owner: Mina - budget: 47";
+    let prior_summary = "Compacted 1 earlier turns\nuser: For this test, remember these facts exactly: - codename: NIMBUS-17 - owner: Mina - budget: 47\n... 1 earlier turns omitted";
     let turns = vec![
         crate::memory::WindowTurn {
             role: "user".into(),
@@ -23910,6 +23910,10 @@ fn compact_window_retains_prior_summary_details_across_repeated_compaction() {
     assert!(
         !summary.contains("[prior compacted summary]"),
         "repeated compaction should retain prior summary details: {summary}"
+    );
+    assert!(
+        !summary.contains("... 1 earlier turns omitted"),
+        "repeated compaction should drop legacy omitted markers from prior summaries: {summary}"
     );
 }
 
@@ -23967,6 +23971,10 @@ fn compact_window_prioritizes_user_fact_turns_when_summary_budget_is_limited() {
     assert!(summary.contains("October"));
     assert!(summary.contains("RIVER-9"));
     assert!(summary.contains("Owen"));
+    assert!(
+        summary.contains("Assistant progress:"),
+        "bounded summaries should still reserve space for assistant progress: {summary}"
+    );
 }
 
 #[test]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23748,6 +23748,12 @@ fn compact_window_preserves_recent_turns_and_summarizes_history() {
     assert_eq!(compacted.len(), 3);
     assert_eq!(compacted[0].role, "user");
     assert!(compacted[0].content.contains("Compacted 4 earlier turns"));
+    assert!(
+        compacted[0]
+            .content
+            .contains("Session-local recall only. Does not replace Runtime Self Context"),
+    );
+    assert!(compacted[0].content.contains("User context:"));
     assert_eq!(compacted[1].content, "recent ask");
     assert_eq!(compacted[2].content, "recent reply");
 }
@@ -23961,6 +23967,42 @@ fn compact_window_prioritizes_user_fact_turns_when_summary_budget_is_limited() {
     assert!(summary.contains("October"));
     assert!(summary.contains("RIVER-9"));
     assert!(summary.contains("Owen"));
+}
+
+#[test]
+fn compact_window_emits_continuity_boundary_and_structured_sections() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "codename: NIMBUS-17 owner: Mina budget: 47".into(),
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-1".into(),
+            ts: Some(2),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(3),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(4),
+        },
+    ];
+
+    let compacted = compact_window(&turns, CompactPolicy::new(2)).expect("should compact");
+    let summary = &compacted[0].content;
+
+    assert!(summary.contains("Session-local recall only."));
+    assert!(summary.contains("User context:"));
+    assert!(summary.contains("Assistant progress:"));
+    assert!(summary.contains("Does not replace Runtime Self Context"));
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -24454,6 +24496,75 @@ async fn default_context_engine_compact_context_preserves_existing_summarized_hi
         }),
         "compaction should preserve preexisting summarized history"
     );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_can_run_again_after_a_prior_checkpoint() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path = unique_memory_sqlite_path("default-context-engine-repeated-compaction");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.sliding_window = 32;
+    config.conversation.compact_preserve_recent_turns = 2;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-default-context-engine-repeated-compaction",
+        &memory_config,
+    );
+    let session_id = "default-context-engine-repeated-compaction";
+
+    for (role, content) in [
+        ("user", "codename: NIMBUS-17"),
+        ("assistant", "ack-1"),
+        ("user", "launch month: October"),
+        ("assistant", "ack-2"),
+        ("user", "owner: Mina"),
+        ("assistant", "ack-3"),
+        ("user", "recent ask"),
+        ("assistant", "recent reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed initial turns should succeed");
+    }
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("first compaction should succeed");
+
+    for (role, content) in [
+        ("user", "fallback code: RIVER-9"),
+        ("assistant", "ack-4"),
+        ("user", "newest ask"),
+        ("assistant", "newest reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("append follow-up turns should succeed");
+    }
+
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("second compaction should succeed");
+
+    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+        .expect("window load should succeed");
+    let summary = &turns[0].content;
+
+    assert_eq!(turns.len(), 3);
+    assert!(summary.contains("Compacted 5 earlier turns"));
+    assert!(summary.contains("NIMBUS-17"));
+    assert!(summary.contains("RIVER-9"));
+    assert!(summary.contains("Session-local recall only."));
+    assert_eq!(turns[1].content, "newest ask");
+    assert_eq!(turns[2].content, "newest reply");
 
     let _ = std::fs::remove_file(&db_path);
 }

--- a/crates/app/src/conversation/turn_checkpoint.rs
+++ b/crates/app/src/conversation/turn_checkpoint.rs
@@ -501,7 +501,7 @@ impl TurnCheckpointFinalizationProgress {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ContextCompactionOutcome {
+pub(crate) enum ContextCompactionOutcome {
     Skipped,
     Completed,
     FailedOpen,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1159,6 +1159,10 @@ impl ConversationTurnCoordinator {
         runtime: &R,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
+        if let Some(kernel_ctx) = binding.kernel_context() {
+            runtime.bootstrap(config, session_id, kernel_ctx).await?;
+        }
+
         let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let before_messages = runtime

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -32,13 +32,14 @@ use crate::operator::delegate_runtime::{
     build_delegate_child_lifecycle_seed, next_delegate_child_depth,
 };
 use crate::runtime_self_continuity;
+use crate::tools::runtime_tool_view_for_config;
 
 use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
 use super::ProviderErrorMode;
 use super::analytics::{
-    SafeLaneEventSummary, TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan,
-    summarize_safe_lane_history,
+    SafeLaneEventSummary, TurnCheckpointProgressStatus as AnalyticsTurnCheckpointProgressStatus,
+    TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
 };
 #[cfg(feature = "memory-sqlite")]
 use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
@@ -139,6 +140,43 @@ use crate::session::repository::{
 
 #[derive(Default)]
 pub struct ConversationTurnCoordinator;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextCompactionReport {
+    pub status: AnalyticsTurnCheckpointProgressStatus,
+    pub estimated_tokens_before: Option<usize>,
+    pub estimated_tokens_after: Option<usize>,
+}
+
+impl ContextCompactionReport {
+    pub fn status_label(&self) -> &'static str {
+        match self.status {
+            AnalyticsTurnCheckpointProgressStatus::Pending => "pending",
+            AnalyticsTurnCheckpointProgressStatus::Skipped => "skipped",
+            AnalyticsTurnCheckpointProgressStatus::Completed => "completed",
+            AnalyticsTurnCheckpointProgressStatus::Failed => "failed",
+            AnalyticsTurnCheckpointProgressStatus::FailedOpen => "failed_open",
+        }
+    }
+
+    pub fn was_applied(&self) -> bool {
+        matches!(
+            self.status,
+            AnalyticsTurnCheckpointProgressStatus::Completed
+        )
+    }
+
+    pub fn was_skipped(&self) -> bool {
+        matches!(self.status, AnalyticsTurnCheckpointProgressStatus::Skipped)
+    }
+
+    pub fn was_failed_open(&self) -> bool {
+        matches!(
+            self.status,
+            AnalyticsTurnCheckpointProgressStatus::FailedOpen
+        )
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneExecutionMetrics {
@@ -1102,6 +1140,66 @@ fn parse_pending_approval_input_decision(input: &str) -> Option<PendingApprovalI
 impl ConversationTurnCoordinator {
     pub fn new() -> Self {
         Self
+    }
+
+    pub async fn compact_session(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ContextCompactionReport> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.compact_session_with_runtime(config, session_id, &runtime, binding)
+            .await
+    }
+
+    pub async fn compact_session_with_runtime<R: ConversationRuntime + ?Sized>(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        runtime: &R,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ContextCompactionReport> {
+        let tool_view = runtime_tool_view_for_config(&config.tools);
+        let before_messages = runtime
+            .build_messages(config, session_id, false, &tool_view, binding)
+            .await?;
+        let estimated_tokens_before = estimate_tokens(&before_messages);
+        let compaction_outcome = maybe_compact_context(
+            config,
+            runtime,
+            session_id,
+            &before_messages,
+            estimated_tokens_before,
+            binding,
+            true,
+        )
+        .await?;
+
+        let mut status = compaction_outcome.checkpoint_status();
+        let mut estimated_tokens_after = estimated_tokens_before;
+
+        if compaction_outcome == ContextCompactionOutcome::Completed {
+            let after_messages = runtime
+                .build_messages(config, session_id, false, &tool_view, binding)
+                .await?;
+            let did_change = before_messages != after_messages;
+            let next_estimated_tokens = estimate_tokens(&after_messages);
+
+            estimated_tokens_after = next_estimated_tokens;
+
+            if !did_change {
+                status = TurnCheckpointProgressStatus::Skipped;
+            }
+        }
+
+        let report = ContextCompactionReport {
+            status: analytics_turn_checkpoint_progress_status(status),
+            estimated_tokens_before,
+            estimated_tokens_after,
+        };
+
+        Ok(report)
     }
 
     pub async fn handle_turn(
@@ -2146,12 +2244,17 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     messages: &[Value],
     estimated_tokens: Option<usize>,
     binding: ConversationRuntimeBinding<'_>,
+    force: bool,
 ) -> CliResult<ContextCompactionOutcome> {
     let estimated_tokens = estimated_tokens.or_else(|| estimate_tokens(messages));
-    if !config
-        .conversation
-        .should_compact_with_estimate(messages.len(), estimated_tokens)
-    {
+    let should_attempt_compaction = if force {
+        true
+    } else {
+        config
+            .conversation
+            .should_compact_with_estimate(messages.len(), estimated_tokens)
+    };
+    if !should_attempt_compaction {
         return Ok(ContextCompactionOutcome::Skipped);
     }
     let Some(kernel_ctx) = binding.kernel_context() else {
@@ -2344,6 +2447,20 @@ fn estimate_tokens(messages: &[Value]) -> Option<usize> {
     });
 
     Some(estimated)
+}
+
+fn analytics_turn_checkpoint_progress_status(
+    status: TurnCheckpointProgressStatus,
+) -> AnalyticsTurnCheckpointProgressStatus {
+    match status {
+        TurnCheckpointProgressStatus::Pending => AnalyticsTurnCheckpointProgressStatus::Pending,
+        TurnCheckpointProgressStatus::Skipped => AnalyticsTurnCheckpointProgressStatus::Skipped,
+        TurnCheckpointProgressStatus::Completed => AnalyticsTurnCheckpointProgressStatus::Completed,
+        TurnCheckpointProgressStatus::Failed => AnalyticsTurnCheckpointProgressStatus::Failed,
+        TurnCheckpointProgressStatus::FailedOpen => {
+            AnalyticsTurnCheckpointProgressStatus::FailedOpen
+        }
+    }
 }
 
 fn lane_policy_from_config(config: &LoongClawConfig) -> LaneArbiterPolicy {
@@ -3376,6 +3493,7 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
             resume_input.messages(),
             resume_input.estimated_tokens(),
             binding,
+            false,
         )
         .await
         {
@@ -3597,6 +3715,7 @@ async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             tail_phase.after_turn_messages(),
             tail_phase.estimated_tokens(),
             binding,
+            false,
         )
         .await
         {
@@ -8033,6 +8152,7 @@ mod tests {
             &messages,
             Some(16),
             binding,
+            false,
         ));
 
         assert_eq!(
@@ -8104,6 +8224,7 @@ mod tests {
             &messages,
             Some(16),
             binding,
+            false,
         ));
 
         assert_eq!(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -32,7 +32,6 @@ use crate::operator::delegate_runtime::{
     build_delegate_child_lifecycle_seed, next_delegate_child_depth,
 };
 use crate::runtime_self_continuity;
-use crate::tools::runtime_tool_view_for_config;
 
 use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
@@ -1160,9 +1159,10 @@ impl ConversationTurnCoordinator {
         runtime: &R,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
-        let tool_view = runtime_tool_view_for_config(&config.tools);
+        let session_context = runtime.session_context(config, session_id, binding)?;
+        let tool_view = session_context.tool_view.clone();
         let before_messages = runtime
-            .build_messages(config, session_id, false, &tool_view, binding)
+            .build_messages(config, session_id, true, &tool_view, binding)
             .await?;
         let estimated_tokens_before = estimate_tokens(&before_messages);
         let compaction_outcome = maybe_compact_context(
@@ -1180,16 +1180,24 @@ impl ConversationTurnCoordinator {
         let mut estimated_tokens_after = estimated_tokens_before;
 
         if compaction_outcome == ContextCompactionOutcome::Completed {
-            let after_messages = runtime
-                .build_messages(config, session_id, false, &tool_view, binding)
-                .await?;
-            let did_change = before_messages != after_messages;
-            let next_estimated_tokens = estimate_tokens(&after_messages);
+            match runtime
+                .build_messages(config, session_id, true, &tool_view, binding)
+                .await
+            {
+                Ok(after_messages) => {
+                    let did_change = before_messages != after_messages;
+                    let next_estimated_tokens = estimate_tokens(&after_messages);
 
-            estimated_tokens_after = next_estimated_tokens;
+                    estimated_tokens_after = next_estimated_tokens;
 
-            if !did_change {
-                status = TurnCheckpointProgressStatus::Skipped;
+                    if !did_change {
+                        status = TurnCheckpointProgressStatus::Skipped;
+                    }
+                }
+                Err(_error) => {
+                    status = TurnCheckpointProgressStatus::Skipped;
+                    estimated_tokens_after = estimated_tokens_before;
+                }
             }
         }
 
@@ -6949,6 +6957,124 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    struct CompactSessionBuildMessagesRuntime {
+        session_tool_view: crate::tools::ToolView,
+        build_messages_calls: StdMutex<Vec<(bool, crate::tools::ToolView)>>,
+        fail_after_first_readback: bool,
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    impl CompactSessionBuildMessagesRuntime {
+        fn new(session_tool_view: crate::tools::ToolView, fail_after_first_readback: bool) -> Self {
+            Self {
+                session_tool_view,
+                build_messages_calls: StdMutex::new(Vec::new()),
+                fail_after_first_readback,
+            }
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl ConversationRuntime for CompactSessionBuildMessagesRuntime {
+        fn session_context(
+            &self,
+            _config: &LoongClawConfig,
+            session_id: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<SessionContext> {
+            Ok(SessionContext::root_with_tool_view(
+                session_id,
+                self.session_tool_view.clone(),
+            ))
+        }
+
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            include_system_prompt: bool,
+            tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            let mut build_messages_calls = self
+                .build_messages_calls
+                .lock()
+                .expect("build_messages lock should not be poisoned");
+            build_messages_calls.push((include_system_prompt, tool_view.clone()));
+            let call_count = build_messages_calls.len();
+
+            if self.fail_after_first_readback && call_count > 1 {
+                return Err("post-compaction readback failed".to_owned());
+            }
+
+            let tool_names = tool_view.tool_names().collect::<Vec<_>>();
+            let tool_names = tool_names.join(",");
+
+            Ok(vec![json!({
+                "role": "system",
+                "content": format!(
+                    "include_system_prompt={include_system_prompt} tools={tool_names}"
+                ),
+            })])
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Ok(String::new())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ProviderTurn> {
+            panic!("request_turn should not be called in compact_session tests")
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+            _on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<ProviderTurn> {
+            panic!("request_turn_streaming should not be called in compact_session tests")
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+
+        async fn compact_context(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _messages: &[Value],
+            _kernel_ctx: &KernelContext,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+    }
+
     #[derive(Default)]
     struct ObserverStreamingRuntime {
         streaming_calls: StdMutex<usize>,
@@ -8235,6 +8361,114 @@ mod tests {
         assert_eq!(*compact_calls, 0);
 
         let _ = std::fs::remove_dir_all(&workspace_root_parent);
+        let _ = std::fs::remove_file(&sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_session_uses_session_context_tool_view_and_turn_like_build_flags() {
+        let mut config = LoongClawConfig::default();
+        let sqlite_path = unique_sqlite_path("compact-session-build-messages");
+        let _ = std::fs::remove_file(&sqlite_path);
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct(
+            "compact-session-build-messages",
+            "user",
+            "remember this detail",
+            &memory_config,
+        )
+        .expect("append user turn");
+
+        let expected_tool_view = crate::tools::ToolView::from_tool_names(["status.inspect"]);
+        let runtime = CompactSessionBuildMessagesRuntime::new(expected_tool_view.clone(), false);
+        let kernel_ctx = bootstrap_test_kernel_context("compact-session-build-messages", 3600)
+            .expect("bootstrap kernel context");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
+        let coordinator = ConversationTurnCoordinator::new();
+
+        let report = coordinator
+            .compact_session_with_runtime(
+                &config,
+                "compact-session-build-messages",
+                &runtime,
+                binding,
+            )
+            .await
+            .expect("manual compaction should succeed");
+
+        assert!(report.was_skipped());
+
+        let build_messages_calls = runtime
+            .build_messages_calls
+            .lock()
+            .expect("build_messages lock should not be poisoned");
+        assert_eq!(build_messages_calls.len(), 2);
+        assert!(
+            build_messages_calls
+                .iter()
+                .all(|(include_system_prompt, _tool_view)| *include_system_prompt),
+            "compact_session should mirror turn assembly by keeping the system prompt enabled"
+        );
+        assert!(
+            build_messages_calls
+                .iter()
+                .all(|(_include_system_prompt, tool_view)| { *tool_view == expected_tool_view }),
+            "compact_session should reuse the session-context tool view for both snapshots"
+        );
+
+        let _ = std::fs::remove_file(&sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_session_skips_when_post_compaction_readback_fails() {
+        let mut config = LoongClawConfig::default();
+        let sqlite_path = unique_sqlite_path("compact-session-readback-fail");
+        let _ = std::fs::remove_file(&sqlite_path);
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct(
+            "compact-session-readback-fail",
+            "user",
+            "keep the context intact",
+            &memory_config,
+        )
+        .expect("append user turn");
+
+        let runtime = CompactSessionBuildMessagesRuntime::new(
+            crate::tools::ToolView::from_tool_names(["status.inspect"]),
+            true,
+        );
+        let kernel_ctx = bootstrap_test_kernel_context("compact-session-readback-fail", 3600)
+            .expect("bootstrap kernel context");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
+        let coordinator = ConversationTurnCoordinator::new();
+
+        let report = coordinator
+            .compact_session_with_runtime(
+                &config,
+                "compact-session-readback-fail",
+                &runtime,
+                binding,
+            )
+            .await
+            .expect("manual compaction should degrade to skipped");
+
+        assert!(report.was_skipped());
+        assert_eq!(
+            report.estimated_tokens_after,
+            report.estimated_tokens_before
+        );
+
+        let build_messages_calls = runtime
+            .build_messages_calls
+            .lock()
+            .expect("build_messages lock should not be poisoned");
+        assert_eq!(build_messages_calls.len(), 2);
+
         let _ = std::fs::remove_file(&sqlite_path);
     }
 

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -33,6 +33,13 @@ const RUNTIME_DURABLE_RECALL_INTRO: &str = concat!(
     "It does not override Resolved Runtime Identity or Session Profile.",
 );
 
+const COMPACTION_SUMMARY_SCOPE_NOTE: &str = concat!(
+    "Session-local recall only. ",
+    "Does not replace Runtime Self Context. ",
+    "Does not override Resolved Runtime Identity, Session Profile, ",
+    "or advisory durable recall.",
+);
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSelfContinuity {
     pub runtime_self: RuntimeSelfModel,
@@ -40,6 +47,10 @@ pub struct RuntimeSelfContinuity {
     pub resolved_identity: Option<ResolvedRuntimeIdentity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_profile_projection: Option<String>,
+}
+
+pub(crate) fn compaction_summary_scope_note() -> &'static str {
+    COMPACTION_SUMMARY_SCOPE_NOTE
 }
 
 impl RuntimeSelfContinuity {

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T16:03:09Z
+- Generated at: 2026-04-06T16:31:11Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,17 +20,17 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2795 | 2800 | 5 | 48 | 65 | 17 | 99.8% | TIGHT | 2698 | 3.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7185 | 7300 | 115 | 153 | 160 | 7 | 98.4% | TIGHT | 6936 | 3.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10638 | 11200 | 562 | 94 | 120 | 26 | 95.0% | WATCH | 10831 | -1.8% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10993 | 11200 | 207 | 95 | 120 | 25 | 98.2% | TIGHT | 10831 | 1.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9746 | 9800 | 54 | 235 | 250 | 15 | 99.4% | TIGHT | 9519 | 2.4% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.0%), daemon_lib (98.9%), onboard_cli (99.4%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), turn_coordinator (95.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (98.4%), turn_coordinator (98.2%), tools_mod (99.0%), daemon_lib (98.9%), onboard_cli (99.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,9 +66,9 @@
 <!-- arch-hotspot key=acpx_runtime lines=2795 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
-<!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
+<!-- arch-hotspot key=chat_runtime lines=7185 functions=153 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10638 functions=94 -->
+<!-- arch-hotspot key=turn_coordinator lines=10993 functions=95 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9746 functions=235 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T16:31:11Z
+- Generated at: 2026-04-06T16:31:28Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,7 +20,7 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2795 | 2800 | 5 | 48 | 65 | 17 | 99.8% | TIGHT | 2698 | 3.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7185 | 7300 | 115 | 153 | 160 | 7 | 98.4% | TIGHT | 6936 | 3.6% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6746 | 7300 | 554 | 122 | 160 | 38 | 92.4% | WATCH | 6936 | -2.7% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10993 | 11200 | 207 | 95 | 120 | 25 | 98.2% | TIGHT | 10831 | 1.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
@@ -29,8 +29,8 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (98.4%), turn_coordinator (98.2%), tools_mod (99.0%), daemon_lib (98.9%), onboard_cli (99.4%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (98.2%), tools_mod (99.0%), daemon_lib (98.9%), onboard_cli (99.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (92.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,7 +66,7 @@
 <!-- arch-hotspot key=acpx_runtime lines=2795 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
-<!-- arch-hotspot key=chat_runtime lines=7185 functions=153 -->
+<!-- arch-hotspot key=chat_runtime lines=6746 functions=122 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10993 functions=95 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-06T16:31:28Z
+- Generated at: 2026-04-06T16:31:48Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,9 +20,9 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2795 | 2800 | 5 | 48 | 65 | 17 | 99.8% | TIGHT | 2698 | 3.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6746 | 7300 | 554 | 122 | 160 | 38 | 92.4% | WATCH | 6936 | -2.7% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10993 | 11200 | 207 | 95 | 120 | 25 | 98.2% | TIGHT | 10831 | 1.5% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10997 | 11200 | 203 | 95 | 120 | 25 | 98.2% | TIGHT | 10831 | 1.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14857 | 15000 | 143 | 53 | 70 | 17 | 99.0% | TIGHT | 14472 | 2.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9746 | 9800 | 54 | 235 | 250 | 15 | 99.4% | TIGHT | 9519 | 2.4% | PASS | 228 |
@@ -30,7 +30,7 @@
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (99.8%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (98.2%), tools_mod (99.0%), daemon_lib (98.9%), onboard_cli (99.4%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (92.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,9 +66,9 @@
 <!-- arch-hotspot key=acpx_runtime lines=2795 functions=48 -->
 <!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
-<!-- arch-hotspot key=chat_runtime lines=6746 functions=122 -->
+<!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10993 functions=95 -->
+<!-- arch-hotspot key=turn_coordinator lines=10997 functions=95 -->
 <!-- arch-hotspot key=tools_mod lines=14857 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9746 functions=235 -->


### PR DESCRIPTION
## Summary

- Problem:
  - `loongclaw chat` had partially wired `/status` and `/compact` surfaces, but the shell path was inconsistent and the continuity/compaction slice was not productized cleanly.
  - Manual compaction reporting and status rendering were split across half-integrated code paths.
  - Deterministic compaction summaries were improving, but repeated compaction still needed a tighter selection/bounding strategy to preserve key facts without bloating the checkpoint.
- Why it matters:
  - Operators need an explicit way to inspect session/runtime continuity state without leaving chat.
  - Operators also need a manual checkpoint path before the next turn when a session is getting long or risky.
  - Compaction summaries are part of LoongClaw's continuity contract, so they need to stay bounded, structured, and explicit about runtime-self boundaries.
- What changed:
  - wired `/status` into `loongclaw chat` as a real operator-facing shell command
  - wired `/compact` into `loongclaw chat` as a real manual compaction path backed by `ConversationTurnCoordinator::compact_session`
  - unified chat status/compaction help and parser constants instead of leaving partially duplicated command strings
  - added `ContextCompactionReport` export + status helpers so manual compaction can report applied/skipped/failed-open outcomes cleanly
  - removed the old "already summarized, so never compact again" guard from the default context engine so a prior checkpoint does not permanently block later compaction
  - tightened deterministic compaction summaries into bounded structured checkpoints with continuity boundary language, balanced fact selection, and repeated-compaction carry-forward behavior
  - added/updated coverage for the CLI chat surfaces and repeated compaction behavior
- extracted the remaining chat shell-surface types, onboarding/history renderers, and manual-compaction parsing helpers into `crates/app/src/chat/operator_surfaces.rs` so `chat.rs` stays focused on the runtime loop and live turn orchestration
- paid down the `chat_runtime` hotspot again by reducing `crates/app/src/chat.rs` from 7185 lines on the prior PR head to 6752 lines after the follow-up extraction
- What did not change (scope boundary):
  - no LLM-based compaction was introduced
  - no new TUI transcript browser or session tree surface was added
  - no new durable-memory authority or profile override path was introduced

## Linked Issues

- Closes #1030
- Related #944
- Related #440

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - deterministic compaction output shape changed
  - repeated compaction is now allowed after a prior checkpoint instead of short-circuiting forever
  - CLI chat command routing now recognizes `/status` and `/compact` as first-class operator surfaces
- Rollout / guardrails:
  - continuity note stays explicit in the compacted summary
  - manual compaction reports applied/skipped/failed-open explicitly instead of pretending all runs rewrote history
  - repeated compaction behavior is covered by dedicated tests
- Rollback path:
  - revert this PR to restore the previous chat command surface and prior compaction short-circuit behavior

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check

export CARGO_TARGET_DIR=/private/tmp/loongclaw-ref-surface-maturity-20260406/.cargo-target-local
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app compact_window --lib --locked
cargo test -p loongclaw-app repeated_compaction --lib --locked
cargo test -p loongclaw-app chat --lib --locked
cargo test --workspace --locked
cargo test --workspace --all-features --locked

./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
```

Results:
- all listed cargo validation commands passed
- `check_dep_graph` passed cleanly
- `check_architecture_boundaries.sh` exited 0 and now reports `chat_runtime` at WATCH pressure (`6752/7300` lines, `122/160` functions) after the follow-up extraction
- `task check:architecture` was not used because `task` is not installed in this shell; the underlying architecture scripts were run directly instead

## User-visible / Operator-visible Changes

- `loongclaw chat` now supports `/status` for a structured runtime/session/continuity snapshot without sending a turn.
- `loongclaw chat` now supports `/compact` for an explicit continuity-aware checkpoint of the active session window.
- Manual compaction output now reports before/after turn counts, token estimates, and continuity-safe detail text.
- Repeated deterministic compaction can carry forward prior checkpoint facts instead of stalling after the first summary.

## Failure Recovery

- Fast rollback or disable path:
  - revert this branch or avoid `/compact`; automatic compaction still follows the existing runtime gates
- Observable failure symptoms reviewers should watch for:
  - `/status` or `/compact` not appearing in `loongclaw chat` help
  - compacted summaries growing too large or dropping carried-forward facts across repeated compaction
  - repeated compaction no longer rewriting a window after a prior summary exists

## Reviewer Focus

- `crates/app/src/chat.rs`
  - runtime loop boundaries after shell-surface extraction
  - direct ownership of live turn orchestration only
- `crates/app/src/chat/operator_surfaces.rs`
  - operator shell surface extraction for startup/status/help/history/manual compaction
  - exact command parsing and turn-checkpoint health rendering
- `crates/app/src/conversation/compaction.rs`
  - summary selection and bounding logic
  - repeated-compaction carry-forward behavior
- `crates/app/src/conversation/context_engine.rs`
  - removal of the one-summary-and-stop short-circuit
- `crates/app/src/conversation/turn_coordinator.rs`
  - `ContextCompactionReport` and manual compaction entrypoint
- `crates/app/src/conversation/tests.rs`
  - regression coverage for repeated compaction and structured checkpoint boundaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact-match slash commands: /status, /compact, and turn-checkpoint repair aliases; interactive startup status, history and manual compaction outputs.

* **Enhancements**
  * Compaction summaries now emit structured sections (scope note, User context, Assistant progress), continuity markers, and a global character budget with improved trimming and selection balance.
  * Startup/status screens show checkpoint durability health and onboarding hints.

* **Tests**
  * Added unit and integration tests for commands, rendering, and compaction continuity.

* **Documentation**
  * Updated release architecture metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->