### PR TITLE
feat(session): persist frozen delegate results

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -217,6 +217,8 @@ pub struct DelegateToolConfig {
     pub child_tool_allowlist: Vec<String>,
     #[serde(default)]
     pub allow_shell_in_child: bool,
+    #[serde(default = "default_delegate_max_frozen_bytes")]
+    pub max_frozen_bytes: usize,
     #[serde(default)]
     pub child_runtime: DelegateChildRuntimeConfig,
 }
@@ -607,6 +609,7 @@ impl Default for DelegateToolConfig {
             timeout_seconds: default_delegate_timeout_seconds(),
             child_tool_allowlist: default_delegate_child_tool_allowlist(),
             allow_shell_in_child: false,
+            max_frozen_bytes: default_delegate_max_frozen_bytes(),
             child_runtime: DelegateChildRuntimeConfig::default(),
         }
     }
@@ -818,6 +821,14 @@ impl ToolConfig {
                 MAX_WEB_FETCH_MAX_REDIRECTS,
             )
         {
+            issues.push(*issue);
+        }
+        if let Err(issue) = validate_numeric_range(
+            "tools.delegate.max_frozen_bytes",
+            self.delegate.max_frozen_bytes,
+            1,
+            usize::MAX,
+        ) {
             issues.push(*issue);
         }
         let timeout_as_usize = usize::try_from(self.web_search.timeout_seconds).map_err(|_e| {
@@ -1248,6 +1259,10 @@ const fn default_delegate_timeout_seconds() -> u64 {
     60
 }
 
+const fn default_delegate_max_frozen_bytes() -> usize {
+    256 * 1024
+}
+
 const fn default_browser_max_sessions() -> usize {
     DEFAULT_BROWSER_MAX_SESSIONS
 }
@@ -1337,6 +1352,7 @@ mod tests {
         assert_eq!(config.delegate.max_depth, 1);
         assert_eq!(config.delegate.max_active_children, 5);
         assert_eq!(config.delegate.timeout_seconds, 60);
+        assert_eq!(config.delegate.max_frozen_bytes, 256 * 1024);
         assert_eq!(
             config.delegate.child_tool_allowlist,
             vec![
@@ -1591,6 +1607,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_zero_delegate_max_frozen_bytes() {
+        let mut config = ToolConfig::default();
+        config.delegate.max_frozen_bytes = 0;
+
+        let issues = config.validate();
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.field_path == "tools.delegate.max_frozen_bytes"),
+            "expected delegate max_frozen_bytes validation issue, got {issues:?}"
+        );
+    }
+
+    #[test]
     fn validate_rejects_zero_tool_execution_per_tool_timeout() {
         let mut config = ToolConfig::default();
         config
@@ -1704,6 +1735,7 @@ max_depth = 2
 max_active_children = 4
 timeout_seconds = 90
 allow_shell_in_child = true
+max_frozen_bytes = 131072
 child_tool_allowlist = ["file.read", "shell.exec"]
 
 [tools.delegate.child_runtime.web]
@@ -1744,6 +1776,7 @@ max_text_chars = 1024
         assert_eq!(parsed.tools.delegate.max_active_children, 4);
         assert_eq!(parsed.tools.delegate.timeout_seconds, 90);
         assert!(parsed.tools.delegate.allow_shell_in_child);
+        assert_eq!(parsed.tools.delegate.max_frozen_bytes, 131072);
         assert_eq!(
             parsed.tools.delegate.child_tool_allowlist,
             vec!["file.read".to_owned(), "shell.exec".to_owned()]

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -19,7 +19,9 @@ pub const DEFAULT_BROWSER_MAX_TEXT_CHARS: usize = 6000;
 pub const DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS: u64 = 30;
 pub const DEFAULT_RUNTIME_SELF_MAX_SOURCE_CHARS: usize = 20_000;
 pub const DEFAULT_RUNTIME_SELF_MAX_TOTAL_CHARS: usize = 150_000;
+pub const DEFAULT_DELEGATE_MAX_FROZEN_BYTES: usize = 256 * 1024;
 pub const DEFAULT_EXTERNAL_SKILLS_BLOCKED_DOMAIN_RULES: [&str; 1] = ["*.clawhub.io"];
+pub(crate) const MIN_DELEGATE_MAX_FROZEN_BYTES: usize = 1;
 pub(crate) const MIN_WEB_FETCH_MAX_BYTES: usize = 1024;
 pub const MAX_WEB_FETCH_MAX_BYTES: usize = 5 * 1024 * 1024;
 pub(crate) const MIN_WEB_FETCH_TIMEOUT_SECONDS: usize = 1;
@@ -826,7 +828,7 @@ impl ToolConfig {
         if let Err(issue) = validate_numeric_range(
             "tools.delegate.max_frozen_bytes",
             self.delegate.max_frozen_bytes,
-            1,
+            MIN_DELEGATE_MAX_FROZEN_BYTES,
             usize::MAX,
         ) {
             issues.push(*issue);
@@ -1260,7 +1262,7 @@ const fn default_delegate_timeout_seconds() -> u64 {
 }
 
 const fn default_delegate_max_frozen_bytes() -> usize {
-    256 * 1024
+    DEFAULT_DELEGATE_MAX_FROZEN_BYTES
 }
 
 const fn default_browser_max_sessions() -> usize {
@@ -1352,7 +1354,10 @@ mod tests {
         assert_eq!(config.delegate.max_depth, 1);
         assert_eq!(config.delegate.max_active_children, 5);
         assert_eq!(config.delegate.timeout_seconds, 60);
-        assert_eq!(config.delegate.max_frozen_bytes, 256 * 1024);
+        assert_eq!(
+            config.delegate.max_frozen_bytes,
+            DEFAULT_DELEGATE_MAX_FROZEN_BYTES
+        );
         assert_eq!(
             config.delegate.child_tool_allowlist,
             vec![

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23869,7 +23869,7 @@ async fn handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirt
     let cleanup_status = std::process::Command::new(git_executable)
         .args([
             "-C",
-            workspace_root.as_str(),
+            repo_root.to_str().expect("repo root path should be utf-8"),
             "worktree",
             "remove",
             "--force",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23486,21 +23486,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
         .collect();
     assert!(event_kinds.contains(&"delegate_queued"));
     assert!(!event_kinds.contains(&"delegate_spawn_failed"));
-
-    let recovery_event = events
-        .iter()
-        .find(|event| event.event_kind == "delegate_recovery_applied")
-        .expect("delegate recovery event");
-    assert_eq!(
-        recovery_event.payload_json["recovery_kind"],
-        "async_spawn_failure_persist_failed"
-    );
-    assert_eq!(recovery_event.payload_json["recovered_state"], "failed");
-    assert_eq!(
-        recovery_event.payload_json["original_error"],
-        "spawn unavailable"
-    );
-
+    assert!(!event_kinds.contains(&"delegate_recovery_applied"));
     assert!(
         repo.load_terminal_outcome(&child.session_id)
             .expect("load terminal outcome")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -19911,6 +19911,12 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
         terminal_outcome.payload_json["final_output"],
         "Child final output"
     );
+    let frozen_result = terminal_outcome.frozen_result.expect("frozen result");
+    assert!(!frozen_result.truncated);
+    assert_eq!(
+        frozen_result.content,
+        crate::session::frozen_result::FrozenContent::Text("Child final output".to_owned())
+    );
 
     let requested = runtime
         .turn_requested_tool_views
@@ -20222,6 +20228,12 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
     assert_eq!(
         terminal_outcome.payload_json["final_output"],
         "Child final output"
+    );
+    let frozen_result = terminal_outcome.frozen_result.expect("frozen result");
+    assert!(!frozen_result.truncated);
+    assert_eq!(
+        frozen_result.content,
+        crate::session::frozen_result::FrozenContent::Text("Child final output".to_owned())
     );
 
     assert_eq!(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -32,6 +32,8 @@ use crate::operator::delegate_runtime::{
     DelegateChildExecutionPolicy, build_delegate_child_lifecycle_seed, next_delegate_child_depth,
 };
 use crate::runtime_self_continuity;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::frozen_result::capture_frozen_result;
 
 use super::super::config::{LoongClawConfig, ToolConsentMode};
 use super::ConversationSessionAddress;
@@ -4438,6 +4440,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
             timeout_seconds: delegate_policy.timeout_seconds,
             binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
         },
+        config.tools.delegate.max_frozen_bytes,
     );
 
     let mut outcome = crate::tools::delegate::delegate_async_queued_outcome(
@@ -4605,6 +4608,8 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
+            let frozen_result =
+                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
             finalize_delegate_child_terminal_with_recovery(
                 &repo,
                 child_session_id,
@@ -4621,6 +4626,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
+                    frozen_result: Some(frozen_result),
                 },
             )?;
             if execution.mode == ConstrainedSubagentMode::Async {
@@ -4662,6 +4668,8 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
+            let frozen_result =
+                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
             finalize_delegate_child_terminal_with_recovery(
                 &repo,
                 child_session_id,
@@ -4678,6 +4686,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
+                    frozen_result: Some(frozen_result),
                 },
             )?;
             if execution.mode == ConstrainedSubagentMode::Async {
@@ -4720,6 +4729,8 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
+            let frozen_result =
+                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
             finalize_delegate_child_terminal_with_recovery(
                 &repo,
                 child_session_id,
@@ -4736,6 +4747,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
+                    frozen_result: Some(frozen_result),
                 },
             )?;
             if execution.mode == ConstrainedSubagentMode::Async {
@@ -4777,6 +4789,8 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
+            let frozen_result =
+                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
             finalize_delegate_child_terminal_with_recovery(
                 &repo,
                 child_session_id,
@@ -4793,6 +4807,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
+                    frozen_result: Some(frozen_result),
                 },
             )?;
             if execution.mode == ConstrainedSubagentMode::Async {
@@ -4827,6 +4842,7 @@ fn finalize_async_delegate_spawn_failure(
     label: Option<String>,
     profile: Option<crate::conversation::DelegateBuiltinProfile>,
     execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
     error: String,
 ) -> Result<(), String> {
     crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure(
@@ -4836,6 +4852,7 @@ fn finalize_async_delegate_spawn_failure(
         label,
         profile,
         execution,
+        max_frozen_bytes,
         error,
     )
 }
@@ -4848,6 +4865,7 @@ fn finalize_async_delegate_spawn_failure_with_recovery(
     label: Option<String>,
     profile: Option<crate::conversation::DelegateBuiltinProfile>,
     execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
     error: String,
 ) -> Result<(), String> {
     crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure_with_recovery(
@@ -4857,6 +4875,7 @@ fn finalize_async_delegate_spawn_failure_with_recovery(
         label,
         profile,
         execution,
+        max_frozen_bytes,
         error,
     )
 }
@@ -4880,6 +4899,7 @@ fn spawn_async_delegate_detached(
     memory_config: MemoryRuntimeConfig,
     spawner: std::sync::Arc<dyn AsyncDelegateSpawner>,
     request: AsyncDelegateSpawnRequest,
+    max_frozen_bytes: usize,
 ) {
     let child_session_id = request.child_session_id.clone();
     let parent_session_id = request.parent_session_id.clone();
@@ -4904,6 +4924,8 @@ fn spawn_async_delegate_detached(
                 label.clone(),
                 profile,
                 &execution,
+                error.clone(),
+                max_frozen_bytes,
                 error.clone(),
             );
             if let Err(finalize_error) = finalize_result {
@@ -8097,6 +8119,7 @@ mod tests {
                 outcome_payload_json: json!({
                     "error": "delegate_recovered"
                 }),
+                frozen_result: None,
             },
         )
         .expect("recover child terminal state")
@@ -8146,6 +8169,7 @@ mod tests {
                     "child_session_id": "child-session",
                     "final_output": "late success",
                 }),
+                frozen_result: None,
             },
         )
         .expect("stale running finalizer should no-op");
@@ -8228,6 +8252,9 @@ mod tests {
             Some("Child".to_owned()),
             None,
             &execution,
+            crate::config::ToolConfig::default()
+                .delegate
+                .max_frozen_bytes,
             "spawn unavailable".to_owned(),
         )
         .expect("stale queued spawn failure finalizer should no-op");
@@ -8288,6 +8315,7 @@ mod tests {
                     "child_session_id": "child-session",
                     "final_output": "late success",
                 }),
+                frozen_result: None,
             },
         )
         .expect_err("missing child session should not be treated as stale");
@@ -8337,6 +8365,9 @@ mod tests {
             Some("Child".to_owned()),
             None,
             &execution,
+            crate::config::ToolConfig::default()
+                .delegate
+                .max_frozen_bytes,
             "spawn unavailable".to_owned(),
         )
         .expect_err("missing child session should not bypass spawn failure recovery");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -131,7 +131,8 @@ use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
 #[cfg(feature = "memory-sqlite")]
 use crate::conversation::workspace_isolation::{
     DelegateWorkspaceCleanupResult, cleanup_delegate_workspace_root,
-    cleanup_prepared_delegate_workspace_root, prepare_delegate_workspace_root,
+    cleanup_prepared_delegate_workspace_root, normalize_delegate_workspace_path,
+    prepare_delegate_workspace_root,
 };
 #[cfg(all(feature = "memory-sqlite", test))]
 use crate::session::recovery::RECOVERY_EVENT_KIND;
@@ -3518,7 +3519,8 @@ fn inject_delegate_workspace_metadata(
 
     object.insert("isolation".to_owned(), json!(execution.isolation.as_str()));
     if let Some(workspace_root) = execution.workspace_root.as_ref() {
-        let display_path = workspace_root.display().to_string();
+        let normalized_workspace_root = normalize_delegate_workspace_path(workspace_root);
+        let display_path = normalized_workspace_root.display().to_string();
         object.insert("workspace_root".to_owned(), json!(display_path));
     }
     if let Some(cleanup) = cleanup {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4924,7 +4924,6 @@ fn spawn_async_delegate_detached(
                 label.clone(),
                 profile,
                 &execution,
-                error.clone(),
                 max_frozen_bytes,
                 error.clone(),
             );
@@ -8103,6 +8102,14 @@ mod tests {
         repo: &SessionRepository,
         expected_state: SessionState,
     ) -> FinalizeSessionTerminalResult {
+        let frozen_result = crate::session::frozen_result::FrozenResult {
+            content: crate::session::frozen_result::FrozenContent::Text(
+                "delegate_recovered".to_owned(),
+            ),
+            captured_at: std::time::SystemTime::now(),
+            byte_len: "delegate_recovered".len(),
+            truncated: false,
+        };
         repo.finalize_session_terminal_if_current(
             "child-session",
             expected_state,
@@ -8119,7 +8126,7 @@ mod tests {
                 outcome_payload_json: json!({
                     "error": "delegate_recovered"
                 }),
-                frozen_result: None,
+                frozen_result: Some(frozen_result),
             },
         )
         .expect("recover child terminal state")
@@ -8197,6 +8204,13 @@ mod tests {
             .expect("terminal outcome row");
         assert_eq!(terminal_outcome.status, "error");
         assert_eq!(terminal_outcome.payload_json["error"], "delegate_recovered");
+        assert_eq!(
+            terminal_outcome
+                .frozen_result
+                .expect("frozen result")
+                .content,
+            crate::session::frozen_result::FrozenContent::Text("delegate_recovered".to_owned())
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -8282,6 +8296,13 @@ mod tests {
             .expect("terminal outcome row");
         assert_eq!(terminal_outcome.status, "error");
         assert_eq!(terminal_outcome.payload_json["error"], "delegate_recovered");
+        assert_eq!(
+            terminal_outcome
+                .frozen_result
+                .expect("frozen result")
+                .content,
+            crate::session::frozen_result::FrozenContent::Text("delegate_recovered".to_owned())
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/workspace_isolation.rs
+++ b/crates/app/src/conversation/workspace_isolation.rs
@@ -18,6 +18,21 @@ pub(super) struct DelegateWorkspaceCleanupResult {
     pub dirty: bool,
 }
 
+pub(super) fn normalize_delegate_workspace_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let raw_path = path.as_os_str().to_string_lossy();
+        if let Some(trimmed_path) = raw_path.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{trimmed_path}"));
+        }
+        if let Some(trimmed_path) = raw_path.strip_prefix(r"\\?\") {
+            return PathBuf::from(trimmed_path);
+        }
+    }
+
+    path.to_path_buf()
+}
+
 pub(super) fn prepare_delegate_workspace_root(
     config: &LoongClawConfig,
     child_session_id: &str,
@@ -176,13 +191,15 @@ fn add_detached_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), S
 }
 
 fn remove_delegate_worktree(worktree_root: &Path) -> Result<(), String> {
+    let repo_root = delegate_worktree_repo_root(worktree_root)?;
+    let normalized_worktree_root = normalize_delegate_workspace_path(worktree_root);
     let args = [
         OsStr::new("-C"),
-        worktree_root.as_os_str(),
+        repo_root.as_os_str(),
         OsStr::new("worktree"),
         OsStr::new("remove"),
         OsStr::new("--force"),
-        worktree_root.as_os_str(),
+        normalized_worktree_root.as_os_str(),
     ];
     let output = run_git_command(&args)?;
     if output.status.success() {
@@ -194,6 +211,26 @@ fn remove_delegate_worktree(worktree_root: &Path) -> Result<(), String> {
     Err(format!(
         "remove delegate worktree `{display_path}` failed: {stderr}"
     ))
+}
+
+fn delegate_worktree_repo_root(worktree_root: &Path) -> Result<&Path, String> {
+    let worktrees_root = worktree_root.parent().ok_or_else(|| {
+        let display_path = worktree_root.display();
+        format!("delegate worktree `{display_path}` is missing a parent directory")
+    })?;
+    let marker = worktrees_root.file_name();
+    if marker != Some(OsStr::new(".worktrees")) {
+        let display_path = worktree_root.display();
+        return Err(format!(
+            "delegate worktree `{display_path}` is not rooted under a `.worktrees` directory"
+        ));
+    }
+
+    let repo_root = worktrees_root.parent().ok_or_else(|| {
+        let display_path = worktree_root.display();
+        format!("delegate worktree `{display_path}` is missing its repository root")
+    })?;
+    Ok(repo_root)
 }
 
 fn delegate_worktree_is_dirty(workspace_root: &Path) -> Result<bool, String> {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -103,7 +103,7 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 9;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 10;
 const CANONICAL_REBUILD_BATCH_SIZE: i64 = 256;
 const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 18;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
@@ -1665,6 +1665,7 @@ fn ensure_sqlite_schema_repairs_if_needed(conn: &mut Connection) -> Result<(), S
     }
 
     ensure_turn_session_index_and_state_metadata(conn)?;
+    ensure_session_terminal_outcome_storage(conn)?;
     ensure_approval_lifecycle_tables(conn)?;
     ensure_session_tool_consent_storage(conn)?;
     ensure_session_tool_policy_storage(conn)?;
@@ -1689,8 +1690,10 @@ fn sqlite_current_schema_objects_ready(conn: &Connection) -> Result<bool, String
         .map_err(|error| format!("probe sqlite current schema objects failed: {error}"))?;
     let object_count_ready = object_count == SQLITE_CURRENT_SCHEMA_OBJECT_COUNT;
     let canonical_fts_ready = !canonical_record_fts_needs_rebuild(conn)?;
+    let terminal_outcome_storage_ready =
+        sqlite_table_has_column(conn, "session_terminal_outcomes", "frozen_result_json")?;
 
-    Ok(object_count_ready && canonical_fts_ready)
+    Ok(object_count_ready && canonical_fts_ready && terminal_outcome_storage_ready)
 }
 
 fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(), String> {
@@ -1754,6 +1757,7 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
           session_id TEXT PRIMARY KEY,
           status TEXT NOT NULL,
           payload_json TEXT NOT NULL,
+          frozen_result_json TEXT NULL,
           recorded_at INTEGER NOT NULL
         );
         ",
@@ -1782,6 +1786,39 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
         [],
     )
     .map_err(|error| format!("remove stale session turn count metadata failed: {error}"))?;
+
+    Ok(())
+}
+
+fn ensure_session_terminal_outcome_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("session_terminal_outcomes");
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
+          session_id TEXT PRIMARY KEY,
+          status TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          frozen_result_json TEXT NULL,
+          recorded_at INTEGER NOT NULL
+        );
+        ",
+    )
+    .map_err(|error| format!("ensure session terminal outcome storage failed: {error}"))?;
+
+    let has_frozen_result_column =
+        sqlite_table_has_column(conn, "session_terminal_outcomes", "frozen_result_json")?;
+    if !has_frozen_result_column {
+        conn.execute(
+            "ALTER TABLE session_terminal_outcomes
+             ADD COLUMN frozen_result_json TEXT NULL",
+            [],
+        )
+        .map_err(|error| {
+            format!("add session terminal outcome frozen result column failed: {error}")
+        })?;
+    }
 
     Ok(())
 }
@@ -5000,6 +5037,67 @@ mod tests {
             .expect("read sqlite user_version");
 
         assert_eq!(user_version, SQLITE_MEMORY_SCHEMA_VERSION);
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_memory_db_ready_repairs_session_terminal_outcome_frozen_result_column() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-session-terminal-outcome-frozen-column-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("terminal-outcome.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let conn = Connection::open(&db_path).expect("open legacy sqlite db");
+        configure_sqlite_connection(&conn).expect("configure legacy sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE turns(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              ts INTEGER NOT NULL
+            );
+            CREATE TABLE session_terminal_outcomes(
+              session_id TEXT PRIMARY KEY,
+              status TEXT NOT NULL,
+              payload_json TEXT NOT NULL,
+              recorded_at INTEGER NOT NULL
+            );
+            PRAGMA user_version = 9;
+            ",
+        )
+        .expect("create legacy terminal outcome schema");
+        drop(conn);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        ensure_memory_db_ready(Some(db_path.clone()), &config).expect("repair sqlite db");
+
+        let conn = Connection::open(&db_path).expect("open repaired sqlite db");
+        let columns = sqlite_table_columns(&conn, "session_terminal_outcomes")
+            .expect("session_terminal_outcomes columns");
+
+        assert!(columns.iter().any(|column| column == "frozen_result_json"));
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -69,6 +69,16 @@ pub struct SqliteContextLoadDiagnostics {
     pub summary_catch_up_ms: f64,
 }
 
+const SESSION_TERMINAL_OUTCOMES_TABLE_SQL: &str = "
+CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
+  session_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  frozen_result_json TEXT NULL,
+  recorded_at INTEGER NOT NULL
+);
+";
+
 #[derive(Debug, Clone, Default)]
 struct SqliteConnectionBootstrapDiagnostics {
     parent_dir_create_ms: f64,
@@ -1753,16 +1763,12 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
         );
         CREATE INDEX IF NOT EXISTS idx_session_events_session_id
           ON session_events(session_id, id);
-        CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
-          session_id TEXT PRIMARY KEY,
-          status TEXT NOT NULL,
-          payload_json TEXT NOT NULL,
-          frozen_result_json TEXT NULL,
-          recorded_at INTEGER NOT NULL
-        );
         ",
     )
     .map_err(|error| format!("backfill session turn index metadata failed: {error}"))?;
+
+    conn.execute_batch(SESSION_TERMINAL_OUTCOMES_TABLE_SQL)
+        .map_err(|error| format!("backfill session terminal outcome storage failed: {error}"))?;
 
     conn.execute(
         "INSERT INTO memory_session_state(session_id, turn_count)
@@ -1794,18 +1800,8 @@ fn ensure_session_terminal_outcome_storage(conn: &Connection) -> Result<(), Stri
     #[cfg(test)]
     test_support::record_sqlite_schema_repair("session_terminal_outcomes");
 
-    conn.execute_batch(
-        "
-        CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
-          session_id TEXT PRIMARY KEY,
-          status TEXT NOT NULL,
-          payload_json TEXT NOT NULL,
-          frozen_result_json TEXT NULL,
-          recorded_at INTEGER NOT NULL
-        );
-        ",
-    )
-    .map_err(|error| format!("ensure session terminal outcome storage failed: {error}"))?;
+    conn.execute_batch(SESSION_TERMINAL_OUTCOMES_TABLE_SQL)
+        .map_err(|error| format!("ensure session terminal outcome storage failed: {error}"))?;
 
     let has_frozen_result_column =
         sqlite_table_has_column(conn, "session_terminal_outcomes", "frozen_result_json")?;

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -17,7 +17,7 @@ use crate::session::recovery::{
 };
 use crate::session::repository::{
     CreateSessionWithEventRequest, FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind,
-    SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    SessionRepository, SessionState,
 };
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::trust::{
@@ -271,6 +271,7 @@ fn build_delegate_child_event_payload(
     payload_with_trust
 }
 
+#[cfg(test)]
 pub(crate) fn finalize_async_delegate_spawn_failure(
     memory_config: &MemoryRuntimeConfig,
     child_session_id: &str,
@@ -282,30 +283,15 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
     error: String,
 ) -> Result<(), String> {
     let repo = SessionRepository::new(memory_config)?;
-    let outcome = crate::tools::delegate::delegate_error_outcome(
-        child_session_id.to_owned(),
-        Some(parent_session_id.to_owned()),
+    let request = build_async_delegate_spawn_failure_request(
+        child_session_id,
+        parent_session_id,
         label,
         profile,
-        error.clone(),
-        0,
+        execution,
+        max_frozen_bytes,
+        error,
     );
-    let frozen_result = capture_frozen_result(&outcome, max_frozen_bytes);
-    let request = FinalizeSessionTerminalRequest {
-        state: SessionState::Failed,
-        last_error: Some(error.clone()),
-        event_kind: "delegate_spawn_failed".to_owned(),
-        actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json: execution.terminal_payload(
-            ConstrainedSubagentTerminalReason::SpawnFailed,
-            0,
-            None,
-            Some(error.as_str()),
-        ),
-        outcome_status: outcome.status,
-        outcome_payload_json: outcome.payload,
-        frozen_result: Some(frozen_result),
-    };
     finalize_terminal_if_current_allowing_stale_state(
         &repo,
         child_session_id,
@@ -327,8 +313,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
     error: String,
 ) -> Result<(), String> {
     let recovery_label = label.clone();
-    let finalize_result = finalize_async_delegate_spawn_failure(
-        memory_config,
+    let request = build_async_delegate_spawn_failure_request(
         child_session_id,
         parent_session_id,
         label,
@@ -337,27 +322,42 @@ pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
         max_frozen_bytes,
         error.clone(),
     );
+    let request_frozen_result = request.frozen_result.clone();
+    let repo = SessionRepository::new(memory_config)?;
+    let finalize_result = finalize_terminal_if_current_allowing_stale_state(
+        &repo,
+        child_session_id,
+        SessionState::Ready,
+        request,
+    );
     match finalize_result {
         Ok(()) => Ok(()),
         Err(finalize_error) => {
-            let repo = SessionRepository::new(memory_config)?;
             let recovery_error = format!(
                 "delegate_async_spawn_failure_persist_failed: {finalize_error}; original spawn error: {error}"
             );
-            let transition_result = repo.transition_session_with_event_if_current(
+            let recovery_frozen_result = request_frozen_result.clone();
+            let fallback_frozen_result = request_frozen_result;
+            let recovery_request = FinalizeSessionTerminalRequest {
+                state: SessionState::Failed,
+                last_error: Some(recovery_error.clone()),
+                event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                actor_session_id: Some(parent_session_id.to_owned()),
+                event_payload_json: build_async_spawn_failure_recovery_payload(
+                    recovery_label.as_deref(),
+                    &error,
+                    &recovery_error,
+                ),
+                outcome_status: "error".to_owned(),
+                outcome_payload_json: json!({
+                    "error": recovery_error.as_str(),
+                }),
+                frozen_result: recovery_frozen_result,
+            };
+            let transition_result = repo.finalize_session_terminal_if_current(
                 child_session_id,
-                TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: SessionState::Ready,
-                    next_state: SessionState::Failed,
-                    last_error: Some(recovery_error.clone()),
-                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: build_async_spawn_failure_recovery_payload(
-                        recovery_label.as_deref(),
-                        &error,
-                        &recovery_error,
-                    ),
-                },
+                SessionState::Ready,
+                recovery_request,
             );
             match transition_result {
                 Ok(Some(_)) => Ok(()),
@@ -379,7 +379,15 @@ pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
                         Some(recovery_error.clone()),
                     );
                     match state_result {
-                        Ok(Some(_)) => Ok(()),
+                        Ok(Some(_)) => {
+                            persist_recovery_terminal_outcome(
+                                &repo,
+                                child_session_id,
+                                &recovery_error,
+                                fallback_frozen_result,
+                            )?;
+                            Ok(())
+                        }
                         Ok(None) => {
                             let current_state = repo
                                 .load_session(child_session_id)?
@@ -419,41 +427,29 @@ pub(crate) fn finalize_delegate_child_terminal_with_recovery(
         Ok(()) => Ok(()),
         Err(finalize_error) => {
             let recovery_error = format!("delegate_terminal_finalize_failed: {finalize_error}");
-            let transition_result = repo.transition_session_with_event_if_current(
+            let fallback_frozen_result = recovery_request.frozen_result.clone();
+            let recovery_request = FinalizeSessionTerminalRequest {
+                state: SessionState::Failed,
+                last_error: Some(recovery_error.clone()),
+                event_kind: RECOVERY_EVENT_KIND.to_owned(),
+                actor_session_id: recovery_request.actor_session_id.clone(),
+                event_payload_json: build_terminal_finalize_recovery_payload(
+                    &recovery_request,
+                    &recovery_error,
+                ),
+                outcome_status: "error".to_owned(),
+                outcome_payload_json: json!({
+                    "error": recovery_error.as_str(),
+                }),
+                frozen_result: recovery_request.frozen_result,
+            };
+            let transition_result = repo.finalize_session_terminal_if_current(
                 child_session_id,
-                TransitionSessionWithEventIfCurrentRequest {
-                    expected_state: SessionState::Running,
-                    next_state: SessionState::Failed,
-                    last_error: Some(recovery_error.clone()),
-                    event_kind: RECOVERY_EVENT_KIND.to_owned(),
-                    actor_session_id: recovery_request.actor_session_id.clone(),
-                    event_payload_json: build_terminal_finalize_recovery_payload(
-                        &recovery_request,
-                        &recovery_error,
-                    ),
-                },
+                SessionState::Running,
+                recovery_request,
             );
             match transition_result {
-                Ok(Some(_)) => {
-                    let recovery_outcome_payload = json!({
-                        "error": recovery_error.as_str(),
-                    });
-                    let upsert_result = repo.upsert_terminal_outcome_with_frozen_result(
-                        child_session_id,
-                        "error",
-                        recovery_outcome_payload,
-                        recovery_request.frozen_result,
-                    );
-                    match upsert_result {
-                        Ok(_) => Err(recovery_error),
-                        Err(persist_error) => {
-                            let message = format!(
-                                "{recovery_error}; delegate_terminal_recovery_outcome_persist_failed: {persist_error}"
-                            );
-                            Err(message)
-                        }
-                    }
-                }
+                Ok(Some(_)) => Err(recovery_error),
                 Ok(None) => {
                     delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
                 }
@@ -466,6 +462,17 @@ pub(crate) fn finalize_delegate_child_terminal_with_recovery(
                     );
                     match state_result {
                         Ok(Some(_)) => {
+                            if let Err(persist_error) = persist_recovery_terminal_outcome(
+                                repo,
+                                child_session_id,
+                                &recovery_error,
+                                fallback_frozen_result,
+                            ) {
+                                let message = format!(
+                                    "{recovery_error}; delegate_terminal_recovery_outcome_persist_failed: {persist_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
+                                );
+                                return Err(message);
+                            }
                             let message = format!(
                                 "{recovery_error}; delegate_terminal_recovery_event_failed: {recovery_event_error}"
                             );
@@ -487,6 +494,61 @@ pub(crate) fn finalize_delegate_child_terminal_with_recovery(
             }
         }
     }
+}
+
+fn build_async_delegate_spawn_failure_request(
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    profile: Option<DelegateBuiltinProfile>,
+    execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
+    error: String,
+) -> FinalizeSessionTerminalRequest {
+    let outcome = crate::tools::delegate::delegate_error_outcome(
+        child_session_id.to_owned(),
+        Some(parent_session_id.to_owned()),
+        label,
+        profile,
+        error.clone(),
+        0,
+    );
+    let frozen_result = capture_frozen_result(&outcome, max_frozen_bytes);
+
+    FinalizeSessionTerminalRequest {
+        state: SessionState::Failed,
+        last_error: Some(error.clone()),
+        event_kind: "delegate_spawn_failed".to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json: execution.terminal_payload(
+            ConstrainedSubagentTerminalReason::SpawnFailed,
+            0,
+            None,
+            Some(error.as_str()),
+        ),
+        outcome_status: outcome.status,
+        outcome_payload_json: outcome.payload,
+        frozen_result: Some(frozen_result),
+    }
+}
+
+fn persist_recovery_terminal_outcome(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    recovery_error: &str,
+    frozen_result: Option<crate::session::frozen_result::FrozenResult>,
+) -> Result<(), String> {
+    let recovery_outcome_payload = json!({
+        "error": recovery_error,
+    });
+    repo.upsert_terminal_outcome_with_frozen_result(
+        child_session_id,
+        "error",
+        recovery_outcome_payload,
+        frozen_result,
+    )?;
+
+    Ok(())
 }
 
 fn finalize_terminal_if_current_allowing_stale_state(
@@ -794,5 +856,108 @@ mod tests {
             .expect("terminal outcome row");
         assert_eq!(terminal_outcome.status, "error");
         assert_eq!(terminal_outcome.frozen_result, Some(frozen_result));
+    }
+
+    #[test]
+    fn finalize_async_delegate_spawn_failure_with_recovery_persists_frozen_result() {
+        let (repo, sqlite_path) = isolated_repo_with_path("spawn-failure-recovery-frozen-result");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child session");
+
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Async,
+            isolation: ConstrainedSubagentIsolation::default(),
+            depth: 1,
+            max_depth: 1,
+            active_children: 0,
+            max_active_children: 1,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec![
+                "file.read".to_owned(),
+                "file.write".to_owned(),
+                "file.edit".to_owned(),
+            ],
+            workspace_root: None,
+            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
+            kernel_bound: false,
+            identity: None,
+            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(1, 1)),
+        };
+
+        let conn = Connection::open(&sqlite_path).expect("open sqlite connection");
+        conn.execute(
+            "CREATE TRIGGER fail_delegate_spawn_failed_event
+             BEFORE INSERT ON session_events
+             WHEN NEW.event_kind = 'delegate_spawn_failed'
+             BEGIN
+                SELECT RAISE(FAIL, 'forced delegate_spawn_failed event failure');
+             END;",
+            [],
+        )
+        .expect("create spawn failure trigger");
+        drop(conn);
+
+        finalize_async_delegate_spawn_failure_with_recovery(
+            &MemoryRuntimeConfig {
+                sqlite_path: Some(sqlite_path),
+                ..MemoryRuntimeConfig::default()
+            },
+            "child-session",
+            "root-session",
+            Some("Child".to_owned()),
+            None,
+            &execution,
+            256 * 1024,
+            "spawn unavailable".to_owned(),
+        )
+        .expect("recovery should persist terminal outcome");
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child session")
+            .expect("child session row");
+        assert_eq!(child.state, SessionState::Failed);
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        let event_kinds: Vec<&str> = events
+            .iter()
+            .map(|event| event.event_kind.as_str())
+            .collect();
+        assert!(event_kinds.contains(&RECOVERY_EVENT_KIND));
+        assert!(!event_kinds.contains(&"delegate_spawn_failed"));
+
+        let terminal_outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(terminal_outcome.status, "error");
+        assert!(terminal_outcome.frozen_result.is_some());
+        assert_eq!(
+            terminal_outcome
+                .frozen_result
+                .expect("frozen result")
+                .content,
+            crate::session::frozen_result::FrozenContent::Error {
+                code: "spawn unavailable".to_owned(),
+                message: "spawn unavailable".to_owned(),
+            }
+        );
     }
 }

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::config::LoongClawConfig;
 use crate::conversation::{
@@ -10,6 +10,7 @@ use crate::conversation::{
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity::RuntimeSelfContinuity;
+use crate::session::frozen_result::capture_frozen_result;
 use crate::session::recovery::{
     RECOVERY_EVENT_KIND, build_async_spawn_failure_recovery_payload,
     build_terminal_finalize_recovery_payload,
@@ -277,6 +278,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
     label: Option<String>,
     profile: Option<DelegateBuiltinProfile>,
     execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
     error: String,
 ) -> Result<(), String> {
     let repo = SessionRepository::new(memory_config)?;
@@ -288,6 +290,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
         error.clone(),
         0,
     );
+    let frozen_result = capture_frozen_result(&outcome, max_frozen_bytes);
     let request = FinalizeSessionTerminalRequest {
         state: SessionState::Failed,
         last_error: Some(error.clone()),
@@ -301,6 +304,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
         ),
         outcome_status: outcome.status,
         outcome_payload_json: outcome.payload,
+        frozen_result: Some(frozen_result),
     };
     finalize_terminal_if_current_allowing_stale_state(
         &repo,
@@ -319,6 +323,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
     label: Option<String>,
     profile: Option<DelegateBuiltinProfile>,
     execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
     error: String,
 ) -> Result<(), String> {
     let recovery_label = label.clone();
@@ -329,6 +334,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
         label,
         profile,
         execution,
+        max_frozen_bytes,
         error.clone(),
     );
     match finalize_result {
@@ -428,7 +434,26 @@ pub(crate) fn finalize_delegate_child_terminal_with_recovery(
                 },
             );
             match transition_result {
-                Ok(Some(_)) => Err(recovery_error),
+                Ok(Some(_)) => {
+                    let recovery_outcome_payload = json!({
+                        "error": recovery_error.as_str(),
+                    });
+                    let upsert_result = repo.upsert_terminal_outcome_with_frozen_result(
+                        child_session_id,
+                        "error",
+                        recovery_outcome_payload,
+                        recovery_request.frozen_result,
+                    );
+                    match upsert_result {
+                        Ok(_) => Err(recovery_error),
+                        Err(persist_error) => {
+                            let message = format!(
+                                "{recovery_error}; delegate_terminal_recovery_outcome_persist_failed: {persist_error}"
+                            );
+                            Err(message)
+                        }
+                    }
+                }
                 Ok(None) => {
                     delegate_terminal_recovery_skipped_error(repo, child_session_id, recovery_error)
                 }
@@ -502,6 +527,7 @@ fn delegate_terminal_recovery_skipped_error(
 
 #[cfg(test)]
 mod tests {
+    use rusqlite::Connection;
     use serde_json::json;
 
     use super::*;
@@ -511,6 +537,11 @@ mod tests {
     use crate::trust::extract_trust_event_payload;
 
     fn isolated_repo(test_name: &str) -> SessionRepository {
+        let (repo, _sqlite_path) = isolated_repo_with_path(test_name);
+        repo
+    }
+
+    fn isolated_repo_with_path(test_name: &str) -> (SessionRepository, std::path::PathBuf) {
         let sqlite_path = std::env::temp_dir().join(format!(
             "loongclaw-operator-delegate-runtime-{test_name}-{}.sqlite3",
             std::process::id()
@@ -520,8 +551,10 @@ mod tests {
             sqlite_path: Some(sqlite_path),
             ..MemoryRuntimeConfig::default()
         };
+        let repo = SessionRepository::new(&config).expect("session repository");
+        let sqlite_path = config.sqlite_path.expect("sqlite path");
 
-        SessionRepository::new(&config).expect("session repository")
+        (repo, sqlite_path)
     }
 
     #[test]
@@ -674,5 +707,92 @@ mod tests {
 
         let trust_event = extract_trust_event_payload(&seed.request.event_payload_json);
         assert!(trust_event.is_some(), "expected trust event payload");
+    }
+
+    #[test]
+    fn finalize_delegate_child_terminal_with_recovery_persists_frozen_result_after_recovery_event()
+    {
+        let (repo, sqlite_path) = isolated_repo_with_path("terminal-recovery-frozen-result");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child session");
+
+        let conn = Connection::open(&sqlite_path).expect("open sqlite connection");
+        conn.execute(
+            "CREATE TRIGGER fail_delegate_completed_event
+             BEFORE INSERT ON session_events
+             WHEN NEW.event_kind = 'delegate_completed'
+             BEGIN
+                SELECT RAISE(FAIL, 'forced delegate_completed event failure');
+             END;",
+            [],
+        )
+        .expect("create event failure trigger");
+        drop(conn);
+
+        let frozen_result = crate::session::frozen_result::FrozenResult {
+            content: crate::session::frozen_result::FrozenContent::Text("done".to_owned()),
+            captured_at: std::time::SystemTime::now(),
+            byte_len: "done".len(),
+            truncated: false,
+        };
+        let error = finalize_delegate_child_terminal_with_recovery(
+            &repo,
+            "child-session",
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some("root-session".to_owned()),
+                event_payload_json: json!({
+                    "turn_count": 1,
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": "child-session",
+                    "final_output": "done",
+                }),
+                frozen_result: Some(frozen_result.clone()),
+            },
+        )
+        .expect_err("forced finalize failure should surface recovery error");
+
+        assert!(error.contains("delegate_terminal_finalize_failed"));
+
+        let child = repo
+            .load_session("child-session")
+            .expect("load child session")
+            .expect("child session row");
+        assert_eq!(child.state, SessionState::Failed);
+
+        let events = repo
+            .list_recent_events("child-session", 10)
+            .expect("list child events");
+        let event_kinds: Vec<&str> = events
+            .iter()
+            .map(|event| event.event_kind.as_str())
+            .collect();
+        assert!(event_kinds.contains(&RECOVERY_EVENT_KIND));
+        assert!(!event_kinds.contains(&"delegate_completed"));
+
+        let terminal_outcome = repo
+            .load_terminal_outcome("child-session")
+            .expect("load terminal outcome")
+            .expect("terminal outcome row");
+        assert_eq!(terminal_outcome.status, "error");
+        assert_eq!(terminal_outcome.frozen_result, Some(frozen_result));
     }
 }

--- a/crates/app/src/session/frozen_result.rs
+++ b/crates/app/src/session/frozen_result.rs
@@ -1,0 +1,291 @@
+use std::time::SystemTime;
+
+use loongclaw_contracts::ToolCoreOutcome;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const FALLBACK_ERROR_CODE: &str = "delegate_failed";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrozenResult {
+    pub content: FrozenContent,
+    pub captured_at: SystemTime,
+    pub byte_len: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FrozenContent {
+    Text(String),
+    ToolResult(Value),
+    Error { code: String, message: String },
+}
+
+pub(crate) fn capture_frozen_result(
+    outcome: &ToolCoreOutcome,
+    max_frozen_bytes: usize,
+) -> FrozenResult {
+    let effective_max_frozen_bytes = max_frozen_bytes.max(1);
+    let frozen_capture = freeze_tool_outcome(outcome, effective_max_frozen_bytes);
+
+    FrozenResult {
+        content: frozen_capture.content,
+        captured_at: SystemTime::now(),
+        byte_len: frozen_capture.byte_len,
+        truncated: frozen_capture.truncated,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FrozenCapture {
+    content: FrozenContent,
+    byte_len: usize,
+    truncated: bool,
+}
+
+fn freeze_tool_outcome(outcome: &ToolCoreOutcome, max_frozen_bytes: usize) -> FrozenCapture {
+    let status = outcome.status.trim();
+    let payload = &outcome.payload;
+
+    if status == "ok" {
+        return freeze_success_payload(payload, max_frozen_bytes);
+    }
+
+    if status == "error" || status == "timeout" {
+        return freeze_error_payload(status, payload, max_frozen_bytes);
+    }
+
+    freeze_structured_payload(payload, max_frozen_bytes)
+}
+
+fn freeze_success_payload(payload: &Value, max_frozen_bytes: usize) -> FrozenCapture {
+    let final_output = payload.get("final_output");
+    let final_output_text = final_output.and_then(Value::as_str);
+    if let Some(final_output_text) = final_output_text {
+        return freeze_text(final_output_text, max_frozen_bytes);
+    }
+
+    freeze_structured_payload(payload, max_frozen_bytes)
+}
+
+fn freeze_error_payload(status: &str, payload: &Value, max_frozen_bytes: usize) -> FrozenCapture {
+    let error_code = extract_error_code(status, payload);
+    let error_message = extract_error_message(status, payload);
+    let truncated_code = truncate_utf8(&error_code, max_frozen_bytes);
+    let stored_code = truncated_code.text;
+    let code_byte_len = stored_code.len();
+    let available_message_bytes = max_frozen_bytes.saturating_sub(code_byte_len);
+    let truncated_message = truncate_utf8(&error_message, available_message_bytes);
+    let stored_message = truncated_message.text;
+    let byte_len = code_byte_len + stored_message.len();
+    let truncated = truncated_code.truncated || truncated_message.truncated;
+
+    FrozenCapture {
+        content: FrozenContent::Error {
+            code: stored_code,
+            message: stored_message,
+        },
+        byte_len,
+        truncated,
+    }
+}
+
+fn freeze_structured_payload(payload: &Value, max_frozen_bytes: usize) -> FrozenCapture {
+    let encoded_payload = serde_json::to_string(payload).unwrap_or_else(|_| "null".to_owned());
+    let encoded_payload_bytes = encoded_payload.len();
+    if encoded_payload_bytes <= max_frozen_bytes {
+        return FrozenCapture {
+            content: FrozenContent::ToolResult(payload.clone()),
+            byte_len: encoded_payload_bytes,
+            truncated: false,
+        };
+    }
+
+    freeze_text(&encoded_payload, max_frozen_bytes)
+}
+
+fn freeze_text(text: &str, max_frozen_bytes: usize) -> FrozenCapture {
+    let truncated_text = truncate_utf8(text, max_frozen_bytes);
+    let stored_text = truncated_text.text;
+    let byte_len = stored_text.len();
+    let truncated = truncated_text.truncated;
+
+    FrozenCapture {
+        content: FrozenContent::Text(stored_text),
+        byte_len,
+        truncated,
+    }
+}
+
+fn extract_error_code(status: &str, payload: &Value) -> String {
+    let payload_error = payload.get("error");
+    let payload_error_text = payload_error.and_then(Value::as_str);
+    let trimmed_payload_error = payload_error_text.map(str::trim);
+    let meaningful_payload_error = trimmed_payload_error.filter(|value| !value.is_empty());
+    if let Some(meaningful_payload_error) = meaningful_payload_error {
+        return meaningful_payload_error.to_owned();
+    }
+
+    let trimmed_status = status.trim();
+    if !trimmed_status.is_empty() {
+        return trimmed_status.to_owned();
+    }
+
+    FALLBACK_ERROR_CODE.to_owned()
+}
+
+fn extract_error_message(status: &str, payload: &Value) -> String {
+    let payload_error = payload.get("error");
+    let payload_error_text = payload_error.and_then(Value::as_str);
+    let trimmed_payload_error = payload_error_text.map(str::trim);
+    let meaningful_payload_error = trimmed_payload_error.filter(|value| !value.is_empty());
+    if let Some(meaningful_payload_error) = meaningful_payload_error {
+        return meaningful_payload_error.to_owned();
+    }
+
+    let payload_message = payload.get("message");
+    let payload_message_text = payload_message.and_then(Value::as_str);
+    let trimmed_payload_message = payload_message_text.map(str::trim);
+    let meaningful_payload_message = trimmed_payload_message.filter(|value| !value.is_empty());
+    if let Some(meaningful_payload_message) = meaningful_payload_message {
+        return meaningful_payload_message.to_owned();
+    }
+
+    let encoded_payload = serde_json::to_string(payload).unwrap_or_else(|_| "null".to_owned());
+    if encoded_payload != "null" && encoded_payload != "{}" {
+        return encoded_payload;
+    }
+
+    extract_error_code(status, payload)
+}
+
+struct TruncatedText {
+    text: String,
+    truncated: bool,
+}
+
+fn truncate_utf8(text: &str, max_bytes: usize) -> TruncatedText {
+    let text_byte_len = text.len();
+    if text_byte_len <= max_bytes {
+        return TruncatedText {
+            text: text.to_owned(),
+            truncated: false,
+        };
+    }
+
+    let mut end = max_bytes.min(text_byte_len);
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    let truncated_text = text[..end].to_owned();
+
+    TruncatedText {
+        text: truncated_text,
+        truncated: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{FrozenContent, capture_frozen_result};
+
+    #[test]
+    fn capture_frozen_result_uses_final_output_text_for_success() {
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "final_output": "delegate completed",
+                "child_session_id": "child-session",
+            }),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 256);
+
+        assert_eq!(
+            frozen_result.content,
+            FrozenContent::Text("delegate completed".to_owned())
+        );
+        assert_eq!(frozen_result.byte_len, "delegate completed".len());
+        assert!(!frozen_result.truncated);
+    }
+
+    #[test]
+    fn capture_frozen_result_truncates_utf8_text_without_splitting_codepoints() {
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "final_output": "你好世界",
+            }),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 5);
+
+        assert_eq!(frozen_result.content, FrozenContent::Text("你".to_owned()));
+        assert_eq!(frozen_result.byte_len, "你".len());
+        assert!(frozen_result.truncated);
+    }
+
+    #[test]
+    fn capture_frozen_result_uses_error_variant_for_failures() {
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "error".to_owned(),
+            payload: json!({
+                "error": "delegate_panic",
+            }),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 256);
+
+        assert_eq!(
+            frozen_result.content,
+            FrozenContent::Error {
+                code: "delegate_panic".to_owned(),
+                message: "delegate_panic".to_owned(),
+            }
+        );
+        assert!(!frozen_result.truncated);
+    }
+
+    #[test]
+    fn capture_frozen_result_bounds_error_code_and_message() {
+        let long_error = "delegate_panic_with_a_very_long_error_code";
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "error".to_owned(),
+            payload: json!({
+                "error": long_error,
+            }),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 8);
+
+        assert!(frozen_result.truncated);
+        assert!(frozen_result.byte_len <= 8);
+        assert_eq!(
+            frozen_result.content,
+            FrozenContent::Error {
+                code: "delegate".to_owned(),
+                message: "".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn capture_frozen_result_preserves_structured_payload_when_it_fits() {
+        let payload = json!({
+            "items": ["a", "b"],
+        });
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: payload.clone(),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 256);
+
+        assert_eq!(frozen_result.content, FrozenContent::ToolResult(payload));
+        assert!(!frozen_result.truncated);
+    }
+}

--- a/crates/app/src/session/frozen_result.rs
+++ b/crates/app/src/session/frozen_result.rs
@@ -136,20 +136,20 @@ fn extract_error_code(status: &str, payload: &Value) -> String {
 }
 
 fn extract_error_message(status: &str, payload: &Value) -> String {
-    let payload_error = payload.get("error");
-    let payload_error_text = payload_error.and_then(Value::as_str);
-    let trimmed_payload_error = payload_error_text.map(str::trim);
-    let meaningful_payload_error = trimmed_payload_error.filter(|value| !value.is_empty());
-    if let Some(meaningful_payload_error) = meaningful_payload_error {
-        return meaningful_payload_error.to_owned();
-    }
-
     let payload_message = payload.get("message");
     let payload_message_text = payload_message.and_then(Value::as_str);
     let trimmed_payload_message = payload_message_text.map(str::trim);
     let meaningful_payload_message = trimmed_payload_message.filter(|value| !value.is_empty());
     if let Some(meaningful_payload_message) = meaningful_payload_message {
         return meaningful_payload_message.to_owned();
+    }
+
+    let payload_error = payload.get("error");
+    let payload_error_text = payload_error.and_then(Value::as_str);
+    let trimmed_payload_error = payload_error_text.map(str::trim);
+    let meaningful_payload_error = trimmed_payload_error.filter(|value| !value.is_empty());
+    if let Some(meaningful_payload_error) = meaningful_payload_error {
+        return meaningful_payload_error.to_owned();
     }
 
     let encoded_payload = serde_json::to_string(payload).unwrap_or_else(|_| "null".to_owned());
@@ -245,6 +245,28 @@ mod tests {
             FrozenContent::Error {
                 code: "delegate_panic".to_owned(),
                 message: "delegate_panic".to_owned(),
+            }
+        );
+        assert!(!frozen_result.truncated);
+    }
+
+    #[test]
+    fn capture_frozen_result_prefers_error_message_field_when_present() {
+        let outcome = loongclaw_contracts::ToolCoreOutcome {
+            status: "error".to_owned(),
+            payload: json!({
+                "error": "delegate_timeout",
+                "message": "timed out after 30s",
+            }),
+        };
+
+        let frozen_result = capture_frozen_result(&outcome, 256);
+
+        assert_eq!(
+            frozen_result.content,
+            FrozenContent::Error {
+                code: "delegate_timeout".to_owned(),
+                message: "timed out after 30s".to_owned(),
             }
         );
         assert!(!frozen_result.truncated);

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -5,6 +5,9 @@ pub mod recovery;
 pub mod repository;
 
 #[cfg(feature = "memory-sqlite")]
+pub mod frozen_result;
+
+#[cfg(feature = "memory-sqlite")]
 pub const LATEST_SESSION_SELECTOR: &str = "latest";
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -7,6 +7,7 @@ use rusqlite::{
 };
 use serde_json::Value;
 
+use super::frozen_result::FrozenResult;
 use crate::config::ToolConsentMode;
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -94,6 +95,7 @@ pub struct SessionTerminalOutcomeRecord {
     pub session_id: String,
     pub status: String,
     pub payload_json: Value,
+    pub frozen_result: Option<FrozenResult>,
     pub recorded_at: i64,
 }
 
@@ -426,6 +428,7 @@ pub struct FinalizeSessionTerminalRequest {
     pub event_payload_json: Value,
     pub outcome_status: String,
     pub outcome_payload_json: Value,
+    pub frozen_result: Option<FrozenResult>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2198,6 +2201,16 @@ impl SessionRepository {
         status: &str,
         payload_json: Value,
     ) -> Result<SessionTerminalOutcomeRecord, String> {
+        self.upsert_terminal_outcome_with_frozen_result(session_id, status, payload_json, None)
+    }
+
+    pub fn upsert_terminal_outcome_with_frozen_result(
+        &self,
+        session_id: &str,
+        status: &str,
+        payload_json: Value,
+        frozen_result: Option<FrozenResult>,
+    ) -> Result<SessionTerminalOutcomeRecord, String> {
         let session_id = normalize_required_text(session_id, "session_id")?;
         let status = normalize_required_text(status, "status")?;
         if self.load_session(&session_id)?.is_none() {
@@ -2206,16 +2219,29 @@ impl SessionRepository {
 
         let encoded_payload = serde_json::to_string(&payload_json)
             .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let encoded_frozen_result = encode_optional_frozen_result(&frozen_result)?;
         let recorded_at = unix_ts_now();
         let conn = self.open_connection()?;
         conn.execute(
-            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
-             VALUES (?1, ?2, ?3, ?4)
+            "INSERT INTO session_terminal_outcomes(
+                session_id,
+                status,
+                payload_json,
+                frozen_result_json,
+                recorded_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
+                frozen_result_json = excluded.frozen_result_json,
                 recorded_at = excluded.recorded_at",
-            params![session_id, status, encoded_payload, recorded_at],
+            params![
+                session_id,
+                status,
+                encoded_payload,
+                encoded_frozen_result,
+                recorded_at
+            ],
         )
         .map_err(|error| format!("upsert session terminal outcome failed: {error}"))?;
 
@@ -2223,6 +2249,7 @@ impl SessionRepository {
             session_id,
             status,
             payload_json,
+            frozen_result,
             recorded_at,
         })
     }
@@ -2239,10 +2266,12 @@ impl SessionRepository {
         let last_error = normalize_optional_text(request.last_error);
         let event_payload_json = request.event_payload_json;
         let outcome_payload_json = request.outcome_payload_json;
+        let frozen_result = request.frozen_result;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
         let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
             .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let encoded_frozen_result = encode_optional_frozen_result(&frozen_result)?;
         let ts = unix_ts_now();
 
         let mut conn = self.open_connection()?;
@@ -2282,13 +2311,25 @@ impl SessionRepository {
         .map_err(|error| format!("insert session terminal event failed: {error}"))?;
         let event_id = tx.last_insert_rowid();
         tx.execute(
-            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
-             VALUES (?1, ?2, ?3, ?4)
+            "INSERT INTO session_terminal_outcomes(
+                session_id,
+                status,
+                payload_json,
+                frozen_result_json,
+                recorded_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
+                frozen_result_json = excluded.frozen_result_json,
                 recorded_at = excluded.recorded_at",
-            params![session_id, outcome_status, encoded_outcome_payload, ts],
+            params![
+                session_id,
+                outcome_status,
+                encoded_outcome_payload,
+                encoded_frozen_result,
+                ts
+            ],
         )
         .map_err(|error| format!("upsert session terminal outcome in finalize failed: {error}"))?;
         tx.commit()
@@ -2312,6 +2353,7 @@ impl SessionRepository {
                 session_id,
                 status: outcome_status,
                 payload_json: outcome_payload_json,
+                frozen_result,
                 recorded_at: ts,
             },
         })
@@ -2330,10 +2372,12 @@ impl SessionRepository {
         let last_error = normalize_optional_text(request.last_error);
         let event_payload_json = request.event_payload_json;
         let outcome_payload_json = request.outcome_payload_json;
+        let frozen_result = request.frozen_result;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
         let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
             .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
+        let encoded_frozen_result = encode_optional_frozen_result(&frozen_result)?;
         let ts = unix_ts_now();
 
         let mut conn = self.open_connection()?;
@@ -2374,13 +2418,25 @@ impl SessionRepository {
         .map_err(|error| format!("insert conditional session terminal event failed: {error}"))?;
         let event_id = tx.last_insert_rowid();
         tx.execute(
-            "INSERT INTO session_terminal_outcomes(session_id, status, payload_json, recorded_at)
-             VALUES (?1, ?2, ?3, ?4)
+            "INSERT INTO session_terminal_outcomes(
+                session_id,
+                status,
+                payload_json,
+                frozen_result_json,
+                recorded_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
+                frozen_result_json = excluded.frozen_result_json,
                 recorded_at = excluded.recorded_at",
-            params![session_id, outcome_status, encoded_outcome_payload, ts],
+            params![
+                session_id,
+                outcome_status,
+                encoded_outcome_payload,
+                encoded_frozen_result,
+                ts
+            ],
         )
         .map_err(|error| {
             format!("upsert session terminal outcome in conditional finalize failed: {error}")
@@ -2407,6 +2463,7 @@ impl SessionRepository {
                 session_id,
                 status: outcome_status,
                 payload_json: outcome_payload_json,
+                frozen_result,
                 recorded_at: ts,
             },
         }))
@@ -3035,7 +3092,7 @@ impl SessionRepository {
     ) -> Result<Option<SessionTerminalOutcomeRecord>, String> {
         let raw = conn
             .query_row(
-                "SELECT session_id, status, payload_json, recorded_at
+                "SELECT session_id, status, payload_json, frozen_result_json, recorded_at
                  FROM session_terminal_outcomes
                  WHERE session_id = ?1",
                 params![session_id],
@@ -3044,7 +3101,8 @@ impl SessionRepository {
                         session_id: row.get(0)?,
                         status: row.get(1)?,
                         payload_json: row.get(2)?,
-                        recorded_at: row.get(3)?,
+                        frozen_result_json: row.get(3)?,
+                        recorded_at: row.get(4)?,
                     })
                 },
             )
@@ -3221,6 +3279,7 @@ struct RawSessionTerminalOutcomeRecord {
     session_id: String,
     status: String,
     payload_json: String,
+    frozen_result_json: Option<String>,
     recorded_at: i64,
 }
 
@@ -3348,15 +3407,44 @@ impl SessionEventRecord {
 
 impl SessionTerminalOutcomeRecord {
     fn try_from_raw(raw: RawSessionTerminalOutcomeRecord) -> Result<Self, String> {
+        let payload_json = serde_json::from_str(&raw.payload_json)
+            .map_err(|error| format!("decode session terminal outcome payload failed: {error}"))?;
+        let frozen_result = decode_optional_frozen_result(raw.frozen_result_json)?;
+
         Ok(Self {
             session_id: raw.session_id,
             status: raw.status,
-            payload_json: serde_json::from_str(&raw.payload_json).map_err(|error| {
-                format!("decode session terminal outcome payload failed: {error}")
-            })?,
+            payload_json,
+            frozen_result,
             recorded_at: raw.recorded_at,
         })
     }
+}
+
+fn encode_optional_frozen_result(
+    frozen_result: &Option<FrozenResult>,
+) -> Result<Option<String>, String> {
+    let Some(frozen_result) = frozen_result else {
+        return Ok(None);
+    };
+
+    let encoded_frozen_result = serde_json::to_string(frozen_result)
+        .map_err(|error| format!("encode frozen session result failed: {error}"))?;
+
+    Ok(Some(encoded_frozen_result))
+}
+
+fn decode_optional_frozen_result(
+    raw_frozen_result: Option<String>,
+) -> Result<Option<FrozenResult>, String> {
+    let Some(raw_frozen_result) = raw_frozen_result else {
+        return Ok(None);
+    };
+
+    let frozen_result = serde_json::from_str(&raw_frozen_result)
+        .map_err(|error| format!("decode frozen session result failed: {error}"))?;
+
+    Ok(Some(frozen_result))
 }
 
 impl ApprovalRequestRecord {
@@ -4493,7 +4581,7 @@ mod tests {
     }
 
     #[test]
-    fn session_terminal_outcome_round_trips_payload() {
+    fn session_terminal_outcome_round_trips_payload_and_frozen_result() {
         let config = isolated_memory_config("terminal-outcome-round-trip");
         let repo = SessionRepository::new(&config).expect("repository");
         repo.create_session(NewSessionRecord {
@@ -4505,7 +4593,14 @@ mod tests {
         })
         .expect("create child");
 
-        repo.upsert_terminal_outcome(
+        let frozen_result = crate::session::frozen_result::FrozenResult {
+            content: crate::session::frozen_result::FrozenContent::Text("done".to_owned()),
+            captured_at: SystemTime::now(),
+            byte_len: "done".len(),
+            truncated: false,
+        };
+
+        repo.upsert_terminal_outcome_with_frozen_result(
             "child-session",
             "ok",
             json!({
@@ -4513,6 +4608,7 @@ mod tests {
                 "final_output": "done",
                 "duration_ms": 12
             }),
+            Some(frozen_result.clone()),
         )
         .expect("upsert terminal outcome");
 
@@ -4524,6 +4620,7 @@ mod tests {
         assert_eq!(outcome.session_id, "child-session");
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload_json["final_output"], "done");
+        assert_eq!(outcome.frozen_result, Some(frozen_result));
         assert!(outcome.recorded_at > 0);
     }
 
@@ -4597,6 +4694,7 @@ mod tests {
                         "turn_count": 2,
                         "duration_ms": 15
                     }),
+                    frozen_result: None,
                 },
             )
             .expect("finalize session");
@@ -4659,6 +4757,7 @@ mod tests {
                 outcome_payload_json: json!({
                     "error": "first"
                 }),
+                frozen_result: None,
             },
         )
         .expect("finalize first terminal state");
@@ -4678,6 +4777,7 @@ mod tests {
                     outcome_payload_json: json!({
                         "error": "delegate_timeout"
                     }),
+                    frozen_result: None,
                 },
             )
             .expect("finalize second terminal state");
@@ -4731,6 +4831,7 @@ mod tests {
                     outcome_payload_json: json!({
                         "error": "delegate_timeout"
                     }),
+                    frozen_result: None,
                 },
             )
             .expect("conditionally finalize session")
@@ -4795,6 +4896,7 @@ mod tests {
                     outcome_payload_json: json!({
                         "error": "delegate_timeout"
                     }),
+                    frozen_result: None,
                 },
             )
             .expect("conditionally finalize session");
@@ -4858,6 +4960,7 @@ mod tests {
                     "child_session_id": "child-session",
                     "final_output": "done"
                 }),
+                frozen_result: None,
             },
         )
         .expect("finalize child");

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -2233,7 +2233,10 @@ impl SessionRepository {
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
-                frozen_result_json = excluded.frozen_result_json,
+                frozen_result_json = COALESCE(
+                    excluded.frozen_result_json,
+                    session_terminal_outcomes.frozen_result_json
+                ),
                 recorded_at = excluded.recorded_at",
             params![
                 session_id,
@@ -2245,13 +2248,8 @@ impl SessionRepository {
         )
         .map_err(|error| format!("upsert session terminal outcome failed: {error}"))?;
 
-        Ok(SessionTerminalOutcomeRecord {
-            session_id,
-            status,
-            payload_json,
-            frozen_result,
-            recorded_at,
-        })
+        self.load_terminal_outcome(&session_id)?
+            .ok_or_else(|| format!("session `{session_id}` missing after terminal outcome upsert"))
     }
 
     pub fn finalize_session_terminal(
@@ -2321,7 +2319,10 @@ impl SessionRepository {
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
-                frozen_result_json = excluded.frozen_result_json,
+                frozen_result_json = COALESCE(
+                    excluded.frozen_result_json,
+                    session_terminal_outcomes.frozen_result_json
+                ),
                 recorded_at = excluded.recorded_at",
             params![
                 session_id,
@@ -2338,24 +2339,21 @@ impl SessionRepository {
         let session = self
             .load_session(&session_id)?
             .ok_or_else(|| format!("session `{session_id}` missing after terminal finalize"))?;
+        let terminal_outcome = self.load_terminal_outcome(&session_id)?.ok_or_else(|| {
+            format!("session `{session_id}` missing terminal outcome after terminal finalize")
+        })?;
 
         Ok(FinalizeSessionTerminalResult {
             session,
             event: SessionEventRecord {
                 id: event_id,
-                session_id: session_id.clone(),
+                session_id,
                 event_kind,
                 actor_session_id,
                 payload_json: event_payload_json,
                 ts,
             },
-            terminal_outcome: SessionTerminalOutcomeRecord {
-                session_id,
-                status: outcome_status,
-                payload_json: outcome_payload_json,
-                frozen_result,
-                recorded_at: ts,
-            },
+            terminal_outcome,
         })
     }
 
@@ -2428,7 +2426,10 @@ impl SessionRepository {
              ON CONFLICT(session_id) DO UPDATE SET
                 status = excluded.status,
                 payload_json = excluded.payload_json,
-                frozen_result_json = excluded.frozen_result_json,
+                frozen_result_json = COALESCE(
+                    excluded.frozen_result_json,
+                    session_terminal_outcomes.frozen_result_json
+                ),
                 recorded_at = excluded.recorded_at",
             params![
                 session_id,
@@ -2448,24 +2449,23 @@ impl SessionRepository {
         let session = self.load_session(&session_id)?.ok_or_else(|| {
             format!("session `{session_id}` missing after conditional terminal finalize")
         })?;
+        let terminal_outcome = self.load_terminal_outcome(&session_id)?.ok_or_else(|| {
+            format!(
+                "session `{session_id}` missing terminal outcome after conditional terminal finalize"
+            )
+        })?;
 
         Ok(Some(FinalizeSessionTerminalResult {
             session,
             event: SessionEventRecord {
                 id: event_id,
-                session_id: session_id.clone(),
+                session_id,
                 event_kind,
                 actor_session_id,
                 payload_json: event_payload_json,
                 ts,
             },
-            terminal_outcome: SessionTerminalOutcomeRecord {
-                session_id,
-                status: outcome_status,
-                payload_json: outcome_payload_json,
-                frozen_result,
-                recorded_at: ts,
-            },
+            terminal_outcome,
         }))
     }
 
@@ -4663,6 +4663,51 @@ mod tests {
     }
 
     #[test]
+    fn session_terminal_outcome_upsert_preserves_existing_frozen_result_when_none_is_supplied() {
+        let config = isolated_memory_config("terminal-outcome-preserve-frozen-result");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Failed,
+        })
+        .expect("create child");
+
+        let frozen_result = crate::session::frozen_result::FrozenResult {
+            content: crate::session::frozen_result::FrozenContent::Text("done".to_owned()),
+            captured_at: SystemTime::now(),
+            byte_len: "done".len(),
+            truncated: false,
+        };
+
+        repo.upsert_terminal_outcome_with_frozen_result(
+            "child-session",
+            "error",
+            json!({
+                "error": "first"
+            }),
+            Some(frozen_result.clone()),
+        )
+        .expect("upsert terminal outcome with frozen result");
+
+        let outcome = repo
+            .upsert_terminal_outcome(
+                "child-session",
+                "timeout",
+                json!({
+                    "error": "delegate_timeout"
+                }),
+            )
+            .expect("upsert terminal outcome without frozen result");
+
+        assert_eq!(outcome.status, "timeout");
+        assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+        assert_eq!(outcome.frozen_result, Some(frozen_result));
+    }
+
+    #[test]
     fn finalize_session_terminal_writes_state_event_and_outcome_together() {
         let config = isolated_memory_config("finalize-session-terminal");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -4864,6 +4909,65 @@ mod tests {
             .expect("terminal outcome row");
         assert_eq!(outcome.status, "error");
         assert_eq!(outcome.payload_json["error"], "delegate_timeout");
+    }
+
+    #[test]
+    fn finalize_session_terminal_if_current_preserves_existing_frozen_result_when_none_is_supplied()
+    {
+        let config = isolated_memory_config("finalize-if-current-preserve-frozen-result");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+
+        let frozen_result = crate::session::frozen_result::FrozenResult {
+            content: crate::session::frozen_result::FrozenContent::Text("done".to_owned()),
+            captured_at: SystemTime::now(),
+            byte_len: "done".len(),
+            truncated: false,
+        };
+        repo.upsert_terminal_outcome_with_frozen_result(
+            "child-session",
+            "ok",
+            json!({
+                "final_output": "done"
+            }),
+            Some(frozen_result.clone()),
+        )
+        .expect("seed terminal outcome");
+
+        let finalized = repo
+            .finalize_session_terminal_if_current(
+                "child-session",
+                SessionState::Ready,
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Failed,
+                    last_error: Some("delegate_timeout".to_owned()),
+                    event_kind: "delegate_recovery_applied".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "kind": "queued_async_overdue_marked_failed",
+                        "reference": "queued"
+                    }),
+                    outcome_status: "error".to_owned(),
+                    outcome_payload_json: json!({
+                        "error": "delegate_timeout"
+                    }),
+                    frozen_result: None,
+                },
+            )
+            .expect("conditionally finalize session")
+            .expect("conditional finalize result");
+
+        assert_eq!(
+            finalized.terminal_outcome.frozen_result,
+            Some(frozen_result)
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -2246,6 +2246,7 @@ fn apply_session_recover_plan(
             event_payload_json,
             outcome_status,
             outcome_payload_json: outcome_payload,
+            frozen_result: None,
         },
     )?;
     if finalized.is_none() {
@@ -2530,6 +2531,7 @@ fn apply_session_cancel_plan(
                     }),
                     outcome_status,
                     outcome_payload_json: outcome_payload,
+                    frozen_result: None,
                 },
             )?;
             if finalized.is_none() {
@@ -3738,6 +3740,7 @@ fn session_terminal_outcome_json(
         "session_id": outcome.session_id,
         "status": outcome.status,
         "payload": outcome.payload_json,
+        "frozen_result": outcome.frozen_result,
         "recorded_at": outcome.recorded_at,
     })
 }
@@ -4066,6 +4069,7 @@ mod tests {
                     event_payload_json: json!({ "result": "ok" }),
                     outcome_status: "ok".to_owned(),
                     outcome_payload_json: json!({ "child_session_id": session_id }),
+                    frozen_result: None,
                 },
             )
             .expect("finalize child");
@@ -4136,6 +4140,7 @@ mod tests {
                 event_payload_json: json!({ "result": "ok" }),
                 outcome_status: "ok".to_owned(),
                 outcome_payload_json: json!({ "child_session_id": "archived-child" }),
+                frozen_result: None,
             },
         )
         .expect("finalize child");
@@ -6867,6 +6872,7 @@ mod tests {
                     "child_session_id": "child-session",
                     "result": "ok"
                 }),
+                frozen_result: None,
             },
         )
         .expect("finalize child");
@@ -6957,6 +6963,7 @@ mod tests {
                     event_payload_json: json!({ "result": "ok" }),
                     outcome_status: "ok".to_owned(),
                     outcome_payload_json: json!({ "child_session_id": session_id }),
+                    frozen_result: None,
                 },
             )
             .expect("finalize child");
@@ -7070,6 +7077,7 @@ mod tests {
                     event_payload_json: json!({ "result": "ok" }),
                     outcome_status: "ok".to_owned(),
                     outcome_payload_json: json!({ "child_session_id": session_id }),
+                    frozen_result: None,
                 },
             )
             .expect("finalize child");

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -26,6 +26,8 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::runtime_self_continuity;
 #[cfg(feature = "memory-sqlite")]
+use crate::session::frozen_result::capture_frozen_result;
+#[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
     RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
     RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED, SessionRecoveryRecord,
@@ -2199,6 +2201,7 @@ fn apply_session_recover_plan(
         recovery_error.clone(),
         recover_plan.elapsed_seconds.saturating_mul(1_000),
     );
+    let frozen_result = capture_frozen_result(&outcome, tool_config.delegate.max_frozen_bytes);
     let outcome_status = outcome.status.clone();
     let outcome_payload = outcome.payload;
     let event_payload_json = match recover_plan.recovery_kind {
@@ -2246,7 +2249,7 @@ fn apply_session_recover_plan(
             event_payload_json,
             outcome_status,
             outcome_payload_json: outcome_payload,
-            frozen_result: None,
+            frozen_result: Some(frozen_result),
         },
     )?;
     if finalized.is_none() {
@@ -2515,6 +2518,8 @@ fn apply_session_cancel_plan(
                 cancel_error.clone(),
                 0,
             );
+            let frozen_result =
+                capture_frozen_result(&outcome, tool_config.delegate.max_frozen_bytes);
             let outcome_status = outcome.status.clone();
             let outcome_payload = outcome.payload;
             let finalized = repo.finalize_session_terminal_if_current(
@@ -2531,7 +2536,7 @@ fn apply_session_cancel_plan(
                     }),
                     outcome_status,
                     outcome_payload_json: outcome_payload,
-                    frozen_result: None,
+                    frozen_result: Some(frozen_result),
                 },
             )?;
             if finalized.is_none() {
@@ -5274,6 +5279,14 @@ mod tests {
         assert!(outcome.payload["delegate_lifecycle"]["staleness"].is_null());
         assert_eq!(outcome.payload["terminal_outcome_state"], "present");
         assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        let frozen_error_code =
+            outcome.payload["terminal_outcome"]["frozen_result"]["content"]["error"]["code"]
+                .as_str()
+                .expect("queued frozen error code");
+        assert!(
+            frozen_error_code.starts_with("delegate_async_queued_overdue_marked_failed:"),
+            "unexpected queued frozen error code: {frozen_error_code}"
+        );
         assert_eq!(
             outcome.payload["recovery_action"]["kind"],
             "queued_async_overdue_marked_failed"
@@ -5408,6 +5421,14 @@ mod tests {
         assert!(outcome.payload["delegate_lifecycle"]["staleness"].is_null());
         assert_eq!(outcome.payload["terminal_outcome_state"], "present");
         assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
+        let frozen_error_code =
+            outcome.payload["terminal_outcome"]["frozen_result"]["content"]["error"]["code"]
+                .as_str()
+                .expect("running frozen error code");
+        assert!(
+            frozen_error_code.starts_with("delegate_async_running_overdue_marked_failed:"),
+            "unexpected running frozen error code: {frozen_error_code}"
+        );
         assert_eq!(
             outcome.payload["recovery_action"]["kind"],
             "running_async_overdue_marked_failed"
@@ -5851,6 +5872,10 @@ mod tests {
         assert_eq!(outcome.payload["terminal_outcome_state"], "present");
         assert_eq!(outcome.payload["terminal_outcome"]["status"], "error");
         assert_eq!(
+            outcome.payload["terminal_outcome"]["frozen_result"]["content"]["error"]["code"],
+            "delegate_cancelled: operator_requested"
+        );
+        assert_eq!(
             outcome.payload["cancel_action"]["kind"],
             "queued_async_cancelled"
         );
@@ -6210,6 +6235,11 @@ mod tests {
                 .expect("load queued outcome")
                 .is_some()
         );
+        let queued_outcome = repo
+            .load_terminal_outcome("queued-child")
+            .expect("load queued outcome")
+            .expect("queued outcome row");
+        assert!(queued_outcome.frozen_result.is_some());
         assert!(
             repo.load_terminal_outcome("running-child")
                 .expect("load running outcome")

--- a/crates/app/src/tools/session_search.rs
+++ b/crates/app/src/tools/session_search.rs
@@ -470,6 +470,7 @@ mod tests {
                 event_payload_json: json!({ "result": "ok" }),
                 outcome_status: "ok".to_owned(),
                 outcome_payload_json: json!({ "child_session_id": "child-session" }),
+                frozen_result: None,
             },
         )
         .expect("finalize child");

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -603,6 +603,7 @@ async fn execute_sessions_command_archive_dry_run_surfaces_archive_action() {
                 "child_session_id": "delegate:session-1",
                 "result": "ok"
             }),
+            frozen_result: None,
         },
     )
     .expect("finalize child session");

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T05:43:03Z
+- Generated at: 2026-04-07T06:28:52Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,7 +22,7 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11449 | 11200 | -249 | 101 | 120 | 19 | 102.2% | BREACH | 10831 | 5.7% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11451 | 11200 | -251 | 101 | 120 | 19 | 102.2% | BREACH | 10831 | 5.7% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11449 functions=101 -->
+<!-- arch-hotspot key=turn_coordinator lines=11451 functions=101 -->
 <!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T04:28:29Z
+- Generated at: 2026-04-07T05:43:03Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,13 +22,13 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11397 | 11200 | -197 | 101 | 120 | 19 | 101.8% | BREACH | 10831 | 5.2% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11449 | 11200 | -249 | 101 | 120 | 19 | 102.2% | BREACH | 10831 | 5.7% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.8%)
+- BREACH hotspots (>100% of any tracked budget): turn_coordinator (102.2%)
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11397 functions=101 -->
+<!-- arch-hotspot key=turn_coordinator lines=11449 functions=101 -->
 <!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->


### PR DESCRIPTION
## Summary

- Problem:
  - Delegate child sessions persisted terminal outcome payloads, but they did not expose a bounded, typed, restart-safe frozen result contract for downstream announce/yield flows.
  - The terminal outcome storage schema also lacked an explicit frozen-result field, so future parent delivery logic would have had to keep reinterpreting raw tool payloads.
- Why it matters:
  - Parent orchestration needs a durable child-result snapshot that survives restarts, cleanup, and later session inspection.
  - A typed frozen result also gives #980 / #981 a stable delivery contract instead of coupling announce flow to delegate payload shape.
- What changed:
  - Added `session::frozen_result` with `FrozenResult`, `FrozenContent`, and bounded capture logic.
  - Persisted `frozen_result_json` alongside `session_terminal_outcomes` and added sqlite schema repair coverage.
  - Captured frozen results synchronously in delegate terminal transitions for completed / failed / timed_out / spawn_failed child outcomes.
  - Preserved frozen results through delegate terminal recovery fallback when the initial finalize path fails but recovery event persistence succeeds.
  - Added `tools.delegate.max_frozen_bytes` config with default + validation.
  - Surfaced frozen results through session inspection/status JSON and added regression coverage in app + daemon tests.
- What did not change (scope boundary):
  - No announce queue, mailbox batching, or `sessions_yield` behavior was introduced in this PR.
  - No new external protocol surface was added beyond the persisted/readable frozen-result field.

## Linked Issues

- Closes #979
- Related #980
- Related #981

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-full-check cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-full-check cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-full-check cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
./scripts/check-docs.sh

Additional targeted regression coverage:
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features --lib capture_frozen_result_ -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features --lib session_terminal_outcome_round_trips_payload_and_frozen_result -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features --lib ensure_memory_db_ready_repairs_session_terminal_outcome_frozen_result_column -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features --lib validate_rejects_zero_delegate_max_frozen_bytes -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features --lib finalize_delegate_child_terminal_with_recovery_persists_frozen_result_after_recovery_event -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_executes_delegate_via_coordinator -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-979-frozen-result-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks -- --test-threads=1

All commands completed successfully.
```

## User-visible / Operator-visible Changes

- Delegate child terminal observations now include a typed `frozen_result` snapshot.
- Delegate config now exposes `tools.delegate.max_frozen_bytes` with a default of `256 * 1024` and validation against zero.

## Failure Recovery

- Fast rollback or disable path:
  - Revert this PR, or set the branch back to the previous session-runtime behavior.
  - The new field is additive; older rows without `frozen_result_json` still repair forward through sqlite schema upgrade.
- Observable failure symptoms reviewers should watch for:
  - Missing `frozen_result` in `session_status` / session observation output after a delegate finishes.
  - Delegate recovery paths that transition the child to failed state without preserving the frozen snapshot.
  - Misconfigured `tools.delegate.max_frozen_bytes = 0` not being rejected during config validation.

## Reviewer Focus

- `crates/app/src/session/frozen_result.rs`
  - Check the bounded capture rules, typed outcome mapping, and UTF-8 truncation behavior.
- `crates/app/src/session/repository.rs`
  - Review the additive persistence change and transaction-bound outcome writes.
- `crates/app/src/operator/delegate_runtime.rs`
  - Focus on the recovery path that now persists a recovery terminal outcome while preserving the original frozen snapshot.
- `crates/app/src/memory/sqlite.rs`
  - Check the sqlite repair path and backward-compatible schema upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable max_frozen_bytes for delegate tools (default 256 KB; zero rejected).
  * Terminal outcomes now include frozen snapshots (content, timestamp, stored byte length, truncation flag).

* **Bug Fixes**
  * Recovery and delegate-failure flows now reliably persist frozen results during terminalization and recovery fallbacks.

* **Chores**
  * SQLite schema bumped to v10 with repair to add frozen outcome column.
  * Tests, fixtures, and a documentation timestamp updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->