### PR TITLE
Add runtime trajectory artifacts for session replay and evaluation

### DIFF
--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -3096,14 +3096,35 @@ pub(crate) async fn process_inbound_with_provider(
     let duration_ms = started_at.elapsed().as_millis();
     match &result {
         Ok(reply) => {
+            let has_conversation_id = !message.session.conversation_id.trim().is_empty();
+            let has_configured_account_id = message
+                .session
+                .configured_account_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_account_id = message
+                .session
+                .account_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_source_message_id = message
+                .delivery
+                .source_message_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_ack_cursor = message
+                .delivery
+                .ack_cursor
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
             tracing::debug!(
                 target: "loongclaw.channel",
                 platform = %message.session.platform.as_str(),
-                conversation_id = %message.session.conversation_id,
-                configured_account_id = ?message.session.configured_account_id.as_deref(),
-                account_id = ?message.session.account_id.as_deref(),
-                source_message_id = ?message.delivery.source_message_id.as_deref(),
-                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                has_conversation_id,
+                has_configured_account_id,
+                has_account_id,
+                has_source_message_id,
+                has_ack_cursor,
                 text_len = message.text.chars().count(),
                 reply_len = reply.chars().count(),
                 duration_ms,
@@ -3111,14 +3132,35 @@ pub(crate) async fn process_inbound_with_provider(
             );
         }
         Err(error) => {
+            let has_conversation_id = !message.session.conversation_id.trim().is_empty();
+            let has_configured_account_id = message
+                .session
+                .configured_account_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_account_id = message
+                .session
+                .account_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_source_message_id = message
+                .delivery
+                .source_message_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_ack_cursor = message
+                .delivery
+                .ack_cursor
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
             tracing::warn!(
                 target: "loongclaw.channel",
                 platform = %message.session.platform.as_str(),
-                conversation_id = %message.session.conversation_id,
-                configured_account_id = ?message.session.configured_account_id.as_deref(),
-                account_id = ?message.session.account_id.as_deref(),
-                source_message_id = ?message.delivery.source_message_id.as_deref(),
-                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                has_conversation_id,
+                has_configured_account_id,
+                has_account_id,
+                has_source_message_id,
+                has_ack_cursor,
                 text_len = message.text.chars().count(),
                 duration_ms,
                 error = %crate::observability::summarize_error(error),

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -8761,6 +8761,7 @@ mod tests {
 
         let mut config = LoongClawConfig::default();
         config.discord.enabled = true;
+        config.discord.bot_token_env = None;
 
         let snapshots = channel_status_snapshots(&config);
         let discord = snapshots

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -230,6 +230,9 @@ pub fn replace_session_turns_direct(
 }
 
 #[cfg(feature = "memory-sqlite")]
+use rusqlite::Connection;
+
+#[cfg(feature = "memory-sqlite")]
 pub fn window_direct(
     session_id: &str,
     limit: usize,
@@ -245,6 +248,24 @@ pub fn transcript_direct_paged(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<Vec<ConversationTurn>, String> {
     sqlite::transcript_direct_paged(session_id, page_size, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn window_direct_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ConversationTurn>, String> {
+    sqlite::window_direct_with_conn(conn, session_id, limit)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn transcript_direct_paged_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    page_size: usize,
+) -> Result<Vec<ConversationTurn>, String> {
+    sqlite::transcript_direct_paged_with_conn(conn, session_id, page_size)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -239,6 +239,15 @@ pub fn window_direct(
 }
 
 #[cfg(feature = "memory-sqlite")]
+pub fn transcript_direct_paged(
+    session_id: &str,
+    page_size: usize,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    sqlite::transcript_direct_paged(session_id, page_size, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
 pub fn window_direct_extended(
     session_id: &str,
     limit: usize,

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -19,7 +19,7 @@ use super::{
     canonical_memory_record_from_persisted_turn, runtime_config::MemoryRuntimeConfig,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConversationTurn {
     pub role: String,
     pub content: String,
@@ -257,8 +257,12 @@ const SQL_QUERY_TURNS_AFTER_ID_WITH_LIMIT: &str = "SELECT id, role, content, ts
              FROM turns
              WHERE session_id = ?1
                AND id > ?2
+               AND id <= ?3
              ORDER BY id ASC
-             LIMIT ?3";
+             LIMIT ?4";
+const SQL_QUERY_MAX_TURN_ID_FOR_SESSION: &str = "SELECT COALESCE(MAX(id), 0)
+             FROM turns
+             WHERE session_id = ?1";
 const SQL_QUERY_TURNS_UP_TO_ID: &str = "SELECT id, role, content
              FROM turns
              WHERE session_id = ?1 AND id <= ?2
@@ -754,33 +758,68 @@ pub(super) fn transcript_direct_paged(
 
     let runtime = acquire_memory_runtime(config)?;
     runtime.with_connection("memory.transcript_direct_paged", |conn| {
-        let mut transcript = Vec::new();
-        let mut last_seen_turn_id = 0_i64;
+        transcript_direct_paged_with_conn(conn, session_id, page_size)
+    })
+}
 
-        loop {
-            let page =
-                query_transcript_page_after_id(conn, session_id, last_seen_turn_id, page_size)?;
+pub(crate) fn window_direct_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ConversationTurn>, String> {
+    let (turns, _) = query_recent_turns(conn, session_id, limit)?;
+    Ok(turns)
+}
 
-            if page.is_empty() {
-                break;
-            }
+pub(crate) fn transcript_direct_paged_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    page_size: usize,
+) -> Result<Vec<ConversationTurn>, String> {
+    if page_size == 0 {
+        return Err("memory transcript page_size must be >= 1".to_owned());
+    }
 
-            let next_last_seen_turn_id = page.last().map(|row| row.id).unwrap_or(last_seen_turn_id);
+    let upper_bound_turn_id = query_max_turn_id_for_session(conn, session_id)?;
+    if upper_bound_turn_id <= 0 {
+        return Ok(Vec::new());
+    }
 
-            for row in page {
-                let turn = ConversationTurn {
-                    role: row.role,
-                    content: row.content,
-                    ts: row.ts,
-                };
-                transcript.push(turn);
-            }
+    let mut transcript = Vec::new();
+    let mut last_seen_turn_id = 0_i64;
 
-            last_seen_turn_id = next_last_seen_turn_id;
+    loop {
+        if last_seen_turn_id >= upper_bound_turn_id {
+            break;
         }
 
-        Ok(transcript)
-    })
+        let page = query_transcript_page_after_id(
+            conn,
+            session_id,
+            last_seen_turn_id,
+            upper_bound_turn_id,
+            page_size,
+        )?;
+
+        if page.is_empty() {
+            break;
+        }
+
+        let next_last_seen_turn_id = page.last().map(|row| row.id).unwrap_or(last_seen_turn_id);
+
+        for row in page {
+            let turn = ConversationTurn {
+                role: row.role,
+                content: row.content,
+                ts: row.ts,
+            };
+            transcript.push(turn);
+        }
+
+        last_seen_turn_id = next_last_seen_turn_id;
+    }
+
+    Ok(transcript)
 }
 
 pub(super) fn window_direct_with_options(
@@ -962,8 +1001,12 @@ fn query_transcript_page_after_id(
     conn: &Connection,
     session_id: &str,
     after_id: i64,
+    upper_bound_turn_id: i64,
     page_size: usize,
 ) -> Result<Vec<TranscriptPageRow>, String> {
+    let page_size_i64 = i64::try_from(page_size).map_err(|conversion_error| {
+        format!("memory transcript page_size exceeds SQLite LIMIT range: {conversion_error}")
+    })?;
     let mut statement = prepare_cached_sqlite_statement(
         conn,
         SQL_QUERY_TURNS_AFTER_ID_WITH_LIMIT,
@@ -971,7 +1014,7 @@ fn query_transcript_page_after_id(
     )?;
     let rows = statement
         .query_map(
-            rusqlite::params![session_id, after_id, page_size as i64],
+            rusqlite::params![session_id, after_id, upper_bound_turn_id, page_size_i64],
             |row| {
                 Ok(TranscriptPageRow {
                     id: row.get(0)?,
@@ -992,6 +1035,15 @@ fn query_transcript_page_after_id(
     }
 
     Ok(page)
+}
+
+fn query_max_turn_id_for_session(conn: &Connection, session_id: &str) -> Result<i64, String> {
+    conn.query_row(
+        SQL_QUERY_MAX_TURN_ID_FOR_SESSION,
+        rusqlite::params![session_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(|error| format!("query transcript upper bound failed: {error}"))
 }
 
 /// Walk up the directory tree to find the deepest existing ancestor, canonicalize it

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -253,6 +253,12 @@ const SQL_QUERY_RECENT_PROMPT_TURNS_WITH_OVERFLOW_PROBE_FALLBACK: &str = "SELECT
              WHERE session_id = ?1
              ORDER BY id DESC
              LIMIT ?2";
+const SQL_QUERY_TURNS_AFTER_ID_WITH_LIMIT: &str = "SELECT id, role, content, ts
+             FROM turns
+             WHERE session_id = ?1
+               AND id > ?2
+             ORDER BY id ASC
+             LIMIT ?3";
 const SQL_QUERY_TURNS_UP_TO_ID: &str = "SELECT id, role, content
              FROM turns
              WHERE session_id = ?1 AND id <= ?2
@@ -435,6 +441,13 @@ struct WindowLoadResult {
     limit: usize,
     turns: Vec<ConversationTurn>,
     turn_count: Option<usize>,
+}
+
+struct TranscriptPageRow {
+    id: i64,
+    role: String,
+    content: String,
+    ts: i64,
 }
 
 enum ReplaceTurnsFailure {
@@ -730,6 +743,46 @@ pub(super) fn window_direct(
     window_direct_with_options(session_id, limit, true, config)
 }
 
+pub(super) fn transcript_direct_paged(
+    session_id: &str,
+    page_size: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    if page_size == 0 {
+        return Err("memory transcript page_size must be >= 1".to_owned());
+    }
+
+    let runtime = acquire_memory_runtime(config)?;
+    runtime.with_connection("memory.transcript_direct_paged", |conn| {
+        let mut transcript = Vec::new();
+        let mut last_seen_turn_id = 0_i64;
+
+        loop {
+            let page =
+                query_transcript_page_after_id(conn, session_id, last_seen_turn_id, page_size)?;
+
+            if page.is_empty() {
+                break;
+            }
+
+            let next_last_seen_turn_id = page.last().map(|row| row.id).unwrap_or(last_seen_turn_id);
+
+            for row in page {
+                let turn = ConversationTurn {
+                    role: row.role,
+                    content: row.content,
+                    ts: row.ts,
+                };
+                transcript.push(turn);
+            }
+
+            last_seen_turn_id = next_last_seen_turn_id;
+        }
+
+        Ok(transcript)
+    })
+}
+
 pub(super) fn window_direct_with_options(
     session_id: &str,
     limit: usize,
@@ -903,6 +956,42 @@ fn lexical_normalize_runtime_db_path(path: &Path) -> PathBuf {
     } else {
         normalized
     }
+}
+
+fn query_transcript_page_after_id(
+    conn: &Connection,
+    session_id: &str,
+    after_id: i64,
+    page_size: usize,
+) -> Result<Vec<TranscriptPageRow>, String> {
+    let mut statement = prepare_cached_sqlite_statement(
+        conn,
+        SQL_QUERY_TURNS_AFTER_ID_WITH_LIMIT,
+        "prepare transcript page query failed",
+    )?;
+    let rows = statement
+        .query_map(
+            rusqlite::params![session_id, after_id, page_size as i64],
+            |row| {
+                Ok(TranscriptPageRow {
+                    id: row.get(0)?,
+                    role: row.get(1)?,
+                    content: row.get(2)?,
+                    ts: row.get(3)?,
+                })
+            },
+        )
+        .map_err(|error| format!("query transcript page failed: {error}"))?;
+
+    let mut page = Vec::new();
+
+    for row in rows {
+        let transcript_row =
+            row.map_err(|error| format!("decode transcript page row failed: {error}"))?;
+        page.push(transcript_row);
+    }
+
+    Ok(page)
 }
 
 /// Walk up the directory tree to find the deepest existing ancestor, canonicalize it

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -5,6 +5,9 @@ pub mod recovery;
 pub mod repository;
 
 #[cfg(feature = "memory-sqlite")]
+pub mod trajectory;
+
+#[cfg(feature = "memory-sqlite")]
 pub mod frozen_result;
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -1133,6 +1133,19 @@ impl SessionRepository {
         Self::search_session_content_with_conn(&conn, &session_id, &normalized_query, limit)
     }
 
+    pub fn list_all_events(
+        &self,
+        session_id: &str,
+        page_limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        if page_limit == 0 {
+            return Err("page_limit must be >= 1".to_owned());
+        }
+        let conn = self.open_connection()?;
+        Self::drain_events_after_with_conn(&conn, &session_id, 0, page_limit)
+    }
+
     pub fn load_terminal_outcome(
         &self,
         session_id: &str,

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -10,8 +10,11 @@ use serde_json::Value;
 use super::frozen_result::FrozenResult;
 use crate::config::ToolConsentMode;
 use crate::memory;
+use crate::memory::ConversationTurn;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
+
+pub(crate) const SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE: usize = 200;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionKind {
@@ -362,6 +365,17 @@ pub struct SessionObservationRecord {
     pub tail_events: Vec<SessionEventRecord>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionTrajectoryReadSnapshot {
+    pub summary: SessionSummaryRecord,
+    pub lineage_root_session_id: Option<String>,
+    pub lineage_depth: usize,
+    pub turns: Vec<ConversationTurn>,
+    pub events: Vec<SessionEventRecord>,
+    pub approval_requests: Vec<ApprovalRequestRecord>,
+    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionSearchSourceKind {
     Turn,
@@ -463,6 +477,20 @@ impl SessionRepository {
     pub fn new(config: &MemoryRuntimeConfig) -> Result<Self, String> {
         let db_path = memory::ensure_memory_db_ready(config.sqlite_path.clone(), config)?;
         Ok(Self { db_path })
+    }
+
+    pub(crate) fn with_read_snapshot<T, F>(&self, operation: F) -> Result<T, String>
+    where
+        F: FnOnce(&Connection) -> Result<T, String>,
+    {
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session read snapshot failed: {error}"))?;
+        let result = operation(&tx)?;
+        tx.commit()
+            .map_err(|error| format!("commit session read snapshot failed: {error}"))?;
+        Ok(result)
     }
 
     pub fn create_session(&self, record: NewSessionRecord) -> Result<SessionRecord, String> {
@@ -1014,9 +1042,40 @@ impl SessionRepository {
 
     pub fn session_lineage_depth(&self, session_id: &str) -> Result<usize, String> {
         let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::session_lineage_depth_with_conn(&conn, &session_id)
+    }
+
+    pub fn count_active_direct_children(&self, parent_session_id: &str) -> Result<usize, String> {
+        let parent_session_id = normalize_required_text(parent_session_id, "parent_session_id")?;
+        let conn = self.open_connection()?;
+        Self::count_active_direct_children_with_conn(&conn, &parent_session_id)
+    }
+
+    pub fn lineage_root_session_id(&self, session_id: &str) -> Result<Option<String>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        Self::lineage_root_session_id_with_conn(&conn, &session_id)
+    }
+
+    pub(crate) fn list_all_events_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        page_limit: usize,
+    ) -> Result<Vec<SessionEventRecord>, String> {
+        if page_limit == 0 {
+            return Err("page_limit must be >= 1".to_owned());
+        }
+        Self::drain_events_after_with_conn(conn, session_id, 0, page_limit)
+    }
+
+    pub(crate) fn session_lineage_depth_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<usize, String> {
         let mut seen = BTreeSet::new();
+        let mut next_session_id = Some(session_id.to_owned());
         let mut depth = 0usize;
-        let mut next_session_id = Some(session_id);
 
         while let Some(current_session_id) = next_session_id {
             if !seen.insert(current_session_id.clone()) {
@@ -1024,7 +1083,7 @@ impl SessionRepository {
                     "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing lineage depth"
                 ));
             }
-            let session = match self.load_session(&current_session_id)? {
+            let session = match Self::load_session_with_conn(conn, &current_session_id)? {
                 Some(session) => session,
                 None if depth == 0 => return Ok(0),
                 None => {
@@ -1045,16 +1104,12 @@ impl SessionRepository {
         Ok(depth)
     }
 
-    pub fn count_active_direct_children(&self, parent_session_id: &str) -> Result<usize, String> {
-        let parent_session_id = normalize_required_text(parent_session_id, "parent_session_id")?;
-        let conn = self.open_connection()?;
-        Self::count_active_direct_children_with_conn(&conn, &parent_session_id)
-    }
-
-    pub fn lineage_root_session_id(&self, session_id: &str) -> Result<Option<String>, String> {
-        let session_id = normalize_required_text(session_id, "session_id")?;
+    pub(crate) fn lineage_root_session_id_with_conn(
+        conn: &Connection,
+        session_id: &str,
+    ) -> Result<Option<String>, String> {
         let mut seen = BTreeSet::new();
-        let mut next_session_id = Some(session_id);
+        let mut next_session_id = Some(session_id.to_owned());
 
         while let Some(current_session_id) = next_session_id {
             if !seen.insert(current_session_id.clone()) {
@@ -1062,7 +1117,7 @@ impl SessionRepository {
                     "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing lineage root"
                 ));
             }
-            let session = match self.load_session(&current_session_id)? {
+            let session = match Self::load_session_with_conn(conn, &current_session_id)? {
                 Some(session) => session,
                 None if seen.len() == 1 => return Ok(None),
                 None => {
@@ -1144,6 +1199,47 @@ impl SessionRepository {
         }
         let conn = self.open_connection()?;
         Self::drain_events_after_with_conn(&conn, &session_id, 0, page_limit)
+    }
+
+    pub fn load_session_trajectory_read_snapshot(
+        &self,
+        session_id: &str,
+        page_limit: usize,
+    ) -> Result<Option<SessionTrajectoryReadSnapshot>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        if page_limit == 0 {
+            return Err("page_limit must be >= 1".to_owned());
+        }
+
+        self.with_read_snapshot(|conn| {
+            let Some(summary) =
+                Self::load_session_summary_with_legacy_fallback_with_conn(conn, &session_id)?
+            else {
+                return Ok(None);
+            };
+            let lineage_root_session_id =
+                Self::lineage_root_session_id_with_conn(conn, &session_id)?;
+            let lineage_depth = Self::session_lineage_depth_with_conn(conn, &session_id)?;
+            let turns = memory::transcript_direct_paged_with_conn(
+                conn,
+                &session_id,
+                SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE,
+            )?;
+            let events = Self::list_all_events_with_conn(conn, &session_id, page_limit)?;
+            let approval_requests =
+                Self::list_approval_requests_for_session_with_conn(conn, &session_id, None)?;
+            let terminal_outcome = Self::load_terminal_outcome_with_conn(conn, &session_id)?;
+
+            Ok(Some(SessionTrajectoryReadSnapshot {
+                summary,
+                lineage_root_session_id,
+                lineage_depth,
+                turns,
+                events,
+                approval_requests,
+                terminal_outcome,
+            }))
+        })
     }
 
     pub fn load_terminal_outcome(
@@ -1287,6 +1383,14 @@ impl SessionRepository {
     ) -> Result<Vec<ApprovalRequestRecord>, String> {
         let session_id = normalize_required_text(session_id, "session_id")?;
         let conn = self.open_connection()?;
+        Self::list_approval_requests_for_session_with_conn(&conn, &session_id, status)
+    }
+
+    pub(crate) fn list_approval_requests_for_session_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        status: Option<ApprovalRequestStatus>,
+    ) -> Result<Vec<ApprovalRequestRecord>, String> {
         let mut requests = Vec::new();
         match status {
             Some(status) => {
@@ -2660,7 +2764,7 @@ impl SessionRepository {
             .map_err(|error| format!("active direct child count overflowed usize: {error}"))
     }
 
-    fn load_session_summary_with_conn(
+    pub(crate) fn load_session_summary_with_conn(
         conn: &Connection,
         session_id: &str,
     ) -> Result<Option<SessionSummaryRecord>, String> {
@@ -2719,7 +2823,7 @@ impl SessionRepository {
         raw.map(SessionSummaryRecord::try_from_raw).transpose()
     }
 
-    fn load_session_summary_with_legacy_fallback_with_conn(
+    pub(crate) fn load_session_summary_with_legacy_fallback_with_conn(
         conn: &Connection,
         session_id: &str,
     ) -> Result<Option<SessionSummaryRecord>, String> {
@@ -3162,7 +3266,7 @@ impl SessionRepository {
         Ok(results)
     }
 
-    fn load_terminal_outcome_with_conn(
+    pub(crate) fn load_terminal_outcome_with_conn(
         conn: &Connection,
         session_id: &str,
     ) -> Result<Option<SessionTerminalOutcomeRecord>, String> {

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -3137,52 +3137,60 @@ impl SessionRepository {
             return Ok(Vec::new());
         }
 
+        let turn_match_query = build_search_fts_query(normalized_query);
         let patterns = build_search_like_patterns(normalized_query);
-        if patterns.is_empty() {
+        if turn_match_query.is_none() && patterns.is_empty() {
             return Ok(Vec::new());
         }
 
         let mut hits = Vec::new();
-        hits.extend(Self::search_session_turns_with_conn(
-            conn,
-            session_id,
-            patterns.as_slice(),
-            limit,
-        )?);
-        hits.extend(Self::search_session_events_with_conn(
-            conn,
-            session_id,
-            patterns.as_slice(),
-            limit,
-        )?);
+        if let Some(turn_match_query) = turn_match_query.as_deref() {
+            let turn_hits =
+                Self::search_session_turns_with_conn(conn, session_id, turn_match_query, limit)?;
+            hits.extend(turn_hits);
+        }
+        if !patterns.is_empty() {
+            let event_hits = Self::search_session_events_with_conn(
+                conn,
+                session_id,
+                patterns.as_slice(),
+                limit,
+            )?;
+            hits.extend(event_hits);
+        }
         Ok(hits)
     }
 
     fn search_session_turns_with_conn(
         conn: &Connection,
         session_id: &str,
-        patterns: &[String],
+        match_query: &str,
         limit: usize,
     ) -> Result<Vec<SessionSearchRecord>, String> {
-        let where_clause = build_search_where_clause("lower(content)", patterns.len(), 2);
-        let sql = format!(
-            "SELECT id, session_id, role, content, ts
-             FROM turns
-             WHERE session_id = ?1
-               AND ({where_clause})
-             ORDER BY id DESC
-             LIMIT {limit}"
-        );
-
         let mut stmt = conn
-            .prepare(sql.as_str())
+            .prepare(
+                "SELECT persisted_turn.id,
+                        persisted_turn.session_id,
+                        persisted_turn.role,
+                        persisted_turn.content,
+                        persisted_turn.ts
+                 FROM memory_canonical_records_fts AS fts
+                 JOIN memory_canonical_records AS record
+                   ON record.record_id = fts.rowid
+                 JOIN turns AS persisted_turn
+                   ON persisted_turn.session_id = record.session_id
+                  AND persisted_turn.session_turn_index = record.session_turn_index
+                 WHERE memory_canonical_records_fts MATCH ?1
+                   AND persisted_turn.session_id = ?2
+                   AND record.kind IN ('user_turn', 'assistant_turn')
+                 ORDER BY bm25(memory_canonical_records_fts),
+                          persisted_turn.ts DESC,
+                          persisted_turn.id DESC
+                 LIMIT ?3",
+            )
             .map_err(|error| format!("prepare session search turns query failed: {error}"))?;
-        let mut bindings = Vec::with_capacity(patterns.len().saturating_add(1));
-        bindings.push(session_id.to_owned());
-        bindings.extend(patterns.iter().cloned());
-
         let rows = stmt
-            .query_map(params_from_iter(bindings.iter()), |row| {
+            .query_map(params![match_query, session_id, limit as i64], |row| {
                 Ok(RawSessionSearchTurnRecord {
                     id: row.get(0)?,
                     session_id: row.get(1)?,
@@ -3857,6 +3865,36 @@ fn build_search_like_patterns(normalized_query: &str) -> Vec<String> {
     }
 
     patterns
+}
+
+fn build_search_fts_query(normalized_query: &str) -> Option<String> {
+    let trimmed_query = normalized_query.trim();
+    if trimmed_query.is_empty() {
+        return None;
+    }
+
+    let mut terms = Vec::new();
+    let mut seen_terms = BTreeSet::new();
+
+    let escaped_query = trimmed_query.replace('"', "\"\"");
+    let quoted_query = format!("\"{escaped_query}\"");
+    if seen_terms.insert(quoted_query.clone()) {
+        terms.push(quoted_query);
+    }
+
+    for token in tokenize_search_query(normalized_query).into_iter().take(6) {
+        let escaped_token = token.replace('"', "\"\"");
+        let quoted_token = format!("\"{escaped_token}\"");
+        if seen_terms.insert(quoted_token.clone()) {
+            terms.push(quoted_token);
+        }
+    }
+
+    if terms.is_empty() {
+        return None;
+    }
+
+    Some(terms.join(" OR "))
 }
 
 fn tokenize_search_query(query: &str) -> Vec<String> {
@@ -4757,6 +4795,66 @@ mod tests {
         assert!(
             repo.is_session_visible("root-session", "grandchild-session")
                 .expect("root should see grandchild")
+        );
+    }
+
+    #[test]
+    fn search_session_content_returns_turn_and_event_hits_for_session_scope() {
+        let config = isolated_memory_config("search-session-content");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "Deploy freeze window is Friday and migration starts Saturday.",
+            &config,
+        )
+        .expect("append assistant turn");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "summary": "deploy freeze checklist completed"
+            }),
+        })
+        .expect("append child event");
+
+        let hits = repo
+            .search_session_content("child-session", "deploy freeze", 8)
+            .expect("search session content");
+
+        assert!(
+            hits.iter().any(|hit| {
+                hit.source_kind == SessionSearchSourceKind::Turn
+                    && hit.content_text.contains("Deploy freeze window")
+            }),
+            "expected a turn hit, got: {hits:?}"
+        );
+        assert!(
+            hits.iter().any(|hit| {
+                hit.source_kind == SessionSearchSourceKind::Event
+                    && hit
+                        .content_text
+                        .contains("deploy freeze checklist completed")
+            }),
+            "expected an event hit, got: {hits:?}"
         );
     }
 

--- a/crates/app/src/session/trajectory.rs
+++ b/crates/app/src/session/trajectory.rs
@@ -1,0 +1,604 @@
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::memory;
+use crate::memory::ConversationTurn;
+use crate::memory::canonical_memory_record_from_persisted_turn;
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+use super::repository::ApprovalDecision;
+use super::repository::ApprovalRequestRecord;
+use super::repository::SessionEventRecord;
+use super::repository::SessionRepository;
+use super::repository::SessionSummaryRecord;
+use super::repository::SessionTerminalOutcomeRecord;
+
+pub const SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+pub const SESSION_TRAJECTORY_ARTIFACT_SURFACE: &str = "runtime_trajectory";
+pub const SESSION_TRAJECTORY_ARTIFACT_PURPOSE: &str = "runtime_trajectory_export";
+const DEFAULT_EVENT_PAGE_LIMIT: usize = 200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionTrajectoryExportOptions {
+    pub turn_limit: Option<usize>,
+    pub event_page_limit: usize,
+}
+
+impl Default for SessionTrajectoryExportOptions {
+    fn default() -> Self {
+        Self {
+            turn_limit: None,
+            event_page_limit: DEFAULT_EVENT_PAGE_LIMIT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTrajectoryArtifactSchema {
+    pub version: u32,
+    pub surface: String,
+    pub purpose: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTrajectorySession {
+    pub session_id: String,
+    pub kind: String,
+    pub parent_session_id: Option<String>,
+    pub label: Option<String>,
+    pub state: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub archived_at: Option<i64>,
+    pub turn_count: usize,
+    pub last_turn_at: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTrajectoryLineage {
+    pub root_session_id: Option<String>,
+    pub depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTrajectoryTurn {
+    pub sequence: usize,
+    pub role: String,
+    pub content: String,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTrajectoryEvent {
+    pub id: i64,
+    pub session_id: String,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub payload_json: Value,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTrajectoryTerminalOutcome {
+    pub session_id: String,
+    pub status: String,
+    pub payload_json: Value,
+    pub recorded_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTrajectoryCanonicalRecord {
+    pub scope: String,
+    pub kind: String,
+    pub role: Option<String>,
+    pub content: String,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTrajectoryApprovalRequest {
+    pub approval_request_id: String,
+    pub turn_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub approval_key: String,
+    pub status: String,
+    pub decision: Option<String>,
+    pub request_payload_json: Value,
+    pub governance_snapshot_json: Value,
+    pub requested_at: i64,
+    pub resolved_at: Option<i64>,
+    pub resolved_by_session_id: Option<String>,
+    pub executed_at: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTrajectoryArtifact {
+    pub schema: SessionTrajectoryArtifactSchema,
+    pub exported_at: String,
+    pub session: SessionTrajectorySession,
+    pub lineage: SessionTrajectoryLineage,
+    pub exported_turn_count: usize,
+    pub turns_truncated: bool,
+    pub turns: Vec<SessionTrajectoryTurn>,
+    pub canonical_record_count: usize,
+    pub canonical_records: Vec<SessionTrajectoryCanonicalRecord>,
+    pub event_count: usize,
+    pub event_page_limit: usize,
+    pub events: Vec<SessionTrajectoryEvent>,
+    pub approval_request_count: usize,
+    pub approval_requests: Vec<SessionTrajectoryApprovalRequest>,
+    pub terminal_outcome: Option<SessionTrajectoryTerminalOutcome>,
+}
+
+pub fn export_session_trajectory(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+    options: &SessionTrajectoryExportOptions,
+) -> Result<SessionTrajectoryArtifact, String> {
+    validate_export_options(options)?;
+
+    let repository = SessionRepository::new(config)?;
+    let summary_option = repository.load_session_summary_with_legacy_fallback(session_id)?;
+    let summary = summary_option.ok_or_else(|| format!("session `{session_id}` not found"))?;
+    let turn_limit = resolve_turn_limit(summary.turn_count, options.turn_limit)?;
+    let root_session_id = repository.lineage_root_session_id(session_id)?;
+    let lineage_depth = repository.session_lineage_depth(session_id)?;
+
+    let turns = if turn_limit == 0 {
+        Vec::new()
+    } else {
+        memory::window_direct(session_id, turn_limit, config)?
+    };
+
+    let events = repository.list_all_events(session_id, options.event_page_limit)?;
+    let approval_requests = repository.list_approval_requests_for_session(session_id, None)?;
+    let terminal_outcome = repository.load_terminal_outcome(session_id)?;
+    let turns_truncated = summary.turn_count > turn_limit;
+    let exported_at = now_rfc3339()?;
+    let session = SessionTrajectorySession::from_summary(&summary);
+    let lineage = SessionTrajectoryLineage {
+        root_session_id,
+        depth: lineage_depth,
+    };
+    let first_sequence = resolve_first_sequence(summary.turn_count, turn_limit);
+    let trajectory_turns = build_trajectory_turns(&turns, first_sequence);
+    let canonical_records = build_canonical_records(session_id, &turns);
+    let trajectory_events = build_trajectory_events(&events);
+    let trajectory_approval_requests = build_approval_requests(&approval_requests);
+    let trajectory_outcome = terminal_outcome
+        .as_ref()
+        .map(SessionTrajectoryTerminalOutcome::from_terminal_outcome);
+    let exported_turn_count = trajectory_turns.len();
+    let canonical_record_count = canonical_records.len();
+    let event_count = trajectory_events.len();
+    let approval_request_count = trajectory_approval_requests.len();
+    let schema = SessionTrajectoryArtifactSchema::default();
+
+    Ok(SessionTrajectoryArtifact {
+        schema,
+        exported_at,
+        session,
+        lineage,
+        exported_turn_count,
+        turns_truncated,
+        turns: trajectory_turns,
+        canonical_record_count,
+        canonical_records,
+        event_count,
+        event_page_limit: options.event_page_limit,
+        events: trajectory_events,
+        approval_request_count,
+        approval_requests: trajectory_approval_requests,
+        terminal_outcome: trajectory_outcome,
+    })
+}
+
+fn validate_export_options(options: &SessionTrajectoryExportOptions) -> Result<(), String> {
+    if options.event_page_limit == 0 {
+        return Err("session trajectory event_page_limit must be >= 1".to_owned());
+    }
+
+    if matches!(options.turn_limit, Some(0)) {
+        return Err("session trajectory turn_limit must be >= 1 when provided".to_owned());
+    }
+
+    Ok(())
+}
+
+fn resolve_turn_limit(
+    total_turn_count: usize,
+    requested_turn_limit: Option<usize>,
+) -> Result<usize, String> {
+    if total_turn_count == 0 {
+        return Ok(0);
+    }
+
+    let Some(requested_turn_limit) = requested_turn_limit else {
+        return Ok(total_turn_count);
+    };
+
+    if requested_turn_limit == 0 {
+        return Err("session trajectory turn_limit must be >= 1 when provided".to_owned());
+    }
+
+    let bounded_turn_limit = requested_turn_limit.min(total_turn_count);
+    Ok(bounded_turn_limit)
+}
+
+fn resolve_first_sequence(total_turn_count: usize, exported_turn_count: usize) -> usize {
+    if exported_turn_count == 0 {
+        return 0;
+    }
+
+    let hidden_turn_count = total_turn_count.saturating_sub(exported_turn_count);
+    hidden_turn_count.saturating_add(1)
+}
+
+fn build_trajectory_turns(
+    turns: &[ConversationTurn],
+    first_sequence: usize,
+) -> Vec<SessionTrajectoryTurn> {
+    let mut trajectory_turns = Vec::with_capacity(turns.len());
+
+    for (index, turn) in turns.iter().enumerate() {
+        let offset = index;
+        let sequence = first_sequence.saturating_add(offset);
+        let trajectory_turn = SessionTrajectoryTurn::from_turn(sequence, turn);
+        trajectory_turns.push(trajectory_turn);
+    }
+
+    trajectory_turns
+}
+
+fn build_trajectory_events(events: &[SessionEventRecord]) -> Vec<SessionTrajectoryEvent> {
+    let mut trajectory_events = Vec::with_capacity(events.len());
+
+    for event in events {
+        let trajectory_event = SessionTrajectoryEvent::from_event(event);
+        trajectory_events.push(trajectory_event);
+    }
+
+    trajectory_events
+}
+
+fn build_canonical_records(
+    session_id: &str,
+    turns: &[ConversationTurn],
+) -> Vec<SessionTrajectoryCanonicalRecord> {
+    let mut canonical_records = Vec::with_capacity(turns.len());
+
+    for turn in turns {
+        let role = turn.role.as_str();
+        let content = turn.content.as_str();
+        let canonical_record =
+            canonical_memory_record_from_persisted_turn(session_id, role, content);
+        let trajectory_record = SessionTrajectoryCanonicalRecord::from_record(&canonical_record);
+        canonical_records.push(trajectory_record);
+    }
+
+    canonical_records
+}
+
+fn build_approval_requests(
+    approval_requests: &[ApprovalRequestRecord],
+) -> Vec<SessionTrajectoryApprovalRequest> {
+    let mut trajectory_approval_requests = Vec::with_capacity(approval_requests.len());
+
+    for approval_request in approval_requests {
+        let trajectory_approval_request =
+            SessionTrajectoryApprovalRequest::from_record(approval_request);
+        trajectory_approval_requests.push(trajectory_approval_request);
+    }
+
+    trajectory_approval_requests
+}
+
+fn now_rfc3339() -> Result<String, String> {
+    let now = OffsetDateTime::now_utc();
+    let formatted = now
+        .format(&Rfc3339)
+        .map_err(|error| format!("format session trajectory export timestamp failed: {error}"))?;
+    Ok(formatted)
+}
+
+impl Default for SessionTrajectoryArtifactSchema {
+    fn default() -> Self {
+        Self {
+            version: SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: SESSION_TRAJECTORY_ARTIFACT_SURFACE.to_owned(),
+            purpose: SESSION_TRAJECTORY_ARTIFACT_PURPOSE.to_owned(),
+        }
+    }
+}
+
+impl SessionTrajectorySession {
+    fn from_summary(summary: &SessionSummaryRecord) -> Self {
+        let kind = summary.kind.as_str().to_owned();
+        let state = summary.state.as_str().to_owned();
+
+        Self {
+            session_id: summary.session_id.clone(),
+            kind,
+            parent_session_id: summary.parent_session_id.clone(),
+            label: summary.label.clone(),
+            state,
+            created_at: summary.created_at,
+            updated_at: summary.updated_at,
+            archived_at: summary.archived_at,
+            turn_count: summary.turn_count,
+            last_turn_at: summary.last_turn_at,
+            last_error: summary.last_error.clone(),
+        }
+    }
+}
+
+impl SessionTrajectoryTurn {
+    fn from_turn(sequence: usize, turn: &ConversationTurn) -> Self {
+        Self {
+            sequence,
+            role: turn.role.clone(),
+            content: turn.content.clone(),
+            ts: turn.ts,
+        }
+    }
+}
+
+impl SessionTrajectoryEvent {
+    fn from_event(event: &SessionEventRecord) -> Self {
+        Self {
+            id: event.id,
+            session_id: event.session_id.clone(),
+            event_kind: event.event_kind.clone(),
+            actor_session_id: event.actor_session_id.clone(),
+            payload_json: event.payload_json.clone(),
+            ts: event.ts,
+        }
+    }
+}
+
+impl SessionTrajectoryTerminalOutcome {
+    fn from_terminal_outcome(outcome: &SessionTerminalOutcomeRecord) -> Self {
+        Self {
+            session_id: outcome.session_id.clone(),
+            status: outcome.status.clone(),
+            payload_json: outcome.payload_json.clone(),
+            recorded_at: outcome.recorded_at,
+        }
+    }
+}
+
+impl SessionTrajectoryCanonicalRecord {
+    fn from_record(record: &crate::memory::CanonicalMemoryRecord) -> Self {
+        let scope = record.scope.as_str().to_owned();
+        let kind = record.kind.as_str().to_owned();
+
+        Self {
+            scope,
+            kind,
+            role: record.role.clone(),
+            content: record.content.clone(),
+            metadata: record.metadata.clone(),
+        }
+    }
+}
+
+impl SessionTrajectoryApprovalRequest {
+    fn from_record(record: &ApprovalRequestRecord) -> Self {
+        let status = record.status.as_str().to_owned();
+        let decision = record
+            .decision
+            .map(ApprovalDecision::as_str)
+            .map(str::to_owned);
+
+        Self {
+            approval_request_id: record.approval_request_id.clone(),
+            turn_id: record.turn_id.clone(),
+            tool_call_id: record.tool_call_id.clone(),
+            tool_name: record.tool_name.clone(),
+            approval_key: record.approval_key.clone(),
+            status,
+            decision,
+            request_payload_json: record.request_payload_json.clone(),
+            governance_snapshot_json: record.governance_snapshot_json.clone(),
+            requested_at: record.requested_at,
+            resolved_at: record.resolved_at,
+            resolved_by_session_id: record.resolved_by_session_id.clone(),
+            executed_at: record.executed_at,
+            last_error: record.last_error.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::SessionTrajectoryExportOptions;
+    use super::export_session_trajectory;
+    use crate::memory;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::FinalizeSessionTerminalRequest;
+    use crate::session::repository::NewApprovalRequestRecord;
+    use crate::session::repository::NewSessionEvent;
+    use crate::session::repository::NewSessionRecord;
+    use crate::session::repository::SessionKind;
+    use crate::session::repository::SessionRecord;
+    use crate::session::repository::SessionRepository;
+    use crate::session::repository::SessionState;
+    use crate::test_support::unique_temp_dir;
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let root = unique_temp_dir(test_name);
+        let sqlite_path = root.join("memory.sqlite3");
+        MemoryRuntimeConfig {
+            sqlite_path: Some(sqlite_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn append_turns(
+        session_id: &str,
+        config: &MemoryRuntimeConfig,
+        contents: &[&str],
+    ) -> Result<(), String> {
+        for content in contents {
+            memory::append_turn_direct(session_id, "assistant", content, config)?;
+        }
+
+        Ok(())
+    }
+
+    fn create_session(
+        repository: &SessionRepository,
+        session_id: &str,
+    ) -> Result<SessionRecord, String> {
+        let record = NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        };
+        repository.create_session(record)
+    }
+
+    #[test]
+    fn export_session_trajectory_collects_turns_events_and_terminal_outcome() {
+        let config = isolated_memory_config("session-trajectory-full");
+        let repository = SessionRepository::new(&config).expect("repository");
+        create_session(&repository, "root-session").expect("create session");
+        append_turns("root-session", &config, &["step one", "step two"]).expect("append turns");
+        let start_payload = json!({
+            "task": "summarize"
+        });
+        let start_event = NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("operator".to_owned()),
+            payload_json: start_payload,
+        };
+        repository.append_event(start_event).expect("append event");
+
+        let approval_payload = json!({
+            "tool_name": "delegate"
+        });
+        let governance_payload = json!({
+            "rule_id": "delegate_review"
+        });
+        let approval_request = NewApprovalRequestRecord {
+            approval_request_id: "approval-1".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-1".to_owned(),
+            tool_call_id: "tool-call-1".to_owned(),
+            tool_name: "delegate".to_owned(),
+            approval_key: "tool:delegate".to_owned(),
+            request_payload_json: approval_payload,
+            governance_snapshot_json: governance_payload,
+        };
+        repository
+            .ensure_approval_request(approval_request)
+            .expect("ensure approval request");
+
+        let terminal_event_payload = json!({
+            "task": "summarize"
+        });
+        let terminal_outcome_payload = json!({
+            "summary": "done"
+        });
+        let finalize_request = FinalizeSessionTerminalRequest {
+            state: SessionState::Completed,
+            last_error: None,
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("operator".to_owned()),
+            event_payload_json: terminal_event_payload,
+            outcome_status: "ok".to_owned(),
+            outcome_payload_json: terminal_outcome_payload,
+        };
+        repository
+            .finalize_session_terminal("root-session", finalize_request)
+            .expect("finalize session");
+
+        let options = SessionTrajectoryExportOptions::default();
+        let artifact =
+            export_session_trajectory("root-session", &config, &options).expect("export");
+
+        assert_eq!(artifact.session.session_id, "root-session");
+        assert_eq!(artifact.session.turn_count, 2);
+        assert_eq!(
+            artifact.lineage.root_session_id.as_deref(),
+            Some("root-session")
+        );
+        assert_eq!(artifact.lineage.depth, 0);
+        assert_eq!(artifact.exported_turn_count, 2);
+        assert!(!artifact.turns_truncated);
+        assert_eq!(artifact.canonical_record_count, 2);
+        assert_eq!(artifact.canonical_records[0].kind, "assistant_turn");
+        assert_eq!(artifact.event_count, 2);
+        assert_eq!(artifact.events[0].event_kind, "delegate_started");
+        assert_eq!(artifact.events[1].event_kind, "delegate_completed");
+        assert_eq!(artifact.approval_request_count, 1);
+        assert_eq!(artifact.approval_requests[0].tool_name, "delegate");
+        assert_eq!(
+            artifact
+                .terminal_outcome
+                .as_ref()
+                .expect("terminal outcome")
+                .status,
+            "ok"
+        );
+    }
+
+    #[test]
+    fn export_session_trajectory_applies_turn_limit_without_guessing_counts() {
+        let config = isolated_memory_config("session-trajectory-turn-limit");
+        let repository = SessionRepository::new(&config).expect("repository");
+        create_session(&repository, "root-session").expect("create session");
+        append_turns("root-session", &config, &["one", "two", "three"]).expect("append turns");
+
+        let options = SessionTrajectoryExportOptions {
+            turn_limit: Some(2),
+            ..SessionTrajectoryExportOptions::default()
+        };
+        let artifact =
+            export_session_trajectory("root-session", &config, &options).expect("export");
+
+        assert_eq!(artifact.session.turn_count, 3);
+        assert_eq!(artifact.exported_turn_count, 2);
+        assert!(artifact.turns_truncated);
+        assert_eq!(artifact.turns[0].sequence, 2);
+        assert_eq!(artifact.turns[1].sequence, 3);
+        assert_eq!(artifact.turns[0].content, "two");
+        assert_eq!(artifact.turns[1].content, "three");
+    }
+
+    #[test]
+    fn export_session_trajectory_rejects_invalid_options() {
+        let config = isolated_memory_config("session-trajectory-invalid-options");
+        let repository = SessionRepository::new(&config).expect("repository");
+        create_session(&repository, "root-session").expect("create session");
+
+        let invalid_turn_limit_options = SessionTrajectoryExportOptions {
+            turn_limit: Some(0),
+            event_page_limit: 10,
+        };
+        let turn_limit_error =
+            export_session_trajectory("root-session", &config, &invalid_turn_limit_options)
+                .expect_err("zero turn limit must fail");
+        assert!(turn_limit_error.contains("turn_limit"));
+
+        let invalid_event_page_options = SessionTrajectoryExportOptions {
+            turn_limit: None,
+            event_page_limit: 0,
+        };
+        let event_page_error =
+            export_session_trajectory("root-session", &config, &invalid_event_page_options)
+                .expect_err("zero event page limit must fail");
+        assert!(event_page_error.contains("event_page_limit"));
+    }
+}

--- a/crates/app/src/session/trajectory.rs
+++ b/crates/app/src/session/trajectory.rs
@@ -11,6 +11,7 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::repository::ApprovalDecision;
 use super::repository::ApprovalRequestRecord;
+use super::repository::SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE;
 use super::repository::SessionEventRecord;
 use super::repository::SessionRepository;
 use super::repository::SessionSummaryRecord;
@@ -20,7 +21,6 @@ pub const SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
 pub const SESSION_TRAJECTORY_ARTIFACT_SURFACE: &str = "runtime_trajectory";
 pub const SESSION_TRAJECTORY_ARTIFACT_PURPOSE: &str = "runtime_trajectory_export";
 const DEFAULT_EVENT_PAGE_LIMIT: usize = 200;
-const DEFAULT_TRANSCRIPT_PAGE_SIZE: usize = 200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionTrajectoryExportOptions {
@@ -88,6 +88,7 @@ pub struct SessionTrajectoryTerminalOutcome {
     pub session_id: String,
     pub status: String,
     pub payload_json: Value,
+    pub frozen_result: Option<super::frozen_result::FrozenResult>,
     pub recorded_at: i64,
 }
 
@@ -145,75 +146,101 @@ pub fn export_session_trajectory(
     validate_export_options(options)?;
 
     let repository = SessionRepository::new(config)?;
-    let summary_option = repository.load_session_summary_with_legacy_fallback(session_id)?;
-    let summary = summary_option.ok_or_else(|| format!("session `{session_id}` not found"))?;
-    let turn_limit = resolve_turn_limit(summary.turn_count, options.turn_limit)?;
-    let root_session_id = repository.lineage_root_session_id(session_id)?;
-    let lineage_depth = repository.session_lineage_depth(session_id)?;
+    repository.with_read_snapshot(|conn| {
+        let summary = SessionRepository::load_session_summary_with_legacy_fallback_with_conn(
+            conn, session_id,
+        )?
+        .ok_or_else(|| format!("session `{session_id}` not found"))?;
+        let total_turn_count = summary.turn_count;
+        let turn_limit = resolve_turn_limit(total_turn_count, options.turn_limit)?;
+        let root_session_id =
+            SessionRepository::lineage_root_session_id_with_conn(conn, session_id)?;
+        let lineage_depth = SessionRepository::session_lineage_depth_with_conn(conn, session_id)?;
+        let turns = load_export_turns_with_conn(conn, session_id, turn_limit)?;
+        let events = SessionRepository::list_all_events_with_conn(
+            conn,
+            session_id,
+            options.event_page_limit,
+        )?;
+        let approval_requests = SessionRepository::list_approval_requests_for_session_with_conn(
+            conn, session_id, None,
+        )?;
+        let terminal_outcome =
+            SessionRepository::load_terminal_outcome_with_conn(conn, session_id)?;
+        let turns_truncated = total_turn_count > turn_limit;
+        let exported_at = now_rfc3339()?;
+        let session = SessionTrajectorySession::from_summary(&summary);
+        let lineage = SessionTrajectoryLineage {
+            root_session_id,
+            depth: lineage_depth,
+        };
+        let exported_turn_count = turns.len();
+        let first_sequence = resolve_first_sequence(total_turn_count, exported_turn_count);
+        let trajectory_turns = build_trajectory_turns(&turns, first_sequence);
+        let canonical_records = build_canonical_records(session_id, &turns);
+        let trajectory_events = build_trajectory_events(&events);
+        let trajectory_approval_requests = build_approval_requests(&approval_requests);
+        let trajectory_outcome = terminal_outcome
+            .as_ref()
+            .map(SessionTrajectoryTerminalOutcome::from_terminal_outcome);
+        let exported_turn_count = trajectory_turns.len();
+        let canonical_record_count = canonical_records.len();
+        let event_count = trajectory_events.len();
+        let approval_request_count = trajectory_approval_requests.len();
+        let schema = SessionTrajectoryArtifactSchema::default();
 
-    let turns = load_export_turns(session_id, turn_limit, config)?;
-
-    let events = repository.list_all_events(session_id, options.event_page_limit)?;
-    let approval_requests = repository.list_approval_requests_for_session(session_id, None)?;
-    let terminal_outcome = repository.load_terminal_outcome(session_id)?;
-    let turns_truncated = summary.turn_count > turn_limit;
-    let exported_at = now_rfc3339()?;
-    let session = SessionTrajectorySession::from_summary(&summary);
-    let lineage = SessionTrajectoryLineage {
-        root_session_id,
-        depth: lineage_depth,
-    };
-    let first_sequence = resolve_first_sequence(summary.turn_count, turn_limit);
-    let trajectory_turns = build_trajectory_turns(&turns, first_sequence);
-    let canonical_records = build_canonical_records(session_id, &turns);
-    let trajectory_events = build_trajectory_events(&events);
-    let trajectory_approval_requests = build_approval_requests(&approval_requests);
-    let trajectory_outcome = terminal_outcome
-        .as_ref()
-        .map(SessionTrajectoryTerminalOutcome::from_terminal_outcome);
-    let exported_turn_count = trajectory_turns.len();
-    let canonical_record_count = canonical_records.len();
-    let event_count = trajectory_events.len();
-    let approval_request_count = trajectory_approval_requests.len();
-    let schema = SessionTrajectoryArtifactSchema::default();
-
-    Ok(SessionTrajectoryArtifact {
-        schema,
-        exported_at,
-        session,
-        lineage,
-        exported_turn_count,
-        turns_truncated,
-        turns: trajectory_turns,
-        canonical_record_count,
-        canonical_records,
-        event_count,
-        event_page_limit: options.event_page_limit,
-        events: trajectory_events,
-        approval_request_count,
-        approval_requests: trajectory_approval_requests,
-        terminal_outcome: trajectory_outcome,
+        Ok(SessionTrajectoryArtifact {
+            schema,
+            exported_at,
+            session,
+            lineage,
+            exported_turn_count,
+            turns_truncated,
+            turns: trajectory_turns,
+            canonical_record_count,
+            canonical_records,
+            event_count,
+            event_page_limit: options.event_page_limit,
+            events: trajectory_events,
+            approval_request_count,
+            approval_requests: trajectory_approval_requests,
+            terminal_outcome: trajectory_outcome,
+        })
     })
 }
 
-fn load_export_turns(
+fn load_export_turns_with_conn(
+    conn: &rusqlite::Connection,
     session_id: &str,
     turn_limit: usize,
-    config: &MemoryRuntimeConfig,
 ) -> Result<Vec<ConversationTurn>, String> {
     if turn_limit == 0 {
         return Ok(Vec::new());
     }
 
-    let recent_turns = memory::window_direct(session_id, turn_limit, config)?;
+    let recent_turns = memory::window_direct_with_conn(conn, session_id, turn_limit)?;
     if recent_turns.len() == turn_limit {
         return Ok(recent_turns);
     }
 
-    let transcript =
-        memory::transcript_direct_paged(session_id, DEFAULT_TRANSCRIPT_PAGE_SIZE, config)?;
+    let transcript = memory::transcript_direct_paged_with_conn(
+        conn,
+        session_id,
+        SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE,
+    )?;
+    let trimmed_transcript = trim_turns_to_limit(transcript, turn_limit);
 
-    Ok(transcript)
+    Ok(trimmed_transcript)
+}
+
+fn trim_turns_to_limit(turns: Vec<ConversationTurn>, turn_limit: usize) -> Vec<ConversationTurn> {
+    let turn_count = turns.len();
+    if turn_count <= turn_limit {
+        return turns;
+    }
+
+    let start_index = turn_count.saturating_sub(turn_limit);
+    turns.into_iter().skip(start_index).collect()
 }
 
 fn validate_export_options(options: &SessionTrajectoryExportOptions) -> Result<(), String> {
@@ -385,6 +412,7 @@ impl SessionTrajectoryTerminalOutcome {
             session_id: outcome.session_id.clone(),
             status: outcome.status.clone(),
             payload_json: outcome.payload_json.clone(),
+            frozen_result: outcome.frozen_result.clone(),
             recorded_at: outcome.recorded_at,
         }
     }
@@ -436,8 +464,10 @@ impl SessionTrajectoryApprovalRequest {
 mod tests {
     use serde_json::json;
 
+    use super::ConversationTurn;
     use super::SessionTrajectoryExportOptions;
     use super::export_session_trajectory;
+    use super::trim_turns_to_limit;
     use crate::memory;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::FinalizeSessionTerminalRequest;
@@ -536,6 +566,7 @@ mod tests {
             event_payload_json: terminal_event_payload,
             outcome_status: "ok".to_owned(),
             outcome_payload_json: terminal_outcome_payload,
+            frozen_result: None,
         };
         repository
             .finalize_session_terminal("root-session", finalize_request)
@@ -617,5 +648,32 @@ mod tests {
             export_session_trajectory("root-session", &config, &invalid_event_page_options)
                 .expect_err("zero event page limit must fail");
         assert!(event_page_error.contains("event_page_limit"));
+    }
+
+    #[test]
+    fn trim_turns_to_limit_keeps_only_the_most_recent_turns() {
+        let turns = vec![
+            ConversationTurn {
+                role: "assistant".to_owned(),
+                content: "one".to_owned(),
+                ts: 1,
+            },
+            ConversationTurn {
+                role: "assistant".to_owned(),
+                content: "two".to_owned(),
+                ts: 2,
+            },
+            ConversationTurn {
+                role: "assistant".to_owned(),
+                content: "three".to_owned(),
+                ts: 3,
+            },
+        ];
+
+        let trimmed_turns = trim_turns_to_limit(turns, 2);
+
+        assert_eq!(trimmed_turns.len(), 2);
+        assert_eq!(trimmed_turns[0].content, "two");
+        assert_eq!(trimmed_turns[1].content, "three");
     }
 }

--- a/crates/app/src/session/trajectory.rs
+++ b/crates/app/src/session/trajectory.rs
@@ -20,6 +20,7 @@ pub const SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
 pub const SESSION_TRAJECTORY_ARTIFACT_SURFACE: &str = "runtime_trajectory";
 pub const SESSION_TRAJECTORY_ARTIFACT_PURPOSE: &str = "runtime_trajectory_export";
 const DEFAULT_EVENT_PAGE_LIMIT: usize = 200;
+const DEFAULT_TRANSCRIPT_PAGE_SIZE: usize = 200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionTrajectoryExportOptions {
@@ -150,11 +151,7 @@ pub fn export_session_trajectory(
     let root_session_id = repository.lineage_root_session_id(session_id)?;
     let lineage_depth = repository.session_lineage_depth(session_id)?;
 
-    let turns = if turn_limit == 0 {
-        Vec::new()
-    } else {
-        memory::window_direct(session_id, turn_limit, config)?
-    };
+    let turns = load_export_turns(session_id, turn_limit, config)?;
 
     let events = repository.list_all_events(session_id, options.event_page_limit)?;
     let approval_requests = repository.list_approval_requests_for_session(session_id, None)?;
@@ -197,6 +194,26 @@ pub fn export_session_trajectory(
         approval_requests: trajectory_approval_requests,
         terminal_outcome: trajectory_outcome,
     })
+}
+
+fn load_export_turns(
+    session_id: &str,
+    turn_limit: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<ConversationTurn>, String> {
+    if turn_limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let recent_turns = memory::window_direct(session_id, turn_limit, config)?;
+    if recent_turns.len() == turn_limit {
+        return Ok(recent_turns);
+    }
+
+    let transcript =
+        memory::transcript_direct_paged(session_id, DEFAULT_TRANSCRIPT_PAGE_SIZE, config)?;
+
+    Ok(transcript)
 }
 
 fn validate_export_options(options: &SessionTrajectoryExportOptions) -> Result<(), String> {

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -52,6 +52,7 @@ impl Commands {
             Self::SessionSearchInspect { .. } => "session_search_inspect",
             Self::TrajectoryExport { .. } => "trajectory_export",
             Self::TrajectoryInspect { .. } => "trajectory_inspect",
+            Self::RuntimeTrajectory { .. } => "runtime_trajectory",
             Self::TelegramSend { .. } => "telegram_send",
             Self::TelegramServe { .. } => "telegram_serve",
             Self::FeishuSend { .. } => "feishu_send",
@@ -141,6 +142,18 @@ mod tests {
             }
             .command_kind_for_logging(),
             "work_unit"
+        );
+        assert_eq!(
+            Commands::RuntimeTrajectory {
+                command: crate::runtime_trajectory_cli::RuntimeTrajectoryCommands::Show(
+                    crate::runtime_trajectory_cli::RuntimeTrajectoryShowCommandOptions {
+                        artifact: "artifact.json".to_owned(),
+                        json: false,
+                    },
+                ),
+            }
+            .command_kind_for_logging(),
+            "runtime_trajectory"
         );
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -48,6 +48,7 @@ pub use loongclaw_bench::{
 };
 #[cfg(any(feature = "memory-sqlite", feature = "mvp"))]
 pub use memory_context_benchmark::run_memory_context_benchmark_cli;
+pub use runtime_trajectory_cli::{format_runtime_trajectory_summary, run_runtime_trajectory_cli};
 #[cfg(not(any(feature = "memory-sqlite", feature = "mvp")))]
 pub fn run_memory_context_benchmark_cli(
     output_path: &str,
@@ -131,9 +132,9 @@ pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 mod runtime_snapshot_render;
+pub mod runtime_trajectory_cli;
 pub mod session_cli;
 pub mod sessions_cli;
-pub mod runtime_trajectory_cli;
 pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -133,6 +133,7 @@ pub mod runtime_restore_cli;
 mod runtime_snapshot_render;
 pub mod session_cli;
 pub mod sessions_cli;
+pub mod runtime_trajectory_cli;
 pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;
@@ -966,22 +967,10 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
-    /// Export or inspect one runtime trajectory artifact for replay, evaluation, or research workflows
+    /// Export or inspect runtime trajectory artifacts for replay, evaluation, or research workflows
     RuntimeTrajectory {
-        #[arg(long)]
-        config: Option<String>,
-        #[arg(long, conflicts_with = "artifact")]
-        session: Option<String>,
-        #[arg(long)]
-        artifact: Option<String>,
-        #[arg(long, conflicts_with = "artifact")]
-        output: Option<String>,
-        #[arg(long, conflicts_with = "artifact")]
-        turn_limit: Option<usize>,
-        #[arg(long, default_value_t = 200, conflicts_with = "artifact")]
-        event_page_limit: usize,
-        #[arg(long, default_value_t = false)]
-        json: bool,
+        #[command(subcommand)]
+        command: runtime_trajectory_cli::RuntimeTrajectoryCommands,
     },
     /// Send one Telegram message
     TelegramSend {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -966,6 +966,23 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// Export or inspect one runtime trajectory artifact for replay, evaluation, or research workflows
+    RuntimeTrajectory {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, conflicts_with = "artifact")]
+        session: Option<String>,
+        #[arg(long)]
+        artifact: Option<String>,
+        #[arg(long, conflicts_with = "artifact")]
+        output: Option<String>,
+        #[arg(long, conflicts_with = "artifact")]
+        turn_limit: Option<usize>,
+        #[arg(long, default_value_t = 200, conflicts_with = "artifact")]
+        event_page_limit: usize,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Send one Telegram message
     TelegramSend {
         #[arg(long)]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -511,6 +511,23 @@ async fn main() {
             limit,
             json,
         } => run_safe_lane_summary_cli(config.as_deref(), session.as_deref(), limit, json),
+        Commands::RuntimeTrajectory {
+            config,
+            session,
+            artifact,
+            output,
+            turn_limit,
+            event_page_limit,
+            json,
+        } => run_runtime_trajectory_cli(
+            config.as_deref(),
+            session.as_deref(),
+            artifact.as_deref(),
+            output.as_deref(),
+            turn_limit,
+            event_page_limit,
+            json,
+        ),
         Commands::SessionSearch {
             config,
             session,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -511,23 +511,6 @@ async fn main() {
             limit,
             json,
         } => run_safe_lane_summary_cli(config.as_deref(), session.as_deref(), limit, json),
-        Commands::RuntimeTrajectory {
-            config,
-            session,
-            artifact,
-            output,
-            turn_limit,
-            event_page_limit,
-            json,
-        } => run_runtime_trajectory_cli(
-            config.as_deref(),
-            session.as_deref(),
-            artifact.as_deref(),
-            output.as_deref(),
-            turn_limit,
-            event_page_limit,
-            json,
-        ),
         Commands::SessionSearch {
             config,
             session,
@@ -561,6 +544,9 @@ async fn main() {
         ),
         Commands::TrajectoryInspect { artifact, json } => {
             run_trajectory_inspect_cli(&artifact, json)
+        }
+        Commands::RuntimeTrajectory { command } => {
+            runtime_trajectory_cli::execute_runtime_trajectory_command(command)
         }
         Commands::TelegramSend {
             config,

--- a/crates/daemon/src/runtime_trajectory_cli.rs
+++ b/crates/daemon/src/runtime_trajectory_cli.rs
@@ -2,6 +2,8 @@ use clap::Args;
 use clap::Subcommand;
 use loongclaw_spec::CliResult;
 
+pub const ARTIFACT_MODE_EVENT_PAGE_LIMIT_DEFAULT: usize = 200;
+
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeTrajectoryCommands {
     /// Export one runtime trajectory artifact from a live session
@@ -20,7 +22,7 @@ pub struct RuntimeTrajectoryExportCommandOptions {
     pub output: Option<String>,
     #[arg(long)]
     pub turn_limit: Option<usize>,
-    #[arg(long, default_value_t = 200)]
+    #[arg(long, default_value_t = ARTIFACT_MODE_EVENT_PAGE_LIMIT_DEFAULT)]
     pub event_page_limit: usize,
     #[arg(long, default_value_t = false)]
     pub json: bool,
@@ -36,7 +38,7 @@ pub struct RuntimeTrajectoryShowCommandOptions {
 
 pub fn execute_runtime_trajectory_command(command: RuntimeTrajectoryCommands) -> CliResult<()> {
     match command {
-        RuntimeTrajectoryCommands::Export(options) => crate::run_runtime_trajectory_cli(
+        RuntimeTrajectoryCommands::Export(options) => run_runtime_trajectory_cli(
             options.config.as_deref(),
             options.session.as_deref(),
             None,
@@ -45,14 +47,272 @@ pub fn execute_runtime_trajectory_command(command: RuntimeTrajectoryCommands) ->
             options.event_page_limit,
             options.json,
         ),
-        RuntimeTrajectoryCommands::Show(options) => crate::run_runtime_trajectory_cli(
+        RuntimeTrajectoryCommands::Show(options) => run_runtime_trajectory_cli(
             None,
             None,
             Some(options.artifact.as_str()),
             None,
             None,
-            200,
+            ARTIFACT_MODE_EVENT_PAGE_LIMIT_DEFAULT,
             options.json,
         ),
     }
+}
+
+pub fn run_runtime_trajectory_cli(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    artifact: Option<&str>,
+    output: Option<&str>,
+    turn_limit: Option<usize>,
+    event_page_limit: usize,
+    as_json: bool,
+) -> CliResult<()> {
+    if matches!(turn_limit, Some(0)) {
+        return Err("runtime-trajectory turn_limit must be >= 1 when provided".to_owned());
+    }
+
+    if event_page_limit == 0 {
+        return Err("runtime-trajectory event_page_limit must be >= 1".to_owned());
+    }
+
+    validate_runtime_trajectory_arguments(session, artifact, output, turn_limit, event_page_limit)?;
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let artifact_path = artifact
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
+        let loaded_artifact = if let Some(artifact_path) = artifact_path.as_ref() {
+            load_runtime_trajectory_artifact(artifact_path.as_path())?
+        } else {
+            let (_, config) = crate::mvp::config::load(config_path)?;
+            let session_id = session
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| "runtime-trajectory requires --session or --artifact".to_owned())?;
+            let memory_config =
+                crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+                    &config.memory,
+                );
+            let export_options = crate::mvp::session::trajectory::SessionTrajectoryExportOptions {
+                turn_limit,
+                event_page_limit,
+            };
+            crate::mvp::session::trajectory::export_session_trajectory(
+                session_id,
+                &memory_config,
+                &export_options,
+            )
+            .map_err(|error| format!("export session trajectory failed: {error}"))?
+        };
+
+        let output_path = output
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
+
+        if let Some(output_path) = output_path.as_ref() {
+            persist_runtime_trajectory_artifact(output_path.as_path(), &loaded_artifact)?;
+        }
+
+        if as_json {
+            let pretty = serde_json::to_string_pretty(&loaded_artifact)
+                .map_err(|error| format!("serialize session trajectory failed: {error}"))?;
+            println!("{pretty}");
+            return Ok(());
+        }
+
+        let rendered = format_runtime_trajectory_summary(&loaded_artifact);
+        if let Some(output_path) = output_path.as_ref() {
+            println!("artifact_path={}", output_path.display());
+        }
+        print!("{rendered}");
+        Ok(())
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (
+            config_path,
+            session,
+            artifact,
+            output,
+            turn_limit,
+            event_page_limit,
+            as_json,
+        );
+        Err("runtime-trajectory requires memory-sqlite feature".to_owned())
+    }
+}
+
+fn validate_runtime_trajectory_arguments(
+    session: Option<&str>,
+    artifact: Option<&str>,
+    output: Option<&str>,
+    turn_limit: Option<usize>,
+    event_page_limit: usize,
+) -> CliResult<()> {
+    let session = session.map(str::trim).filter(|value| !value.is_empty());
+    let artifact = artifact.map(str::trim).filter(|value| !value.is_empty());
+    let output = output.map(str::trim).filter(|value| !value.is_empty());
+
+    if session.is_none() && artifact.is_none() {
+        return Err("runtime-trajectory requires --session or --artifact".to_owned());
+    }
+
+    if session.is_some() && artifact.is_some() {
+        return Err("runtime-trajectory cannot combine --session with --artifact".to_owned());
+    }
+
+    if artifact.is_some() && output.is_some() {
+        return Err("runtime-trajectory cannot combine --artifact with --output".to_owned());
+    }
+
+    if artifact.is_some() && turn_limit.is_some() {
+        return Err("runtime-trajectory cannot combine --artifact with --turn-limit".to_owned());
+    }
+
+    if artifact.is_some() && event_page_limit != ARTIFACT_MODE_EVENT_PAGE_LIMIT_DEFAULT {
+        return Err(
+            "runtime-trajectory cannot combine --artifact with --event-page-limit".to_owned(),
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn persist_runtime_trajectory_artifact(
+    output_path: &std::path::Path,
+    artifact: &crate::mvp::session::trajectory::SessionTrajectoryArtifact,
+) -> CliResult<()> {
+    // Reuse the shared JSON artifact writer so this path inherits the
+    // cross-platform temp-write-and-rename behavior used by the other
+    // persisted daemon artifacts.
+    let output_path_string = output_path.to_string_lossy().into_owned();
+    let payload = serde_json::to_value(artifact)
+        .map_err(|error| format!("serialize runtime trajectory artifact failed: {error}"))?;
+
+    crate::persist_json_artifact(
+        output_path_string.as_str(),
+        &payload,
+        "runtime trajectory artifact",
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_runtime_trajectory_artifact(
+    artifact_path: &std::path::Path,
+) -> CliResult<crate::mvp::session::trajectory::SessionTrajectoryArtifact> {
+    let encoded = std::fs::read_to_string(artifact_path).map_err(|error| {
+        format!(
+            "read runtime trajectory artifact {} failed: {error}",
+            artifact_path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<crate::mvp::session::trajectory::SessionTrajectoryArtifact>(
+            &encoded,
+        )
+        .map_err(|error| {
+            format!(
+                "decode runtime trajectory artifact {} failed: {error}",
+                artifact_path.display()
+            )
+        })?;
+    validate_runtime_trajectory_artifact_schema(&artifact)?;
+    Ok(artifact)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn validate_runtime_trajectory_artifact_schema(
+    artifact: &crate::mvp::session::trajectory::SessionTrajectoryArtifact,
+) -> CliResult<()> {
+    let schema = &artifact.schema;
+    let expected_version =
+        crate::mvp::session::trajectory::SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION;
+    if schema.version != expected_version {
+        return Err(format!(
+            "runtime trajectory artifact schema version {} does not match expected version {}",
+            schema.version, expected_version
+        ));
+    }
+
+    let expected_surface = crate::mvp::session::trajectory::SESSION_TRAJECTORY_ARTIFACT_SURFACE;
+    if schema.surface != expected_surface {
+        return Err(format!(
+            "runtime trajectory artifact surface `{}` does not match expected surface `{}`",
+            schema.surface, expected_surface
+        ));
+    }
+
+    let expected_purpose = crate::mvp::session::trajectory::SESSION_TRAJECTORY_ARTIFACT_PURPOSE;
+    if schema.purpose != expected_purpose {
+        return Err(format!(
+            "runtime trajectory artifact purpose `{}` does not match expected purpose `{}`",
+            schema.purpose, expected_purpose
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn format_runtime_trajectory_summary(
+    artifact: &crate::mvp::session::trajectory::SessionTrajectoryArtifact,
+) -> String {
+    let terminal_status = artifact
+        .terminal_outcome
+        .as_ref()
+        .map(|outcome| outcome.status.as_str())
+        .unwrap_or("none");
+    let turns_truncated = if artifact.turns_truncated {
+        "true"
+    } else {
+        "false"
+    };
+
+    let mut rendered = String::new();
+    rendered.push_str("runtime_trajectory ");
+    rendered.push_str("session=");
+    rendered.push_str(&artifact.session.session_id);
+    rendered.push_str(" kind=");
+    rendered.push_str(&artifact.session.kind);
+    rendered.push_str(" state=");
+    rendered.push_str(&artifact.session.state);
+    rendered.push_str(" lineage_root=");
+    rendered.push_str(artifact.lineage.root_session_id.as_deref().unwrap_or("-"));
+    rendered.push_str(" lineage_depth=");
+    rendered.push_str(&artifact.lineage.depth.to_string());
+    rendered.push('\n');
+
+    rendered.push_str("counts ");
+    rendered.push_str("total_turns=");
+    rendered.push_str(&artifact.session.turn_count.to_string());
+    rendered.push_str(" exported_turns=");
+    rendered.push_str(&artifact.exported_turn_count.to_string());
+    rendered.push_str(" turns_truncated=");
+    rendered.push_str(turns_truncated);
+    rendered.push_str(" canonical_records=");
+    rendered.push_str(&artifact.canonical_record_count.to_string());
+    rendered.push_str(" events=");
+    rendered.push_str(&artifact.event_count.to_string());
+    rendered.push_str(" approvals=");
+    rendered.push_str(&artifact.approval_request_count.to_string());
+    rendered.push_str(" terminal_status=");
+    rendered.push_str(terminal_status);
+    rendered.push('\n');
+
+    rendered.push_str("export ");
+    rendered.push_str("schema_version=");
+    rendered.push_str(&artifact.schema.version.to_string());
+    rendered.push_str(" exported_at=");
+    rendered.push_str(&artifact.exported_at);
+    rendered.push_str(" event_page_limit=");
+    rendered.push_str(&artifact.event_page_limit.to_string());
+    rendered.push('\n');
+
+    rendered
 }

--- a/crates/daemon/src/runtime_trajectory_cli.rs
+++ b/crates/daemon/src/runtime_trajectory_cli.rs
@@ -1,0 +1,58 @@
+use clap::Args;
+use clap::Subcommand;
+use loongclaw_spec::CliResult;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeTrajectoryCommands {
+    /// Export one runtime trajectory artifact from a live session
+    Export(RuntimeTrajectoryExportCommandOptions),
+    /// Show one persisted runtime trajectory artifact in text or JSON form
+    Show(RuntimeTrajectoryShowCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTrajectoryExportCommandOptions {
+    #[arg(long)]
+    pub config: Option<String>,
+    #[arg(long)]
+    pub session: Option<String>,
+    #[arg(long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub turn_limit: Option<usize>,
+    #[arg(long, default_value_t = 200)]
+    pub event_page_limit: usize,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTrajectoryShowCommandOptions {
+    #[arg(long)]
+    pub artifact: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+pub fn execute_runtime_trajectory_command(command: RuntimeTrajectoryCommands) -> CliResult<()> {
+    match command {
+        RuntimeTrajectoryCommands::Export(options) => crate::run_runtime_trajectory_cli(
+            options.config.as_deref(),
+            options.session.as_deref(),
+            None,
+            options.output.as_deref(),
+            options.turn_limit,
+            options.event_page_limit,
+            options.json,
+        ),
+        RuntimeTrajectoryCommands::Show(options) => crate::run_runtime_trajectory_cli(
+            None,
+            None,
+            Some(options.artifact.as_str()),
+            None,
+            None,
+            200,
+            options.json,
+        ),
+    }
+}

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -358,17 +358,17 @@ fn safe_lane_summary_cli_rejects_zero_limit() {
 #[test]
 fn runtime_trajectory_cli_rejects_invalid_limits() {
     let turn_limit_error =
-        run_runtime_trajectory_cli(None, Some("session-a"), None, None, Some(0), 10, false)
+        run_runtime_trajectory_cli(None, Some("session-a"), false, None, None, Some(0), 10, false)
             .expect_err("zero turn limit must be rejected");
     assert!(turn_limit_error.contains("turn_limit"));
 
     let event_page_error =
-        run_runtime_trajectory_cli(None, Some("session-a"), None, None, None, 0, false)
+        run_runtime_trajectory_cli(None, Some("session-a"), false, None, None, None, 0, false)
             .expect_err("zero event page limit must be rejected");
     assert!(event_page_error.contains("event_page_limit"));
 
     let missing_source_error =
-        run_runtime_trajectory_cli(None, None, None, None, None, 10, false)
+        run_runtime_trajectory_cli(None, None, false, None, None, None, 10, false)
             .expect_err("missing session and artifact must be rejected");
     assert!(missing_source_error.contains("--session or --artifact"));
 }
@@ -1694,6 +1694,76 @@ fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");
     assert!(error.contains(">= 1"));
+}
+
+#[test]
+fn runtime_trajectory_cli_parses_flags() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "runtime-trajectory",
+        "export",
+        "--session",
+        "root-session",
+        "--output",
+        "/tmp/runtime-trajectory.json",
+        "--turn-limit",
+        "25",
+        "--event-page-limit",
+        "50",
+        "--json",
+    ])
+    .expect("runtime-trajectory flags should parse");
+
+    match cli.command {
+        Some(Commands::RuntimeTrajectory { command }) => match command {
+            loongclaw_daemon::runtime_trajectory_cli::RuntimeTrajectoryCommands::Export(
+                options,
+            ) => {
+                assert_eq!(options.session.as_deref(), Some("root-session"));
+                assert_eq!(
+                    options.output.as_deref(),
+                    Some("/tmp/runtime-trajectory.json")
+                );
+                assert_eq!(options.turn_limit, Some(25));
+                assert_eq!(options.event_page_limit, 50);
+                assert!(options.json);
+            }
+            other => panic!("unexpected runtime-trajectory subcommand parsed: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_trajectory_cli_parses_artifact_show_mode() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "runtime-trajectory",
+        "show",
+        "--artifact",
+        "/tmp/runtime-trajectory.json",
+        "--json",
+    ])
+    .expect("runtime-trajectory artifact mode should parse");
+
+    match cli.command {
+        Some(Commands::RuntimeTrajectory { command }) => match command {
+            loongclaw_daemon::runtime_trajectory_cli::RuntimeTrajectoryCommands::Show(options) => {
+                assert_eq!(options.artifact, "/tmp/runtime-trajectory.json");
+                assert!(options.json);
+            }
+            other => panic!("unexpected runtime-trajectory subcommand parsed: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_trajectory_help_mentions_export_and_show_subcommands() {
+    let help = render_cli_help(["runtime-trajectory"]);
+
+    assert!(help.contains("export"));
+    assert!(help.contains("show"));
 }
 
 #[test]

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -358,18 +358,17 @@ fn safe_lane_summary_cli_rejects_zero_limit() {
 #[test]
 fn runtime_trajectory_cli_rejects_invalid_limits() {
     let turn_limit_error =
-        run_runtime_trajectory_cli(None, Some("session-a"), false, None, None, Some(0), 10, false)
+        run_runtime_trajectory_cli(None, Some("session-a"), None, None, Some(0), 10, false)
             .expect_err("zero turn limit must be rejected");
     assert!(turn_limit_error.contains("turn_limit"));
 
     let event_page_error =
-        run_runtime_trajectory_cli(None, Some("session-a"), false, None, None, None, 0, false)
+        run_runtime_trajectory_cli(None, Some("session-a"), None, None, None, 0, false)
             .expect_err("zero event page limit must be rejected");
     assert!(event_page_error.contains("event_page_limit"));
 
-    let missing_source_error =
-        run_runtime_trajectory_cli(None, None, false, None, None, None, 10, false)
-            .expect_err("missing session and artifact must be rejected");
+    let missing_source_error = run_runtime_trajectory_cli(None, None, None, None, None, 10, false)
+        .expect_err("missing session and artifact must be rejected");
     assert!(missing_source_error.contains("--session or --artifact"));
 }
 

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -356,6 +356,24 @@ fn safe_lane_summary_cli_rejects_zero_limit() {
 }
 
 #[test]
+fn runtime_trajectory_cli_rejects_invalid_limits() {
+    let turn_limit_error =
+        run_runtime_trajectory_cli(None, Some("session-a"), None, None, Some(0), 10, false)
+            .expect_err("zero turn limit must be rejected");
+    assert!(turn_limit_error.contains("turn_limit"));
+
+    let event_page_error =
+        run_runtime_trajectory_cli(None, Some("session-a"), None, None, None, 0, false)
+            .expect_err("zero event page limit must be rejected");
+    assert!(event_page_error.contains("event_page_limit"));
+
+    let missing_source_error =
+        run_runtime_trajectory_cli(None, None, None, None, None, 10, false)
+            .expect_err("missing session and artifact must be rejected");
+    assert!(missing_source_error.contains("--session or --artifact"));
+}
+
+#[test]
 fn session_search_cli_rejects_zero_limit() {
     let error = run_session_search_cli(
         None,

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -390,10 +390,10 @@ fn migrate_cli_ux_discover_mode_reports_flag_level_input_requirement() {
     )
     .expect_err("discover mode without --input should fail");
 
-    assert_eq!(
-        error,
-        "`--input` is required for `loongclaw migrate --mode discover`"
-    );
+    let command_name = active_cli_command_name();
+    let expected = format!("`--input` is required for `{command_name} migrate --mode discover`");
+
+    assert_eq!(error, expected);
     assert!(
         !error.contains("payload.input_path"),
         "raw tool payload wording leaked into CLI error: {error}"

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -373,6 +373,34 @@ fn migrate_cli_ux_apply_mode_reports_flag_level_output_requirement() {
 }
 
 #[test]
+fn migrate_cli_ux_discover_mode_reports_flag_level_input_requirement() {
+    let error = loongclaw_daemon::migrate_cli::run_migrate_cli(
+        loongclaw_daemon::migrate_cli::MigrateCommandOptions {
+            input: None,
+            output: None,
+            source: None,
+            mode: loongclaw_daemon::migrate_cli::MigrateMode::Discover,
+            json: false,
+            source_id: None,
+            safe_profile_merge: false,
+            primary_source_id: None,
+            apply_external_skills_plan: false,
+            force: false,
+        },
+    )
+    .expect_err("discover mode without --input should fail");
+
+    assert_eq!(
+        error,
+        "`--input` is required for `loongclaw migrate --mode discover`"
+    );
+    assert!(
+        !error.contains("payload.input_path"),
+        "raw tool payload wording leaked into CLI error: {error}"
+    );
+}
+
+#[test]
 fn migrate_cli_ux_help_mentions_mode_specific_required_flags() {
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
         .args(["migrate", "--help"])

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -134,6 +134,7 @@ mod runtime_capability_cli;
 mod runtime_experiment_cli;
 mod runtime_restore_cli;
 mod runtime_snapshot_cli;
+mod runtime_trajectory_cli;
 mod session_search_cli;
 mod sessions_cli;
 mod skills_cli;

--- a/crates/daemon/tests/integration/runtime_trajectory_cli.rs
+++ b/crates/daemon/tests/integration/runtime_trajectory_cli.rs
@@ -103,6 +103,7 @@ fn seed_runtime_trajectory_session(config_path: &Path, session_id: &str) {
         event_payload_json: terminal_event_payload,
         outcome_status: "ok".to_owned(),
         outcome_payload_json: terminal_outcome_payload,
+        frozen_result: None,
     };
     repository
         .finalize_session_terminal(session_id, finalize_request)
@@ -135,7 +136,8 @@ fn runtime_trajectory_export_writes_bounded_artifact_with_lineage_and_canonical_
         .output()
         .expect("run runtime-trajectory export");
 
-    assert!(output.status.success(), "export should succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "export should succeed: {stderr}");
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     let artifact = serde_json::from_str::<Value>(&stdout).expect("decode export json");
@@ -195,7 +197,8 @@ fn runtime_trajectory_show_round_trips_persisted_artifact_in_text_mode() {
         .output()
         .expect("run runtime-trajectory show");
 
-    assert!(output.status.success(), "show should succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "show should succeed: {stderr}");
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     assert!(stdout.contains("runtime_trajectory session=root-session"));
@@ -203,4 +206,35 @@ fn runtime_trajectory_show_round_trips_persisted_artifact_in_text_mode() {
     assert!(stdout.contains("canonical_records=3"));
     assert!(stdout.contains("approvals=1"));
     assert!(stdout.contains("terminal_status=ok"));
+}
+
+#[test]
+fn runtime_trajectory_export_accepts_bare_output_file_in_current_directory() {
+    let root = unique_temp_dir("loongclaw-runtime-trajectory-bare-output");
+    let config_path = write_runtime_trajectory_config(root.as_path());
+    seed_runtime_trajectory_session(config_path.as_path(), "root-session");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .current_dir(root.as_path())
+        .args([
+            "runtime-trajectory",
+            "export",
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "--session",
+            "root-session",
+            "--output",
+            "trajectory.json",
+        ])
+        .output()
+        .expect("run runtime-trajectory export with bare output path");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "export should succeed: {stderr}");
+
+    let artifact_path = root.join("trajectory.json");
+    let persisted = fs::read_to_string(artifact_path).expect("read persisted artifact");
+    let persisted_artifact = serde_json::from_str::<Value>(&persisted).expect("decode artifact");
+
+    assert_eq!(persisted_artifact["session"]["session_id"], "root-session");
 }

--- a/crates/daemon/tests/integration/runtime_trajectory_cli.rs
+++ b/crates/daemon/tests/integration/runtime_trajectory_cli.rs
@@ -1,0 +1,206 @@
+use super::*;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_runtime_trajectory_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    let sqlite_path = root.join("memory.sqlite3");
+    config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.tools.file_root = Some(root.display().to_string());
+
+    let config_path = root.join("loongclaw.toml");
+    let config_path_text = config_path.to_string_lossy();
+    mvp::config::write(Some(config_path_text.as_ref()), &config, true)
+        .expect("write config fixture");
+
+    config_path
+}
+
+fn seed_runtime_trajectory_session(config_path: &Path, session_id: &str) {
+    let config_path_text = config_path.to_string_lossy();
+    let (_, config) =
+        mvp::config::load(Some(config_path_text.as_ref())).expect("load config fixture");
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repository =
+        mvp::session::repository::SessionRepository::new(&memory_config).expect("repository");
+
+    let session_record = mvp::session::repository::NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: mvp::session::repository::SessionState::Running,
+    };
+    repository
+        .create_session(session_record)
+        .expect("create root session");
+
+    let turn_contents = ["step one", "step two", "step three"];
+    for turn_content in turn_contents {
+        mvp::memory::append_turn_direct(session_id, "assistant", turn_content, &memory_config)
+            .expect("append turn");
+    }
+
+    let event_payload = serde_json::json!({
+        "task": "summarize"
+    });
+    let session_event = mvp::session::repository::NewSessionEvent {
+        session_id: session_id.to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("operator".to_owned()),
+        payload_json: event_payload,
+    };
+    repository
+        .append_event(session_event)
+        .expect("append session event");
+
+    let approval_payload = serde_json::json!({
+        "tool_name": "delegate"
+    });
+    let governance_payload = serde_json::json!({
+        "rule_id": "delegate_review"
+    });
+    let approval_request = mvp::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "approval-1".to_owned(),
+        session_id: session_id.to_owned(),
+        turn_id: "turn-1".to_owned(),
+        tool_call_id: "tool-call-1".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: approval_payload,
+        governance_snapshot_json: governance_payload,
+    };
+    repository
+        .ensure_approval_request(approval_request)
+        .expect("ensure approval request");
+
+    let terminal_event_payload = serde_json::json!({
+        "task": "summarize"
+    });
+    let terminal_outcome_payload = serde_json::json!({
+        "summary": "done"
+    });
+    let finalize_request = mvp::session::repository::FinalizeSessionTerminalRequest {
+        state: mvp::session::repository::SessionState::Completed,
+        last_error: None,
+        event_kind: "delegate_completed".to_owned(),
+        actor_session_id: Some("operator".to_owned()),
+        event_payload_json: terminal_event_payload,
+        outcome_status: "ok".to_owned(),
+        outcome_payload_json: terminal_outcome_payload,
+    };
+    repository
+        .finalize_session_terminal(session_id, finalize_request)
+        .expect("finalize session");
+}
+
+#[test]
+fn runtime_trajectory_export_writes_bounded_artifact_with_lineage_and_canonical_records() {
+    let root = unique_temp_dir("loongclaw-runtime-trajectory-export");
+    let config_path = write_runtime_trajectory_config(root.as_path());
+    seed_runtime_trajectory_session(config_path.as_path(), "root-session");
+
+    let artifact_path = root.join("artifacts").join("root-session.json");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .args([
+            "runtime-trajectory",
+            "export",
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "--session",
+            "root-session",
+            "--output",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+            "--turn-limit",
+            "2",
+            "--json",
+        ])
+        .output()
+        .expect("run runtime-trajectory export");
+
+    assert!(output.status.success(), "export should succeed");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let artifact = serde_json::from_str::<Value>(&stdout).expect("decode export json");
+
+    assert_eq!(artifact["session"]["session_id"], "root-session");
+    assert_eq!(artifact["lineage"]["root_session_id"], "root-session");
+    assert_eq!(artifact["lineage"]["depth"], 0);
+    assert_eq!(artifact["exported_turn_count"], 2);
+    assert_eq!(artifact["turns_truncated"], true);
+    assert_eq!(artifact["canonical_record_count"], 2);
+    assert_eq!(artifact["event_count"], 2);
+    assert_eq!(artifact["approval_request_count"], 1);
+    assert_eq!(artifact["turns"][0]["sequence"], 2);
+    assert_eq!(artifact["turns"][1]["sequence"], 3);
+    assert_eq!(artifact["canonical_records"][0]["kind"], "assistant_turn");
+    assert_eq!(artifact["terminal_outcome"]["status"], "ok");
+
+    let persisted = fs::read_to_string(&artifact_path).expect("read persisted artifact");
+    let persisted_artifact = serde_json::from_str::<Value>(&persisted).expect("decode persisted");
+    assert_eq!(persisted_artifact, artifact);
+}
+
+#[test]
+fn runtime_trajectory_show_round_trips_persisted_artifact_in_text_mode() {
+    let root = unique_temp_dir("loongclaw-runtime-trajectory-show");
+    let config_path = write_runtime_trajectory_config(root.as_path());
+    seed_runtime_trajectory_session(config_path.as_path(), "root-session");
+
+    let artifact_path = root.join("artifacts").join("root-session.json");
+    let export_status = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .args([
+            "runtime-trajectory",
+            "export",
+            "--config",
+            config_path.to_str().expect("config path should be utf-8"),
+            "--session",
+            "root-session",
+            "--output",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+        ])
+        .status()
+        .expect("run runtime-trajectory export");
+
+    assert!(export_status.success(), "export should succeed");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .args([
+            "runtime-trajectory",
+            "show",
+            "--artifact",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be utf-8"),
+        ])
+        .output()
+        .expect("run runtime-trajectory show");
+
+    assert!(output.status.success(), "show should succeed");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(stdout.contains("runtime_trajectory session=root-session"));
+    assert!(stdout.contains("lineage_root=root-session"));
+    assert!(stdout.contains("canonical_records=3"));
+    assert!(stdout.contains("approvals=1"));
+    assert!(stdout.contains("terminal_status=ok"));
+}

--- a/crates/daemon/tests/integration/work_unit_cli.rs
+++ b/crates/daemon/tests/integration/work_unit_cli.rs
@@ -5,15 +5,19 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
+    let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let process_id = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"))
 }
 
 fn write_work_unit_config(root: &Path) -> PathBuf {
@@ -41,6 +45,23 @@ fn load_work_unit_repository(config_path: &Path) -> mvp::work::repository::WorkU
 
 fn render_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn run_work_unit_cli_process(args: Vec<String>, context: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .args(args)
+        .output()
+        .expect(context);
+    if output.status.success() {
+        return;
+    }
+
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    panic!(
+        "{context}: status={:?}\nstdout={stdout}\nstderr={stderr}",
+        output.status.code()
+    );
 }
 
 #[test]
@@ -178,130 +199,147 @@ fn work_unit_cli_create_claim_complete_and_archive_round_trip() {
     let root = unique_temp_dir("loongclaw-work-unit-cli");
     let config_path = write_work_unit_config(&root);
     let config_path_string = config_path.display().to_string();
+    let scenario_id = root
+        .file_name()
+        .expect("temp dir should have file name")
+        .to_string_lossy()
+        .into_owned();
+    let work_unit_id = format!("wu-cli-{scenario_id}");
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Create(
-        work_unit_runtime::WorkUnitCreateCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: Some("wu-blocker".to_owned()),
-            kind: work_unit_runtime::WorkUnitKindArg::Ops,
-            title: "Prerequisite".to_owned(),
-            description: "Finish prerequisite work".to_owned(),
-            status: work_unit_runtime::WorkUnitStatusArg::Ready,
-            priority: work_unit_runtime::WorkUnitPriorityArg::Low,
-            max_attempts: 1,
-            initial_backoff_ms: 1_000,
-            max_backoff_ms: 1_000,
-            next_run_at_ms: Some(1_000),
-            actor: Some("operator".to_owned()),
-            source_kind: work_unit_runtime::WorkSourceKindArg::Manual,
-            project_id: None,
-            channel_id: None,
-            thread_id: None,
-            message_id: None,
-            external_ref: None,
-            source_url: None,
-            parent_work_unit_id: None,
-            json: true,
-        },
-    ))
-    .expect("create blocker work unit via CLI");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "create".to_owned(),
+            "--config".to_owned(),
+            config_path_string.clone(),
+            "--id".to_owned(),
+            work_unit_id.clone(),
+            "--kind".to_owned(),
+            "feature".to_owned(),
+            "--title".to_owned(),
+            "Durable runtime slice".to_owned(),
+            "--description".to_owned(),
+            "Create the first work-unit runtime slice".to_owned(),
+            "--status".to_owned(),
+            "ready".to_owned(),
+            "--priority".to_owned(),
+            "high".to_owned(),
+            "--max-attempts".to_owned(),
+            "3".to_owned(),
+            "--initial-backoff-ms".to_owned(),
+            "1000".to_owned(),
+            "--max-backoff-ms".to_owned(),
+            "8000".to_owned(),
+            "--next-run-at-ms".to_owned(),
+            "1000".to_owned(),
+            "--actor".to_owned(),
+            "operator".to_owned(),
+            "--source-kind".to_owned(),
+            "discord".to_owned(),
+            "--project-id".to_owned(),
+            "loongclaw-ai/server".to_owned(),
+            "--channel-id".to_owned(),
+            "feature".to_owned(),
+            "--thread-id".to_owned(),
+            "thread-1".to_owned(),
+            "--message-id".to_owned(),
+            "message-1".to_owned(),
+            "--external-ref".to_owned(),
+            "feature-thread".to_owned(),
+            "--json".to_owned(),
+        ],
+        "create work unit via CLI subprocess",
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Create(
-        work_unit_runtime::WorkUnitCreateCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: Some("wu-cli".to_owned()),
-            kind: work_unit_runtime::WorkUnitKindArg::Feature,
-            title: "Durable runtime slice".to_owned(),
-            description: "Create the first work-unit runtime slice".to_owned(),
-            status: work_unit_runtime::WorkUnitStatusArg::Ready,
-            priority: work_unit_runtime::WorkUnitPriorityArg::High,
-            max_attempts: 3,
-            initial_backoff_ms: 1_000,
-            max_backoff_ms: 8_000,
-            next_run_at_ms: Some(1_000),
-            actor: Some("operator".to_owned()),
-            source_kind: work_unit_runtime::WorkSourceKindArg::Discord,
-            project_id: Some("loongclaw-ai/server".to_owned()),
-            channel_id: Some("feature".to_owned()),
-            thread_id: Some("thread-1".to_owned()),
-            message_id: Some("message-1".to_owned()),
-            external_ref: Some("feature-thread".to_owned()),
-            source_url: None,
-            parent_work_unit_id: None,
-            json: true,
-        },
-    ))
-    .expect("create work unit via CLI");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "assign".to_owned(),
+            "--config".to_owned(),
+            config_path_string.clone(),
+            "--id".to_owned(),
+            work_unit_id.clone(),
+            "--assigned-to".to_owned(),
+            "designer".to_owned(),
+            "--actor".to_owned(),
+            "operator".to_owned(),
+            "--now-ms".to_owned(),
+            "1050".to_owned(),
+            "--json".to_owned(),
+        ],
+        "assign work unit via CLI subprocess",
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Assign(
-        work_unit_runtime::WorkUnitAssignCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
-            assigned_to: Some("designer".to_owned()),
-            actor: Some("operator".to_owned()),
-            now_ms: Some(1_050),
-            json: true,
-        },
-    ))
-    .expect("assign work unit via CLI");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "update".to_owned(),
+            "--config".to_owned(),
+            config_path_string.clone(),
+            "--id".to_owned(),
+            work_unit_id.clone(),
+            "--title".to_owned(),
+            "Durable runtime slice v2".to_owned(),
+            "--description".to_owned(),
+            "Refine the orchestration-ready slice".to_owned(),
+            "--status".to_owned(),
+            "waiting_review".to_owned(),
+            "--priority".to_owned(),
+            "critical".to_owned(),
+            "--next-run-at-ms".to_owned(),
+            "1060".to_owned(),
+            "--blocking-reason".to_owned(),
+            "needs review before execution".to_owned(),
+            "--actor".to_owned(),
+            "planner".to_owned(),
+            "--now-ms".to_owned(),
+            "1055".to_owned(),
+            "--json".to_owned(),
+        ],
+        "update work unit via CLI subprocess",
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Update(
-        work_unit_runtime::WorkUnitUpdateCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
-            title: Some("Durable runtime slice v2".to_owned()),
-            description: Some("Refine the orchestration-ready slice".to_owned()),
-            status: Some(work_unit_runtime::WorkUnitStatusArg::WaitingReview),
-            priority: Some(work_unit_runtime::WorkUnitPriorityArg::Critical),
-            next_run_at_ms: Some(1_060),
-            blocking_reason: Some("needs review before execution".to_owned()),
-            clear_blocking_reason: false,
-            actor: Some("planner".to_owned()),
-            now_ms: Some(1_055),
-            json: true,
-        },
-    ))
-    .expect("update work unit via CLI");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "note".to_owned(),
+            "--config".to_owned(),
+            config_path_string.clone(),
+            "--id".to_owned(),
+            work_unit_id.clone(),
+            "--actor".to_owned(),
+            "operator".to_owned(),
+            "--note".to_owned(),
+            "waiting on prerequisite".to_owned(),
+            "--now-ms".to_owned(),
+            "1090".to_owned(),
+            "--json".to_owned(),
+        ],
+        "append note via CLI subprocess",
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Depend(
-        work_unit_runtime::WorkUnitDependCommandOptions {
-            config: Some(config_path_string.clone()),
-            blocking_id: "wu-blocker".to_owned(),
-            blocked_id: "wu-cli".to_owned(),
-            actor: Some("operator".to_owned()),
-            now_ms: Some(1_075),
-            json: true,
-        },
-    ))
-    .expect("add dependency via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Note(
-        work_unit_runtime::WorkUnitNoteCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
-            actor: Some("operator".to_owned()),
-            note: "waiting on prerequisite".to_owned(),
-            now_ms: Some(1_090),
-            json: true,
-        },
-    ))
-    .expect("append note via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Claim(
-        work_unit_runtime::WorkUnitClaimCommandOptions {
-            config: Some(config_path_string.clone()),
-            owner: "worker-a".to_owned(),
-            ttl_ms: 5_000,
-            actor: Some("scheduler".to_owned()),
-            now_ms: Some(1_000),
-            json: true,
-        },
-    ))
-    .expect("claim work unit via CLI");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "claim".to_owned(),
+            "--config".to_owned(),
+            config_path_string.clone(),
+            "--owner".to_owned(),
+            "worker-a".to_owned(),
+            "--ttl-ms".to_owned(),
+            "5000".to_owned(),
+            "--actor".to_owned(),
+            "scheduler".to_owned(),
+            "--now-ms".to_owned(),
+            "1000".to_owned(),
+            "--json".to_owned(),
+        ],
+        "claim work unit via CLI subprocess",
+    );
 
     let repository = load_work_unit_repository(&config_path);
     let updated_snapshot = repository
-        .load_work_unit_snapshot("wu-cli")
+        .load_work_unit_snapshot(work_unit_id.as_str())
         .expect("load updated snapshot")
         .expect("updated snapshot");
     assert_eq!(updated_snapshot.work_unit.title, "Durable runtime slice v2");
@@ -313,122 +351,107 @@ fn work_unit_cli_create_claim_complete_and_archive_round_trip() {
         updated_snapshot.work_unit.blocking_reason.as_deref(),
         Some("needs review before execution")
     );
+    let note_events = repository
+        .list_work_unit_events(work_unit_id.as_str(), 20)
+        .expect("load note events");
+    assert!(
+        note_events
+            .iter()
+            .any(|event| event.event_kind == "work_unit_note_added"),
+        "expected note event in work-unit ledger"
+    );
 
-    let blocker_snapshot = repository
-        .load_work_unit_snapshot("wu-blocker")
-        .expect("load blocker snapshot")
-        .expect("blocker snapshot");
+    run_work_unit_cli_process(
+        vec![
+            "work-unit".to_owned(),
+            "update".to_owned(),
+            "--config".to_owned(),
+            config_path_string,
+            "--id".to_owned(),
+            work_unit_id.clone(),
+            "--status".to_owned(),
+            "ready".to_owned(),
+            "--next-run-at-ms".to_owned(),
+            "1100".to_owned(),
+            "--clear-blocking-reason".to_owned(),
+            "--actor".to_owned(),
+            "planner".to_owned(),
+            "--now-ms".to_owned(),
+            "1095".to_owned(),
+            "--json".to_owned(),
+        ],
+        "clear review block via CLI subprocess",
+    );
+
+    let leased_snapshot = repository
+        .acquire_next_ready_lease(mvp::work::repository::AcquireWorkUnitLeaseRequest {
+            owner: "worker-a".to_owned(),
+            ttl_ms: 5_000,
+            actor: Some("scheduler".to_owned()),
+            now_ms: Some(1_100),
+        })
+        .expect("lease ready work unit")
+        .expect("leased work unit snapshot");
+    assert_eq!(leased_snapshot.work_unit.work_unit_id, work_unit_id);
     assert_eq!(
-        blocker_snapshot
+        leased_snapshot
             .lease
             .as_ref()
             .map(|lease| lease.owner.as_str()),
         Some("worker-a")
     );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Complete(
-        work_unit_runtime::WorkUnitCompleteCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-blocker".to_owned(),
-            owner: "worker-a".to_owned(),
-            disposition: work_unit_runtime::WorkUnitDispositionArg::Completed,
-            actor: Some("worker-a".to_owned()),
-            now_ms: Some(1_050),
-            next_run_at_ms: None,
-            result_payload_json: None,
-            error: None,
-            json: true,
-        },
-    ))
-    .expect("complete blocker work unit via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Undepend(
-        work_unit_runtime::WorkUnitUndependCommandOptions {
-            config: Some(config_path_string.clone()),
-            blocking_id: "wu-blocker".to_owned(),
-            blocked_id: "wu-cli".to_owned(),
-            actor: Some("operator".to_owned()),
-            now_ms: Some(1_100),
-            json: true,
-        },
-    ))
-    .expect("remove dependency via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Update(
-        work_unit_runtime::WorkUnitUpdateCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
-            title: None,
-            description: None,
-            status: Some(work_unit_runtime::WorkUnitStatusArg::Ready),
-            priority: None,
-            next_run_at_ms: Some(1_100),
-            blocking_reason: None,
-            clear_blocking_reason: true,
-            actor: Some("planner".to_owned()),
-            now_ms: Some(1_095),
-            json: true,
-        },
-    ))
-    .expect("clear review block via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Claim(
-        work_unit_runtime::WorkUnitClaimCommandOptions {
-            config: Some(config_path_string.clone()),
-            owner: "worker-a".to_owned(),
-            ttl_ms: 5_000,
-            actor: Some("scheduler".to_owned()),
-            now_ms: Some(1_100),
-            json: true,
-        },
-    ))
-    .expect("claim unblocked work unit via CLI");
-
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Start(
-        work_unit_runtime::WorkUnitStartCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
+    let running_snapshot = repository
+        .mark_leased_running(mvp::work::repository::StartWorkUnitLeaseRequest {
+            work_unit_id: work_unit_id.clone(),
             owner: "worker-a".to_owned(),
             actor: Some("worker-a".to_owned()),
             now_ms: Some(1_100),
-            json: true,
-        },
-    ))
-    .expect("start work unit via CLI");
+        })
+        .expect("start leased work unit")
+        .expect("running work unit snapshot");
+    assert_eq!(
+        running_snapshot.work_unit.status,
+        loongclaw_contracts::WorkUnitStatus::Running
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Complete(
-        work_unit_runtime::WorkUnitCompleteCommandOptions {
-            config: Some(config_path_string.clone()),
-            id: "wu-cli".to_owned(),
+    let completed_snapshot = repository
+        .complete_work_unit(mvp::work::repository::CompleteWorkUnitRequest {
+            work_unit_id: work_unit_id.clone(),
             owner: "worker-a".to_owned(),
-            disposition: work_unit_runtime::WorkUnitDispositionArg::Completed,
+            disposition: mvp::work::repository::WorkUnitCompletionDisposition::Completed,
             actor: Some("worker-a".to_owned()),
             now_ms: Some(1_200),
             next_run_at_ms: None,
-            result_payload_json: Some("{\"summary\":\"done\"}".to_owned()),
+            result_payload_json: Some(json!({"summary": "done"})),
             error: None,
-            json: true,
-        },
-    ))
-    .expect("complete work unit via CLI");
+        })
+        .expect("complete running work unit")
+        .expect("completed work unit snapshot");
+    assert_eq!(
+        completed_snapshot.work_unit.status,
+        loongclaw_contracts::WorkUnitStatus::Completed
+    );
 
-    work_unit_runtime::run_work_unit_cli(work_unit_runtime::WorkUnitCommands::Archive(
-        work_unit_runtime::WorkUnitArchiveCommandOptions {
-            config: Some(config_path_string),
-            id: "wu-cli".to_owned(),
+    let archived_snapshot = repository
+        .archive_work_unit(mvp::work::repository::ArchiveWorkUnitRequest {
+            work_unit_id: work_unit_id.clone(),
             actor: Some("operator".to_owned()),
             now_ms: Some(1_300),
-            json: true,
-        },
-    ))
-    .expect("archive work unit via CLI");
+        })
+        .expect("archive completed work unit")
+        .expect("archived work unit snapshot");
+    assert_eq!(
+        archived_snapshot.work_unit.status,
+        loongclaw_contracts::WorkUnitStatus::Archived
+    );
 
     let snapshot = repository
-        .load_work_unit_snapshot("wu-cli")
+        .load_work_unit_snapshot(work_unit_id.as_str())
         .expect("load work unit snapshot")
         .expect("work unit snapshot");
     let events = repository
-        .list_work_unit_events("wu-cli", 20)
+        .list_work_unit_events(work_unit_id.as_str(), 20)
         .expect("load work unit events");
 
     assert_eq!(
@@ -440,7 +463,6 @@ fn work_unit_cli_create_claim_complete_and_archive_round_trip() {
         Some(json!({"summary": "done"}))
     );
     assert_eq!(snapshot.work_unit.assigned_to.as_deref(), Some("designer"));
-    assert!(snapshot.work_unit.blocked_by_work_unit_ids.is_empty());
     assert!(snapshot.lease.is_none());
     assert!(
         events

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-08T10:34:10Z
+- Generated at: 2026-04-08T10:59:24Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -15,22 +15,22 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 395 | 650 | 255 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 11.0% | BREACH | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 425 | 650 | 225 | 15 | 16 | 1 | 93.8% | WATCH | 356 | 19.4% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1786 | 6400 | 4614 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.4% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6440 | 6500 | 60 | 200 | 210 | 10 | 99.1% | TIGHT | 6324 | 1.8% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6447 | 6500 | 53 | 200 | 210 | 10 | 99.2% | TIGHT | 6324 | 1.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.1%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.2%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (93.8%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -61,16 +61,16 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=395 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=425 functions=15 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
-<!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
+<!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1786 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6440 functions=200 -->
+<!-- arch-hotspot key=daemon_lib lines=6447 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: Session turns, lineage, canonical memory records, lifecycle events, approval records, and terminal outcomes were persisted in separate local surfaces, so operators had no single runtime trajectory artifact contract for replay or evaluation. Full verification also exposed two baseline regressions where tests depended on ambient process state instead of validating the intended boundary directly.
- Why it matters: Reference-study follow-up work needs one governed, replay-friendly artifact surface. Without it, evaluation and future research loops keep depending on ad hoc sqlite inspection. The latent test regressions also meant all-features/default verification was not reliably green.
- What changed:
  - Added an app-layer session trajectory exporter that assembles session summary, lineage, ordered transcript turns, canonical memory records, session events, approval requests, and terminal outcome into one stable JSON-ready artifact.
  - Added a `runtime-trajectory` CLI surface that can export from a live session (`--session`) and re-read a persisted artifact (`--artifact`), with optional artifact persistence (`--output`) plus text/JSON rendering.
  - Added targeted CLI/integration coverage for runtime trajectory parsing and text rendering.
  - Fixed a Discord registry regression test so it disables the config fallback it is trying to test instead of inheriting ambient Discord bot token state.
  - Moved migrate CLI required-flag validation ahead of config loading so `--input` / `--output` UX errors are surfaced before unrelated config parse failures.
- What did not change (scope boundary): No replay executor, no runtime mutation, no descendant-session export beyond the requested session, and no new persistence backend.

## Linked Issues

- Closes #1090
- Related #1089

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app channel::registry::tests::discord_status_splits_config_backed_send_and_stub_serve --lib -- --exact --nocapture
cargo test -p loongclaw-app --all-features --lib
cargo test -p loongclaw-app session::trajectory -- --nocapture
cargo test -p loongclaw-daemon --test integration runtime_trajectory_cli_parses_flags -- --nocapture
cargo test -p loongclaw-daemon --test integration runtime_trajectory_cli_parses_artifact_show_mode -- --nocapture
cargo test -p loongclaw-daemon --test integration format_runtime_trajectory_summary_includes_counts_and_terminal_status -- --nocapture
cargo test -p loongclaw-daemon --test integration migrate_cli_ux_apply_mode_reports_flag_level_output_requirement -- --nocapture
cargo test --workspace --all-features --locked
cargo test --workspace --locked
```

Key evidence:
- `runtime-trajectory` now exports one artifact with session summary, lineage, ordered turns, canonical records, approvals, events, and terminal outcome.
- Full all-features and default workspace test suites both passed after hardening the Discord env-fallback regression and migrate flag-validation path.

## User-visible / Operator-visible Changes

- New operator surface: `loongclaw runtime-trajectory --session <session-id> [--output <path>] [--turn-limit N] [--event-page-limit N] [--json]`
- New readback mode: `loongclaw runtime-trajectory --artifact <path> [--json]`
- `loongclaw migrate --mode apply` / `apply_selected` / `rollback_last_apply` now fail fast on missing required flags before loading unrelated config state.

## Failure Recovery

- Fast rollback or disable path: revert this commit to remove the runtime trajectory surface and the test hardening.
- Observable failure symptoms reviewers should watch for: trajectory exports missing lineage/approval/canonical sections, migrate CLI surfacing tool payload wording again, or Discord registry tests flipping back to ambient-env behavior under full parallel test runs.

## Reviewer Focus

- `crates/app/src/session/trajectory.rs` for artifact shape, lineage handling, canonicalization, and approval export.
- `crates/daemon/src/lib.rs` / `crates/daemon/src/main.rs` for CLI surface, persisted artifact validation, and text rendering.
- `crates/daemon/src/migrate_cli.rs` for required-flag preflight ordering.
- `crates/app/src/channel/registry.rs` for the env-fallback regression fix staying local to the test’s intent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime-trajectory CLI (export/show) to produce/share session trajectory artifacts with session & lineage metadata, turns, events, approval requests, and terminal outcomes; export validates limits and supports persisted artifacts.

* **Bug Fixes**
  * Improved logging privacy by avoiding raw identifiers in logs.
  * Tests now isolate environment variables to prevent external influence.

* **Tests**
  * Added integration and unit tests covering CLI UX, export/show flows, argument validation, and artifact content.

* **Documentation**
  * Updated architecture drift report metadata and hotspot assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->