### PR TITLE
fix(cli): restore web subcommand buildability

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -83,7 +83,6 @@ rand.workspace = true
 sha2.workspace = true
 semver.workspace = true
 ed25519-dalek.workspace = true
-futures-util.workspace = true
 dunce = "1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing.workspace = true

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1422,6 +1422,7 @@ impl Commands {
             Self::SlackSend { .. } => "slack_send",
             Self::LineSend { .. } => "line_send",
             Self::WhatsappSend { .. } => "whatsapp_send",
+            Self::WhatsappServe { .. } => "whatsapp_serve",
             Self::EmailSend { .. } => "email_send",
             Self::WebhookSend { .. } => "webhook_send",
             Self::GoogleChatSend { .. } => "google_chat_send",


### PR DESCRIPTION
## Summary

This PR restores `loongclaw web ...` buildability by fixing two daemon CLI issues that prevented the updated binary from being rebuilt cleanly.

## Included

- remove the duplicate `futures-util.workspace = true` dependency entry from `crates/daemon/Cargo.toml`
- add the missing `WhatsappServe` match arm in `command_kind_for_logging()`
- unblock rebuilding `loongclaw` so the `web` subcommand is present again in the CLI help output

## Why

On Linux, rebuilding `loongclaw` failed before the binary could be refreshed, which left developers running an older binary that did not include the `web` subcommand.

Observed symptoms included:
- `cargo build --bin loongclaw` failing in `crates/daemon`
- `loongclaw --help` not listing `web`
- `loongclaw web ...` returning `unrecognized subcommand 'web'`

## Validation

After the fix:
- `./target/debug/loongclaw --help` includes `web`

## Notes

A separate local Windows issue may still block overwriting `target/debug/loongclaw.exe` when the binary is actively running, but that is unrelated to this source-level fix.
