### PR TITLE
fix(memory): harden current registry and rank diagnostics

### DIFF
--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -621,16 +621,21 @@ mod tests {
         register_memory_system,
     };
 
-    struct RegistryRetrieveOnlyMemorySystem;
+    const REGISTRY_RETRIEVE_ONLY_SYSTEM_ID: &str = "registry-retrieve-only";
+    const REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID: &str = "registry-retrieve-only-compact";
+
+    struct RegistryRetrieveOnlyMemorySystem {
+        id: &'static str,
+    }
 
     impl MemorySystem for RegistryRetrieveOnlyMemorySystem {
         fn id(&self) -> &'static str {
-            "registry-retrieve-only"
+            self.id
         }
 
         fn metadata(&self) -> MemorySystemMetadata {
             MemorySystemMetadata::new(
-                "registry-retrieve-only",
+                self.id,
                 [MemorySystemCapability::PromptHydration],
                 "Registry system without an execution adapter yet",
             )
@@ -699,6 +704,7 @@ mod tests {
         assert!(!hydrated.diagnostics.degraded);
         assert_eq!(hydrated.diagnostics.derivation_error, None);
         assert_eq!(hydrated.diagnostics.retrieval_error, None);
+        assert_eq!(hydrated.diagnostics.rank_error, None);
         assert_eq!(hydrated.diagnostics.recent_window_count, 0);
         assert_eq!(hydrated.diagnostics.entry_count, 0);
 
@@ -1222,8 +1228,10 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn registry_selected_system_skips_builtin_pre_assembly_execution() {
-        register_memory_system("registry-retrieve-only", || {
-            Box::new(RegistryRetrieveOnlyMemorySystem)
+        register_memory_system(REGISTRY_RETRIEVE_ONLY_SYSTEM_ID, || {
+            Box::new(RegistryRetrieveOnlyMemorySystem {
+                id: REGISTRY_RETRIEVE_ONLY_SYSTEM_ID,
+            })
         })
         .expect("register registry-selected memory system");
 
@@ -1239,7 +1247,7 @@ mod tests {
             sliding_window: 2,
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
-        config.resolved_system_id = Some("registry-retrieve-only".to_owned());
+        config.resolved_system_id = Some(REGISTRY_RETRIEVE_ONLY_SYSTEM_ID.to_owned());
 
         append_turn_direct("registry-selected", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1253,7 +1261,7 @@ mod tests {
 
         assert_eq!(
             envelope.hydrated.diagnostics.system_id,
-            "registry-retrieve-only"
+            REGISTRY_RETRIEVE_ONLY_SYSTEM_ID
         );
         assert_eq!(envelope.hydrated.recent_window.len(), 2);
         assert_eq!(
@@ -1622,9 +1630,11 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[tokio::test]
-    async fn compact_stage_remains_runtime_owned_for_registry_selected_system_without_executor() {
-        register_memory_system("registry-retrieve-only", || {
-            Box::new(RegistryRetrieveOnlyMemorySystem)
+    async fn compact_stage_skips_for_registry_selected_system_without_executor() {
+        register_memory_system(REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID, || {
+            Box::new(RegistryRetrieveOnlyMemorySystem {
+                id: REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID,
+            })
         })
         .expect("register registry-selected memory system");
 
@@ -1640,7 +1650,7 @@ mod tests {
             sliding_window: 2,
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
-        config.resolved_system_id = Some("registry-retrieve-only".to_owned());
+        config.resolved_system_id = Some(REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID.to_owned());
 
         append_turn_direct("compact-stage-registry-selected", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1764,6 +1774,57 @@ mod tests {
         assert_eq!(
             hydrated.diagnostics.retrieval_error.as_deref(),
             Some("simulated retrieval failure")
+        );
+        assert!(hydrated.diagnostics.degraded);
+        assert!(hydrated.diagnostics.fail_open);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn fail_open_memory_rank_failure_keeps_recent_window_behavior() {
+        let session_id = "fail-open-rank";
+        let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            session_id: Some(session_id.to_owned()),
+            rank_error: Some("simulated rank failure".to_owned()),
+            ..MemoryOrchestratorTestFaults::default()
+        });
+        let tmp = hydrated_memory_temp_dir("loongclaw-fail-open-rank");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("rank.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(session_id, "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct(session_id, "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct(session_id, "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let hydrated = hydrate_memory_context(session_id, &config)
+            .expect("fail-open rank should preserve hydration");
+
+        let turn_entries = hydrated
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == MemoryContextKind::Turn)
+            .collect::<Vec<_>>();
+        assert_eq!(turn_entries.len(), 2);
+        assert_eq!(turn_entries[0].content, "turn 2");
+        assert_eq!(turn_entries[1].content, "turn 3");
+        assert_eq!(
+            hydrated.diagnostics.rank_error.as_deref(),
+            Some("simulated rank failure")
         );
         assert!(hydrated.diagnostics.degraded);
         assert!(hydrated.diagnostics.fail_open);

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -12,8 +12,7 @@ use crate::config::{
 use super::runtime_config::MemoryRuntimeConfig;
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
-    RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
-    WorkspaceRecallMemorySystem,
+    WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
 };
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
@@ -94,10 +93,6 @@ fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
             WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned(),
             Arc::new(|| Box::new(WorkspaceRecallMemorySystem)),
         );
-        map.insert(
-            RECALL_FIRST_MEMORY_SYSTEM_ID.to_owned(),
-            Arc::new(|| Box::new(RecallFirstMemorySystem)),
-        );
         RwLock::new(map)
     })
 }
@@ -116,7 +111,6 @@ where
     let reserved_system_id = match normalized.as_str() {
         DEFAULT_MEMORY_SYSTEM_ID => Some(DEFAULT_MEMORY_SYSTEM_ID),
         WORKSPACE_RECALL_MEMORY_SYSTEM_ID => Some(WORKSPACE_RECALL_MEMORY_SYSTEM_ID),
-        RECALL_FIRST_MEMORY_SYSTEM_ID => Some(RECALL_FIRST_MEMORY_SYSTEM_ID),
         _ => None,
     };
     if let Some(reserved_system_id) = reserved_system_id {
@@ -142,6 +136,11 @@ where
     let mut guard = registry()
         .write()
         .map_err(|_error| "memory system registry lock poisoned".to_owned())?;
+    let already_registered = guard.contains_key(&normalized);
+    if already_registered {
+        let error = format!("memory system `{normalized}` is already registered");
+        return Err(error);
+    }
     guard.insert(normalized, Arc::new(factory));
     Ok(())
 }
@@ -295,6 +294,38 @@ mod tests {
         }
     }
 
+    struct MatchingRegistryEnvSystem;
+
+    impl MemorySystem for MatchingRegistryEnvSystem {
+        fn id(&self) -> &'static str {
+            "registry-custom-env"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-custom-env",
+                [MemorySystemCapability::PromptHydration],
+                "Test env registry system",
+            )
+        }
+    }
+
+    struct DuplicateRegistrySystem;
+
+    impl MemorySystem for DuplicateRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-duplicate-check"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-duplicate-check",
+                [MemorySystemCapability::PromptHydration],
+                "Duplicate registry test system",
+            )
+        }
+    }
+
     struct MismatchedRegistrySystem;
 
     impl MemorySystem for MismatchedRegistrySystem {
@@ -385,21 +416,27 @@ mod tests {
     }
 
     #[test]
-    fn registry_rejects_recall_first_override() {
-        let error = register_memory_system(RECALL_FIRST_MEMORY_SYSTEM_ID, || {
-            Box::new(MatchingRegistrySystem)
-        })
-        .expect_err("recall_first memory system should stay reserved");
-        assert!(error.contains("reserved"), "error: {error}");
-    }
-
-    #[test]
     fn registry_rejects_registry_id_mismatches() {
         let error = register_memory_system("registry-custom-alias", || {
             Box::new(MismatchedRegistrySystem)
         })
         .expect_err("registry id mismatch should fail");
         assert!(error.contains("must match"), "error: {error}");
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_custom_id() {
+        register_memory_system("registry-duplicate-check", || {
+            Box::new(DuplicateRegistrySystem)
+        })
+        .expect("register first custom system");
+
+        let error = register_memory_system("registry-duplicate-check", || {
+            Box::new(DuplicateRegistrySystem)
+        })
+        .expect_err("duplicate custom ids should fail");
+
+        assert!(error.contains("already registered"), "error: {error}");
     }
 
     #[test]
@@ -447,17 +484,6 @@ mod tests {
         assert_eq!(
             workspace_recall.supported_recall_modes,
             vec![MemoryRecallMode::PromptAssembly]
-        );
-
-        let recall_first = metadata
-            .iter()
-            .find(|entry| entry.id == RECALL_FIRST_MEMORY_SYSTEM_ID)
-            .expect("recall_first metadata entry");
-        assert!(
-            recall_first
-                .capabilities
-                .contains(&MemorySystemCapability::RetrievalProvenance),
-            "recall_first metadata should include retrieval provenance capability"
         );
     }
 
@@ -564,15 +590,17 @@ mod tests {
     fn registry_backed_memory_system_env_surfaces_in_runtime_snapshot() {
         let mut env = ScopedEnv::new();
         clear_memory_runtime_env_overrides(&mut env);
-        register_memory_system("registry-custom", || Box::new(MatchingRegistrySystem))
-            .expect("register custom registry system");
-        env.set(MEMORY_SYSTEM_ENV, "registry-custom");
+        register_memory_system("registry-custom-env", || {
+            Box::new(MatchingRegistryEnvSystem)
+        })
+        .expect("register custom registry system");
+        env.set(MEMORY_SYSTEM_ENV, "registry-custom-env");
 
         let config = LoongClawConfig::default();
         let snapshot =
             collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
 
-        assert_eq!(snapshot.selected.id, "registry-custom");
+        assert_eq!(snapshot.selected.id, "registry-custom-env");
         assert_eq!(snapshot.selected.source, MemorySystemSelectionSource::Env);
     }
 

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -12,7 +12,8 @@ use crate::config::{
 use super::runtime_config::MemoryRuntimeConfig;
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
-    WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
+    RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+    WorkspaceRecallMemorySystem,
 };
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
@@ -93,6 +94,10 @@ fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
             WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned(),
             Arc::new(|| Box::new(WorkspaceRecallMemorySystem)),
         );
+        map.insert(
+            RECALL_FIRST_MEMORY_SYSTEM_ID.to_owned(),
+            Arc::new(|| Box::new(RecallFirstMemorySystem)),
+        );
         RwLock::new(map)
     })
 }
@@ -111,6 +116,7 @@ where
     let reserved_system_id = match normalized.as_str() {
         DEFAULT_MEMORY_SYSTEM_ID => Some(DEFAULT_MEMORY_SYSTEM_ID),
         WORKSPACE_RECALL_MEMORY_SYSTEM_ID => Some(WORKSPACE_RECALL_MEMORY_SYSTEM_ID),
+        RECALL_FIRST_MEMORY_SYSTEM_ID => Some(RECALL_FIRST_MEMORY_SYSTEM_ID),
         _ => None,
     };
     if let Some(reserved_system_id) = reserved_system_id {
@@ -416,6 +422,15 @@ mod tests {
     }
 
     #[test]
+    fn registry_rejects_recall_first_override() {
+        let error = register_memory_system(RECALL_FIRST_MEMORY_SYSTEM_ID, || {
+            Box::new(MatchingRegistrySystem)
+        })
+        .expect_err("recall_first memory system should stay reserved");
+        assert!(error.contains("reserved"), "error: {error}");
+    }
+
+    #[test]
     fn registry_rejects_registry_id_mismatches() {
         let error = register_memory_system("registry-custom-alias", || {
             Box::new(MismatchedRegistrySystem)
@@ -484,6 +499,17 @@ mod tests {
         assert_eq!(
             workspace_recall.supported_recall_modes,
             vec![MemoryRecallMode::PromptAssembly]
+        );
+
+        let recall_first = metadata
+            .iter()
+            .find(|entry| entry.id == RECALL_FIRST_MEMORY_SYSTEM_ID)
+            .expect("recall_first metadata entry");
+        assert!(
+            recall_first
+                .capabilities
+                .contains(&MemorySystemCapability::RetrievalProvenance),
+            "recall_first metadata should include retrieval provenance capability"
         );
     }
 


### PR DESCRIPTION
## Summary

- problem:
  the original executable pre-assembly work from #1027 was developed against an older memory-system shape. current `dev` has since moved to the newer `workspace_recall` runtime path, but it still leaves a few correctness gaps and test hazards in the current implementation.
- why it matters:
  even on the newer memory runtime, the registry can still silently overwrite duplicate ids, reserved in-tree ids are not fully protected, rank-stage fail-open diagnostics are not surfaced through `MemoryDiagnostics`, and two registry tests still share the same id.
- what changed:
  - reject duplicate memory-system registrations instead of silently overwriting them
  - reserve `workspace_recall` against external registry override
  - surface rank-stage fallback failures through `MemoryDiagnostics` and protocol payloads
  - add a rank-stage fail-open regression test
  - split registry test ids so they no longer depend on global insertion order
  - refresh `docs/releases/architecture-drift-2026-04.md` so governance stays current
- what did not change:
  - no attempt to reintroduce the older `recall_first` executor design on top of the newer `workspace_recall` architecture
  - no new provider or embedding retrieval work

## linked issues

- related #726
- supersedes #1027

## replacement note

this pr intentionally supersedes #1027 because the base branch evolved underneath the older design. the useful hardening from that review has been narrowed onto the current `dev` architecture instead of forcing the obsolete runtime shape back in.

## change type

- [x] bug fix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] security hardening
- [ ] ci / workflow / release

## touched areas

- [ ] kernel / policy / approvals
- [ ] contracts / protocol / spec
- [ ] daemon / cli / install
- [ ] providers / routing
- [ ] tools
- [ ] browser automation
- [ ] channels / integrations
- [x] acp / conversation / session runtime
- [x] memory / context assembly
- [ ] config / migration / onboarding
- [x] docs / contributor workflow
- [ ] ci / release / workflows

## validation

- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_architecture_boundaries.sh`
- [x] `bash scripts/check_dep_graph.sh`
- [x] targeted rust regressions for registry hardening, rank diagnostics, stage envelope round-trip, and current runtime-path behavior
- [x] `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
- [x] `bash scripts/generate_architecture_drift_report.sh docs/releases/architecture-drift-2026-04.md`
- [x] `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md`

## reviewer focus

- `crates/app/src/memory/system_registry.rs` for reserved-id and duplicate-id protection
- `crates/app/src/memory/orchestrator.rs` for rank-stage diagnostics and isolated registry test ids
- `crates/app/src/memory/protocol.rs` plus snapshot fixtures for the new `rank_error` field
- `docs/releases/architecture-drift-2026-04.md` for the refreshed governance artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory system registration to prevent duplicate entries and provide clearer error messages.
  * Enhanced error handling for memory system failures with better diagnostics tracking.

* **Tests**
  * Expanded test coverage for memory system behavior under various scenarios, including error conditions and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->