### PR TITLE
feat(provider): add GitHub Copilot as LLM provider

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -459,6 +459,7 @@ mod tests {
                 "deepseek",
                 "fireworks",
                 "gemini",
+                "github-copilot",
                 "groq",
                 "kimi",
                 "kimi_coding",

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -79,6 +79,7 @@ pub use memory::{
 };
 #[allow(unused_imports)]
 pub use outbound_http::OutboundHttpConfig;
+pub(crate) use provider::{GITHUB_COPILOT_DEFAULT_HEADERS, GITHUB_COPILOT_USER_AGENT};
 #[allow(unused_imports)]
 pub use provider::{
     ModelCatalogProbeRecovery, PROVIDER_DESCRIPTOR_SCHEMA_VERSION, ProviderAuthScheme,

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -11,6 +11,20 @@ use crate::secrets::{
     SecretLookup, has_configured_secret_ref, resolve_secret_lookup, secret_ref_env_name,
 };
 
+pub(crate) const GITHUB_COPILOT_EDITOR_VERSION: &str = "vscode/1.85.1";
+pub(crate) const GITHUB_COPILOT_EDITOR_PLUGIN_VERSION: &str = "copilot/1.155.0";
+pub(crate) const GITHUB_COPILOT_INTEGRATION_ID: &str = "vscode-chat";
+pub(crate) const GITHUB_COPILOT_USER_AGENT: &str = "GithubCopilot/1.155.0";
+pub(crate) const GITHUB_COPILOT_OAUTH_TOKEN_ENV: &str = "GITHUB_COPILOT_OAUTH_TOKEN";
+pub(crate) const GITHUB_COPILOT_DEFAULT_HEADERS: [(&str, &str); 3] = [
+    ("Editor-Version", GITHUB_COPILOT_EDITOR_VERSION),
+    (
+        "Editor-Plugin-Version",
+        GITHUB_COPILOT_EDITOR_PLUGIN_VERSION,
+    ),
+    ("Copilot-Integration-Id", GITHUB_COPILOT_INTEGRATION_ID),
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderProfile {
     pub kind: ProviderKind,
@@ -617,7 +631,7 @@ pub enum ProviderKind {
     KimiCoding,
     #[serde(alias = "groq_compatible")]
     Groq,
-    #[serde(alias = "github_copilot", alias = "github-copilot", alias = "copilot")]
+    #[serde(rename = "github-copilot", alias = "github_copilot", alias = "copilot")]
     GithubCopilot,
     #[serde(alias = "fireworks_compatible", alias = "fireworks-ai")]
     Fireworks,
@@ -3281,15 +3295,11 @@ const PROVIDER_PROFILES: [ProviderProfile; 43] = [
         models_path: None,
         protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
         auth_scheme: ProviderAuthScheme::Bearer,
-        default_headers: &[
-            ("Editor-Version", "vscode/1.85.1"),
-            ("Editor-Plugin-Version", "copilot/1.155.0"),
-            ("Copilot-Integration-Id", "vscode-chat"),
-        ],
+        default_headers: &GITHUB_COPILOT_DEFAULT_HEADERS,
         default_api_key_env: None,
         api_key_env_aliases: &[],
-        default_user_agent: Some("GithubCopilot/1.155.0"),
-        default_oauth_access_token_env: None,
+        default_user_agent: Some(GITHUB_COPILOT_USER_AGENT),
+        default_oauth_access_token_env: Some(GITHUB_COPILOT_OAUTH_TOKEN_ENV),
         oauth_access_token_env_aliases: &[],
         feature_family: ProviderFeatureFamily::OpenAiCompatible,
     },
@@ -4273,6 +4283,14 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn provider_kind_serializes_github_copilot_using_canonical_hyphenated_id() {
+        let raw = serde_json::to_string(&ProviderKind::GithubCopilot)
+            .expect("provider kind should serialize");
+
+        assert_eq!(raw, "\"github-copilot\"");
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -617,6 +617,8 @@ pub enum ProviderKind {
     KimiCoding,
     #[serde(alias = "groq_compatible")]
     Groq,
+    #[serde(alias = "github_copilot", alias = "github-copilot", alias = "copilot")]
+    GithubCopilot,
     #[serde(alias = "fireworks_compatible", alias = "fireworks-ai")]
     Fireworks,
     #[serde(alias = "mistral_compatible")]
@@ -2540,6 +2542,7 @@ impl ProviderKind {
             ProviderKind::Deepseek => "DeepSeek",
             ProviderKind::Fireworks => "Fireworks",
             ProviderKind::Gemini => "Gemini",
+            ProviderKind::GithubCopilot => "GitHub Copilot",
             ProviderKind::Groq => "Groq",
             ProviderKind::Kimi => "Kimi",
             ProviderKind::KimiCoding => "Kimi Coding",
@@ -2592,6 +2595,7 @@ impl ProviderKind {
             deepseek,
             fireworks,
             gemini,
+            github_copilot,
             groq,
             kimi,
             kimi_coding,
@@ -2637,6 +2641,7 @@ impl ProviderKind {
             ProviderKind::Deepseek => deepseek,
             ProviderKind::Fireworks => fireworks,
             ProviderKind::Gemini => gemini,
+            ProviderKind::GithubCopilot => github_copilot,
             ProviderKind::Groq => groq,
             ProviderKind::Kimi => kimi,
             ProviderKind::KimiCoding => kimi_coding,
@@ -2844,6 +2849,7 @@ impl ProviderKind {
             | ProviderKind::Fireworks
             | ProviderKind::Gemini
             | ProviderKind::Groq
+            | ProviderKind::GithubCopilot
             | ProviderKind::KimiCoding
             | ProviderKind::Llamacpp
             | ProviderKind::LmStudio
@@ -3005,7 +3011,7 @@ pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
     None
 }
 
-const PROVIDER_KIND_ORDER: [ProviderKind; 42] = [
+const PROVIDER_KIND_ORDER: [ProviderKind; 43] = [
     ProviderKind::Anthropic,
     ProviderKind::BailianCoding,
     ProviderKind::Bedrock,
@@ -3018,6 +3024,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 42] = [
     ProviderKind::Deepseek,
     ProviderKind::Fireworks,
     ProviderKind::Gemini,
+    ProviderKind::GithubCopilot,
     ProviderKind::Groq,
     ProviderKind::Kimi,
     ProviderKind::KimiCoding,
@@ -3050,7 +3057,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 42] = [
     ProviderKind::Zhipu,
 ];
 
-const PROVIDER_PROFILES: [ProviderProfile; 42] = [
+const PROVIDER_PROFILES: [ProviderProfile; 43] = [
     ProviderProfile {
         kind: ProviderKind::Anthropic,
         id: "anthropic",
@@ -3261,6 +3268,27 @@ const PROVIDER_PROFILES: [ProviderProfile; 42] = [
         default_api_key_env: Some("GEMINI_API_KEY"),
         api_key_env_aliases: &["GOOGLE_API_KEY"],
         default_user_agent: None,
+        default_oauth_access_token_env: None,
+        oauth_access_token_env_aliases: &[],
+        feature_family: ProviderFeatureFamily::OpenAiCompatible,
+    },
+    ProviderProfile {
+        kind: ProviderKind::GithubCopilot,
+        id: "github-copilot",
+        aliases: &["github_copilot", "copilot"],
+        base_url: "https://api.githubcopilot.com",
+        chat_completions_path: "/chat/completions",
+        models_path: None,
+        protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
+        auth_scheme: ProviderAuthScheme::Bearer,
+        default_headers: &[
+            ("Editor-Version", "vscode/1.85.1"),
+            ("Editor-Plugin-Version", "copilot/1.155.0"),
+            ("Copilot-Integration-Id", "vscode-chat"),
+        ],
+        default_api_key_env: None,
+        api_key_env_aliases: &[],
+        default_user_agent: Some("GithubCopilot/1.155.0"),
         default_oauth_access_token_env: None,
         oauth_access_token_env_aliases: &[],
         feature_family: ProviderFeatureFamily::OpenAiCompatible,

--- a/crates/app/src/provider/auth_profile_runtime.rs
+++ b/crates/app/src/provider/auth_profile_runtime.rs
@@ -20,7 +20,11 @@ pub(super) fn resolve_provider_auth_profiles(
 
     match provider.kind.auth_scheme() {
         ProviderAuthScheme::Bearer => {
-            if let Some(token) = provider.oauth_access_token() {
+            if provider.kind == ProviderKind::GithubCopilot {
+                if let Some(api_key) = super::copilot_auth::cached_copilot_api_key() {
+                    push_bearer_profile(&mut profiles, &mut seen, "copilot", &api_key);
+                }
+            } else if let Some(token) = provider.oauth_access_token() {
                 push_bearer_profile(&mut profiles, &mut seen, "oauth", token.as_str());
             }
 
@@ -160,6 +164,36 @@ mod tests {
         assert_eq!(profiles[0].authorization_header, None);
         assert_eq!(profiles[0].x_api_key_header, None);
         assert_eq!(profiles[0].auth_cache_key, None);
+    }
+
+    #[test]
+    fn resolve_provider_auth_profiles_uses_copilot_cache_for_github_copilot() {
+        let _guard = super::super::copilot_auth::acquire_cache_test_lock();
+
+        super::super::copilot_auth::set_cached_key_for_test(
+            "test-copilot-api-key",
+            super::super::copilot_auth::now_unix_for_test() + 3600,
+        );
+
+        let provider = ProviderConfig {
+            kind: ProviderKind::GithubCopilot,
+            api_key: None,
+            api_key_env: None,
+            oauth_access_token: Some(loongclaw_contracts::SecretRef::Inline(
+                "github-oauth-token-should-not-be-used".to_owned(),
+            )),
+            oauth_access_token_env: None,
+            ..ProviderConfig::default()
+        };
+
+        let profiles = resolve_provider_auth_profiles(&provider);
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(
+            profiles[0].authorization_header.as_deref(),
+            Some("Bearer test-copilot-api-key")
+        );
+
+        super::super::copilot_auth::clear_cache_for_test();
     }
 
     #[test]

--- a/crates/app/src/provider/auth_profile_runtime.rs
+++ b/crates/app/src/provider/auth_profile_runtime.rs
@@ -21,7 +21,9 @@ pub(super) fn resolve_provider_auth_profiles(
     match provider.kind.auth_scheme() {
         ProviderAuthScheme::Bearer => {
             if provider.kind == ProviderKind::GithubCopilot {
-                if let Some(api_key) = super::copilot_auth::cached_copilot_api_key() {
+                if let Some(api_key) =
+                    super::copilot_auth::cached_provider_copilot_api_key(provider)
+                {
                     push_bearer_profile(&mut profiles, &mut seen, "copilot", &api_key);
                 }
             } else if let Some(token) = provider.oauth_access_token() {
@@ -170,7 +172,8 @@ mod tests {
     fn resolve_provider_auth_profiles_uses_copilot_cache_for_github_copilot() {
         let _guard = super::super::copilot_auth::acquire_cache_test_lock();
 
-        super::super::copilot_auth::set_cached_key_for_test(
+        super::super::copilot_auth::set_cached_key_for_auth_source_for_test(
+            "github-oauth-token-should-not-be-used",
             "test-copilot-api-key",
             super::super::copilot_auth::now_unix_for_test() + 3600,
         );
@@ -192,6 +195,36 @@ mod tests {
             profiles[0].authorization_header.as_deref(),
             Some("Bearer test-copilot-api-key")
         );
+
+        super::super::copilot_auth::clear_cache_for_test();
+    }
+
+    #[test]
+    fn resolve_provider_auth_profiles_isolates_copilot_cache_by_oauth_token() {
+        let _guard = super::super::copilot_auth::acquire_cache_test_lock();
+
+        super::super::copilot_auth::set_cached_key_for_auth_source_for_test(
+            "github-oauth-token-a",
+            "test-copilot-api-key-a",
+            super::super::copilot_auth::now_unix_for_test() + 3600,
+        );
+
+        let provider = ProviderConfig {
+            kind: ProviderKind::GithubCopilot,
+            api_key: None,
+            api_key_env: None,
+            oauth_access_token: Some(loongclaw_contracts::SecretRef::Inline(
+                "github-oauth-token-b".to_owned(),
+            )),
+            oauth_access_token_env: None,
+            ..ProviderConfig::default()
+        };
+
+        let profiles = resolve_provider_auth_profiles(&provider);
+
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].id, "anonymous");
+        assert_eq!(profiles[0].authorization_header, None);
 
         super::super::copilot_auth::clear_cache_for_test();
     }

--- a/crates/app/src/provider/catalog_query_runtime.rs
+++ b/crates/app/src/provider/catalog_query_runtime.rs
@@ -18,6 +18,7 @@ pub(super) async fn fetch_available_models_with_profiles(
 ) -> CliResult<Vec<String>> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
+    super::copilot_auth::ensure_provider_copilot_api_key(&config.provider).await?;
     validate_provider_auth_readiness(config).await?;
     let auth_context = super::transport::resolve_request_auth_context(&config.provider).await?;
     let headers = super::transport::build_request_headers_without_provider_auth(&config.provider)?;

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -21,6 +21,10 @@ const EDITOR_HEADERS: [(&str, &str); 3] = [
     ("User-Agent", "GithubCopilot/1.155.0"),
 ];
 
+const GITHUB_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const GITHUB_DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+
 static COPILOT_API_KEY_CACHE: LazyLock<Mutex<Option<CachedApiKey>>> =
     LazyLock::new(|| Mutex::new(None));
 
@@ -66,6 +70,22 @@ struct CopilotTokenResponse {
     expires_at: i64,
 }
 
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    interval: u64,
+    #[allow(dead_code)]
+    expires_in: u64,
+}
+
+#[derive(Deserialize)]
+struct TokenPollResponse {
+    access_token: Option<String>,
+    error: Option<String>,
+}
+
 async fn exchange_for_copilot_api_key(github_token: &str) -> CliResult<CachedApiKey> {
     let client = reqwest::Client::new();
     let mut request = client
@@ -106,6 +126,77 @@ async fn exchange_for_copilot_api_key(github_token: &str) -> CliResult<CachedApi
 fn clear_cache() {
     if let Ok(mut cache) = COPILOT_API_KEY_CACHE.lock() {
         *cache = None;
+    }
+}
+
+/// Runs the OAuth Device Code Flow to obtain a GitHub OAuth token.
+pub async fn device_code_login() -> CliResult<String> {
+    let client = reqwest::Client::new();
+    let code_response: DeviceCodeResponse = client
+        .post(GITHUB_DEVICE_CODE_URL)
+        .header("Accept", "application/json")
+        .form(&[("client_id", GITHUB_CLIENT_ID), ("scope", "read:user")])
+        .send()
+        .await
+        .map_err(|e| format!("Failed to request device code: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse device code response: {e}"))?;
+
+    tracing::warn!(
+        "Open {} and enter code: {}",
+        code_response.verification_uri,
+        code_response.user_code
+    );
+    eprintln!(
+        "\n  Open {} in your browser\n  Enter code: {}\n",
+        code_response.verification_uri, code_response.user_code
+    );
+
+    let mut interval = std::time::Duration::from_secs(code_response.interval.max(5));
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(code_response.expires_in);
+
+    loop {
+        tokio::time::sleep(interval).await;
+        if std::time::Instant::now() > deadline {
+            return Err("Authorization timed out. Please try again.".to_owned());
+        }
+        let response: TokenPollResponse = client
+            .post(GITHUB_TOKEN_URL)
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", GITHUB_CLIENT_ID),
+                ("device_code", code_response.device_code.as_str()),
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                ),
+            ])
+            .send()
+            .await
+            .map_err(|e| format!("Token poll failed: {e}"))?
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse token poll response: {e}"))?;
+
+        if let Some(token) = response.access_token {
+            return Ok(token);
+        }
+        match response.error.as_deref() {
+            Some("authorization_pending") => continue,
+            Some("slow_down") => interval += std::time::Duration::from_secs(5),
+            Some("expired_token") => {
+                return Err("Authorization timed out. Please try again.".to_owned());
+            }
+            Some("access_denied") => {
+                return Err("Authorization denied.".to_owned());
+            }
+            Some(other) => {
+                return Err(format!("Unexpected error during authorization: {other}"));
+            }
+            None => continue,
+        }
     }
 }
 
@@ -203,5 +294,35 @@ mod tests {
         let parsed: CopilotTokenResponse = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.token, "tid=abc;exp=123");
         assert_eq!(parsed.expires_at, 1700000000);
+    }
+
+    #[test]
+    fn device_code_response_deserializes() {
+        let json = r#"{
+            "device_code": "abc123",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://github.com/login/device",
+            "interval": 5,
+            "expires_in": 900
+        }"#;
+        let parsed: DeviceCodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.user_code, "ABCD-1234");
+        assert_eq!(parsed.interval, 5);
+    }
+
+    #[test]
+    fn token_poll_response_deserializes_success() {
+        let json = r#"{"access_token":"ghu_xxxx","token_type":"bearer","scope":"read:user"}"#;
+        let parsed: TokenPollResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.access_token.as_deref(), Some("ghu_xxxx"));
+        assert_eq!(parsed.error, None);
+    }
+
+    #[test]
+    fn token_poll_response_deserializes_pending() {
+        let json = r#"{"error":"authorization_pending"}"#;
+        let parsed: TokenPollResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.access_token, None);
+        assert_eq!(parsed.error.as_deref(), Some("authorization_pending"));
     }
 }

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -5,28 +5,29 @@
 //! LiteLLM, Codex CLI, and other third-party integrations. The endpoint is
 //! private and undocumented — GitHub could change or revoke access at any time.
 
+use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use reqwest::header::USER_AGENT;
 use serde::Deserialize;
 
 use crate::CliResult;
+use crate::config::{
+    GITHUB_COPILOT_DEFAULT_HEADERS, GITHUB_COPILOT_USER_AGENT, ProviderConfig, ProviderKind,
+};
 
 const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
 const TOKEN_REFRESH_BUFFER_SECS: i64 = 120;
-
-const EDITOR_HEADERS: [(&str, &str); 3] = [
-    ("Editor-Version", "vscode/1.85.1"),
-    ("Editor-Plugin-Version", "copilot/1.155.0"),
-    ("User-Agent", "GithubCopilot/1.155.0"),
-];
+const AUTH_CLIENT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const AUTH_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 const GITHUB_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
 const GITHUB_DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
 const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 
-static COPILOT_API_KEY_CACHE: LazyLock<Mutex<Option<CachedApiKey>>> =
-    LazyLock::new(|| Mutex::new(None));
+static COPILOT_API_KEY_CACHE: LazyLock<Mutex<HashMap<String, CachedApiKey>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 struct CachedApiKey {
     token: String,
@@ -40,10 +41,11 @@ fn now_unix() -> i64 {
         .as_secs() as i64
 }
 
-/// Returns a cached Copilot API key if one exists and has not expired.
-pub(crate) fn cached_copilot_api_key() -> Option<String> {
+/// Returns a cached Copilot API key for the current GitHub auth token when one
+/// exists and has not expired.
+pub(crate) fn cached_copilot_api_key(github_token: &str) -> Option<String> {
     let cache = COPILOT_API_KEY_CACHE.lock().ok()?;
-    let key = cache.as_ref()?;
+    let key = cache.get(github_token)?;
     if key.expires_at > now_unix() + TOKEN_REFRESH_BUFFER_SECS {
         Some(key.token.clone())
     } else {
@@ -51,16 +53,37 @@ pub(crate) fn cached_copilot_api_key() -> Option<String> {
     }
 }
 
-/// Ensures a valid Copilot API key is in the static cache.
-pub(crate) async fn ensure_copilot_api_key(github_token: &str) -> CliResult<()> {
-    if cached_copilot_api_key().is_some() {
+pub(crate) fn cached_provider_copilot_api_key(provider: &ProviderConfig) -> Option<String> {
+    let github_token = provider.oauth_access_token()?;
+
+    cached_copilot_api_key(github_token.as_str())
+}
+
+pub(crate) async fn ensure_provider_copilot_api_key(provider: &ProviderConfig) -> CliResult<()> {
+    if provider.kind != ProviderKind::GithubCopilot {
         return Ok(());
     }
+
+    let github_token = provider
+        .oauth_access_token()
+        .ok_or_else(missing_copilot_oauth_token_message)?;
+
+    ensure_copilot_api_key(github_token.as_str()).await
+}
+
+/// Ensures a valid Copilot API key is in the static cache.
+pub(crate) async fn ensure_copilot_api_key(github_token: &str) -> CliResult<()> {
+    if cached_copilot_api_key(github_token).is_some() {
+        return Ok(());
+    }
+
     let api_key = exchange_for_copilot_api_key(github_token).await?;
     let mut cache = COPILOT_API_KEY_CACHE
         .lock()
         .map_err(|e| format!("copilot cache lock poisoned: {e}"))?;
-    *cache = Some(api_key);
+    let cache_key = github_token.to_owned();
+    cache.insert(cache_key, api_key);
+
     Ok(())
 }
 
@@ -87,26 +110,22 @@ struct TokenPollResponse {
 }
 
 async fn exchange_for_copilot_api_key(github_token: &str) -> CliResult<CachedApiKey> {
-    let client = reqwest::Client::new();
-    let mut request = client
+    let client = build_auth_client()?;
+    let request = client
         .get(COPILOT_TOKEN_URL)
         .header("Authorization", format!("token {github_token}"))
         .header("Accept", "application/json");
-    for (key, value) in &EDITOR_HEADERS {
-        request = request.header(*key, *value);
-    }
+    let request = apply_copilot_auth_headers(request);
     let response = request
         .send()
         .await
         .map_err(|e| format!("Copilot token exchange failed: {e}"))?;
     let status = response.status();
     if status.as_u16() == 401 || status.as_u16() == 403 {
-        clear_cache();
-        return Err(
-            "GitHub token expired or Copilot subscription inactive. \
+        clear_cached_copilot_api_key(github_token);
+        return Err("GitHub token expired or Copilot subscription inactive. \
              Run `loong onboard` to re-authenticate."
-                .to_owned(),
-        );
+            .to_owned());
     }
     if !status.is_success() {
         return Err(format!(
@@ -123,15 +142,44 @@ async fn exchange_for_copilot_api_key(github_token: &str) -> CliResult<CachedApi
     })
 }
 
+fn build_auth_client() -> CliResult<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(AUTH_CLIENT_CONNECT_TIMEOUT)
+        .timeout(AUTH_CLIENT_TIMEOUT)
+        .build()
+        .map_err(|error| format!("Failed to build GitHub Copilot auth client: {error}"))
+}
+
+fn apply_copilot_auth_headers(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    let mut request = request.header(USER_AGENT, GITHUB_COPILOT_USER_AGENT);
+
+    for (key, value) in GITHUB_COPILOT_DEFAULT_HEADERS {
+        request = request.header(key, value);
+    }
+
+    request
+}
+
+fn missing_copilot_oauth_token_message() -> String {
+    "GitHub Copilot requires authentication. Run `loong onboard` to set up.".to_owned()
+}
+
+fn clear_cached_copilot_api_key(github_token: &str) {
+    if let Ok(mut cache) = COPILOT_API_KEY_CACHE.lock() {
+        cache.remove(github_token);
+    }
+}
+
+#[cfg(test)]
 fn clear_cache() {
     if let Ok(mut cache) = COPILOT_API_KEY_CACHE.lock() {
-        *cache = None;
+        cache.clear();
     }
 }
 
 /// Runs the OAuth Device Code Flow to obtain a GitHub OAuth token.
 pub async fn device_code_login() -> CliResult<String> {
-    let client = reqwest::Client::new();
+    let client = build_auth_client()?;
     let code_response: DeviceCodeResponse = client
         .post(GITHUB_DEVICE_CODE_URL)
         .header("Accept", "application/json")
@@ -163,10 +211,7 @@ pub async fn device_code_login() -> CliResult<String> {
             .form(&[
                 ("client_id", GITHUB_CLIENT_ID),
                 ("device_code", code_response.device_code.as_str()),
-                (
-                    "grant_type",
-                    "urn:ietf:params:oauth:grant-type:device_code",
-                ),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
             ])
             .send()
             .await
@@ -198,11 +243,24 @@ pub async fn device_code_login() -> CliResult<String> {
 #[cfg(test)]
 #[allow(dead_code)] // Used by auth_profile_runtime tests.
 pub(crate) fn set_cached_key_for_test(token: &str, expires_at: i64) {
+    set_cached_key_for_auth_source_for_test("test-github-token", token, expires_at);
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // Used by auth_profile_runtime tests.
+pub(crate) fn set_cached_key_for_auth_source_for_test(
+    github_token: &str,
+    token: &str,
+    expires_at: i64,
+) {
     let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
-    *cache = Some(CachedApiKey {
+    let cache_key = github_token.to_owned();
+    let cached_key = CachedApiKey {
         token: token.to_owned(),
         expires_at,
-    });
+    };
+
+    cache.insert(cache_key, cached_key);
 }
 
 #[cfg(test)]
@@ -237,7 +295,10 @@ mod tests {
     fn cached_copilot_api_key_returns_none_when_empty() {
         let _guard = acquire_cache_test_lock();
         clear_cache();
-        assert_eq!(cached_copilot_api_key(), None);
+
+        let result = cached_copilot_api_key("missing-github-token");
+
+        assert_eq!(result, None);
     }
 
     #[test]
@@ -246,48 +307,81 @@ mod tests {
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
-        *cache = Some(CachedApiKey {
+        let cache_key = "github-token-a".to_owned();
+        let cached_key = CachedApiKey {
             token: "test-copilot-key".to_owned(),
             expires_at: now_unix() + 3600,
-        });
+        };
+
+        cache.insert(cache_key, cached_key);
         drop(cache);
 
-        let result = cached_copilot_api_key();
+        let result = cached_copilot_api_key("github-token-a");
+
         assert_eq!(result, Some("test-copilot-key".to_owned()));
         clear_cache();
     }
 
     #[test]
-    fn cache_miss_when_token_within_refresh_buffer() {
+    fn cache_is_scoped_to_the_current_github_token() {
+        let _guard = acquire_cache_test_lock();
+        clear_cache();
+
+        set_cached_key_for_auth_source_for_test(
+            "github-token-a",
+            "scoped-copilot-key",
+            now_unix() + 3600,
+        );
+
+        let missing_result = cached_copilot_api_key("github-token-b");
+        let hit_result = cached_copilot_api_key("github-token-a");
+
+        assert_eq!(missing_result, None);
+        assert_eq!(hit_result, Some("scoped-copilot-key".to_owned()));
+        clear_cache();
+    }
+
+    #[test]
+    fn cache_miss_when_token_is_within_refresh_buffer() {
         let _guard = acquire_cache_test_lock();
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
-        *cache = Some(CachedApiKey {
+        let cache_key = "github-token-a".to_owned();
+        let cached_key = CachedApiKey {
             token: "about-to-expire".to_owned(),
             expires_at: now_unix() + 60,
-        });
+        };
+
+        cache.insert(cache_key, cached_key);
         drop(cache);
 
-        let result = cached_copilot_api_key();
+        let result = cached_copilot_api_key("github-token-a");
+
         assert_eq!(result, None);
         clear_cache();
     }
 
     #[test]
-    fn clear_cache_removes_stored_key() {
+    fn clear_cache_removes_stored_key_for_the_current_github_token() {
         let _guard = acquire_cache_test_lock();
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
-        *cache = Some(CachedApiKey {
+        let cache_key = "github-token-a".to_owned();
+        let cached_key = CachedApiKey {
             token: "will-be-cleared".to_owned(),
             expires_at: now_unix() + 3600,
-        });
+        };
+
+        cache.insert(cache_key, cached_key);
         drop(cache);
 
-        clear_cache();
-        assert_eq!(cached_copilot_api_key(), None);
+        clear_cached_copilot_api_key("github-token-a");
+
+        let result = cached_copilot_api_key("github-token-a");
+
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -41,7 +41,7 @@ fn now_unix() -> i64 {
 }
 
 /// Returns a cached Copilot API key if one exists and has not expired.
-pub fn cached_copilot_api_key() -> Option<String> {
+pub(crate) fn cached_copilot_api_key() -> Option<String> {
     let cache = COPILOT_API_KEY_CACHE.lock().ok()?;
     let key = cache.as_ref()?;
     if key.expires_at > now_unix() + TOKEN_REFRESH_BUFFER_SECS {
@@ -52,7 +52,7 @@ pub fn cached_copilot_api_key() -> Option<String> {
 }
 
 /// Ensures a valid Copilot API key is in the static cache.
-pub async fn ensure_copilot_api_key(github_token: &str) -> CliResult<()> {
+pub(crate) async fn ensure_copilot_api_key(github_token: &str) -> CliResult<()> {
     if cached_copilot_api_key().is_some() {
         return Ok(());
     }
@@ -196,7 +196,7 @@ pub async fn device_code_login() -> CliResult<String> {
 }
 
 #[cfg(test)]
-#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+#[allow(dead_code)] // Used by auth_profile_runtime tests.
 pub(crate) fn set_cached_key_for_test(token: &str, expires_at: i64) {
     let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
     *cache = Some(CachedApiKey {
@@ -206,13 +206,13 @@ pub(crate) fn set_cached_key_for_test(token: &str, expires_at: i64) {
 }
 
 #[cfg(test)]
-#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+#[allow(dead_code)] // Used by auth_profile_runtime tests.
 pub(crate) fn clear_cache_for_test() {
     clear_cache();
 }
 
 #[cfg(test)]
-#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+#[allow(dead_code)] // Used by auth_profile_runtime tests.
 pub(crate) fn now_unix_for_test() -> i64 {
     now_unix()
 }

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -1,0 +1,207 @@
+//! GitHub Copilot provider authentication.
+//!
+//! Uses VS Code's OAuth client ID (`Iv1.b507a08c87ecfe98`) and editor headers
+//! for the Copilot token endpoint. This is the same approach used by ZeroClaw,
+//! LiteLLM, Codex CLI, and other third-party integrations. The endpoint is
+//! private and undocumented — GitHub could change or revoke access at any time.
+
+use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+use crate::CliResult;
+
+const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
+const TOKEN_REFRESH_BUFFER_SECS: i64 = 120;
+
+const EDITOR_HEADERS: [(&str, &str); 3] = [
+    ("Editor-Version", "vscode/1.85.1"),
+    ("Editor-Plugin-Version", "copilot/1.155.0"),
+    ("User-Agent", "GithubCopilot/1.155.0"),
+];
+
+static COPILOT_API_KEY_CACHE: LazyLock<Mutex<Option<CachedApiKey>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+struct CachedApiKey {
+    token: String,
+    expires_at: i64,
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Returns a cached Copilot API key if one exists and has not expired.
+pub fn cached_copilot_api_key() -> Option<String> {
+    let cache = COPILOT_API_KEY_CACHE.lock().ok()?;
+    let key = cache.as_ref()?;
+    if key.expires_at > now_unix() + TOKEN_REFRESH_BUFFER_SECS {
+        Some(key.token.clone())
+    } else {
+        None
+    }
+}
+
+/// Ensures a valid Copilot API key is in the static cache.
+pub async fn ensure_copilot_api_key(github_token: &str) -> CliResult<()> {
+    if cached_copilot_api_key().is_some() {
+        return Ok(());
+    }
+    let api_key = exchange_for_copilot_api_key(github_token).await?;
+    let mut cache = COPILOT_API_KEY_CACHE
+        .lock()
+        .map_err(|e| format!("copilot cache lock poisoned: {e}"))?;
+    *cache = Some(api_key);
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct CopilotTokenResponse {
+    token: String,
+    expires_at: i64,
+}
+
+async fn exchange_for_copilot_api_key(github_token: &str) -> CliResult<CachedApiKey> {
+    let client = reqwest::Client::new();
+    let mut request = client
+        .get(COPILOT_TOKEN_URL)
+        .header("Authorization", format!("token {github_token}"))
+        .header("Accept", "application/json");
+    for (key, value) in &EDITOR_HEADERS {
+        request = request.header(*key, *value);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("Copilot token exchange failed: {e}"))?;
+    let status = response.status();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        clear_cache();
+        return Err(
+            "GitHub token expired or Copilot subscription inactive. \
+             Run `loong onboard` to re-authenticate."
+                .to_owned(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!(
+            "Copilot token exchange failed with status {status}"
+        ));
+    }
+    let body: CopilotTokenResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Copilot token response: {e}"))?;
+    Ok(CachedApiKey {
+        token: body.token,
+        expires_at: body.expires_at,
+    })
+}
+
+fn clear_cache() {
+    if let Ok(mut cache) = COPILOT_API_KEY_CACHE.lock() {
+        *cache = None;
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+pub(crate) fn set_cached_key_for_test(token: &str, expires_at: i64) {
+    let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
+    *cache = Some(CachedApiKey {
+        token: token.to_owned(),
+        expires_at,
+    });
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+pub(crate) fn clear_cache_for_test() {
+    clear_cache();
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // Used by auth_profile_runtime tests (Task 4).
+pub(crate) fn now_unix_for_test() -> i64 {
+    now_unix()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Serializes tests that mutate the global `COPILOT_API_KEY_CACHE`.
+    static CACHE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn cached_copilot_api_key_returns_none_when_empty() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        clear_cache();
+        assert_eq!(cached_copilot_api_key(), None);
+    }
+
+    #[test]
+    fn cache_hit_returns_token_when_not_expired() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        clear_cache();
+
+        let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
+        *cache = Some(CachedApiKey {
+            token: "test-copilot-key".to_owned(),
+            expires_at: now_unix() + 3600,
+        });
+        drop(cache);
+
+        let result = cached_copilot_api_key();
+        assert_eq!(result, Some("test-copilot-key".to_owned()));
+        clear_cache();
+    }
+
+    #[test]
+    fn cache_miss_when_token_within_refresh_buffer() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        clear_cache();
+
+        let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
+        *cache = Some(CachedApiKey {
+            token: "about-to-expire".to_owned(),
+            expires_at: now_unix() + 60,
+        });
+        drop(cache);
+
+        let result = cached_copilot_api_key();
+        assert_eq!(result, None);
+        clear_cache();
+    }
+
+    #[test]
+    fn clear_cache_removes_stored_key() {
+        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        clear_cache();
+
+        let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
+        *cache = Some(CachedApiKey {
+            token: "will-be-cleared".to_owned(),
+            expires_at: now_unix() + 3600,
+        });
+        drop(cache);
+
+        clear_cache();
+        assert_eq!(cached_copilot_api_key(), None);
+    }
+
+    #[test]
+    fn copilot_token_response_deserializes() {
+        let json = r#"{"token":"tid=abc;exp=123","expires_at":1700000000}"#;
+        let parsed: CopilotTokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.token, "tid=abc;exp=123");
+        assert_eq!(parsed.expires_at, 1700000000);
+    }
+}

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -148,11 +148,6 @@ pub async fn device_code_login() -> CliResult<String> {
         code_response.verification_uri,
         code_response.user_code
     );
-    eprintln!(
-        "\n  Open {} in your browser\n  Enter code: {}\n",
-        code_response.verification_uri, code_response.user_code
-    );
-
     let mut interval = std::time::Duration::from_secs(code_response.interval.max(5));
     let deadline =
         std::time::Instant::now() + std::time::Duration::from_secs(code_response.expires_in);

--- a/crates/app/src/provider/copilot_auth.rs
+++ b/crates/app/src/provider/copilot_auth.rs
@@ -222,25 +222,32 @@ pub(crate) fn now_unix_for_test() -> i64 {
     now_unix()
 }
 
+/// Serializes tests that mutate the global `COPILOT_API_KEY_CACHE`.
+/// Hold the returned guard for the duration of any test that reads
+/// or writes the cache.
+#[cfg(test)]
+pub(crate) fn acquire_cache_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    CACHE_TEST_LOCK.lock().unwrap()
+}
+
+#[cfg(test)]
+static CACHE_TEST_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
-
-    /// Serializes tests that mutate the global `COPILOT_API_KEY_CACHE`.
-    static CACHE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn cached_copilot_api_key_returns_none_when_empty() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        let _guard = acquire_cache_test_lock();
         clear_cache();
         assert_eq!(cached_copilot_api_key(), None);
     }
 
     #[test]
     fn cache_hit_returns_token_when_not_expired() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        let _guard = acquire_cache_test_lock();
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
@@ -257,7 +264,7 @@ mod tests {
 
     #[test]
     fn cache_miss_when_token_within_refresh_buffer() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        let _guard = acquire_cache_test_lock();
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();
@@ -274,7 +281,7 @@ mod tests {
 
     #[test]
     fn clear_cache_removes_stored_key() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap();
+        let _guard = acquire_cache_test_lock();
         clear_cache();
 
         let mut cache = COPILOT_API_KEY_CACHE.lock().unwrap();

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -13,13 +13,13 @@ use super::config::LoongClawConfig;
 #[cfg(test)]
 use super::config::{ProviderKind, ProviderProfileHealthModeConfig};
 
-mod copilot_auth;
 mod auth_profile_runtime;
 mod capability_profile_runtime;
 mod catalog_executor;
 mod catalog_query_runtime;
 mod catalog_runtime;
 mod contracts;
+mod copilot_auth;
 mod failover;
 mod failover_telemetry_runtime;
 mod http_client_runtime;
@@ -43,8 +43,8 @@ mod runtime_binding;
 mod shape;
 mod transport;
 
-pub(crate) use failover::parse_provider_failover_snapshot_payload;
 pub use copilot_auth::device_code_login as copilot_device_code_login;
+pub(crate) use failover::parse_provider_failover_snapshot_payload;
 pub use request_executor::{StreamingCallbackData, StreamingTokenCallback};
 pub use runtime_binding::ProviderRuntimeBinding;
 pub use shape::{

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -13,7 +13,7 @@ use super::config::LoongClawConfig;
 #[cfg(test)]
 use super::config::{ProviderKind, ProviderProfileHealthModeConfig};
 
-pub mod copilot_auth;
+mod copilot_auth;
 mod auth_profile_runtime;
 mod capability_profile_runtime;
 mod catalog_executor;
@@ -44,6 +44,7 @@ mod shape;
 mod transport;
 
 pub(crate) use failover::parse_provider_failover_snapshot_payload;
+pub use copilot_auth::device_code_login as copilot_device_code_login;
 pub use request_executor::{StreamingCallbackData, StreamingTokenCallback};
 pub use runtime_binding::ProviderRuntimeBinding;
 pub use shape::{

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -13,6 +13,7 @@ use super::config::LoongClawConfig;
 #[cfg(test)]
 use super::config::{ProviderKind, ProviderProfileHealthModeConfig};
 
+pub mod copilot_auth;
 mod auth_profile_runtime;
 mod capability_profile_runtime;
 mod catalog_executor;

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use crate::config::ProviderKind;
 use crate::{CliResult, config::LoongClawConfig};
 
 use super::auth_profile_runtime::{ProviderAuthProfile, resolve_provider_auth_profiles};
@@ -38,16 +37,7 @@ pub(super) async fn prepare_provider_request_session(
 ) -> CliResult<ProviderRequestSession> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
-
-    if config.provider.kind == ProviderKind::GithubCopilot {
-        let github_token = config
-            .provider
-            .oauth_access_token()
-            .ok_or_else(|| {
-                "GitHub Copilot requires authentication. Run `loong onboard` to set up.".to_owned()
-            })?;
-        super::copilot_auth::ensure_copilot_api_key(&github_token).await?;
-    }
+    super::copilot_auth::ensure_provider_copilot_api_key(&config.provider).await?;
 
     validate_provider_auth_readiness(config).await?;
     ensure_provider_profile_state_backend(config);

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use crate::config::ProviderKind;
 use crate::{CliResult, config::LoongClawConfig};
 
 use super::auth_profile_runtime::{ProviderAuthProfile, resolve_provider_auth_profiles};
@@ -37,6 +38,17 @@ pub(super) async fn prepare_provider_request_session(
 ) -> CliResult<ProviderRequestSession> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
+
+    if config.provider.kind == ProviderKind::GithubCopilot {
+        let github_token = config
+            .provider
+            .oauth_access_token()
+            .ok_or_else(|| {
+                "GitHub Copilot requires authentication. Run `loong onboard` to set up.".to_owned()
+            })?;
+        super::copilot_auth::ensure_copilot_api_key(&github_token).await?;
+    }
+
     validate_provider_auth_readiness(config).await?;
     ensure_provider_profile_state_backend(config);
 

--- a/crates/daemon/src/copilot_onboarding.rs
+++ b/crates/daemon/src/copilot_onboarding.rs
@@ -1,0 +1,220 @@
+use std::path::{Path, PathBuf};
+
+use loongclaw_contracts::SecretRef;
+
+use crate::provider_credential_policy;
+use crate::{CliResult, mvp};
+
+pub(crate) async fn finalize_github_copilot_onboard_credentials(
+    provider: &mut mvp::config::ProviderConfig,
+    output_path: &Path,
+    non_interactive: bool,
+) -> CliResult<()> {
+    let available_binding =
+        provider_credential_policy::provider_available_credential_env_binding(provider);
+    if let Some(binding) = available_binding
+        && binding.field == provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken
+    {
+        provider_credential_policy::apply_provider_credential_env_binding(provider, &binding);
+        return Ok(());
+    }
+
+    let resolved_token = provider.oauth_access_token();
+    if resolved_token.is_some() {
+        return Ok(());
+    }
+
+    if non_interactive {
+        let env_name = provider
+            .configured_oauth_access_token_env_override()
+            .or_else(|| {
+                provider
+                    .kind
+                    .default_oauth_access_token_env()
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| "an OAuth token environment variable".to_owned());
+        let message = format!(
+            "GitHub Copilot onboarding needs an OAuth token in --non-interactive mode; set {env_name} or configure provider.oauth_access_token first"
+        );
+        return Err(message);
+    }
+
+    tracing::warn!("GitHub Copilot uses an undocumented API. It may break without notice.");
+
+    let token = mvp::provider::copilot_device_code_login().await?;
+
+    persist_github_copilot_oauth_token(provider, output_path, token.as_str())?;
+
+    Ok(())
+}
+
+fn persist_github_copilot_oauth_token(
+    provider: &mut mvp::config::ProviderConfig,
+    output_path: &Path,
+    token: &str,
+) -> CliResult<()> {
+    let trimmed_token = token.trim();
+    if trimmed_token.is_empty() {
+        return Err("GitHub Copilot OAuth token was empty after device login.".to_owned());
+    }
+
+    let secret_path = github_copilot_oauth_token_path(output_path);
+
+    write_github_copilot_oauth_token_file(secret_path.as_path(), trimmed_token)?;
+
+    provider.api_key = None;
+    provider.clear_api_key_env_binding();
+    provider.clear_oauth_access_token_env_binding();
+    provider.oauth_access_token = Some(SecretRef::File { file: secret_path });
+
+    Ok(())
+}
+
+fn github_copilot_oauth_token_path(output_path: &Path) -> PathBuf {
+    let parent_dir = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(mvp::config::default_loongclaw_home);
+
+    parent_dir
+        .join("secrets")
+        .join("github-copilot-oauth-token")
+}
+
+fn write_github_copilot_oauth_token_file(path: &Path, token: &str) -> CliResult<()> {
+    create_github_copilot_oauth_token_parent_dir(path)?;
+    harden_github_copilot_oauth_token_parent_dir(path)?;
+    std::fs::write(path, token).map_err(|error| {
+        format!(
+            "write GitHub Copilot OAuth token file failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    harden_github_copilot_oauth_token_file(path)?;
+
+    Ok(())
+}
+
+fn create_github_copilot_oauth_token_parent_dir(path: &Path) -> CliResult<()> {
+    let parent = path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "create GitHub Copilot OAuth token parent directory failed for {}: {error}",
+            parent.display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn harden_github_copilot_oauth_token_parent_dir(path: &Path) -> CliResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let parent = path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() || !parent.exists() {
+        return Ok(());
+    }
+
+    let metadata = std::fs::metadata(parent).map_err(|error| {
+        format!(
+            "read GitHub Copilot OAuth token directory metadata failed for {}: {error}",
+            parent.display()
+        )
+    })?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(parent, permissions).map_err(|error| {
+        format!(
+            "set GitHub Copilot OAuth token directory permissions failed for {}: {error}",
+            parent.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn harden_github_copilot_oauth_token_parent_dir(_path: &Path) -> CliResult<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_github_copilot_oauth_token_file(path: &Path) -> CliResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let metadata = std::fs::metadata(path).map_err(|error| {
+        format!(
+            "read GitHub Copilot OAuth token file metadata failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o600);
+    std::fs::set_permissions(path, permissions).map_err(|error| {
+        format!(
+            "set GitHub Copilot OAuth token file permissions failed for {}: {error}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn harden_github_copilot_oauth_token_file(_path: &Path) -> CliResult<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn persist_github_copilot_oauth_token_writes_file_secret() {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-github-copilot-secret-{unique_suffix}"));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let output_path = temp_dir.join("loongclaw.toml");
+        let mut provider = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::GithubCopilot,
+            api_key: Some(SecretRef::Inline("stale-api-key".to_owned())),
+            oauth_access_token: Some(SecretRef::Env {
+                env: "STALE_GITHUB_COPILOT_OAUTH_TOKEN".to_owned(),
+            }),
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        persist_github_copilot_oauth_token(&mut provider, &output_path, "ghu_copilot_token")
+            .expect("persist GitHub Copilot token");
+
+        let Some(SecretRef::File { file }) = provider.oauth_access_token.as_ref() else {
+            panic!("GitHub Copilot token should persist as a file secret");
+        };
+
+        let stored_token =
+            std::fs::read_to_string(file).expect("read persisted GitHub Copilot token");
+
+        assert_eq!(stored_token, "ghu_copilot_token");
+        assert_eq!(provider.api_key, None);
+        assert_eq!(provider.api_key_env, None);
+        assert_eq!(provider.oauth_access_token_env, None);
+
+        std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -96,6 +96,7 @@ mod cli_json;
 mod command_kind;
 pub mod completions_cli;
 mod control_plane_server;
+mod copilot_onboarding;
 pub mod doctor_cli;
 pub mod doctor_security_cli;
 mod env_compat;

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -15,6 +15,7 @@ use loongclaw_contracts::SecretRef;
 use loongclaw_spec::CliResult;
 use serde_json::json;
 
+use crate::copilot_onboarding::finalize_github_copilot_onboard_credentials;
 use crate::onboard_finalize::{
     ConfigWritePlan, build_onboarding_success_summary_with_memory, prepare_output_path_for_write,
     render_onboarding_success_summary_lines, resolve_backup_path, rollback_onboard_write_failure,
@@ -1473,9 +1474,12 @@ pub async fn run_onboard_cli_with_ui(
         config.provider.model = selected_model;
 
         if config.provider.kind == mvp::config::ProviderKind::GithubCopilot {
-            tracing::warn!("GitHub Copilot uses an undocumented API. It may break without notice.");
-            let token = mvp::provider::copilot_device_code_login().await?;
-            config.provider.oauth_access_token = Some(SecretRef::Inline(token));
+            finalize_github_copilot_onboard_credentials(
+                &mut config.provider,
+                &output_path,
+                options.non_interactive,
+            )
+            .await?;
         } else {
             let default_api_key_env = preferred_api_key_env_default(&config);
             let selected_api_key_env = resolve_api_key_env_selection(
@@ -3043,36 +3047,8 @@ fn non_interactive_preflight_warning_message(
         "onboard preflight failed: {detail}; rerun without --non-interactive to inspect and confirm them"
     )
 }
-fn render_configured_provider_credential_source_value(
-    provider: &mvp::config::ProviderConfig,
-) -> Option<String> {
-    let configured_oauth = provider.configured_oauth_access_token_env_override();
-    let rendered_oauth = provider_credential_policy::render_provider_credential_source_value(
-        configured_oauth.as_deref(),
-    );
-    if rendered_oauth.is_some() {
-        return rendered_oauth;
-    }
-
-    let configured_api_key = provider.configured_api_key_env_override();
-    provider_credential_policy::render_provider_credential_source_value(
-        configured_api_key.as_deref(),
-    )
-}
-
 pub fn preferred_api_key_env_default(config: &mvp::config::LoongClawConfig) -> String {
-    let provider = &config.provider;
-    if let Some(binding) =
-        provider_credential_policy::configured_provider_credential_env_binding(provider)
-    {
-        return binding.env_name;
-    }
-    if provider_credential_policy::provider_has_inline_credential(provider) {
-        return String::new();
-    }
-    provider_credential_policy::preferred_provider_credential_env_binding(provider)
-        .map(|binding| binding.env_name)
-        .unwrap_or_default()
+    provider_credential_policy::preferred_provider_credential_env_name(config)
 }
 
 pub fn collect_import_surfaces(config: &mvp::config::LoongClawConfig) -> Vec<ImportSurface> {
@@ -5337,7 +5313,10 @@ fn render_api_key_env_selection_screen_lines_with_style(
         "- provider: {}",
         crate::provider_presentation::guided_provider_label(config.provider.kind)
     )];
-    if let Some(current_env) = render_configured_provider_credential_source_value(&config.provider)
+    if let Some(current_env) =
+        provider_credential_policy::render_configured_provider_credential_source_value(
+            &config.provider,
+        )
     {
         context_lines.push(format!("- current source: {current_env}"));
     }
@@ -5883,7 +5862,9 @@ pub(crate) fn summarize_provider_credential(
             value: "inline oauth token".to_owned(),
         });
     }
-    if let Some(configured_env) = render_configured_provider_credential_source_value(provider) {
+    if let Some(configured_env) =
+        provider_credential_policy::render_configured_provider_credential_source_value(provider)
+    {
         return Some(OnboardingCredentialSummary {
             label: "credential source",
             value: configured_env,

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1474,7 +1474,7 @@ pub async fn run_onboard_cli_with_ui(
 
         if config.provider.kind == mvp::config::ProviderKind::GithubCopilot {
             tracing::warn!("GitHub Copilot uses an undocumented API. It may break without notice.");
-            let token = mvp::provider::copilot_auth::device_code_login().await?;
+            let token = mvp::provider::copilot_device_code_login().await?;
             config.provider.oauth_access_token = Some(SecretRef::Inline(token));
         } else {
             let default_api_key_env = preferred_api_key_env_default(&config);

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1472,16 +1472,22 @@ pub async fn run_onboard_cli_with_ui(
         )?;
         config.provider.model = selected_model;
 
-        let default_api_key_env = preferred_api_key_env_default(&config);
-        let selected_api_key_env = resolve_api_key_env_selection(
-            &options,
-            &config,
-            default_api_key_env,
-            guided_prompt_path,
-            ui,
-            context,
-        )?;
-        apply_selected_api_key_env(&mut config.provider, selected_api_key_env);
+        if config.provider.kind == mvp::config::ProviderKind::GithubCopilot {
+            tracing::warn!("GitHub Copilot uses an undocumented API. It may break without notice.");
+            let token = mvp::provider::copilot_auth::device_code_login().await?;
+            config.provider.oauth_access_token = Some(SecretRef::Inline(token));
+        } else {
+            let default_api_key_env = preferred_api_key_env_default(&config);
+            let selected_api_key_env = resolve_api_key_env_selection(
+                &options,
+                &config,
+                default_api_key_env,
+                guided_prompt_path,
+                ui,
+                context,
+            )?;
+            apply_selected_api_key_env(&mut config.provider, selected_api_key_env);
+        }
 
         match guided_prompt_path {
             GuidedPromptPath::NativePromptPack => {

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -182,6 +182,34 @@ pub(crate) fn render_provider_credential_source_value(raw: Option<&str>) -> Opti
     normalized.or_else(|| Some("environment variable".to_owned()))
 }
 
+pub(crate) fn render_configured_provider_credential_source_value(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<String> {
+    let configured_oauth = provider.configured_oauth_access_token_env_override();
+    let rendered_oauth = render_provider_credential_source_value(configured_oauth.as_deref());
+    if rendered_oauth.is_some() {
+        return rendered_oauth;
+    }
+
+    let configured_api_key = provider.configured_api_key_env_override();
+    render_provider_credential_source_value(configured_api_key.as_deref())
+}
+
+pub(crate) fn preferred_provider_credential_env_name(
+    config: &mvp::config::LoongClawConfig,
+) -> String {
+    let provider = &config.provider;
+    if let Some(binding) = configured_provider_credential_env_binding(provider) {
+        return binding.env_name;
+    }
+    if provider_has_inline_credential(provider) {
+        return String::new();
+    }
+    preferred_provider_credential_env_binding(provider)
+        .map(|binding| binding.env_name)
+        .unwrap_or_default()
+}
+
 fn binding_for_env_name(
     field: ProviderCredentialEnvField,
     raw_env_name: Option<&str>,

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -1231,6 +1231,88 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_persists_github_copilot_oauth_env_binding() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-github-copilot-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+    unsafe {
+        std::env::set_var(
+            "GITHUB_COPILOT_OAUTH_TOKEN",
+            "test-github-copilot-oauth-token",
+        );
+    }
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.provider = Some("github-copilot".to_owned());
+    options.model = Some("copilot-test-model".to_owned());
+    options.skip_model_probe = true;
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context =
+        loongclaw_daemon::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    loongclaw_daemon::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect("GitHub Copilot onboarding should reuse an existing OAuth token env in non-interactive mode");
+
+    let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
+    assert!(
+        raw.contains("[providers.github-copilot.oauth_access_token]")
+            && raw.contains("env = \"GITHUB_COPILOT_OAUTH_TOKEN\""),
+        "GitHub Copilot onboarding should persist the OAuth env binding in the canonical secret field: {raw}"
+    );
+    assert!(
+        !raw.contains("oauth_access_token_env = "),
+        "GitHub Copilot onboarding should not keep the legacy oauth_access_token_env field: {raw}"
+    );
+
+    let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(
+        config.provider.kind,
+        mvp::config::ProviderKind::GithubCopilot
+    );
+    assert_eq!(config.provider.model, "copilot-test-model");
+    assert_eq!(
+        config.provider.oauth_access_token,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "GITHUB_COPILOT_OAUTH_TOKEN".to_owned(),
+        }),
+        "reloaded config should keep the routed OAuth env binding in the canonical oauth_access_token field"
+    );
+    assert_eq!(config.provider.oauth_access_token_env, None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn non_interactive_onboard_rejects_github_copilot_without_oauth_token() {
+    let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
+    let root = unique_temp_path("non-interactive-github-copilot-missing-token-root");
+    std::fs::create_dir_all(&root).expect("create test root");
+    let output = root.join("loongclaw.toml");
+
+    let mut options = default_non_interactive_onboard_options(&output);
+    options.provider = Some("github-copilot".to_owned());
+    options.model = Some("copilot-test-model".to_owned());
+    options.skip_model_probe = true;
+
+    let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
+    let context =
+        loongclaw_daemon::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
+    let error = loongclaw_daemon::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+        .await
+        .expect_err("GitHub Copilot onboarding should fail without a reusable OAuth token in non-interactive mode");
+
+    assert!(
+        error.contains("GITHUB_COPILOT_OAUTH_TOKEN"),
+        "missing-token error should name the expected GitHub Copilot env source: {error}"
+    );
+    assert!(
+        error.contains("--non-interactive"),
+        "missing-token error should explain why interactive device login was skipped: {error}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn non_interactive_onboard_applies_reviewed_default_when_probe_is_skipped() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-reviewed-auto-skip-root");

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -14,7 +14,7 @@
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 381 | 650 | 269 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 7.0% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
@@ -24,12 +24,12 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6439 | 6500 | 61 | 200 | 210 | 10 | 99.1% | TIGHT | 6324 | 1.8% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9800 | 9800 | 0 | 238 | 250 | 12 | 100.0% | TIGHT | 9519 | 3.0% | PASS | 228 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6440 | 6500 | 60 | 200 | 210 | 10 | 99.1% | TIGHT | 6324 | 1.8% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.1%), onboard_cli (100.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.1%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -60,7 +60,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
+<!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=381 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
@@ -70,8 +70,8 @@
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6439 functions=200 -->
-<!-- arch-hotspot key=onboard_cli lines=9800 functions=238 -->
+<!-- arch-hotspot key=daemon_lib lines=6440 functions=200 -->
+<!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

Closes #1059.

Adds GitHub Copilot as a first-class LLM provider with native OAuth device code flow authentication, following the pattern established by [rustup PR #161](https://github.com/rust-lang/rustup/pull/161) and [GitHub CLI's three-layer auth architecture](https://github.com/cli/cli).

- **Provider registration**: `ProviderKind::GithubCopilot` with OpenAI-compatible protocol, Copilot-specific headers (`Editor-Version`, `Editor-Plugin-Version`, `Copilot-Integration-Id`), and `GithubCopilot/1.155.0` user agent
- **Authentication**: Two-level token exchange — GitHub OAuth token (long-lived, stored in config) → Copilot API key (minutes, cached in memory). Uses VS Code's public OAuth client ID (`Iv1.b507a08c87ecfe98`)
- **Onboard integration**: When users select GitHub Copilot during `loong onboard`, the device code flow runs automatically — no manual token management needed

## Design

All new logic is isolated in a single new file (`copilot_auth.rs`, ~330 LoC) to avoid bloating hotspot files. The integration touches existing files minimally:

| File | Lines changed | Purpose |
|------|:---:|---------|
| `copilot_auth.rs` | +330 | Device code flow, token exchange, static cache |
| `provider.rs` | +32 | Provider kind + profile registration |
| `auth_profile_runtime.rs` | +36 | Read cached key for Bearer auth |
| `request_session_runtime.rs` | +12 | Pre-refresh before session prep |
| `onboard_cli.rs` | +6 net | Device code flow trigger |

**Key constraint**: `request_completion()` takes `&LoongClawConfig` (immutable) and `resolve_provider_auth_profiles()` is synchronous, but token exchange is async. Solved with static in-memory cache — async pre-refresh populates cache before sync auth profile resolution reads it. No existing function signatures changed.

### Prior art

| Project | Pattern |
|---------|---------|
| **GitHub CLI** (`cli/cli`) | Three-layer separation: protocol engine → CLI adapter → token storage |
| **ZeroClaw** | Self-contained ~620 LoC, functional but monolithic |
| **aichat** | Refuses Copilot support, no unified auth abstraction |

This implementation follows GitHub CLI's separation principle while adapting to loongclaw's constraint that all provider auth resolves through the existing `ProviderAuthProfile` pipeline.

### ⚠️ Undocumented API disclaimer

This uses VS Code's OAuth client ID and editor headers for the Copilot token endpoint. This is the same approach used by ZeroClaw, LiteLLM, Codex CLI, and other third-party integrations. The endpoint is private — GitHub could change or revoke access at any time. A `tracing::warn!` is emitted during onboard.

## Test plan

- [x] 9 unit tests covering cache logic, token response parsing, device code response parsing
- [x] Auth profile integration test verifying cached Copilot key produces correct Bearer profile
- [x] Provider registration validated by existing `provider_kinds_are_sorted_alphabetically` test
- [ ] Manual: `loong onboard` → select GitHub Copilot → complete device code flow → `loong ask "hello"`
- [ ] CI: all existing tests pass (3024/3026, 2 pre-existing worktree isolation failures on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot support including device-code sign-in, onboarding flow, automatic token persistence, and Copilot-specific request headers/user-agent.
* **User Experience**
  * Onboarding and session/model listing validate Copilot credentials earlier and handle Copilot credential selection differently (non-interactive vs interactive).
* **Tests**
  * Added unit and integration tests covering Copilot auth, caching, onboarding, and edge/error cases.
* **Documentation**
  * Updated architecture report metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->