### PR TITLE
fix(config): change default home directory from .loongclaw to .loong

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -107,8 +107,9 @@ pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_chann
 pub(crate) use shared::ConfigValidationIssue;
 #[allow(unused_imports)]
 pub use shared::{
-    CLI_COMMAND_NAME, LEGACY_CLI_COMMAND_NAME, PRODUCT_DISPLAY_NAME, active_cli_command_name,
-    detect_invoked_cli_command_name, detect_invoked_cli_command_name_from_arg0, expand_path,
+    CLI_COMMAND_NAME, HOME_DIR_NAME, LEGACY_CLI_COMMAND_NAME, LEGACY_HOME_DIR_NAME,
+    PRODUCT_DISPLAY_NAME, active_cli_command_name, detect_invoked_cli_command_name,
+    detect_invoked_cli_command_name_from_arg0, detect_legacy_home, expand_path,
     set_active_cli_command_name,
 };
 #[allow(unused_imports)]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -31,7 +31,7 @@ use super::{
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
         DEFAULT_CONFIG_FILE, default_loongclaw_home as shared_default_loongclaw_home, expand_path,
-        format_config_validation_issues,
+        format_config_validation_issues, warn_legacy_home_once,
     },
     tools::{
         DEFAULT_WEB_SEARCH_PROVIDER, ExternalSkillsConfig, RuntimePluginsConfig, ToolConfig,
@@ -2113,6 +2113,7 @@ pub fn render(config: &LoongClawConfig) -> CliResult<String> {
 }
 
 pub fn default_config_path() -> PathBuf {
+    warn_legacy_home_once();
     default_loongclaw_home().join(DEFAULT_CONFIG_FILE)
 }
 

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -31,7 +31,7 @@ use super::{
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
         DEFAULT_CONFIG_FILE, default_loongclaw_home as shared_default_loongclaw_home, expand_path,
-        format_config_validation_issues, warn_legacy_home_once,
+        format_config_validation_issues,
     },
     tools::{
         DEFAULT_WEB_SEARCH_PROVIDER, ExternalSkillsConfig, RuntimePluginsConfig, ToolConfig,
@@ -2113,7 +2113,6 @@ pub fn render(config: &LoongClawConfig) -> CliResult<String> {
 }
 
 pub fn default_config_path() -> PathBuf {
-    warn_legacy_home_once();
     default_loongclaw_home().join(DEFAULT_CONFIG_FILE)
 }
 

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -518,7 +518,7 @@ fn resolve_loongclaw_home(
     loongclaw_home
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loongclaw"))
+        .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loong"))
 }
 
 pub(super) fn default_loongclaw_home() -> PathBuf {

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -537,20 +537,17 @@ fn detect_legacy_home(user_home: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Prints a one-time migration hint to stderr when the legacy home directory
+/// Emits a one-time migration hint when the legacy home directory
 /// exists but the new one does not.
 pub(super) fn warn_legacy_home_once() {
     LEGACY_HOME_WARNING.call_once(|| {
         let user_home = get_user_home();
         if let Some(legacy) = detect_legacy_home(&user_home) {
             let new_home = user_home.join(".loong");
-            eprintln!(
-                "[loong] Legacy home directory {} found, but {} does not exist.",
+            tracing::warn!(
+                "Legacy home directory {} found, but {} does not exist. To migrate: mv {} {}",
                 legacy.display(),
                 new_home.display(),
-            );
-            eprintln!(
-                "[loong] To migrate: mv {} {}",
                 legacy.display(),
                 new_home.display(),
             );

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::{Once, OnceLock},
+    sync::OnceLock,
 };
 
 use loongclaw_contracts::SecretRef;
@@ -12,6 +12,8 @@ pub(super) const DEFAULT_CONFIG_FILE: &str = "config.toml";
 pub(super) const DEFAULT_SQLITE_FILE: &str = "memory.sqlite3";
 pub const CLI_COMMAND_NAME: &str = "loong";
 pub const LEGACY_CLI_COMMAND_NAME: &str = "loongclaw";
+pub const HOME_DIR_NAME: &str = ".loong";
+pub const LEGACY_HOME_DIR_NAME: &str = ".loongclaw";
 pub const PRODUCT_DISPLAY_NAME: &str = "LoongClaw";
 static ACTIVE_CLI_COMMAND_NAME: OnceLock<&'static str> = OnceLock::new();
 pub(super) const DEFAULT_FEISHU_SQLITE_FILE: &str = "feishu.sqlite3";
@@ -518,41 +520,21 @@ fn resolve_loongclaw_home(
     loongclaw_home
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loong"))
+        .unwrap_or_else(|| resolve_user_home(home, userprofile).join(HOME_DIR_NAME))
 }
 
-static LEGACY_HOME_WARNING: Once = Once::new();
-
-/// Returns `Some(legacy_path)` if `~/.loongclaw` exists but `~/.loong` does not.
-fn detect_legacy_home(user_home: &Path) -> Option<PathBuf> {
-    let new_home = user_home.join(".loong");
+/// Returns `Some(legacy_path)` if the legacy home exists but the new home does not.
+pub fn detect_legacy_home(user_home: &Path) -> Option<PathBuf> {
+    let new_home = user_home.join(HOME_DIR_NAME);
     if new_home.exists() {
         return None;
     }
-    let legacy_home = user_home.join(".loongclaw");
+    let legacy_home = user_home.join(LEGACY_HOME_DIR_NAME);
     if legacy_home.exists() {
         Some(legacy_home)
     } else {
         None
     }
-}
-
-/// Emits a one-time migration hint when the legacy home directory
-/// exists but the new one does not.
-pub(super) fn warn_legacy_home_once() {
-    LEGACY_HOME_WARNING.call_once(|| {
-        let user_home = get_user_home();
-        if let Some(legacy) = detect_legacy_home(&user_home) {
-            let new_home = user_home.join(".loong");
-            tracing::warn!(
-                "Legacy home directory {} found, but {} does not exist. To migrate: mv {} {}",
-                legacy.display(),
-                new_home.display(),
-                legacy.display(),
-                new_home.display(),
-            );
-        }
-    });
 }
 
 pub(super) fn default_loongclaw_home() -> PathBuf {

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -1024,6 +1024,9 @@ mod legacy_home_tests {
     fn detect_legacy_home_no_warning_fresh_install() {
         let temp = tempfile::tempdir().unwrap();
         let result = detect_legacy_home(temp.path());
-        assert!(result.is_none(), "should not detect legacy on fresh install");
+        assert!(
+            result.is_none(),
+            "should not detect legacy on fresh install"
+        );
     }
 }

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -985,7 +985,7 @@ mod tests {
         let resolved =
             resolve_loongclaw_home(Some(std::ffi::OsStr::new("")), Some(home.as_os_str()), None);
 
-        assert_eq!(resolved, home.join(".loongclaw"));
+        assert_eq!(resolved, home.join(".loong"));
     }
 
     #[test]
@@ -1002,7 +1002,7 @@ mod tests {
 
         let resolved = default_loongclaw_home();
 
-        assert_eq!(resolved, home.join(".loongclaw"));
+        assert_eq!(resolved, home.join(".loong"));
     }
 }
 

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::{Once, OnceLock},
 };
 
 use loongclaw_contracts::SecretRef;
@@ -521,6 +521,43 @@ fn resolve_loongclaw_home(
         .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loong"))
 }
 
+static LEGACY_HOME_WARNING: Once = Once::new();
+
+/// Returns `Some(legacy_path)` if `~/.loongclaw` exists but `~/.loong` does not.
+fn detect_legacy_home(user_home: &Path) -> Option<PathBuf> {
+    let new_home = user_home.join(".loong");
+    if new_home.exists() {
+        return None;
+    }
+    let legacy_home = user_home.join(".loongclaw");
+    if legacy_home.exists() {
+        Some(legacy_home)
+    } else {
+        None
+    }
+}
+
+/// Prints a one-time migration hint to stderr when the legacy home directory
+/// exists but the new one does not.
+pub(super) fn warn_legacy_home_once() {
+    LEGACY_HOME_WARNING.call_once(|| {
+        let user_home = get_user_home();
+        if let Some(legacy) = detect_legacy_home(&user_home) {
+            let new_home = user_home.join(".loong");
+            eprintln!(
+                "[loong] Legacy home directory {} found, but {} does not exist.",
+                legacy.display(),
+                new_home.display(),
+            );
+            eprintln!(
+                "[loong] To migrate: mv {} {}",
+                legacy.display(),
+                new_home.display(),
+            );
+        }
+    });
+}
+
 pub(super) fn default_loongclaw_home() -> PathBuf {
     get_loongclaw_home()
 }
@@ -969,5 +1006,45 @@ mod tests {
         let resolved = default_loongclaw_home();
 
         assert_eq!(resolved, home.join(".loongclaw"));
+    }
+}
+
+#[cfg(test)]
+mod legacy_home_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn detect_legacy_home_finds_legacy_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let legacy = temp.path().join(".loongclaw");
+        fs::create_dir_all(&legacy).unwrap();
+        // .loong does NOT exist
+        let result = detect_legacy_home(temp.path());
+        assert!(
+            result.is_some(),
+            "should detect legacy home when .loongclaw exists but .loong does not"
+        );
+    }
+
+    #[test]
+    fn detect_legacy_home_no_warning_when_new_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let new_home = temp.path().join(".loong");
+        let legacy = temp.path().join(".loongclaw");
+        fs::create_dir_all(&new_home).unwrap();
+        fs::create_dir_all(&legacy).unwrap();
+        let result = detect_legacy_home(temp.path());
+        assert!(
+            result.is_none(),
+            "should not detect legacy when .loong already exists"
+        );
+    }
+
+    #[test]
+    fn detect_legacy_home_no_warning_fresh_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = detect_legacy_home(temp.path());
+        assert!(result.is_none(), "should not detect legacy on fresh install");
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1802,7 +1802,7 @@ mod tests {
     ) -> (runtime_config::BashExecRuntimePolicy, PathBuf) {
         let log_path = root.join("bash-args.log");
         let runtime_path = write_fake_bash_runtime(root, "fake-bash", &log_path);
-        let rules_dir = root.join(".loongclaw").join("rules");
+        let rules_dir = root.join(crate::config::HOME_DIR_NAME).join("rules");
         let rules = bash_rules::load_rules_from_dir(&rules_dir).expect("load rules");
 
         (

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -365,7 +365,7 @@ fn bash_exec_allows_plain_command_when_prefix_rule_allows() {
     use std::fs;
 
     let root = unique_tool_temp_dir("loongclaw-bash-governance-allow");
-    let rules_dir = root.join(".loongclaw").join("rules");
+    let rules_dir = root.join(crate::config::HOME_DIR_NAME).join("rules");
     fs::create_dir_all(&rules_dir).expect("rules dir");
     fs::write(
         rules_dir.join("allow.rules"),
@@ -399,7 +399,7 @@ fn bash_exec_uses_loongclaw_home_rules_dir_even_when_runtime_is_built_without_co
 
     let home = unique_tool_temp_dir("loongclaw-bash-home-rules");
     let workspace = unique_tool_temp_dir("loongclaw-bash-home-rules-workspace");
-    let rules_dir = home.join(".loongclaw").join("rules");
+    let rules_dir = home.join(crate::config::HOME_DIR_NAME).join("rules");
     fs::create_dir_all(&rules_dir).expect("rules dir");
     fs::write(
         rules_dir.join("allow.rules"),
@@ -457,7 +457,7 @@ fn bash_exec_denies_plain_command_when_prefix_rule_denies() {
     use std::fs;
 
     let root = unique_tool_temp_dir("loongclaw-bash-governance-deny");
-    let rules_dir = root.join(".loongclaw").join("rules");
+    let rules_dir = root.join(crate::config::HOME_DIR_NAME).join("rules");
     fs::create_dir_all(&rules_dir).expect("rules dir");
     fs::write(
         rules_dir.join("deny.rules"),
@@ -494,7 +494,7 @@ fn bash_exec_denies_escaped_static_command_name_when_deny_rule_matches_under_def
     use std::fs;
 
     let root = unique_tool_temp_dir("loongclaw-bash-governance-escaped-deny");
-    let rules_dir = root.join(".loongclaw").join("rules");
+    let rules_dir = root.join(crate::config::HOME_DIR_NAME).join("rules");
     fs::create_dir_all(&rules_dir).expect("rules dir");
     fs::write(
         rules_dir.join("deny.rules"),
@@ -532,7 +532,7 @@ fn bash_exec_denies_or_list_when_rhs_branch_matches_deny_rule() {
     use std::fs;
 
     let root = unique_tool_temp_dir("loongclaw-bash-governance-or-deny");
-    let rules_dir = root.join(".loongclaw").join("rules");
+    let rules_dir = root.join(crate::config::HOME_DIR_NAME).join("rules");
     fs::create_dir_all(&rules_dir).expect("rules dir");
     fs::write(
         rules_dir.join("rules.rules"),

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -56,14 +56,16 @@ fn redacted_command_name(command: &Commands) -> &'static str {
 }
 
 fn check_legacy_home_migration() {
-    let user_home = std::env::var_os("HOME")
+    let Some(user_home) = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(std::path::PathBuf::from)
-        .unwrap_or_default();
+    else {
+        return;
+    };
     if let Some(legacy) = mvp::config::detect_legacy_home(&user_home) {
         let new_home = user_home.join(mvp::config::HOME_DIR_NAME);
         tracing::warn!(
-            "Legacy home directory {} found, but {} does not exist. To migrate: mv {} {}",
+            "Legacy home directory {} found, but {} does not exist. Rename {} to {} to migrate.",
             legacy.display(),
             new_home.display(),
             legacy.display(),

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -56,6 +56,9 @@ fn redacted_command_name(command: &Commands) -> &'static str {
 }
 
 fn check_legacy_home_migration() {
+    if std::env::var_os("LOONGCLAW_HOME").is_some() {
+        return;
+    }
     let Some(user_home) = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(std::path::PathBuf::from)

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -55,11 +55,29 @@ fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
+fn check_legacy_home_migration() {
+    let user_home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_default();
+    if let Some(legacy) = mvp::config::detect_legacy_home(&user_home) {
+        let new_home = user_home.join(mvp::config::HOME_DIR_NAME);
+        tracing::warn!(
+            "Legacy home directory {} found, but {} does not exist. To migrate: mv {} {}",
+            legacy.display(),
+            new_home.display(),
+            legacy.display(),
+            new_home.display(),
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
+    check_legacy_home_migration();
     let cli = parse_cli();
     let command_source = if cli.command.is_some() {
         "explicit"

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -426,7 +426,10 @@ fn memory_sqlite_path_looks_default(
         && candidate_path
             .parent()
             .and_then(Path::file_name)
-            .is_some_and(|component| component == ".loong" || component == ".loongclaw")
+            .is_some_and(|component| {
+                component == mvp::config::HOME_DIR_NAME
+                    || component == mvp::config::LEGACY_HOME_DIR_NAME
+            })
 }
 
 fn map_surface_level(level: ImportSurfaceLevel) -> PreviewStatus {

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -426,7 +426,7 @@ fn memory_sqlite_path_looks_default(
         && candidate_path
             .parent()
             .and_then(Path::file_name)
-            .is_some_and(|component| component == ".loongclaw")
+            .is_some_and(|component| component == ".loong" || component == ".loongclaw")
 }
 
 fn map_surface_level(level: ImportSurfaceLevel) -> PreviewStatus {

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -60,7 +60,7 @@ impl MigrationEnvironmentGuard {
             ));
             match home_override {
                 Some(home) => unsafe {
-                    std::env::set_var("LOONGCLAW_HOME", home.join(".loongclaw"))
+                    std::env::set_var("LOONGCLAW_HOME", home.join(mvp::config::HOME_DIR_NAME))
                 },
                 None => unsafe { std::env::remove_var("LOONGCLAW_HOME") },
             }

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -96,7 +96,7 @@ impl ImportEnvironmentGuard {
             ));
             match home_override {
                 Some(home) => unsafe {
-                    std::env::set_var("LOONGCLAW_HOME", home.join(".loongclaw"))
+                    std::env::set_var("LOONGCLAW_HOME", home.join(mvp::config::HOME_DIR_NAME))
                 },
                 None => unsafe {
                     std::env::remove_var("LOONGCLAW_HOME");

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -1196,7 +1196,7 @@ async fn multi_channel_serve_ctrl_c_waits_for_background_joins_and_reports_shutd
 #[tokio::test(flavor = "current_thread")]
 async fn multi_channel_serve_cooperative_stop_clears_channel_runtime_running_state() {
     let temp_home = unique_runtime_dir("cooperative-stop-home");
-    let runtime_dir = temp_home.join(".loongclaw").join("channel-runtime");
+    let runtime_dir = temp_home.join(".loong").join("channel-runtime");
     let _env =
         MigrationEnvironmentGuard::set(&[("HOME", Some(temp_home.to_string_lossy().as_ref()))]);
     let runtime_entered = Arc::new(Notify::new());

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -49,7 +49,7 @@ impl RuntimeCapabilityEnvironmentGuard {
     fn set(root: &Path) -> Self {
         let lock = super::lock_daemon_test_environment();
         let home = root.join("home");
-        let loongclaw_home = home.join(".loongclaw");
+        let loongclaw_home = home.join(mvp::config::HOME_DIR_NAME);
         fs::create_dir_all(&loongclaw_home).expect("create isolated loongclaw home");
         let home_text = home.to_string_lossy().into_owned();
         let loongclaw_home_text = loongclaw_home.to_string_lossy().into_owned();


### PR DESCRIPTION
## Summary

- Problem: `loong onboard` defaults home to `~/.loongclaw` (legacy name), causing missing-file warnings for follow-up commands (`loong ask`, `loong chat`, `loong feishu-serve`).
- Why it matters: The binary was renamed from `loongclaw` to `loong`, but the home directory path was not updated to match. New users see confusing warnings; existing users get no migration guidance.
- What changed: Default home path `.loongclaw` → `.loong`, with a `tracing::warn` migration hint when `~/.loongclaw` exists but `~/.loong` does not. Warning is skipped when `LOONGCLAW_HOME` is explicitly set.
- What did not change (scope boundary): Function name `default_loongclaw_home()` kept as-is (40 call sites, zero behavior change). No automatic directory migration. `LOONGCLAW_HOME` env var override still works. Env var rename tracked separately in #1055.

## Linked Issues

- Related #1043
- Related #1055 (follow-up: `LOONG_HOME` env var alias)

## Change Type

- [x] Bug fix

## Touched Areas

- [x] Daemon / CLI / install

## Details

### 10 files changed, +102/-16

**Production code (3 files):**

| File | Change |
|------|--------|
| `crates/app/src/config/shared.rs` | Add `HOME_DIR_NAME` / `LEGACY_HOME_DIR_NAME` constants; change default from `.loongclaw` to `.loong`; add `detect_legacy_home()` pure function + 3 unit tests |
| `crates/app/src/config/mod.rs` | Export new constants and `detect_legacy_home` |
| `crates/daemon/src/main.rs` | Add `check_legacy_home_migration()` in startup after `init_tracing()` — emits one-time warning when legacy home exists; skips when `LOONGCLAW_HOME` is explicitly set |

**Migration logic (1 file):**

| File | Change |
|------|--------|
| `crates/daemon/src/migration/discovery.rs` | Recognize both `.loong` and `.loongclaw` as default home paths using constants |

**Test updates (6 files):**

| File | Change |
|------|--------|
| `crates/daemon/tests/integration.rs` | `MigrationEnvironmentGuard`: derive `LOONGCLAW_HOME` from `HOME_DIR_NAME` instead of hardcoded `.loongclaw` |
| `crates/daemon/tests/integration/import_cli.rs` | `ImportEnvironmentGuard`: same fix |
| `crates/daemon/tests/integration/runtime_capability_cli.rs` | `RuntimeCapabilityEnvironmentGuard`: same fix |
| `crates/daemon/tests/integration/multi_channel_serve_cli.rs` | Update cooperative-stop test assertion `.loongclaw` → `.loong` |
| `crates/app/src/tools/mod.rs` | `configured_test_bash_runtime_with_rules`: use `HOME_DIR_NAME` constant |
| `crates/app/src/tools/tests/bash_exec_tests.rs` | 5 bash governance tests: use `HOME_DIR_NAME` constant for fixture paths |

### Architecture

Migration warning lives in daemon's `main.rs` (not app crate), because:
- `default_config_path()` stays a pure function with no side effects
- App crate is consumed by bench/spec/tests which don't need migration warnings
- Tracing is guaranteed initialized at the call site

### Test evidence

```
cargo test -p loongclaw-app --lib config -- → 572 passed, 0 failed
cargo clippy -p loongclaw-app --all-features -- -D warnings → 0 errors in changed files
cargo fmt --all -- --check → 0 formatting diffs
CI: rust-quality + rust-test-default + rust-test-all-features → all green (ubuntu + windows)
```

### CI note

`governance` check fails on `turn_coordinator.rs` line count budget (11451/11200) — this is a pre-existing issue on `dev` branch (tracked in #1061), not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application now uses `.loong` as the default home directory instead of `.loongclaw`.
  * Added legacy home directory detection to identify existing installations using the previous directory structure.
  * Warnings are now displayed at startup if legacy directories are detected.

* **Tests**
  * Updated test suite to reference the new home directory structure throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
