### PR TITLE
fix(provider): quiet successful auto-model failover logs

### DIFF
--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -62,7 +62,7 @@ pub(super) async fn prepare_provider_request_session(
     );
     let auto_model_mode = config.provider.model_selection_requires_fetch();
     let model_candidates = if auto_model_mode {
-        let mut resolved = None;
+        let mut resolved_candidates = None;
         let mut last_error = None;
         for profile in &auth_profiles {
             match resolve_request_models(
@@ -76,7 +76,7 @@ pub(super) async fn prepare_provider_request_session(
             .await
             {
                 Ok(candidates) => {
-                    resolved = Some(candidates);
+                    resolved_candidates = Some(candidates);
                     break;
                 }
                 Err(error) => {
@@ -87,7 +87,7 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
-                    tracing::warn!(
+                    tracing::debug!(
                         target: "loongclaw.provider",
                         provider_id = %config.provider.kind.profile().id,
                         auth_profile_id = %profile.id,
@@ -99,11 +99,24 @@ pub(super) async fn prepare_provider_request_session(
                 }
             }
         }
-        resolved.ok_or_else(|| {
-            last_error.unwrap_or_else(|| {
+        if let Some(model_candidates) = resolved_candidates {
+            model_candidates
+        } else {
+            let error_message = last_error.unwrap_or_else(|| {
                 "provider model-list unavailable for every auth profile".to_owned()
-            })
-        })?
+            });
+
+            tracing::warn!(
+                target: "loongclaw.provider",
+                provider_id = %config.provider.kind.profile().id,
+                auth_profile_count = auth_profiles.len(),
+                auto_model_mode,
+                error = %crate::observability::summarize_error(error_message.as_str()),
+                "provider model catalog resolution failed for every auth profile"
+            );
+
+            return Err(error_message);
+        }
     } else {
         resolve_request_models(
             config,

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -402,6 +402,127 @@ async fn fetch_available_models_rejects_missing_openai_credentials_before_transp
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn request_completion_auto_model_falls_forward_to_next_auth_profile_after_catalog_auth_failure()
+ {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut requests = Vec::new();
+
+        while requests.len() < 3 {
+            if Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for provider auth-profile fallback requests: {requests:#?}"
+                );
+            }
+
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let request = read_local_provider_request(&mut stream, deadline);
+                    requests.push(request.clone());
+
+                    let request_index = requests.len();
+                    let (status_line, body) = if request_index == 1 {
+                        (
+                            "HTTP/1.1 401 Unauthorized",
+                            r#"{"error":{"message":"invalid oauth token"}}"#.to_owned(),
+                        )
+                    } else if request_index == 2 {
+                        (
+                            "HTTP/1.1 200 OK",
+                            r#"{"data":[{"id":"gpt-4.1-mini","object":"model"}]}"#.to_owned(),
+                        )
+                    } else {
+                        (
+                            "HTTP/1.1 200 OK",
+                            r#"{"choices":[{"message":{"role":"assistant","content":"fallback auth ok"}}]}"#
+                                .to_owned(),
+                        )
+                    };
+
+                    let response = format!(
+                        "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write response");
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("accept local provider request: {error}"),
+            }
+        }
+
+        requests
+    });
+
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::Openai,
+        base_url: format!("http://{addr}"),
+        model: "auto".to_owned(),
+        wire_api: crate::config::ProviderWireApi::ChatCompletions,
+        oauth_access_token: Some(SecretRef::Inline("oauth-token".to_owned())),
+        api_key: Some(SecretRef::Inline("api-key".to_owned())),
+        api_key_env: None,
+        oauth_access_token_env: None,
+        ..ProviderConfig::default()
+    });
+
+    let completion = request_completion(
+        &config,
+        &[json!({
+            "role": "user",
+            "content": "ping"
+        })],
+        ProviderRuntimeBinding::direct(),
+    )
+    .await
+    .expect("request should succeed with the next auth profile after catalog auth failure");
+
+    assert_eq!(completion, "fallback auth ok");
+
+    let requests = server.join().expect("join local provider server");
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests[0].starts_with("GET /v1/models "),
+        "first request should probe the model catalog: {requests:#?}"
+    );
+    assert!(
+        requests[0]
+            .to_ascii_lowercase()
+            .contains("authorization: bearer oauth-token"),
+        "first catalog probe should use the first auth profile: {requests:#?}"
+    );
+    assert!(
+        requests[1].starts_with("GET /v1/models "),
+        "second request should retry the model catalog with the next auth profile: {requests:#?}"
+    );
+    assert!(
+        requests[1]
+            .to_ascii_lowercase()
+            .contains("authorization: bearer api-key"),
+        "second catalog probe should use the fallback auth profile: {requests:#?}"
+    );
+    assert!(
+        requests[2].starts_with("POST /v1/chat/completions "),
+        "completion request should use the selected chat-completions endpoint: {requests:#?}"
+    );
+    assert!(
+        requests[2]
+            .to_ascii_lowercase()
+            .contains("authorization: bearer api-key"),
+        "completion request should stay on the auth profile that resolved the catalog successfully: {requests:#?}"
+    );
+}
+
 #[test]
 fn byteplus_auth_guidance_uses_byteplus_api_key_env() {
     let provider = ProviderConfig {


### PR DESCRIPTION
## summary
- downgrade per-profile model-catalog failures inside the auto-model auth-profile loop from `warn!` to `debug!`
- keep a warning-level log only when every auth profile fails to resolve a model catalog
- preserve existing error propagation while making successful failover paths less noisy

## why
A later auth profile can still succeed after an earlier profile fails. Warning-level logs on each intermediate miss make healthy failover look like operational failure and flood provider logs.

## scope notes
- this follow-up closes the remaining runtime logging item from #1045
- the runtime-binding label test coverage and CLI command redaction are already present on current `dev`, so they are not repeated here

## validation
- `cargo fmt --all -- --check`
- `cargo test -p loongclaw-app request_turn_auto_model_rejects_missing_volcengine_credentials_before_transport -- --test-threads=1`
- `cargo test -p loongclaw-app responses_turn_falls_back_to_chat_completions_for_compatible_endpoints -- --test-threads=1`
- `cargo test -p loongclaw-app provider_runtime_binding_labels_are_stable -- --test-threads=1`

Closes #1045
