### PR TITLE
fix(install): auto-configure PATH before onboard

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,6 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+$Prefix = [IO.Path]::GetFullPath(($Prefix -replace '^~', $HOME))
 $ReleaseBaseUrl = if ($env:LOONGCLAW_INSTALL_RELEASE_BASE_URL) { $env:LOONGCLAW_INSTALL_RELEASE_BASE_URL } else { "https://github.com/$Repository/releases" }
 $BinName = "loong"
 $LegacyBinName = "loongclaw"
@@ -191,16 +192,46 @@ $installResult = if ($Source) { Install-FromSource } else { Install-FromRelease 
 Write-Host "==> Installed loong to $($installResult.Primary)"
 Write-Host "==> Installed compatible loongclaw command to $($installResult.Legacy)"
 
-if ($Onboard) {
-    Write-Host "==> Running guided onboarding"
-    & $installResult.Primary onboard | Out-Host
+$normalizedPrefix = $Prefix
+$pathItems = ($env:PATH -split [IO.Path]::PathSeparator) |
+    Where-Object { $_ } |
+    ForEach-Object { [IO.Path]::GetFullPath($_) }
+$alreadyInSessionPath = $pathItems | Where-Object { $_ -ieq $normalizedPrefix }
+if (-not $alreadyInSessionPath) {
+    $currentUserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $userPathItems = if ($currentUserPath) {
+        ($currentUserPath -split [IO.Path]::PathSeparator) |
+            Where-Object { $_ } |
+            ForEach-Object { [IO.Path]::GetFullPath($_) }
+    } else { @() }
+    $alreadyInUserPath = $userPathItems | Where-Object { $_ -ieq $normalizedPrefix }
+    if (-not $alreadyInUserPath) {
+        $newUserPath = if ($currentUserPath) { "$normalizedPrefix$([IO.Path]::PathSeparator)$currentUserPath" } else { $normalizedPrefix }
+        try {
+            [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+            Write-Host "==> Added $normalizedPrefix to user PATH"
+        } catch {
+            Write-Host "==> Could not persist PATH automatically: $_"
+            Write-Host "    Add manually: `$env:PATH = `"$normalizedPrefix`$([IO.Path]::PathSeparator)`$env:PATH`""
+        }
+    } else {
+        Write-Host "==> PATH entry already present in user environment"
+    }
+    $env:PATH = "$normalizedPrefix$([IO.Path]::PathSeparator)$env:PATH"
 }
 
-$pathItems = ($env:PATH -split [IO.Path]::PathSeparator)
-if (-not ($pathItems -contains $Prefix)) {
-    Write-Host ""
-    Write-Host "Add to PATH if needed:"
-    Write-Host "  `$env:PATH = \"$Prefix$([IO.Path]::PathSeparator)$env:PATH\""
+if ($Onboard) {
+    Write-Host "==> Running guided onboarding"
+    try {
+        & $installResult.Primary onboard | Out-Host
+        if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+            Write-Host "==> Onboarding exited with code $LASTEXITCODE"
+            Write-Host "==> You can run 'loong onboard' later to complete setup"
+        }
+    } catch {
+        Write-Host "==> Onboarding encountered an error: $_"
+        Write-Host "==> You can run 'loong onboard' later to complete setup"
+    }
 }
 
 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -187,6 +187,18 @@ function Install-FromRelease {
     }
 }
 
+function Resolve-NormalizedPathEntryOrNull([string]$PathEntry) {
+    if ([string]::IsNullOrWhiteSpace($PathEntry)) {
+        return $null
+    }
+
+    try {
+        return [IO.Path]::GetFullPath($PathEntry)
+    } catch {
+        return $null
+    }
+}
+
 $installResult = if ($Source) { Install-FromSource } else { Install-FromRelease }
 
 Write-Host "==> Installed loong to $($installResult.Primary)"
@@ -195,14 +207,16 @@ Write-Host "==> Installed compatible loongclaw command to $($installResult.Legac
 $normalizedPrefix = $Prefix
 $pathItems = ($env:PATH -split [IO.Path]::PathSeparator) |
     Where-Object { $_ } |
-    ForEach-Object { [IO.Path]::GetFullPath($_) }
+    ForEach-Object { Resolve-NormalizedPathEntryOrNull $_ } |
+    Where-Object { $_ }
 $alreadyInSessionPath = $pathItems | Where-Object { $_ -ieq $normalizedPrefix }
 if (-not $alreadyInSessionPath) {
     $currentUserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
     $userPathItems = if ($currentUserPath) {
         ($currentUserPath -split [IO.Path]::PathSeparator) |
             Where-Object { $_ } |
-            ForEach-Object { [IO.Path]::GetFullPath($_) }
+            ForEach-Object { Resolve-NormalizedPathEntryOrNull $_ } |
+            Where-Object { $_ }
     } else { @() }
     $alreadyInUserPath = $userPathItems | Where-Object { $_ -ieq $normalizedPrefix }
     if (-not $alreadyInUserPath) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -858,17 +858,42 @@ fi
 printf '==> Installed loong to %s\n' "${prefix}/${bin_name}"
 printf '==> Installed compatible loongclaw command to %s\n' "${prefix}/${legacy_bin_name}"
 
-if [[ "${run_onboard}" -eq 1 ]]; then
-  printf '==> Running guided onboarding\n'
-  run_guided_onboarding
-fi
-
 case ":${PATH}:" in
   *":${prefix}:"*)
     ;;
   *)
-    printf '\nAdd to PATH if needed:\n  export PATH="%s:$PATH"\n' "${prefix}"
+    path_line="export PATH=\"${prefix}:\$PATH\""
+    # Pick the rc file for the user's current shell
+    case "${SHELL:-}" in
+      */zsh)  rc_file="${HOME}/.zshrc" ;;
+      */bash) rc_file="${HOME}/.bashrc" ;;
+      *)      rc_file="" ;;
+    esac
+    if [[ -n "${rc_file}" ]]; then
+      if [[ ! -f "${rc_file}" ]]; then
+        touch "${rc_file}"
+      fi
+      if ! grep -qF "${path_line}" "${rc_file}"; then
+        # Ensure existing content ends with a newline before appending
+        if [[ -s "${rc_file}" ]] && [[ "$(tail -c 1 "${rc_file}" | wc -l)" -eq 0 ]]; then
+          printf '\n' >> "${rc_file}"
+        fi
+        printf '\n# Added by Loong installer\n%s\n' "${path_line}" >> "${rc_file}"
+        printf '==> Added %s to PATH in %s\n' "${prefix}" "${rc_file}"
+      else
+        printf '==> PATH entry already present in %s\n' "${rc_file}"
+      fi
+    else
+      printf '\nAdd to PATH if needed:\n  export PATH="%s:$PATH"\n' "${prefix}"
+    fi
+    # Make loong available for the onboarding step below
+    export PATH="${prefix}:${PATH}"
     ;;
 esac
+
+if [[ "${run_onboard}" -eq 1 ]]; then
+  printf '==> Running guided onboarding\n'
+  run_guided_onboarding
+fi
 
 printf '\nDone. Try:\n  loong --help\n'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -891,8 +891,13 @@ case ":${PATH}:" in
     ;;
 esac
 
+printf '\n'
+printf 'Note: if loong is not found after this script exits, run:\n'
+printf '  source "%s"\n' "${rc_file:-\$HOME/.profile}"
+printf 'or open a new terminal.\n'
+
 if [[ "${run_onboard}" -eq 1 ]]; then
-  printf '==> Running guided onboarding\n'
+  printf '\n==> Running guided onboarding\n'
   run_guided_onboarding
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -557,6 +557,7 @@ run_guided_onboarding() {
   local selected_provider
   local provider_source
   local recommendation
+  local onboard_status
 
   if [[ -n "${LOONGCLAW_WEB_SEARCH_PROVIDER:-}" ]]; then
     selected_provider="${LOONGCLAW_WEB_SEARCH_PROVIDER}"
@@ -572,7 +573,8 @@ run_guided_onboarding() {
       "$(install_web_search_provider_display_name "${selected_provider}")" \
       "$(format_install_web_search_provider_source "${provider_source}")"
     "${prefix}/${bin_name}" onboard --web-search-provider "${selected_provider}"
-    return 0
+    onboard_status="$?"
+    return "${onboard_status}"
   fi
 
   "${prefix}/${bin_name}" onboard
@@ -858,6 +860,8 @@ fi
 printf '==> Installed loong to %s\n' "${prefix}/${bin_name}"
 printf '==> Installed compatible loongclaw command to %s\n' "${prefix}/${legacy_bin_name}"
 
+should_print_source_hint=0
+
 case ":${PATH}:" in
   *":${prefix}:"*)
     ;;
@@ -883,6 +887,7 @@ case ":${PATH}:" in
       else
         printf '==> PATH entry already present in %s\n' "${rc_file}"
       fi
+      should_print_source_hint=1
     else
       printf '\nAdd to PATH if needed:\n  export PATH="%s:$PATH"\n' "${prefix}"
     fi
@@ -891,14 +896,22 @@ case ":${PATH}:" in
     ;;
 esac
 
-printf '\n'
-printf 'Note: if loong is not found after this script exits, run:\n'
-printf '  source "%s"\n' "${rc_file:-\$HOME/.profile}"
-printf 'or open a new terminal.\n'
+if [[ "${should_print_source_hint}" -eq 1 ]]; then
+  printf '\n'
+  printf 'Note: if loong is not found after this script exits, run:\n'
+  printf '  source "%s"\n' "${rc_file}"
+  printf 'or open a new terminal.\n'
+fi
 
 if [[ "${run_onboard}" -eq 1 ]]; then
   printf '\n==> Running guided onboarding\n'
-  run_guided_onboarding
+  if run_guided_onboarding; then
+    :
+  else
+    onboard_status="$?"
+    printf '==> Onboarding exited with code %s\n' "${onboard_status}"
+    printf "==> You can run 'loong onboard' later to complete setup\n"
+  fi
 fi
 
 printf '\nDone. Try:\n  loong --help\n'

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -18,6 +18,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "did not expect to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 assert_installed_binary_pair() {
   local install_dir="$1"
   local expected_output="$2"
@@ -96,6 +106,7 @@ if [[ "\${1:-}" == "onboard" ]]; then
     printf 'onboard\n'
     printf 'web_search_provider=%s\n' "\${selected_provider:-}"
   } >> "\${ONBOARD_MARKER:?}"
+  exit "\${ONBOARD_EXIT_CODE:-0}"
 fi
 printf '%s\n' "$binary_label"
 EOF
@@ -629,6 +640,156 @@ run_release_override_install_and_onboard_test() {
   assert_contains "$marker" "onboard"
 }
 
+run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
+  local fixture
+  local home_dir
+  local install_dir
+  local output_file
+  local bashrc_file
+  local expected_path_line
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  home_dir="$fixture/home"
+  install_dir="$fixture/install"
+  output_file="$fixture/install-bashrc.out"
+  bashrc_file="$home_dir/.bashrc"
+  expected_path_line="export PATH=\"$install_dir:\$PATH\""
+  mkdir -p "$home_dir"
+
+  (
+    cd "$REPO_ROOT"
+    HOME="$home_dir" \
+      SHELL="/bin/bash" \
+      PATH="/usr/bin:/bin" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$bashrc_file" "# Added by Loong installer"
+  assert_contains "$bashrc_file" "$expected_path_line"
+  assert_contains "$output_file" "Added $install_dir to PATH in $bashrc_file"
+  assert_contains "$output_file" "source \"$bashrc_file\""
+}
+
+run_release_install_skips_source_hint_when_path_is_already_available_test() {
+  local fixture
+  local home_dir
+  local install_dir
+  local output_file
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  home_dir="$fixture/home"
+  install_dir="$fixture/install"
+  output_file="$fixture/install-path-present.out"
+  mkdir -p "$home_dir"
+
+  (
+    cd "$REPO_ROOT"
+    HOME="$home_dir" \
+      SHELL="/bin/bash" \
+      PATH="$install_dir:/usr/bin:/bin" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_not_contains "$output_file" "source \"$home_dir/.bashrc\""
+  assert_not_contains "$output_file" "Add to PATH if needed:"
+}
+
+run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test() {
+  local fixture
+  local home_dir
+  local install_dir
+  local output_file
+  local bashrc_file
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  home_dir="$fixture/home"
+  install_dir="$fixture/install"
+  output_file="$fixture/install-rc-already-set.out"
+  bashrc_file="$home_dir/.bashrc"
+  mkdir -p "$home_dir"
+  printf 'export PATH="%s:$PATH"\n' "$install_dir" >"$bashrc_file"
+
+  (
+    cd "$REPO_ROOT"
+    HOME="$home_dir" \
+      SHELL="/bin/bash" \
+      PATH="/usr/bin:/bin" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$output_file" "PATH entry already present in $bashrc_file"
+  assert_contains "$output_file" "source \"$bashrc_file\""
+}
+
+run_release_install_unsupported_shell_uses_manual_path_hint_only_test() {
+  local fixture
+  local home_dir
+  local install_dir
+  local output_file
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  home_dir="$fixture/home"
+  install_dir="$fixture/install"
+  output_file="$fixture/install-fish-shell.out"
+  mkdir -p "$home_dir"
+
+  (
+    cd "$REPO_ROOT"
+    HOME="$home_dir" \
+      SHELL="/usr/bin/fish" \
+      PATH="/usr/bin:/bin" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$output_file" "Add to PATH if needed:"
+  assert_not_contains "$output_file" 'source "$HOME/.profile"'
+}
+
+run_release_override_install_and_onboard_failure_preserves_install_test() {
+  local fixture
+  local install_dir
+  local output_file
+  local marker
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install-onboard-failure.out"
+  marker="$fixture/onboard-failure.log"
+  : >"$marker"
+  make_install_curl_stub_bin "$fixture" "success" "__FAIL__"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      ONBOARD_EXIT_CODE="130" \
+      ONBOARD_MARKER="$marker" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      BRAVE_API_KEY="" \
+      TAVILY_API_KEY="" \
+      PERPLEXITY_API_KEY="" \
+      EXA_API_KEY="" \
+      FIRECRAWL_API_KEY="" \
+      JINA_API_KEY="" \
+      JINA_AUTH_TOKEN="" \
+      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$marker" "onboard"
+  assert_contains "$output_file" "Onboarding exited with code 130"
+  assert_contains "$output_file" "You can run 'loong onboard' later to complete setup"
+  assert_contains "$output_file" "Done. Try:"
+}
+
 run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
@@ -898,6 +1059,11 @@ run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
 }
 
 run_release_override_install_and_onboard_test
+run_release_install_adds_path_to_bashrc_and_prints_source_hint_test
+run_release_install_skips_source_hint_when_path_is_already_available_test
+run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test
+run_release_install_unsupported_shell_uses_manual_path_hint_only_test
+run_release_override_install_and_onboard_failure_preserves_install_test
 run_release_override_install_and_onboard_detects_duckduckgo_default_test
 run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test
 run_release_override_install_and_onboard_prefers_unique_ready_credential_test


### PR DESCRIPTION
## Summary

- Move PATH setup before onboard so `Ctrl+C` during onboarding does not leave `loong` undiscoverable
- Auto-append `export PATH=...` to the user's shell rc file (`.bashrc`/`.zshrc`) instead of only printing a manual hint
- Detect current shell via `$SHELL`; fall back to manual hint for unsupported shells (fish, nushell, etc.)
- PowerShell: normalize prefix path early to avoid forward-slash/backslash mismatch and duplicate PATH entries on Windows

## What changed

**`scripts/install.sh`**
- PATH block moved before `run_guided_onboarding`
- Detects user shell and writes to the appropriate rc file only
- Creates rc file if missing (fresh system)
- Guards against duplicate writes with exact-line `grep -qF` matching
- Handles rc files missing trailing newline

**`scripts/install.ps1`**
- `$Prefix` normalized at script start (tilde expansion + `GetFullPath`)
- Case-insensitive PATH comparison with `-ieq`
- `SetEnvironmentVariable` wrapped in `try/catch` with fallback hint
- Onboard wrapped in `try/catch` with `$LASTEXITCODE` check

## Test plan

- [ ] Fresh Linux install: verify `.bashrc` gets PATH entry and `loong` works after install
- [ ] Re-run installer: verify no duplicate PATH entry added
- [ ] `Ctrl+C` during onboard: verify `loong` command is still available
- [ ] Zsh user: verify `.zshrc` gets the entry instead of `.bashrc`
- [ ] Fish user: verify manual hint is printed, no file written
- [ ] Windows PowerShell: verify PATH persisted to user environment with backslashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer detects your shell, updates PATH persistently in the appropriate rc file (avoiding duplicates), and updates the current session so the tool is immediately available.

* **Bug Fixes**
  * Improved PATH normalization and persistence logic; clearer messaging when persistence fails.
  * Onboarding run is guarded; failures and non-zero exits now report exit codes and instructions to run onboarding later.

* **Tests**
  * Added tests covering PATH persistence, messaging, and onboarding failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->