### PR TITLE
Improve memory recall provenance and deterministic advisory ranking

### DIFF
--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -935,6 +935,10 @@ fn format_prompt_context_history_lines(entries: &[memory::MemoryContextEntry]) -
                 lines.push("[summary]".to_owned());
                 lines.push(entry.content.clone());
             }
+            memory::MemoryContextKind::Derived => {
+                lines.push("[derived]".to_owned());
+                lines.push(entry.content.clone());
+            }
             memory::MemoryContextKind::RetrievedMemory => {
                 lines.push("[retrieved_memory]".to_owned());
                 lines.push(entry.content.clone());

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -7,8 +7,9 @@ use crate::runtime_identity;
 #[cfg(feature = "memory-sqlite")]
 use super::sqlite;
 use super::{
-    MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, MemoryContextProvenance,
-    MemoryProvenanceSourceKind, MemoryRecallMode, MemoryScope, encode_stage_envelope_payload,
+    DerivedMemoryKind, MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, MemoryAuthority,
+    MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode, MemoryRecordStatus,
+    MemoryScope, MemoryTrustLevel, encode_stage_envelope_payload,
     orchestrator::hydrate_stage_envelope_with_workspace_root,
     protocol::{MemoryContextEntry, MemoryContextKind},
     runtime_config::MemoryRuntimeConfig,
@@ -219,29 +220,41 @@ pub fn load_prompt_context(
                 kind: MemoryContextKind::Summary,
                 role: "system".to_owned(),
                 content: summary,
-                provenance: vec![MemoryContextProvenance::new(
-                    selected_system_id.as_str(),
-                    MemoryProvenanceSourceKind::SummaryCheckpoint,
-                    Some(session_id.to_owned()),
-                    None,
-                    Some(MemoryScope::Session),
-                    MemoryRecallMode::PromptAssembly,
-                )],
+                provenance: vec![
+                    MemoryContextProvenance::new(
+                        selected_system_id.as_str(),
+                        MemoryProvenanceSourceKind::SummaryCheckpoint,
+                        Some("summary_checkpoint".to_owned()),
+                        None,
+                        Some(MemoryScope::Session),
+                        MemoryRecallMode::PromptAssembly,
+                    )
+                    .with_trust_level(MemoryTrustLevel::Derived)
+                    .with_authority(MemoryAuthority::Advisory)
+                    .with_derived_kind(DerivedMemoryKind::Summary)
+                    .with_record_status(MemoryRecordStatus::Active),
+                ],
             });
         }
         for turn in snapshot.window_turns {
+            let turn_role = turn.role;
+            let turn_content = turn.content;
+            let provenance = MemoryContextProvenance::new(
+                selected_system_id.as_str(),
+                MemoryProvenanceSourceKind::RecentWindowTurn,
+                Some("recent_window_turn".to_owned()),
+                None,
+                Some(MemoryScope::Session),
+                MemoryRecallMode::PromptAssembly,
+            )
+            .with_trust_level(MemoryTrustLevel::Session)
+            .with_authority(MemoryAuthority::Advisory)
+            .with_record_status(MemoryRecordStatus::Active);
             entries.push(MemoryContextEntry {
                 kind: MemoryContextKind::Turn,
-                role: turn.role,
-                content: turn.content,
-                provenance: vec![MemoryContextProvenance::new(
-                    selected_system_id.as_str(),
-                    MemoryProvenanceSourceKind::RecentWindowTurn,
-                    Some(session_id.to_owned()),
-                    None,
-                    Some(MemoryScope::Session),
-                    MemoryRecallMode::PromptAssembly,
-                )],
+                role: turn_role,
+                content: turn_content,
+                provenance: vec![provenance],
             });
         }
     }
@@ -269,14 +282,20 @@ pub(super) fn build_profile_entry(config: &MemoryRuntimeConfig) -> Option<Memory
         kind: MemoryContextKind::Profile,
         role: "system".to_owned(),
         content: profile_section,
-        provenance: vec![MemoryContextProvenance::new(
-            super::selected_prompt_hydration_system_id(config).as_str(),
-            MemoryProvenanceSourceKind::ProfileNote,
-            None,
-            None,
-            Some(MemoryScope::Session),
-            MemoryRecallMode::PromptAssembly,
-        )],
+        provenance: vec![
+            MemoryContextProvenance::new(
+                super::selected_prompt_hydration_system_id(config).as_str(),
+                MemoryProvenanceSourceKind::ProfileNote,
+                Some("profile_note".to_owned()),
+                None,
+                Some(MemoryScope::Session),
+                MemoryRecallMode::PromptAssembly,
+            )
+            .with_trust_level(MemoryTrustLevel::Derived)
+            .with_authority(MemoryAuthority::Advisory)
+            .with_derived_kind(DerivedMemoryKind::Profile)
+            .with_record_status(MemoryRecordStatus::Active),
+        ],
     })
 }
 
@@ -343,8 +362,16 @@ mod tests {
             MemoryProvenanceSourceKind::SummaryCheckpoint
         );
         assert_eq!(
+            summary_entry.provenance[0].source_label.as_deref(),
+            Some("summary_checkpoint")
+        );
+        assert_eq!(
             summary_entry.provenance[0].scope,
             Some(MemoryScope::Session)
+        );
+        assert_eq!(
+            summary_entry.provenance[0].record_status,
+            Some(MemoryRecordStatus::Active)
         );
         let turn_entry = hydrated
             .iter()
@@ -354,6 +381,14 @@ mod tests {
         assert_eq!(
             turn_entry.provenance[0].source_kind,
             MemoryProvenanceSourceKind::RecentWindowTurn
+        );
+        assert_eq!(
+            turn_entry.provenance[0].source_label.as_deref(),
+            Some("recent_window_turn")
+        );
+        assert_eq!(
+            turn_entry.provenance[0].record_status,
+            Some(MemoryRecordStatus::Active)
         );
 
         let _ = std::fs::remove_file(&db_path);
@@ -408,8 +443,16 @@ mod tests {
             MemoryProvenanceSourceKind::ProfileNote
         );
         assert_eq!(
+            profile_entry.provenance[0].source_label.as_deref(),
+            Some("profile_note")
+        );
+        assert_eq!(
             profile_entry.provenance[0].scope,
             Some(MemoryScope::Session)
+        );
+        assert_eq!(
+            profile_entry.provenance[0].record_status,
+            Some(MemoryRecordStatus::Active)
         );
 
         let _ = std::fs::remove_file(&db_path);
@@ -678,6 +721,15 @@ mod tests {
                 .any(|entry| entry.get("kind") == Some(&json!("summary"))),
             "expected read_context payload to include a summary entry"
         );
+        let maybe_summary_entry = entries
+            .iter()
+            .find(|entry| entry.get("kind") == Some(&json!("summary")));
+        let summary_entry = maybe_summary_entry.expect("summary entry");
+        assert_eq!(
+            summary_entry["provenance"][0]["source_label"],
+            "summary_checkpoint"
+        );
+        assert_eq!(summary_entry["provenance"][0]["record_status"], "active");
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
@@ -726,6 +778,20 @@ mod tests {
         assert!(!envelope.hydrated.entries.is_empty());
         assert!(!envelope.diagnostics.is_empty());
         assert_eq!(envelope.hydrated.diagnostics.system_id, "builtin");
+        let maybe_summary_entry = envelope
+            .hydrated
+            .entries
+            .iter()
+            .find(|entry| entry.kind == MemoryContextKind::Summary);
+        let summary_entry = maybe_summary_entry.expect("summary entry");
+        assert_eq!(
+            summary_entry.provenance[0].source_label.as_deref(),
+            Some("summary_checkpoint")
+        );
+        assert_eq!(
+            summary_entry.provenance[0].record_status,
+            Some(MemoryRecordStatus::Active)
+        );
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -5,9 +5,10 @@ use std::path::Path;
 use crate::runtime_self_continuity;
 
 use super::{
-    MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind,
-    MemoryRecallMode, MemoryScope, WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
-    collect_workspace_memory_document_locations, runtime_config::MemoryRuntimeConfig,
+    MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryRecallMode, MemoryScope,
+    WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
+    collect_workspace_memory_document_locations, parse_workspace_memory_document,
+    runtime_config::MemoryRuntimeConfig,
 };
 
 const RECENT_DAILY_LOG_LIMIT: usize = 2;
@@ -16,9 +17,8 @@ const DURABLE_RECALL_READ_SLACK_BYTES: usize = 1024;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DurableRecallDocument {
     pub label: String,
-    pub path: String,
-    pub scope: MemoryScope,
     pub content: String,
+    pub provenance: MemoryContextProvenance,
 }
 
 pub(crate) fn load_durable_recall_entries(
@@ -32,8 +32,12 @@ pub(crate) fn load_durable_recall_entries(
     };
 
     let per_file_char_budget = config.summary_max_chars.max(256);
-    let documents = collect_durable_recall_documents(workspace_root, per_file_char_budget)?;
-
+    let documents = collect_durable_recall_documents(
+        workspace_root,
+        per_file_char_budget,
+        memory_system_id,
+        recall_mode,
+    )?;
     if documents.is_empty() {
         return Ok(Vec::new());
     }
@@ -41,9 +45,7 @@ pub(crate) fn load_durable_recall_entries(
     let content = render_durable_recall_block(documents.as_slice());
     let provenance = documents
         .iter()
-        .map(|document| {
-            build_workspace_document_provenance(document, memory_system_id, recall_mode)
-        })
+        .map(|document| document.provenance.clone())
         .collect::<Vec<_>>();
     let entry = MemoryContextEntry {
         kind: MemoryContextKind::RetrievedMemory,
@@ -68,7 +70,12 @@ pub(crate) fn load_workspace_document_recall_entries(
     };
 
     let per_file_char_budget = config.summary_max_chars.max(256);
-    let documents = collect_durable_recall_documents(workspace_root, per_file_char_budget)?;
+    let documents = collect_durable_recall_documents(
+        workspace_root,
+        per_file_char_budget,
+        memory_system_id,
+        recall_mode,
+    )?;
     if documents.is_empty() {
         return Ok(Vec::new());
     }
@@ -84,13 +91,11 @@ pub(crate) fn load_workspace_document_recall_entries(
         let heading = format!("## Advisory Durable Recall — {}", document.label);
         let intro = runtime_self_continuity::runtime_durable_recall_intro().to_owned();
         let content = [heading, intro, document.content.clone()].join("\n\n");
-        let provenance =
-            build_workspace_document_provenance(&document, memory_system_id, recall_mode);
         let entry = MemoryContextEntry {
             kind: MemoryContextKind::RetrievedMemory,
             role: "system".to_owned(),
             content,
-            provenance: vec![provenance],
+            provenance: vec![document.provenance.clone()],
         };
         entries.push(entry);
     }
@@ -108,13 +113,18 @@ fn filter_recall_documents_by_scope(
 
     documents
         .into_iter()
-        .filter(|document| scopes.contains(&document.scope))
+        .filter(|document| {
+            let scope = document.provenance.scope.unwrap_or(MemoryScope::Workspace);
+            scopes.contains(&scope)
+        })
         .collect()
 }
 
 pub(crate) fn collect_durable_recall_documents(
     workspace_root: &Path,
     per_file_char_budget: usize,
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
 ) -> Result<Vec<DurableRecallDocument>, String> {
     let document_locations = collect_workspace_memory_document_locations(workspace_root)?;
     let mut documents = Vec::new();
@@ -123,7 +133,12 @@ pub(crate) fn collect_durable_recall_documents(
         .iter()
         .filter(|location| location.kind == WorkspaceMemoryDocumentKind::Curated);
     for location in curated_locations {
-        let maybe_document = load_document_from_location(location, per_file_char_budget)?;
+        let maybe_document = load_document_from_location(
+            location,
+            per_file_char_budget,
+            memory_system_id,
+            recall_mode,
+        )?;
         let Some(document) = maybe_document else {
             continue;
         };
@@ -135,7 +150,12 @@ pub(crate) fn collect_durable_recall_documents(
         .filter(|location| location.kind == WorkspaceMemoryDocumentKind::DailyLog)
         .take(RECENT_DAILY_LOG_LIMIT);
     for location in daily_locations {
-        let maybe_document = load_document_from_location(location, per_file_char_budget)?;
+        let maybe_document = load_document_from_location(
+            location,
+            per_file_char_budget,
+            memory_system_id,
+            recall_mode,
+        )?;
         let Some(document) = maybe_document else {
             continue;
         };
@@ -148,27 +168,40 @@ pub(crate) fn collect_durable_recall_documents(
 fn load_document_from_location(
     location: &WorkspaceMemoryDocumentLocation,
     per_file_char_budget: usize,
+    memory_system_id: &str,
+    recall_mode: MemoryRecallMode,
 ) -> Result<Option<DurableRecallDocument>, String> {
     let path = location.path.as_path();
-    let maybe_content = load_trimmed_document_content(path, per_file_char_budget)?;
-    let Some(content) = maybe_content else {
+    let maybe_raw_content = load_trimmed_document_content(path, per_file_char_budget)?;
+    let Some(raw_content) = maybe_raw_content else {
         return Ok(None);
     };
 
+    let maybe_parsed_document = parse_workspace_memory_document(
+        raw_content.as_str(),
+        location,
+        memory_system_id,
+        recall_mode,
+    )?;
+    let Some(parsed_document) = maybe_parsed_document else {
+        return Ok(None);
+    };
+
+    let record_status = parsed_document
+        .provenance
+        .record_status
+        .unwrap_or(super::MemoryRecordStatus::Active);
+    if !record_status.is_active() {
+        return Ok(None);
+    }
+
     let document = DurableRecallDocument {
         label: location.label.clone(),
-        path: location.path.display().to_string(),
-        scope: document_scope(location.kind),
-        content,
+        content: parsed_document.body,
+        provenance: parsed_document.provenance,
     };
-    Ok(Some(document))
-}
 
-fn document_scope(kind: WorkspaceMemoryDocumentKind) -> MemoryScope {
-    match kind {
-        WorkspaceMemoryDocumentKind::Curated => MemoryScope::Workspace,
-        WorkspaceMemoryDocumentKind::DailyLog => MemoryScope::Session,
-    }
+    Ok(Some(document))
 }
 
 fn load_trimmed_document_content(
@@ -253,25 +286,12 @@ pub(crate) fn render_durable_recall_block(documents: &[DurableRecallDocument]) -
     sections.join("\n\n")
 }
 
-fn build_workspace_document_provenance(
-    document: &DurableRecallDocument,
-    memory_system_id: &str,
-    recall_mode: MemoryRecallMode,
-) -> MemoryContextProvenance {
-    MemoryContextProvenance::new(
-        memory_system_id,
-        MemoryProvenanceSourceKind::WorkspaceDocument,
-        Some(document.label.clone()),
-        Some(document.path.clone()),
-        Some(document.scope),
-        recall_mode,
-    )
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tempfile::tempdir;
+
+    use super::*;
+    use crate::memory::{DerivedMemoryKind, MemoryAuthority, MemoryRecordStatus, MemoryTrustLevel};
 
     #[test]
     fn collect_recent_daily_log_documents_prefers_newest_dated_logs() {
@@ -281,21 +301,25 @@ mod tests {
 
         std::fs::create_dir_all(&memory_dir).expect("create memory dir");
         std::fs::write(workspace_root.join("MEMORY.md"), "curated").expect("write curated memory");
-
         std::fs::write(memory_dir.join("2026-03-20.md"), "old").expect("write old log");
         std::fs::write(memory_dir.join("2026-03-21.md"), "middle").expect("write middle log");
         std::fs::write(memory_dir.join("2026-03-22.md"), "new").expect("write new log");
 
-        let documents = collect_durable_recall_documents(workspace_root, 256)
-            .expect("collect durable recall documents");
+        let documents = collect_durable_recall_documents(
+            workspace_root,
+            256,
+            "builtin",
+            MemoryRecallMode::PromptAssembly,
+        )
+        .expect("collect durable recall documents");
 
         assert_eq!(documents.len(), 3);
         assert_eq!(documents[0].label, "MEMORY.md");
-        assert_eq!(documents[0].scope, MemoryScope::Workspace);
+        assert_eq!(documents[0].provenance.scope, Some(MemoryScope::Workspace));
         assert_eq!(documents[1].label, "memory/2026-03-22.md");
-        assert_eq!(documents[1].scope, MemoryScope::Session);
+        assert_eq!(documents[1].provenance.scope, Some(MemoryScope::Session));
         assert_eq!(documents[2].label, "memory/2026-03-21.md");
-        assert_eq!(documents[2].scope, MemoryScope::Session);
+        assert_eq!(documents[2].provenance.scope, Some(MemoryScope::Session));
     }
 
     #[test]
@@ -308,8 +332,13 @@ mod tests {
         std::fs::create_dir_all(&memory_dir).expect("create memory dir");
         std::fs::write(memory_dir.join("2026-03-22.md"), "daily log").expect("write daily log");
 
-        let documents = collect_durable_recall_documents(workspace_root, 256)
-            .expect("collect durable recall documents");
+        let documents = collect_durable_recall_documents(
+            workspace_root,
+            256,
+            "builtin",
+            MemoryRecallMode::PromptAssembly,
+        )
+        .expect("collect durable recall documents");
 
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].label, "memory/2026-03-22.md");
@@ -326,9 +355,9 @@ mod tests {
 
         std::fs::write(&document_path, bytes).expect("write memory fixture");
 
-        let content = load_trimmed_document_content(&document_path, 64)
-            .expect("bounded durable recall read should succeed")
-            .expect("content should be present");
+        let maybe_content = load_trimmed_document_content(&document_path, 64)
+            .expect("bounded durable recall read should succeed");
+        let content = maybe_content.expect("content should be present");
 
         assert!(content.starts_with("aaaaaaaa"));
         assert!(content.contains("(truncated "));
@@ -391,12 +420,59 @@ mod tests {
             Some(expected_curated_path.as_str())
         );
         assert_eq!(curated_provenance.scope, Some(MemoryScope::Workspace));
+        assert_eq!(
+            curated_provenance.derived_kind,
+            Some(DerivedMemoryKind::Overview)
+        );
+        assert_eq!(
+            curated_provenance.trust_level,
+            Some(MemoryTrustLevel::WorkspaceCurated)
+        );
+        assert_eq!(
+            curated_provenance.authority,
+            Some(MemoryAuthority::Advisory)
+        );
+        assert_eq!(
+            curated_provenance.record_status,
+            Some(MemoryRecordStatus::Active)
+        );
 
         let daily_provenance = &entry.provenance[1];
         assert_eq!(daily_provenance.scope, Some(MemoryScope::Session));
         assert_eq!(
             daily_provenance.recall_mode,
             MemoryRecallMode::PromptAssembly
+        );
+    }
+
+    #[test]
+    fn load_durable_recall_entries_skips_inactive_workspace_documents() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(
+            workspace_root.join("MEMORY.md"),
+            concat!("---\n", "status: tombstoned\n", "---\n", "stale note\n"),
+        )
+        .expect("write tombstoned file");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "daily").expect("write daily file");
+
+        let config = MemoryRuntimeConfig::default();
+        let entries = load_durable_recall_entries(
+            Some(workspace_root),
+            &config,
+            "builtin",
+            MemoryRecallMode::PromptAssembly,
+        )
+        .expect("load durable recall entries");
+
+        let entry = entries.first().expect("retrieved entry");
+        assert_eq!(entry.provenance.len(), 1);
+        assert_eq!(
+            entry.provenance[0].source_label.as_deref(),
+            Some("memory/2026-03-22.md")
         );
     }
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -27,6 +27,7 @@ mod system_registry;
 mod system_runtime;
 #[cfg(test)]
 mod tests;
+mod workspace_document;
 mod workspace_files;
 
 pub use canonical::{
@@ -60,8 +61,9 @@ pub(crate) use sqlite::CanonicalMemorySearchHit;
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
 pub use stage::{
-    DerivedMemoryKind, MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
-    MemoryRetrievalRequest, MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
+    DerivedMemoryKind, MemoryAuthority, MemoryContextProvenance, MemoryProvenanceSourceKind,
+    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryStageFamily,
+    MemoryTrustLevel, StageDiagnostics, StageEnvelope, StageOutcome,
     builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
 };
 pub use system::{
@@ -82,6 +84,9 @@ pub use system_registry::{
 pub use system_runtime::{
     BuiltinMemorySystemRuntime, MemorySystemRuntime, MetadataOnlyMemorySystemRuntime,
     SystemBackedMemorySystemRuntime,
+};
+pub(crate) use workspace_document::{
+    ParsedWorkspaceMemoryDocument, parse_workspace_memory_document,
 };
 pub(crate) use workspace_files::{
     WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1419,7 +1419,7 @@ mod tests {
         assert_eq!(
             diagnostics,
             vec![
-                (MemoryStageFamily::Derive, StageOutcome::Skipped),
+                (MemoryStageFamily::Derive, StageOutcome::Succeeded),
                 (MemoryStageFamily::Retrieve, StageOutcome::Succeeded),
                 (MemoryStageFamily::Rank, StageOutcome::Succeeded),
             ]
@@ -1467,7 +1467,7 @@ mod tests {
             envelope.hydrated.diagnostics.system_id,
             crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID
         );
-        assert_eq!(envelope.diagnostics[0].outcome, StageOutcome::Skipped);
+        assert_eq!(envelope.diagnostics[0].outcome, StageOutcome::Succeeded);
         assert_eq!(envelope.diagnostics[1].outcome, StageOutcome::Succeeded);
         assert_eq!(envelope.diagnostics[2].outcome, StageOutcome::Succeeded);
         assert_eq!(

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -31,6 +31,7 @@ pub struct WindowTurn {
 pub enum MemoryContextKind {
     Profile,
     Summary,
+    Derived,
     RetrievedMemory,
     Turn,
 }

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -63,7 +63,8 @@ impl StageOutcome {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DerivedMemoryKind {
     Summary,
     Profile,
@@ -140,6 +141,7 @@ impl MemoryRecallMode {
 pub enum MemoryProvenanceSourceKind {
     WorkspaceDocument,
     CanonicalMemoryRecord,
+    DerivedSessionOverview,
     ProfileNote,
     SummaryCheckpoint,
     RecentWindowTurn,
@@ -151,11 +153,72 @@ impl MemoryProvenanceSourceKind {
         match self {
             Self::WorkspaceDocument => "workspace_document",
             Self::CanonicalMemoryRecord => "canonical_memory_record",
+            Self::DerivedSessionOverview => "derived_session_overview",
             Self::ProfileNote => "profile_note",
             Self::SummaryCheckpoint => "summary_checkpoint",
             Self::RecentWindowTurn => "recent_window_turn",
             Self::MemorySystem => "memory_system",
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryTrustLevel {
+    Session,
+    Derived,
+    WorkspaceCurated,
+    WorkspaceLog,
+}
+
+impl MemoryTrustLevel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Derived => "derived",
+            Self::WorkspaceCurated => "workspace_curated",
+            Self::WorkspaceLog => "workspace_log",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryAuthority {
+    Advisory,
+    IdentityForbidden,
+}
+
+impl MemoryAuthority {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Advisory => "advisory",
+            Self::IdentityForbidden => "identity_forbidden",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryRecordStatus {
+    Active,
+    Superseded,
+    Tombstoned,
+    Archived,
+}
+
+impl MemoryRecordStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Superseded => "superseded",
+            Self::Tombstoned => "tombstoned",
+            Self::Archived => "archived",
+        }
+    }
+
+    pub const fn is_active(self) -> bool {
+        matches!(self, Self::Active)
     }
 }
 
@@ -167,6 +230,20 @@ pub struct MemoryContextProvenance {
     pub source_path: Option<String>,
     pub scope: Option<MemoryScope>,
     pub recall_mode: MemoryRecallMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_level: Option<MemoryTrustLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority: Option<MemoryAuthority>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derived_kind: Option<DerivedMemoryKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness_ts: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub record_status: Option<MemoryRecordStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
 }
 
 impl MemoryContextProvenance {
@@ -188,7 +265,49 @@ impl MemoryContextProvenance {
             source_path,
             scope,
             recall_mode,
+            trust_level: None,
+            authority: None,
+            derived_kind: None,
+            freshness_ts: None,
+            content_hash: None,
+            record_status: None,
+            superseded_by: None,
         }
+    }
+
+    pub fn with_trust_level(mut self, trust_level: MemoryTrustLevel) -> Self {
+        self.trust_level = Some(trust_level);
+        self
+    }
+
+    pub fn with_authority(mut self, authority: MemoryAuthority) -> Self {
+        self.authority = Some(authority);
+        self
+    }
+
+    pub fn with_derived_kind(mut self, derived_kind: DerivedMemoryKind) -> Self {
+        self.derived_kind = Some(derived_kind);
+        self
+    }
+
+    pub fn with_freshness_ts(mut self, freshness_ts: i64) -> Self {
+        self.freshness_ts = Some(freshness_ts);
+        self
+    }
+
+    pub fn with_content_hash(mut self, content_hash: impl Into<String>) -> Self {
+        self.content_hash = Some(content_hash.into());
+        self
+    }
+
+    pub fn with_record_status(mut self, record_status: MemoryRecordStatus) -> Self {
+        self.record_status = Some(record_status);
+        self
+    }
+
+    pub fn with_superseded_by(mut self, superseded_by: impl Into<String>) -> Self {
+        self.superseded_by = Some(superseded_by.into());
+        self
     }
 }
 

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -6,10 +6,11 @@ use crate::CliResult;
 
 use super::system_runtime::{BuiltinMemorySystemRuntime, MemorySystemRuntime};
 use super::{
-    CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryContextEntry,
-    MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
-    MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, WindowTurn,
-    builtin_pre_assembly_stage_families, durable_recall, runtime_config::MemoryRuntimeConfig,
+    CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryAuthority,
+    MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind,
+    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily,
+    MemoryTrustLevel, WindowTurn, builtin_pre_assembly_stage_families, durable_recall,
+    runtime_config::MemoryRuntimeConfig,
 };
 
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
@@ -324,6 +325,7 @@ fn run_builtin_retrieve_stage(
 
 fn rank_recall_first_entries(entries: Vec<MemoryContextEntry>) -> Vec<MemoryContextEntry> {
     let mut profile_entries = Vec::new();
+    let mut derived_entries = Vec::new();
     let mut retrieved_entries = Vec::new();
     let mut summary_entries = Vec::new();
     let mut history_entries = Vec::new();
@@ -331,6 +333,7 @@ fn rank_recall_first_entries(entries: Vec<MemoryContextEntry>) -> Vec<MemoryCont
     for entry in entries {
         match entry.kind {
             MemoryContextKind::Profile => profile_entries.push(entry),
+            MemoryContextKind::Derived => derived_entries.push(entry),
             MemoryContextKind::RetrievedMemory => retrieved_entries.push(entry),
             MemoryContextKind::Summary => summary_entries.push(entry),
             MemoryContextKind::Turn => history_entries.push(entry),
@@ -340,6 +343,7 @@ fn rank_recall_first_entries(entries: Vec<MemoryContextEntry>) -> Vec<MemoryCont
     let has_retrieved_entries = !retrieved_entries.is_empty();
     let mut ranked_entries = Vec::new();
     ranked_entries.extend(profile_entries);
+    ranked_entries.extend(derived_entries);
     ranked_entries.extend(retrieved_entries);
     if !has_retrieved_entries {
         ranked_entries.extend(summary_entries);
@@ -407,11 +411,14 @@ impl MemorySystem for BuiltinMemorySystem {
 
     fn run_derive_stage(
         &self,
-        _session_id: &str,
+        session_id: &str,
         _config: &MemoryRuntimeConfig,
-        _recent_window: &[WindowTurn],
+        recent_window: &[WindowTurn],
     ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
-        Ok(Some(Vec::new()))
+        let maybe_entry = derive_session_overview_entry(session_id, recent_window, self.id());
+        let entries = maybe_entry.into_iter().collect::<Vec<_>>();
+
+        Ok(Some(entries))
     }
 
     fn run_retrieve_stage(
@@ -429,7 +436,9 @@ impl MemorySystem for BuiltinMemorySystem {
         entries: Vec<MemoryContextEntry>,
         _config: &MemoryRuntimeConfig,
     ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
-        Ok(Some(entries))
+        let ranked_entries = rank_builtin_entries(entries);
+
+        Ok(Some(ranked_entries))
     }
 }
 
@@ -542,6 +551,249 @@ fn build_cross_session_recall_provenance(
         Some(hit.record.scope),
         recall_mode,
     )
+    .with_trust_level(MemoryTrustLevel::Session)
+    .with_authority(MemoryAuthority::Advisory)
+    .with_derived_kind(derived_memory_kind_for_canonical_kind(hit.record.kind))
+    .with_record_status(MemoryRecordStatus::Active)
+}
+
+fn derive_session_overview_entry(
+    session_id: &str,
+    recent_window: &[WindowTurn],
+    memory_system_id: &str,
+) -> Option<MemoryContextEntry> {
+    let records = collect_structured_canonical_records(session_id, recent_window);
+    if records.is_empty() {
+        return None;
+    }
+
+    let content = render_session_overview_block(records.as_slice());
+    let maybe_freshness_ts = recent_window.iter().filter_map(|turn| turn.ts).max();
+    let mut provenance = MemoryContextProvenance::new(
+        memory_system_id,
+        MemoryProvenanceSourceKind::DerivedSessionOverview,
+        Some("session_local_overview".to_owned()),
+        None,
+        Some(MemoryScope::Session),
+        MemoryRecallMode::PromptAssembly,
+    )
+    .with_trust_level(MemoryTrustLevel::Derived)
+    .with_authority(MemoryAuthority::Advisory)
+    .with_derived_kind(DerivedMemoryKind::Overview)
+    .with_record_status(MemoryRecordStatus::Active);
+
+    if let Some(freshness_ts) = maybe_freshness_ts {
+        provenance = provenance.with_freshness_ts(freshness_ts);
+    }
+
+    let entry = MemoryContextEntry {
+        kind: MemoryContextKind::Derived,
+        role: "system".to_owned(),
+        content,
+        provenance: vec![provenance],
+    };
+
+    Some(entry)
+}
+
+fn collect_structured_canonical_records(
+    session_id: &str,
+    recent_window: &[WindowTurn],
+) -> Vec<super::CanonicalMemoryRecord> {
+    let mut records = Vec::new();
+
+    for turn in recent_window {
+        let record = super::canonical_memory_record_from_persisted_turn(
+            session_id,
+            turn.role.as_str(),
+            turn.content.as_str(),
+        );
+        let is_structured_kind = matches!(
+            record.kind,
+            CanonicalMemoryKind::ToolDecision
+                | CanonicalMemoryKind::ToolOutcome
+                | CanonicalMemoryKind::ConversationEvent
+                | CanonicalMemoryKind::AcpRuntimeEvent
+                | CanonicalMemoryKind::AcpFinalEvent
+        );
+        if !is_structured_kind {
+            continue;
+        }
+
+        records.push(record);
+    }
+
+    records
+}
+
+fn render_session_overview_block(records: &[super::CanonicalMemoryRecord]) -> String {
+    let mut sections = Vec::new();
+    let mut lines = Vec::new();
+    let tool_decision_count = count_canonical_kind(records, CanonicalMemoryKind::ToolDecision);
+    let tool_outcome_count = count_canonical_kind(records, CanonicalMemoryKind::ToolOutcome);
+    let conversation_event_count =
+        count_canonical_kind(records, CanonicalMemoryKind::ConversationEvent);
+    let acp_runtime_event_count =
+        count_canonical_kind(records, CanonicalMemoryKind::AcpRuntimeEvent);
+    let acp_final_event_count = count_canonical_kind(records, CanonicalMemoryKind::AcpFinalEvent);
+    let record_kinds = collect_record_kind_names(records);
+
+    sections.push("## Session Local Overview".to_owned());
+    sections.push(
+        "Advisory session-local overview derived from persisted internal records. It preserves runtime continuity without replacing runtime-self guidance, resolved runtime identity, or the session profile."
+            .to_owned(),
+    );
+
+    if tool_decision_count > 0 {
+        lines.push(format!("- tool_decisions: {tool_decision_count}"));
+    }
+    if tool_outcome_count > 0 {
+        lines.push(format!("- tool_outcomes: {tool_outcome_count}"));
+    }
+    if conversation_event_count > 0 {
+        lines.push(format!("- conversation_events: {conversation_event_count}"));
+    }
+    if acp_runtime_event_count > 0 {
+        lines.push(format!("- acp_runtime_events: {acp_runtime_event_count}"));
+    }
+    if acp_final_event_count > 0 {
+        lines.push(format!("- acp_final_events: {acp_final_event_count}"));
+    }
+    if !record_kinds.is_empty() {
+        let record_kind_summary = record_kinds.join(", ");
+        lines.push(format!("- observed_record_kinds: {record_kind_summary}"));
+    }
+
+    sections.push(lines.join("\n"));
+
+    sections.join("\n\n")
+}
+
+fn count_canonical_kind(
+    records: &[super::CanonicalMemoryRecord],
+    kind: CanonicalMemoryKind,
+) -> usize {
+    records.iter().filter(|record| record.kind == kind).count()
+}
+
+fn collect_record_kind_names(records: &[super::CanonicalMemoryRecord]) -> Vec<String> {
+    let mut names = BTreeSet::new();
+
+    for record in records {
+        names.insert(record.kind.as_str().to_owned());
+    }
+
+    names.into_iter().collect()
+}
+
+fn rank_builtin_entries(entries: Vec<MemoryContextEntry>) -> Vec<MemoryContextEntry> {
+    let mut advisory_entries = Vec::new();
+    let mut turn_entries = Vec::new();
+
+    for entry in entries {
+        let is_turn = entry.kind == MemoryContextKind::Turn;
+        if is_turn {
+            turn_entries.push(entry);
+            continue;
+        }
+
+        if !memory_entry_is_active(&entry) {
+            continue;
+        }
+
+        advisory_entries.push(entry);
+    }
+
+    advisory_entries.sort_by(rank_builtin_entry_cmp);
+
+    let mut ranked_entries = advisory_entries;
+    ranked_entries.extend(turn_entries);
+
+    ranked_entries
+}
+
+fn memory_entry_is_active(entry: &MemoryContextEntry) -> bool {
+    let maybe_status = entry
+        .provenance
+        .first()
+        .and_then(|provenance| provenance.record_status);
+
+    match maybe_status {
+        Some(status) => status.is_active(),
+        None => true,
+    }
+}
+
+fn rank_builtin_entry_cmp(
+    left: &MemoryContextEntry,
+    right: &MemoryContextEntry,
+) -> std::cmp::Ordering {
+    let left_kind_priority = memory_entry_kind_priority(left.kind);
+    let right_kind_priority = memory_entry_kind_priority(right.kind);
+    let kind_order = left_kind_priority.cmp(&right_kind_priority);
+    if kind_order != std::cmp::Ordering::Equal {
+        return kind_order;
+    }
+
+    let left_trust_priority = memory_entry_trust_priority(left);
+    let right_trust_priority = memory_entry_trust_priority(right);
+    let trust_order = left_trust_priority.cmp(&right_trust_priority);
+    if trust_order != std::cmp::Ordering::Equal {
+        return trust_order;
+    }
+
+    let left_freshness = memory_entry_freshness(left);
+    let right_freshness = memory_entry_freshness(right);
+    let freshness_order = right_freshness.cmp(&left_freshness);
+    if freshness_order != std::cmp::Ordering::Equal {
+        return freshness_order;
+    }
+
+    let left_label = memory_entry_label(left);
+    let right_label = memory_entry_label(right);
+    left_label.cmp(right_label)
+}
+
+fn memory_entry_kind_priority(kind: MemoryContextKind) -> u8 {
+    match kind {
+        MemoryContextKind::Profile => 0,
+        MemoryContextKind::Summary => 1,
+        MemoryContextKind::Derived => 2,
+        MemoryContextKind::RetrievedMemory => 3,
+        MemoryContextKind::Turn => 4,
+    }
+}
+
+fn memory_entry_trust_priority(entry: &MemoryContextEntry) -> u8 {
+    let maybe_trust_level = entry
+        .provenance
+        .first()
+        .and_then(|provenance| provenance.trust_level);
+    let trust_level = maybe_trust_level.unwrap_or(MemoryTrustLevel::Derived);
+
+    match trust_level {
+        MemoryTrustLevel::WorkspaceCurated => 0,
+        MemoryTrustLevel::Derived => 1,
+        MemoryTrustLevel::WorkspaceLog => 2,
+        MemoryTrustLevel::Session => 3,
+    }
+}
+
+fn memory_entry_freshness(entry: &MemoryContextEntry) -> i64 {
+    let maybe_freshness = entry
+        .provenance
+        .first()
+        .and_then(|provenance| provenance.freshness_ts);
+
+    maybe_freshness.unwrap_or_default()
+}
+
+fn memory_entry_label(entry: &MemoryContextEntry) -> &str {
+    entry
+        .provenance
+        .first()
+        .and_then(|provenance| provenance.source_label.as_deref())
+        .unwrap_or_default()
 }
 
 #[derive(Default)]
@@ -562,6 +814,7 @@ impl MemorySystem for WorkspaceRecallMemorySystem {
             "Workspace-document recall system with provenance-aware retrieval and rank-stage reordering.",
         )
         .with_supported_pre_assembly_stage_families([
+            MemoryStageFamily::Derive,
             MemoryStageFamily::Retrieve,
             MemoryStageFamily::Rank,
         ])
@@ -595,6 +848,18 @@ impl MemorySystem for WorkspaceRecallMemorySystem {
             budget_items: normalized_budget_items,
             allowed_kinds: vec![crate::memory::DerivedMemoryKind::Reference],
         })
+    }
+
+    fn run_derive_stage(
+        &self,
+        session_id: &str,
+        _config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        let maybe_entry = derive_session_overview_entry(session_id, recent_window, self.id());
+        let entries = maybe_entry.into_iter().collect::<Vec<_>>();
+
+        Ok(Some(entries))
     }
 
     fn run_retrieve_stage(
@@ -644,6 +909,7 @@ impl MemorySystem for RecallFirstMemorySystem {
             "Recall-first memory system with provenance-aware retrieval and summary suppression when recall is available.",
         )
         .with_supported_pre_assembly_stage_families([
+            MemoryStageFamily::Derive,
             MemoryStageFamily::Retrieve,
             MemoryStageFamily::Rank,
         ])
@@ -664,6 +930,18 @@ impl MemorySystem for RecallFirstMemorySystem {
             config,
             recent_window,
         )
+    }
+
+    fn run_derive_stage(
+        &self,
+        session_id: &str,
+        _config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        let maybe_entry = derive_session_overview_entry(session_id, recent_window, self.id());
+        let entries = maybe_entry.into_iter().collect::<Vec<_>>();
+
+        Ok(Some(entries))
     }
 
     fn run_retrieve_stage(
@@ -784,7 +1062,11 @@ mod tests {
         );
         assert_eq!(
             metadata.supported_pre_assembly_stage_families,
-            vec![MemoryStageFamily::Retrieve, MemoryStageFamily::Rank]
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
         );
         assert_eq!(
             metadata.supported_recall_modes,
@@ -802,7 +1084,11 @@ mod tests {
         );
         assert_eq!(
             metadata.supported_pre_assembly_stage_families,
-            vec![MemoryStageFamily::Retrieve, MemoryStageFamily::Rank]
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
         );
         assert_eq!(
             metadata.supported_recall_modes,
@@ -1035,6 +1321,145 @@ mod tests {
             MemoryProvenanceSourceKind::CanonicalMemoryRecord
         );
         assert_eq!(entries[0].provenance[0].scope, Some(MemoryScope::Session));
+        assert_eq!(
+            entries[0].provenance[0].trust_level,
+            Some(MemoryTrustLevel::Session)
+        );
+        assert_eq!(
+            entries[0].provenance[0].record_status,
+            Some(MemoryRecordStatus::Active)
+        );
+    }
+
+    #[test]
+    fn builtin_memory_system_derives_session_local_overview_from_structured_turns() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: crate::memory::build_tool_decision_content(
+                    "turn-1",
+                    "call-1",
+                    json!({"tool": "memory_search"}),
+                ),
+                ts: Some(10),
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: crate::memory::build_conversation_event_content(
+                    "tool_discovery",
+                    json!({"state": "visible"}),
+                ),
+                ts: Some(20),
+            },
+        ];
+
+        let derived_entries = BuiltinMemorySystem
+            .run_derive_stage(
+                "session-local-overview-session",
+                &MemoryRuntimeConfig::default(),
+                recent_window.as_slice(),
+            )
+            .expect("derive stage should succeed")
+            .expect("derive stage should return entries");
+
+        assert_eq!(derived_entries.len(), 1);
+        assert_eq!(derived_entries[0].kind, MemoryContextKind::Derived);
+        assert!(
+            derived_entries[0]
+                .content
+                .contains("## Session Local Overview")
+        );
+        assert_eq!(
+            derived_entries[0].provenance[0].source_kind,
+            MemoryProvenanceSourceKind::DerivedSessionOverview
+        );
+        assert_eq!(
+            derived_entries[0].provenance[0].derived_kind,
+            Some(DerivedMemoryKind::Overview)
+        );
+    }
+
+    #[test]
+    fn builtin_rank_stage_filters_inactive_workspace_entries_and_orders_advisory_blocks() {
+        let inactive_entry = MemoryContextEntry {
+            kind: MemoryContextKind::RetrievedMemory,
+            role: "system".to_owned(),
+            content: "inactive".to_owned(),
+            provenance: vec![
+                MemoryContextProvenance::new(
+                    DEFAULT_MEMORY_SYSTEM_ID,
+                    MemoryProvenanceSourceKind::WorkspaceDocument,
+                    Some("MEMORY.md".to_owned()),
+                    None,
+                    Some(MemoryScope::Workspace),
+                    MemoryRecallMode::PromptAssembly,
+                )
+                .with_trust_level(MemoryTrustLevel::WorkspaceCurated)
+                .with_record_status(MemoryRecordStatus::Tombstoned),
+            ],
+        };
+        let summary_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Summary,
+            role: "system".to_owned(),
+            content: "summary".to_owned(),
+            provenance: vec![
+                MemoryContextProvenance::new(
+                    DEFAULT_MEMORY_SYSTEM_ID,
+                    MemoryProvenanceSourceKind::SummaryCheckpoint,
+                    Some("summary_checkpoint".to_owned()),
+                    None,
+                    Some(MemoryScope::Session),
+                    MemoryRecallMode::PromptAssembly,
+                )
+                .with_trust_level(MemoryTrustLevel::Derived)
+                .with_record_status(MemoryRecordStatus::Active),
+            ],
+        };
+        let derived_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Derived,
+            role: "system".to_owned(),
+            content: "derived".to_owned(),
+            provenance: vec![
+                MemoryContextProvenance::new(
+                    DEFAULT_MEMORY_SYSTEM_ID,
+                    MemoryProvenanceSourceKind::DerivedSessionOverview,
+                    Some("session_local_overview".to_owned()),
+                    None,
+                    Some(MemoryScope::Session),
+                    MemoryRecallMode::PromptAssembly,
+                )
+                .with_trust_level(MemoryTrustLevel::Derived)
+                .with_record_status(MemoryRecordStatus::Active),
+            ],
+        };
+        let turn_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Turn,
+            role: "user".to_owned(),
+            content: "turn".to_owned(),
+            provenance: Vec::new(),
+        };
+
+        let ranked_entries = BuiltinMemorySystem
+            .run_rank_stage(
+                vec![turn_entry, inactive_entry, derived_entry, summary_entry],
+                &MemoryRuntimeConfig::default(),
+            )
+            .expect("rank stage should succeed")
+            .expect("rank stage should return entries");
+
+        let kinds = ranked_entries
+            .into_iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            kinds,
+            vec![
+                MemoryContextKind::Summary,
+                MemoryContextKind::Derived,
+                MemoryContextKind::Turn,
+            ]
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/workspace_document.rs
+++ b/crates/app/src/memory/workspace_document.rs
@@ -1,0 +1,471 @@
+use std::time::UNIX_EPOCH;
+
+use serde::Deserialize;
+use serde_yaml::Value as YamlValue;
+use sha2::{Digest, Sha256};
+
+use super::{
+    DerivedMemoryKind, MemoryAuthority, MemoryContextProvenance, MemoryRecordStatus,
+    MemoryTrustLevel, WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedWorkspaceMemoryDocument {
+    pub body: String,
+    pub body_line_offset: usize,
+    pub provenance: MemoryContextProvenance,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct WorkspaceMemoryFrontmatter {
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    trust: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    superseded_by: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceFrontmatterSplit<'a> {
+    raw_frontmatter: WorkspaceMemoryFrontmatter,
+    body: &'a str,
+    body_line_offset: usize,
+}
+
+pub(crate) fn parse_workspace_memory_document(
+    raw_content: &str,
+    location: &WorkspaceMemoryDocumentLocation,
+    memory_system_id: &str,
+    recall_mode: super::MemoryRecallMode,
+) -> Result<Option<ParsedWorkspaceMemoryDocument>, String> {
+    let split = split_workspace_memory_frontmatter(raw_content)?;
+    let trimmed_body = split.body.trim();
+    if trimmed_body.is_empty() {
+        return Ok(None);
+    }
+
+    let normalized_frontmatter = normalize_workspace_memory_frontmatter(split.raw_frontmatter);
+    let derived_kind = resolve_workspace_memory_kind(
+        &normalized_frontmatter,
+        location.kind,
+        location.label.as_str(),
+    )?;
+    let trust_level = resolve_workspace_memory_trust(
+        &normalized_frontmatter,
+        location.kind,
+        location.label.as_str(),
+    )?;
+    let record_status =
+        resolve_workspace_memory_status(&normalized_frontmatter, location.label.as_str())?;
+    let content_hash = workspace_memory_content_hash(trimmed_body);
+    let maybe_freshness_ts = workspace_memory_freshness_ts(location)?;
+    let maybe_superseded_by = normalized_frontmatter.superseded_by;
+    let scope = workspace_memory_scope(location.kind);
+    let mut provenance = MemoryContextProvenance::new(
+        memory_system_id,
+        super::MemoryProvenanceSourceKind::WorkspaceDocument,
+        Some(location.label.clone()),
+        Some(location.path.display().to_string()),
+        Some(scope),
+        recall_mode,
+    )
+    .with_trust_level(trust_level)
+    .with_authority(MemoryAuthority::Advisory)
+    .with_derived_kind(derived_kind)
+    .with_content_hash(content_hash)
+    .with_record_status(record_status);
+
+    if let Some(freshness_ts) = maybe_freshness_ts {
+        provenance = provenance.with_freshness_ts(freshness_ts);
+    }
+
+    if let Some(superseded_by) = maybe_superseded_by {
+        provenance = provenance.with_superseded_by(superseded_by);
+    }
+
+    let parsed_document = ParsedWorkspaceMemoryDocument {
+        body: trimmed_body.to_owned(),
+        body_line_offset: split.body_line_offset,
+        provenance,
+    };
+
+    Ok(Some(parsed_document))
+}
+
+fn split_workspace_memory_frontmatter(
+    raw_content: &str,
+) -> Result<WorkspaceFrontmatterSplit<'_>, String> {
+    let mut segments = raw_content.split_inclusive('\n');
+    let Some(first_segment) = segments.next() else {
+        return Ok(WorkspaceFrontmatterSplit {
+            raw_frontmatter: WorkspaceMemoryFrontmatter::default(),
+            body: raw_content,
+            body_line_offset: 0,
+        });
+    };
+
+    let first_trimmed = first_segment.trim();
+    if first_trimmed != "---" {
+        return Ok(WorkspaceFrontmatterSplit {
+            raw_frontmatter: WorkspaceMemoryFrontmatter::default(),
+            body: raw_content,
+            body_line_offset: 0,
+        });
+    }
+
+    let mut raw_frontmatter_segments = Vec::new();
+    let mut consumed_bytes = first_segment.len();
+    let mut consumed_lines = 1usize;
+
+    for segment in segments {
+        consumed_bytes = consumed_bytes.saturating_add(segment.len());
+        consumed_lines = consumed_lines.saturating_add(1);
+
+        let trimmed_segment = segment.trim();
+        if trimmed_segment == "---" {
+            let raw_frontmatter =
+                decode_workspace_memory_frontmatter(raw_frontmatter_segments.as_slice())?;
+            let body = &raw_content[consumed_bytes..];
+            let split = WorkspaceFrontmatterSplit {
+                raw_frontmatter,
+                body,
+                body_line_offset: consumed_lines,
+            };
+            return Ok(split);
+        }
+
+        raw_frontmatter_segments.push(segment);
+    }
+
+    Err("workspace memory frontmatter is missing a closing `---` delimiter".to_owned())
+}
+
+fn decode_workspace_memory_frontmatter(
+    raw_frontmatter_segments: &[&str],
+) -> Result<WorkspaceMemoryFrontmatter, String> {
+    let raw_frontmatter = raw_frontmatter_segments.concat();
+    let trimmed_frontmatter = raw_frontmatter.trim();
+    if trimmed_frontmatter.is_empty() {
+        return Ok(WorkspaceMemoryFrontmatter::default());
+    }
+
+    let parsed = serde_yaml::from_str::<YamlValue>(trimmed_frontmatter)
+        .map_err(|error| format!("failed to parse workspace memory frontmatter: {error}"))?;
+    match parsed {
+        YamlValue::Null => Ok(WorkspaceMemoryFrontmatter::default()),
+        YamlValue::Mapping(_) => serde_yaml::from_value(parsed).map_err(|error| {
+            format!("failed to decode supported workspace memory frontmatter fields: {error}")
+        }),
+        YamlValue::Bool(_)
+        | YamlValue::Number(_)
+        | YamlValue::String(_)
+        | YamlValue::Sequence(_)
+        | YamlValue::Tagged(_) => {
+            Err("workspace memory frontmatter must decode to a YAML mapping".to_owned())
+        }
+    }
+}
+
+fn normalize_workspace_memory_frontmatter(
+    mut frontmatter: WorkspaceMemoryFrontmatter,
+) -> WorkspaceMemoryFrontmatter {
+    frontmatter.kind = normalize_optional_workspace_memory_enum_string(frontmatter.kind.take());
+    frontmatter.trust = normalize_optional_workspace_memory_enum_string(frontmatter.trust.take());
+    frontmatter.status = normalize_optional_workspace_memory_enum_string(frontmatter.status.take());
+    frontmatter.superseded_by =
+        normalize_optional_workspace_memory_string(frontmatter.superseded_by.take());
+
+    frontmatter
+}
+
+fn normalize_optional_workspace_memory_enum_string(value: Option<String>) -> Option<String> {
+    let normalized = normalize_optional_workspace_memory_string(value);
+    normalized.map(|value| value.to_ascii_lowercase())
+}
+
+fn normalize_optional_workspace_memory_string(value: Option<String>) -> Option<String> {
+    let normalized = value.map(|value| value.trim().to_owned());
+    normalized.filter(|value| !value.is_empty())
+}
+
+fn resolve_workspace_memory_kind(
+    frontmatter: &WorkspaceMemoryFrontmatter,
+    document_kind: WorkspaceMemoryDocumentKind,
+    source_label: &str,
+) -> Result<DerivedMemoryKind, String> {
+    if let Some(kind_text) = frontmatter.kind.as_deref() {
+        let maybe_parsed_kind = DerivedMemoryKind::parse_id(kind_text);
+        let Some(parsed_kind) = maybe_parsed_kind else {
+            return Err(format!(
+                "workspace memory file {source_label} declares unsupported frontmatter kind `{kind_text}`"
+            ));
+        };
+        return Ok(parsed_kind);
+    }
+
+    let default_kind = match document_kind {
+        WorkspaceMemoryDocumentKind::Curated => DerivedMemoryKind::Overview,
+        WorkspaceMemoryDocumentKind::DailyLog => DerivedMemoryKind::Episode,
+    };
+
+    Ok(default_kind)
+}
+
+fn resolve_workspace_memory_trust(
+    frontmatter: &WorkspaceMemoryFrontmatter,
+    document_kind: WorkspaceMemoryDocumentKind,
+    source_label: &str,
+) -> Result<MemoryTrustLevel, String> {
+    if let Some(trust_text) = frontmatter.trust.as_deref() {
+        let maybe_parsed_trust = match trust_text {
+            "session" => Some(MemoryTrustLevel::Session),
+            "derived" => Some(MemoryTrustLevel::Derived),
+            "workspace_curated" => Some(MemoryTrustLevel::WorkspaceCurated),
+            "workspace_log" => Some(MemoryTrustLevel::WorkspaceLog),
+            _ => None,
+        };
+        let Some(parsed_trust) = maybe_parsed_trust else {
+            return Err(format!(
+                "workspace memory file {source_label} declares unsupported frontmatter trust `{trust_text}`"
+            ));
+        };
+        return Ok(parsed_trust);
+    }
+
+    let default_trust = match document_kind {
+        WorkspaceMemoryDocumentKind::Curated => MemoryTrustLevel::WorkspaceCurated,
+        WorkspaceMemoryDocumentKind::DailyLog => MemoryTrustLevel::WorkspaceLog,
+    };
+
+    Ok(default_trust)
+}
+
+fn resolve_workspace_memory_status(
+    frontmatter: &WorkspaceMemoryFrontmatter,
+    source_label: &str,
+) -> Result<MemoryRecordStatus, String> {
+    let Some(status_text) = frontmatter.status.as_deref() else {
+        return Ok(MemoryRecordStatus::Active);
+    };
+
+    let maybe_parsed_status = match status_text {
+        "active" => Some(MemoryRecordStatus::Active),
+        "superseded" => Some(MemoryRecordStatus::Superseded),
+        "tombstoned" => Some(MemoryRecordStatus::Tombstoned),
+        "archived" => Some(MemoryRecordStatus::Archived),
+        _ => None,
+    };
+    let Some(parsed_status) = maybe_parsed_status else {
+        return Err(format!(
+            "workspace memory file {source_label} declares unsupported frontmatter status `{status_text}`"
+        ));
+    };
+
+    Ok(parsed_status)
+}
+
+fn workspace_memory_content_hash(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+
+    let digest = hasher.finalize();
+    digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
+fn workspace_memory_freshness_ts(
+    location: &WorkspaceMemoryDocumentLocation,
+) -> Result<Option<i64>, String> {
+    if let Some(date) = location.date {
+        let maybe_date_time = date.and_hms_opt(0, 0, 0);
+        let Some(date_time) = maybe_date_time else {
+            return Err(format!(
+                "workspace memory file {} has an invalid date",
+                location.label
+            ));
+        };
+        let timestamp = date_time.and_utc().timestamp();
+        return Ok(Some(timestamp));
+    }
+
+    let metadata = std::fs::metadata(location.path.as_path()).map_err(|error| {
+        format!(
+            "read workspace memory metadata {} failed: {error}",
+            location.path.display()
+        )
+    })?;
+    let modified_time = metadata.modified().map_err(|error| {
+        format!(
+            "read workspace memory modified time {} failed: {error}",
+            location.path.display()
+        )
+    })?;
+    let duration_since_epoch = modified_time.duration_since(UNIX_EPOCH).map_err(|error| {
+        format!(
+            "read workspace memory modified time {} failed: {error}",
+            location.path.display()
+        )
+    })?;
+    let seconds = duration_since_epoch.as_secs();
+    let freshness_ts = i64::try_from(seconds).map_err(|error| {
+        format!(
+            "workspace memory modified time {} exceeds i64: {error}",
+            location.path.display()
+        )
+    })?;
+
+    Ok(Some(freshness_ts))
+}
+
+fn workspace_memory_scope(document_kind: WorkspaceMemoryDocumentKind) -> super::MemoryScope {
+    match document_kind {
+        WorkspaceMemoryDocumentKind::Curated => super::MemoryScope::Workspace,
+        WorkspaceMemoryDocumentKind::DailyLog => super::MemoryScope::Session,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn curated_location(path: &std::path::Path) -> WorkspaceMemoryDocumentLocation {
+        WorkspaceMemoryDocumentLocation {
+            label: "MEMORY.md".to_owned(),
+            path: path.to_path_buf(),
+            kind: WorkspaceMemoryDocumentKind::Curated,
+            date: None,
+        }
+    }
+
+    #[test]
+    fn parse_workspace_memory_document_strips_frontmatter_and_keeps_metadata() {
+        let temp_dir = tempdir().expect("tempdir");
+        let path = temp_dir.path().join("MEMORY.md");
+        let raw = concat!(
+            "---\n",
+            "kind: procedure\n",
+            "trust: workspace_curated\n",
+            "status: active\n",
+            "---\n",
+            "Remember the deploy runbook.\n",
+        );
+
+        std::fs::write(&path, raw).expect("write memory");
+
+        let maybe_parsed = parse_workspace_memory_document(
+            raw,
+            &curated_location(path.as_path()),
+            "builtin",
+            super::super::MemoryRecallMode::PromptAssembly,
+        )
+        .expect("parse workspace document");
+        let parsed = maybe_parsed.expect("workspace document");
+
+        assert_eq!(parsed.body, "Remember the deploy runbook.");
+        assert_eq!(parsed.body_line_offset, 5);
+        assert_eq!(
+            parsed.provenance.derived_kind,
+            Some(DerivedMemoryKind::Procedure)
+        );
+        assert_eq!(
+            parsed.provenance.trust_level,
+            Some(MemoryTrustLevel::WorkspaceCurated)
+        );
+        assert_eq!(
+            parsed.provenance.record_status,
+            Some(MemoryRecordStatus::Active)
+        );
+    }
+
+    #[test]
+    fn parse_workspace_memory_document_defaults_kind_and_trust_from_location_kind() {
+        let temp_dir = tempdir().expect("tempdir");
+        let path = temp_dir.path().join("memory").join("2026-04-08.md");
+
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(&path, "Captured rollout follow-up.\n").expect("write memory");
+
+        let location = WorkspaceMemoryDocumentLocation {
+            label: "memory/2026-04-08.md".to_owned(),
+            path,
+            kind: WorkspaceMemoryDocumentKind::DailyLog,
+            date: Some(NaiveDate::from_ymd_opt(2026, 4, 8).expect("date")),
+        };
+        let maybe_parsed = parse_workspace_memory_document(
+            "Captured rollout follow-up.\n",
+            &location,
+            "builtin",
+            super::super::MemoryRecallMode::PromptAssembly,
+        )
+        .expect("parse workspace document");
+        let parsed = maybe_parsed.expect("workspace document");
+
+        assert_eq!(
+            parsed.provenance.derived_kind,
+            Some(DerivedMemoryKind::Episode)
+        );
+        assert_eq!(
+            parsed.provenance.trust_level,
+            Some(MemoryTrustLevel::WorkspaceLog)
+        );
+        assert_eq!(
+            parsed.provenance.record_status,
+            Some(MemoryRecordStatus::Active)
+        );
+    }
+
+    #[test]
+    fn parse_workspace_memory_document_accepts_archived_status() {
+        let temp_dir = tempdir().expect("tempdir");
+        let path = temp_dir.path().join("MEMORY.md");
+        let raw = concat!(
+            "---\n",
+            "status: archived\n",
+            "---\n",
+            "Remember the deploy runbook.\n",
+        );
+
+        std::fs::write(&path, raw).expect("write memory");
+
+        let maybe_parsed = parse_workspace_memory_document(
+            raw,
+            &curated_location(path.as_path()),
+            "builtin",
+            super::super::MemoryRecallMode::PromptAssembly,
+        )
+        .expect("parse workspace document");
+        let parsed = maybe_parsed.expect("workspace document");
+
+        assert_eq!(
+            parsed.provenance.record_status,
+            Some(MemoryRecordStatus::Archived)
+        );
+    }
+
+    #[test]
+    fn parse_workspace_memory_document_returns_none_for_empty_body_after_frontmatter() {
+        let temp_dir = tempdir().expect("tempdir");
+        let path = temp_dir.path().join("MEMORY.md");
+        let raw = concat!("---\n", "kind: overview\n", "---\n", "   \n");
+
+        std::fs::write(&path, raw).expect("write memory");
+
+        let parsed = parse_workspace_memory_document(
+            raw,
+            &curated_location(path.as_path()),
+            "builtin",
+            super::super::MemoryRecallMode::PromptAssembly,
+        )
+        .expect("parse workspace document");
+
+        assert!(parsed.is_none());
+    }
+}

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -646,6 +646,7 @@ fn append_hydrated_memory_messages(
         match entry.kind {
             memory::MemoryContextKind::Profile
             | memory::MemoryContextKind::Summary
+            | memory::MemoryContextKind::Derived
             | memory::MemoryContextKind::RetrievedMemory => {
                 append_advisory_memory_message(messages, artifacts, entry);
             }
@@ -760,6 +761,7 @@ fn advisory_artifact_kind(kind: memory::MemoryContextKind) -> ContextArtifactKin
     match kind {
         memory::MemoryContextKind::Profile => ContextArtifactKind::Profile,
         memory::MemoryContextKind::Summary => ContextArtifactKind::Summary,
+        memory::MemoryContextKind::Derived => ContextArtifactKind::Summary,
         memory::MemoryContextKind::RetrievedMemory => ContextArtifactKind::RetrievedMemory,
         memory::MemoryContextKind::Turn => ContextArtifactKind::ConversationTurn,
     }
@@ -770,6 +772,7 @@ fn advisory_allowed_root_headings(kind: memory::MemoryContextKind) -> &'static [
     match kind {
         memory::MemoryContextKind::Profile => &["session profile"],
         memory::MemoryContextKind::Summary => &["memory summary"],
+        memory::MemoryContextKind::Derived => &["session local overview"],
         memory::MemoryContextKind::RetrievedMemory => &["advisory durable recall"],
         memory::MemoryContextKind::Turn => &[],
     }

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -1,14 +1,13 @@
-use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::fs;
 use std::path::Path;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Map, Value, json};
 
 use crate::memory::{
-    MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode, MemoryScope,
-    WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
-    collect_workspace_memory_document_locations,
+    MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
+    ParsedWorkspaceMemoryDocument, WorkspaceMemoryDocumentLocation,
+    collect_workspace_memory_document_locations, parse_workspace_memory_document,
 };
 
 const DEFAULT_MEMORY_SEARCH_MAX_RESULTS: usize = 5;
@@ -30,6 +29,7 @@ struct MemorySearchResult {
     snippet: String,
     score: u32,
     provenance: MemoryContextProvenance,
+    metadata: Option<Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,17 +161,35 @@ pub(super) fn execute_memory_get_tool_with_config(
             )
         })?;
 
+    let raw_content = read_workspace_memory_text_lossy(matched_location.path.as_path())?;
+    let maybe_parsed_document = parse_workspace_memory_document(
+        raw_content.as_str(),
+        matched_location,
+        config.selected_memory_system_id.as_str(),
+        MemoryRecallMode::OperatorInspection,
+    )?;
+    let Some(parsed_document) = maybe_parsed_document else {
+        return Err(format!("memory file `{}` is empty", matched_location.label));
+    };
+
+    let record_status = parsed_document
+        .provenance
+        .record_status
+        .unwrap_or(crate::memory::MemoryRecordStatus::Active);
+    if !record_status.is_active() {
+        return Err(format!(
+            "memory file `{}` is inactive and cannot be inspected",
+            matched_location.label
+        ));
+    }
+
     let file_window = read_memory_file_window(
-        matched_location.path.as_path(),
+        parsed_document.body.as_str(),
         requested_start_line,
         requested_line_count,
-    )?;
+    );
     let total_lines = file_window.total_lines;
     let selected_lines = file_window.selected_lines;
-
-    if total_lines == 0 {
-        return Err(format!("memory file `{}` is empty", matched_location.label));
-    }
     if requested_start_line > total_lines {
         return Err(format!(
             "memory_get start line {} exceeds file length {} for `{}`",
@@ -185,6 +203,7 @@ pub(super) fn execute_memory_get_tool_with_config(
         .saturating_add(selected_line_count)
         .saturating_sub(1);
     let text = selected_lines.join("\n");
+    let provenance = &parsed_document.provenance;
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -195,7 +214,8 @@ pub(super) fn execute_memory_get_tool_with_config(
             "start_line": start_line,
             "end_line": end_line,
             "text": text,
-            "provenance": workspace_memory_location_provenance(config, matched_location),
+            "provenance": provenance,
+            "metadata": memory_document_metadata_payload(&parsed_document),
         }),
     })
 }
@@ -233,27 +253,13 @@ fn workspace_root_from_config(
 }
 
 fn read_memory_file_window(
-    path: &Path,
+    content: &str,
     requested_start_line: usize,
     requested_line_count: usize,
-) -> Result<MemoryFileWindow, String> {
-    let file = File::open(path)
-        .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
-    let mut reader = BufReader::new(file);
+) -> MemoryFileWindow {
     let mut total_lines = 0usize;
     let mut selected_lines = Vec::new();
-    let mut buffer = String::new();
-
-    loop {
-        buffer.clear();
-
-        let bytes_read = reader
-            .read_line(&mut buffer)
-            .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
-        if bytes_read == 0 {
-            break;
-        }
-
+    for line in content.lines() {
         total_lines = total_lines.saturating_add(1);
 
         if total_lines < requested_start_line {
@@ -263,22 +269,13 @@ fn read_memory_file_window(
             break;
         }
 
-        let line = trim_trailing_line_endings(&buffer);
-        let owned_line = line.to_owned();
-
-        selected_lines.push(owned_line);
-
-        if selected_lines.len() >= requested_line_count {
-            break;
-        }
+        selected_lines.push(line.to_owned());
     }
 
-    let file_window = MemoryFileWindow {
+    MemoryFileWindow {
         total_lines,
         selected_lines,
-    };
-
-    Ok(file_window)
+    }
 }
 
 fn parse_optional_usize_field(
@@ -351,13 +348,26 @@ fn search_memory_location(
     config: &super::runtime_config::ToolRuntimeConfig,
     location: &WorkspaceMemoryDocumentLocation,
 ) -> Result<Option<MemorySearchResult>, String> {
-    let content = fs::read_to_string(location.path.as_path()).map_err(|error| {
-        format!(
-            "failed to read memory file {}: {error}",
-            location.path.display()
-        )
-    })?;
-    let lines = content.lines().collect::<Vec<_>>();
+    let content = read_workspace_memory_text_lossy(location.path.as_path())?;
+    let maybe_parsed_document = parse_workspace_memory_document(
+        content.as_str(),
+        location,
+        config.selected_memory_system_id.as_str(),
+        MemoryRecallMode::OperatorInspection,
+    )?;
+    let Some(parsed_document) = maybe_parsed_document else {
+        return Ok(None);
+    };
+
+    let record_status = parsed_document
+        .provenance
+        .record_status
+        .unwrap_or(crate::memory::MemoryRecordStatus::Active);
+    if !record_status.is_active() {
+        return Ok(None);
+    }
+
+    let lines = parsed_document.body.lines().collect::<Vec<_>>();
     if lines.is_empty() {
         return Ok(None);
     }
@@ -389,7 +399,8 @@ fn search_memory_location(
         end_line: Some(end_line),
         snippet,
         score: best_match.score,
-        provenance: workspace_memory_location_provenance(config, location),
+        provenance: parsed_document.provenance.clone(),
+        metadata: Some(memory_document_metadata_payload(&parsed_document)),
     };
 
     Ok(Some(result))
@@ -532,6 +543,7 @@ fn search_canonical_memory_results(
                 snippet: hit.record.content,
                 score,
                 provenance,
+                metadata: None,
             }
         })
         .collect())
@@ -578,28 +590,8 @@ fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
         "snippet": result.snippet,
         "score": result.score,
         "provenance": result.provenance,
+        "metadata": result.metadata,
     })
-}
-
-fn workspace_memory_location_provenance(
-    config: &super::runtime_config::ToolRuntimeConfig,
-    location: &WorkspaceMemoryDocumentLocation,
-) -> MemoryContextProvenance {
-    let scope = match location.kind {
-        WorkspaceMemoryDocumentKind::Curated => MemoryScope::Workspace,
-        WorkspaceMemoryDocumentKind::DailyLog => MemoryScope::Session,
-    };
-    let source_label = Some(location.label.clone());
-    let source_path = Some(location.path.display().to_string());
-
-    MemoryContextProvenance::new(
-        config.selected_memory_system_id.as_str(),
-        MemoryProvenanceSourceKind::WorkspaceDocument,
-        source_label,
-        source_path,
-        Some(scope),
-        MemoryRecallMode::OperatorInspection,
-    )
 }
 
 fn canonical_memory_hit_provenance(
@@ -618,12 +610,43 @@ fn canonical_memory_hit_provenance(
         scope,
         MemoryRecallMode::OperatorInspection,
     )
+    .with_trust_level(crate::memory::MemoryTrustLevel::Session)
+    .with_authority(crate::memory::MemoryAuthority::Advisory)
+    .with_record_status(crate::memory::MemoryRecordStatus::Active)
 }
 
-fn trim_trailing_line_endings(line: &str) -> &str {
-    let without_newline = line.strip_suffix('\n').unwrap_or(line);
-    let without_carriage_return = without_newline.strip_suffix('\r');
-    without_carriage_return.unwrap_or(without_newline)
+fn read_workspace_memory_text_lossy(path: &Path) -> Result<String, String> {
+    let bytes = fs::read(path)
+        .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
+    let text = String::from_utf8_lossy(bytes.as_slice()).into_owned();
+
+    Ok(text)
+}
+
+fn memory_document_metadata_payload(document: &ParsedWorkspaceMemoryDocument) -> Value {
+    let provenance = &document.provenance;
+    let derived_kind = provenance.derived_kind.map(|kind| kind.as_str().to_owned());
+    let freshness_ts = provenance.freshness_ts;
+    let record_status = provenance
+        .record_status
+        .map(|status| status.as_str().to_owned());
+    let trust_level = provenance
+        .trust_level
+        .map(|trust| trust.as_str().to_owned());
+    let authority = provenance
+        .authority
+        .map(|authority| authority.as_str().to_owned());
+    let superseded_by = provenance.superseded_by.clone();
+
+    json!({
+        "derived_kind": derived_kind,
+        "freshness_ts": freshness_ts,
+        "record_status": record_status,
+        "trust_level": trust_level,
+        "authority": authority,
+        "superseded_by": superseded_by,
+        "body_line_offset": document.body_line_offset,
+    })
 }
 
 #[cfg(test)]
@@ -764,5 +787,104 @@ mod tests {
             results[0]["score"].as_u64().is_some_and(|value| value > 0),
             "metadata-only matches should keep a stable score: {results:?}"
         );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_search_tool_skips_tombstoned_workspace_memory_files() {
+        let root = unique_temp_dir("loongclaw-memory-search-tombstoned");
+        let memory_dir = root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(
+            root.join("MEMORY.md"),
+            concat!(
+                "---\n",
+                "status: tombstoned\n",
+                "---\n",
+                "Deploy freeze window is Friday.\n",
+            ),
+        )
+        .expect("write tombstoned memory");
+        std::fs::write(
+            memory_dir.join("2026-03-23.md"),
+            "Deploy freeze window remains Friday for customer migration.\n",
+        )
+        .expect("write daily log");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deploy freeze window",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            results.iter().any(|entry| entry["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("2026-03-23.md"))),
+            "expected a matching active document to remain searchable: {results:?}"
+        );
+        assert!(
+            results.iter().all(|entry| entry["path"] != "MEMORY.md"),
+            "tombstoned documents should be filtered from search results: {results:?}"
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_get_tool_strips_frontmatter_and_surfaces_workspace_metadata() {
+        let root = unique_temp_dir("loongclaw-memory-get-frontmatter");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(
+            &memory_path,
+            concat!(
+                "---\n",
+                "kind: procedure\n",
+                "trust: workspace_curated\n",
+                "status: active\n",
+                "---\n",
+                "line one\n",
+                "line two\n",
+            ),
+        )
+        .expect("write root memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "from": 1,
+                    "lines": 2
+                }),
+            },
+            &config,
+        )
+        .expect("memory get should succeed");
+
+        assert_eq!(outcome.payload["text"], "line one\nline two");
+        assert_eq!(outcome.payload["metadata"]["derived_kind"], "procedure");
+        assert_eq!(
+            outcome.payload["metadata"]["trust_level"],
+            "workspace_curated"
+        );
+        assert_eq!(outcome.payload["metadata"]["body_line_offset"], 5);
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2806,6 +2806,13 @@ mod tests {
             }),
             "expected structured operator-inspection provenance: {results:?}"
         );
+        assert!(
+            results.iter().all(|entry| {
+                entry["metadata"]["record_status"] == "active"
+                    && entry["metadata"]["body_line_offset"].as_u64().is_some()
+            }),
+            "expected structured workspace metadata: {results:?}"
+        );
     }
 
     #[cfg(feature = "tool-file")]
@@ -2850,6 +2857,7 @@ mod tests {
             outcome.payload["provenance"]["recall_mode"],
             "operator_inspection"
         );
+        assert_eq!(outcome.payload["metadata"]["record_status"], "active");
     }
 
     #[cfg(feature = "tool-file")]

--- a/crates/daemon/src/memory_context_benchmark.rs
+++ b/crates/daemon/src/memory_context_benchmark.rs
@@ -1659,6 +1659,7 @@ fn memory_context_shape(entries: &[MemoryContextEntry]) -> MemoryContextShape {
                 summary_chars = summary_chars.saturating_add(entry.content.len());
             }
             MemoryContextKind::Profile => {}
+            MemoryContextKind::Derived => {}
             MemoryContextKind::RetrievedMemory => {}
         }
     }
@@ -1830,16 +1831,25 @@ mod tests {
             content: "hello".to_owned(),
             provenance: Vec::new(),
         };
-        let entries = vec![retrieved_entry, summary_entry, turn_entry];
+        let derived_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Derived,
+            role: "system".to_owned(),
+            content: "derived overview".to_owned(),
+            provenance: Vec::new(),
+        };
+        let entries = vec![retrieved_entry, summary_entry, turn_entry, derived_entry];
         let retrieved_payload_chars = "system".len() + "durable recall".len();
         let summary_payload_chars = "system".len() + "summary block".len();
         let turn_payload_chars = "user".len() + "hello".len();
-        let expected_payload_chars =
-            retrieved_payload_chars + summary_payload_chars + turn_payload_chars;
+        let derived_payload_chars = "system".len() + "derived overview".len();
+        let expected_payload_chars = retrieved_payload_chars
+            + summary_payload_chars
+            + turn_payload_chars
+            + derived_payload_chars;
 
         let shape = memory_context_shape(entries.as_slice());
 
-        assert_eq!(shape.entry_count, 3);
+        assert_eq!(shape.entry_count, 4);
         assert_eq!(shape.turn_entries, 1);
         assert_eq!(shape.summary_chars, "summary block".len());
         assert_eq!(shape.payload_chars, expected_payload_chars);

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1494,7 +1494,7 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
         "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
     ));
     assert!(rendered.contains(
-        "- recall_first api_version=1 capabilities=prompt_hydration,retrieval_provenance pre_assembly_stages=retrieve,rank recall_modes=prompt_assembly"
+        "- recall_first api_version=1 capabilities=prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
     ));
 }
 

--- a/docs/product-specs/memory-profiles.md
+++ b/docs/product-specs/memory-profiles.md
@@ -14,6 +14,9 @@ how continuity is preserved without manually wiring different memory systems.
 - [ ] Existing SQLite-based configs continue to work without migration.
 - [ ] `window_plus_summary` injects condensed earlier session context before the
       recent sliding window.
+- [ ] Hydrated advisory memory entries carry deterministic provenance metadata
+      that explains source kind, scope, recall mode, trust level, authority,
+      derived kind, and record status.
 - [ ] `profile_plus_window` can inject a durable `profile_note` block for
       preferences, tuning, or advisory imported context.
 - [ ] `profile_plus_window` remains the durable advisory lane that future recall
@@ -28,6 +31,12 @@ how continuity is preserved without manually wiring different memory systems.
 - [ ] Canonical session-history recall is exposed through a separate
       `session_search` surface instead of overloading durable workspace-memory
       search.
+- [ ] Workspace durable recall honors explicit record status metadata so
+      superseded, tombstoned, or archived files are excluded from prompt
+      assembly and operator inspection.
+- [ ] Session-local derived overview artifacts remain advisory and do not
+      replace runtime-self guidance, resolved runtime identity, or the session
+      profile.
 - [ ] Legacy imported identity can still be recovered from `profile_note`, but
       it is resolved into a separate runtime identity lane rather than being
       projected back into the session profile block.

--- a/docs/product-specs/memory-retrieval.md
+++ b/docs/product-specs/memory-retrieval.md
@@ -15,6 +15,8 @@ channel.
       instead of being permanently fixed to session-local summary only.
 - [ ] Retrieved artifacts surface provenance that is meaningful to operators,
       including where the result came from and why it was injected.
+- [ ] Workspace-document retrieval honors explicit record-status metadata so
+      inactive records are filtered before ranking or operator inspection.
 - [ ] The first slice includes a local text-search path before any
       embedding-dependent retrieval becomes required.
 - [ ] Retrieved memory remains advisory and does not override runtime self,

--- a/docs/product-specs/runtime-self-continuity.md
+++ b/docs/product-specs/runtime-self-continuity.md
@@ -48,7 +48,8 @@ mixing identity authority with transient task context.
 - When a safe workspace file root is configured and durable memory files are
   present, LoongClaw may bootstrap advisory durable recall from `MEMORY.md`,
   `memory/MEMORY.md`, and recent `memory/YYYY-MM-DD.md` logs into runtime
-  context.
+  context. Workspace memory frontmatter may further mark records as active,
+  superseded, tombstoned, or archived; inactive records must not be replayed.
 - Session-local content is never promoted into durable self-state implicitly.
 
 ## Selected Direction
@@ -91,5 +92,7 @@ Related public specs:
   advisory and do not become an identity override path.
 - Runtime durable-recall bootstrap, when enabled by workspace configuration,
   stays advisory and does not become an identity override path.
+- Session-local derived overview artifacts stay advisory and are clearly
+  distinguished from summary checkpoints and retrieved durable recall.
 - The relationship to `#421` and `#429` is explicit: retrieval may enrich
   durable context, but it must not become an identity override path.

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 425 | 650 | 225 | 15 | 16 | 1 | 93.8% | WATCH | 356 | 19.4% | BREACH | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 430 | 650 | 220 | 15 | 16 | 1 | 93.8% | WATCH | 356 | 20.8% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1786 | 6400 | 4614 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.4% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14962 | 15000 | 38 | 54 | 70 | 16 | 99.7% | TIGHT | 14472 | 3.4% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14970 | 15000 | 30 | 54 | 70 | 16 | 99.8% | TIGHT | 14472 | 3.4% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6447 | 6500 | 53 | 200 | 210 | 10 | 99.2% | TIGHT | 6324 | 1.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (99.7%), daemon_lib (99.2%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (99.8%), daemon_lib (99.2%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (93.8%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -61,7 +61,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=425 functions=15 -->
+<!-- arch-hotspot key=memory_mod lines=430 functions=15 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1786 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
-<!-- arch-hotspot key=tools_mod lines=14962 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14970 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6447 functions=200 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: memory/context assembly preserved continuity but lacked provenance-aware recall ranking and governance metadata, and a couple of CLI/runtime tests were failing for environment/order-of-validation reasons instead of the intended contracts.
- Why it matters: operators need deterministic, explainable advisory recall; reviewers need confidence that stale/tombstoned workspace memory can be governed; CI should fail on the real contract break, not on ambient env/policy-root leakage.
- What changed: added structured memory provenance/status metadata, workspace-memory frontmatter parsing, session-local derived overview generation, deterministic advisory ranking/truncation, richer memory tool metadata, and fixed the migrate/discord tests so they fail for the intended reasons.
- What did not change (scope boundary): no new memory backend, no vector retrieval, no identity-authority promotion, no new public durable-memory write surface.

## Linked Issues

- Closes #1099
- Related #468
- Related #469

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh

Targeted memory verification also passed:
- cargo test -p loongclaw-app memory:: -- --nocapture
- cargo test -p loongclaw-app message_builder_bootstraps_advisory_durable_recall_from_workspace_memory_files -- --nocapture
- cargo test -p loongclaw-app append_advisory_memory_message_preserves_session_local_overview_heading -- --nocapture
- cargo test -p loongclaw-daemon migrate_cli_ux_apply_mode_reports_flag_level_output_requirement -- --nocapture
```

## User-visible / Operator-visible Changes

- Memory/context assembly now carries structured provenance/status metadata for advisory memory entries.
- Workspace memory files can declare optional frontmatter for derived kind, trust level, active/superseded/tombstoned status, and supersession hints.
- Memory search/get surfaces now return metadata describing the matched workspace memory record.
- Session-local internal tool/event records now contribute a bounded advisory overview instead of remaining invisible continuity-only data.

## Failure Recovery

- Fast rollback or disable path: revert commit `279c81771`; memory remains on the builtin sqlite backend and no data migration is required.
- Observable failure symptoms reviewers should watch for: advisory recall blocks missing expected metadata, workspace memory search unexpectedly returning tombstoned files, or derived overview messages surfacing without the advisory heading.

## Reviewer Focus

- `crates/app/src/memory/orchestrator.rs`: derive/rank behavior, retrieval budget truncation, inactive-record filtering
- `crates/app/src/memory/workspace_document.rs`: frontmatter parsing and provenance defaults
- `crates/app/src/tools/memory_tools.rs`: metadata returned by memory_get/memory_search and inactive-record filtering
- `crates/daemon/src/migrate_cli.rs` and `crates/app/src/channel/registry.rs`: CLI/test fixes that harden validation ordering and env isolation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-local derived memory overviews are generated and surfaced in recall and chat history.
  * Workspace memory files may include YAML frontmatter and are parsed into structured documents.

* **Improvements**
  * Memory entries carry richer, deterministic provenance (source label, trust, authority, derived kind, record status, freshness, content hash).
  * Searches/retrievals exclude inactive records and return structured metadata (body offset, record status); advisory-derived items are ranked alongside summaries/profiles.

* **Documentation**
  * Acceptance criteria updated for record-status governance and advisory derived artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->