### PR TITLE
fix: isolate Windows audit journal locks in chat tests

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -4097,6 +4097,7 @@ mod tests {
         cleanup_chat_test_memory(&sqlite_path);
 
         let mut config = LoongClawConfig::default();
+        config.audit.mode = crate::config::AuditMode::InMemory;
         config.memory.sqlite_path = sqlite_path.display().to_string();
         let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
         crate::memory::ensure_memory_db_ready(
@@ -4106,6 +4107,16 @@ mod tests {
         .expect("initialize sqlite memory");
 
         (config, memory_config, sqlite_path)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn init_chat_test_memory_uses_in_memory_audit_mode() {
+        let (config, _memory_config, sqlite_path) = init_chat_test_memory("audit-mode");
+
+        assert_eq!(config.audit.mode, crate::config::AuditMode::InMemory);
+
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[cfg(feature = "memory-sqlite")]


### PR DESCRIPTION
## Summary

- Problem: Windows `rust-test-all-features` can still fail after the worktree-cleanup fix because chat selector tests initialize the durable audit journal under the shared runner home and race on the same JSONL file.
- Why it matters: this leaves required Windows CI red even when the original workspace-isolation fix is correct, so blocker PRs still cannot merge cleanly.
- What changed: the shared `init_chat_test_memory` helper now forces `AuditMode::InMemory`, and a small regression test locks that expectation in place.
- What did not change (scope boundary): no production runtime defaults changed, no durable audit behavior changed outside test helpers, and no session-selection logic changed.

## Linked Issues

- Closes #1065
- Related #1062
- Related #1027

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --cached --check
GitHub Actions job 70184102584 (PR #1062):
- failing test: chat::latest_session_selector_tests::cli_runtime_rejects_latest_session_selector_when_no_resumable_root_exists
- failure: durable audit journal lock on C:\Users\runneradmin\.loongclaw\audit\events.jsonl (os error 33)

Evidence:
- init_chat_test_memory now uses AuditMode::InMemory before constructing runtime-bound test configs
- added regression: init_chat_test_memory_uses_in_memory_audit_mode
- PR CI is the final confirmation path for the Windows matrix
```

## User-visible / Operator-visible Changes

- None. This only changes chat test helper isolation.

## Failure Recovery

- Fast rollback or disable path: revert this commit to restore the previous test helper.
- Observable failure symptoms reviewers should watch for: Windows all-features still failing on audit-journal file locks, or unexpected tests depending on durable audit defaults.

## Reviewer Focus

- Confirm the helper-only audit-mode change is scoped to tests.
- Confirm the regression test protects against reintroducing the shared durable audit path.
- Confirm this is the remaining Windows unblock after #1062.
