### PR TITLE
feat(audit): add explicit repair command for legacy journals

### DIFF
--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use clap::Subcommand;
 
 use crate::kernel::{
-    AuditEvent, AuditEventKind, AuditRepairOutcome, PluginTrustTier,
-    repair_jsonl_audit_journal, verify_jsonl_audit_journal,
+    AuditEvent, AuditEventKind, AuditRepairOutcome, PluginTrustTier, repair_jsonl_audit_journal,
+    verify_jsonl_audit_journal,
 };
 use loongclaw_spec::CliResult;
 use serde_json::{Map, Value, json};

--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -5,7 +5,10 @@ use std::path::Path;
 
 use clap::Subcommand;
 
-use crate::kernel::{AuditEvent, AuditEventKind, PluginTrustTier, verify_jsonl_audit_journal};
+use crate::kernel::{
+    AuditEvent, AuditEventKind, AuditRepairOutcome, PluginTrustTier,
+    repair_jsonl_audit_journal, verify_jsonl_audit_journal,
+};
 use loongclaw_spec::CliResult;
 use serde_json::{Map, Value, json};
 
@@ -103,6 +106,8 @@ pub enum AuditCommands {
     },
     /// Verify the integrity chain of the durable audit journal
     Verify,
+    /// Repair legacy journals missing integrity sidecars
+    Repair,
 }
 
 #[derive(Debug, Clone)]
@@ -267,6 +272,14 @@ pub enum AuditCommandResult {
         first_invalid_line: Option<usize>,
         reason: Option<String>,
     },
+    Repair {
+        total_events: usize,
+        repaired_events: usize,
+        already_valid_events: usize,
+        outcome: String,
+        refused_line: Option<usize>,
+        refused_reason: Option<String>,
+    },
 }
 
 pub fn run_audit_cli(options: AuditCommandOptions) -> CliResult<()> {
@@ -416,13 +429,27 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
             None,
             "audit verify",
         ),
+        AuditCommands::Repair => (
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "audit repair",
+        ),
     };
-    let _limit = if matches!(command, AuditCommands::Verify) {
+    let _limit = if matches!(command, AuditCommands::Verify | AuditCommands::Repair) {
         0
     } else {
         validate_audit_limit(limit, command_name)?
     };
-    if !matches!(command, AuditCommands::Verify) {
+    if !matches!(command, AuditCommands::Verify | AuditCommands::Repair) {
         validate_audit_time_range(since_epoch_s_filter, until_epoch_s_filter, command_name)?;
     }
     let filter = AuditEventFilter {
@@ -500,6 +527,26 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
                 last_entry_hash: report.last_entry_hash,
                 first_invalid_line: report.first_invalid_line,
                 reason: report.reason,
+            }
+        }
+        AuditCommands::Repair => {
+            ensure_audit_journal_preflight(&config.audit, &journal_path)?;
+            let report = repair_jsonl_audit_journal(&journal_path)
+                .map_err(|error| format!("repair audit journal failed: {error}"))?;
+            let (outcome_str, refused_line, refused_reason) = match &report.outcome {
+                AuditRepairOutcome::Healthy => ("healthy".to_owned(), None, None),
+                AuditRepairOutcome::Repaired => ("repaired".to_owned(), None, None),
+                AuditRepairOutcome::Refused { line, reason } => {
+                    ("refused".to_owned(), Some(*line), Some(reason.clone()))
+                }
+            };
+            AuditCommandResult::Repair {
+                total_events: report.total_events,
+                repaired_events: report.repaired_events,
+                already_valid_events: report.already_valid_events,
+                outcome: outcome_str,
+                refused_line,
+                refused_reason,
             }
         }
     };
@@ -838,6 +885,26 @@ pub fn audit_cli_json(execution: &AuditCommandExecution) -> Value {
             payload.insert("last_entry_hash".to_owned(), json!(last_entry_hash));
             payload.insert("first_invalid_line".to_owned(), json!(first_invalid_line));
             payload.insert("reason".to_owned(), json!(reason));
+            Value::Object(payload)
+        }
+        AuditCommandResult::Repair {
+            total_events,
+            repaired_events,
+            already_valid_events,
+            outcome,
+            refused_line,
+            refused_reason,
+        } => {
+            let mut payload = audit_cli_base_json(execution, "repair");
+            payload.insert("total_events".to_owned(), json!(total_events));
+            payload.insert("repaired_events".to_owned(), json!(repaired_events));
+            payload.insert(
+                "already_valid_events".to_owned(),
+                json!(already_valid_events),
+            );
+            payload.insert("outcome".to_owned(), json!(outcome));
+            payload.insert("refused_line".to_owned(), json!(refused_line));
+            payload.insert("refused_reason".to_owned(), json!(refused_reason));
             Value::Object(payload)
         }
     }
@@ -1733,6 +1800,27 @@ pub fn render_audit_cli_text(execution: &AuditCommandExecution) -> CliResult<Str
                     .unwrap_or_else(|| "-".to_owned()),
                 reason.as_deref().unwrap_or("-")
             ));
+        }
+        AuditCommandResult::Repair {
+            total_events,
+            repaired_events,
+            already_valid_events,
+            outcome,
+            refused_line,
+            refused_reason,
+        } => {
+            lines.push(format!(
+                "audit repair config={} journal={} total_events={} repaired_events={} already_valid_events={} outcome={}",
+                execution.resolved_config_path,
+                execution.journal_path,
+                total_events,
+                repaired_events,
+                already_valid_events,
+                outcome
+            ));
+            if let (Some(line), Some(reason)) = (refused_line, refused_reason) {
+                lines.push(format!("refused_line={line} refused_reason={reason}"));
+            }
         }
     }
     Ok(lines.join("\n"))

--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -6654,6 +6654,215 @@ mod tests {
     }
 
     #[test]
+    fn audit_repair_reports_healthy_for_valid_chain() {
+        let root = unique_temp_dir("loongclaw-audit-cli-repair-healthy");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let sink =
+            crate::kernel::JsonlAuditSink::new(journal_path).expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-repair-healthy-1",
+            1_700_010_330,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-healthy-1".to_owned(),
+            },
+        ))
+        .expect("record first event");
+
+        sink.record(sample_audit_event(
+            "evt-repair-healthy-2",
+            1_700_010_331,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-healthy-2".to_owned(),
+            },
+        ))
+        .expect("record second event");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Repair,
+        })
+        .expect("execute audit repair");
+
+        match &execution.result {
+            AuditCommandResult::Repair {
+                total_events,
+                repaired_events,
+                already_valid_events,
+                outcome,
+                refused_line,
+                refused_reason,
+            } => {
+                assert_eq!(*total_events, 2);
+                assert_eq!(*repaired_events, 0);
+                assert_eq!(*already_valid_events, 2);
+                assert_eq!(outcome, "healthy");
+                assert_eq!(*refused_line, None);
+                assert!(refused_reason.is_none());
+            }
+            other => panic!("unexpected audit repair result: {other:?}"),
+        }
+
+        let rendered = render_audit_cli_text(&execution).expect("render audit repair");
+
+        assert!(rendered.contains("audit repair"));
+        assert!(rendered.contains("already_valid_events=2"));
+        assert!(rendered.contains("outcome=healthy"));
+    }
+
+    #[test]
+    fn audit_repair_reports_repaired_for_legacy_prefix() {
+        let root = unique_temp_dir("loongclaw-audit-cli-repair-legacy-prefix");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let legacy_event = sample_audit_event(
+            "evt-repair-legacy-1",
+            1_700_010_340,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-legacy-1".to_owned(),
+            },
+        );
+
+        write_journal(&journal_path, &[legacy_event]);
+
+        let sink = crate::kernel::JsonlAuditSink::new(journal_path.clone())
+            .expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-repair-tail-1",
+            1_700_010_341,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-tail-1".to_owned(),
+            },
+        ))
+        .expect("record protected event");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: true,
+            command: AuditCommands::Repair,
+        })
+        .expect("execute audit repair");
+
+        match &execution.result {
+            AuditCommandResult::Repair {
+                total_events,
+                repaired_events,
+                already_valid_events,
+                outcome,
+                refused_line,
+                refused_reason,
+            } => {
+                assert_eq!(*total_events, 2);
+                assert_eq!(*repaired_events, 2);
+                assert_eq!(*already_valid_events, 0);
+                assert_eq!(outcome, "repaired");
+                assert_eq!(*refused_line, None);
+                assert!(refused_reason.is_none());
+            }
+            other => panic!("unexpected audit repair result: {other:?}"),
+        }
+
+        let payload = audit_cli_json(&execution);
+        let verify_report = crate::kernel::verify_jsonl_audit_journal(&journal_path)
+            .expect("verify repaired journal");
+
+        assert_eq!(payload["command"], "repair");
+        assert_eq!(payload["total_events"], json!(2));
+        assert_eq!(payload["repaired_events"], json!(2));
+        assert_eq!(payload["already_valid_events"], json!(0));
+        assert_eq!(payload["outcome"], json!("repaired"));
+        assert_eq!(payload["refused_line"], Value::Null);
+        assert_eq!(payload["refused_reason"], Value::Null);
+        assert!(verify_report.valid);
+        assert_eq!(verify_report.verified_events, 2);
+    }
+
+    #[test]
+    fn audit_repair_reports_refused_for_tampered_journal() {
+        let root = unique_temp_dir("loongclaw-audit-cli-repair-refused");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let sink = crate::kernel::JsonlAuditSink::new(journal_path.clone())
+            .expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-repair-refused-1",
+            1_700_010_350,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-refused-1".to_owned(),
+            },
+        ))
+        .expect("record first event");
+
+        sink.record(sample_audit_event(
+            "evt-repair-refused-2",
+            1_700_010_351,
+            Some("agent-repair"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-repair-refused-2".to_owned(),
+            },
+        ))
+        .expect("record second event");
+
+        let original_contents = fs::read_to_string(&journal_path).expect("read audit journal");
+        let tampered_contents =
+            original_contents.replacen("token-repair-refused-2", "token-repair-refused-x", 1);
+
+        fs::write(&journal_path, &tampered_contents).expect("rewrite tampered journal");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: true,
+            command: AuditCommands::Repair,
+        })
+        .expect("execute audit repair");
+
+        match &execution.result {
+            AuditCommandResult::Repair {
+                total_events,
+                repaired_events,
+                already_valid_events,
+                outcome,
+                refused_line,
+                refused_reason,
+            } => {
+                assert_eq!(*total_events, 2);
+                assert_eq!(*repaired_events, 0);
+                assert_eq!(*already_valid_events, 1);
+                assert_eq!(outcome, "refused");
+                assert_eq!(*refused_line, Some(2));
+                assert_eq!(
+                    refused_reason.as_deref(),
+                    Some("entry_hash mismatch — event data may be tampered")
+                );
+            }
+            other => panic!("unexpected audit repair result: {other:?}"),
+        }
+
+        let payload = audit_cli_json(&execution);
+        let rendered = render_audit_cli_text(&execution).expect("render audit repair");
+
+        assert_eq!(payload["command"], "repair");
+        assert_eq!(payload["outcome"], json!("refused"));
+        assert_eq!(payload["refused_line"], json!(2));
+        assert_eq!(
+            payload["refused_reason"],
+            json!("entry_hash mismatch — event data may be tampered")
+        );
+        assert!(rendered.contains("outcome=refused"));
+        assert!(rendered.contains("refused_line=2"));
+        assert!(rendered.contains("refused_reason=entry_hash mismatch"));
+    }
+
+    #[test]
     fn audit_summary_json_uses_empty_and_null_triage_fields_when_no_triage_events_exist() {
         let execution = AuditCommandExecution {
             resolved_config_path: "/tmp/loongclaw.toml".to_owned(),

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -372,6 +372,167 @@ pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport
     })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuditRepairOutcome {
+    Healthy,
+    Repaired,
+    Refused { line: usize, reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditRepairReport {
+    pub total_events: usize,
+    pub repaired_events: usize,
+    pub already_valid_events: usize,
+    pub outcome: AuditRepairOutcome,
+}
+
+pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, AuditError> {
+    if !path.exists() {
+        return Ok(AuditRepairReport {
+            total_events: 0,
+            repaired_events: 0,
+            already_valid_events: 0,
+            outcome: AuditRepairOutcome::Healthy,
+        });
+    }
+
+    let verify_report = verify_jsonl_audit_journal(path)?;
+    if verify_report.valid {
+        return Ok(AuditRepairReport {
+            total_events: verify_report.total_events,
+            repaired_events: 0,
+            already_valid_events: verify_report.verified_events,
+            outcome: AuditRepairOutcome::Healthy,
+        });
+    }
+
+    let file = File::open(path).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to open audit journal `{}` for repair: {error}",
+            path.display()
+        ))
+    })?;
+    let reader = BufReader::new(file);
+    let mut repaired_lines: Vec<Vec<u8>> = Vec::new();
+    let mut previous_hash: Option<String> = None;
+    let mut total_events = 0usize;
+    let mut repaired_events = 0usize;
+    let mut already_valid_events = 0usize;
+
+    for (index, line_result) in reader.lines().enumerate() {
+        let line_number = index + 1;
+        let line = line_result.map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to read audit journal `{}` at line {line_number}: {error}",
+                path.display()
+            ))
+        })?;
+        if line.trim().is_empty() {
+            repaired_lines.push(b"\n".to_vec());
+            continue;
+        }
+
+        total_events += 1;
+        let line_label = format!("line {line_number}");
+        let persisted = decode_persisted_audit_event_line(&line, path, &line_label)?;
+        let event = persisted.event;
+
+        if let Some(integrity) = persisted.integrity.as_ref() {
+            if integrity.algorithm.trim() != "sha256" {
+                return Ok(AuditRepairReport {
+                    total_events,
+                    repaired_events,
+                    already_valid_events,
+                    outcome: AuditRepairOutcome::Refused {
+                        line: line_number,
+                        reason: format!(
+                            "unsupported integrity algorithm `{}`",
+                            integrity.algorithm
+                        ),
+                    },
+                });
+            }
+
+            let expected_hash =
+                compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
+
+            if integrity.prev_hash != previous_hash || integrity.entry_hash != expected_hash {
+                return Ok(AuditRepairReport {
+                    total_events,
+                    repaired_events,
+                    already_valid_events,
+                    outcome: AuditRepairOutcome::Refused {
+                        line: line_number,
+                        reason: "hash mismatch — journal may be tampered".to_owned(),
+                    },
+                });
+            }
+
+            previous_hash = Some(integrity.entry_hash.clone());
+            already_valid_events += 1;
+            let mut encoded = line.into_bytes();
+            encoded.push(b'\n');
+            repaired_lines.push(encoded);
+        } else {
+            let entry_hash =
+                compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
+            let repaired = event_with_integrity(event, previous_hash.clone(), entry_hash.clone());
+            let encoded = serialize_audit_event_line(&repaired, path)?;
+            repaired_lines.push(encoded);
+            previous_hash = Some(entry_hash);
+            repaired_events += 1;
+        }
+    }
+
+    if repaired_events == 0 {
+        return Ok(AuditRepairReport {
+            total_events,
+            repaired_events: 0,
+            already_valid_events,
+            outcome: AuditRepairOutcome::Healthy,
+        });
+    }
+
+    let temp_path = path.with_extension("jsonl.repair-tmp");
+    {
+        let mut temp_file = File::create(&temp_path).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to create repair temp file `{}`: {error}",
+                temp_path.display()
+            ))
+        })?;
+        for line_bytes in &repaired_lines {
+            temp_file.write_all(line_bytes).map_err(|error| {
+                AuditError::Sink(format!(
+                    "failed to write repair temp file `{}`: {error}",
+                    temp_path.display()
+                ))
+            })?;
+        }
+        temp_file.flush().map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to flush repair temp file `{}`: {error}",
+                temp_path.display()
+            ))
+        })?;
+    }
+
+    fs::rename(&temp_path, path).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to replace journal with repaired file `{}`: {error}",
+            path.display()
+        ))
+    })?;
+
+    Ok(AuditRepairReport {
+        total_events,
+        repaired_events,
+        already_valid_events,
+        outcome: AuditRepairOutcome::Repaired,
+    })
+}
+
 fn serialize_audit_event_line(
     event: &PersistedAuditEvent,
     journal_path: &Path,

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -408,9 +408,7 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
             path.display()
         ))
     })?;
-    let original_permissions = fs::metadata(path)
-        .map(|m| m.permissions())
-        .ok();
+    let original_permissions = fs::metadata(path).map(|m| m.permissions()).ok();
 
     let reader = BufReader::new(file);
     let mut repaired_lines: Vec<Vec<u8>> = Vec::new();
@@ -497,11 +495,8 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
             } else {
                 // Prior legacy entries were repaired, so the chain position
                 // changed. Re-seal this entry with the rebuilt prev_hash.
-                let entry_hash = compute_audit_event_entry_hash(
-                    &event,
-                    rebuilt_previous_hash.as_deref(),
-                    path,
-                )?;
+                let entry_hash =
+                    compute_audit_event_entry_hash(&event, rebuilt_previous_hash.as_deref(), path)?;
                 let resealed =
                     event_with_integrity(event, rebuilt_previous_hash.clone(), entry_hash.clone());
                 let encoded = serialize_audit_event_line(&resealed, path)?;
@@ -522,11 +517,8 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                     },
                 });
             }
-            let entry_hash = compute_audit_event_entry_hash(
-                &event,
-                rebuilt_previous_hash.as_deref(),
-                path,
-            )?;
+            let entry_hash =
+                compute_audit_event_entry_hash(&event, rebuilt_previous_hash.as_deref(), path)?;
             let repaired =
                 event_with_integrity(event, rebuilt_previous_hash.clone(), entry_hash.clone());
             let encoded = serialize_audit_event_line(&repaired, path)?;

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -451,11 +451,8 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
 
             // Check if the entry is internally consistent: does entry_hash
             // match the event data when computed with the entry's own prev_hash?
-            let self_consistent_hash = compute_audit_event_entry_hash(
-                &event,
-                integrity.prev_hash.as_deref(),
-                path,
-            )?;
+            let self_consistent_hash =
+                compute_audit_event_entry_hash(&event, integrity.prev_hash.as_deref(), path)?;
             if integrity.entry_hash != self_consistent_hash {
                 return Ok(AuditRepairReport {
                     total_events,

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -408,7 +408,13 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
             path.display()
         ))
     })?;
-    let original_permissions = fs::metadata(path).map(|m| m.permissions()).ok();
+    let original_metadata = fs::metadata(path).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to read audit journal metadata `{}` before repair: {error}",
+            path.display()
+        ))
+    })?;
+    let original_permissions = original_metadata.permissions();
 
     let reader = BufReader::new(file);
     let mut repaired_lines: Vec<Vec<u8>> = Vec::new();
@@ -455,7 +461,7 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
 
             // Validate source chain: prev_hash must match the previous
             // source entry_hash (mirrors verify_jsonl_audit_journal).
-            if protected_chain_started && integrity.prev_hash != source_previous_hash {
+            if integrity.prev_hash != source_previous_hash {
                 return Ok(AuditRepairReport {
                     total_events,
                     repaired_events,
@@ -545,9 +551,12 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 temp_path.display()
             ))
         })?;
-        if let Some(permissions) = &original_permissions {
-            let _ = fs::set_permissions(&temp_path, permissions.clone());
-        }
+        fs::set_permissions(&temp_path, original_permissions.clone()).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to apply original permissions to repair temp file `{}`: {error}",
+                temp_path.display()
+            ))
+        })?;
         for line_bytes in &repaired_lines {
             temp_file.write_all(line_bytes).map_err(|error| {
                 AuditError::Sink(format!(
@@ -562,6 +571,13 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 temp_path.display()
             ))
         })?;
+        temp_file.sync_all().map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to sync repair temp file `{}`: {error}",
+                temp_path.display()
+            ))
+        })?;
+        drop(temp_file);
         fs::rename(&temp_path, path).map_err(|error| {
             AuditError::Sink(format!(
                 "failed to replace journal with repaired file `{}`: {error}",

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -408,9 +408,15 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
             path.display()
         ))
     })?;
+    let original_permissions = fs::metadata(path)
+        .map(|m| m.permissions())
+        .ok();
+
     let reader = BufReader::new(file);
     let mut repaired_lines: Vec<Vec<u8>> = Vec::new();
-    let mut previous_hash: Option<String> = None;
+    let mut rebuilt_previous_hash: Option<String> = None;
+    let mut source_previous_hash: Option<String> = None;
+    let mut protected_chain_started = false;
     let mut total_events = 0usize;
     let mut repaired_events = 0usize;
     let mut already_valid_events = 0usize;
@@ -449,8 +455,21 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 });
             }
 
-            // Check if the entry is internally consistent: does entry_hash
-            // match the event data when computed with the entry's own prev_hash?
+            // Validate source chain: prev_hash must match the previous
+            // source entry_hash (mirrors verify_jsonl_audit_journal).
+            if protected_chain_started && integrity.prev_hash != source_previous_hash {
+                return Ok(AuditRepairReport {
+                    total_events,
+                    repaired_events,
+                    already_valid_events,
+                    outcome: AuditRepairOutcome::Refused {
+                        line: line_number,
+                        reason: "prev_hash mismatch in source chain".to_owned(),
+                    },
+                });
+            }
+
+            // Check self-consistency: does entry_hash match the event data?
             let self_consistent_hash =
                 compute_audit_event_entry_hash(&event, integrity.prev_hash.as_deref(), path)?;
             if integrity.entry_hash != self_consistent_hash {
@@ -465,9 +484,12 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 });
             }
 
-            if repaired_events == 0 && integrity.prev_hash == previous_hash {
+            protected_chain_started = true;
+            source_previous_hash = Some(integrity.entry_hash.clone());
+
+            if repaired_events == 0 && integrity.prev_hash == rebuilt_previous_hash {
                 // No prior repairs and chain is continuous — keep as-is.
-                previous_hash = Some(integrity.entry_hash.clone());
+                rebuilt_previous_hash = Some(integrity.entry_hash.clone());
                 already_valid_events += 1;
                 let mut encoded = line.into_bytes();
                 encoded.push(b'\n');
@@ -475,22 +497,41 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
             } else {
                 // Prior legacy entries were repaired, so the chain position
                 // changed. Re-seal this entry with the rebuilt prev_hash.
-                let entry_hash =
-                    compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
+                let entry_hash = compute_audit_event_entry_hash(
+                    &event,
+                    rebuilt_previous_hash.as_deref(),
+                    path,
+                )?;
                 let resealed =
-                    event_with_integrity(event, previous_hash.clone(), entry_hash.clone());
+                    event_with_integrity(event, rebuilt_previous_hash.clone(), entry_hash.clone());
                 let encoded = serialize_audit_event_line(&resealed, path)?;
                 repaired_lines.push(encoded);
-                previous_hash = Some(entry_hash);
+                rebuilt_previous_hash = Some(entry_hash);
                 repaired_events += 1;
             }
         } else {
-            let entry_hash =
-                compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
-            let repaired = event_with_integrity(event, previous_hash.clone(), entry_hash.clone());
+            if protected_chain_started {
+                return Ok(AuditRepairReport {
+                    total_events,
+                    repaired_events,
+                    already_valid_events,
+                    outcome: AuditRepairOutcome::Refused {
+                        line: line_number,
+                        reason: "missing integrity envelope after protected chain started"
+                            .to_owned(),
+                    },
+                });
+            }
+            let entry_hash = compute_audit_event_entry_hash(
+                &event,
+                rebuilt_previous_hash.as_deref(),
+                path,
+            )?;
+            let repaired =
+                event_with_integrity(event, rebuilt_previous_hash.clone(), entry_hash.clone());
             let encoded = serialize_audit_event_line(&repaired, path)?;
             repaired_lines.push(encoded);
-            previous_hash = Some(entry_hash);
+            rebuilt_previous_hash = Some(entry_hash);
             repaired_events += 1;
         }
     }
@@ -512,6 +553,9 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 temp_path.display()
             ))
         })?;
+        if let Some(permissions) = &original_permissions {
+            let _ = fs::set_permissions(&temp_path, permissions.clone());
+        }
         for line_bytes in &repaired_lines {
             temp_file.write_all(line_bytes).map_err(|error| {
                 AuditError::Sink(format!(

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -387,22 +387,17 @@ pub struct AuditRepairReport {
     pub outcome: AuditRepairOutcome,
 }
 
+/// Repair legacy journal entries that are missing integrity envelopes.
+///
+/// **Must be run while the daemon is stopped.** A running `JsonlAuditSink` holds
+/// an open file handle and cached tail hash that would be invalidated by the
+/// atomic rename.
 pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, AuditError> {
     if !path.exists() {
         return Ok(AuditRepairReport {
             total_events: 0,
             repaired_events: 0,
             already_valid_events: 0,
-            outcome: AuditRepairOutcome::Healthy,
-        });
-    }
-
-    let verify_report = verify_jsonl_audit_journal(path)?;
-    if verify_report.valid {
-        return Ok(AuditRepairReport {
-            total_events: verify_report.total_events,
-            repaired_events: 0,
-            already_valid_events: verify_report.verified_events,
             outcome: AuditRepairOutcome::Healthy,
         });
     }
@@ -454,26 +449,44 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 });
             }
 
-            let expected_hash =
-                compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
-
-            if integrity.prev_hash != previous_hash || integrity.entry_hash != expected_hash {
+            // Check if the entry is internally consistent: does entry_hash
+            // match the event data when computed with the entry's own prev_hash?
+            let self_consistent_hash = compute_audit_event_entry_hash(
+                &event,
+                integrity.prev_hash.as_deref(),
+                path,
+            )?;
+            if integrity.entry_hash != self_consistent_hash {
                 return Ok(AuditRepairReport {
                     total_events,
                     repaired_events,
                     already_valid_events,
                     outcome: AuditRepairOutcome::Refused {
                         line: line_number,
-                        reason: "hash mismatch — journal may be tampered".to_owned(),
+                        reason: "entry_hash mismatch — event data may be tampered".to_owned(),
                     },
                 });
             }
 
-            previous_hash = Some(integrity.entry_hash.clone());
-            already_valid_events += 1;
-            let mut encoded = line.into_bytes();
-            encoded.push(b'\n');
-            repaired_lines.push(encoded);
+            if repaired_events == 0 && integrity.prev_hash == previous_hash {
+                // No prior repairs and chain is continuous — keep as-is.
+                previous_hash = Some(integrity.entry_hash.clone());
+                already_valid_events += 1;
+                let mut encoded = line.into_bytes();
+                encoded.push(b'\n');
+                repaired_lines.push(encoded);
+            } else {
+                // Prior legacy entries were repaired, so the chain position
+                // changed. Re-seal this entry with the rebuilt prev_hash.
+                let entry_hash =
+                    compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
+                let resealed =
+                    event_with_integrity(event, previous_hash.clone(), entry_hash.clone());
+                let encoded = serialize_audit_event_line(&resealed, path)?;
+                repaired_lines.push(encoded);
+                previous_hash = Some(entry_hash);
+                repaired_events += 1;
+            }
         } else {
             let entry_hash =
                 compute_audit_event_entry_hash(&event, previous_hash.as_deref(), path)?;
@@ -495,7 +508,7 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
     }
 
     let temp_path = path.with_extension("jsonl.repair-tmp");
-    {
+    let write_result = (|| {
         let mut temp_file = File::create(&temp_path).map_err(|error| {
             AuditError::Sink(format!(
                 "failed to create repair temp file `{}`: {error}",
@@ -516,14 +529,18 @@ pub fn repair_jsonl_audit_journal(path: &Path) -> Result<AuditRepairReport, Audi
                 temp_path.display()
             ))
         })?;
-    }
+        fs::rename(&temp_path, path).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to replace journal with repaired file `{}`: {error}",
+                path.display()
+            ))
+        })
+    })();
 
-    fs::rename(&temp_path, path).map_err(|error| {
-        AuditError::Sink(format!(
-            "failed to replace journal with repaired file `{}`: {error}",
-            path.display()
-        ))
-    })?;
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    write_result?;
 
     Ok(AuditRepairReport {
         total_events,

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -26,10 +26,10 @@ pub use architecture::{
     ArchitecturePathReport,
 };
 pub use audit::{
-    AuditEvent, AuditEventKind, AuditSink, AuditVerificationReport, ExecutionPlane,
-    FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink, NoopAuditSink, PlaneTier,
-    probe_jsonl_audit_journal_runtime_ready, repair_jsonl_audit_journal,
-    verify_jsonl_audit_journal, AuditRepairOutcome, AuditRepairReport,
+    AuditEvent, AuditEventKind, AuditRepairOutcome, AuditRepairReport, AuditSink,
+    AuditVerificationReport, ExecutionPlane, FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink,
+    NoopAuditSink, PlaneTier, probe_jsonl_audit_journal_runtime_ready, repair_jsonl_audit_journal,
+    verify_jsonl_audit_journal,
 };
 pub use awareness::{CodebaseAwarenessConfig, CodebaseAwarenessEngine, CodebaseAwarenessSnapshot};
 pub use bootstrap::{

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -28,7 +28,8 @@ pub use architecture::{
 pub use audit::{
     AuditEvent, AuditEventKind, AuditSink, AuditVerificationReport, ExecutionPlane,
     FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink, NoopAuditSink, PlaneTier,
-    probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal,
+    probe_jsonl_audit_journal_runtime_ready, repair_jsonl_audit_journal,
+    verify_jsonl_audit_journal, AuditRepairOutcome, AuditRepairReport,
 };
 pub use awareness::{CodebaseAwarenessConfig, CodebaseAwarenessEngine, CodebaseAwarenessSnapshot};
 pub use bootstrap::{

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -8,10 +8,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use proptest::prelude::*;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 use crate::audit::{
-    AuditEvent, AuditEventKind, AuditSink, FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink,
-    probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal,
+    AuditEvent, AuditEventKind, AuditRepairOutcome, AuditSink, FanoutAuditSink, InMemoryAuditSink,
+    JsonlAuditSink, probe_jsonl_audit_journal_runtime_ready, repair_jsonl_audit_journal,
+    verify_jsonl_audit_journal,
 };
 use crate::clock::FixedClock;
 use crate::contracts::{Capability, HarnessOutcome, TaskIntent};
@@ -49,6 +51,19 @@ fn sample_audit_event(event_id: &str, timestamp_epoch_s: u64) -> AuditEvent {
             required_capabilities: vec![Capability::InvokeTool],
         },
     }
+}
+
+fn compute_test_entry_hash(event: &AuditEvent, prev_hash: Option<&str>) -> String {
+    let material = serde_json::to_vec(&json!({
+        "event_id": event.event_id,
+        "timestamp_epoch_s": event.timestamp_epoch_s,
+        "agent_id": event.agent_id,
+        "kind": event.kind,
+        "prev_hash": prev_hash,
+    }))
+    .expect("serialize audit chain material");
+    let digest = Sha256::digest(material);
+    hex::encode(digest)
 }
 
 #[test]
@@ -144,6 +159,127 @@ fn verify_jsonl_audit_journal_accepts_legacy_prefix_before_protected_entries() {
     assert_eq!(report.total_events, 2);
     assert_eq!(report.verified_events, 1);
     assert!(report.last_entry_hash.is_some());
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn repair_jsonl_audit_journal_reports_healthy_for_valid_chain() {
+    let path = fresh_audit_temp_path("jsonl-repair-healthy");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-repair-healthy-1", 600))
+        .expect("first event should record");
+    sink.record(sample_audit_event("evt-repair-healthy-2", 601))
+        .expect("second event should record");
+
+    let original_contents = fs::read_to_string(&path).expect("read original journal");
+    let report = repair_jsonl_audit_journal(&path).expect("repair should succeed");
+    let repaired_contents = fs::read_to_string(&path).expect("read repaired journal");
+
+    assert_eq!(report.total_events, 2);
+    assert_eq!(report.repaired_events, 0);
+    assert_eq!(report.already_valid_events, 2);
+    assert_eq!(report.outcome, AuditRepairOutcome::Healthy);
+    assert_eq!(repaired_contents, original_contents);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn repair_jsonl_audit_journal_repairs_legacy_prefix_and_reseals_tail() {
+    let path = fresh_audit_temp_path("jsonl-repair-legacy-prefix");
+    let legacy_event = sample_audit_event("evt-repair-legacy-1", 700);
+    let legacy_line = serde_json::to_string(&legacy_event).expect("serialize legacy event");
+    let legacy_contents = format!("{legacy_line}\n");
+
+    fs::write(&path, legacy_contents).expect("write legacy journal");
+
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-repair-tail-1", 701))
+        .expect("protected event should record");
+
+    let report = repair_jsonl_audit_journal(&path).expect("repair should succeed");
+    let verify_report = verify_jsonl_audit_journal(&path).expect("verify repaired journal");
+
+    assert_eq!(report.total_events, 2);
+    assert_eq!(report.repaired_events, 2);
+    assert_eq!(report.already_valid_events, 0);
+    assert_eq!(report.outcome, AuditRepairOutcome::Repaired);
+    assert!(verify_report.valid);
+    assert_eq!(verify_report.verified_events, 2);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn repair_jsonl_audit_journal_refuses_tampered_entry_hash() {
+    let path = fresh_audit_temp_path("jsonl-repair-tamper");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-repair-tamper-1", 800))
+        .expect("first event should record");
+    sink.record(sample_audit_event("evt-repair-tamper-2", 801))
+        .expect("second event should record");
+
+    let original_contents = fs::read_to_string(&path).expect("read audit journal");
+    let tampered_contents =
+        original_contents.replacen("evt-repair-tamper-2", "evt-repair-tamper-x", 1);
+
+    fs::write(&path, &tampered_contents).expect("rewrite tampered audit journal");
+
+    let report = repair_jsonl_audit_journal(&path).expect("repair should report refusal");
+    let after_contents = fs::read_to_string(&path).expect("read journal after refusal");
+
+    assert_eq!(report.total_events, 2);
+    assert_eq!(report.repaired_events, 0);
+    assert_eq!(report.already_valid_events, 1);
+    assert_eq!(
+        report.outcome,
+        AuditRepairOutcome::Refused {
+            line: 2,
+            reason: "entry_hash mismatch — event data may be tampered".to_owned(),
+        }
+    );
+    assert_eq!(after_contents, tampered_contents);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn repair_jsonl_audit_journal_refuses_first_protected_row_with_prev_hash() {
+    let path = fresh_audit_temp_path("jsonl-repair-prev-hash");
+    let event = sample_audit_event("evt-repair-prev-hash-1", 900);
+    let prev_hash = "unexpected-prev-hash".to_owned();
+    let entry_hash = compute_test_entry_hash(&event, Some(&prev_hash));
+    let encoded = serde_json::to_string(&json!({
+        "event_id": event.event_id,
+        "timestamp_epoch_s": event.timestamp_epoch_s,
+        "agent_id": event.agent_id,
+        "kind": event.kind,
+        "integrity": {
+            "algorithm": "sha256",
+            "prev_hash": prev_hash,
+            "entry_hash": entry_hash,
+        },
+    }))
+    .expect("serialize protected audit event");
+
+    fs::write(&path, format!("{encoded}\n")).expect("write forged journal");
+
+    let report = repair_jsonl_audit_journal(&path).expect("repair should report refusal");
+
+    assert_eq!(report.total_events, 1);
+    assert_eq!(report.repaired_events, 0);
+    assert_eq!(report.already_valid_events, 0);
+    assert_eq!(
+        report.outcome,
+        AuditRepairOutcome::Refused {
+            line: 1,
+            reason: "prev_hash mismatch in source chain".to_owned(),
+        }
+    );
 
     let _ = fs::remove_file(path);
 }

--- a/docs/superpowers/specs/2026-04-07-audit-repair-command.md
+++ b/docs/superpowers/specs/2026-04-07-audit-repair-command.md
@@ -10,7 +10,8 @@
 |---|---|
 | missing integrity envelope | **Repair**: compute and inject SHA256 hash chain |
 | healthy (already has valid integrity) | **Skip**: report as already healthy |
-| prev_hash mismatch (after legacy prefix repair) | **Re-seal**: rebuild chain with new prev_hash |
+| valid protected tail after legacy prefix repair | **Re-seal**: rebuild chain with new prev_hash |
+| source prev_hash mismatch | **Refuse**: report chain corruption, do not reseal |
 | entry_hash vs event data mismatch | **Refuse**: report as tampered, do not reseal |
 
 Repair writes a new journal file (`.jsonl.repair-tmp`), then atomically renames. Original is never modified in-place. Temp file is cleaned up on rename failure. **Must be run while daemon is stopped** (running `JsonlAuditSink` holds stale file handle).

--- a/docs/superpowers/specs/2026-04-07-audit-repair-command.md
+++ b/docs/superpowers/specs/2026-04-07-audit-repair-command.md
@@ -1,0 +1,56 @@
+# Audit Repair Command
+
+**Goal:** Add `loongclaw audit repair` to rebuild integrity sidecars for legacy journals (#876).
+
+**Architecture:** New `Repair` variant in `AuditCommands` enum (daemon), new `repair_jsonl_audit_journal()` function (kernel). Mirrors existing `verify` pattern.
+
+## Repair Semantics
+
+| Verify finding | Repair action |
+|---|---|
+| missing integrity envelope | **Repair**: compute and inject SHA256 hash chain |
+| healthy (already has valid integrity) | **Skip**: report as already healthy |
+| prev_hash mismatch | **Refuse**: report as tampered, do not reseal |
+| entry_hash mismatch | **Refuse**: report as tampered, do not reseal |
+
+Repair writes a new journal file (`.repaired`), then atomically renames. Original is never modified in-place.
+
+## Result Type
+
+```rust
+pub struct AuditRepairReport {
+    pub total_events: usize,
+    pub repaired_events: usize,    // events that got new integrity envelopes
+    pub already_valid_events: usize, // events that already had valid integrity
+    pub outcome: AuditRepairOutcome,
+}
+
+pub enum AuditRepairOutcome {
+    Healthy,              // journal already fully valid, nothing to repair
+    Repaired,             // legacy events got integrity envelopes
+    Refused { line: usize, reason: String }, // tampered/mismatched, cannot repair
+}
+```
+
+## Files
+
+| File | Change |
+|---|---|
+| `crates/kernel/src/audit.rs` | Add `repair_jsonl_audit_journal()`, `AuditRepairReport`, `AuditRepairOutcome` |
+| `crates/daemon/src/audit_cli.rs` | Add `Repair` variant to `AuditCommands`, handler, JSON/text rendering |
+
+## Algorithm
+
+1. First run `verify`. If valid → return `Healthy`
+2. Read journal line by line, rebuild hash chain:
+   - Event has valid integrity → verify chain continuity, keep as-is
+   - Event missing integrity → compute entry_hash from event + prev_hash, inject integrity envelope
+   - Event has mismatched hash → return `Refused`
+3. Write repaired lines to temp file
+4. Atomic rename temp → original
+
+## Out of Scope
+
+- Background auto-repair
+- Journal rotation/pruning
+- Resealing tampered journals

--- a/docs/superpowers/specs/2026-04-07-audit-repair-command.md
+++ b/docs/superpowers/specs/2026-04-07-audit-repair-command.md
@@ -10,10 +10,10 @@
 |---|---|
 | missing integrity envelope | **Repair**: compute and inject SHA256 hash chain |
 | healthy (already has valid integrity) | **Skip**: report as already healthy |
-| prev_hash mismatch | **Refuse**: report as tampered, do not reseal |
-| entry_hash mismatch | **Refuse**: report as tampered, do not reseal |
+| prev_hash mismatch (after legacy prefix repair) | **Re-seal**: rebuild chain with new prev_hash |
+| entry_hash vs event data mismatch | **Refuse**: report as tampered, do not reseal |
 
-Repair writes a new journal file (`.repaired`), then atomically renames. Original is never modified in-place.
+Repair writes a new journal file (`.jsonl.repair-tmp`), then atomically renames. Original is never modified in-place. Temp file is cleaned up on rename failure. **Must be run while daemon is stopped** (running `JsonlAuditSink` holds stale file handle).
 
 ## Result Type
 
@@ -41,13 +41,15 @@ pub enum AuditRepairOutcome {
 
 ## Algorithm
 
-1. First run `verify`. If valid → return `Healthy`
-2. Read journal line by line, rebuild hash chain:
-   - Event has valid integrity → verify chain continuity, keep as-is
-   - Event missing integrity → compute entry_hash from event + prev_hash, inject integrity envelope
-   - Event has mismatched hash → return `Refused`
-3. Write repaired lines to temp file
+1. Read journal line by line, rebuild hash chain:
+   - Event missing integrity → compute entry_hash from event + prev_hash, inject envelope
+   - Event has integrity, chain matches, no prior repairs → keep as-is
+   - Event has integrity, prior entries were repaired → re-seal with rebuilt prev_hash
+   - Event entry_hash doesn't match its own event data → `Refused` (tampering)
+2. If no events were repaired → return `Healthy`
+3. Write repaired lines to `.jsonl.repair-tmp` temp file
 4. Atomic rename temp → original
+5. If rename fails, remove temp file and return error
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- **Problem**: Operators have no first-class way to repair legacy audit journals missing integrity sidecars
- **Solution**: Add `loongclaw audit repair` that rebuilds SHA256 hash chain envelopes for legacy entries, while refusing to reseal tampered journals
- **Constraint**: Must be run while daemon is stopped (offline-only)

## Linked Issues

- Closes #876

## Change Type

- [x] New feature

## Touched Areas

- [x] Kernel / audit
- [x] Daemon / CLI

## Details

### 4 files changed, +372/-6

**`crates/kernel/src/audit.rs`** (+219) — Core repair logic:
- `repair_jsonl_audit_journal(path)` → `AuditRepairReport`
- `AuditRepairOutcome` enum: `Healthy` / `Repaired` / `Refused { line, reason }`
- Dual-chain tracking: `source_previous_hash` validates original chain integrity, `rebuilt_previous_hash` builds repaired output
- Tampering detection: self-consistency check (entry_hash vs event data), source chain prev_hash validation
- Refuses: missing envelope after protected chain starts, source prev_hash mismatch, entry_hash tampering
- Atomic write via temp file (.jsonl.repair-tmp) → rename; cleanup on failure; preserves original file permissions

**`crates/kernel/src/lib.rs`** (+7/-6) — Re-export new types

**`crates/daemon/src/audit_cli.rs`** (+94) — CLI integration:
- `Repair` variant in `AuditCommands` enum
- Handler mirrors `Verify` pattern
- JSON and text output rendering

**`docs/superpowers/specs/2026-04-07-audit-repair-command.md`** (+58) — Design spec

### Repair Semantics

| Journal state | Action |
|---|---|
| Missing integrity envelope (legacy prefix) | Compute SHA256 hash chain, inject envelope |
| Missing envelope after protected chain started | **Refuse** (structural corruption) |
| Already has valid integrity, chain matches | Preserve as-is, report healthy |
| Protected tail after repaired prefix | Re-seal with rebuilt prev_hash |
| Source prev_hash mismatch (chain break) | **Refuse** (structural corruption) |
| entry_hash vs event data mismatch | **Refuse** (data tampering) |

### Test evidence

```
cargo test -p loongclaw-kernel --lib audit → 12 passed, 0 failed
cargo check -p loongclaw → ok (0 errors)
```

### CodeRabbit feedback addressed (2 rounds)

**Round 1:**
- [x] Don't short-circuit legacy journals via verify (Critical)
- [x] Re-seal protected tail after legacy prefix repair (Critical)
- [x] Document offline-only contract for running sink (Critical)
- [x] Temp file cleanup on rename failure (Major)
- [x] Fix spec temp file naming (Minor)
- [ ] CLI regression tests (deferred — kernel logic is the critical path)

**Round 2:**
- [x] Separate source-chain validation from rebuilt-chain state (Critical)
- [x] Preserve original journal file permissions on temp file (Major)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `audit repair` subcommand to rebuild and validate audit journal integrity. The command scans the JSONL audit journal, reconstructs missing integrity envelopes, validates hash chains and event consistency, atomically applies repairs, and reports total events processed, repaired entries, and already-valid entries.

* **Documentation**
  * Added specification for the audit repair command workflow and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->