### PR TITLE
Fix Windows delegate worktree cleanup for workspace isolation

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -23807,10 +23807,11 @@ async fn handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirt
     assert_eq!(payloads[0]["workspace_retained"], true);
 
     let git_executable = delegate_test_git_executable();
+    let repo_root_string = repo_root.display().to_string();
     let cleanup_status = std::process::Command::new(git_executable)
         .args([
             "-C",
-            workspace_root.as_str(),
+            repo_root_string.as_str(),
             "worktree",
             "remove",
             "--force",

--- a/crates/app/src/conversation/workspace_isolation.rs
+++ b/crates/app/src/conversation/workspace_isolation.rs
@@ -176,9 +176,13 @@ fn add_detached_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), S
 }
 
 fn remove_delegate_worktree(worktree_root: &Path) -> Result<(), String> {
+    // Removing a linked worktree from inside that same worktree is fragile on
+    // Windows because Git then tries to delete its own current working
+    // directory. Resolve the owning repo root and run the removal from there.
+    let repo_root = resolve_git_repo_root_for_worktree(worktree_root)?;
     let args = [
         OsStr::new("-C"),
-        worktree_root.as_os_str(),
+        repo_root.as_os_str(),
         OsStr::new("worktree"),
         OsStr::new("remove"),
         OsStr::new("--force"),
@@ -194,6 +198,58 @@ fn remove_delegate_worktree(worktree_root: &Path) -> Result<(), String> {
     Err(format!(
         "remove delegate worktree `{display_path}` failed: {stderr}"
     ))
+}
+
+fn resolve_git_repo_root_for_worktree(worktree_root: &Path) -> Result<PathBuf, String> {
+    let common_dir = resolve_git_common_dir(worktree_root)?;
+    let repo_root = common_dir.parent().ok_or_else(|| {
+        let display_path = common_dir.display();
+        format!("resolve git repo root from common dir `{display_path}` failed: missing parent")
+    })?;
+    let canonical_repo_root = std::fs::canonicalize(repo_root).map_err(|error| {
+        let display_path = repo_root.display();
+        format!("canonicalize git repo root `{display_path}` failed: {error}")
+    })?;
+    Ok(canonical_repo_root)
+}
+
+fn resolve_git_common_dir(worktree_root: &Path) -> Result<PathBuf, String> {
+    let args = [
+        OsStr::new("-C"),
+        worktree_root.as_os_str(),
+        OsStr::new("rev-parse"),
+        OsStr::new("--git-common-dir"),
+    ];
+    let output = run_git_command(&args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let display_path = worktree_root.display();
+        return Err(format!(
+            "resolve git common dir from `{display_path}` failed: {stderr}"
+        ));
+    }
+
+    let raw_stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed_stdout = raw_stdout.trim();
+    if trimmed_stdout.is_empty() {
+        let display_path = worktree_root.display();
+        return Err(format!(
+            "resolve git common dir from `{display_path}` returned empty output"
+        ));
+    }
+
+    let raw_path = PathBuf::from(trimmed_stdout);
+    let normalized_path = if raw_path.is_absolute() {
+        raw_path
+    } else {
+        worktree_root.join(raw_path)
+    };
+    let canonical_path = std::fs::canonicalize(&normalized_path).map_err(|error| {
+        let display_path = normalized_path.display();
+        format!("canonicalize git common dir `{display_path}` failed: {error}")
+    })?;
+
+    Ok(canonical_path)
 }
 
 fn delegate_worktree_is_dirty(workspace_root: &Path) -> Result<bool, String> {


### PR DESCRIPTION
## Summary

- Problem:
  - Windows delegate worktree cleanup ran `git worktree remove` from inside the worktree being deleted, which can fail with `Permission denied` and leave runtime cleanup metadata unset.
- Why it matters:
  - PR CI stays red on Windows for workspace isolation paths and blocks unrelated delivery work.
- What changed:
  - Resolve the owning repo root for a linked delegate worktree via `git rev-parse --git-common-dir`.
  - Run `git worktree remove --force <worktree>` from the owning repo root instead of from the worktree itself.
  - Update the retained-worktree cleanup test to use the same repo-root removal path.
- What did not change (scope boundary):
  - No change to dirty-vs-clean retention policy.
  - No change to delegate workspace creation layout or broader conversation runtime behavior.

## Linked Issues

- Closes #1060
- Related #1027

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
cargo test -p loongclaw-app --all-features --locked conversation::workspace_isolation::tests::cleanup_delegate_workspace_root_removes_clean_worktree_and_retains_dirty_one -- --exact --nocapture
cargo test -p loongclaw-app --all-features --locked conversation::tests::handle_turn_with_runtime_delegate_supports_worktree_isolation_for_clean_child -- --exact --nocapture
cargo test -p loongclaw-app --all-features --locked conversation::tests::handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirty_child_tree -- --exact --nocapture

Manual regression scenarios:
- create temp repo + linked worktree, run `git -C <worktree> status`, then remove from `git -C <repo> worktree remove --force <worktree>` for a clean child -> passed
- same scenario after dirtying the child README before removal -> passed

Attempted default-feature targeted test commands hit an unrelated existing compile failure in crates/app/src/config/tools.rs:
PluginBridgeKind::parse_label not found
```

## User-visible / Operator-visible Changes

- Windows delegate worktree cleanup now removes linked child worktrees from the owning repo root, which avoids the permission-denied cleanup failure seen in CI.

## Failure Recovery

- Fast rollback or disable path:
  - Revert this PR to restore the prior cleanup path.
- Observable failure symptoms reviewers should watch for:
  - Windows CI still reporting `failed to delete ... Permission denied` during delegate worktree cleanup.
  - `workspace_retained` missing from delegate terminal payloads for clean children.

## Reviewer Focus

- `crates/app/src/conversation/workspace_isolation.rs`
  - Confirm the repo-root resolution for linked worktrees is correct and narrowly scoped.
- `crates/app/src/conversation/tests.rs`
  - Confirm the retained-worktree cleanup path mirrors production behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of worktree removal by executing commands from the correct repository context, preventing failures when deleting a worktree from within itself.
  * Enhanced error handling with more specific failure messages during worktree cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->