### PR TITLE
fix(tools): remove top-level anyOf/oneOf from built-in tool schemas

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1996,10 +1996,6 @@ fn tool_search_definition(descriptor: &ToolDescriptor) -> Value {
                     }
                 },
                 "required": [],
-                "anyOf": [
-                    { "required": ["query"] },
-                    { "required": ["exact_tool_id"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -2475,10 +2471,6 @@ fn external_skills_fetch_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Maximum download size in bytes. Defaults to 5242880 and is capped at 20971520."
                     }
                 },
-                "anyOf": [
-                    { "required": ["reference"] },
-                    { "required": ["url"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -2648,10 +2640,6 @@ fn external_skills_install_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Replace an existing installed skill with the same id. Defaults to false."
                     }
                 },
-                "anyOf": [
-                    { "required": ["path"] },
-                    { "required": ["bundled_skill_id"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3260,10 +3248,6 @@ fn session_status_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Visible session identifiers to inspect in one request."
                     }
                 },
-                "oneOf": [
-                    { "required": ["session_id"] },
-                    { "required": ["session_ids"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3385,10 +3369,6 @@ fn session_tool_policy_set_definition(descriptor: &ToolDescriptor) -> Value {
                     },
                     "runtime_narrowing": session_tool_runtime_narrowing_schema()
                 },
-                "anyOf": [
-                    { "required": ["tool_ids"] },
-                    { "required": ["runtime_narrowing"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3441,10 +3421,6 @@ fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "When true, preview which targets are recoverable without mutating state."
                     }
                 },
-                "oneOf": [
-                    { "required": ["session_id"] },
-                    { "required": ["session_ids"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3477,10 +3453,6 @@ fn session_archive_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "When true, preview which targets are archivable without mutating state."
                     }
                 },
-                "oneOf": [
-                    { "required": ["session_id"] },
-                    { "required": ["session_ids"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3513,10 +3485,6 @@ fn session_cancel_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "When true, preview which targets are cancellable without mutating state."
                     }
                 },
-                "oneOf": [
-                    { "required": ["session_id"] },
-                    { "required": ["session_ids"] }
-                ],
                 "additionalProperties": false
             }
         }
@@ -3586,10 +3554,6 @@ fn session_wait_definition(descriptor: &ToolDescriptor) -> Value {
                         "description": "Bounded wait timeout in milliseconds."
                     }
                 },
-                "oneOf": [
-                    { "required": ["session_id"] },
-                    { "required": ["session_ids"] }
-                ],
                 "additionalProperties": false
             }
         }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2427,12 +2427,9 @@ mod tests {
         assert!(tool_search_properties.contains_key("query"));
         assert!(tool_search_properties.contains_key("exact_tool_id"));
         assert!(!tool_search_required.contains(&Value::String("query".to_owned())));
-        assert_eq!(
-            tool_search["function"]["parameters"]["anyOf"],
-            json!([
-                { "required": ["query"] },
-                { "required": ["exact_tool_id"] }
-            ])
+        assert!(
+            tool_search["function"]["parameters"].get("anyOf").is_none(),
+            "anyOf removed for OpenAI-compatible provider compatibility"
         );
     }
 
@@ -4079,7 +4076,7 @@ mod tests {
         );
         assert_eq!(
             searchable.required_field_groups,
-            vec![vec!["path".to_owned()], vec!["bundled_skill_id".to_owned()]]
+            Vec::<Vec<String>>::new()
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -4074,10 +4074,7 @@ mod tests {
             searchable.required_fields.is_empty(),
             "search should not flatten grouped alternatives into required_fields"
         );
-        assert_eq!(
-            searchable.required_field_groups,
-            Vec::<Vec<String>>::new()
-        );
+        assert_eq!(searchable.required_field_groups, Vec::<Vec<String>>::new());
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -4060,7 +4060,7 @@ mod tests {
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
-    fn tool_search_reports_alternative_required_fields_for_bundled_skill_install() {
+    fn tool_search_reports_no_required_field_groups_for_bundled_skill_install() {
         let descriptor = catalog::tool_catalog()
             .descriptor("external_skills.install")
             .expect("external_skills.install should exist in the catalog");

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T11:36:21Z
+- Generated at: 2026-04-07T13:11:53Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10052 | 11200 | 1148 | 83 | 120 | 37 | 89.8% | WATCH | 10831 | -7.2% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14968 | 15000 | 32 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9790 | 9800 | 10 | 238 | 250 | 12 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.8%), daemon_lib (98.9%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (98.9%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (89.8%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10052 functions=83 -->
-<!-- arch-hotspot key=tools_mod lines=14968 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9790 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- **Problem**: OpenAI and compatible providers reject tool parameter schemas containing top-level `anyOf`/`oneOf` keywords with `invalid_function_parameters` error
- **Root cause**: 9 built-in tool definitions in `catalog.rs` use `anyOf`/`oneOf` to express "at least one of X or Y required"
- **Fix**: Remove all 9 `anyOf`/`oneOf` blocks. Safe because all tool handlers already validate parameter requirements at runtime

## Linked Issues

- Closes #813

## Change Type

- [x] Bug fix

## Touched Areas

- [x] Tools / capabilities

## Details

### 3 files changed, +8/-50

**`crates/app/src/tools/catalog.rs`** — Remove 9 top-level `anyOf`/`oneOf` blocks from tool parameter schemas:

| Tool | Removed pattern |
|------|----------------|
| `tool_search` | `anyOf: [query, exact_tool_id]` |
| `external_skills.download` | `anyOf: [reference, url]` |
| `external_skills.install` | `anyOf: [path, bundled_skill_id]` |
| `session.status` | `oneOf: [session_id, session_ids]` |
| `session.tool_policy_set` | `anyOf: [tool_ids, runtime_narrowing]` |
| `session.recover` | `oneOf: [session_id, session_ids]` |
| `session.archive` | `oneOf: [session_id, session_ids]` |
| `session.cancel` | `oneOf: [session_id, session_ids]` |
| `session.kill` | `oneOf: [session_id, session_ids]` |

**`crates/app/src/tools/mod.rs`** — Update 2 test assertions that verified `anyOf`/`oneOf` schema structure; rename test to match new expectation

**`docs/releases/architecture-drift-2026-04.md`** — Refresh drift report: `tools_mod` 14968→14962 lines

### Why this is safe

1. All affected properties are already defined as optional (`"required": []`)
2. All tool handlers validate at runtime — e.g., `"tool.search requires payload.query or payload.exact_tool_id"` (mod.rs:1239), `"external_skills.install requires payload.path or payload.bundled_skill_id"` (external_skills.rs:704)
3. Follows the pattern established by OpenClaw: *"We intentionally avoid top-level allOf/anyOf/oneOf conditionals here: OpenAI rejects tool schemas that include these keywords at the top-level."*

### Test evidence

```
cargo test -p loongclaw-app --lib provider_tool_definitions_are_stable_and_core_only → ok
cargo test -p loongclaw-app --lib tool_search_reports_no_required_field_groups → ok
CI: governance + rust-quality + rust-test-default + rust-test-all-features → all green
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified several tool parameter schemas by removing conditional alternation rules, reducing validation complexity for search, external skills, and session-related tools.

* **Tests**
  * Updated and renamed tests to align with the simplified schema shape and adjusted required-field-group expectations.

* **Documentation**
  * Updated architecture report metrics and timestamp to reflect current repository state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->