### PR TITLE
feat: add Xiaomi provider support with configuration and profiles

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -558,6 +558,7 @@ mod tests {
             (ProviderKind::Kimi, Some("MOONSHOT_API_KEY")),
             (ProviderKind::Minimax, Some("MINIMAX_API_KEY")),
             (ProviderKind::Openai, Some("OPENAI_API_KEY")),
+            (ProviderKind::Xiaomi, Some("XIAOMI_API_KEY")),
         ];
         for (kind, expected) in cases {
             let config = ProviderConfig {
@@ -2453,6 +2454,7 @@ safe_lane_health_replan_warn_threshold = 0.55
                 "https://ark.cn-beijing.volces.com/api/v3/models",
             ),
             (ProviderKind::Xai, "https://api.x.ai/v1/language-models"),
+            (ProviderKind::Xiaomi, "https://api.xiaomimimo.com/v1/models"),
             (ProviderKind::Zai, "https://api.z.ai/api/paas/v4/models"),
             (
                 ProviderKind::Zhipu,

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -485,6 +485,7 @@ mod tests {
                 "volcengine",
                 "volcengine_coding",
                 "xai",
+                "xiaomi",
                 "zai",
                 "zhipu"
             ]
@@ -529,6 +530,10 @@ mod tests {
                 "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
             ),
             (ProviderKind::Xai, "https://api.x.ai/v1/chat/completions"),
+            (
+                ProviderKind::Xiaomi,
+                "https://api.xiaomimimo.com/v1/chat/completions",
+            ),
             (
                 ProviderKind::Zai,
                 "https://api.z.ai/api/paas/v4/chat/completions",

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2884,6 +2884,8 @@ impl ProviderKind {
             Some("deepseek-chat")
         } else if matches!(self, ProviderKind::Minimax) {
             Some("MiniMax-M2.7")
+        } else if matches!(self, ProviderKind::Xiaomi) {
+            Some("mimo-v2-pro")
         } else {
             None
         }
@@ -4799,7 +4801,7 @@ api_key_env = "OPENAI_API_KEY"
         );
         assert_eq!(
             ProviderKind::Xiaomi.recommended_onboarding_model(),
-            Some("mimo-v2-flash")
+            Some("mimo-v2-pro")
         );
         assert_eq!(
             ProviderKind::KimiCoding.recommended_onboarding_model(),

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -688,6 +688,14 @@ pub enum ProviderKind {
     VolcengineCoding,
     #[serde(alias = "xai_compatible", alias = "grok")]
     Xai,
+    #[serde(
+        alias = "xiaomi_compatible",
+        alias = "xiaomi_mimo",
+        alias = "xiaomi-mimo",
+        alias = "mimo",
+        alias = "mimo_compatible"
+    )]
+    Xiaomi,
     #[serde(alias = "zai_compatible", alias = "z.ai")]
     Zai,
     #[serde(alias = "zhipu_compatible", alias = "glm", alias = "bigmodel")]
@@ -2560,6 +2568,7 @@ impl ProviderKind {
             ProviderKind::Volcengine => "Volcengine",
             ProviderKind::VolcengineCoding => "Volcengine Coding",
             ProviderKind::Xai => "xAI",
+            ProviderKind::Xiaomi => "Xiaomi",
             ProviderKind::Zai => "Z.ai",
             ProviderKind::Zhipu => "Zhipu",
         }
@@ -2610,6 +2619,7 @@ impl ProviderKind {
             volcengine,
             volcengine_coding,
             xai,
+            xiaomi,
             zai,
             zhipu,
         ] = &PROVIDER_PROFILES;
@@ -2654,6 +2664,7 @@ impl ProviderKind {
             ProviderKind::Volcengine => volcengine,
             ProviderKind::VolcengineCoding => volcengine_coding,
             ProviderKind::Xai => xai,
+            ProviderKind::Xiaomi => xiaomi,
             ProviderKind::Zai => zai,
             ProviderKind::Zhipu => zhipu,
         }
@@ -2855,7 +2866,8 @@ impl ProviderKind {
             | ProviderKind::Vllm
             | ProviderKind::Volcengine
             | ProviderKind::VolcengineCoding
-            | ProviderKind::Xai => None,
+            | ProviderKind::Xai
+            | ProviderKind::Xiaomi => None,
         }
     }
 
@@ -2991,7 +3003,7 @@ pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
     None
 }
 
-const PROVIDER_KIND_ORDER: [ProviderKind; 41] = [
+const PROVIDER_KIND_ORDER: [ProviderKind; 42] = [
     ProviderKind::Anthropic,
     ProviderKind::BailianCoding,
     ProviderKind::Bedrock,
@@ -3031,11 +3043,12 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 41] = [
     ProviderKind::Volcengine,
     ProviderKind::VolcengineCoding,
     ProviderKind::Xai,
+    ProviderKind::Xiaomi,
     ProviderKind::Zai,
     ProviderKind::Zhipu,
 ];
 
-const PROVIDER_PROFILES: [ProviderProfile; 41] = [
+const PROVIDER_PROFILES: [ProviderProfile; 42] = [
     ProviderProfile {
         kind: ProviderKind::Anthropic,
         id: "anthropic",
@@ -3714,6 +3727,29 @@ const PROVIDER_PROFILES: [ProviderProfile; 41] = [
         default_headers: &[],
         default_api_key_env: Some("XAI_API_KEY"),
         api_key_env_aliases: &[],
+        default_user_agent: None,
+        default_oauth_access_token_env: None,
+        oauth_access_token_env_aliases: &[],
+        feature_family: ProviderFeatureFamily::OpenAiCompatible,
+    },
+    ProviderProfile {
+        kind: ProviderKind::Xiaomi,
+        id: "xiaomi",
+        aliases: &[
+            "xiaomi_compatible",
+            "xiaomi_mimo",
+            "xiaomi-mimo",
+            "mimo",
+            "mimo_compatible",
+        ],
+        base_url: "https://api.xiaomimimo.com",
+        chat_completions_path: "/v1/chat/completions",
+        models_path: Some("/v1/models"),
+        protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
+        auth_scheme: ProviderAuthScheme::Bearer,
+        default_headers: &[],
+        default_api_key_env: Some("XIAOMI_API_KEY"),
+        api_key_env_aliases: &["MIMO_API_KEY", "XIAOMIMIMO_API_KEY"],
         default_user_agent: None,
         default_oauth_access_token_env: None,
         oauth_access_token_env_aliases: &[],
@@ -4760,6 +4796,10 @@ api_key_env = "OPENAI_API_KEY"
         assert_eq!(
             ProviderKind::Minimax.recommended_onboarding_model(),
             Some("MiniMax-M2.7")
+        );
+        assert_eq!(
+            ProviderKind::Xiaomi.recommended_onboarding_model(),
+            Some("mimo-v2-flash")
         );
         assert_eq!(
             ProviderKind::KimiCoding.recommended_onboarding_model(),

--- a/crates/daemon/src/onboarding_model_policy.rs
+++ b/crates/daemon/src/onboarding_model_policy.rs
@@ -185,6 +185,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_onboarding_model_prompt_default_uses_xiaomi_reviewed_default_for_auto() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Xiaomi;
+        config.provider.model = "auto".to_owned();
+
+        let prompt_default = resolve_onboarding_model_prompt_default(&config.provider, None)
+            .expect("resolve prompt default");
+
+        assert_eq!(prompt_default, "mimo-v2-pro");
+    }
+
+    #[test]
     fn resolve_onboarding_model_prompt_default_keeps_auto_for_unreviewed_provider() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Custom;

--- a/crates/daemon/src/provider_model_probe_policy.rs
+++ b/crates/daemon/src/provider_model_probe_policy.rs
@@ -274,6 +274,23 @@ mod tests {
     }
 
     #[test]
+    fn provider_model_probe_failure_preserves_xiaomi_reviewed_model_recovery() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Xiaomi;
+        config.provider.model = "auto".to_owned();
+
+        let failure = provider_model_probe_failure(&config, "401 Unauthorized");
+
+        assert_eq!(failure.level, ProviderModelProbeFailureLevel::Fail);
+        assert_eq!(
+            failure.kind,
+            ProviderModelProbeFailureKind::RequiresExplicitModel {
+                recommended_onboarding_model: Some("mimo-v2-pro".to_owned()),
+            }
+        );
+    }
+
+    #[test]
     fn provider_model_probe_failure_appends_region_hint_for_auth_failures() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw does not currently ship a built-in Xiaomi MiMo provider, so users cannot select Xiaomi through the standard provider kind flow.

- Why it matters:
  Without a first-class provider entry, Xiaomi MiMo users have to fall back to custom provider configuration and miss the existing defaults for provider metadata, model discovery, credential hints, and onboarding behavior.

- What changed:
  Added `ProviderKind::Xiaomi` and wired in the Xiaomi MiMo provider profile, aliases, default request endpoint, models endpoint, default API key environment variable, display name, and default / recommended onboarding model. Added config-level stability tests for the new provider.

- What did not change (scope boundary):
  This does not introduce Xiaomi-specific transport execution logic, request-shape branching, or auth handling. The change only extends the existing OpenAI-compatible provider metadata/config path.

## Linked Issues

- Closes #1040
- Related #1040

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw provider_credential_check_passes_for_auth_optional_provider -- --exact
- Passed

cargo test -p loongclaw-app provider_kinds_are_sorted_alphabetically -- --exact
- Passed

Manual verification:
- Confirmed ProviderKind ordering includes `xiaomi`
- Confirmed default endpoint resolves to https://api.xiaomimimo.com/v1/chat/completions
- Confirmed models endpoint resolves to https://api.xiaomimimo.com/v1/models
- Confirmed default credential env mapping uses `XIAOMI_API_KEY`
- Confirmed onboarding/default model selection uses `mimo-v2-pro`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xiaomi as a supported provider with multiple naming aliases, dedicated API endpoints, and a default onboarding model recommendation ("mimo-v2-pro").

* **Tests**
  * Added unit tests validating Xiaomi’s onboarding-model default and that probe failures preserve the reviewed model recommendation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
