### PR TITLE
fix(runtime): recover shell repair workflow in safe lane

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -13709,6 +13709,46 @@ async fn turn_engine_tool_execution_error_is_marked_retryable() {
     }
 }
 
+#[cfg(feature = "tool-shell")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_marks_repairable_shell_preflight_failure_retryable() {
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnFailureKind, TurnResult};
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![provider_tool_intent(
+            "shell.exec",
+            json!({"command": "/bin/echo", "args": ["hello"]}),
+            "s1",
+            "t1",
+            "c1",
+        )],
+        raw_meta: Value::Null,
+    };
+
+    let result = engine.execute_turn(&turn, &harness.kernel_ctx).await;
+
+    match result {
+        TurnResult::ToolError(failure) => {
+            assert_eq!(failure.kind, TurnFailureKind::Retryable);
+            assert_eq!(failure.code, "tool_preflight_denied");
+            assert!(failure.retryable);
+            assert!(failure.reason.contains("tool input needs repair"));
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolError, got {:?}", other)
+        }
+    }
+}
+
 #[test]
 fn kernel_error_classification_table_is_stable() {
     use crate::conversation::turn_engine::{KernelFailureClass, classify_kernel_error};

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6512,8 +6512,7 @@ mod tests {
         let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
             "shell.exec",
             json!({
-                "command": "/bin/echo",
-                "args": ["hello"],
+                "command": "\"ls -la\"",
             }),
             Some("root-session"),
             Some("turn-shell-plan-node"),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6503,6 +6503,49 @@ mod tests {
         assert_eq!(error.message, "no_kernel_context");
     }
 
+    #[cfg(feature = "tool-shell")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_single_tool_intent_marks_repairable_shell_preflight_failure_retryable() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "shell.exec",
+            json!({
+                "command": "/bin/echo",
+                "args": ["hello"],
+            }),
+            Some("root-session"),
+            Some("turn-shell-plan-node"),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-shell-plan-node".to_owned(),
+            tool_call_id: "call-shell-plan-node".to_owned(),
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::planned_root_tool_view(),
+        );
+
+        let error = execute_single_tool_intent(
+            &intent,
+            &session_context,
+            &DefaultAppToolDispatcher::runtime(),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+            None,
+            2_048,
+        )
+        .await
+        .expect_err("repairable shell preflight should return a plan-node error");
+
+        assert_eq!(error.kind, PlanNodeErrorKind::Retryable);
+        assert!(error.message.contains("tool input needs repair"));
+    }
+
     fn unique_sqlite_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
             "loongclaw-turn-coordinator-{label}-{}.sqlite3",

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1728,6 +1728,10 @@ fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
     }
 }
 
+fn is_repairable_tool_preflight_denial(reason: &str) -> bool {
+    reason.starts_with("tool_preflight_denied: tool input needs repair:")
+}
+
 fn render_app_tool_denied_reason(reason: &str) -> String {
     reason
         .strip_prefix("app_tool_denied: ")
@@ -3496,8 +3500,11 @@ impl TurnEngine {
                 });
             }
             Err(reason) if reason.starts_with("tool_preflight_denied:") => {
-                let turn_result =
-                    TurnResult::policy_denied("tool_preflight_denied", reason.clone());
+                let turn_result = if is_repairable_tool_preflight_denial(reason.as_str()) {
+                    TurnResult::retryable_tool_error("tool_preflight_denied", reason.clone())
+                } else {
+                    TurnResult::policy_denied("tool_preflight_denied", reason.clone())
+                };
                 let denial_decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
                     reason,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1124,7 +1124,7 @@ impl DefaultAppToolDispatcher {
                 let stripped = crate::tools::shell_policy_ext::strip_repairable_tool_input_prefix(
                     reason.as_str(),
                 );
-                return format!("tool_preflight_denied: tool input needs repair: {stripped}");
+                return format!("{REPAIRABLE_TOOL_PREFLIGHT_PREFIX}{stripped}");
             }
             format!("tool_preflight_denied: {reason}")
         })?;
@@ -1728,8 +1728,10 @@ fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
     }
 }
 
-fn is_repairable_tool_preflight_denial(reason: &str) -> bool {
-    reason.starts_with("tool_preflight_denied: tool input needs repair:")
+const REPAIRABLE_TOOL_PREFLIGHT_PREFIX: &str = "tool_preflight_repairable: ";
+
+fn render_repairable_tool_preflight_denial(reason: &str) -> String {
+    format!("tool_preflight_denied: tool input needs repair: {reason}")
 }
 
 fn render_app_tool_denied_reason(reason: &str) -> String {
@@ -3499,12 +3501,27 @@ impl TurnEngine {
                     decision: denial_decision,
                 });
             }
+            Err(reason) if reason.starts_with(REPAIRABLE_TOOL_PREFLIGHT_PREFIX) => {
+                let stripped = reason
+                    .strip_prefix(REPAIRABLE_TOOL_PREFLIGHT_PREFIX)
+                    .unwrap_or(reason.as_str());
+                let human_reason = render_repairable_tool_preflight_denial(stripped);
+                let turn_result =
+                    TurnResult::retryable_tool_error("tool_preflight_denied", human_reason.clone());
+                let denial_decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
+                    human_reason,
+                    "tool_preflight_denied",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision: denial_decision,
+                });
+            }
             Err(reason) if reason.starts_with("tool_preflight_denied:") => {
-                let turn_result = if is_repairable_tool_preflight_denial(reason.as_str()) {
-                    TurnResult::retryable_tool_error("tool_preflight_denied", reason.clone())
-                } else {
-                    TurnResult::policy_denied("tool_preflight_denied", reason.clone())
-                };
+                let turn_result =
+                    TurnResult::policy_denied("tool_preflight_denied", reason.clone());
                 let denial_decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
                     reason,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1124,7 +1124,7 @@ impl DefaultAppToolDispatcher {
                 let stripped = crate::tools::shell_policy_ext::strip_repairable_tool_input_prefix(
                     reason.as_str(),
                 );
-                return format!("{REPAIRABLE_TOOL_PREFLIGHT_PREFIX}{stripped}");
+                return RepairableToolPreflight::encode(stripped);
             }
             format!("tool_preflight_denied: {reason}")
         })?;
@@ -1728,10 +1728,22 @@ fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
     }
 }
 
-const REPAIRABLE_TOOL_PREFLIGHT_PREFIX: &str = "tool_preflight_repairable: ";
+struct RepairableToolPreflight;
 
-fn render_repairable_tool_preflight_denial(reason: &str) -> String {
-    format!("tool_preflight_denied: tool input needs repair: {reason}")
+impl RepairableToolPreflight {
+    const PREFIX: &str = "tool_preflight_repairable: ";
+
+    fn encode(reason: &str) -> String {
+        format!("{}{reason}", Self::PREFIX)
+    }
+
+    fn parse(encoded: &str) -> Option<&str> {
+        encoded.strip_prefix(Self::PREFIX)
+    }
+
+    fn render(reason: &str) -> String {
+        format!("tool_preflight_denied: tool input needs repair: {reason}")
+    }
 }
 
 fn render_app_tool_denied_reason(reason: &str) -> String {
@@ -3501,11 +3513,10 @@ impl TurnEngine {
                     decision: denial_decision,
                 });
             }
-            Err(reason) if reason.starts_with(REPAIRABLE_TOOL_PREFLIGHT_PREFIX) => {
-                let stripped = reason
-                    .strip_prefix(REPAIRABLE_TOOL_PREFLIGHT_PREFIX)
-                    .unwrap_or(reason.as_str());
-                let human_reason = render_repairable_tool_preflight_denial(stripped);
+            Err(reason) if RepairableToolPreflight::parse(reason.as_str()).is_some() => {
+                let stripped =
+                    RepairableToolPreflight::parse(reason.as_str()).unwrap_or(reason.as_str());
+                let human_reason = RepairableToolPreflight::render(stripped);
                 let turn_result =
                     TurnResult::retryable_tool_error("tool_preflight_denied", human_reason.clone());
                 let denial_decision = ToolDecisionTelemetry::deny(

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -1699,15 +1699,35 @@ fn render_tool_failure_repair_guidance(
         return None;
     }
 
-    let bare_command = command
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(command)
-        .to_ascii_lowercase();
+    let bare_command = suggested_shell_command_name(command);
     let guidance = format!(
         "Repair guidance for shell.exec:\nUse a bare lowercase executable name in `payload.command`.\nThe failed request used `{command}`; retry with `{bare_command}`."
     );
     Some(guidance)
+}
+
+fn suggested_shell_command_name(command: &str) -> String {
+    let candidate = first_shell_command_segment(command);
+    candidate
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(candidate)
+        .to_ascii_lowercase()
+}
+
+fn first_shell_command_segment(command: &str) -> &str {
+    let trimmed = command.trim();
+    if let Some(rest) = trimmed.strip_prefix('"')
+        && let Some((quoted, _)) = rest.split_once('"')
+    {
+        return quoted;
+    }
+    if let Some(rest) = trimmed.strip_prefix('\'')
+        && let Some((quoted, _)) = rest.split_once('\'')
+    {
+        return quoted;
+    }
+    trimmed.split_whitespace().next().unwrap_or(trimmed)
 }
 
 pub fn build_tool_loop_guard_tail<F>(
@@ -2653,6 +2673,31 @@ mod tests {
         assert!(user_prompt.contains(TOOL_LOOP_GUARD_PROMPT));
         assert!(user_prompt.contains("Loop guard reason:\nstop"));
         assert!(user_prompt.contains("Original request:\nsummarize note.md"));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_strips_shell_arguments_from_repair_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.command must be a bare executable name; move arguments into payload.args.".to_owned(),
+        };
+        let tool_request_summary = r#"{"tool":"shell.exec","request":{"command":"ls -la"}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "list the current directory",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for shell.exec"));
+        assert!(user_prompt.contains("The failed request used `ls -la`; retry with `ls`"));
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -1707,7 +1707,12 @@ fn render_tool_failure_repair_guidance(
 }
 
 fn suggested_shell_command_name(command: &str) -> String {
-    let candidate = first_shell_command_segment(command);
+    let candidate = first_shell_command_segment(command).trim();
+    let candidate = if !candidate.contains('/') && !candidate.contains('\\') {
+        candidate.split_whitespace().next().unwrap_or(candidate)
+    } else {
+        candidate
+    };
     candidate
         .rsplit(['/', '\\'])
         .next()
@@ -2698,6 +2703,31 @@ mod tests {
 
         assert!(user_prompt.contains("Repair guidance for shell.exec"));
         assert!(user_prompt.contains("The failed request used `ls -la`; retry with `ls`"));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_strips_quoted_shell_arguments_from_repair_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.command must be a bare executable name; move arguments into payload.args.".to_owned(),
+        };
+        let tool_request_summary = r#"{"tool":"shell.exec","request":{"command":"\"ls -la\" "}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "list the current directory",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for shell.exec"));
+        assert!(user_prompt.contains("The failed request used `\"ls -la\" `; retry with `ls`"));
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7625,7 +7625,6 @@ mod tests {
             }
         }
     }
-
     #[test]
     fn recommend_web_search_provider_from_available_credentials_prefers_unique_ready_provider() {
         let mut config = mvp::config::LoongClawConfig::default();

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7615,17 +7615,24 @@ mod tests {
         assert!(error.contains("unknown-provider"));
     }
 
+    fn clear_web_search_credential_envs(env: &mut ScopedEnv) {
+        for descriptor in mvp::config::web_search_provider_descriptors() {
+            if let Some(default_env) = descriptor.default_api_key_env {
+                env.remove(default_env);
+            }
+            for env_name in descriptor.api_key_env_names {
+                env.remove(*env_name);
+            }
+        }
+    }
+
     #[test]
     fn recommend_web_search_provider_from_available_credentials_prefers_unique_ready_provider() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.web_search.perplexity_api_key = Some("${PERPLEXITY_API_KEY}".to_owned());
 
         let mut env = ScopedEnv::new();
-        for descriptor in mvp::config::web_search_provider_descriptors() {
-            for env_name in descriptor.api_key_env_names {
-                env.remove(*env_name);
-            }
-        }
+        clear_web_search_credential_envs(&mut env);
         env.set("PERPLEXITY_API_KEY", "perplexity-test-token");
 
         let recommendation = recommend_web_search_provider_from_available_credentials(&config)
@@ -7652,6 +7659,7 @@ mod tests {
         config.tools.web_search.perplexity_api_key = Some("${PERPLEXITY_API_KEY}".to_owned());
 
         let mut env = ScopedEnv::new();
+        clear_web_search_credential_envs(&mut env);
         env.set("TAVILY_API_KEY", "tavily-test-token");
         env.set("PERPLEXITY_API_KEY", "perplexity-test-token");
 
@@ -7705,6 +7713,7 @@ mod tests {
         config.tools.web_search.tavily_api_key = Some("${TAVILY_API_KEY}".to_owned());
 
         let mut env = ScopedEnv::new();
+        clear_web_search_credential_envs(&mut env);
         env.set("TAVILY_API_KEY", "tavily-test-token");
 
         let mut ui = TestOnboardUi::with_inputs([""]);
@@ -7817,6 +7826,8 @@ mod tests {
             skip_model_probe: false,
         };
         let config = mvp::config::LoongClawConfig::default();
+        let mut env = ScopedEnv::new();
+        clear_web_search_credential_envs(&mut env);
         let recommendation = WebSearchProviderRecommendation {
             provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
             reason: "domestic locale or timezone was detected".to_owned(),

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T13:11:53Z
+- Generated at: 2026-04-07T16:39:15Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10052 | 11200 | 1148 | 83 | 120 | 37 | 89.8% | WATCH | 10831 | -7.2% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9790 | 9800 | 10 | 238 | 250 | 12 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9800 | 9800 | 0 | 238 | 250 | 12 | 100.0% | TIGHT | 9519 | 3.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (98.9%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (89.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (98.9%), onboard_cli (100.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,10 +68,10 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10052 functions=83 -->
+<!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
-<!-- arch-hotspot key=onboard_cli lines=9790 functions=238 -->
+<!-- arch-hotspot key=onboard_cli lines=9800 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - `shell.exec` preflight failures that already say "tool input needs repair" were still being emitted as `PolicyDenied`, so SafeLane treated them as terminal and interrupted the workflow instead of replanning.
  - `render_tool_failure_repair_guidance` also produced bad shell suggestions for commands that included arguments, such as `ls -la`.
  - two daemon onboarding tests were also reading machine-global web-search credential env vars, which made local test outcomes depend on the operator environment instead of the test fixture.
- Why it matters:
  - issue #1069 is an S1 workflow blocker. the model can recognize that the shell payload is repairable, but the runtime still stopped before the model could apply the fix.
  - invalid repair guidance for spaced commands weakens the follow-up loop even when the retry path is available.
  - env-sensitive tests hide real regressions and make local validation noisy.
- What changed:
  - routed repairable `shell.exec` preflight failures through a dedicated retryable path in `TurnEngine` instead of collapsing them into `ToolDenied(policy_denied)`.
  - replaced the retryability check's dependence on the human-facing `"tool input needs repair"` string with an internal repairable preflight marker, while preserving the same user-visible failure reason text.
  - added regression coverage at the engine boundary and the plan-node boundary so SafeLane keeps the failure retryable through replanning.
  - fixed shell repair guidance so commands like `ls -la` now suggest retrying with the bare executable name `ls`.
  - isolated daemon onboarding web-search recommendation tests from process-global credential env vars so they run deterministically on machines that already have Tavily / Perplexity / other provider keys set.
- What did not change (scope boundary):
  - no shell policy rules, allowlists, approval policy, or genuine policy-denied paths were relaxed.
  - no new user-facing CLI surface was added.
  - no SafeLane route table behavior was broadened for non-repairable denials; the fix stays scoped to repairable shell preflight failures.

## Linked Issues

- Closes #1069

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
- PASS

cargo test -p loongclaw-app --all-features repairable_shell
- PASS
- covers:
  - conversation::tests::turn_engine_marks_repairable_shell_preflight_failure_retryable
  - conversation::turn_coordinator::tests::execute_single_tool_intent_marks_repairable_shell_preflight_failure_retryable
  - conversation::tests::handle_turn_with_runtime_repairable_shell_failure_followup_includes_failed_request_context

cargo test -p loongclaw-app --all-features tool_failure_followup_tail_strips_shell_arguments_from_repair_guidance
- PASS

cargo test -p loongclaw --lib onboard_cli::tests::recommend_web_search_provider_from_available_credentials_prefers_unique_ready_provider -- --nocapture
- PASS

cargo test -p loongclaw --lib onboard_cli::tests::resolve_effective_web_search_default_provider_falls_back_for_detected_tavily_without_credential -- --nocapture
- PASS

cargo test --workspace
- attempted, but currently red on daemon integration tests outside the changed runtime path:
  - integration::ask_cli::ask_cli_latest_session_selector_process_uses_selected_root_session_history
  - integration::import_cli::import_cli_applies_codex_source_and_imported_config_is_usable
  - integration::import_cli::import_cli_applies_codex_source_and_imported_turn_falls_back_from_responses

notes:
- the daemon onboarding test updates explicitly clear web-search provider credential env vars before each affected test, so local operator credentials no longer change recommendation behavior.
- the shell repair runtime fix now uses an internal repairable preflight marker instead of depending on the visible failure wording.
```

## User-visible / Operator-visible Changes

- repairable `shell.exec` preflight failures no longer terminate the turn as policy denials.
- SafeLane can now replan after the model emits an invalid shell command shape such as putting arguments or paths into `payload.command`.
- shell repair guidance for spaced commands now suggests the bare executable name, for example `ls -la` -> `ls`.

## Failure Recovery

- Fast rollback or disable path:
  - revert commits `e6419600` and `3acf345e`
- Observable failure symptoms reviewers should watch for:
  - repairable shell preflight failures still surfacing as `ToolDenied` / `PolicyDenied`
  - SafeLane still terminating instead of replanning after `"tool input needs repair"`
  - follow-up guidance still suggesting `ls -la` instead of `ls`
  - daemon onboarding recommendation tests changing behavior depending on local web-search credential env vars

## Reviewer Focus

- review `crates/app/src/conversation/turn_engine.rs` for the repairable preflight split and the internal retry marker path.
- review `crates/app/src/conversation/turn_shared.rs` for shell guidance extraction when `payload.command` contains arguments or quoted command paths.
- review `crates/app/src/conversation/tests.rs` and `crates/app/src/conversation/turn_coordinator.rs` for the engine-level and plan-node-level retryability regressions.
- review `crates/daemon/src/onboard_cli.rs` to confirm the web-search env cleanup is test-only and does not alter product behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering shell preflight denial handling and repairable failure classification; added test helpers to isolate web-search credential envs.

* **Chores**
  * Standardized repairable preflight denial encoding; repairable denials are now classified as retryable tool errors.
  * Improved repair guidance generation to extract and normalize suggested shell command names.

* **Documentation**
  * Updated architecture-drift report metrics and timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->