### PR TITLE
feat(memory): narrow cross-session recall artifacts

### DIFF
--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -446,42 +446,7 @@ pub(super) fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -
 }
 
 #[cfg(feature = "memory-sqlite")]
-pub(super) fn render_cross_session_recall_block(
-    hits: &[super::sqlite::CanonicalMemorySearchHit],
-) -> String {
-    let mut sections = Vec::new();
-    sections.push("## Advisory Cross-Session Recall".to_owned());
-    sections.push(
-        "These snippets were retrieved from prior persisted sessions. Treat them as advisory hints and verify before acting."
-            .to_owned(),
-    );
-
-    for hit in hits {
-        let turn_label = hit
-            .session_turn_index
-            .map(|value| format!("turn {value}"))
-            .unwrap_or_else(|| "turn ?".to_owned());
-        let role_label = hit.record.role.as_deref();
-        let content = truncate_recall_content(hit.record.content.as_str(), 280);
-        sections.push(format!(
-            "### {} · {} · {} · {}",
-            hit.record.session_id,
-            turn_label,
-            hit.record.scope.as_str(),
-            hit.record.kind.as_str()
-        ));
-        let recall_line = match role_label {
-            Some(role_label) => format!("{role_label}: {content}"),
-            None => content,
-        };
-        sections.push(recall_line);
-    }
-
-    sections.join("\n\n")
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn truncate_recall_content(input: &str, max_chars: usize) -> String {
+pub(super) fn truncate_recall_content(input: &str, max_chars: usize) -> String {
     let char_count = input.chars().count();
     if char_count <= max_chars {
         return input.to_owned();
@@ -800,6 +765,15 @@ mod tests {
                 .content
                 .contains("Deployment cutoff is 17:00 Beijing time")
         );
+        assert_eq!(recalled.provenance.len(), 1);
+        assert_eq!(
+            recalled.provenance[0].source_kind,
+            crate::memory::MemoryProvenanceSourceKind::CanonicalMemoryRecord
+        );
+        assert_eq!(
+            recalled.provenance[0].memory_system_id,
+            crate::memory::DEFAULT_MEMORY_SYSTEM_ID
+        );
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
@@ -1037,8 +1011,8 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
-    fn render_cross_session_recall_block_keeps_roleless_records_neutral() {
-        let hits = vec![crate::memory::CanonicalMemorySearchHit {
+    fn truncate_recall_content_keeps_roleless_records_neutral() {
+        let hit = crate::memory::CanonicalMemorySearchHit {
             record: crate::memory::CanonicalMemoryRecord {
                 session_id: "workspace-session".to_owned(),
                 scope: crate::memory::MemoryScope::Workspace,
@@ -1050,17 +1024,17 @@ mod tests {
                 }),
             },
             session_turn_index: Some(2),
-        }];
+        };
 
-        let rendered = render_cross_session_recall_block(hits.as_slice());
+        let rendered = truncate_recall_content(hit.record.content.as_str(), 280);
 
         assert!(
             rendered.contains("Imported release checklist with smoke tests."),
             "expected rendered recall content: {rendered}"
         );
         assert!(
-            !rendered.contains("assistant: Imported release checklist with smoke tests."),
-            "roleless recall should not fabricate assistant provenance: {rendered}"
+            !rendered.contains("assistant:"),
+            "roleless recall truncation should not fabricate assistant provenance: {rendered}"
         );
     }
 

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -139,6 +139,7 @@ impl MemoryRecallMode {
 #[serde(rename_all = "snake_case")]
 pub enum MemoryProvenanceSourceKind {
     WorkspaceDocument,
+    CanonicalMemoryRecord,
     ProfileNote,
     SummaryCheckpoint,
     RecentWindowTurn,
@@ -149,6 +150,7 @@ impl MemoryProvenanceSourceKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::WorkspaceDocument => "workspace_document",
+            Self::CanonicalMemoryRecord => "canonical_memory_record",
             Self::ProfileNote => "profile_note",
             Self::SummaryCheckpoint => "summary_checkpoint",
             Self::RecentWindowTurn => "recent_window_turn",

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -351,7 +351,10 @@ impl MemorySystem for BuiltinMemorySystem {
             "Built-in SQLite-backed canonical memory with deterministic prompt hydration.",
         )
         .with_supported_pre_assembly_stage_families(builtin_pre_assembly_stage_families())
-        .with_supported_recall_modes([MemoryRecallMode::PromptAssembly])
+        .with_supported_recall_modes([
+            MemoryRecallMode::PromptAssembly,
+            MemoryRecallMode::OperatorInspection,
+        ])
     }
 
     fn build_retrieval_request(
@@ -419,7 +422,10 @@ impl MemorySystem for WorkspaceRecallMemorySystem {
             MemoryStageFamily::Retrieve,
             MemoryStageFamily::Rank,
         ])
-        .with_supported_recall_modes([MemoryRecallMode::PromptAssembly])
+        .with_supported_recall_modes([
+            MemoryRecallMode::PromptAssembly,
+            MemoryRecallMode::OperatorInspection,
+        ])
     }
 
     fn build_retrieval_request(
@@ -575,7 +581,10 @@ mod tests {
         );
         assert_eq!(
             metadata.supported_recall_modes,
-            vec![MemoryRecallMode::PromptAssembly]
+            vec![
+                MemoryRecallMode::PromptAssembly,
+                MemoryRecallMode::OperatorInspection
+            ]
         );
     }
 
@@ -653,7 +662,10 @@ mod tests {
         );
         assert_eq!(
             metadata.supported_recall_modes,
-            vec![MemoryRecallMode::PromptAssembly]
+            vec![
+                MemoryRecallMode::PromptAssembly,
+                MemoryRecallMode::OperatorInspection
+            ]
         );
     }
 

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -3,16 +3,19 @@ use std::path::Path;
 use std::collections::BTreeSet;
 
 use super::{
-    DerivedMemoryKind, MemoryContextEntry, MemoryContextKind, MemoryContextProvenance,
-    MemoryProvenanceSourceKind, MemoryRecallMode, MemoryRetrievalRequest, MemoryScope,
-    MemoryStageFamily, WindowTurn, builtin_pre_assembly_stage_families, durable_recall,
-    runtime_config::MemoryRuntimeConfig,
+    CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryContextEntry,
+    MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
+    MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, WindowTurn,
+    builtin_pre_assembly_stage_families, durable_recall, runtime_config::MemoryRuntimeConfig,
 };
 
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
 pub const DEFAULT_MEMORY_SYSTEM_ID: &str = "builtin";
 pub const WORKSPACE_RECALL_MEMORY_SYSTEM_ID: &str = "workspace_recall";
 pub const RECALL_FIRST_MEMORY_SYSTEM_ID: &str = "recall_first";
+
+#[cfg(feature = "memory-sqlite")]
+const MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MemorySystemCapability {
@@ -274,29 +277,26 @@ fn run_builtin_retrieve_stage(
 
     #[cfg(feature = "memory-sqlite")]
     if let Some(query) = request.query.as_deref() {
+        let search_limit = cross_session_recall_search_limit(request);
         let hits = super::sqlite::search_canonical_records_for_recall(
             query,
-            request.budget_items,
+            search_limit,
             Some(request.session_id.as_str()),
             config,
         )?;
-        if !hits.is_empty() {
-            let content = super::orchestrator::render_cross_session_recall_block(hits.as_slice());
-            let provenance = MemoryContextProvenance::new(
-                memory_system_id,
-                MemoryProvenanceSourceKind::MemorySystem,
-                Some("cross_session_recall".to_owned()),
-                None,
-                Some(MemoryScope::Session),
-                request.recall_mode,
-            );
-            let entry = MemoryContextEntry {
-                kind: MemoryContextKind::RetrievedMemory,
-                role: "system".to_owned(),
-                content,
-                provenance: vec![provenance],
-            };
-            entries.push(entry);
+        let filtered_hits = filter_cross_session_recall_hits(request, hits);
+        let bounded_budget = request.budget_items.max(1);
+        let bounded_filtered_hits = filtered_hits
+            .into_iter()
+            .take(bounded_budget)
+            .collect::<Vec<_>>();
+        let recall_entries = build_cross_session_recall_entries(
+            memory_system_id,
+            request.recall_mode,
+            bounded_filtered_hits.as_slice(),
+        );
+        if !recall_entries.is_empty() {
+            entries.extend(recall_entries);
         }
     }
 
@@ -399,6 +399,117 @@ impl MemorySystem for BuiltinMemorySystem {
     ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
         Ok(Some(entries))
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn cross_session_recall_search_limit(request: &MemoryRetrievalRequest) -> usize {
+    let requested_budget = request.budget_items.max(1);
+    let bounded_budget = requested_budget.min(MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES);
+    let has_scope_filter = !request.scopes.is_empty();
+    let has_kind_filter = !request.allowed_kinds.is_empty();
+    let has_filter = has_scope_filter || has_kind_filter;
+
+    if has_filter {
+        return MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES;
+    }
+
+    bounded_budget
+}
+
+fn filter_cross_session_recall_hits(
+    request: &MemoryRetrievalRequest,
+    hits: Vec<CanonicalMemorySearchHit>,
+) -> Vec<CanonicalMemorySearchHit> {
+    hits.into_iter()
+        .filter(|hit| request.scopes.is_empty() || request.scopes.contains(&hit.record.scope))
+        .filter(|hit| {
+            request.allowed_kinds.is_empty()
+                || request
+                    .allowed_kinds
+                    .contains(&derived_memory_kind_for_canonical_kind(hit.record.kind))
+        })
+        .collect()
+}
+
+fn derived_memory_kind_for_canonical_kind(kind: CanonicalMemoryKind) -> DerivedMemoryKind {
+    match kind {
+        CanonicalMemoryKind::ImportedProfile => DerivedMemoryKind::Profile,
+        CanonicalMemoryKind::ToolDecision | CanonicalMemoryKind::ToolOutcome => {
+            DerivedMemoryKind::Procedure
+        }
+        CanonicalMemoryKind::ConversationEvent
+        | CanonicalMemoryKind::AcpRuntimeEvent
+        | CanonicalMemoryKind::AcpFinalEvent => DerivedMemoryKind::Fact,
+        CanonicalMemoryKind::UserTurn | CanonicalMemoryKind::AssistantTurn => {
+            DerivedMemoryKind::Episode
+        }
+    }
+}
+
+fn build_cross_session_recall_entries(
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
+    hits: &[CanonicalMemorySearchHit],
+) -> Vec<MemoryContextEntry> {
+    let mut entries = Vec::new();
+
+    for hit in hits {
+        let content = render_cross_session_recall_entry(hit);
+        let provenance = build_cross_session_recall_provenance(memory_system_id, recall_mode, hit);
+        let entry = MemoryContextEntry {
+            kind: MemoryContextKind::RetrievedMemory,
+            role: "system".to_owned(),
+            content,
+            provenance: vec![provenance],
+        };
+        entries.push(entry);
+    }
+
+    entries
+}
+
+fn render_cross_session_recall_entry(hit: &CanonicalMemorySearchHit) -> String {
+    let turn_label = hit
+        .session_turn_index
+        .map(|value| format!("turn {value}"))
+        .unwrap_or_else(|| "turn ?".to_owned());
+    let header = "## Advisory Durable Recall".to_owned();
+    let source_line = format!(
+        "Cross-session source: {} · {} · {} · {}",
+        hit.record.session_id,
+        turn_label,
+        hit.record.scope.as_str(),
+        hit.record.kind.as_str()
+    );
+    let content = super::orchestrator::truncate_recall_content(hit.record.content.as_str(), 280);
+    let recall_line = match hit.record.role.as_deref() {
+        Some(role) => format!("{role}: {content}"),
+        None => content,
+    };
+
+    [header, source_line, recall_line].join("\n\n")
+}
+
+fn build_cross_session_recall_provenance(
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
+    hit: &CanonicalMemorySearchHit,
+) -> MemoryContextProvenance {
+    let source_label = Some(format!(
+        "{}:{}:{}",
+        hit.record.session_id,
+        hit.record.scope.as_str(),
+        hit.record.kind.as_str()
+    ));
+
+    MemoryContextProvenance::new(
+        memory_system_id,
+        MemoryProvenanceSourceKind::CanonicalMemoryRecord,
+        source_label,
+        None,
+        Some(hit.record.scope),
+        recall_mode,
+    )
 }
 
 #[derive(Default)]
@@ -546,6 +657,7 @@ impl MemorySystem for RecallFirstMemorySystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     struct StageAwareRegistryMemorySystem;
 
@@ -813,5 +925,83 @@ mod tests {
                 MemoryContextKind::Turn,
             ]
         );
+    }
+
+    #[test]
+    fn filter_cross_session_recall_hits_respects_scopes_and_allowed_kinds() {
+        let profile_hit = CanonicalMemorySearchHit {
+            record: crate::memory::CanonicalMemoryRecord {
+                session_id: "profile-session".to_owned(),
+                scope: MemoryScope::Workspace,
+                kind: CanonicalMemoryKind::ImportedProfile,
+                role: None,
+                content: "release checklist".to_owned(),
+                metadata: json!({}),
+            },
+            session_turn_index: Some(1),
+        };
+        let turn_hit = CanonicalMemorySearchHit {
+            record: crate::memory::CanonicalMemoryRecord {
+                session_id: "turn-session".to_owned(),
+                scope: MemoryScope::Session,
+                kind: CanonicalMemoryKind::AssistantTurn,
+                role: Some("assistant".to_owned()),
+                content: "deployment cutoff is 17:00".to_owned(),
+                metadata: json!({}),
+            },
+            session_turn_index: Some(2),
+        };
+        let request = MemoryRetrievalRequest {
+            session_id: "active-session".to_owned(),
+            memory_system_id: DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+            query: Some("deployment release".to_owned()),
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes: vec![MemoryScope::Workspace],
+            budget_items: 4,
+            allowed_kinds: vec![DerivedMemoryKind::Profile],
+        };
+
+        let filtered_hits = filter_cross_session_recall_hits(&request, vec![profile_hit, turn_hit]);
+
+        assert_eq!(filtered_hits.len(), 1);
+        assert_eq!(filtered_hits[0].record.session_id, "profile-session");
+        assert_eq!(
+            filtered_hits[0].record.kind,
+            CanonicalMemoryKind::ImportedProfile
+        );
+    }
+
+    #[test]
+    fn build_cross_session_recall_entries_attach_canonical_record_provenance() {
+        let hit = CanonicalMemorySearchHit {
+            record: crate::memory::CanonicalMemoryRecord {
+                session_id: "prior-session".to_owned(),
+                scope: MemoryScope::Session,
+                kind: CanonicalMemoryKind::AssistantTurn,
+                role: Some("assistant".to_owned()),
+                content: "deployment cutoff is 17:00 Beijing time".to_owned(),
+                metadata: json!({}),
+            },
+            session_turn_index: Some(3),
+        };
+
+        let entries = build_cross_session_recall_entries(
+            DEFAULT_MEMORY_SYSTEM_ID,
+            MemoryRecallMode::PromptAssembly,
+            &[hit],
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0]
+                .content
+                .contains("Cross-session source: prior-session")
+        );
+        assert_eq!(entries[0].provenance.len(), 1);
+        assert_eq!(
+            entries[0].provenance[0].source_kind,
+            MemoryProvenanceSourceKind::CanonicalMemoryRecord
+        );
+        assert_eq!(entries[0].provenance[0].scope, Some(MemoryScope::Session));
     }
 }

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -1012,7 +1012,7 @@ mod tests {
         let workspace_root = temp_dir.path();
         let db_path = workspace_root.join("memory.sqlite3");
         let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
+            sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         };
         let allowed_payload = json!({

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -17,6 +17,9 @@ pub const RECALL_FIRST_MEMORY_SYSTEM_ID: &str = "recall_first";
 #[cfg(feature = "memory-sqlite")]
 const MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES: usize = 16;
 
+#[cfg(feature = "memory-sqlite")]
+const MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES: usize = 16;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MemorySystemCapability {
     CanonicalStore,
@@ -1003,5 +1006,64 @@ mod tests {
             MemoryProvenanceSourceKind::CanonicalMemoryRecord
         );
         assert_eq!(entries[0].provenance[0].scope, Some(MemoryScope::Session));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn builtin_retrieve_stage_keeps_allowed_hits_when_top_match_is_filtered_out() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let db_path = workspace_root.join("memory.sqlite3");
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        let allowed_payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "release checklist",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+        let recent_window = Vec::new();
+        let request = MemoryRetrievalRequest {
+            session_id: "active-session".to_owned(),
+            memory_system_id: DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+            query: Some("release checklist".to_owned()),
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes: vec![MemoryScope::Workspace],
+            budget_items: 1,
+            allowed_kinds: vec![DerivedMemoryKind::Profile],
+        };
+
+        crate::memory::append_turn_direct(
+            "workspace-session",
+            "assistant",
+            allowed_payload.as_str(),
+            &config,
+        )
+        .expect("append allowed canonical payload");
+        crate::memory::append_turn_direct(
+            "session-session",
+            "assistant",
+            "release checklist",
+            &config,
+        )
+        .expect("append disallowed session hit");
+
+        let entries = BuiltinMemorySystem
+            .run_retrieve_stage(&request, None, &config, recent_window.as_slice())
+            .expect("retrieve stage should succeed")
+            .expect("retrieve stage should return entries");
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].content.contains("workspace-session"));
+        assert!(!entries[0].content.contains("session-session"));
+        assert_eq!(entries[0].provenance.len(), 1);
+        assert_eq!(entries[0].provenance[0].scope, Some(MemoryScope::Workspace));
     }
 }

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -17,9 +17,6 @@ pub const RECALL_FIRST_MEMORY_SYSTEM_ID: &str = "recall_first";
 #[cfg(feature = "memory-sqlite")]
 const MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES: usize = 16;
 
-#[cfg(feature = "memory-sqlite")]
-const MAX_CROSS_SESSION_RECALL_SEARCH_CANDIDATES: usize = 16;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MemorySystemCapability {
     CanonicalStore,

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -431,7 +431,10 @@ mod tests {
         );
         assert_eq!(
             builtin.supported_recall_modes,
-            vec![MemoryRecallMode::PromptAssembly]
+            vec![
+                MemoryRecallMode::PromptAssembly,
+                MemoryRecallMode::OperatorInspection
+            ]
         );
 
         let workspace_recall = metadata
@@ -446,7 +449,10 @@ mod tests {
         );
         assert_eq!(
             workspace_recall.supported_recall_modes,
-            vec![MemoryRecallMode::PromptAssembly]
+            vec![
+                MemoryRecallMode::PromptAssembly,
+                MemoryRecallMode::OperatorInspection
+            ]
         );
 
         let recall_first = metadata

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -5,7 +5,11 @@ use std::path::Path;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Map, Value, json};
 
-use crate::memory::{WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations};
+use crate::memory::{
+    MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode, MemoryScope,
+    WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
+    collect_workspace_memory_document_locations,
+};
 
 const DEFAULT_MEMORY_SEARCH_MAX_RESULTS: usize = 5;
 const MAX_MEMORY_SEARCH_RESULTS: usize = 8;
@@ -25,6 +29,7 @@ struct MemorySearchResult {
     end_line: Option<usize>,
     snippet: String,
     score: u32,
+    provenance: MemoryContextProvenance,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -75,6 +80,7 @@ pub(super) fn execute_memory_search_tool_with_config(
             let maybe_result = search_memory_location(
                 query_normalized.as_str(),
                 query_tokens.as_slice(),
+                config,
                 &location,
             )?;
             let Some(result) = maybe_result else {
@@ -189,6 +195,7 @@ pub(super) fn execute_memory_get_tool_with_config(
             "start_line": start_line,
             "end_line": end_line,
             "text": text,
+            "provenance": workspace_memory_location_provenance(config, matched_location),
         }),
     })
 }
@@ -341,6 +348,7 @@ fn invalid_numeric_field_message(
 fn search_memory_location(
     query: &str,
     query_tokens: &[String],
+    config: &super::runtime_config::ToolRuntimeConfig,
     location: &WorkspaceMemoryDocumentLocation,
 ) -> Result<Option<MemorySearchResult>, String> {
     let content = fs::read_to_string(location.path.as_path()).map_err(|error| {
@@ -381,6 +389,7 @@ fn search_memory_location(
         end_line: Some(end_line),
         snippet,
         score: best_match.score,
+        provenance: workspace_memory_location_provenance(config, location),
     };
 
     Ok(Some(result))
@@ -510,6 +519,7 @@ fn search_canonical_memory_results(
             let score = canonical_memory_match_score(query, query_tokens, &hit);
             let scope = hit.record.scope.as_str().to_owned();
             let kind = hit.record.kind.as_str().to_owned();
+            let provenance = canonical_memory_hit_provenance(config, &hit);
             MemorySearchResult {
                 source: "canonical_session",
                 path: None,
@@ -521,6 +531,7 @@ fn search_canonical_memory_results(
                 end_line: None,
                 snippet: hit.record.content,
                 score,
+                provenance,
             }
         })
         .collect())
@@ -566,7 +577,47 @@ fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
         "end_line": result.end_line,
         "snippet": result.snippet,
         "score": result.score,
+        "provenance": result.provenance,
     })
+}
+
+fn workspace_memory_location_provenance(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    location: &WorkspaceMemoryDocumentLocation,
+) -> MemoryContextProvenance {
+    let scope = match location.kind {
+        WorkspaceMemoryDocumentKind::Curated => MemoryScope::Workspace,
+        WorkspaceMemoryDocumentKind::DailyLog => MemoryScope::Session,
+    };
+    let source_label = Some(location.label.clone());
+    let source_path = Some(location.path.display().to_string());
+
+    MemoryContextProvenance::new(
+        config.selected_memory_system_id.as_str(),
+        MemoryProvenanceSourceKind::WorkspaceDocument,
+        source_label,
+        source_path,
+        Some(scope),
+        MemoryRecallMode::OperatorInspection,
+    )
+}
+
+fn canonical_memory_hit_provenance(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    hit: &crate::memory::CanonicalMemorySearchHit,
+) -> MemoryContextProvenance {
+    let source_label = Some(hit.record.kind.as_str().to_owned());
+    let source_path = None;
+    let scope = Some(hit.record.scope);
+
+    MemoryContextProvenance::new(
+        config.selected_memory_system_id.as_str(),
+        MemoryProvenanceSourceKind::CanonicalMemoryRecord,
+        source_label,
+        source_path,
+        scope,
+        MemoryRecallMode::OperatorInspection,
+    )
 }
 
 fn trim_trailing_line_endings(line: &str) -> &str {
@@ -638,6 +689,16 @@ mod tests {
                 .is_some_and(|value| value.contains("17:00 Beijing time")),
             "expected canonical snippet in result payload: {results:?}"
         );
+        assert_eq!(results[0]["provenance"]["memory_system_id"], "builtin");
+        assert_eq!(
+            results[0]["provenance"]["source_kind"],
+            "canonical_memory_record"
+        );
+        assert_eq!(results[0]["provenance"]["scope"], "session");
+        assert_eq!(
+            results[0]["provenance"]["recall_mode"],
+            "operator_inspection"
+        );
     }
 
     #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
@@ -694,6 +755,11 @@ mod tests {
         assert_eq!(results[0]["session_id"], "metadata-session");
         assert_eq!(results[0]["scope"], "workspace");
         assert_eq!(results[0]["kind"], "imported_profile");
+        assert_eq!(
+            results[0]["provenance"]["source_kind"],
+            "canonical_memory_record"
+        );
+        assert_eq!(results[0]["provenance"]["scope"], "workspace");
         assert!(
             results[0]["score"].as_u64().is_some_and(|value| value > 0),
             "metadata-only matches should keep a stable score: {results:?}"

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2801,6 +2801,14 @@ mod tests {
                 .all(|entry| entry["source"] == "workspace_file"),
             "expected workspace-file results only: {results:?}"
         );
+        assert!(
+            results.iter().all(|entry| {
+                entry["provenance"]["memory_system_id"] == "builtin"
+                    && entry["provenance"]["source_kind"] == "workspace_document"
+                    && entry["provenance"]["recall_mode"] == "operator_inspection"
+            }),
+            "expected structured operator-inspection provenance: {results:?}"
+        );
     }
 
     #[cfg(feature = "tool-file")]
@@ -2835,6 +2843,47 @@ mod tests {
         assert_eq!(outcome.payload["start_line"], 2);
         assert_eq!(outcome.payload["end_line"], 3);
         assert_eq!(outcome.payload["text"], "line two\nline three");
+        assert_eq!(outcome.payload["provenance"]["memory_system_id"], "builtin");
+        assert_eq!(
+            outcome.payload["provenance"]["source_kind"],
+            "workspace_document"
+        );
+        assert_eq!(outcome.payload["provenance"]["scope"], "workspace");
+        assert_eq!(
+            outcome.payload["provenance"]["recall_mode"],
+            "operator_inspection"
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_get_tool_uses_selected_memory_system_id_in_provenance() {
+        let root = unique_tool_temp_dir("loongclaw-memory-get-selected-system");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(&memory_path, "line one\nline two\n").expect("write root memory");
+
+        let mut config = test_tool_runtime_config(root);
+        config.selected_memory_system_id = "workspace_recall".to_owned();
+
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "from": 1,
+                    "lines": 1
+                }),
+            },
+            &config,
+        )
+        .expect("memory get should succeed");
+
+        assert_eq!(
+            outcome.payload["provenance"]["memory_system_id"],
+            "workspace_recall"
+        );
     }
 
     #[cfg(feature = "tool-file")]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -2252,6 +2252,20 @@ mod tests {
     }
 
     #[test]
+    fn selected_memory_system_id_from_env_falls_back_on_unknown_value() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set(crate::memory::MEMORY_SYSTEM_ENV, "unknown_memory_system");
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(
+            runtime.selected_memory_system_id,
+            crate::memory::DEFAULT_MEMORY_SYSTEM_ID
+        );
+    }
+
+    #[test]
     fn memory_sqlite_path_from_env_falls_back_to_loongclaw_home() {
         let mut env = ScopedEnv::new();
         let runtime_home = std::env::temp_dir().join("loongclaw-tool-runtime-home");

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -670,6 +670,7 @@ impl ToolExecutionConfig {
 pub struct ToolRuntimeConfig {
     pub file_root: Option<PathBuf>,
     pub memory_sqlite_path: Option<PathBuf>,
+    pub selected_memory_system_id: String,
     pub shell_allow: BTreeSet<String>,
     pub shell_deny: BTreeSet<String>,
     pub shell_default_mode: ShellPolicyDefault,
@@ -696,6 +697,7 @@ impl Default for ToolRuntimeConfig {
         Self {
             file_root: None,
             memory_sqlite_path: None,
+            selected_memory_system_id: crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
             shell_allow: crate::config::DEFAULT_SHELL_ALLOW
                 .iter()
                 .map(|s| (*s).to_owned())
@@ -736,6 +738,8 @@ impl ToolRuntimeConfig {
     }
 
     pub fn from_loongclaw_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
+        let memory_system_selection = crate::memory::resolve_memory_system_selection(config);
+        let selected_memory_system_id = memory_system_selection.id;
         let web_fetch_allowed_domains = config.tools.web.normalized_allowed_domains();
         let web_fetch_enforce_allowed_domains = !web_fetch_allowed_domains.is_empty();
         let browser_companion_allowed_domains =
@@ -762,6 +766,7 @@ impl ToolRuntimeConfig {
         Self {
             file_root: Some(config.tools.resolved_file_root()),
             memory_sqlite_path: Some(config.memory.resolved_sqlite_path()),
+            selected_memory_system_id,
             shell_allow,
             shell_deny,
             shell_default_mode: ShellPolicyDefault::parse(&config.tools.shell_default_mode),
@@ -906,6 +911,8 @@ impl ToolRuntimeConfig {
             let default_config = crate::config::LoongClawConfig::default();
             Some(default_config.memory.resolved_sqlite_path())
         });
+        let selected_memory_system_id = crate::memory::registered_memory_system_id_from_env()
+            .unwrap_or_else(|| crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned());
         let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
             .ok()
             .map(PathBuf::from);
@@ -1056,6 +1063,7 @@ impl ToolRuntimeConfig {
         Self {
             file_root,
             memory_sqlite_path,
+            selected_memory_system_id,
             shell_allow,
             shell_deny,
             shell_default_mode: ShellPolicyDefault::Deny,
@@ -2209,6 +2217,16 @@ mod tests {
     }
 
     #[test]
+    fn selected_memory_system_id_uses_injected_config() {
+        let mut config = crate::config::LoongClawConfig::default();
+        config.memory.system = crate::config::MemorySystemKind::WorkspaceRecall;
+
+        let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
+
+        assert_eq!(runtime.selected_memory_system_id, "workspace_recall");
+    }
+
+    #[test]
     fn memory_sqlite_path_from_env_uses_legacy_override() {
         let mut env = ScopedEnv::new();
         clear_tool_runtime_env(&mut env);
@@ -2220,6 +2238,17 @@ mod tests {
             runtime.memory_sqlite_path,
             Some(PathBuf::from("/tmp/tool-runtime-memory.sqlite3"))
         );
+    }
+
+    #[test]
+    fn selected_memory_system_id_from_env_uses_registered_override() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set(crate::memory::MEMORY_SYSTEM_ENV, "workspace_recall");
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(runtime.selected_memory_system_id, "workspace_recall");
     }
 
     #[test]

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1426,7 +1426,7 @@ fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
     );
     assert_eq!(
         payload["supported_recall_modes"],
-        json!(["prompt_assembly"])
+        json!(["prompt_assembly", "operator_inspection"])
     );
 }
 
@@ -1455,7 +1455,7 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
     );
     assert_eq!(
         payload["selected"]["supported_recall_modes"],
-        json!(["prompt_assembly"])
+        json!(["prompt_assembly", "operator_inspection"])
     );
     assert_eq!(payload["policy"]["backend"], "sqlite");
     assert_eq!(payload["policy"]["profile"], "window_plus_summary");
@@ -1485,11 +1485,11 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains(
-        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
+        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
     ));
     assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
     assert!(rendered.contains(
-        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
+        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
     ));
     assert!(rendered.contains(
         "- recall_first api_version=1 capabilities=prompt_hydration,retrieval_provenance pre_assembly_stages=retrieve,rank recall_modes=prompt_assembly"

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T03:24:27Z
+- Generated at: 2026-04-07T04:28:29Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6837 | 7300 | 463 | 123 | 160 | 37 | 93.7% | WATCH | 6936 | -1.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11397 | 11200 | -197 | 101 | 120 | 19 | 101.8% | BREACH | 10831 | 5.2% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14919 | 15000 | 81 | 54 | 70 | 16 | 99.5% | TIGHT | 14472 | 3.1% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9785 | 9800 | 15 | 238 | 250 | 12 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.8%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.5%), daemon_lib (98.9%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.7%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6837 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=11397 functions=101 -->
-<!-- arch-hotspot key=tools_mod lines=14919 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9785 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - builtin cross-session recall still emitted coarse retrieval artifacts even after typed recall and tool-inspection provenance landed; it did not fully honor retrieval `scopes` / `allowed_kinds`, and narrow budgets could still lose eligible hits when a higher-ranked disallowed hit consumed the raw sqlite search limit.
- Why it matters:
  - the builtin path needs to be a truthful provider-facing reference path, and this stack now needs to land on `dev` as one coherent slice.
- What changed:
  - folded the stacked tool-inspection alignment slice from #1048 into this dev-targeting PR
  - filtered builtin cross-session recall hits by retrieval `scopes` and `allowed_kinds`
  - widened candidate fan-out before filtering so eligible hits are not lost under narrow budgets
  - converted recalled entry provenance from `memory_system` to `canonical_memory_record`
  - rendered cross-session recall as per-hit retrieval artifacts instead of one coarse aggregate bucket
  - refreshed the tracked architecture drift report for the tool-inspection slice
  - added regression coverage for retrieval filtering, canonical-record provenance, and invalid memory-system env fallback behavior
- What did not change (scope boundary):
  - no vector retrieval or embeddings
  - no external memory provider plugin/runtime
  - no docs-only planning material

## Linked Issues

- Closes #1037
- Closes #1024
- Related #1023
- Related #1048

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed

Commands and evidence:

```text
PASS cargo fmt --all -- --check
PASS bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md
PASS cargo test -p loongclaw-app filter_cross_session_recall_hits_respects_scopes_and_allowed_kinds -- --test-threads=1
PASS cargo test -p loongclaw-app build_cross_session_recall_entries_attach_canonical_record_provenance -- --test-threads=1
PASS cargo test -p loongclaw-app builtin_retrieve_stage_keeps_allowed_hits_when_top_match_is_filtered_out -- --test-threads=1
PASS cargo test -p loongclaw-app hydrated_memory_builtin_orchestrator_retrieves_cross_session_recall_hits -- --test-threads=1
PASS cargo test -p loongclaw-app workspace_recall_system_executes_retrieve_and_rank_stages -- --test-threads=1
PENDING GitHub CI on the dev-targeting PR after retargeting this stack to dev
```

## User-visible / Operator-visible Changes

- `memory_search` and `memory_get` provenance alignment lands together with narrower builtin cross-session recall artifacts.
- cross-session builtin recall now respects retrieval-request scope/kind controls and preserves eligible hits even when the raw search budget is small.
- recalled entries now expose canonical-record provenance instead of coarse memory-system provenance.

## Failure Recovery

- Fast rollback or disable path:
  - revert commits `90958aa0`, `af82fb60`, and `a1a9ad4f`
- Observable failure symptoms reviewers should watch for:
  - cross-session recall ignores retrieval scopes or allowed kinds
  - eligible cross-session hits disappear when a disallowed hit ranks first
  - recalled entries still show coarse memory-system provenance only

## Reviewer Focus

- Check that the combined stack still stays additive and backward-compatible.
- Check that cross-session recall eligibility is decided before budget truncation.
- Check that operator-inspection provenance and prompt-hydration provenance now land together cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for operator inspection mode in memory systems, enabling new recall capabilities alongside existing prompt assembly functionality.
  * Enhanced memory search results with provenance tracking, displaying source information and metadata for recalled entries.
  * Added memory system selection configuration for users to choose between available memory backends.

* **Improvements**
  * Improved cross-session memory recall functionality with refined hit filtering and per-entry provenance attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->