### PR TITLE
feat: expand the native prompt personality catalog

### DIFF
--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -2703,9 +2703,26 @@ api_key_env = "{secret}"
         write(Some(&path_string), &config, true).expect("config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read config text");
-        let legacy_raw = raw.replace(
-            "personality = \"hermit\"",
-            "personality = \"friendly_collab\"",
+        let serialized_personality = "personality = \"hermit\"";
+        let legacy_personality = "personality = \"friendly_collab\"";
+        let fixture_contains_serialized_personality = raw.contains(serialized_personality);
+
+        assert!(
+            fixture_contains_serialized_personality,
+            "serialized personality fixture changed unexpectedly: {raw}"
+        );
+
+        let legacy_raw = raw.replacen(serialized_personality, legacy_personality, 1);
+        let replacement_happened = legacy_raw != raw;
+        let legacy_personality_written = legacy_raw.contains(legacy_personality);
+
+        assert!(
+            replacement_happened,
+            "fixture rewrite failed; serialized personality format changed"
+        );
+        assert!(
+            legacy_personality_written,
+            "fixture rewrite did not persist the legacy personality alias"
         );
 
         fs::write(&path, legacy_raw).expect("write legacy config text");

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -2674,7 +2674,7 @@ api_key_env = "{secret}"
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
         config.cli.prompt_pack_id = Some("loongclaw-core-v1".to_owned());
-        config.cli.personality = Some(crate::prompt::PromptPersonality::AutonomousExecutor);
+        config.cli.personality = Some(crate::prompt::PromptPersonality::CyberRadical);
 
         write(Some(&path_string), &config, true).expect("config write should pass");
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
@@ -2685,7 +2685,36 @@ api_key_env = "{secret}"
         );
         assert_eq!(
             loaded.cli.personality,
-            Some(crate::prompt::PromptPersonality::AutonomousExecutor)
+            Some(crate::prompt::PromptPersonality::CyberRadical)
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn load_accepts_legacy_prompt_personality_ids() {
+        let path = unique_config_path("loongclaw-legacy-prompt-config");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
+        config.cli.prompt_pack_id = Some("loongclaw-core-v1".to_owned());
+        config.cli.personality = Some(crate::prompt::PromptPersonality::Hermit);
+
+        write(Some(&path_string), &config, true).expect("config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read config text");
+        let legacy_raw = raw.replace(
+            "personality = \"hermit\"",
+            "personality = \"friendly_collab\"",
+        );
+
+        fs::write(&path, legacy_raw).expect("write legacy config text");
+
+        let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
+
+        assert_eq!(
+            loaded.cli.personality,
+            Some(crate::prompt::PromptPersonality::Hermit)
         );
 
         let _ = fs::remove_file(path);

--- a/crates/app/src/prompt/mod.rs
+++ b/crates/app/src/prompt/mod.rs
@@ -20,6 +20,7 @@ pub enum PromptPersonality {
 pub struct PromptPersonalityDescriptor {
     pub personality: PromptPersonality,
     pub id: &'static str,
+    pub aliases: &'static [&'static str],
     pub label: &'static str,
     pub selection_summary: &'static str,
     pub overlay_title: &'static str,
@@ -27,16 +28,11 @@ pub struct PromptPersonalityDescriptor {
     pub experimental: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PromptPersonalityAlias {
-    alias: &'static str,
-    personality: PromptPersonality,
-}
-
 const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Classicist,
         id: "classicist",
+        aliases: &["calm_engineering", "engineering", "calm", "classical"],
         label: "classicist",
         selection_summary: "formal, precise, and orderly",
         overlay_title: "Classicist",
@@ -50,6 +46,13 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Pragmatist,
         id: "pragmatist",
+        aliases: &[
+            "autonomous_executor",
+            "autonomous",
+            "executor",
+            "pragmatic",
+            "practical",
+        ],
         label: "pragmatist",
         selection_summary: "lean, decisive, and outcome-first",
         overlay_title: "Pragmatist",
@@ -63,6 +66,7 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Idealist,
         id: "idealist",
+        aliases: &["idealism"],
         label: "idealist",
         selection_summary: "principled, long-horizon, and mission-driven",
         overlay_title: "Idealist",
@@ -76,6 +80,7 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Romanticist,
         id: "romanticist",
+        aliases: &["romantic"],
         label: "romanticist",
         selection_summary: "vivid, expressive, and metaphor-aware",
         overlay_title: "Romanticist",
@@ -89,6 +94,7 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Hermit,
         id: "hermit",
+        aliases: &["friendly_collab", "friendly", "collab", "watcher"],
         label: "hermit",
         selection_summary: "gentle, patient, and grounding",
         overlay_title: "Hermit",
@@ -102,6 +108,7 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::CyberRadical,
         id: "cyber_radical",
+        aliases: &["cyberpunk", "radical"],
         label: "cyber radical",
         selection_summary: "bold, unconventional, and high-energy",
         overlay_title: "Cyber Radical",
@@ -115,6 +122,7 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
     PromptPersonalityDescriptor {
         personality: PromptPersonality::Nihilist,
         id: "nihilist",
+        aliases: &["nihilism"],
         label: "nihilist",
         selection_summary: "dry, skeptical, and darkly witty",
         overlay_title: "Nihilist",
@@ -124,81 +132,6 @@ const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
 - Confirmation threshold: medium. Do not let detachment erase caution.
 - Tool-use bias: unsentimental and direct."#,
         experimental: true,
-    },
-];
-
-const PROMPT_PERSONALITY_ALIASES: [PromptPersonalityAlias; 18] = [
-    PromptPersonalityAlias {
-        alias: "romantic",
-        personality: PromptPersonality::Romanticist,
-    },
-    PromptPersonalityAlias {
-        alias: "idealism",
-        personality: PromptPersonality::Idealist,
-    },
-    PromptPersonalityAlias {
-        alias: "pragmatic",
-        personality: PromptPersonality::Pragmatist,
-    },
-    PromptPersonalityAlias {
-        alias: "practical",
-        personality: PromptPersonality::Pragmatist,
-    },
-    PromptPersonalityAlias {
-        alias: "nihilism",
-        personality: PromptPersonality::Nihilist,
-    },
-    PromptPersonalityAlias {
-        alias: "calm_engineering",
-        personality: PromptPersonality::Classicist,
-    },
-    PromptPersonalityAlias {
-        alias: "engineering",
-        personality: PromptPersonality::Classicist,
-    },
-    PromptPersonalityAlias {
-        alias: "calm",
-        personality: PromptPersonality::Classicist,
-    },
-    PromptPersonalityAlias {
-        alias: "classical",
-        personality: PromptPersonality::Classicist,
-    },
-    PromptPersonalityAlias {
-        alias: "cyberpunk",
-        personality: PromptPersonality::CyberRadical,
-    },
-    PromptPersonalityAlias {
-        alias: "radical",
-        personality: PromptPersonality::CyberRadical,
-    },
-    PromptPersonalityAlias {
-        alias: "friendly_collab",
-        personality: PromptPersonality::Hermit,
-    },
-    PromptPersonalityAlias {
-        alias: "friendly",
-        personality: PromptPersonality::Hermit,
-    },
-    PromptPersonalityAlias {
-        alias: "collab",
-        personality: PromptPersonality::Hermit,
-    },
-    PromptPersonalityAlias {
-        alias: "watcher",
-        personality: PromptPersonality::Hermit,
-    },
-    PromptPersonalityAlias {
-        alias: "autonomous_executor",
-        personality: PromptPersonality::Pragmatist,
-    },
-    PromptPersonalityAlias {
-        alias: "autonomous",
-        personality: PromptPersonality::Pragmatist,
-    },
-    PromptPersonalityAlias {
-        alias: "executor",
-        personality: PromptPersonality::Pragmatist,
     },
 ];
 
@@ -294,18 +227,10 @@ pub fn parse_prompt_personality(raw: &str) -> Option<PromptPersonality> {
     let normalized_id = normalized.as_str();
 
     for descriptor in prompt_personality_catalog() {
-        let matches_descriptor = descriptor.id == normalized_id;
+        let matches_descriptor = prompt_personality_matches_token(descriptor, normalized_id);
 
         if matches_descriptor {
             return Some(descriptor.personality);
-        }
-    }
-
-    for alias in PROMPT_PERSONALITY_ALIASES {
-        let matches_alias = alias.alias == normalized_id;
-
-        if matches_alias {
-            return Some(alias.personality);
         }
     }
 
@@ -331,8 +256,7 @@ pub fn render_system_prompt(input: PromptRenderInput) -> String {
     let descriptor = prompt_personality_descriptor(input.personality);
     let overlay_section = render_personality_overlay(descriptor);
     let mut sections = vec![base_prompt().to_owned(), overlay_section];
-    let trimmed_addendum = input.addendum.map(|value| value.trim().to_owned());
-    let addendum = trimmed_addendum.filter(|value| !value.is_empty());
+    let addendum = input.addendum.filter(|value| !value.trim().is_empty());
 
     if let Some(addendum) = addendum {
         let addendum_section = format!("## User Addendum\n{addendum}");
@@ -422,6 +346,28 @@ fn normalize_prompt_personality_token(raw: &str) -> String {
     normalized.trim_matches('_').to_owned()
 }
 
+fn prompt_personality_matches_token(
+    descriptor: &PromptPersonalityDescriptor,
+    normalized_id: &str,
+) -> bool {
+    let matches_id = descriptor.id == normalized_id;
+
+    if matches_id {
+        return true;
+    }
+
+    for alias in descriptor.aliases {
+        let normalized_alias = normalize_prompt_personality_token(alias);
+        let matches_alias = normalized_alias == normalized_id;
+
+        if matches_alias {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,10 +385,47 @@ mod tests {
     }
 
     #[test]
+    fn personality_catalog_aliases_are_unique_and_do_not_shadow_ids() {
+        let mut tokens = BTreeSet::new();
+
+        for descriptor in prompt_personality_catalog() {
+            let normalized_id = normalize_prompt_personality_token(descriptor.id);
+            let inserted_id = tokens.insert(normalized_id.clone());
+
+            assert!(
+                inserted_id,
+                "duplicate normalized personality token: {}",
+                normalized_id
+            );
+
+            for alias in descriptor.aliases {
+                let normalized_alias = normalize_prompt_personality_token(alias);
+                let inserted_alias = tokens.insert(normalized_alias.clone());
+
+                assert!(
+                    inserted_alias,
+                    "duplicate normalized personality token: {}",
+                    normalized_alias
+                );
+            }
+        }
+    }
+
+    #[test]
     fn default_prompt_personality_is_classicist() {
         let default_id = PromptPersonality::default().id();
 
         assert_eq!(default_id, "classicist");
+    }
+
+    #[test]
+    fn descriptor_lookup_matches_catalog_personality_entries() {
+        for descriptor in prompt_personality_catalog() {
+            let resolved = prompt_personality_descriptor(descriptor.personality);
+
+            assert_eq!(resolved.id, descriptor.id);
+            assert_eq!(resolved.personality, descriptor.personality);
+        }
     }
 
     #[test]
@@ -491,6 +474,17 @@ mod tests {
 
         assert!(rendered.contains("Always prefer concise summaries."));
         assert!(rendered.contains("## User Addendum"));
+    }
+
+    #[test]
+    fn render_prompt_preserves_non_empty_addendum_whitespace() {
+        let addendum = "  Keep the indentation.\n";
+        let rendered = render_system_prompt(PromptRenderInput {
+            personality: PromptPersonality::Hermit,
+            addendum: Some(addendum.to_owned()),
+        });
+
+        assert!(rendered.contains(addendum));
     }
 
     #[test]

--- a/crates/app/src/prompt/mod.rs
+++ b/crates/app/src/prompt/mod.rs
@@ -1,15 +1,206 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
 
 pub const DEFAULT_PROMPT_PACK_ID: &str = "loongclaw-core-v1";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PromptPersonality {
+    Romanticist,
+    Idealist,
+    Pragmatist,
+    Nihilist,
     #[default]
-    CalmEngineering,
-    FriendlyCollab,
-    AutonomousExecutor,
+    Classicist,
+    CyberRadical,
+    Hermit,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptPersonalityDescriptor {
+    pub personality: PromptPersonality,
+    pub id: &'static str,
+    pub label: &'static str,
+    pub selection_summary: &'static str,
+    pub overlay_title: &'static str,
+    pub overlay_body: &'static str,
+    pub experimental: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PromptPersonalityAlias {
+    alias: &'static str,
+    personality: PromptPersonality,
+}
+
+const PROMPT_PERSONALITY_CATALOG: [PromptPersonalityDescriptor; 7] = [
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Classicist,
+        id: "classicist",
+        label: "classicist",
+        selection_summary: "formal, precise, and orderly",
+        overlay_title: "Classicist",
+        overlay_body: r#"- Sound formal, precise, and orderly.
+- Protect terminology, structure, and logical sequencing.
+- Initiative: medium. Advance deliberate work without theatrics.
+- Confirmation threshold: medium. Clarify when standards, taste, or user-visible polish could vary.
+- Tool-use bias: careful and methodical."#,
+        experimental: false,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Pragmatist,
+        id: "pragmatist",
+        label: "pragmatist",
+        selection_summary: "lean, decisive, and outcome-first",
+        overlay_title: "Pragmatist",
+        overlay_body: r#"- Sound lean, direct, and outcome-focused.
+- Favor concrete next steps, decision criteria, and checklists over rhetorical flourish.
+- Initiative: high on clear tasks. Break work down and move.
+- Confirmation threshold: low for safe and reversible actions, high for destructive, privileged, or externally visible actions.
+- Tool-use bias: direct and efficient."#,
+        experimental: false,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Idealist,
+        id: "idealist",
+        label: "idealist",
+        selection_summary: "principled, long-horizon, and mission-driven",
+        overlay_title: "Idealist",
+        overlay_body: r#"- Sound principled, inspiring, and long-horizon.
+- Connect recommendations to values, mission, or durable user benefit before diving into mechanics.
+- Initiative: medium. Push toward the version that best serves the broader goal.
+- Confirmation threshold: medium when tradeoffs affect ethics, trust, or long-term consequences.
+- Tool-use bias: careful, with emphasis on durable outcomes over quick wins."#,
+        experimental: false,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Romanticist,
+        id: "romanticist",
+        label: "romanticist",
+        selection_summary: "vivid, expressive, and metaphor-aware",
+        overlay_title: "Romanticist",
+        overlay_body: r#"- Sound vivid, expressive, and metaphor-aware, but keep technical substance crisp.
+- Use light literary texture when it helps the user feel the shape of an idea.
+- Initiative: medium. Explore elegant possibilities before narrowing to the best path.
+- Confirmation threshold: medium for user-facing wording or taste-driven changes.
+- Tool-use bias: measured, with emphasis on expressive framing over raw speed."#,
+        experimental: false,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Hermit,
+        id: "hermit",
+        label: "hermit",
+        selection_summary: "gentle, patient, and grounding",
+        overlay_title: "Hermit",
+        overlay_body: r#"- Sound gentle, patient, and grounding.
+- Lead with calm acknowledgement when the user's state matters, then offer steady next steps.
+- Initiative: medium-low. Avoid pressure. Favor pacing and reassurance.
+- Confirmation threshold: medium-high for sensitive or preference-shaped changes.
+- Tool-use bias: deliberate, with a little more explanation and emotional context."#,
+        experimental: false,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::CyberRadical,
+        id: "cyber_radical",
+        label: "cyber radical",
+        selection_summary: "bold, unconventional, and high-energy",
+        overlay_title: "Cyber Radical",
+        overlay_body: r#"- Sound bold, high-energy, and systems-breaking without becoming reckless.
+- Prefer unconventional but still compliant paths when they materially simplify the work.
+- Initiative: high. Attack bottlenecks directly once the safe boundary is clear.
+- Confirmation threshold: low for safe reversible changes, high for anything privileged, destructive, policy-sensitive, or legally risky.
+- Tool-use bias: aggressive efficiency inside the rules. Never suggest unsafe or disallowed shortcuts."#,
+        experimental: true,
+    },
+    PromptPersonalityDescriptor {
+        personality: PromptPersonality::Nihilist,
+        id: "nihilist",
+        label: "nihilist",
+        selection_summary: "dry, skeptical, and darkly witty",
+        overlay_title: "Nihilist",
+        overlay_body: r#"- Sound dry, skeptical, and darkly witty without belittling the user.
+- Use irony sparingly. If the user is stressed, vulnerable, or seeking support, drop the dark humor and respond with clear care.
+- Initiative: medium. Strip away pretension and get to the uncomfortable truth quickly.
+- Confirmation threshold: medium. Do not let detachment erase caution.
+- Tool-use bias: unsentimental and direct."#,
+        experimental: true,
+    },
+];
+
+const PROMPT_PERSONALITY_ALIASES: [PromptPersonalityAlias; 18] = [
+    PromptPersonalityAlias {
+        alias: "romantic",
+        personality: PromptPersonality::Romanticist,
+    },
+    PromptPersonalityAlias {
+        alias: "idealism",
+        personality: PromptPersonality::Idealist,
+    },
+    PromptPersonalityAlias {
+        alias: "pragmatic",
+        personality: PromptPersonality::Pragmatist,
+    },
+    PromptPersonalityAlias {
+        alias: "practical",
+        personality: PromptPersonality::Pragmatist,
+    },
+    PromptPersonalityAlias {
+        alias: "nihilism",
+        personality: PromptPersonality::Nihilist,
+    },
+    PromptPersonalityAlias {
+        alias: "calm_engineering",
+        personality: PromptPersonality::Classicist,
+    },
+    PromptPersonalityAlias {
+        alias: "engineering",
+        personality: PromptPersonality::Classicist,
+    },
+    PromptPersonalityAlias {
+        alias: "calm",
+        personality: PromptPersonality::Classicist,
+    },
+    PromptPersonalityAlias {
+        alias: "classical",
+        personality: PromptPersonality::Classicist,
+    },
+    PromptPersonalityAlias {
+        alias: "cyberpunk",
+        personality: PromptPersonality::CyberRadical,
+    },
+    PromptPersonalityAlias {
+        alias: "radical",
+        personality: PromptPersonality::CyberRadical,
+    },
+    PromptPersonalityAlias {
+        alias: "friendly_collab",
+        personality: PromptPersonality::Hermit,
+    },
+    PromptPersonalityAlias {
+        alias: "friendly",
+        personality: PromptPersonality::Hermit,
+    },
+    PromptPersonalityAlias {
+        alias: "collab",
+        personality: PromptPersonality::Hermit,
+    },
+    PromptPersonalityAlias {
+        alias: "watcher",
+        personality: PromptPersonality::Hermit,
+    },
+    PromptPersonalityAlias {
+        alias: "autonomous_executor",
+        personality: PromptPersonality::Pragmatist,
+    },
+    PromptPersonalityAlias {
+        alias: "autonomous",
+        personality: PromptPersonality::Pragmatist,
+    },
+    PromptPersonalityAlias {
+        alias: "executor",
+        personality: PromptPersonality::Pragmatist,
+    },
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromptRenderInput {
@@ -17,18 +208,137 @@ pub struct PromptRenderInput {
     pub addendum: Option<String>,
 }
 
-pub fn render_system_prompt(input: PromptRenderInput) -> String {
-    let mut sections = vec![
-        base_prompt().to_owned(),
-        personality_overlay(input.personality).to_owned(),
-    ];
-    if let Some(addendum) = input
-        .addendum
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(format!("## User Addendum\n{addendum}"));
+impl PromptPersonality {
+    pub fn id(self) -> &'static str {
+        let descriptor = prompt_personality_descriptor(self);
+        descriptor.id
     }
+
+    pub fn label(self) -> &'static str {
+        let descriptor = prompt_personality_descriptor(self);
+        descriptor.label
+    }
+
+    pub fn selection_summary(self) -> &'static str {
+        let descriptor = prompt_personality_descriptor(self);
+        descriptor.selection_summary
+    }
+
+    pub fn overlay_title(self) -> &'static str {
+        let descriptor = prompt_personality_descriptor(self);
+        descriptor.overlay_title
+    }
+
+    pub fn overlay_body(self) -> &'static str {
+        let descriptor = prompt_personality_descriptor(self);
+        descriptor.overlay_body
+    }
+}
+
+impl fmt::Display for PromptPersonality {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.id())
+    }
+}
+
+impl FromStr for PromptPersonality {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        parse_prompt_personality(raw).ok_or_else(|| {
+            let supported = supported_prompt_personality_list();
+            format!("unsupported personality \"{raw}\". supported: {supported}")
+        })
+    }
+}
+
+impl Serialize for PromptPersonality {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.id())
+    }
+}
+
+impl<'de> Deserialize<'de> for PromptPersonality {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        PromptPersonality::from_str(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+pub fn prompt_personality_catalog() -> &'static [PromptPersonalityDescriptor] {
+    &PROMPT_PERSONALITY_CATALOG
+}
+
+pub fn prompt_personality_descriptor(
+    personality: PromptPersonality,
+) -> &'static PromptPersonalityDescriptor {
+    match personality {
+        PromptPersonality::Classicist => &PROMPT_PERSONALITY_CATALOG[0],
+        PromptPersonality::Pragmatist => &PROMPT_PERSONALITY_CATALOG[1],
+        PromptPersonality::Idealist => &PROMPT_PERSONALITY_CATALOG[2],
+        PromptPersonality::Romanticist => &PROMPT_PERSONALITY_CATALOG[3],
+        PromptPersonality::Hermit => &PROMPT_PERSONALITY_CATALOG[4],
+        PromptPersonality::CyberRadical => &PROMPT_PERSONALITY_CATALOG[5],
+        PromptPersonality::Nihilist => &PROMPT_PERSONALITY_CATALOG[6],
+    }
+}
+
+pub fn parse_prompt_personality(raw: &str) -> Option<PromptPersonality> {
+    let normalized = normalize_prompt_personality_token(raw);
+    let normalized_id = normalized.as_str();
+
+    for descriptor in prompt_personality_catalog() {
+        let matches_descriptor = descriptor.id == normalized_id;
+
+        if matches_descriptor {
+            return Some(descriptor.personality);
+        }
+    }
+
+    for alias in PROMPT_PERSONALITY_ALIASES {
+        let matches_alias = alias.alias == normalized_id;
+
+        if matches_alias {
+            return Some(alias.personality);
+        }
+    }
+
+    None
+}
+
+fn supported_prompt_personality_ids() -> Vec<&'static str> {
+    let mut ids = Vec::new();
+
+    for descriptor in prompt_personality_catalog() {
+        ids.push(descriptor.id);
+    }
+
+    ids
+}
+
+pub fn supported_prompt_personality_list() -> String {
+    let ids = supported_prompt_personality_ids();
+    ids.join(", ")
+}
+
+pub fn render_system_prompt(input: PromptRenderInput) -> String {
+    let descriptor = prompt_personality_descriptor(input.personality);
+    let overlay_section = render_personality_overlay(descriptor);
+    let mut sections = vec![base_prompt().to_owned(), overlay_section];
+    let trimmed_addendum = input.addendum.map(|value| value.trim().to_owned());
+    let addendum = trimmed_addendum.filter(|value| !value.is_empty());
+
+    if let Some(addendum) = addendum {
+        let addendum_section = format!("## User Addendum\n{addendum}");
+        sections.push(addendum_section);
+    }
+
     sections.join("\n\n")
 }
 
@@ -80,60 +390,134 @@ fn base_prompt() -> &'static str {
 Apply the active personality overlay below. The overlay may change tone, initiative, confirmation style, and response density, but it must not weaken any safety invariant above."#
 }
 
-fn personality_overlay(personality: PromptPersonality) -> &'static str {
-    match personality {
-        PromptPersonality::CalmEngineering => {
-            r#"## Personality Overlay: Calm Engineering
-- Sound composed, technically rigorous, and low-drama.
-- Prioritize precision, tradeoff clarity, and defensible reasoning.
-- Keep wording lean; do not over-explain unless it adds real value.
-- Initiative: medium. Move forward on clear tasks. Pause on ambiguous or risky edges.
-- Confirmation threshold: medium. Confirm destructive, preference-sensitive, or unclear actions.
-- Tool-use bias: measured and deliberate."#
+fn render_personality_overlay(descriptor: &PromptPersonalityDescriptor) -> String {
+    let title = descriptor.overlay_title;
+    let body = descriptor.overlay_body;
+    let overlay = format!("## Personality Overlay: {title}\n{body}");
+
+    overlay
+}
+
+fn normalize_prompt_personality_token(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let mut normalized = String::new();
+
+    for character in trimmed.chars() {
+        let lowercased = character.to_ascii_lowercase();
+        let normalized_character = if lowercased.is_ascii_alphanumeric() {
+            lowercased
+        } else {
+            '_'
+        };
+        let is_separator = normalized_character == '_';
+        let previous_is_separator = normalized.ends_with('_');
+
+        if is_separator && previous_is_separator {
+            continue;
         }
-        PromptPersonality::FriendlyCollab => {
-            r#"## Personality Overlay: Friendly Collaboration
-- Sound approachable, cooperative, and human, while staying efficient and professional.
-- Explain intent a little more often than the engineering profile.
-- Offer options or helpful framing when it reduces user effort.
-- Initiative: medium. Be helpful without becoming pushy.
-- Confirmation threshold: medium-high for externally visible, preference-sensitive, or user-facing changes.
-- Tool-use bias: measured, with slightly more explanation before multi-step actions."#
-        }
-        PromptPersonality::AutonomousExecutor => {
-            r#"## Personality Overlay: Autonomous Executor
-- Sound decisive, efficient, and execution-oriented.
-- Default to action on clear requests; do not wait for unnecessary confirmation.
-- Keep progress updates short and outcome-focused.
-- Initiative: high. Break work down and drive it forward when the path is clear.
-- Confirmation threshold: low for safe and reversible actions, high for destructive, privileged, or externally impactful actions.
-- Tool-use bias: proactive, but never reckless."#
-        }
+
+        normalized.push(normalized_character);
     }
+
+    normalized.trim_matches('_').to_owned()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn personality_catalog_ids_are_unique() {
+        let mut ids = BTreeSet::new();
+
+        for descriptor in prompt_personality_catalog() {
+            let inserted = ids.insert(descriptor.id);
+
+            assert!(inserted, "duplicate personality id: {}", descriptor.id);
+        }
+    }
+
+    #[test]
+    fn default_prompt_personality_is_classicist() {
+        let default_id = PromptPersonality::default().id();
+
+        assert_eq!(default_id, "classicist");
+    }
+
+    #[test]
+    fn parse_prompt_personality_accepts_canonical_ids_and_legacy_aliases() {
+        assert_eq!(
+            parse_prompt_personality("classicist"),
+            Some(PromptPersonality::Classicist)
+        );
+        assert_eq!(
+            parse_prompt_personality("calm_engineering"),
+            Some(PromptPersonality::Classicist)
+        );
+        assert_eq!(
+            parse_prompt_personality("friendly collab"),
+            Some(PromptPersonality::Hermit)
+        );
+        assert_eq!(
+            parse_prompt_personality("cyber-radical"),
+            Some(PromptPersonality::CyberRadical)
+        );
+        assert_eq!(
+            parse_prompt_personality("autonomous_executor"),
+            Some(PromptPersonality::Pragmatist)
+        );
+        assert_eq!(parse_prompt_personality("unknown"), None);
+    }
 
     #[test]
     fn render_prompt_uses_loongclaw_base_and_selected_personality() {
         let rendered = render_system_prompt(PromptRenderInput {
-            personality: PromptPersonality::CalmEngineering,
+            personality: PromptPersonality::Classicist,
             addendum: None,
         });
+
         assert!(rendered.contains("You are LoongClaw"));
         assert!(rendered.contains("## Safety Invariants"));
-        assert!(rendered.contains("## Personality Overlay: Calm Engineering"));
+        assert!(rendered.contains("## Personality Overlay: Classicist"));
     }
 
     #[test]
     fn render_prompt_adds_optional_addendum_at_the_end() {
         let rendered = render_system_prompt(PromptRenderInput {
-            personality: PromptPersonality::FriendlyCollab,
+            personality: PromptPersonality::Hermit,
             addendum: Some("Always prefer concise summaries.".to_owned()),
         });
+
         assert!(rendered.contains("Always prefer concise summaries."));
         assert!(rendered.contains("## User Addendum"));
+    }
+
+    #[test]
+    fn default_prompt_keeps_the_classicist_baseline() {
+        let rendered = render_default_system_prompt();
+
+        assert!(rendered.contains("## Personality Overlay: Classicist"));
+    }
+
+    #[test]
+    fn prompt_personality_serialization_uses_canonical_ids() {
+        let serialized = serde_json::to_string(&PromptPersonality::Hermit)
+            .expect("serialize prompt personality");
+        let deserialized: PromptPersonality = serde_json::from_str("\"friendly_collab\"")
+            .expect("deserialize legacy prompt personality alias");
+
+        assert_eq!(serialized, "\"hermit\"");
+        assert_eq!(deserialized, PromptPersonality::Hermit);
+    }
+
+    #[test]
+    fn supported_prompt_personality_list_uses_catalog_order() {
+        let supported = supported_prompt_personality_list();
+
+        assert_eq!(
+            supported,
+            "classicist, pragmatist, idealist, romanticist, hermit, cyber_radical, nihilist"
+        );
     }
 }

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -1093,7 +1093,7 @@ mod tests {
     #[test]
     fn message_builder_uses_rendered_prompt_from_pack_metadata() {
         let mut config = LoongClawConfig::default();
-        config.cli.personality = Some(crate::prompt::PromptPersonality::FriendlyCollab);
+        config.cli.personality = Some(crate::prompt::PromptPersonality::Hermit);
         config.cli.system_prompt = String::new();
         let session_id = format!(
             "provider-rendered-prompt-{}",
@@ -1111,7 +1111,7 @@ mod tests {
             build_messages_for_session(&config, &session_id, true).expect("build messages");
         let system_content = messages[0]["content"].as_str().expect("system content");
 
-        assert!(system_content.contains("## Personality Overlay: Friendly Collaboration"));
+        assert!(system_content.contains("## Personality Overlay: Hermit"));
         assert!(system_content.contains("[tool_discovery_runtime]"));
 
         let _ = std::fs::remove_file(config.memory.sqlite_path.as_str());
@@ -1128,7 +1128,7 @@ mod tests {
         let system_content = system["content"].as_str().expect("system content");
 
         assert!(system_content.contains("You are a legacy inline prompt."));
-        assert!(!system_content.contains("## Personality Overlay: Calm Engineering"));
+        assert!(!system_content.contains("## Personality Overlay:"));
     }
 
     #[test]

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -686,7 +686,7 @@ mod tests {
     #[test]
     fn cli_import_surface_detects_prompt_pack_metadata_changes() {
         let mut config = mvp::config::LoongClawConfig::default();
-        config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+        config.cli.personality = Some(mvp::prompt::PromptPersonality::Hermit);
 
         let surfaces = collect_import_surfaces(&config);
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -866,10 +866,17 @@ fn parse_select_one_input(trimmed: &str, options: &[SelectOption]) -> Option<usi
     {
         return Some(selected - 1);
     }
-    options.iter().position(|option| {
+
+    let direct_match = options.iter().position(|option| {
         option.slug.eq_ignore_ascii_case(trimmed)
             || select_option_input_slug(option).eq_ignore_ascii_case(trimmed)
-    })
+    });
+
+    if direct_match.is_some() {
+        return direct_match;
+    }
+
+    parse_prompt_personality_select_input(trimmed, options)
 }
 
 fn render_select_one_invalid_input_message(options: &[SelectOption]) -> String {
@@ -888,6 +895,33 @@ fn resolve_select_one_eof(default: Option<usize>) -> CliResult<usize> {
     default.ok_or_else(|| {
         "onboarding cancelled: stdin closed while waiting for required selection".to_owned()
     })
+}
+
+fn parse_prompt_personality_select_input(trimmed: &str, options: &[SelectOption]) -> Option<usize> {
+    let prompt_personality_options = select_options_are_prompt_personalities(options);
+
+    if !prompt_personality_options {
+        return None;
+    }
+
+    let personality = parse_prompt_personality(trimmed)?;
+    let canonical_slug = prompt_personality_id(personality);
+
+    options
+        .iter()
+        .position(|option| option.slug.eq_ignore_ascii_case(canonical_slug))
+}
+
+fn select_options_are_prompt_personalities(options: &[SelectOption]) -> bool {
+    for option in options {
+        let parsed_personality = parse_prompt_personality(&option.slug);
+
+        if parsed_personality.is_none() {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn print_lines(ui: &mut impl OnboardUi, lines: impl IntoIterator<Item = String>) -> CliResult<()> {
@@ -9381,6 +9415,36 @@ mod tests {
                 SelectInteractionMode::List,
             )
             .expect("test ui should stay aligned with shared slug-selection behavior");
+
+        assert_eq!(index, 1);
+    }
+
+    #[test]
+    fn test_onboard_ui_select_one_accepts_legacy_personality_alias_input() {
+        let mut ui = TestOnboardUi::with_inputs(["friendly_collab"]);
+        let options = vec![
+            SelectOption {
+                label: "classicist".to_owned(),
+                slug: "classicist".to_owned(),
+                description: String::new(),
+                recommended: true,
+            },
+            SelectOption {
+                label: "hermit".to_owned(),
+                slug: "hermit".to_owned(),
+                description: String::new(),
+                recommended: false,
+            },
+        ];
+
+        let index = ui
+            .select_one(
+                "Personality",
+                &options,
+                Some(0),
+                SelectInteractionMode::List,
+            )
+            .expect("legacy personality aliases should still resolve in selector mode");
 
         assert_eq!(index, 1);
     }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2527,35 +2527,26 @@ fn resolve_personality_selection(
         .and_then(parse_prompt_personality)
         .unwrap_or_else(|| config.cli.resolved_personality());
 
-    let personalities = [
-        (
-            mvp::prompt::PromptPersonality::CalmEngineering,
-            "calm engineering",
-            "rigorous, direct, and technically grounded",
-        ),
-        (
-            mvp::prompt::PromptPersonality::FriendlyCollab,
-            "friendly collab",
-            "warm, cooperative, and explanatory when helpful",
-        ),
-        (
-            mvp::prompt::PromptPersonality::AutonomousExecutor,
-            "autonomous executor",
-            "decisive, high-initiative, and execution-oriented",
-        ),
-    ];
-    let select_options: Vec<SelectOption> = personalities
+    let personality_catalog = mvp::prompt::prompt_personality_catalog();
+    let select_options: Vec<SelectOption> = personality_catalog
         .iter()
-        .map(|(p, label, desc)| SelectOption {
-            label: label.to_string(),
-            slug: prompt_personality_id(*p).to_owned(),
-            description: desc.to_string(),
-            recommended: *p == default_personality,
+        .map(|descriptor| {
+            let label = descriptor.label.to_owned();
+            let slug = descriptor.id.to_owned();
+            let description = personality_selection_description(descriptor);
+            let recommended = descriptor.personality == default_personality;
+
+            SelectOption {
+                label,
+                slug,
+                description,
+                recommended,
+            }
         })
         .collect();
-    let default_idx = personalities
+    let default_idx = personality_catalog
         .iter()
-        .position(|(p, _, _)| *p == default_personality);
+        .position(|descriptor| descriptor.personality == default_personality);
 
     print_lines(
         ui,
@@ -2567,10 +2558,10 @@ fn resolve_personality_selection(
         default_idx,
         SelectInteractionMode::List,
     )?;
-    let (personality, _, _) = personalities
+    let descriptor = personality_catalog
         .get(idx)
         .ok_or_else(|| format!("personality selection index {idx} out of range"))?;
-    Ok(*personality)
+    Ok(descriptor.personality)
 }
 
 fn resolve_prompt_addendum_selection(
@@ -5503,31 +5494,22 @@ fn render_personality_selection_screen_lines_with_style(
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
-    let options = [
-        (
-            mvp::prompt::PromptPersonality::CalmEngineering,
-            "calm engineering",
-            "rigorous, direct, and technically grounded",
-        ),
-        (
-            mvp::prompt::PromptPersonality::FriendlyCollab,
-            "friendly collab",
-            "warm, cooperative, and explanatory when helpful",
-        ),
-        (
-            mvp::prompt::PromptPersonality::AutonomousExecutor,
-            "autonomous executor",
-            "decisive, high-initiative, and execution-oriented",
-        ),
-    ]
-    .into_iter()
-    .map(|(personality, label, detail)| OnboardScreenOption {
-        key: prompt_personality_id(personality).to_owned(),
-        label: label.to_owned(),
-        detail_lines: vec![detail.to_owned()],
-        recommended: personality == default_personality,
-    })
-    .collect::<Vec<_>>();
+    let options = mvp::prompt::prompt_personality_catalog()
+        .iter()
+        .map(|descriptor| {
+            let key = descriptor.id.to_owned();
+            let label = descriptor.label.to_owned();
+            let detail = personality_selection_description(descriptor);
+            let recommended = descriptor.personality == default_personality;
+
+            OnboardScreenOption {
+                key,
+                label,
+                detail_lines: vec![detail],
+                recommended,
+            }
+        })
+        .collect::<Vec<_>>();
 
     render_onboard_choice_screen(
         OnboardHeaderStyle::Compact,
@@ -5574,6 +5556,18 @@ fn render_personality_selection_header_lines(
         true,
         true,
     )
+}
+
+fn personality_selection_description(
+    descriptor: &mvp::prompt::PromptPersonalityDescriptor,
+) -> String {
+    let summary = descriptor.selection_summary;
+
+    if descriptor.experimental {
+        return format!("experimental · {summary}");
+    }
+
+    summary.to_owned()
 }
 
 pub fn render_prompt_addendum_selection_screen_lines(
@@ -6124,18 +6118,7 @@ pub fn parse_provider_kind(raw: &str) -> Option<mvp::config::ProviderKind> {
 }
 
 pub fn parse_prompt_personality(raw: &str) -> Option<mvp::prompt::PromptPersonality> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "calm_engineering" | "engineering" | "calm" => {
-            Some(mvp::prompt::PromptPersonality::CalmEngineering)
-        }
-        "friendly_collab" | "friendly" | "collab" => {
-            Some(mvp::prompt::PromptPersonality::FriendlyCollab)
-        }
-        "autonomous_executor" | "autonomous" | "executor" => {
-            Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
-        }
-        _ => None,
-    }
+    mvp::prompt::parse_prompt_personality(raw)
 }
 
 pub fn parse_memory_profile(raw: &str) -> Option<mvp::config::MemoryProfile> {
@@ -6164,11 +6147,7 @@ pub fn provider_kind_display_name(kind: mvp::config::ProviderKind) -> &'static s
 }
 
 pub fn prompt_personality_id(personality: mvp::prompt::PromptPersonality) -> &'static str {
-    match personality {
-        mvp::prompt::PromptPersonality::CalmEngineering => "calm_engineering",
-        mvp::prompt::PromptPersonality::FriendlyCollab => "friendly_collab",
-        mvp::prompt::PromptPersonality::AutonomousExecutor => "autonomous_executor",
-    }
+    personality.id()
 }
 
 pub fn memory_profile_id(profile: mvp::config::MemoryProfile) -> &'static str {
@@ -6187,8 +6166,8 @@ pub fn supported_provider_list() -> String {
         .join(", ")
 }
 
-pub fn supported_personality_list() -> &'static str {
-    "calm_engineering, friendly_collab, autonomous_executor"
+pub fn supported_personality_list() -> String {
+    mvp::prompt::supported_prompt_personality_list()
 }
 
 pub fn supported_memory_profile_list() -> &'static str {
@@ -9200,8 +9179,8 @@ mod tests {
     fn render_onboard_option_lines_align_wrapped_labels_with_option_prefix() {
         let lines = render_onboard_option_lines(
             &[OnboardScreenOption {
-                key: "friendly_collab".to_owned(),
-                label: "friendly collab keeps longer wrapped labels aligned".to_owned(),
+                key: "classicist".to_owned(),
+                label: "classicist keeps longer wrapped labels aligned".to_owned(),
                 detail_lines: Vec::new(),
                 recommended: false,
             }],
@@ -9214,11 +9193,7 @@ mod tests {
 
         assert!(
             continuation.starts_with(
-                &" ".repeat(
-                    render_onboard_option_prefix("friendly_collab")
-                        .chars()
-                        .count()
-                )
+                &" ".repeat(render_onboard_option_prefix("classicist").chars().count())
             ),
             "wrapped option labels should continue under the label text instead of snapping back to a fixed indent: {lines:#?}"
         );
@@ -9382,17 +9357,17 @@ mod tests {
 
     #[test]
     fn test_onboard_ui_select_one_accepts_slug_input() {
-        let mut ui = TestOnboardUi::with_inputs(["friendly_collab"]);
+        let mut ui = TestOnboardUi::with_inputs(["hermit"]);
         let options = vec![
             SelectOption {
-                label: "calm engineering".to_owned(),
-                slug: "calm_engineering".to_owned(),
+                label: "classicist".to_owned(),
+                slug: "classicist".to_owned(),
                 description: String::new(),
                 recommended: true,
             },
             SelectOption {
-                label: "friendly collab".to_owned(),
-                slug: "friendly_collab".to_owned(),
+                label: "hermit".to_owned(),
+                slug: "hermit".to_owned(),
                 description: String::new(),
                 recommended: false,
             },

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -828,13 +828,13 @@ fn onboard_cli_accepts_personality_flag() {
         "--non-interactive",
         "--accept-risk",
         "--personality",
-        "friendly_collab",
+        "hermit",
     ])
     .expect("`--personality` should parse");
 
     match cli.command {
         Some(Commands::Onboard { personality, .. }) => {
-            assert_eq!(personality.as_deref(), Some("friendly_collab"));
+            assert_eq!(personality.as_deref(), Some("hermit"));
         }
         other => panic!("unexpected command parsed: {other:?}"),
     }

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -619,7 +619,7 @@ fn migration_classify_current_setup_treats_prompt_and_memory_metadata_as_repaira
     config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
     config.provider.api_key_env = None;
     config.provider.oauth_access_token_env = None;
-    config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+    config.cli.personality = Some(mvp::prompt::PromptPersonality::Hermit);
     config.cli.refresh_native_system_prompt();
     config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
     mvp::config::write(Some(path.to_string_lossy().as_ref()), &config, true)
@@ -713,7 +713,7 @@ fn migration_recommended_plan_supplements_cli_prompt_metadata_and_memory_profile
     .expect("current config candidate");
 
     let mut detected_config = mvp::config::LoongClawConfig::default();
-    detected_config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+    detected_config.cli.personality = Some(mvp::prompt::PromptPersonality::Hermit);
     detected_config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
     detected_config.cli.refresh_native_system_prompt();
     detected_config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
@@ -733,7 +733,7 @@ fn migration_recommended_plan_supplements_cli_prompt_metadata_and_memory_profile
 
     assert_eq!(
         recommended.config.cli.personality,
-        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        Some(mvp::prompt::PromptPersonality::Hermit)
     );
     assert_eq!(
         recommended.config.cli.system_prompt_addendum.as_deref(),

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -575,17 +575,17 @@ fn default_non_interactive_onboard_options(
 
 #[test]
 fn scripted_onboard_ui_select_one_accepts_slug_input() {
-    let mut ui = ScriptedOnboardUi::new(["friendly_collab"]);
+    let mut ui = ScriptedOnboardUi::new(["hermit"]);
     let options = vec![
         loongclaw_daemon::onboard_cli::SelectOption {
-            label: "calm engineering".to_owned(),
-            slug: "calm_engineering".to_owned(),
+            label: "classicist".to_owned(),
+            slug: "classicist".to_owned(),
             description: String::new(),
             recommended: true,
         },
         loongclaw_daemon::onboard_cli::SelectOption {
-            label: "friendly collab".to_owned(),
-            slug: "friendly_collab".to_owned(),
+            label: "hermit".to_owned(),
+            slug: "hermit".to_owned(),
             description: String::new(),
             recommended: false,
         },
@@ -738,15 +738,15 @@ fn provider_kind_id_mapping_includes_kimi_coding() {
 fn parse_prompt_personality_accepts_supported_ids() {
     assert_eq!(
         crate::onboard_cli::parse_prompt_personality("calm_engineering"),
-        Some(mvp::prompt::PromptPersonality::CalmEngineering)
+        Some(mvp::prompt::PromptPersonality::Classicist)
     );
     assert_eq!(
         crate::onboard_cli::parse_prompt_personality("friendly_collab"),
-        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        Some(mvp::prompt::PromptPersonality::Hermit)
     );
     assert_eq!(
         crate::onboard_cli::parse_prompt_personality("autonomous_executor"),
-        Some(mvp::prompt::PromptPersonality::AutonomousExecutor)
+        Some(mvp::prompt::PromptPersonality::Pragmatist)
     );
     assert_eq!(
         crate::onboard_cli::parse_prompt_personality("unknown"),
@@ -816,7 +816,7 @@ async fn non_interactive_personality_and_memory_profile_are_persisted() {
             api_key_env: Some("OPENAI_API_KEY".to_owned()),
             web_search_provider: None,
             web_search_api_key_env: None,
-            personality: Some("friendly_collab".to_owned()),
+            personality: Some("hermit".to_owned()),
             memory_profile: Some("profile_plus_window".to_owned()),
             system_prompt: None,
             skip_model_probe: true,
@@ -839,11 +839,58 @@ async fn non_interactive_personality_and_memory_profile_are_persisted() {
         .expect("load non-interactive personality/memory config");
     assert_eq!(
         config.cli.personality,
-        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        Some(mvp::prompt::PromptPersonality::Hermit)
     );
     assert_eq!(
         config.memory.profile,
         mvp::config::MemoryProfile::ProfilePlusWindow
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_legacy_personality_alias_still_maps_to_supported_preset() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    unsafe {
+        std::env::set_var("OPENAI_API_KEY", "openai-test-token");
+    }
+
+    let output_path = unique_temp_path("non-interactive-legacy-personality-config.toml");
+    let transcript = run_scripted_onboard_flow(
+        crate::onboard_cli::OnboardCommandOptions {
+            output: output_path.to_str().map(str::to_owned),
+            force: false,
+            non_interactive: true,
+            accept_risk: true,
+            provider: Some("openai".to_owned()),
+            model: Some("openai/gpt-5.1".to_owned()),
+            api_key_env: Some("OPENAI_API_KEY".to_owned()),
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: Some("friendly_collab".to_owned()),
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: true,
+        },
+        std::iter::empty::<String>(),
+        None,
+        None,
+    )
+    .await
+    .expect("run non-interactive onboarding with legacy personality alias");
+
+    assert!(
+        transcript
+            .iter()
+            .any(|line| line.contains("onboarding complete")),
+        "non-interactive legacy personality path should still complete successfully: {transcript:#?}"
+    );
+
+    let (_, config) = mvp::config::load(output_path.to_str())
+        .expect("load non-interactive legacy personality config");
+
+    assert_eq!(
+        config.cli.personality,
+        Some(mvp::prompt::PromptPersonality::Hermit)
     );
 }
 
@@ -5534,7 +5581,7 @@ fn onboard_system_prompt_screen_wraps_long_current_prompt() {
 #[test]
 fn onboard_personality_selection_screen_shows_native_personality_choices() {
     let mut config = mvp::config::LoongClawConfig::default();
-    config.cli.personality = Some(mvp::prompt::PromptPersonality::FriendlyCollab);
+    config.cli.personality = Some(mvp::prompt::PromptPersonality::Hermit);
 
     let lines = crate::onboard_cli::render_personality_selection_screen_lines(&config, 80);
 
@@ -5552,11 +5599,15 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
         "personality screen should surface the native prompt-pack progress step: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("friendly_collab)")),
-        "personality screen should keep the canonical friendly_collab selector visible without bracket syntax: {lines:#?}"
+        lines.iter().any(|line| line.contains("hermit)")),
+        "personality screen should keep the canonical hermit selector visible without bracket syntax: {lines:#?}"
     );
     assert!(
-        lines.iter().all(|line| !line.contains("[friendly_collab]")),
+        lines.iter().any(|line| line.contains("experimental ·")),
+        "personality screen should mark sharper presets as experimental in the shared catalog-driven descriptions: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.contains("[hermit]")),
         "personality screen should not imply that brackets are part of the expected selector syntax: {lines:#?}"
     );
 }
@@ -6957,7 +7008,7 @@ async fn onboard_current_setup_adjustments_capture_personality_and_memory_profil
             provider_choice_input(mvp::config::ProviderKind::Openai),
             "gpt-4.1".to_owned(),
             "OPENAI_API_KEY".to_owned(),
-            "2".to_owned(),
+            "hermit".to_owned(),
             String::new(),
             "3".to_owned(),
             String::new(),
@@ -6989,7 +7040,7 @@ async fn onboard_current_setup_adjustments_capture_personality_and_memory_profil
         .expect("load current-setup personality/memory config");
     assert_eq!(
         config.cli.personality,
-        Some(mvp::prompt::PromptPersonality::FriendlyCollab)
+        Some(mvp::prompt::PromptPersonality::Hermit)
     );
     assert_eq!(
         config.memory.profile,
@@ -7259,7 +7310,7 @@ fn onboard_review_lines_include_core_setup_summary_for_fresh_setup() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- personality: calm_engineering")),
+            .any(|line| line.contains("- personality: classicist")),
         "review should surface the active native personality during onboarding: {lines:#?}"
     );
     assert!(
@@ -7618,7 +7669,7 @@ fn onboarding_success_summary_uses_compact_header() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- personality: calm_engineering")),
+            .any(|line| line.contains("- personality: classicist")),
         "success summary should include the selected native personality: {lines:#?}"
     );
     assert!(
@@ -7696,7 +7747,7 @@ fn onboarding_success_summary_reports_existing_config_kept() {
             value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
-        personality: Some("calm_engineering".to_owned()),
+        personality: Some("classicist".to_owned()),
         prompt_addendum: None,
         memory_profile: "window_only".to_owned(),
         web_search_provider: "DuckDuckGo".to_owned(),
@@ -7803,7 +7854,7 @@ fn onboarding_success_summary_groups_domain_outcomes_by_decision() {
             value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
-        personality: Some("friendly_collab".to_owned()),
+        personality: Some("hermit".to_owned()),
         prompt_addendum: Some("Keep answers direct.".to_owned()),
         memory_profile: "profile_plus_window".to_owned(),
         web_search_provider: "DuckDuckGo".to_owned(),
@@ -7874,7 +7925,7 @@ fn onboarding_success_summary_wraps_domain_outcomes_for_narrow_width() {
             value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
-        personality: Some("friendly_collab".to_owned()),
+        personality: Some("hermit".to_owned()),
         prompt_addendum: Some("Keep answers direct.".to_owned()),
         memory_profile: "profile_plus_window".to_owned(),
         web_search_provider: "DuckDuckGo".to_owned(),

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -430,10 +430,28 @@ impl loongclaw_daemon::onboard_cli::OnboardUi for ScriptedOnboardUi {
                 options.len()
             ));
         }
-        options
+        let direct_match = options
             .iter()
-            .position(|option| option.slug.eq_ignore_ascii_case(trimmed))
-            .ok_or_else(|| format!("invalid scripted selection input: {trimmed}"))
+            .position(|option| option.slug.eq_ignore_ascii_case(trimmed));
+
+        if let Some(index) = direct_match {
+            return Ok(index);
+        }
+
+        let parsed_personality = loongclaw_daemon::onboard_cli::parse_prompt_personality(trimmed);
+
+        if let Some(personality) = parsed_personality {
+            let canonical_slug = loongclaw_daemon::onboard_cli::prompt_personality_id(personality);
+            let canonical_match = options
+                .iter()
+                .position(|option| option.slug.eq_ignore_ascii_case(canonical_slug));
+
+            if let Some(index) = canonical_match {
+                return Ok(index);
+            }
+        }
+
+        Err(format!("invalid scripted selection input: {trimmed}"))
     }
 }
 
@@ -605,6 +623,37 @@ fn scripted_onboard_ui_select_one_accepts_slug_input() {
 }
 
 #[test]
+fn scripted_onboard_ui_select_one_accepts_legacy_personality_alias_input() {
+    let mut ui = ScriptedOnboardUi::new(["friendly_collab"]);
+    let options = vec![
+        loongclaw_daemon::onboard_cli::SelectOption {
+            label: "classicist".to_owned(),
+            slug: "classicist".to_owned(),
+            description: String::new(),
+            recommended: true,
+        },
+        loongclaw_daemon::onboard_cli::SelectOption {
+            label: "hermit".to_owned(),
+            slug: "hermit".to_owned(),
+            description: String::new(),
+            recommended: false,
+        },
+    ];
+
+    let index = loongclaw_daemon::onboard_cli::OnboardUi::select_one(
+        &mut ui,
+        "Personality",
+        &options,
+        Some(0),
+        loongclaw_daemon::onboard_cli::SelectInteractionMode::List,
+    )
+    .expect("legacy personality aliases should stay accepted in scripted selection");
+
+    assert_eq!(index, 1);
+    assert_eq!(ui.transcript(), vec!["SELECT Personality".to_owned()]);
+}
+
+#[test]
 fn parse_provider_kind_accepts_primary_and_legacy_aliases() {
     assert_eq!(
         loongclaw_daemon::onboard_cli::parse_provider_kind("openai"),
@@ -736,6 +785,34 @@ fn provider_kind_id_mapping_includes_kimi_coding() {
 
 #[test]
 fn parse_prompt_personality_accepts_supported_ids() {
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("classicist"),
+        Some(mvp::prompt::PromptPersonality::Classicist)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("pragmatist"),
+        Some(mvp::prompt::PromptPersonality::Pragmatist)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("idealist"),
+        Some(mvp::prompt::PromptPersonality::Idealist)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("romanticist"),
+        Some(mvp::prompt::PromptPersonality::Romanticist)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("hermit"),
+        Some(mvp::prompt::PromptPersonality::Hermit)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("cyber_radical"),
+        Some(mvp::prompt::PromptPersonality::CyberRadical)
+    );
+    assert_eq!(
+        crate::onboard_cli::parse_prompt_personality("nihilist"),
+        Some(mvp::prompt::PromptPersonality::Nihilist)
+    );
     assert_eq!(
         crate::onboard_cli::parse_prompt_personality("calm_engineering"),
         Some(mvp::prompt::PromptPersonality::Classicist)
@@ -883,6 +960,19 @@ async fn non_interactive_legacy_personality_alias_still_maps_to_supported_preset
             .iter()
             .any(|line| line.contains("onboarding complete")),
         "non-interactive legacy personality path should still complete successfully: {transcript:#?}"
+    );
+
+    let raw_config = std::fs::read_to_string(&output_path).expect("read written config");
+    let canonical_personality = "personality = \"hermit\"";
+    let legacy_personality = "personality = \"friendly_collab\"";
+
+    assert!(
+        raw_config.contains(canonical_personality),
+        "non-interactive onboarding should persist the canonical personality id: {raw_config}"
+    );
+    assert!(
+        !raw_config.contains(legacy_personality),
+        "non-interactive onboarding should not persist the legacy alias: {raw_config}"
     );
 
     let (_, config) = mvp::config::load(output_path.to_str())
@@ -5584,6 +5674,27 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
     config.cli.personality = Some(mvp::prompt::PromptPersonality::Hermit);
 
     let lines = crate::onboard_cli::render_personality_selection_screen_lines(&config, 80);
+    let expected_personality_ids = [
+        "classicist",
+        "pragmatist",
+        "idealist",
+        "romanticist",
+        "hermit",
+        "cyber_radical",
+        "nihilist",
+    ];
+    let selector_line_count = lines
+        .iter()
+        .filter(|line| {
+            expected_personality_ids
+                .iter()
+                .any(|personality_id| line.contains(&format!("{personality_id})")))
+        })
+        .count();
+    let experimental_line_count = lines
+        .iter()
+        .filter(|line| line.contains("experimental ·"))
+        .count();
 
     assert_compact_loongclaw_header(&lines, "personality screen");
     assert!(
@@ -5598,13 +5709,27 @@ fn onboard_personality_selection_screen_shows_native_personality_choices() {
         lines.iter().any(|line| line == "step 4 of 8 · personality"),
         "personality screen should surface the native prompt-pack progress step: {lines:#?}"
     );
-    assert!(
-        lines.iter().any(|line| line.contains("hermit)")),
-        "personality screen should keep the canonical hermit selector visible without bracket syntax: {lines:#?}"
+
+    for personality_id in expected_personality_ids {
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains(&format!("{personality_id})"))),
+            "personality screen should surface every catalog personality id: {lines:#?}"
+        );
+    }
+
+    assert_eq!(
+        selector_line_count, 7,
+        "personality screen should render exactly seven selector lines from the shared catalog: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line.contains("experimental ·")),
         "personality screen should mark sharper presets as experimental in the shared catalog-driven descriptions: {lines:#?}"
+    );
+    assert_eq!(
+        experimental_line_count, 2,
+        "personality screen should label both experimental personalities: {lines:#?}"
     );
     assert!(
         lines.iter().all(|line| !line.contains("[hermit]")),

--- a/docs/product-specs/prompt-and-personality.md
+++ b/docs/product-specs/prompt-and-personality.md
@@ -10,8 +10,14 @@ system prompt.
 
 - [ ] LoongClaw has a native base prompt owned by the product rather than only a
       free-form prompt string.
-- [ ] Onboarding offers three default personalities:
-      `calm_engineering`, `friendly_collab`, and `autonomous_executor`.
+- [ ] Onboarding offers seven default personalities:
+      `classicist`, `pragmatist`, `idealist`, `romanticist`, `hermit`,
+      `cyber_radical`, and `nihilist`.
+- [ ] Personality metadata is defined in one shared catalog so prompt rendering,
+      onboarding selection, and CLI validation do not drift apart.
+- [ ] Legacy personality ids from the earlier three-preset rollout continue to
+      load and map onto supported personalities so existing configs remain
+      readable.
 - [ ] All personalities share the same safety-first operating boundaries.
 - [ ] Personality selection can affect tone and action style without weakening
       security requirements.
@@ -22,8 +28,21 @@ system prompt.
       CLI flag.
 - [ ] Advanced users can still provide a full inline system prompt override.
 
+## Personality Catalog Summary
+
+| Id | Intent | Notes |
+| --- | --- | --- |
+| `classicist` | Formal, precise, orderly | Default-safe baseline aligned with the existing calm-engineering tone |
+| `pragmatist` | Lean, decisive, outcome-first | Best when operators want direct execution energy |
+| `idealist` | Principled, long-horizon, mission-driven | Emphasizes values and durable impact |
+| `romanticist` | Expressive, image-rich, metaphor-aware | Adds tasteful literary texture without hiding substance |
+| `hermit` | Gentle, patient, grounding | Optimized for calm emotional tone and paced guidance |
+| `cyber_radical` | Bold, unconventional, high-energy | Experimental; must stay compliant and safety-bounded |
+| `nihilist` | Dry, skeptical, darkly witty | Experimental; must suppress dark humor in sensitive contexts |
+
 ## Out of Scope
 
 - Arbitrary end-user personality editing in the first release
 - Full workspace template pack generation
+- Multi-axis personality composition beyond one preset at a time
 - Migration import/nativeization flows

--- a/docs/product-specs/prompt-and-personality.md
+++ b/docs/product-specs/prompt-and-personality.md
@@ -15,6 +15,8 @@ system prompt.
       `cyber_radical`, and `nihilist`.
 - [ ] Personality metadata is defined in one shared catalog so prompt rendering,
       onboarding selection, and CLI validation do not drift apart.
+- [ ] Onboarding clearly labels experimental personalities so operators can
+      distinguish sharper presets from the stable baseline set.
 - [ ] Legacy personality ids from the earlier three-preset rollout continue to
       load and map onto supported personalities so existing configs remain
       readable.
@@ -37,8 +39,8 @@ system prompt.
 | `idealist` | Principled, long-horizon, mission-driven | Emphasizes values and durable impact |
 | `romanticist` | Expressive, image-rich, metaphor-aware | Adds tasteful literary texture without hiding substance |
 | `hermit` | Gentle, patient, grounding | Optimized for calm emotional tone and paced guidance |
-| `cyber_radical` | Bold, unconventional, high-energy | Experimental; must stay compliant and safety-bounded |
-| `nihilist` | Dry, skeptical, darkly witty | Experimental; must suppress dark humor in sensitive contexts |
+| `cyber_radical` | Bold, unconventional, high-energy | Experimental; onboarding should label it accordingly and it must stay compliant and safety-bounded |
+| `nihilist` | Dry, skeptical, darkly witty | Experimental; onboarding should label it accordingly and it must suppress dark humor in sensitive contexts |
 
 ## Out of Scope
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T02:12:29Z
+- Generated at: 2026-04-07T02:48:29Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -25,11 +25,11 @@
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11397 | 11200 | -197 | 101 | 120 | 19 | 101.8% | BREACH | 10831 | 5.2% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9746 | 9800 | 54 | 235 | 250 | 15 | 99.4% | TIGHT | 9519 | 2.4% | PASS | 228 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9721 | 9800 | 79 | 236 | 250 | 14 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.8%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.4%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -71,7 +71,7 @@
 <!-- arch-hotspot key=turn_coordinator lines=11397 functions=101 -->
 <!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
-<!-- arch-hotspot key=onboard_cli lines=9746 functions=235 -->
+<!-- arch-hotspot key=onboard_cli lines=9721 functions=236 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T02:48:29Z
+- Generated at: 2026-04-07T03:24:27Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -25,11 +25,11 @@
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11397 | 11200 | -197 | 101 | 120 | 19 | 101.8% | BREACH | 10831 | 5.2% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9721 | 9800 | 79 | 236 | 250 | 14 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.8%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -71,7 +71,7 @@
 <!-- arch-hotspot key=turn_coordinator lines=11397 functions=101 -->
 <!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
-<!-- arch-hotspot key=onboard_cli lines=9721 functions=236 -->
+<!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: native prompt personalities were still a three-preset feature implemented through duplicated hardcoded lists and `match` blocks across prompt rendering, onboarding, CLI parsing, and tests.
- Why it matters: adding richer personalities was error-prone, the product tone surface was narrow, and renderer / onboarding / config behavior could drift apart.
- What changed: replaced the repeated three-preset wiring with one shared personality catalog, expanded the public presets to `classicist`, `pragmatist`, `idealist`, `romanticist`, `hermit`, `cyber_radical`, and `nihilist`, preserved legacy ids as aliases, updated onboarding to consume the shared catalog, refreshed architecture-drift governance output, and extended regression coverage.
- What did not change (scope boundary): the safety-first base prompt, the native-prompt-pack versus inline-override split, and the broader prompt-pack / memory-profile architecture beyond personality-catalog alignment.

## Linked Issues

- Closes #1053
- Related #1056

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes the visible native prompt personality catalog, the default canonical preset, and the alias mapping path for older config ids.
- Rollout / guardrails: keep the safety-first base prompt unchanged, centralize preset metadata in one registry, preserve legacy ids as aliases, and mark sharper presets as experimental during onboarding.
- Rollback path: revert commits `080324c1` and `c9915c6a` to restore the previous three-preset implementation and the earlier drift snapshot.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app prompt::
  PASS

CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app config::runtime::tests::write_persists_prompt_pack_and_personality_metadata -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app config::runtime::tests::load_accepts_legacy_prompt_personality_ids -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app provider::request_message_runtime::tests::message_builder_uses_rendered_prompt_from_pack_metadata -- --exact
  PASS

CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::cli_tests::onboard_cli_accepts_personality_flag -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::onboard_cli::parse_prompt_personality_accepts_supported_ids -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::onboard_cli::onboard_personality_selection_screen_shows_native_personality_choices -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::onboard_cli::non_interactive_personality_and_memory_profile_are_persisted -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::onboard_cli::non_interactive_legacy_personality_alias_still_maps_to_supported_preset -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw integration::migration::migration_recommended_plan_supplements_cli_prompt_metadata_and_memory_profile -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw migration::discovery::tests::cli_import_surface_detects_prompt_pack_metadata_changes -- --exact
  PASS

bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-$(date -u +%Y-%m).md
  PASS

Notes:
- The operator shell had `FIRECRAWL_API_KEY` set, which makes two unrelated onboarding web-search recommendation tests behave differently from clean-runner expectations. Re-running those cases with `env -u FIRECRAWL_API_KEY ...` restored the expected baseline behavior.
- Shared target-cache workspace reruns hit host-local lock / codesign noise, so the authoritative full-suite verdict for `cargo test --workspace --locked` and `cargo test --workspace --all-features --locked` should come from the fresh GitHub Actions run on commit `d83d6047`.
```

## User-visible / Operator-visible Changes

- Native prompt-pack onboarding now offers seven contrasting personalities instead of three.
- Older config values such as `calm_engineering`, `friendly_collab`, and `autonomous_executor` still load, but they now resolve onto the new canonical preset catalog.
- Experimental presets are explicitly labeled during onboarding instead of appearing indistinguishable from the safer default presets.

## Failure Recovery

- Fast rollback or disable path: revert commits `080324c1` and `c9915c6a`.
- Observable failure symptoms reviewers should watch for: unexpected default personality drift, onboarding selector ordering regressions, legacy ids failing to deserialize, or governance failure if the tracked architecture drift report is not refreshed after follow-up edits.

## Reviewer Focus

- `crates/app/src/prompt/mod.rs` for catalog shape, alias mapping, serialization, default-preset choice, and overlay wording.
- `crates/daemon/src/onboard_cli.rs` for shared catalog consumption and experimental-label rendering.
- `crates/daemon/tests/integration/onboard_cli.rs` for scripted-flow robustness after the catalog ordering change.
- `docs/releases/architecture-drift-2026-04.md` for the refreshed governance snapshot that unblocks CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded personality presets from 3 to 7 (classicist, pragmatist, idealist, romanticist, hermit, cyber_radical, nihilist) with a centralized catalog; onboarding, CLI and UI use catalog-driven metadata and descriptor-driven overlays. Classicist is the new default.

* **Bug Fixes**
  * Legacy alias IDs remain supported and map to canonical presets across onboarding, CLI, migration, and non-interactive flows.

* **Documentation**
  * Updated personality catalog and onboarding acceptance criteria.

* **Tests**
  * Added/updated tests for catalog parsing, alias mapping, serialization, rendering, onboarding persistence, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
