### PR TITLE
feat(conversation): announce delegate results to parent sessions

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -221,6 +221,10 @@ pub struct DelegateToolConfig {
     pub allow_shell_in_child: bool,
     #[serde(default = "default_delegate_max_frozen_bytes")]
     pub max_frozen_bytes: usize,
+    #[serde(default = "default_delegate_announce_debounce_ms")]
+    pub announce_debounce_ms: u64,
+    #[serde(default = "default_delegate_announce_max_batch")]
+    pub announce_max_batch: usize,
     #[serde(default)]
     pub child_runtime: DelegateChildRuntimeConfig,
 }
@@ -612,6 +616,8 @@ impl Default for DelegateToolConfig {
             child_tool_allowlist: default_delegate_child_tool_allowlist(),
             allow_shell_in_child: false,
             max_frozen_bytes: default_delegate_max_frozen_bytes(),
+            announce_debounce_ms: default_delegate_announce_debounce_ms(),
+            announce_max_batch: default_delegate_announce_max_batch(),
             child_runtime: DelegateChildRuntimeConfig::default(),
         }
     }
@@ -829,6 +835,14 @@ impl ToolConfig {
             "tools.delegate.max_frozen_bytes",
             self.delegate.max_frozen_bytes,
             MIN_DELEGATE_MAX_FROZEN_BYTES,
+            usize::MAX,
+        ) {
+            issues.push(*issue);
+        }
+        if let Err(issue) = validate_numeric_range(
+            "tools.delegate.announce_max_batch",
+            self.delegate.announce_max_batch,
+            1,
             usize::MAX,
         ) {
             issues.push(*issue);
@@ -1265,6 +1279,14 @@ const fn default_delegate_max_frozen_bytes() -> usize {
     DEFAULT_DELEGATE_MAX_FROZEN_BYTES
 }
 
+const fn default_delegate_announce_debounce_ms() -> u64 {
+    500
+}
+
+const fn default_delegate_announce_max_batch() -> usize {
+    20
+}
+
 const fn default_browser_max_sessions() -> usize {
     DEFAULT_BROWSER_MAX_SESSIONS
 }
@@ -1358,6 +1380,8 @@ mod tests {
             config.delegate.max_frozen_bytes,
             DEFAULT_DELEGATE_MAX_FROZEN_BYTES
         );
+        assert_eq!(config.delegate.announce_debounce_ms, 500);
+        assert_eq!(config.delegate.announce_max_batch, 20);
         assert_eq!(
             config.delegate.child_tool_allowlist,
             vec![
@@ -1627,6 +1651,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_zero_delegate_announce_max_batch() {
+        let mut config = ToolConfig::default();
+        config.delegate.announce_max_batch = 0;
+
+        let issues = config.validate();
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.field_path == "tools.delegate.announce_max_batch"),
+            "expected delegate announce_max_batch validation issue, got {issues:?}"
+        );
+    }
+
+    #[test]
     fn validate_rejects_zero_tool_execution_per_tool_timeout() {
         let mut config = ToolConfig::default();
         config
@@ -1741,6 +1780,8 @@ max_active_children = 4
 timeout_seconds = 90
 allow_shell_in_child = true
 max_frozen_bytes = 131072
+announce_debounce_ms = 250
+announce_max_batch = 7
 child_tool_allowlist = ["file.read", "shell.exec"]
 
 [tools.delegate.child_runtime.web]
@@ -1782,6 +1823,8 @@ max_text_chars = 1024
         assert_eq!(parsed.tools.delegate.timeout_seconds, 90);
         assert!(parsed.tools.delegate.allow_shell_in_child);
         assert_eq!(parsed.tools.delegate.max_frozen_bytes, 131072);
+        assert_eq!(parsed.tools.delegate.announce_debounce_ms, 250);
+        assert_eq!(parsed.tools.delegate.announce_max_batch, 7);
         assert_eq!(
             parsed.tools.delegate.child_tool_allowlist,
             vec!["file.read".to_owned(), "shell.exec".to_owned()]

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -449,8 +449,10 @@ pub(crate) fn reset_delegate_announce_queues_for_tests() {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::OnceLock;
 
     use serde_json::json;
+    use tokio::sync::Mutex as AsyncMutex;
     use tokio::time::{Duration, sleep};
 
     use super::{
@@ -477,6 +479,12 @@ mod tests {
             sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         }
+    }
+
+    fn announce_test_lock() -> &'static AsyncMutex<()> {
+        static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+
+        LOCK.get_or_init(|| AsyncMutex::new(()))
     }
 
     fn create_parent_session(repo: &SessionRepository, session_id: &str, state: SessionState) {
@@ -559,6 +567,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegate_announce_queue_delivers_single_result_to_parent_session_events() {
+        let _guard = announce_test_lock().lock().await;
         reset_delegate_announce_queues_for_tests();
         let memory_config = isolated_memory_config("single");
         let repo = SessionRepository::new(&memory_config).expect("session repository");
@@ -589,6 +598,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegate_announce_queue_batches_children_completed_within_debounce_window() {
+        let _guard = announce_test_lock().lock().await;
         reset_delegate_announce_queues_for_tests();
         let memory_config = isolated_memory_config("batch");
         let repo = SessionRepository::new(&memory_config).expect("session repository");
@@ -638,6 +648,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegate_announce_queue_summarizes_oldest_results_when_batch_limit_is_exceeded() {
+        let _guard = announce_test_lock().lock().await;
         reset_delegate_announce_queues_for_tests();
         let memory_config = isolated_memory_config("overflow");
         let repo = SessionRepository::new(&memory_config).expect("session repository");
@@ -685,6 +696,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegate_announce_queue_drops_delivery_when_parent_is_terminal() {
+        let _guard = announce_test_lock().lock().await;
         reset_delegate_announce_queues_for_tests();
         let memory_config = isolated_memory_config("drop-terminal-parent");
         let repo = SessionRepository::new(&memory_config).expect("session repository");

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -1,0 +1,746 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use serde::Serialize;
+use tokio::runtime::Handle;
+use tokio::time::{Duration, sleep};
+
+use crate::config::LoongClawConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::session::frozen_result::FrozenResult;
+use crate::session::repository::{NewSessionEvent, SessionRepository};
+
+pub(crate) const DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND: &str = "delegate_results_announced";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DelegateAnnounceSettings {
+    pub debounce_ms: u64,
+    pub max_batch: usize,
+}
+
+impl DelegateAnnounceSettings {
+    pub(crate) fn from_config(config: &LoongClawConfig) -> Self {
+        let delegate_config = &config.tools.delegate;
+
+        Self {
+            debounce_ms: delegate_config.announce_debounce_ms,
+            max_batch: delegate_config.announce_max_batch.max(1),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DelegateAnnounceQueueState {
+    pending_child_session_ids: VecDeque<String>,
+    last_enqueued_at: Instant,
+    draining: bool,
+    settings: DelegateAnnounceSettings,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct DelegateResultAnnouncement {
+    child_session_id: String,
+    label: Option<String>,
+    state: String,
+    status: String,
+    recorded_at: i64,
+    frozen_result: Option<FrozenResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DelegateResultOverflowSummary {
+    omitted_count: usize,
+    omitted_child_session_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DelegateAnnounceBatch {
+    child_session_ids: Vec<String>,
+    settings: DelegateAnnounceSettings,
+}
+
+pub(crate) fn enqueue_delegate_result_announce(
+    memory_config: MemoryRuntimeConfig,
+    parent_session_id: String,
+    child_session_id: String,
+    settings: DelegateAnnounceSettings,
+) {
+    let queue_key = delegate_announce_queue_key(&memory_config, parent_session_id.as_str());
+    let immediate_flush = settings.debounce_ms == 0;
+    let should_spawn = {
+        let queues = delegate_announce_queues();
+        let mut queues = queues
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let queue = queues
+            .entry(queue_key.clone())
+            .or_insert_with(|| DelegateAnnounceQueueState {
+                pending_child_session_ids: VecDeque::new(),
+                last_enqueued_at: Instant::now(),
+                draining: false,
+                settings: settings.clone(),
+            });
+        queue.pending_child_session_ids.push_back(child_session_id);
+        queue.last_enqueued_at = Instant::now();
+        queue.settings = settings;
+        let already_draining = queue.draining;
+        if !already_draining {
+            queue.draining = true;
+        }
+        !already_draining
+    };
+
+    if !should_spawn {
+        return;
+    }
+
+    if immediate_flush {
+        loop {
+            let batch = take_delegate_announce_batch(queue_key.as_str());
+            let Some(batch) = batch else {
+                let has_pending = finish_delegate_announce_batch(queue_key.as_str());
+                if !has_pending {
+                    return;
+                }
+                continue;
+            };
+
+            let flush_result =
+                flush_delegate_announce_batch(&memory_config, parent_session_id.as_str(), &batch);
+            if let Err(error) = flush_result {
+                restore_delegate_announce_batch(queue_key.as_str(), &batch);
+                tracing::warn!(
+                    parent_session_id = %parent_session_id,
+                    error = %error,
+                    "delegate announce immediate flush failed"
+                );
+                let has_pending = finish_delegate_announce_batch(queue_key.as_str());
+                if !has_pending {
+                    return;
+                }
+
+                if let Ok(runtime_handle) = Handle::try_current() {
+                    let retry_memory_config = memory_config;
+                    let retry_queue_key = queue_key;
+                    let retry_parent_session_id = parent_session_id;
+                    runtime_handle.spawn(async move {
+                        drain_delegate_announce_queue(
+                            retry_memory_config,
+                            retry_queue_key,
+                            retry_parent_session_id,
+                        )
+                        .await;
+                    });
+                    return;
+                }
+
+                pause_delegate_announce_queue(queue_key.as_str());
+                return;
+            }
+
+            let has_pending = finish_delegate_announce_batch(queue_key.as_str());
+            if !has_pending {
+                return;
+            }
+        }
+    }
+
+    let handle = Handle::try_current();
+    let Ok(handle) = handle else {
+        tracing::warn!(
+            parent_session_id = %parent_session_id,
+            "delegate announce queue skipped because no tokio runtime was available"
+        );
+        pause_delegate_announce_queue(queue_key.as_str());
+        return;
+    };
+
+    handle.spawn(async move {
+        drain_delegate_announce_queue(memory_config, queue_key, parent_session_id).await;
+    });
+}
+
+async fn drain_delegate_announce_queue(
+    memory_config: MemoryRuntimeConfig,
+    queue_key: String,
+    parent_session_id: String,
+) {
+    loop {
+        let wait_duration = next_delegate_announce_wait_duration(queue_key.as_str());
+        let Some(wait_duration) = wait_duration else {
+            return;
+        };
+        if !wait_duration.is_zero() {
+            sleep(wait_duration).await;
+            continue;
+        }
+
+        let batch = take_delegate_announce_batch(queue_key.as_str());
+        let Some(batch) = batch else {
+            continue;
+        };
+
+        let flush_result =
+            flush_delegate_announce_batch(&memory_config, parent_session_id.as_str(), &batch);
+        if let Err(error) = flush_result {
+            restore_delegate_announce_batch(queue_key.as_str(), &batch);
+            tracing::warn!(
+                parent_session_id = %parent_session_id,
+                error = %error,
+                "delegate announce queue flush failed"
+            );
+        }
+
+        let has_pending = finish_delegate_announce_batch(queue_key.as_str());
+        if !has_pending {
+            return;
+        }
+    }
+}
+
+fn flush_delegate_announce_batch(
+    memory_config: &MemoryRuntimeConfig,
+    parent_session_id: &str,
+    batch: &DelegateAnnounceBatch,
+) -> Result<(), String> {
+    let repo = SessionRepository::new(memory_config)?;
+
+    let deduped_child_session_ids = dedupe_child_session_ids(batch.child_session_ids.clone());
+    let announce_results =
+        load_delegate_announce_results(&repo, parent_session_id, &deduped_child_session_ids)?;
+    if announce_results.is_empty() {
+        return Ok(());
+    }
+
+    let overflow_summary =
+        build_delegate_announce_overflow_summary(&announce_results, batch.settings.max_batch);
+    let total_result_count = announce_results.len();
+    let visible_results =
+        trim_delegate_announce_results(announce_results, batch.settings.max_batch);
+    let announce_kind = if visible_results.len() == 1 && overflow_summary.is_none() {
+        "delegate_result"
+    } else {
+        "batch_delegate_results"
+    };
+
+    let payload = serde_json::json!({
+        "announce_kind": announce_kind,
+        "trigger_turn": false,
+        "result_count": total_result_count,
+        "visible_result_count": visible_results.len(),
+        "results": visible_results,
+        "overflow_summary": overflow_summary,
+    });
+    let event = NewSessionEvent {
+        session_id: parent_session_id.to_owned(),
+        event_kind: DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND.to_owned(),
+        actor_session_id: None,
+        payload_json: payload,
+    };
+    let append_result = repo.append_event_if_session_active(event)?;
+    let append_succeeded = append_result.is_some();
+    if !append_succeeded {
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+fn load_delegate_announce_results(
+    repo: &SessionRepository,
+    parent_session_id: &str,
+    child_session_ids: &[String],
+) -> Result<Vec<DelegateResultAnnouncement>, String> {
+    let mut results = Vec::new();
+
+    for child_session_id in child_session_ids {
+        let child_session = repo.load_session_summary_with_legacy_fallback(child_session_id)?;
+        let Some(child_session) = child_session else {
+            continue;
+        };
+        let child_parent_session_id = child_session.parent_session_id.clone();
+        if child_parent_session_id.as_deref() != Some(parent_session_id) {
+            continue;
+        }
+        let terminal_outcome = repo.load_terminal_outcome(child_session_id)?;
+        let Some(terminal_outcome) = terminal_outcome else {
+            continue;
+        };
+
+        let result = DelegateResultAnnouncement {
+            child_session_id: child_session.session_id,
+            label: child_session.label,
+            state: child_session.state.as_str().to_owned(),
+            status: terminal_outcome.status,
+            recorded_at: terminal_outcome.recorded_at,
+            frozen_result: terminal_outcome.frozen_result,
+        };
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
+fn dedupe_child_session_ids(child_session_ids: Vec<String>) -> Vec<String> {
+    let mut pending = child_session_ids;
+    let mut deduped = Vec::new();
+
+    while let Some(child_session_id) = pending.pop() {
+        let already_present = deduped.iter().any(|current| current == &child_session_id);
+        if already_present {
+            continue;
+        }
+        deduped.push(child_session_id);
+    }
+
+    deduped.reverse();
+
+    deduped
+}
+
+fn trim_delegate_announce_results(
+    results: Vec<DelegateResultAnnouncement>,
+    max_batch: usize,
+) -> Vec<DelegateResultAnnouncement> {
+    if results.len() <= max_batch {
+        return results;
+    }
+
+    let keep_from_index = results.len().saturating_sub(max_batch);
+    results.into_iter().skip(keep_from_index).collect()
+}
+
+fn build_delegate_announce_overflow_summary(
+    results: &[DelegateResultAnnouncement],
+    max_batch: usize,
+) -> Option<DelegateResultOverflowSummary> {
+    if results.len() <= max_batch {
+        return None;
+    }
+
+    let omitted_count = results.len().saturating_sub(max_batch);
+    let omitted_child_session_ids = results
+        .iter()
+        .take(omitted_count)
+        .map(|result| result.child_session_id.clone())
+        .collect();
+
+    Some(DelegateResultOverflowSummary {
+        omitted_count,
+        omitted_child_session_ids,
+    })
+}
+
+fn next_delegate_announce_wait_duration(parent_session_id: &str) -> Option<Duration> {
+    let queues = delegate_announce_queues();
+    let queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let queue = queues.get(parent_session_id)?;
+    let debounce_duration = Duration::from_millis(queue.settings.debounce_ms);
+    let elapsed_duration = queue.last_enqueued_at.elapsed();
+    if elapsed_duration >= debounce_duration {
+        return Some(Duration::ZERO);
+    }
+
+    let wait_duration = debounce_duration - elapsed_duration;
+
+    Some(wait_duration)
+}
+
+fn take_delegate_announce_batch(parent_session_id: &str) -> Option<DelegateAnnounceBatch> {
+    let queues = delegate_announce_queues();
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let queue = queues.get_mut(parent_session_id)?;
+    let debounce_duration = Duration::from_millis(queue.settings.debounce_ms);
+    let elapsed_duration = queue.last_enqueued_at.elapsed();
+    if elapsed_duration < debounce_duration {
+        return None;
+    }
+
+    let child_session_ids = queue.pending_child_session_ids.drain(..).collect();
+    let settings = queue.settings.clone();
+
+    Some(DelegateAnnounceBatch {
+        child_session_ids,
+        settings,
+    })
+}
+
+fn finish_delegate_announce_batch(parent_session_id: &str) -> bool {
+    let queues = delegate_announce_queues();
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(queue) = queues.get_mut(parent_session_id) else {
+        return false;
+    };
+    let has_pending = !queue.pending_child_session_ids.is_empty();
+    if has_pending {
+        return true;
+    }
+
+    queues.remove(parent_session_id);
+
+    false
+}
+
+fn restore_delegate_announce_batch(parent_session_id: &str, batch: &DelegateAnnounceBatch) {
+    let queues = delegate_announce_queues();
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(queue) = queues.get_mut(parent_session_id) else {
+        return;
+    };
+
+    let child_session_ids = batch.child_session_ids.iter().rev();
+    for child_session_id in child_session_ids {
+        queue
+            .pending_child_session_ids
+            .push_front(child_session_id.clone());
+    }
+    queue.last_enqueued_at = Instant::now();
+    queue.settings = batch.settings.clone();
+}
+
+fn pause_delegate_announce_queue(parent_session_id: &str) {
+    let queues = delegate_announce_queues();
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(queue) = queues.get_mut(parent_session_id) else {
+        return;
+    };
+
+    queue.draining = false;
+}
+
+fn delegate_announce_queue_key(
+    memory_config: &MemoryRuntimeConfig,
+    parent_session_id: &str,
+) -> String {
+    let sqlite_path = memory_config.sqlite_path.clone();
+    let sqlite_path = sqlite_path
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| "in-memory".to_owned());
+
+    format!("{sqlite_path}::{parent_session_id}")
+}
+
+fn delegate_announce_queues() -> &'static Mutex<HashMap<String, DelegateAnnounceQueueState>> {
+    static QUEUES: OnceLock<Mutex<HashMap<String, DelegateAnnounceQueueState>>> = OnceLock::new();
+
+    QUEUES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+pub(crate) fn reset_delegate_announce_queues_for_tests() {
+    let queues = delegate_announce_queues();
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    queues.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tokio::time::{Duration, sleep};
+
+    use super::{
+        DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND, DelegateAnnounceSettings,
+        enqueue_delegate_result_announce, reset_delegate_announce_queues_for_tests,
+    };
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::frozen_result::{FrozenContent, FrozenResult};
+    use crate::session::repository::{
+        FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind, SessionRepository,
+        SessionState,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-announce-{test_name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&base);
+        let db_path = base.join("memory.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn create_parent_session(repo: &SessionRepository, session_id: &str, state: SessionState) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Parent".to_owned()),
+            state,
+        })
+        .expect("create parent session");
+    }
+
+    fn create_child_session(
+        repo: &SessionRepository,
+        parent_session_id: &str,
+        child_session_id: &str,
+        label: &str,
+        frozen_text: &str,
+    ) {
+        repo.create_session(NewSessionRecord {
+            session_id: child_session_id.to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(parent_session_id.to_owned()),
+            label: Some(label.to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child session");
+        let frozen_result = FrozenResult {
+            content: FrozenContent::Text(frozen_text.to_owned()),
+            captured_at: std::time::SystemTime::now(),
+            byte_len: frozen_text.len(),
+            truncated: false,
+        };
+        repo.finalize_session_terminal(
+            child_session_id,
+            FinalizeSessionTerminalRequest {
+                state: SessionState::Completed,
+                last_error: None,
+                event_kind: "delegate_completed".to_owned(),
+                actor_session_id: Some(parent_session_id.to_owned()),
+                event_payload_json: json!({
+                    "result": "ok",
+                }),
+                outcome_status: "ok".to_owned(),
+                outcome_payload_json: json!({
+                    "child_session_id": child_session_id,
+                    "final_output": frozen_text,
+                }),
+                frozen_result: Some(frozen_result),
+            },
+        )
+        .expect("finalize child session");
+    }
+
+    async fn wait_for_parent_announce_event(
+        repo: &SessionRepository,
+        parent_session_id: &str,
+    ) -> serde_json::Value {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+        loop {
+            let events = repo
+                .list_recent_events(parent_session_id, 20)
+                .expect("list parent events");
+            let announce_event = events
+                .into_iter()
+                .find(|event| event.event_kind == DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND);
+            if let Some(announce_event) = announce_event {
+                return announce_event.payload_json;
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                panic!("timed out waiting for delegate announce event");
+            }
+
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn delegate_announce_queue_delivers_single_result_to_parent_session_events() {
+        reset_delegate_announce_queues_for_tests();
+        let memory_config = isolated_memory_config("single");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        create_parent_session(&repo, "root-session", SessionState::Ready);
+        create_child_session(&repo, "root-session", "child-session", "Research", "done");
+
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-session".to_owned(),
+            DelegateAnnounceSettings {
+                debounce_ms: 0,
+                max_batch: 20,
+            },
+        );
+
+        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let results = payload["results"].as_array().expect("results array");
+
+        assert_eq!(payload["announce_kind"], "delegate_result");
+        assert_eq!(payload["trigger_turn"], false);
+        assert_eq!(payload["result_count"], 1);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["child_session_id"], "child-session");
+        assert_eq!(results[0]["label"], "Research");
+        assert_eq!(results[0]["frozen_result"]["content"]["text"], "done");
+    }
+
+    #[tokio::test]
+    async fn delegate_announce_queue_batches_children_completed_within_debounce_window() {
+        reset_delegate_announce_queues_for_tests();
+        let memory_config = isolated_memory_config("batch");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        create_parent_session(&repo, "root-session", SessionState::Ready);
+        create_child_session(&repo, "root-session", "child-1", "One", "alpha");
+        create_child_session(&repo, "root-session", "child-2", "Two", "beta");
+        create_child_session(&repo, "root-session", "child-3", "Three", "gamma");
+
+        let settings = DelegateAnnounceSettings {
+            debounce_ms: 100,
+            max_batch: 20,
+        };
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-1".to_owned(),
+            settings.clone(),
+        );
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-2".to_owned(),
+            settings.clone(),
+        );
+        enqueue_delegate_result_announce(
+            memory_config,
+            "root-session".to_owned(),
+            "child-3".to_owned(),
+            settings,
+        );
+
+        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let results = payload["results"].as_array().expect("results array");
+        let events = repo
+            .list_recent_events("root-session", 20)
+            .expect("list parent events");
+        let announce_events: Vec<_> = events
+            .into_iter()
+            .filter(|event| event.event_kind == DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND)
+            .collect();
+
+        assert_eq!(announce_events.len(), 1);
+        assert_eq!(payload["announce_kind"], "batch_delegate_results");
+        assert_eq!(payload["result_count"], 3);
+        assert_eq!(results.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delegate_announce_queue_summarizes_oldest_results_when_batch_limit_is_exceeded() {
+        reset_delegate_announce_queues_for_tests();
+        let memory_config = isolated_memory_config("overflow");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        create_parent_session(&repo, "root-session", SessionState::Ready);
+        create_child_session(&repo, "root-session", "child-1", "One", "alpha");
+        create_child_session(&repo, "root-session", "child-2", "Two", "beta");
+        create_child_session(&repo, "root-session", "child-3", "Three", "gamma");
+
+        let settings = DelegateAnnounceSettings {
+            debounce_ms: 100,
+            max_batch: 2,
+        };
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-1".to_owned(),
+            settings.clone(),
+        );
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-2".to_owned(),
+            settings.clone(),
+        );
+        enqueue_delegate_result_announce(
+            memory_config,
+            "root-session".to_owned(),
+            "child-3".to_owned(),
+            settings,
+        );
+
+        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let results = payload["results"].as_array().expect("results array");
+
+        assert_eq!(payload["announce_kind"], "batch_delegate_results");
+        assert_eq!(payload["overflow_summary"]["omitted_count"], 1);
+        assert_eq!(
+            payload["overflow_summary"]["omitted_child_session_ids"][0],
+            "child-1"
+        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["child_session_id"], "child-2");
+        assert_eq!(results[1]["child_session_id"], "child-3");
+    }
+
+    #[tokio::test]
+    async fn delegate_announce_queue_drops_delivery_when_parent_is_terminal() {
+        reset_delegate_announce_queues_for_tests();
+        let memory_config = isolated_memory_config("drop-terminal-parent");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        create_parent_session(&repo, "root-session", SessionState::Completed);
+        create_child_session(&repo, "root-session", "child-session", "Research", "done");
+
+        enqueue_delegate_result_announce(
+            memory_config,
+            "root-session".to_owned(),
+            "child-session".to_owned(),
+            DelegateAnnounceSettings {
+                debounce_ms: 0,
+                max_batch: 20,
+            },
+        );
+
+        sleep(Duration::from_millis(50)).await;
+
+        let events = repo
+            .list_recent_events("root-session", 20)
+            .expect("list parent events");
+        let announce_events: Vec<_> = events
+            .into_iter()
+            .filter(|event| event.event_kind == DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND)
+            .collect();
+
+        assert!(announce_events.is_empty());
+    }
+
+    #[test]
+    fn delegate_announce_queue_keeps_pending_batch_when_no_runtime_is_available() {
+        reset_delegate_announce_queues_for_tests();
+        let memory_config = isolated_memory_config("no-runtime");
+
+        enqueue_delegate_result_announce(
+            memory_config.clone(),
+            "root-session".to_owned(),
+            "child-session".to_owned(),
+            DelegateAnnounceSettings {
+                debounce_ms: 100,
+                max_batch: 20,
+            },
+        );
+
+        let queue_key = super::delegate_announce_queue_key(&memory_config, "root-session");
+        let queues = super::delegate_announce_queues();
+        let queues = queues
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let queue = queues
+            .get(queue_key.as_str())
+            .expect("queue should remain available");
+        let pending_child_session_ids = queue.pending_child_session_ids.clone();
+        let pending_child_session_ids: Vec<_> = pending_child_session_ids.into_iter().collect();
+
+        assert_eq!(pending_child_session_ids, vec!["child-session".to_owned()]);
+        assert!(!queue.draining);
+    }
+}

--- a/crates/app/src/conversation/delegate_support.rs
+++ b/crates/app/src/conversation/delegate_support.rs
@@ -1,0 +1,365 @@
+#[cfg(feature = "memory-sqlite")]
+use std::any::Any;
+#[cfg(feature = "memory-sqlite")]
+use std::future::Future;
+#[cfg(feature = "memory-sqlite")]
+use std::panic::AssertUnwindSafe;
+#[cfg(feature = "memory-sqlite")]
+use std::sync::Arc;
+
+#[cfg(feature = "memory-sqlite")]
+use futures_util::FutureExt;
+#[cfg(feature = "memory-sqlite")]
+use serde_json::Value;
+#[cfg(feature = "memory-sqlite")]
+use tokio::runtime::Handle;
+
+use crate::config::LoongClawConfig;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::delegate_runtime::next_delegate_child_depth;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::frozen_result::capture_frozen_result;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{FinalizeSessionTerminalRequest, SessionRepository, SessionState};
+
+#[cfg(feature = "memory-sqlite")]
+use super::announce::{DelegateAnnounceSettings, enqueue_delegate_result_announce};
+#[cfg(feature = "memory-sqlite")]
+use super::runtime::{
+    AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime,
+    DefaultConversationRuntime, SessionContext,
+};
+#[cfg(feature = "memory-sqlite")]
+use super::runtime_binding::ConversationRuntimeBinding;
+#[cfg(feature = "memory-sqlite")]
+use super::subagent::{ConstrainedSubagentExecution, ConstrainedSubagentTerminalReason};
+#[cfg(feature = "memory-sqlite")]
+use super::turn_coordinator::emit_async_delegate_child_terminal_event;
+
+#[cfg(all(feature = "memory-sqlite", test))]
+pub(crate) fn finalize_async_delegate_spawn_failure(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    profile: Option<crate::conversation::DelegateBuiltinProfile>,
+    execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
+    error: String,
+) -> Result<(), String> {
+    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure(
+        memory_config,
+        child_session_id,
+        parent_session_id,
+        label,
+        profile,
+        execution,
+        max_frozen_bytes,
+        error,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
+    memory_config: &MemoryRuntimeConfig,
+    child_session_id: &str,
+    parent_session_id: &str,
+    label: Option<String>,
+    profile: Option<crate::conversation::DelegateBuiltinProfile>,
+    execution: &ConstrainedSubagentExecution,
+    max_frozen_bytes: usize,
+    error: String,
+) -> Result<(), String> {
+    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure_with_recovery(
+        memory_config,
+        child_session_id,
+        parent_session_id,
+        label,
+        profile,
+        execution,
+        max_frozen_bytes,
+        error,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_async_spawn_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_async_spawn_panic: {}", *message),
+        Err(_) => "delegate_async_spawn_panic".to_owned(),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn spawn_async_delegate_detached(
+    runtime_handle: Handle,
+    config: Arc<LoongClawConfig>,
+    memory_config: MemoryRuntimeConfig,
+    spawner: Arc<dyn AsyncDelegateSpawner>,
+    request: AsyncDelegateSpawnRequest,
+    max_frozen_bytes: usize,
+    announce_settings: DelegateAnnounceSettings,
+) {
+    let child_session_id = request.child_session_id.clone();
+    let parent_session_id = request.parent_session_id.clone();
+    let label = request.label.clone();
+    let profile = request.profile;
+    let execution = request.execution.clone();
+    let binding = request.binding.clone();
+
+    runtime_handle.spawn(async move {
+        let spawn_failure = match AssertUnwindSafe(spawner.spawn(request))
+            .catch_unwind()
+            .await
+        {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error),
+            Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
+        };
+
+        let Some(error) = spawn_failure else {
+            return;
+        };
+
+        let spawn_error = error.clone();
+        let finalize_result = finalize_async_delegate_spawn_failure_with_recovery(
+            &memory_config,
+            &child_session_id,
+            &parent_session_id,
+            label.clone(),
+            profile,
+            &execution,
+            max_frozen_bytes,
+            error.clone(),
+        );
+        if let Err(finalize_error) = &finalize_result {
+            tracing::warn!(
+                child_session_id = %child_session_id,
+                parent_session_id = %parent_session_id,
+                spawn_error = %spawn_error,
+                error = %finalize_error,
+                "delegate async spawn failure finalize fell back with error"
+            );
+        }
+
+        enqueue_delegate_result_announce_with_memory_config(
+            memory_config.clone(),
+            parent_session_id.clone(),
+            child_session_id.clone(),
+            announce_settings.clone(),
+        );
+
+        let runtime = DefaultConversationRuntime::from_config_or_env(config.as_ref());
+        match runtime {
+            Ok(runtime) => {
+                emit_async_delegate_child_terminal_event(
+                    &runtime,
+                    &parent_session_id,
+                    &child_session_id,
+                    label.as_deref(),
+                    profile,
+                    "failed",
+                    execution.isolation,
+                    0,
+                    None,
+                    Some(error.as_str()),
+                    None,
+                    execution.workspace_root.as_deref(),
+                    None,
+                    binding.as_borrowed(),
+                )
+                .await;
+            }
+            Err(runtime_error) => {
+                tracing::warn!(
+                    child_session_id = %child_session_id,
+                    parent_session_id = %parent_session_id,
+                    error = %runtime_error,
+                    "delegate async spawn failure could not emit parent terminal projection"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn enqueue_delegate_result_announce_for_parent(
+    config: &LoongClawConfig,
+    parent_session_id: &str,
+    child_session_id: &str,
+) {
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let announce_settings = DelegateAnnounceSettings::from_config(config);
+
+    enqueue_delegate_result_announce_with_memory_config(
+        memory_config,
+        parent_session_id.to_owned(),
+        child_session_id.to_owned(),
+        announce_settings,
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn enqueue_delegate_result_announce_with_memory_config(
+    memory_config: MemoryRuntimeConfig,
+    parent_session_id: String,
+    child_session_id: String,
+    announce_settings: DelegateAnnounceSettings,
+) {
+    enqueue_delegate_result_announce(
+        memory_config,
+        parent_session_id,
+        child_session_id,
+        announce_settings,
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn next_delegate_child_depth_for_delegate(
+    config: &LoongClawConfig,
+    repo: &SessionRepository,
+    session_context: &SessionContext,
+) -> Result<usize, String> {
+    next_delegate_child_depth(
+        repo,
+        &session_context.session_id,
+        config.tools.delegate.max_depth,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) async fn with_prepared_subagent_spawn_cleanup_if_kernel_bound<
+    R: ConversationRuntime + ?Sized,
+    F,
+    Fut,
+    T,
+>(
+    runtime: &R,
+    parent_session_id: &str,
+    child_session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+    work: F,
+) -> Result<T, String>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    prepare_subagent_spawn_if_kernel_bound(runtime, parent_session_id, child_session_id, binding)
+        .await?;
+
+    let work_result = work().await;
+    let notify_result = notify_subagent_ended_if_kernel_bound(
+        runtime,
+        parent_session_id,
+        child_session_id,
+        binding,
+    )
+    .await;
+
+    match (work_result, notify_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(work_error), Ok(())) => Err(work_error),
+        (Ok(_), Err(notify_error)) => {
+            Err(format!("delegate_subagent_end_hook_failed: {notify_error}"))
+        }
+        (Err(work_error), Err(notify_error)) => Err(format!(
+            "{work_error}; delegate_subagent_end_hook_failed: {notify_error}"
+        )),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn prepare_subagent_spawn_if_kernel_bound<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    parent_session_id: &str,
+    child_session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<(), String> {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return Ok(());
+    };
+
+    runtime
+        .prepare_subagent_spawn(parent_session_id, child_session_id, kernel_ctx)
+        .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn notify_subagent_ended_if_kernel_bound<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    parent_session_id: &str,
+    child_session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<(), String> {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return Ok(());
+    };
+
+    runtime
+        .on_subagent_ended(parent_session_id, child_session_id, kernel_ctx)
+        .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn finalize_delegate_child_terminal_with_recovery(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    request: FinalizeSessionTerminalRequest,
+) -> Result<(), String> {
+    crate::operator::delegate_runtime::finalize_delegate_child_terminal_with_recovery(
+        repo,
+        child_session_id,
+        request,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn finalize_and_announce_delegate_child_terminal(
+    config: &LoongClawConfig,
+    repo: &SessionRepository,
+    child_session_id: &str,
+    parent_session_id: &str,
+    outcome: &loongclaw_contracts::ToolCoreOutcome,
+    state: SessionState,
+    last_error: Option<String>,
+    event_kind: &str,
+    event_payload_json: Value,
+) -> Result<(), String> {
+    let max_frozen_bytes = config.tools.delegate.max_frozen_bytes;
+    let frozen_result = capture_frozen_result(outcome, max_frozen_bytes);
+
+    let request = FinalizeSessionTerminalRequest {
+        state,
+        last_error,
+        event_kind: event_kind.to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json,
+        outcome_status: outcome.status.clone(),
+        outcome_payload_json: outcome.payload.clone(),
+        frozen_result: Some(frozen_result),
+    };
+
+    finalize_delegate_child_terminal_with_recovery(repo, child_session_id, request)?;
+    enqueue_delegate_result_announce_for_parent(config, parent_session_id, child_session_id);
+
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn format_delegate_child_panic(panic_payload: Box<dyn Any + Send>) -> String {
+    let panic_payload = match panic_payload.downcast::<String>() {
+        Ok(message) => return format!("delegate_child_panic: {}", *message),
+        Err(panic_payload) => panic_payload,
+    };
+
+    match panic_payload.downcast::<&'static str>() {
+        Ok(message) => format!("delegate_child_panic: {}", *message),
+        Err(_) => "delegate_child_panic".to_owned(),
+    }
+}

--- a/crates/app/src/conversation/delegate_support.rs
+++ b/crates/app/src/conversation/delegate_support.rs
@@ -33,7 +33,7 @@ use super::runtime::{
 #[cfg(feature = "memory-sqlite")]
 use super::runtime_binding::ConversationRuntimeBinding;
 #[cfg(feature = "memory-sqlite")]
-use super::subagent::{ConstrainedSubagentExecution, ConstrainedSubagentTerminalReason};
+use super::subagent::ConstrainedSubagentExecution;
 #[cfg(feature = "memory-sqlite")]
 use super::turn_coordinator::emit_async_delegate_child_terminal_event;
 

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -57,6 +57,8 @@ pub use context_engine_registry::{
     context_engine_id_from_env, describe_context_engine, list_context_engine_ids,
     list_context_engine_metadata, register_context_engine, resolve_context_engine,
 };
+#[cfg(feature = "memory-sqlite")]
+pub(crate) use delegate_support::with_prepared_subagent_spawn_cleanup_if_kernel_bound;
 pub use ingress::{
     ConversationIngressChannel, ConversationIngressContext, ConversationIngressDelivery,
     ConversationIngressDeliveryResource, ConversationIngressFeishuCallbackContext,
@@ -109,13 +111,10 @@ pub use turn_checkpoint::{
     TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
     TurnCheckpointTailRepairStatus,
 };
+#[cfg(feature = "memory-sqlite")]
+pub(crate) use turn_coordinator::run_started_delegate_child_turn_with_runtime;
 pub use turn_coordinator::{
     ContextCompactionReport, ConversationTurnCoordinator, spawn_background_delegate_with_runtime,
-};
-#[cfg(feature = "memory-sqlite")]
-pub(crate) use turn_coordinator::{
-    run_started_delegate_child_turn_with_runtime,
-    with_prepared_subagent_spawn_cleanup_if_kernel_bound,
 };
 pub use turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, NoopAppToolDispatcher, ProviderTurn, ToolDecision,

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+mod announce;
 mod approval_resolution;
 mod autonomy_policy;
 mod compaction;

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -5,6 +5,7 @@ mod autonomy_policy;
 mod compaction;
 mod context_engine;
 mod context_engine_registry;
+mod delegate_support;
 mod ingress;
 mod lane_arbiter;
 mod persistence;

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -746,7 +746,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
         let parent_session_id_for_spawn = parent_session_id.clone();
         let borrowed_binding = binding.as_borrowed();
         let child_binding = binding.clone();
-        super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
+        super::delegate_support::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime_ref,
             &parent_session_id,
             &child_session_id,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -304,7 +304,7 @@ impl crate::conversation::AsyncDelegateSpawner for PostPrepareFailingAsyncDelega
             .get()
             .ok_or_else(|| "test_post_prepare_runtime_missing".to_owned())?;
         let binding = request.binding.as_borrowed();
-        super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
+        super::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
             &request.parent_session_id,
             &request.child_session_id,
@@ -349,7 +349,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
         let parent_session_id_for_spawn = parent_session_id.clone();
         let borrowed_binding = binding.as_borrowed();
         let child_binding = binding.clone();
-        super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
+        super::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
             &parent_session_id,
             &child_session_id,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -20125,10 +20125,7 @@ async fn handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_s
     ));
     let _ = std::fs::remove_file(&db_path);
 
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    config.tools.delegate.announce_debounce_ms = 0;
-    enable_guided_autonomy(&mut config);
+    let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -20208,10 +20205,7 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
     ));
     let _ = std::fs::remove_file(&db_path);
 
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    config.tools.delegate.announce_debounce_ms = 0;
-    enable_guided_autonomy(&mut config);
+    let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23950,6 +23950,7 @@ async fn handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirt
     assert_eq!(payloads[0]["workspace_retained"], true);
 
     let git_executable = delegate_test_git_executable();
+    let cleanup_root = dunce::canonicalize(&worktree_root).unwrap_or(worktree_root);
     let cleanup_status = std::process::Command::new(git_executable)
         .args([
             "-C",
@@ -23957,7 +23958,10 @@ async fn handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirt
             "worktree",
             "remove",
             "--force",
-            workspace_root.as_str(),
+            cleanup_root
+                .as_os_str()
+                .to_str()
+                .expect("cleanup root utf-8"),
         ])
         .status()
         .expect("cleanup retained worktree status");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -41,7 +41,7 @@ use crate::memory::{
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
-    NewSessionToolPolicyRecord, SessionKind, SessionRepository, SessionState,
+    NewSessionToolPolicyRecord, SessionEventRecord, SessionKind, SessionRepository, SessionState,
     TransitionApprovalRequestIfCurrentRequest,
 };
 #[cfg(feature = "memory-sqlite")]
@@ -49,6 +49,58 @@ use crate::test_support::unique_temp_dir;
 
 #[cfg(feature = "memory-sqlite")]
 const DEEP_DELEGATE_REENTRY_TEST_STACK_SIZE_BYTES: usize = 32 * 1024 * 1024;
+
+#[cfg(feature = "memory-sqlite")]
+async fn wait_for_delegate_announce_event(
+    repo: &SessionRepository,
+    parent_session_id: &str,
+    expected_child_session_id: &str,
+) -> SessionEventRecord {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+
+    loop {
+        let events = repo
+            .list_recent_events(parent_session_id, 20)
+            .expect("list parent events");
+        let announce_event = events.into_iter().find(|event| {
+            let event_kind_matches =
+                event.event_kind == super::announce::DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND;
+            if !event_kind_matches {
+                return false;
+            }
+
+            let results = event.payload_json.get("results");
+            let results = results.and_then(Value::as_array);
+            let Some(results) = results else {
+                return false;
+            };
+
+            results.iter().any(|result| {
+                let child_session_id = result.get("child_session_id");
+                child_session_id == Some(&Value::String(expected_child_session_id.to_owned()))
+            })
+        });
+        if let Some(announce_event) = announce_event {
+            return announce_event;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for delegate announce event");
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn make_delegate_announce_test_config(db_path: &std::path::Path) -> LoongClawConfig {
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.announce_debounce_ms = 0;
+    enable_guided_autonomy(&mut config);
+
+    config
+}
 
 #[cfg(feature = "memory-sqlite")]
 fn run_conversation_test_on_large_stack<F>(thread_name: &str, operation: F)
@@ -19675,9 +19727,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
     ));
     let _ = std::fs::remove_file(&db_path);
 
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    enable_guided_autonomy(&mut config);
+    let mut config = make_delegate_announce_test_config(&db_path);
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -19793,9 +19843,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
     ));
     let _ = std::fs::remove_file(&db_path);
 
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    enable_guided_autonomy(&mut config);
+    let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -19917,6 +19965,21 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
         frozen_result.content,
         crate::session::frozen_result::FrozenContent::Text("Child final output".to_owned())
     );
+    let announce_event =
+        wait_for_delegate_announce_event(&repo, "root-session", &child.session_id).await;
+    assert_eq!(
+        announce_event.payload_json["announce_kind"],
+        "delegate_result"
+    );
+    assert_eq!(announce_event.payload_json["result_count"], 1);
+    assert_eq!(
+        announce_event.payload_json["results"][0]["child_session_id"],
+        child.session_id
+    );
+    assert_eq!(
+        announce_event.payload_json["results"][0]["frozen_result"]["content"]["text"],
+        "Child final output"
+    );
 
     let requested = runtime
         .turn_requested_tool_views
@@ -19936,9 +19999,7 @@ async fn handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks
     ));
     let _ = std::fs::remove_file(&db_path);
 
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    enable_guided_autonomy(&mut config);
+    let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -20066,6 +20127,7 @@ async fn handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_s
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.announce_debounce_ms = 0;
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
@@ -20148,6 +20210,7 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.announce_debounce_ms = 0;
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
@@ -20234,6 +20297,17 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
     assert_eq!(
         frozen_result.content,
         crate::session::frozen_result::FrozenContent::Text("Child final output".to_owned())
+    );
+    let announce_event =
+        wait_for_delegate_announce_event(&repo, "root-session", &child.session_id).await;
+    assert_eq!(
+        announce_event.payload_json["announce_kind"],
+        "delegate_result"
+    );
+    assert_eq!(announce_event.payload_json["result_count"], 1);
+    assert_eq!(
+        announce_event.payload_json["results"][0]["child_session_id"],
+        child.session_id
     );
 
     assert_eq!(
@@ -23150,6 +23224,22 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
         .collect();
     assert!(event_kinds.contains(&"delegate_queued"));
     assert!(event_kinds.contains(&"delegate_spawn_failed"));
+
+    let announce_event =
+        wait_for_delegate_announce_event(&repo, "root-session", &child.session_id).await;
+    assert_eq!(
+        announce_event.payload_json["announce_kind"],
+        "delegate_result"
+    );
+    assert_eq!(announce_event.payload_json["result_count"], 1);
+    assert_eq!(
+        announce_event.payload_json["results"][0]["child_session_id"],
+        child.session_id
+    );
+    assert_eq!(
+        announce_event.payload_json["results"][0]["frozen_result"]["content"]["error"]["code"],
+        "spawn unavailable"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -7910,7 +7910,7 @@ mod tests {
         assert_eq!(recovered.session.state, SessionState::Failed);
         assert_eq!(recovered.terminal_outcome.status, "error");
 
-        super::delegate_support::finalize_delegate_child_terminal_with_recovery(
+        finalize_delegate_child_terminal_with_recovery(
             &repo,
             "child-session",
             FinalizeSessionTerminalRequest {
@@ -8010,7 +8010,7 @@ mod tests {
         assert_eq!(recovered.session.state, SessionState::Failed);
         assert_eq!(recovered.terminal_outcome.status, "error");
 
-        super::delegate_support::finalize_async_delegate_spawn_failure(
+        finalize_async_delegate_spawn_failure(
             &memory_config,
             "child-session",
             "root-session",
@@ -8070,7 +8070,7 @@ mod tests {
         })
         .expect("create root session");
 
-        let error = super::delegate_support::finalize_delegate_child_terminal_with_recovery(
+        let error = finalize_delegate_child_terminal_with_recovery(
             &repo,
             "child-session",
             FinalizeSessionTerminalRequest {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4613,32 +4613,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
-            let frozen_result =
-                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
-            finalize_delegate_child_terminal_with_recovery(
+            let event_payload_json = execution.terminal_payload(
+                ConstrainedSubagentTerminalReason::Completed,
+                duration_ms,
+                Some(turn_count),
+                None,
+            );
+            finalize_and_announce_delegate_child_terminal(
+                config,
                 &repo,
                 child_session_id,
-                FinalizeSessionTerminalRequest {
-                    state: SessionState::Completed,
-                    last_error: None,
-                    event_kind: "delegate_completed".to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: execution.terminal_payload(
-                        ConstrainedSubagentTerminalReason::Completed,
-                        duration_ms,
-                        Some(turn_count),
-                        None,
-                    ),
-                    outcome_status: outcome.status.clone(),
-                    outcome_payload_json: outcome.payload.clone(),
-                    frozen_result: Some(frozen_result),
-                },
-            )?;
-            enqueue_delegate_result_announce_for_parent(
-                config,
                 parent_session_id,
-                child_session_id,
-            );
+                &outcome,
+                SessionState::Completed,
+                None,
+                "delegate_completed",
+                event_payload_json,
+            )?;
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4678,32 +4669,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
-            let frozen_result =
-                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
-            finalize_delegate_child_terminal_with_recovery(
+            let event_payload_json = execution.terminal_payload(
+                ConstrainedSubagentTerminalReason::Failed,
+                duration_ms,
+                None,
+                Some(error.as_str()),
+            );
+            finalize_and_announce_delegate_child_terminal(
+                config,
                 &repo,
                 child_session_id,
-                FinalizeSessionTerminalRequest {
-                    state: SessionState::Failed,
-                    last_error: Some(error.clone()),
-                    event_kind: "delegate_failed".to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: execution.terminal_payload(
-                        ConstrainedSubagentTerminalReason::Failed,
-                        duration_ms,
-                        None,
-                        Some(error.as_str()),
-                    ),
-                    outcome_status: outcome.status.clone(),
-                    outcome_payload_json: outcome.payload.clone(),
-                    frozen_result: Some(frozen_result),
-                },
-            )?;
-            enqueue_delegate_result_announce_for_parent(
-                config,
                 parent_session_id,
-                child_session_id,
-            );
+                &outcome,
+                SessionState::Failed,
+                Some(error.clone()),
+                "delegate_failed",
+                event_payload_json,
+            )?;
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4744,32 +4726,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
-            let frozen_result =
-                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
-            finalize_delegate_child_terminal_with_recovery(
+            let event_payload_json = execution.terminal_payload(
+                ConstrainedSubagentTerminalReason::Failed,
+                duration_ms,
+                None,
+                Some(panic_error.as_str()),
+            );
+            finalize_and_announce_delegate_child_terminal(
+                config,
                 &repo,
                 child_session_id,
-                FinalizeSessionTerminalRequest {
-                    state: SessionState::Failed,
-                    last_error: Some(panic_error.clone()),
-                    event_kind: "delegate_failed".to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: execution.terminal_payload(
-                        ConstrainedSubagentTerminalReason::Failed,
-                        duration_ms,
-                        None,
-                        Some(panic_error.as_str()),
-                    ),
-                    outcome_status: outcome.status.clone(),
-                    outcome_payload_json: outcome.payload.clone(),
-                    frozen_result: Some(frozen_result),
-                },
-            )?;
-            enqueue_delegate_result_announce_for_parent(
-                config,
                 parent_session_id,
-                child_session_id,
-            );
+                &outcome,
+                SessionState::Failed,
+                Some(panic_error.clone()),
+                "delegate_failed",
+                event_payload_json,
+            )?;
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4809,32 +4782,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 cleanup_metadata.as_ref(),
                 cleanup_error,
             );
-            let frozen_result =
-                capture_frozen_result(&outcome, config.tools.delegate.max_frozen_bytes);
-            finalize_delegate_child_terminal_with_recovery(
+            let event_payload_json = execution.terminal_payload(
+                ConstrainedSubagentTerminalReason::TimedOut,
+                duration_ms,
+                None,
+                Some(timeout_error.as_str()),
+            );
+            finalize_and_announce_delegate_child_terminal(
+                config,
                 &repo,
                 child_session_id,
-                FinalizeSessionTerminalRequest {
-                    state: SessionState::TimedOut,
-                    last_error: Some(timeout_error.clone()),
-                    event_kind: "delegate_timed_out".to_owned(),
-                    actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: execution.terminal_payload(
-                        ConstrainedSubagentTerminalReason::TimedOut,
-                        duration_ms,
-                        None,
-                        Some(timeout_error.as_str()),
-                    ),
-                    outcome_status: outcome.status.clone(),
-                    outcome_payload_json: outcome.payload.clone(),
-                    frozen_result: Some(frozen_result),
-                },
-            )?;
-            enqueue_delegate_result_announce_for_parent(
-                config,
                 parent_session_id,
-                child_session_id,
-            );
+                &outcome,
+                SessionState::TimedOut,
+                Some(timeout_error.clone()),
+                "delegate_timed_out",
+                event_payload_json,
+            )?;
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -5128,6 +5092,38 @@ fn finalize_delegate_child_terminal_with_recovery(
         child_session_id,
         request,
     )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn finalize_and_announce_delegate_child_terminal(
+    config: &LoongClawConfig,
+    repo: &SessionRepository,
+    child_session_id: &str,
+    parent_session_id: &str,
+    outcome: &loongclaw_contracts::ToolCoreOutcome,
+    state: SessionState,
+    last_error: Option<String>,
+    event_kind: &str,
+    event_payload_json: Value,
+) -> Result<(), String> {
+    let max_frozen_bytes = config.tools.delegate.max_frozen_bytes;
+    let frozen_result = capture_frozen_result(outcome, max_frozen_bytes);
+
+    let request = FinalizeSessionTerminalRequest {
+        state,
+        last_error,
+        event_kind: event_kind.to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json,
+        outcome_status: outcome.status.clone(),
+        outcome_payload_json: outcome.payload.clone(),
+        frozen_result: Some(frozen_result),
+    };
+
+    finalize_delegate_child_terminal_with_recovery(repo, child_session_id, request)?;
+    enqueue_delegate_result_announce_for_parent(config, parent_session_id, child_session_id);
+
+    Ok(())
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,9 +1,15 @@
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "memory-sqlite")]
+use std::panic::AssertUnwindSafe;
 
 use async_trait::async_trait;
+#[cfg(feature = "memory-sqlite")]
+use futures_util::FutureExt;
 use loongclaw_contracts::{AuditEventKind, ExecutionPlane, PlaneTier};
 use serde::Serialize;
 use serde_json::{Value, json};
+#[cfg(feature = "memory-sqlite")]
+use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 #[cfg(feature = "memory-sqlite")]
 use tokio::time::{Duration, Instant, timeout};
@@ -37,11 +43,8 @@ use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 #[cfg(feature = "memory-sqlite")]
 use super::delegate_support::{
-    finalize_and_announce_delegate_child_terminal, finalize_async_delegate_spawn_failure,
-    finalize_async_delegate_spawn_failure_with_recovery,
-    finalize_delegate_child_terminal_with_recovery, format_delegate_child_panic,
+    finalize_and_announce_delegate_child_terminal, format_delegate_child_panic,
     next_delegate_child_depth_for_delegate, spawn_async_delegate_detached,
-    with_prepared_subagent_spawn_cleanup_if_kernel_bound,
 };
 use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
@@ -62,8 +65,7 @@ use super::plan_verifier::{
     PlanVerificationReport, verify_output,
 };
 use super::runtime::{
-    AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime,
-    DefaultConversationRuntime, SessionContext,
+    AsyncDelegateSpawnRequest, ConversationRuntime, DefaultConversationRuntime, SessionContext,
 };
 use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::safe_lane_failure::{
@@ -135,11 +137,13 @@ use crate::conversation::workspace_isolation::{
 #[cfg(all(feature = "memory-sqlite", test))]
 use crate::session::recovery::RECOVERY_EVENT_KIND;
 #[cfg(all(test, feature = "memory-sqlite"))]
+use crate::session::repository::FinalizeSessionTerminalRequest;
+#[cfg(all(test, feature = "memory-sqlite"))]
 use crate::session::repository::TransitionApprovalRequestIfCurrentRequest;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    ApprovalDecision, ApprovalRequestStatus, FinalizeSessionTerminalRequest, NewSessionEvent,
-    NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    ApprovalDecision, ApprovalRequestStatus, NewSessionEvent, NewSessionRecord, SessionKind,
+    SessionRepository, SessionState,
 };
 
 #[derive(Default)]
@@ -4268,7 +4272,7 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let workspace_cleanup_owned_by_child_for_work =
         std::sync::Arc::clone(&workspace_cleanup_owned_by_child);
-    with_prepared_subagent_spawn_cleanup_if_kernel_bound(
+    super::delegate_support::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
         runtime,
         &session_context.session_id,
         &child_session_id,
@@ -7906,7 +7910,7 @@ mod tests {
         assert_eq!(recovered.session.state, SessionState::Failed);
         assert_eq!(recovered.terminal_outcome.status, "error");
 
-        finalize_delegate_child_terminal_with_recovery(
+        super::delegate_support::finalize_delegate_child_terminal_with_recovery(
             &repo,
             "child-session",
             FinalizeSessionTerminalRequest {
@@ -8006,7 +8010,7 @@ mod tests {
         assert_eq!(recovered.session.state, SessionState::Failed);
         assert_eq!(recovered.terminal_outcome.status, "error");
 
-        finalize_async_delegate_spawn_failure(
+        super::delegate_support::finalize_async_delegate_spawn_failure(
             &memory_config,
             "child-session",
             "root-session",
@@ -8066,7 +8070,7 @@ mod tests {
         })
         .expect("create root session");
 
-        let error = finalize_delegate_child_terminal_with_recovery(
+        let error = super::delegate_support::finalize_delegate_child_terminal_with_recovery(
             &repo,
             "child-session",
             FinalizeSessionTerminalRequest {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,19 +1,9 @@
-#[cfg(feature = "memory-sqlite")]
-use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(feature = "memory-sqlite")]
-use std::future::Future;
-#[cfg(feature = "memory-sqlite")]
-use std::panic::AssertUnwindSafe;
 
 use async_trait::async_trait;
-#[cfg(feature = "memory-sqlite")]
-use futures_util::FutureExt;
 use loongclaw_contracts::{AuditEventKind, ExecutionPlane, PlaneTier};
 use serde::Serialize;
 use serde_json::{Value, json};
-#[cfg(feature = "memory-sqlite")]
-use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 #[cfg(feature = "memory-sqlite")]
 use tokio::time::{Duration, Instant, timeout};
@@ -29,11 +19,9 @@ use crate::acp::{
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::delegate_runtime::{
-    DelegateChildExecutionPolicy, build_delegate_child_lifecycle_seed, next_delegate_child_depth,
+    DelegateChildExecutionPolicy, build_delegate_child_lifecycle_seed,
 };
 use crate::runtime_self_continuity;
-#[cfg(feature = "memory-sqlite")]
-use crate::session::frozen_result::capture_frozen_result;
 
 use super::super::config::{LoongClawConfig, ToolConsentMode};
 use super::ConversationSessionAddress;
@@ -43,10 +31,18 @@ use super::analytics::{
     TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
 };
 #[cfg(feature = "memory-sqlite")]
-use super::announce::{DelegateAnnounceSettings, enqueue_delegate_result_announce};
+use super::announce::DelegateAnnounceSettings;
 #[cfg(feature = "memory-sqlite")]
 use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
+#[cfg(feature = "memory-sqlite")]
+use super::delegate_support::{
+    finalize_and_announce_delegate_child_terminal, finalize_async_delegate_spawn_failure,
+    finalize_async_delegate_spawn_failure_with_recovery,
+    finalize_delegate_child_terminal_with_recovery, format_delegate_child_panic,
+    next_delegate_child_depth_for_delegate, spawn_async_delegate_detached,
+    with_prepared_subagent_spawn_cleanup_if_kernel_bound,
+};
 use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 use super::persistence::{
@@ -3427,7 +3423,7 @@ async fn emit_async_delegate_child_queued_event<R: ConversationRuntime + ?Sized>
 }
 
 #[cfg(feature = "memory-sqlite")]
-async fn emit_async_delegate_child_terminal_event<R: ConversationRuntime + ?Sized>(
+pub(crate) async fn emit_async_delegate_child_terminal_event<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     parent_session_id: &str,
     child_session_id: &str,
@@ -4820,321 +4816,6 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
             }
             Ok(outcome)
         }
-    }
-}
-
-#[cfg(all(feature = "memory-sqlite", test))]
-fn finalize_async_delegate_spawn_failure(
-    memory_config: &MemoryRuntimeConfig,
-    child_session_id: &str,
-    parent_session_id: &str,
-    label: Option<String>,
-    profile: Option<crate::conversation::DelegateBuiltinProfile>,
-    execution: &ConstrainedSubagentExecution,
-    max_frozen_bytes: usize,
-    error: String,
-) -> Result<(), String> {
-    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure(
-        memory_config,
-        child_session_id,
-        parent_session_id,
-        label,
-        profile,
-        execution,
-        max_frozen_bytes,
-        error,
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn finalize_async_delegate_spawn_failure_with_recovery(
-    memory_config: &MemoryRuntimeConfig,
-    child_session_id: &str,
-    parent_session_id: &str,
-    label: Option<String>,
-    profile: Option<crate::conversation::DelegateBuiltinProfile>,
-    execution: &ConstrainedSubagentExecution,
-    max_frozen_bytes: usize,
-    error: String,
-) -> Result<(), String> {
-    crate::operator::delegate_runtime::finalize_async_delegate_spawn_failure_with_recovery(
-        memory_config,
-        child_session_id,
-        parent_session_id,
-        label,
-        profile,
-        execution,
-        max_frozen_bytes,
-        error,
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Send>) -> String {
-    let panic_payload = match panic_payload.downcast::<String>() {
-        Ok(message) => return format!("delegate_async_spawn_panic: {}", *message),
-        Err(panic_payload) => panic_payload,
-    };
-    match panic_payload.downcast::<&'static str>() {
-        Ok(message) => format!("delegate_async_spawn_panic: {}", *message),
-        Err(_) => "delegate_async_spawn_panic".to_owned(),
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn spawn_async_delegate_detached(
-    runtime_handle: Handle,
-    config: std::sync::Arc<LoongClawConfig>,
-    memory_config: MemoryRuntimeConfig,
-    spawner: std::sync::Arc<dyn AsyncDelegateSpawner>,
-    request: AsyncDelegateSpawnRequest,
-    max_frozen_bytes: usize,
-    announce_settings: DelegateAnnounceSettings,
-) {
-    let child_session_id = request.child_session_id.clone();
-    let parent_session_id = request.parent_session_id.clone();
-    let label = request.label.clone();
-    let profile = request.profile;
-    let execution = request.execution.clone();
-    let binding = request.binding.clone();
-    runtime_handle.spawn(async move {
-        let spawn_failure = match AssertUnwindSafe(spawner.spawn(request))
-            .catch_unwind()
-            .await
-        {
-            Ok(Ok(())) => None,
-            Ok(Err(error)) => Some(error),
-            Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
-        };
-        if let Some(error) = spawn_failure {
-            let spawn_error = error.clone();
-            let finalize_result = finalize_async_delegate_spawn_failure_with_recovery(
-                &memory_config,
-                &child_session_id,
-                &parent_session_id,
-                label.clone(),
-                profile,
-                &execution,
-                max_frozen_bytes,
-                error.clone(),
-            );
-            if let Err(finalize_error) = &finalize_result {
-                tracing::warn!(
-                    child_session_id = %child_session_id,
-                    parent_session_id = %parent_session_id,
-                    spawn_error = %spawn_error,
-                    error = %finalize_error,
-                    "delegate async spawn failure finalize fell back with error"
-                );
-            }
-            enqueue_delegate_result_announce_with_memory_config(
-                memory_config.clone(),
-                parent_session_id.clone(),
-                child_session_id.clone(),
-                announce_settings.clone(),
-            );
-
-            let runtime = DefaultConversationRuntime::from_config_or_env(config.as_ref());
-            match runtime {
-                Ok(runtime) => {
-                    emit_async_delegate_child_terminal_event(
-                        &runtime,
-                        &parent_session_id,
-                        &child_session_id,
-                        label.as_deref(),
-                        profile,
-                        "failed",
-                        execution.isolation,
-                        0,
-                        None,
-                        Some(error.as_str()),
-                        None,
-                        execution.workspace_root.as_deref(),
-                        None,
-                        binding.as_borrowed(),
-                    )
-                    .await;
-                }
-                Err(runtime_error) => {
-                    tracing::warn!(
-                        child_session_id = %child_session_id,
-                        parent_session_id = %parent_session_id,
-                        error = %runtime_error,
-                        "delegate async spawn failure could not emit parent terminal projection"
-                    );
-                }
-            }
-        }
-    });
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn enqueue_delegate_result_announce_for_parent(
-    config: &LoongClawConfig,
-    parent_session_id: &str,
-    child_session_id: &str,
-) {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let announce_settings = DelegateAnnounceSettings::from_config(config);
-    enqueue_delegate_result_announce_with_memory_config(
-        memory_config,
-        parent_session_id.to_owned(),
-        child_session_id.to_owned(),
-        announce_settings,
-    );
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn enqueue_delegate_result_announce_with_memory_config(
-    memory_config: MemoryRuntimeConfig,
-    parent_session_id: String,
-    child_session_id: String,
-    announce_settings: DelegateAnnounceSettings,
-) {
-    enqueue_delegate_result_announce(
-        memory_config,
-        parent_session_id,
-        child_session_id,
-        announce_settings,
-    );
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn next_delegate_child_depth_for_delegate(
-    config: &LoongClawConfig,
-    repo: &SessionRepository,
-    session_context: &SessionContext,
-) -> Result<usize, String> {
-    next_delegate_child_depth(
-        repo,
-        &session_context.session_id,
-        config.tools.delegate.max_depth,
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(crate) async fn with_prepared_subagent_spawn_cleanup_if_kernel_bound<
-    R: ConversationRuntime + ?Sized,
-    F,
-    Fut,
-    T,
->(
-    runtime: &R,
-    parent_session_id: &str,
-    child_session_id: &str,
-    binding: ConversationRuntimeBinding<'_>,
-    work: F,
-) -> Result<T, String>
-where
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<T, String>>,
-{
-    prepare_subagent_spawn_if_kernel_bound(runtime, parent_session_id, child_session_id, binding)
-        .await?;
-    let work_result = work().await;
-    let notify_result = notify_subagent_ended_if_kernel_bound(
-        runtime,
-        parent_session_id,
-        child_session_id,
-        binding,
-    )
-    .await;
-    match (work_result, notify_result) {
-        (Ok(value), Ok(())) => Ok(value),
-        (Err(work_error), Ok(())) => Err(work_error),
-        (Ok(_), Err(notify_error)) => {
-            Err(format!("delegate_subagent_end_hook_failed: {notify_error}"))
-        }
-        (Err(work_error), Err(notify_error)) => Err(format!(
-            "{work_error}; delegate_subagent_end_hook_failed: {notify_error}"
-        )),
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-async fn prepare_subagent_spawn_if_kernel_bound<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    parent_session_id: &str,
-    child_session_id: &str,
-    binding: ConversationRuntimeBinding<'_>,
-) -> Result<(), String> {
-    let Some(kernel_ctx) = binding.kernel_context() else {
-        return Ok(());
-    };
-    runtime
-        .prepare_subagent_spawn(parent_session_id, child_session_id, kernel_ctx)
-        .await
-}
-
-#[cfg(feature = "memory-sqlite")]
-async fn notify_subagent_ended_if_kernel_bound<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    parent_session_id: &str,
-    child_session_id: &str,
-    binding: ConversationRuntimeBinding<'_>,
-) -> Result<(), String> {
-    let Some(kernel_ctx) = binding.kernel_context() else {
-        return Ok(());
-    };
-    runtime
-        .on_subagent_ended(parent_session_id, child_session_id, kernel_ctx)
-        .await
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn finalize_delegate_child_terminal_with_recovery(
-    repo: &SessionRepository,
-    child_session_id: &str,
-    request: FinalizeSessionTerminalRequest,
-) -> Result<(), String> {
-    crate::operator::delegate_runtime::finalize_delegate_child_terminal_with_recovery(
-        repo,
-        child_session_id,
-        request,
-    )
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn finalize_and_announce_delegate_child_terminal(
-    config: &LoongClawConfig,
-    repo: &SessionRepository,
-    child_session_id: &str,
-    parent_session_id: &str,
-    outcome: &loongclaw_contracts::ToolCoreOutcome,
-    state: SessionState,
-    last_error: Option<String>,
-    event_kind: &str,
-    event_payload_json: Value,
-) -> Result<(), String> {
-    let max_frozen_bytes = config.tools.delegate.max_frozen_bytes;
-    let frozen_result = capture_frozen_result(outcome, max_frozen_bytes);
-
-    let request = FinalizeSessionTerminalRequest {
-        state,
-        last_error,
-        event_kind: event_kind.to_owned(),
-        actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json,
-        outcome_status: outcome.status.clone(),
-        outcome_payload_json: outcome.payload.clone(),
-        frozen_result: Some(frozen_result),
-    };
-
-    finalize_delegate_child_terminal_with_recovery(repo, child_session_id, request)?;
-    enqueue_delegate_result_announce_for_parent(config, parent_session_id, child_session_id);
-
-    Ok(())
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn format_delegate_child_panic(panic_payload: Box<dyn Any + Send>) -> String {
-    let panic_payload = match panic_payload.downcast::<String>() {
-        Ok(message) => return format!("delegate_child_panic: {}", *message),
-        Err(panic_payload) => panic_payload,
-    };
-    match panic_payload.downcast::<&'static str>() {
-        Ok(message) => format!("delegate_child_panic: {}", *message),
-        Err(_) => "delegate_child_panic".to_owned(),
     }
 }
 
@@ -7072,6 +6753,10 @@ mod tests {
     use super::*;
     use crate::config::ToolConfig;
     use crate::context::bootstrap_test_kernel_context;
+    use crate::conversation::delegate_support::{
+        finalize_async_delegate_spawn_failure, finalize_async_delegate_spawn_failure_with_recovery,
+        finalize_delegate_child_terminal_with_recovery,
+    };
     use crate::conversation::turn_engine::ToolBatchExecutionIntentTrace;
     use crate::conversation::{
         ConversationTurnObserver, ConversationTurnPhase, ConversationTurnToolState,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -43,6 +43,8 @@ use super::analytics::{
     TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
 };
 #[cfg(feature = "memory-sqlite")]
+use super::announce::{DelegateAnnounceSettings, enqueue_delegate_result_announce};
+#[cfg(feature = "memory-sqlite")]
 use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 use super::ingress::ConversationIngressContext;
@@ -4443,6 +4445,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
             binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
         },
         config.tools.delegate.max_frozen_bytes,
+        DelegateAnnounceSettings::from_config(config),
     );
 
     let mut outcome = crate::tools::delegate::delegate_async_queued_outcome(
@@ -4631,6 +4634,11 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     frozen_result: Some(frozen_result),
                 },
             )?;
+            enqueue_delegate_result_announce_for_parent(
+                config,
+                parent_session_id,
+                child_session_id,
+            );
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4691,6 +4699,11 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     frozen_result: Some(frozen_result),
                 },
             )?;
+            enqueue_delegate_result_announce_for_parent(
+                config,
+                parent_session_id,
+                child_session_id,
+            );
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4752,6 +4765,11 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     frozen_result: Some(frozen_result),
                 },
             )?;
+            enqueue_delegate_result_announce_for_parent(
+                config,
+                parent_session_id,
+                child_session_id,
+            );
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4812,6 +4830,11 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     frozen_result: Some(frozen_result),
                 },
             )?;
+            enqueue_delegate_result_announce_for_parent(
+                config,
+                parent_session_id,
+                child_session_id,
+            );
             if execution.mode == ConstrainedSubagentMode::Async {
                 emit_async_delegate_child_terminal_event(
                     runtime,
@@ -4902,6 +4925,7 @@ fn spawn_async_delegate_detached(
     spawner: std::sync::Arc<dyn AsyncDelegateSpawner>,
     request: AsyncDelegateSpawnRequest,
     max_frozen_bytes: usize,
+    announce_settings: DelegateAnnounceSettings,
 ) {
     let child_session_id = request.child_session_id.clone();
     let parent_session_id = request.parent_session_id.clone();
@@ -4919,6 +4943,7 @@ fn spawn_async_delegate_detached(
             Err(panic_payload) => Some(format_async_delegate_spawn_panic(panic_payload)),
         };
         if let Some(error) = spawn_failure {
+            let spawn_error = error.clone();
             let finalize_result = finalize_async_delegate_spawn_failure_with_recovery(
                 &memory_config,
                 &child_session_id,
@@ -4929,14 +4954,21 @@ fn spawn_async_delegate_detached(
                 max_frozen_bytes,
                 error.clone(),
             );
-            if let Err(finalize_error) = finalize_result {
+            if let Err(finalize_error) = &finalize_result {
                 tracing::warn!(
                     child_session_id = %child_session_id,
                     parent_session_id = %parent_session_id,
+                    spawn_error = %spawn_error,
                     error = %finalize_error,
-                    "delegate async spawn failure recovery did not fully persist"
+                    "delegate async spawn failure finalize fell back with error"
                 );
             }
+            enqueue_delegate_result_announce_with_memory_config(
+                memory_config.clone(),
+                parent_session_id.clone(),
+                child_session_id.clone(),
+                announce_settings.clone(),
+            );
 
             let runtime = DefaultConversationRuntime::from_config_or_env(config.as_ref());
             match runtime {
@@ -4972,6 +5004,38 @@ fn spawn_async_delegate_detached(
     });
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn enqueue_delegate_result_announce_for_parent(
+    config: &LoongClawConfig,
+    parent_session_id: &str,
+    child_session_id: &str,
+) {
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let announce_settings = DelegateAnnounceSettings::from_config(config);
+    enqueue_delegate_result_announce_with_memory_config(
+        memory_config,
+        parent_session_id.to_owned(),
+        child_session_id.to_owned(),
+        announce_settings,
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn enqueue_delegate_result_announce_with_memory_config(
+    memory_config: MemoryRuntimeConfig,
+    parent_session_id: String,
+    child_session_id: String,
+    announce_settings: DelegateAnnounceSettings,
+) {
+    enqueue_delegate_result_announce(
+        memory_config,
+        parent_session_id,
+        child_session_id,
+        announce_settings,
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn next_delegate_child_depth_for_delegate(
     config: &LoongClawConfig,
     repo: &SessionRepository,

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -1775,6 +1775,8 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
         ",
     )
     .map_err(|error| format!("backfill session turn index metadata failed: {error}"))?;
+    conn.execute_batch(SESSION_TERMINAL_OUTCOMES_DDL)
+        .map_err(|error| format!("ensure session terminal outcome storage failed: {error}"))?;
 
     conn.execute_batch(SESSION_TERMINAL_OUTCOMES_TABLE_SQL)
         .map_err(|error| format!("backfill session terminal outcome storage failed: {error}"))?;

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -119,6 +119,15 @@ const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 18;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SESSION_TOOL_CONSENT_MODE_CHECK_SQL: &str = "CHECK (mode IN ('prompt', 'auto', 'full'))";
+const SESSION_TERMINAL_OUTCOMES_DDL: &str = "
+CREATE TABLE IF NOT EXISTS session_terminal_outcomes(
+  session_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  frozen_result_json TEXT NULL,
+  recorded_at INTEGER NOT NULL
+);
+";
 const SQL_INSERT_TURN: &str = "INSERT INTO turns(session_id, session_turn_index, role, content, ts) VALUES (?1, ?2, ?3, ?4, ?5)";
 const SQL_DELETE_TURNS_FOR_SESSION: &str = "DELETE FROM turns WHERE session_id = ?1";
 const SQL_UPSERT_SESSION_TURN_COUNT: &str =

--- a/crates/app/src/session/frozen_result.rs
+++ b/crates/app/src/session/frozen_result.rs
@@ -61,9 +61,13 @@ fn freeze_tool_outcome(outcome: &ToolCoreOutcome, max_frozen_bytes: usize) -> Fr
 
 fn freeze_success_payload(payload: &Value, max_frozen_bytes: usize) -> FrozenCapture {
     let final_output = payload.get("final_output");
-    let final_output_text = final_output.and_then(Value::as_str);
-    if let Some(final_output_text) = final_output_text {
-        return freeze_text(final_output_text, max_frozen_bytes);
+    if let Some(final_output_value) = final_output {
+        let final_output_text = final_output_value.as_str();
+        if let Some(final_output_text) = final_output_text {
+            return freeze_text(final_output_text, max_frozen_bytes);
+        }
+
+        return freeze_structured_payload(final_output_value, max_frozen_bytes);
     }
 
     freeze_structured_payload(payload, max_frozen_bytes)

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -2508,6 +2508,69 @@ impl SessionRepository {
         })
     }
 
+    pub fn append_event_if_session_active(
+        &self,
+        event: NewSessionEvent,
+    ) -> Result<Option<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(&event.session_id, "session_id")?;
+        let event_kind = normalize_required_text(&event.event_kind, "event_kind")?;
+        let actor_session_id = normalize_optional_text(event.actor_session_id);
+        let ts = unix_ts_now();
+        let payload_value = event.payload_json;
+        let payload_json = serde_json::to_string(&payload_value)
+            .map_err(|error| format!("encode session event payload failed: {error}"))?;
+
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| format!("open session append transaction failed: {error}"))?;
+        let raw_state = tx
+            .query_row(
+                "SELECT state FROM sessions WHERE session_id = ?1",
+                params![session_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|error| format!("load session state for append failed: {error}"))?;
+        let Some(raw_state) = raw_state else {
+            return Ok(None);
+        };
+        let session_state = SessionState::from_db(raw_state.as_str())?;
+        let session_is_terminal = matches!(
+            session_state,
+            SessionState::Completed | SessionState::Failed | SessionState::TimedOut
+        );
+        if session_is_terminal {
+            return Ok(None);
+        }
+
+        tx.execute(
+            "INSERT INTO session_events(
+                session_id, event_kind, actor_session_id, payload_json, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id.as_str(),
+                event_kind.as_str(),
+                actor_session_id.as_deref(),
+                payload_json.as_str(),
+                ts,
+            ],
+        )
+        .map_err(|error| format!("insert session event failed: {error}"))?;
+        let event_id = tx.last_insert_rowid();
+        tx.commit()
+            .map_err(|error| format!("commit session append transaction failed: {error}"))?;
+
+        Ok(Some(SessionEventRecord {
+            id: event_id,
+            session_id,
+            event_kind,
+            actor_session_id,
+            payload_json: payload_value,
+            ts,
+        }))
+    }
+
     fn open_connection(&self) -> Result<Connection, String> {
         Connection::open(&self.db_path)
             .map_err(|error| format!("open session repository sqlite db failed: {error}"))

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T05:39:47Z
+- Generated at: 2026-04-07T07:12:41Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11176 | 11200 | 24 | 91 | 120 | 29 | 99.8% | TIGHT | 10831 | 3.2% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11200 | 11200 | 0 | 91 | 120 | 29 | 100.0% | TIGHT | 10831 | 3.4% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (99.8%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (100.0%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11176 functions=91 -->
+<!-- arch-hotspot key=turn_coordinator lines=11200 functions=91 -->
 <!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T04:55:39Z
+- Generated at: 2026-04-07T04:56:38Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11487 | 11200 | -287 | 104 | 120 | 16 | 102.6% | BREACH | 10831 | 6.1% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11172 | 11200 | 28 | 91 | 120 | 29 | 99.8% | TIGHT | 10831 | 3.1% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (102.6%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
+- BREACH hotspots (>100% of any tracked budget): none
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (99.8%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11487 functions=104 -->
+<!-- arch-hotspot key=turn_coordinator lines=11172 functions=91 -->
 <!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T04:56:38Z
+- Generated at: 2026-04-07T05:11:06Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,7 +22,7 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11172 | 11200 | 28 | 91 | 120 | 29 | 99.8% | TIGHT | 10831 | 3.1% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11176 | 11200 | 24 | 91 | 120 | 29 | 99.8% | TIGHT | 10831 | 3.2% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11172 functions=91 -->
+<!-- arch-hotspot key=turn_coordinator lines=11176 functions=91 -->
 <!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T06:28:52Z
+- Generated at: 2026-04-07T04:55:39Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11451 | 11200 | -251 | 101 | 120 | 19 | 102.2% | BREACH | 10831 | 5.7% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11487 | 11200 | -287 | 104 | 120 | 16 | 102.6% | BREACH | 10831 | 6.1% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (102.2%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
+- BREACH hotspots (>100% of any tracked budget): turn_coordinator (102.6%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,8 +68,8 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11451 functions=101 -->
-<!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
+<!-- arch-hotspot key=turn_coordinator lines=11487 functions=104 -->
+<!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T05:11:06Z
+- Generated at: 2026-04-07T05:39:47Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11176 | 11200 | 24 | 91 | 120 | 29 | 99.8% | TIGHT | 10831 | 3.2% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (99.8%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), turn_coordinator (99.8%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=11176 functions=91 -->
-<!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - Delegate child sessions already persisted terminal outcomes and frozen results, but parent sessions still had no automatic delivery path for those results.
  - Completion discovery still depended on explicit polling of child sessions instead of a parent-directed announce flow.
- Why it matters:
  - Multi-child orchestration should not require the parent to repeatedly poll each child just to notice that work finished.
  - A stable announce surface is the prerequisite for `sessions_yield` and later mailbox-style coordination.
- What changed:
  - Added `conversation::announce` as the delegate-result announce runtime.
  - Child terminal outcomes now enqueue a parent-directed announce event after persisted terminal completion.
  - Async spawn-failure terminalization also enqueues parent-directed announce delivery when a terminal outcome exists.
  - Parent delivery reuses durable `session_events` instead of introducing a parallel mailbox storage layer.
  - Added configurable announce batching knobs:
    - `tools.delegate.announce_debounce_ms` (default `500`)
    - `tools.delegate.announce_max_batch` (default `20`)
  - Batched announce payloads summarize oldest overflowed child results instead of silently dropping them.
  - Added regression coverage for:
    - single-result announce
    - batched announce within debounce window
    - overflow summarization
    - drop-on-terminal-parent behavior
    - inline delegate wiring
    - kernel-bound delegate wiring
    - async spawn-failure wiring
- What did not change (scope boundary):
  - No `sessions_yield` tool yet.
  - No server-managed mailbox cursor table yet.
  - No new external protocol endpoint was added; announce currently lands in parent `session_events`.

## Linked Issues

- Closes #980
- Related #979
- Related #981

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-full cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-full cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-full cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
./scripts/check-docs.sh

Additional targeted regression coverage:
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features --lib delegate_announce_queue_ -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features --lib validate_rejects_zero_delegate_announce_max_batch -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_executes_delegate_via_coordinator -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_completion -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-issue-980-check cargo test -p loongclaw-app --all-features handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_after_queueing -- --test-threads=1

All commands completed successfully.
```

## User-visible / Operator-visible Changes

- Parent sessions now receive durable `delegate_results_announced` events when delegate children finish.
- Delegate config now exposes announce debounce and batch sizing knobs.

## Failure Recovery

- Fast rollback or disable path:
  - Revert this PR, or set `tools.delegate.announce_debounce_ms`/`announce_max_batch` back to defaults after rollback.
  - Because announce reuse is built on `session_events`, no extra mailbox table or migration state must be unwound.
- Observable failure symptoms reviewers should watch for:
  - Parent sessions missing `delegate_results_announced` after a child reaches terminal state.
  - Multiple announce events being emitted for children that should have batched together.
  - Overflow batches silently dropping child ids instead of surfacing `overflow_summary`.

## Reviewer Focus

- `crates/app/src/conversation/announce.rs`
  - Core queueing logic, durable parent event payload shape, and per-workspace queue isolation.
- `crates/app/src/conversation/turn_coordinator.rs`
  - Production wiring for inline delegate completion and async spawn-failure completion.
- `crates/app/src/config/tools.rs`
  - New announce config defaults and validation behavior.
- `crates/app/src/conversation/tests.rs`
  - End-to-end wiring checks for inline, kernel-bound, and async spawn-failure paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable delegate settings: max frozen bytes, announcement debounce, and max batch size (with defaults and validation).
  * Debounced, batched announcements of delegate child-session results to parent sessions, including overflow summaries and immediate delivery when debounce is zero.
  * Capture and persist size‑bounded frozen snapshots of delegate outcomes with truncation metadata.

* **Database Updates**
  * SQLite schema extended to store frozen outcomes and migrate legacy databases (schema version bump + repair path).

* **Tests**
  * Expanded coverage for announcements, overflow behavior, frozen-result capture, and schema repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->