### PR TITLE
feat(config): add LOONG_HOME env var alias with LOONGCLAW_HOME deprecation

### DIFF
--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -991,7 +991,7 @@ mod tests {
     fn default_loongclaw_home_reads_loong_home_env() {
         let mut env = ScopedEnv::new();
         let override_home = std::env::temp_dir().join("loong-home-env-test");
-        env.set("LOONG_HOME", &override_home);
+        env.set(LOONGCLAW_HOME_ENV, &override_home);
         env.remove("LOONGCLAW_HOME");
 
         assert_eq!(default_loongclaw_home(), override_home);
@@ -1002,10 +1002,11 @@ mod tests {
         let mut env = ScopedEnv::new();
         let new_home = std::env::temp_dir().join("loong-home-preferred");
         let old_home = std::env::temp_dir().join("loongclaw-home-deprecated");
-        env.set("LOONG_HOME", &new_home);
+        env.set(LOONGCLAW_HOME_ENV, &new_home);
         env.set("LOONGCLAW_HOME", &old_home);
 
-        // The constant reads LOONG_HOME, so LOONGCLAW_HOME is ignored
+        // The active env constant reads the preferred name, so the legacy
+        // fallback stays ignored when both are present.
         assert_eq!(default_loongclaw_home(), new_home);
     }
 }

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -17,7 +17,7 @@ pub const LEGACY_HOME_DIR_NAME: &str = ".loongclaw";
 pub const PRODUCT_DISPLAY_NAME: &str = "LoongClaw";
 static ACTIVE_CLI_COMMAND_NAME: OnceLock<&'static str> = OnceLock::new();
 pub(super) const DEFAULT_FEISHU_SQLITE_FILE: &str = "feishu.sqlite3";
-pub(crate) const LOONGCLAW_HOME_ENV: &str = "LOONGCLAW_HOME";
+pub(crate) const LOONGCLAW_HOME_ENV: &str = "LOONG_HOME";
 
 fn normalize_cli_command_name(raw: &str) -> &'static str {
     if raw.eq_ignore_ascii_case(LEGACY_CLI_COMMAND_NAME) {

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -986,6 +986,28 @@ mod tests {
 
         assert_eq!(resolved, home.join(".loong"));
     }
+
+    #[test]
+    fn default_loongclaw_home_reads_loong_home_env() {
+        let mut env = ScopedEnv::new();
+        let override_home = std::env::temp_dir().join("loong-home-env-test");
+        env.set("LOONG_HOME", &override_home);
+        env.remove("LOONGCLAW_HOME");
+
+        assert_eq!(default_loongclaw_home(), override_home);
+    }
+
+    #[test]
+    fn default_loongclaw_home_prefers_loong_home_over_loongclaw_home() {
+        let mut env = ScopedEnv::new();
+        let new_home = std::env::temp_dir().join("loong-home-preferred");
+        let old_home = std::env::temp_dir().join("loongclaw-home-deprecated");
+        env.set("LOONG_HOME", &new_home);
+        env.set("LOONGCLAW_HOME", &old_home);
+
+        // The constant reads LOONG_HOME, so LOONGCLAW_HOME is ignored
+        assert_eq!(default_loongclaw_home(), new_home);
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -9137,7 +9137,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
     let temp_home = crate::test_support::unique_temp_dir("safe-lane-runtime-events-home");
     std::fs::create_dir_all(&temp_home).expect("create safe-lane runtime-events home");
     env.set("HOME", &temp_home);
-    env.remove("LOONGCLAW_HOME");
+    env.remove("LOONG_HOME");
 
     let runtime = FakeRuntime::with_turn_and_completion(
         vec![],

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1973,7 +1973,7 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let mut env = ScopedEnv::new();
         env.set("HOME", tempdir.path());
-        env.remove("LOONGCLAW_HOME");
+        env.remove("LOONG_HOME");
         let config_path = tempdir.path().join("loongclaw.toml");
 
         let runtime = ToolRuntimeConfig::from_loongclaw_config(
@@ -2270,7 +2270,7 @@ mod tests {
         let mut env = ScopedEnv::new();
         let runtime_home = std::env::temp_dir().join("loongclaw-tool-runtime-home");
         clear_tool_runtime_env(&mut env);
-        env.set("LOONGCLAW_HOME", &runtime_home);
+        env.set("LOONG_HOME", &runtime_home);
 
         let runtime = ToolRuntimeConfig::from_env();
 
@@ -2285,7 +2285,7 @@ mod tests {
         let mut env = ScopedEnv::new();
         let runtime_home = std::env::temp_dir().join("loongclaw-tool-runtime-empty-sqlite-path");
         clear_tool_runtime_env(&mut env);
-        env.set("LOONGCLAW_HOME", &runtime_home);
+        env.set("LOONG_HOME", &runtime_home);
         env.set("LOONGCLAW_SQLITE_PATH", "");
 
         let runtime = ToolRuntimeConfig::from_env();

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1709,6 +1709,7 @@ mod tests {
 
     fn clear_tool_runtime_env(env: &mut ScopedEnv) {
         for key in [
+            "LOONG_HOME",
             "LOONGCLAW_CONFIG_PATH",
             "LOONGCLAW_FILE_ROOT",
             "LOONGCLAW_SQLITE_PATH",

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -410,7 +410,7 @@ fn bash_exec_uses_loongclaw_home_rules_dir_even_when_runtime_is_built_without_co
 
     let mut env = ScopedEnv::new();
     env.set("HOME", &home);
-    env.remove("LOONGCLAW_HOME");
+    env.remove("LOONG_HOME");
     let _cwd = ScopedCurrentDir::new(&workspace);
 
     let mut runtime = runtime_config::ToolRuntimeConfig::from_loongclaw_config(

--- a/crates/daemon/src/env_compat.rs
+++ b/crates/daemon/src/env_compat.rs
@@ -1,0 +1,119 @@
+fn non_empty_env_var(name: &str) -> Option<std::ffi::OsString> {
+    let value = std::env::var_os(name);
+    let value_ref = value.as_deref();
+    let value_is_non_empty = value_ref.is_some_and(|candidate| !candidate.is_empty());
+
+    if value_is_non_empty {
+        return value;
+    }
+
+    None
+}
+
+/// Copies deprecated `LOONGCLAW_*` env vars into their `LOONG_*` replacements
+/// and emits a deprecation warning. No-op when the new name is already set.
+pub fn make_env_compatible() {
+    const MIGRATIONS: &[(&str, &str)] = &[("LOONG_HOME", "LOONGCLAW_HOME")];
+
+    for &(new_name, old_name) in MIGRATIONS {
+        let old_value = non_empty_env_var(old_name);
+        let new_value = non_empty_env_var(new_name);
+        let new_is_unset = new_value.is_none();
+
+        if !new_is_unset {
+            continue;
+        }
+
+        let Some(old_value) = old_value else {
+            continue;
+        };
+
+        // SAFETY: single-threaded — called before tokio runtime and parse_cli.
+        #[allow(unsafe_code, clippy::disallowed_methods)]
+        unsafe {
+            std::env::set_var(new_name, &old_value);
+        }
+        tracing::warn!("{old_name} is deprecated. Set {new_name} instead.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::make_env_compatible;
+    use crate::test_support::ScopedEnv;
+
+    fn loong_home() -> Option<std::path::PathBuf> {
+        std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from)
+    }
+
+    #[test]
+    fn migrates_deprecated_env_when_new_is_unset() {
+        let mut env = ScopedEnv::new();
+        let value = std::env::temp_dir().join("loong-compat-old-only");
+        env.set("LOONGCLAW_HOME", &value);
+        env.remove("LOONG_HOME");
+
+        make_env_compatible();
+
+        assert_eq!(loong_home(), Some(value));
+    }
+
+    #[test]
+    fn does_not_overwrite_new_env_when_both_set() {
+        let mut env = ScopedEnv::new();
+        let new_value = std::env::temp_dir().join("loong-compat-new");
+        let old_value = std::env::temp_dir().join("loong-compat-old");
+        env.set("LOONG_HOME", &new_value);
+        env.set("LOONGCLAW_HOME", &old_value);
+
+        make_env_compatible();
+
+        assert_eq!(loong_home(), Some(new_value));
+    }
+
+    #[test]
+    fn migrates_deprecated_env_when_new_is_empty() {
+        let mut env = ScopedEnv::new();
+        let old_value = std::env::temp_dir().join("loong-compat-old-when-new-empty");
+        env.set("LOONGCLAW_HOME", &old_value);
+        env.set("LOONG_HOME", "");
+
+        make_env_compatible();
+
+        assert_eq!(loong_home(), Some(old_value));
+    }
+
+    #[test]
+    fn ignores_empty_deprecated_env_value() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONGCLAW_HOME", "");
+        env.remove("LOONG_HOME");
+
+        make_env_compatible();
+
+        assert!(loong_home().is_none());
+    }
+
+    #[test]
+    fn no_op_when_only_new_env_is_set() {
+        let mut env = ScopedEnv::new();
+        let value = std::env::temp_dir().join("loong-compat-new-only");
+        env.set("LOONG_HOME", &value);
+        env.remove("LOONGCLAW_HOME");
+
+        make_env_compatible();
+
+        assert_eq!(loong_home(), Some(value));
+    }
+
+    #[test]
+    fn no_op_when_neither_env_is_set() {
+        let mut env = ScopedEnv::new();
+        env.remove("LOONG_HOME");
+        env.remove("LOONGCLAW_HOME");
+
+        make_env_compatible();
+
+        assert!(loong_home().is_none());
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1568,6 +1568,43 @@ pub fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
+/// Bridges deprecated `LOONGCLAW_*` environment variables to their `LOONG_*`
+/// replacements. Runs once at startup before any config reads.
+///
+/// For each entry: if the old name is set but the new name is not, copy the
+/// value into the new name and emit a deprecation warning. When both are set
+/// the new name wins silently.
+///
+/// Based on the pattern established by rustup (PR #161) for the
+/// `MULTIRUST_*` → `RUSTUP_*` migration.
+pub fn make_env_compatible() {
+    // (new_name, deprecated_name)
+    const MIGRATIONS: &[(&str, &str)] = &[
+        ("LOONG_HOME", "LOONGCLAW_HOME"),
+        // Future: ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"), etc.
+    ];
+    for &(new, old) in MIGRATIONS {
+        let old_val = std::env::var_os(old);
+        let new_val = std::env::var_os(new);
+        match (old_val, new_val) {
+            (Some(old_val), None) => {
+                // SAFETY: single-threaded at this point in startup — no other
+                // threads have been spawned yet (tokio runtime runs after main
+                // setup, and this function is called before parse_cli).
+                #[allow(unsafe_code, clippy::disallowed_methods)]
+                unsafe {
+                    std::env::set_var(new, &old_val);
+                }
+                tracing::warn!(
+                    "{old} is deprecated and will be removed in a future release. \
+                     Set {new} instead."
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
 fn resolve_welcome_config_path() -> CliResult<PathBuf> {
     let config_path = resolved_default_entry_config_path();
     if config_path.is_file() {
@@ -1611,6 +1648,72 @@ pub fn run_welcome_cli() -> CliResult<()> {
     let (_resolved_path, config) = load_result;
     println!("{}", render_welcome_banner(config_path.as_path(), &config));
     Ok(())
+}
+
+#[cfg(test)]
+mod env_compat_tests {
+    use crate::test_support::ScopedEnv;
+
+    #[test]
+    fn migrates_deprecated_env_when_new_is_unset() {
+        let mut env = ScopedEnv::new();
+        let value = std::env::temp_dir().join("loong-compat-old-only");
+        env.set("LOONGCLAW_HOME", &value);
+        env.remove("LOONG_HOME");
+
+        super::make_env_compatible();
+
+        assert_eq!(
+            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn does_not_overwrite_new_env_when_both_set() {
+        let mut env = ScopedEnv::new();
+        let new_val = std::env::temp_dir().join("loong-compat-new");
+        let old_val = std::env::temp_dir().join("loong-compat-old");
+        env.set("LOONG_HOME", &new_val);
+        env.set("LOONGCLAW_HOME", &old_val);
+
+        super::make_env_compatible();
+
+        assert_eq!(
+            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
+            Some(new_val),
+            "LOONG_HOME must not be overwritten by LOONGCLAW_HOME"
+        );
+    }
+
+    #[test]
+    fn no_op_when_only_new_env_is_set() {
+        let mut env = ScopedEnv::new();
+        let value = std::env::temp_dir().join("loong-compat-new-only");
+        env.set("LOONG_HOME", &value);
+        env.remove("LOONGCLAW_HOME");
+
+        super::make_env_compatible();
+
+        assert_eq!(
+            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn no_op_when_neither_env_is_set() {
+        let mut env = ScopedEnv::new();
+        env.remove("LOONG_HOME");
+        env.remove("LOONGCLAW_HOME");
+
+        super::make_env_compatible();
+
+        assert!(
+            std::env::var_os("LOONG_HOME").is_none(),
+            "LOONG_HOME must remain unset when neither var is provided"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1571,17 +1571,16 @@ pub fn redacted_command_name(command: &Commands) -> &'static str {
 /// Copies deprecated `LOONGCLAW_*` env vars into their `LOONG_*` replacements
 /// and emits a deprecation warning. No-op when the new name is already set.
 pub fn make_env_compatible() {
-    const MIGRATIONS: &[(&str, &str)] = &[
-        ("LOONG_HOME", "LOONGCLAW_HOME"),
-        // Future: ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"), etc.
-    ];
+    const MIGRATIONS: &[(&str, &str)] = &[("LOONG_HOME", "LOONGCLAW_HOME")];
     for &(new, old) in MIGRATIONS {
         let old_val = std::env::var_os(old);
         let new_val = std::env::var_os(new);
         if let (Some(old_val), None) = (old_val, new_val) {
             // SAFETY: single-threaded — called before tokio runtime and parse_cli.
             #[allow(unsafe_code, clippy::disallowed_methods)]
-            unsafe { std::env::set_var(new, &old_val) }
+            unsafe {
+                std::env::set_var(new, &old_val);
+            }
             tracing::warn!("{old} is deprecated. Set {new} instead.");
         }
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -37,6 +37,7 @@ pub use self::channel_send_target_kind::{
     default_twitch_send_target_kind, parse_twitch_send_target_kind,
 };
 pub use self::cli_json::build_runtime_snapshot_cli_json_payload;
+pub use self::env_compat::make_env_compatible;
 pub use self::mcp_cli::{
     build_mcp_server_detail_cli_json_payload, build_mcp_servers_cli_json_payload,
     run_list_mcp_servers_cli, run_show_mcp_server_cli,
@@ -97,6 +98,7 @@ pub mod completions_cli;
 mod control_plane_server;
 pub mod doctor_cli;
 pub mod doctor_security_cli;
+mod env_compat;
 mod external_skills_policy_probe;
 pub mod feishu_cli;
 pub mod feishu_support;
@@ -1568,24 +1570,6 @@ pub fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
-/// Copies deprecated `LOONGCLAW_*` env vars into their `LOONG_*` replacements
-/// and emits a deprecation warning. No-op when the new name is already set.
-pub fn make_env_compatible() {
-    const MIGRATIONS: &[(&str, &str)] = &[("LOONG_HOME", "LOONGCLAW_HOME")];
-    for &(new, old) in MIGRATIONS {
-        let old_val = std::env::var_os(old);
-        let new_val = std::env::var_os(new);
-        if let (Some(old_val), None) = (old_val, new_val) {
-            // SAFETY: single-threaded — called before tokio runtime and parse_cli.
-            #[allow(unsafe_code, clippy::disallowed_methods)]
-            unsafe {
-                std::env::set_var(new, &old_val);
-            }
-            tracing::warn!("{old} is deprecated. Set {new} instead.");
-        }
-    }
-}
-
 fn resolve_welcome_config_path() -> CliResult<PathBuf> {
     let config_path = resolved_default_entry_config_path();
     if config_path.is_file() {
@@ -1629,54 +1613,6 @@ pub fn run_welcome_cli() -> CliResult<()> {
     let (_resolved_path, config) = load_result;
     println!("{}", render_welcome_banner(config_path.as_path(), &config));
     Ok(())
-}
-
-#[cfg(test)]
-mod env_compat_tests {
-    use crate::test_support::ScopedEnv;
-    fn loong_home() -> Option<std::path::PathBuf> {
-        std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from)
-    }
-
-    #[test]
-    fn migrates_deprecated_env_when_new_is_unset() {
-        let mut env = ScopedEnv::new();
-        let val = std::env::temp_dir().join("loong-compat-old-only");
-        env.set("LOONGCLAW_HOME", &val);
-        env.remove("LOONG_HOME");
-        super::make_env_compatible();
-        assert_eq!(loong_home(), Some(val));
-    }
-
-    #[test]
-    fn does_not_overwrite_new_env_when_both_set() {
-        let mut env = ScopedEnv::new();
-        let new = std::env::temp_dir().join("loong-compat-new");
-        let old = std::env::temp_dir().join("loong-compat-old");
-        env.set("LOONG_HOME", &new);
-        env.set("LOONGCLAW_HOME", &old);
-        super::make_env_compatible();
-        assert_eq!(loong_home(), Some(new));
-    }
-
-    #[test]
-    fn no_op_when_only_new_env_is_set() {
-        let mut env = ScopedEnv::new();
-        let val = std::env::temp_dir().join("loong-compat-new-only");
-        env.set("LOONG_HOME", &val);
-        env.remove("LOONGCLAW_HOME");
-        super::make_env_compatible();
-        assert_eq!(loong_home(), Some(val));
-    }
-
-    #[test]
-    fn no_op_when_neither_env_is_set() {
-        let mut env = ScopedEnv::new();
-        env.remove("LOONG_HOME");
-        env.remove("LOONGCLAW_HOME");
-        super::make_env_compatible();
-        assert!(loong_home().is_none());
-    }
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1642,7 +1642,7 @@ mod first_run_entry_tests {
         let home = unique_temp_dir(prefix);
         fs::create_dir_all(&home).expect("create isolated home");
         env.set("HOME", &home);
-        env.remove("LOONGCLAW_HOME");
+        env.remove("LOONG_HOME");
         env.remove("LOONGCLAW_CONFIG_PATH");
         (env, home)
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1568,17 +1568,9 @@ pub fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
-/// Bridges deprecated `LOONGCLAW_*` environment variables to their `LOONG_*`
-/// replacements. Runs once at startup before any config reads.
-///
-/// For each entry: if the old name is set but the new name is not, copy the
-/// value into the new name and emit a deprecation warning. When both are set
-/// the new name wins silently.
-///
-/// Based on the pattern established by rustup (PR #161) for the
-/// `MULTIRUST_*` → `RUSTUP_*` migration.
+/// Copies deprecated `LOONGCLAW_*` env vars into their `LOONG_*` replacements
+/// and emits a deprecation warning. No-op when the new name is already set.
 pub fn make_env_compatible() {
-    // (new_name, deprecated_name)
     const MIGRATIONS: &[(&str, &str)] = &[
         ("LOONG_HOME", "LOONGCLAW_HOME"),
         // Future: ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"), etc.
@@ -1586,21 +1578,11 @@ pub fn make_env_compatible() {
     for &(new, old) in MIGRATIONS {
         let old_val = std::env::var_os(old);
         let new_val = std::env::var_os(new);
-        match (old_val, new_val) {
-            (Some(old_val), None) => {
-                // SAFETY: single-threaded at this point in startup — no other
-                // threads have been spawned yet (tokio runtime runs after main
-                // setup, and this function is called before parse_cli).
-                #[allow(unsafe_code, clippy::disallowed_methods)]
-                unsafe {
-                    std::env::set_var(new, &old_val);
-                }
-                tracing::warn!(
-                    "{old} is deprecated and will be removed in a future release. \
-                     Set {new} instead."
-                );
-            }
-            _ => {}
+        if let (Some(old_val), None) = (old_val, new_val) {
+            // SAFETY: single-threaded — called before tokio runtime and parse_cli.
+            #[allow(unsafe_code, clippy::disallowed_methods)]
+            unsafe { std::env::set_var(new, &old_val) }
+            tracing::warn!("{old} is deprecated. Set {new} instead.");
         }
     }
 }
@@ -1653,52 +1635,39 @@ pub fn run_welcome_cli() -> CliResult<()> {
 #[cfg(test)]
 mod env_compat_tests {
     use crate::test_support::ScopedEnv;
+    fn loong_home() -> Option<std::path::PathBuf> {
+        std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from)
+    }
 
     #[test]
     fn migrates_deprecated_env_when_new_is_unset() {
         let mut env = ScopedEnv::new();
-        let value = std::env::temp_dir().join("loong-compat-old-only");
-        env.set("LOONGCLAW_HOME", &value);
+        let val = std::env::temp_dir().join("loong-compat-old-only");
+        env.set("LOONGCLAW_HOME", &val);
         env.remove("LOONG_HOME");
-
         super::make_env_compatible();
-
-        assert_eq!(
-            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
-            Some(value)
-        );
+        assert_eq!(loong_home(), Some(val));
     }
 
     #[test]
     fn does_not_overwrite_new_env_when_both_set() {
         let mut env = ScopedEnv::new();
-        let new_val = std::env::temp_dir().join("loong-compat-new");
-        let old_val = std::env::temp_dir().join("loong-compat-old");
-        env.set("LOONG_HOME", &new_val);
-        env.set("LOONGCLAW_HOME", &old_val);
-
+        let new = std::env::temp_dir().join("loong-compat-new");
+        let old = std::env::temp_dir().join("loong-compat-old");
+        env.set("LOONG_HOME", &new);
+        env.set("LOONGCLAW_HOME", &old);
         super::make_env_compatible();
-
-        assert_eq!(
-            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
-            Some(new_val),
-            "LOONG_HOME must not be overwritten by LOONGCLAW_HOME"
-        );
+        assert_eq!(loong_home(), Some(new));
     }
 
     #[test]
     fn no_op_when_only_new_env_is_set() {
         let mut env = ScopedEnv::new();
-        let value = std::env::temp_dir().join("loong-compat-new-only");
-        env.set("LOONG_HOME", &value);
+        let val = std::env::temp_dir().join("loong-compat-new-only");
+        env.set("LOONG_HOME", &val);
         env.remove("LOONGCLAW_HOME");
-
         super::make_env_compatible();
-
-        assert_eq!(
-            std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from),
-            Some(value)
-        );
+        assert_eq!(loong_home(), Some(val));
     }
 
     #[test]
@@ -1706,13 +1675,8 @@ mod env_compat_tests {
         let mut env = ScopedEnv::new();
         env.remove("LOONG_HOME");
         env.remove("LOONGCLAW_HOME");
-
         super::make_env_compatible();
-
-        assert!(
-            std::env::var_os("LOONG_HOME").is_none(),
-            "LOONG_HOME must remain unset when neither var is provided"
-        );
+        assert!(loong_home().is_none());
     }
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -55,43 +55,6 @@ fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
-/// Bridges deprecated `LOONGCLAW_*` environment variables to their `LOONG_*`
-/// replacements. Runs once at startup before any config reads.
-///
-/// For each entry: if the old name is set but the new name is not, copy the
-/// value into the new name and emit a deprecation warning. When both are set
-/// the new name wins silently.
-///
-/// Based on the pattern established by rustup (PR #161) for the
-/// `MULTIRUST_*` → `RUSTUP_*` migration.
-fn make_env_compatible() {
-    // (new_name, deprecated_name)
-    const MIGRATIONS: &[(&str, &str)] = &[
-        ("LOONG_HOME", "LOONGCLAW_HOME"),
-        // Future: ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"), etc.
-    ];
-    for &(new, old) in MIGRATIONS {
-        let old_val = std::env::var_os(old);
-        let new_val = std::env::var_os(new);
-        match (old_val, new_val) {
-            (Some(old_val), None) => {
-                // SAFETY: single-threaded at this point in startup — no other
-                // threads have been spawned yet (tokio runtime runs after main
-                // setup, and this function is called before parse_cli).
-                #[allow(unsafe_code, clippy::disallowed_methods)]
-                unsafe {
-                    std::env::set_var(new, &old_val);
-                }
-                tracing::warn!(
-                    "{old} is deprecated and will be removed in a future release. \
-                     Set {new} instead."
-                );
-            }
-            _ => {}
-        }
-    }
-}
-
 fn check_legacy_home_migration() {
     if std::env::var_os("LOONG_HOME").is_some() {
         return;
@@ -119,7 +82,7 @@ async fn main() {
     let _stdin_guard = StdinGuard;
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
-    make_env_compatible();
+    loongclaw_daemon::make_env_compatible();
     check_legacy_home_migration();
     let cli = parse_cli();
     let command_source = if cli.command.is_some() {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -56,7 +56,10 @@ fn redacted_command_name(command: &Commands) -> &'static str {
 }
 
 fn check_legacy_home_migration() {
-    if std::env::var_os("LOONG_HOME").is_some() {
+    if std::env::var_os("LOONG_HOME")
+        .as_deref()
+        .is_some_and(|v| !v.is_empty())
+    {
         return;
     }
     let Some(user_home) = std::env::var_os("HOME")

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -55,8 +55,45 @@ fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
+/// Bridges deprecated `LOONGCLAW_*` environment variables to their `LOONG_*`
+/// replacements. Runs once at startup before any config reads.
+///
+/// For each entry: if the old name is set but the new name is not, copy the
+/// value into the new name and emit a deprecation warning. When both are set
+/// the new name wins silently.
+///
+/// Based on the pattern established by rustup (PR #161) for the
+/// `MULTIRUST_*` → `RUSTUP_*` migration.
+fn make_env_compatible() {
+    // (new_name, deprecated_name)
+    const MIGRATIONS: &[(&str, &str)] = &[
+        ("LOONG_HOME", "LOONGCLAW_HOME"),
+        // Future: ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"), etc.
+    ];
+    for &(new, old) in MIGRATIONS {
+        let old_val = std::env::var_os(old);
+        let new_val = std::env::var_os(new);
+        match (old_val, new_val) {
+            (Some(old_val), None) => {
+                // SAFETY: single-threaded at this point in startup — no other
+                // threads have been spawned yet (tokio runtime runs after main
+                // setup, and this function is called before parse_cli).
+                #[allow(unsafe_code, clippy::disallowed_methods)]
+                unsafe {
+                    std::env::set_var(new, &old_val);
+                }
+                tracing::warn!(
+                    "{old} is deprecated and will be removed in a future release. \
+                     Set {new} instead."
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
 fn check_legacy_home_migration() {
-    if std::env::var_os("LOONGCLAW_HOME").is_some() {
+    if std::env::var_os("LOONG_HOME").is_some() {
         return;
     }
     let Some(user_home) = std::env::var_os("HOME")
@@ -82,6 +119,7 @@ async fn main() {
     let _stdin_guard = StdinGuard;
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
+    make_env_compatible();
     check_legacy_home_migration();
     let cli = parse_cli();
     let command_source = if cli.command.is_some() {

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -54,10 +54,7 @@ impl MigrationEnvironmentGuard {
             }
         }
         if !explicit_loongclaw_home {
-            saved.push((
-                "LOONG_HOME".to_owned(),
-                std::env::var_os("LOONG_HOME"),
-            ));
+            saved.push(("LOONG_HOME".to_owned(), std::env::var_os("LOONG_HOME")));
             match home_override {
                 Some(home) => unsafe {
                     std::env::set_var("LOONG_HOME", home.join(mvp::config::HOME_DIR_NAME))

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -45,7 +45,10 @@ impl MigrationEnvironmentGuard {
             .find_map(|(key, value)| (*key == "HOME").then_some(*value))
             .flatten()
             .map(std::path::PathBuf::from);
-        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONG_HOME");
+        let explicit_home_override = pairs
+            .iter()
+            .any(|(key, _)| *key == "LOONG_HOME" || *key == "LOONGCLAW_HOME");
+
         for (key, value) in pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
@@ -53,7 +56,7 @@ impl MigrationEnvironmentGuard {
                 None => unsafe { std::env::remove_var(key) },
             }
         }
-        if !explicit_loongclaw_home {
+        if !explicit_home_override {
             saved.push(("LOONG_HOME".to_owned(), std::env::var_os("LOONG_HOME")));
             match home_override {
                 Some(home) => unsafe {

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -45,7 +45,7 @@ impl MigrationEnvironmentGuard {
             .find_map(|(key, value)| (*key == "HOME").then_some(*value))
             .flatten()
             .map(std::path::PathBuf::from);
-        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONGCLAW_HOME");
+        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONG_HOME");
         for (key, value) in pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
@@ -55,14 +55,14 @@ impl MigrationEnvironmentGuard {
         }
         if !explicit_loongclaw_home {
             saved.push((
-                "LOONGCLAW_HOME".to_owned(),
-                std::env::var_os("LOONGCLAW_HOME"),
+                "LOONG_HOME".to_owned(),
+                std::env::var_os("LOONG_HOME"),
             ));
             match home_override {
                 Some(home) => unsafe {
-                    std::env::set_var("LOONGCLAW_HOME", home.join(mvp::config::HOME_DIR_NAME))
+                    std::env::set_var("LOONG_HOME", home.join(mvp::config::HOME_DIR_NAME))
                 },
-                None => unsafe { std::env::remove_var("LOONGCLAW_HOME") },
+                None => unsafe { std::env::remove_var("LOONG_HOME") },
             }
         }
         Self { _lock: lock, saved }

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -113,7 +113,7 @@ impl ChatCliFixture {
             .arg("chat")
             .current_dir(&self.root)
             .env("HOME", &self.home_dir)
-            .env("LOONGCLAW_HOME", &loongclaw_home)
+            .env("LOONG_HOME", &loongclaw_home)
             .env_remove("LOONGCLAW_CONFIG_PATH")
             .env_remove("USERPROFILE")
             .stdin(Stdio::piped())

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -77,7 +77,10 @@ impl ImportEnvironmentGuard {
             .find_map(|(key, value)| (*key == "HOME").then_some(*value))
             .flatten()
             .map(std::path::PathBuf::from);
-        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONG_HOME");
+        let explicit_home_override = pairs
+            .iter()
+            .any(|(key, _)| *key == "LOONG_HOME" || *key == "LOONGCLAW_HOME");
+
         for (key, value) in pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
@@ -89,7 +92,7 @@ impl ImportEnvironmentGuard {
                 },
             }
         }
-        if !explicit_loongclaw_home {
+        if !explicit_home_override {
             saved.push(("LOONG_HOME".to_owned(), std::env::var_os("LOONG_HOME")));
             match home_override {
                 Some(home) => unsafe {

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -77,7 +77,7 @@ impl ImportEnvironmentGuard {
             .find_map(|(key, value)| (*key == "HOME").then_some(*value))
             .flatten()
             .map(std::path::PathBuf::from);
-        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONGCLAW_HOME");
+        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONG_HOME");
         for (key, value) in pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
@@ -91,15 +91,15 @@ impl ImportEnvironmentGuard {
         }
         if !explicit_loongclaw_home {
             saved.push((
-                "LOONGCLAW_HOME".to_owned(),
-                std::env::var_os("LOONGCLAW_HOME"),
+                "LOONG_HOME".to_owned(),
+                std::env::var_os("LOONG_HOME"),
             ));
             match home_override {
                 Some(home) => unsafe {
-                    std::env::set_var("LOONGCLAW_HOME", home.join(mvp::config::HOME_DIR_NAME))
+                    std::env::set_var("LOONG_HOME", home.join(mvp::config::HOME_DIR_NAME))
                 },
                 None => unsafe {
-                    std::env::remove_var("LOONGCLAW_HOME");
+                    std::env::remove_var("LOONG_HOME");
                 },
             }
         }

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -90,10 +90,7 @@ impl ImportEnvironmentGuard {
             }
         }
         if !explicit_loongclaw_home {
-            saved.push((
-                "LOONG_HOME".to_owned(),
-                std::env::var_os("LOONG_HOME"),
-            ));
+            saved.push(("LOONG_HOME".to_owned(), std::env::var_os("LOONG_HOME")));
             match home_override {
                 Some(home) => unsafe {
                     std::env::set_var("LOONG_HOME", home.join(mvp::config::HOME_DIR_NAME))

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -176,9 +176,9 @@ impl DetectedEnvironmentGuard {
             })
             .collect::<Vec<_>>();
         let isolated_home = isolated_loongclaw_home("detected-env-home");
-        let saved_loongclaw_home = std::env::var_os("LOONGCLAW_HOME");
+        let saved_loongclaw_home = std::env::var_os("LOONG_HOME");
         unsafe {
-            std::env::set_var("LOONGCLAW_HOME", &isolated_home);
+            std::env::set_var("LOONG_HOME", &isolated_home);
         }
         let isolated_sqlite = isolated_sqlite_path("detected-env-memory");
         let saved_loongclaw_sqlite_path = std::env::var_os("LOONGCLAW_SQLITE_PATH");
@@ -186,7 +186,7 @@ impl DetectedEnvironmentGuard {
             std::env::set_var("LOONGCLAW_SQLITE_PATH", &isolated_sqlite);
         }
         let mut saved = saved;
-        saved.push(("LOONGCLAW_HOME".to_owned(), saved_loongclaw_home));
+        saved.push(("LOONG_HOME".to_owned(), saved_loongclaw_home));
         saved.push((
             "LOONGCLAW_SQLITE_PATH".to_owned(),
             saved_loongclaw_sqlite_path,

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -56,7 +56,7 @@ impl RuntimeCapabilityEnvironmentGuard {
 
         let pairs = [
             ("HOME", Some(home_text.as_str())),
-            ("LOONGCLAW_HOME", Some(loongclaw_home_text.as_str())),
+            ("LOONG_HOME", Some(loongclaw_home_text.as_str())),
             ("LOONGCLAW_BROWSER_COMPANION_READY", None),
         ];
         let mut saved = Vec::new();

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T13:11:53Z
+- Generated at: 2026-04-07T16:39:15Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10052 | 11200 | 1148 | 83 | 120 | 37 | 89.8% | WATCH | 10831 | -7.2% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6431 | 6500 | 69 | 200 | 210 | 10 | 98.9% | TIGHT | 6324 | 1.7% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9790 | 9800 | 10 | 238 | 250 | 12 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6497 | 6500 | 3 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.7% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9800 | 9800 | 0 | 238 | 250 | 12 | 100.0% | TIGHT | 9519 | 3.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (98.9%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (89.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (100.0%), onboard_cli (100.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,10 +68,10 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10052 functions=83 -->
+<!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6431 functions=200 -->
-<!-- arch-hotspot key=onboard_cli lines=9790 functions=238 -->
+<!-- arch-hotspot key=daemon_lib lines=6497 functions=201 -->
+<!-- arch-hotspot key=onboard_cli lines=9800 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-07T16:39:15Z
+- Generated at: 2026-04-08T02:08:04Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -24,12 +24,12 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1788 | 6400 | 4612 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.5% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6497 | 6500 | 3 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.7% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6433 | 6500 | 67 | 200 | 210 | 10 | 99.0% | TIGHT | 6324 | 1.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9800 | 9800 | 0 | 238 | 250 | 12 | 100.0% | TIGHT | 9519 | 3.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (100.0%), onboard_cli (100.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_registry (97.4%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.0%), onboard_cli (100.0%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -70,7 +70,7 @@
 <!-- arch-hotspot key=channel_mod lines=1788 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6497 functions=201 -->
+<!-- arch-hotspot key=daemon_lib lines=6433 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9800 functions=238 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## summary

- restore the loong home env migration work on top of current `dev`
- keep `LOONG_HOME` as the preferred override with `LOONGCLAW_HOME` as the deprecated fallback
- preserve the maintainer follow-up that keeps empty-value handling aligned with existing config resolution and stops legacy-only test guards from auto-deriving `LOONG_HOME`

## linked issues

- closes #1055
- related #1054
- related #1043
- supersedes #1071 because that fork branch picked up unrelated shell-repair commits that are already tracked in #1080


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable auto-migration with deprecation warnings to support the transition from legacy naming conventions.

* **Chores**
  * Updated primary home directory environment variable to `LOONG_HOME`; legacy variable remains supported for backward compatibility.
  * Updated test infrastructure and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->