### PR TITLE
fix(unix): restore daemon build after dev merge

### DIFF
--- a/crates/daemon/src/doctor_security_cli.rs
+++ b/crates/daemon/src/doctor_security_cli.rs
@@ -1,4 +1,6 @@
 #[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -45,6 +45,11 @@ use super::state::{
 
 type GatewayControlJsonResponse = (StatusCode, Json<Value>);
 
+#[cfg(unix)]
+const GATEWAY_CONTROL_RUNTIME_DIR_MODE: u32 = 0o700;
+#[cfg(unix)]
+const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
+
 #[derive(Clone)]
 pub(crate) struct GatewayControlAppState {
     pub(crate) runtime_dir: PathBuf,


### PR DESCRIPTION
## Summary

Restore `loongclaw web ...` buildability after the recent merge.

## Included

- remove the duplicate `futures-util.workspace = true` entry from `crates/daemon/Cargo.toml`
- add the missing `WhatsappServe` logging match arm
- add the missing unix-only `std::fs` import in `doctor_security_cli`
- restore the missing gateway control file-mode constants in `gateway/control.rs`

## Result

Linux rebuilds can produce a `loongclaw` binary that includes the `web` subcommand again.
