### PR TITLE
Make memory systems executable instead of metadata-only selectors

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -8756,6 +8756,9 @@ mod tests {
 
     #[test]
     fn discord_status_splits_config_backed_send_and_stub_serve() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.remove(DISCORD_BOT_TOKEN_ENV);
+
         let mut config = LoongClawConfig::default();
         config.discord.enabled = true;
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -24,6 +24,7 @@ mod sqlite;
 mod stage;
 mod system;
 mod system_registry;
+mod system_runtime;
 #[cfg(test)]
 mod tests;
 mod workspace_files;
@@ -68,15 +69,19 @@ pub use system::{
     MemorySystemCapability, MemorySystemMetadata, RECALL_FIRST_MEMORY_SYSTEM_ID,
     RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
 };
+pub(crate) use system_registry::registered_memory_system_id;
+pub(crate) use system_registry::registered_memory_system_id_from_env;
 pub use system_registry::{
     MEMORY_SYSTEM_ENV, MemorySystemPolicySnapshot, MemorySystemRuntimeSnapshot,
     MemorySystemSelection, MemorySystemSelectionSource, collect_memory_system_runtime_snapshot,
     describe_memory_system, list_memory_system_ids, list_memory_system_metadata,
     memory_system_id_from_env, register_memory_system, resolve_memory_system,
-    resolve_memory_system_selection, supported_memory_system_kind_from_env,
+    resolve_memory_system_runtime, resolve_memory_system_selection,
+    supported_memory_system_kind_from_env,
 };
-pub(crate) use system_registry::{
-    registered_memory_system_id, registered_memory_system_id_from_env,
+pub use system_runtime::{
+    BuiltinMemorySystemRuntime, MemorySystemRuntime, MetadataOnlyMemorySystemRuntime,
+    SystemBackedMemorySystemRuntime,
 };
 pub(crate) use workspace_files::{
     WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
@@ -103,6 +108,15 @@ pub fn execute_memory_core_with_config(
     #[cfg(test)]
     test_support::record_core_dispatch();
 
+    let runtime = resolve_memory_system_runtime(config)?;
+
+    runtime.execute_core(request)
+}
+
+pub(crate) fn execute_builtin_backend_memory_core(
+    request: MemoryCoreRequest,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<MemoryCoreOutcome, String> {
     match config.backend {
         MemoryBackendKind::Sqlite => match request.operation.as_str() {
             MEMORY_OP_APPEND_TURN => append_turn(request, config),

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::{
-    DEFAULT_MEMORY_SYSTEM_ID, MemoryContextEntry, MemoryRetrievalRequest, MemoryStageFamily,
-    MemorySystem, MemorySystemMetadata, StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn,
-    describe_memory_system, load_prompt_context, resolve_memory_system,
-    runtime_config::MemoryRuntimeConfig,
+    MemoryContextEntry, MemoryRetrievalRequest, MemoryStageFamily, MemorySystem,
+    MemorySystemMetadata, StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn,
+    load_prompt_context, resolve_memory_system_runtime, runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -358,7 +357,7 @@ fn handle_rank_error(
     ))
 }
 
-fn skipped_stage_diagnostics(
+pub(crate) fn skipped_stage_diagnostics(
     family: MemoryStageFamily,
     message: Option<String>,
 ) -> StageDiagnostics {
@@ -372,16 +371,28 @@ fn skipped_stage_diagnostics(
     }
 }
 
+pub(crate) fn skip_compact_stage_without_execution_adapter(
+    family: MemoryStageFamily,
+) -> StageDiagnostics {
+    let message = Some(
+        "memory system is registered but has no compact-stage execution adapter yet".to_owned(),
+    );
+
+    skipped_stage_diagnostics(family, message)
+}
+
 pub async fn run_compact_stage(
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<StageDiagnostics, String> {
-    run_builtin_compact_stage(session_id, workspace_root, config).await
+    let runtime = resolve_memory_system_runtime(config)?;
+
+    runtime.run_compact_stage(session_id, workspace_root).await
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
-async fn run_builtin_compact_stage(
+pub(crate) async fn run_builtin_compact_stage(
     _session_id: &str,
     _workspace_root: Option<&Path>,
     _config: &MemoryRuntimeConfig,
@@ -397,7 +408,7 @@ async fn run_builtin_compact_stage(
 }
 
 #[cfg(feature = "memory-sqlite")]
-async fn run_builtin_compact_stage(
+pub(crate) async fn run_builtin_compact_stage(
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
@@ -536,18 +547,43 @@ pub(crate) fn hydrate_stage_envelope_with_workspace_root(
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<StageEnvelope, String> {
-    let selected_system_id = super::registered_memory_system_id(Some(config.selected_system_id()))
-        .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
-    let system = resolve_memory_system(Some(selected_system_id.as_str()))?;
-    let metadata = describe_memory_system(Some(selected_system_id.as_str()))?;
+    let runtime = resolve_memory_system_runtime(config)?;
 
-    BuiltinMemoryOrchestrator.hydrate_stage_envelope(
-        session_id,
-        workspace_root,
+    runtime.hydrate_stage_envelope(session_id, workspace_root)
+}
+
+pub(crate) fn hydrate_stage_envelope_without_execution_adapter(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+    metadata: &MemorySystemMetadata,
+) -> Result<StageEnvelope, String> {
+    let recent_window = recent_window_records(session_id, config)?;
+    let entries = load_prompt_context(session_id, config)?;
+    let diagnostics = metadata
+        .supported_pre_assembly_stage_families
+        .iter()
+        .copied()
+        .map(|family| {
+            let message = Some(missing_execution_adapter_message(family));
+
+            skipped_stage_diagnostics(family, message)
+        })
+        .collect::<Vec<_>>();
+
+    let hydrated = HydratedMemoryContext::from_stage_parts(
+        entries,
+        recent_window,
+        &diagnostics,
+        metadata.id,
         config,
-        system.as_ref(),
-        &metadata,
-    )
+    );
+    let envelope = StageEnvelope {
+        hydrated,
+        retrieval_request: None,
+        diagnostics,
+    };
+
+    Ok(envelope)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -580,9 +616,9 @@ mod tests {
     use super::*;
     use crate::config::{MemoryMode, MemoryProfile};
     use crate::memory::{
-        DerivedMemoryKind, MemoryContextKind, MemoryRecallMode, MemoryScope, MemoryStageFamily,
-        MemorySystem, MemorySystemCapability, MemorySystemMetadata, StageOutcome,
-        WORKSPACE_RECALL_MEMORY_SYSTEM_ID, append_turn_direct, builtin_pre_assembly_stage_families,
+        DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, MemoryContextKind, MemoryRecallMode,
+        MemoryScope, MemoryStageFamily, MemorySystem, MemorySystemCapability, MemorySystemMetadata,
+        StageOutcome, WORKSPACE_RECALL_MEMORY_SYSTEM_ID, append_turn_direct,
         register_memory_system,
     };
 
@@ -1255,10 +1291,11 @@ mod tests {
                 .iter()
                 .map(|diag| (diag.family, diag.outcome))
                 .collect::<Vec<_>>(),
-            builtin_pre_assembly_stage_families()
-                .into_iter()
-                .map(|family| (family, StageOutcome::Skipped))
-                .collect::<Vec<_>>()
+            vec![
+                (MemoryStageFamily::Derive, StageOutcome::Skipped),
+                (MemoryStageFamily::Retrieve, StageOutcome::Skipped),
+                (MemoryStageFamily::Rank, StageOutcome::Skipped),
+            ]
         );
         assert_eq!(
             envelope.diagnostics[1].message.as_deref(),
@@ -1647,7 +1684,7 @@ mod tests {
         .expect("run compact stage");
 
         assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
-        assert_eq!(diagnostics.outcome, StageOutcome::Succeeded);
+        assert_eq!(diagnostics.outcome, StageOutcome::Skipped);
         assert!(!diagnostics.fallback_activated);
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -2,6 +2,9 @@ use std::path::Path;
 
 use std::collections::BTreeSet;
 
+use crate::CliResult;
+
+use super::system_runtime::{BuiltinMemorySystemRuntime, MemorySystemRuntime};
 use super::{
     CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryContextEntry,
     MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
@@ -101,6 +104,15 @@ pub trait MemorySystem: Send + Sync {
 
     fn metadata(&self) -> MemorySystemMetadata;
 
+    fn create_runtime(
+        &self,
+        config: &MemoryRuntimeConfig,
+    ) -> CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+        let _ = config;
+
+        Ok(None)
+    }
+
     fn build_retrieval_request(
         &self,
         _session_id: &str,
@@ -149,6 +161,13 @@ where
 
     fn metadata(&self) -> MemorySystemMetadata {
         self.as_ref().metadata()
+    }
+
+    fn create_runtime(
+        &self,
+        config: &MemoryRuntimeConfig,
+    ) -> CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+        self.as_ref().create_runtime(config)
     }
 
     fn build_retrieval_request(
@@ -355,6 +374,19 @@ impl MemorySystem for BuiltinMemorySystem {
             MemoryRecallMode::PromptAssembly,
             MemoryRecallMode::OperatorInspection,
         ])
+    }
+
+    fn create_runtime(
+        &self,
+        config: &MemoryRuntimeConfig,
+    ) -> CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+        let runtime_config = config.clone();
+        let metadata = self.metadata();
+        let system: std::sync::Arc<dyn MemorySystem> = std::sync::Arc::new(BuiltinMemorySystem);
+        let runtime = BuiltinMemorySystemRuntime::new(runtime_config, metadata, system);
+        let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+        Ok(Some(boxed_runtime))
     }
 
     fn build_retrieval_request(

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -203,6 +203,18 @@ pub fn resolve_memory_system_runtime(
     let system = resolve_memory_system(Some(resolved_system_id.as_str()))?;
     let custom_runtime = system.create_runtime(config)?;
     if let Some(runtime) = custom_runtime {
+        let runtime_metadata = runtime.metadata();
+        let runtime_id = super::normalize_system_id(runtime_metadata.id)
+            .ok_or_else(|| "memory system runtime id must not be empty".to_owned())?;
+        if runtime_id != resolved_system_id {
+            let error = format!(
+                "memory system runtime id `{}` must match selected system `{resolved_system_id}`",
+                runtime_metadata.id
+            );
+
+            return Err(error);
+        }
+
         return Ok(runtime);
     }
 
@@ -303,6 +315,7 @@ pub fn collect_memory_system_runtime_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::{BuiltinMemorySystemRuntime, MemorySystemRuntime};
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemoryRecallMode, MemorySystemCapability};
     use crate::test_support::ScopedEnv;
 
@@ -420,6 +433,35 @@ mod tests {
         }
     }
 
+    struct RuntimeIdMismatchRegistrySystem;
+
+    impl MemorySystem for RuntimeIdMismatchRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-runtime-mismatch"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-runtime-mismatch",
+                [MemorySystemCapability::PromptHydration],
+                "Registry system with mismatched runtime id",
+            )
+        }
+
+        fn create_runtime(
+            &self,
+            config: &MemoryRuntimeConfig,
+        ) -> CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+            let runtime_config = config.clone();
+            let metadata = BuiltinMemorySystem.metadata();
+            let system: std::sync::Arc<dyn MemorySystem> = std::sync::Arc::new(BuiltinMemorySystem);
+            let runtime = BuiltinMemorySystemRuntime::new(runtime_config, metadata, system);
+            let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+            Ok(Some(boxed_runtime))
+        }
+    }
+
     #[test]
     fn resolve_memory_system_includes_builtin() {
         let ids = list_memory_system_ids().expect("list ids");
@@ -486,6 +528,34 @@ mod tests {
         .expect_err("duplicate custom ids should fail");
 
         assert!(error.contains("already registered"), "error: {error}");
+    }
+
+    #[test]
+    fn resolve_memory_system_runtime_rejects_mismatched_custom_runtime_id() {
+        register_memory_system("registry-runtime-mismatch", || {
+            Box::new(RuntimeIdMismatchRegistrySystem)
+        })
+        .expect("register runtime mismatch system");
+
+        let config = MemoryRuntimeConfig {
+            resolved_system_id: Some("registry-runtime-mismatch".to_owned()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let error = match resolve_memory_system_runtime(&config) {
+            Ok(_runtime) => panic!("mismatched runtime id should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.contains("must match selected system"),
+            "error: {error}"
+        );
+        assert!(error.contains("builtin"), "error: {error}");
+        assert!(
+            error.contains("registry-runtime-mismatch"),
+            "error: {error}"
+        );
     }
 
     #[test]

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -15,6 +15,9 @@ use super::system::{
     RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
     WorkspaceRecallMemorySystem,
 };
+use super::system_runtime::{
+    MemorySystemRuntime, MetadataOnlyMemorySystemRuntime, SystemBackedMemorySystemRuntime,
+};
 
 pub const MEMORY_SYSTEM_ENV: &str = "LOONGCLAW_MEMORY_SYSTEM";
 
@@ -189,6 +192,37 @@ pub fn resolve_memory_system(id: Option<&str>) -> CliResult<Box<dyn MemorySystem
 
 pub fn describe_memory_system(id: Option<&str>) -> CliResult<MemorySystemMetadata> {
     resolve_memory_system(id).map(|system| system.metadata())
+}
+
+pub fn resolve_memory_system_runtime(
+    config: &MemoryRuntimeConfig,
+) -> CliResult<Box<dyn MemorySystemRuntime>> {
+    let requested_system_id = config.selected_system_id();
+    let resolved_system_id = registered_memory_system_id(Some(requested_system_id))
+        .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
+    let system = resolve_memory_system(Some(resolved_system_id.as_str()))?;
+    let custom_runtime = system.create_runtime(config)?;
+    if let Some(runtime) = custom_runtime {
+        return Ok(runtime);
+    }
+
+    let metadata = system.metadata();
+    let metadata_supports_stages = !metadata.supported_pre_assembly_stage_families.is_empty();
+    let shared_system: Arc<dyn MemorySystem> = Arc::from(system);
+
+    if metadata_supports_stages {
+        let runtime_config = config.clone();
+        let runtime = SystemBackedMemorySystemRuntime::new(runtime_config, metadata, shared_system);
+        let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+        return Ok(boxed_runtime);
+    }
+
+    let runtime_config = config.clone();
+    let runtime = MetadataOnlyMemorySystemRuntime::new(runtime_config, metadata);
+    let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+    Ok(boxed_runtime)
 }
 
 pub fn memory_system_id_from_env() -> Option<String> {

--- a/crates/app/src/memory/system_runtime.rs
+++ b/crates/app/src/memory/system_runtime.rs
@@ -1,0 +1,208 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
+
+use super::orchestrator::{
+    BuiltinMemoryOrchestrator, hydrate_stage_envelope_without_execution_adapter,
+    skip_compact_stage_without_execution_adapter,
+};
+use super::runtime_config::MemoryRuntimeConfig;
+use super::{
+    MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics, StageEnvelope,
+};
+
+#[async_trait]
+pub trait MemorySystemRuntime: Send + Sync {
+    fn metadata(&self) -> &MemorySystemMetadata;
+
+    fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String>;
+
+    fn hydrate_stage_envelope(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+    ) -> Result<StageEnvelope, String>;
+
+    async fn run_compact_stage(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+    ) -> Result<StageDiagnostics, String>;
+}
+
+pub struct SystemBackedMemorySystemRuntime {
+    config: MemoryRuntimeConfig,
+    metadata: MemorySystemMetadata,
+    system: Arc<dyn MemorySystem>,
+}
+
+impl SystemBackedMemorySystemRuntime {
+    pub fn new(
+        config: MemoryRuntimeConfig,
+        metadata: MemorySystemMetadata,
+        system: Arc<dyn MemorySystem>,
+    ) -> Self {
+        Self {
+            config,
+            metadata,
+            system,
+        }
+    }
+}
+
+#[async_trait]
+impl MemorySystemRuntime for SystemBackedMemorySystemRuntime {
+    fn metadata(&self) -> &MemorySystemMetadata {
+        &self.metadata
+    }
+
+    fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
+        super::execute_builtin_backend_memory_core(request, &self.config)
+    }
+
+    fn hydrate_stage_envelope(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+    ) -> Result<StageEnvelope, String> {
+        let orchestrator = BuiltinMemoryOrchestrator;
+        let system = self.system.as_ref();
+        let metadata = &self.metadata;
+        let config = &self.config;
+        let envelope = orchestrator.hydrate_stage_envelope(
+            session_id,
+            workspace_root,
+            config,
+            system,
+            metadata,
+        )?;
+
+        Ok(envelope)
+    }
+
+    async fn run_compact_stage(
+        &self,
+        _session_id: &str,
+        _workspace_root: Option<&Path>,
+    ) -> Result<StageDiagnostics, String> {
+        let family = MemoryStageFamily::Compact;
+        let diagnostics = skip_compact_stage_without_execution_adapter(family);
+
+        Ok(diagnostics)
+    }
+}
+
+pub struct BuiltinMemorySystemRuntime {
+    config: MemoryRuntimeConfig,
+    metadata: MemorySystemMetadata,
+    system: Arc<dyn MemorySystem>,
+}
+
+impl BuiltinMemorySystemRuntime {
+    pub fn new(
+        config: MemoryRuntimeConfig,
+        metadata: MemorySystemMetadata,
+        system: Arc<dyn MemorySystem>,
+    ) -> Self {
+        Self {
+            config,
+            metadata,
+            system,
+        }
+    }
+}
+
+#[async_trait]
+impl MemorySystemRuntime for BuiltinMemorySystemRuntime {
+    fn metadata(&self) -> &MemorySystemMetadata {
+        &self.metadata
+    }
+
+    fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
+        super::execute_builtin_backend_memory_core(request, &self.config)
+    }
+
+    fn hydrate_stage_envelope(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+    ) -> Result<StageEnvelope, String> {
+        let orchestrator = BuiltinMemoryOrchestrator;
+        let system = self.system.as_ref();
+        let metadata = &self.metadata;
+        let config = &self.config;
+        let envelope = orchestrator.hydrate_stage_envelope(
+            session_id,
+            workspace_root,
+            config,
+            system,
+            metadata,
+        )?;
+
+        Ok(envelope)
+    }
+
+    async fn run_compact_stage(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+    ) -> Result<StageDiagnostics, String> {
+        let diagnostics = super::orchestrator::run_builtin_compact_stage(
+            session_id,
+            workspace_root,
+            &self.config,
+        )
+        .await?;
+
+        Ok(diagnostics)
+    }
+}
+
+pub struct MetadataOnlyMemorySystemRuntime {
+    config: MemoryRuntimeConfig,
+    metadata: MemorySystemMetadata,
+}
+
+impl MetadataOnlyMemorySystemRuntime {
+    pub fn new(config: MemoryRuntimeConfig, metadata: MemorySystemMetadata) -> Self {
+        Self { config, metadata }
+    }
+}
+
+#[async_trait]
+impl MemorySystemRuntime for MetadataOnlyMemorySystemRuntime {
+    fn metadata(&self) -> &MemorySystemMetadata {
+        &self.metadata
+    }
+
+    fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
+        super::execute_builtin_backend_memory_core(request, &self.config)
+    }
+
+    fn hydrate_stage_envelope(
+        &self,
+        session_id: &str,
+        _workspace_root: Option<&Path>,
+    ) -> Result<StageEnvelope, String> {
+        let envelope = hydrate_stage_envelope_without_execution_adapter(
+            session_id,
+            &self.config,
+            &self.metadata,
+        )?;
+
+        Ok(envelope)
+    }
+
+    async fn run_compact_stage(
+        &self,
+        _session_id: &str,
+        _workspace_root: Option<&Path>,
+    ) -> Result<StageDiagnostics, String> {
+        let family = MemoryStageFamily::Compact;
+        let diagnostics = skip_compact_stage_without_execution_adapter(family);
+
+        Ok(diagnostics)
+    }
+}

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -732,14 +732,21 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
         }
     }
 
+    fn ensure_registry_runtime_executing_system_registered() {
+        static REGISTRY_RUNTIME_EXECUTING_SYSTEM: OnceLock<()> = OnceLock::new();
+        REGISTRY_RUNTIME_EXECUTING_SYSTEM.get_or_init(|| {
+            register_memory_system("registry-runtime-executing", || {
+                Box::new(RuntimeExecutingMemorySystem)
+            })
+            .expect("register runtime-executing memory system");
+        });
+    }
+
     let _guard = core_dispatch_test_lock()
         .lock()
-        .expect("core dispatch test lock");
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-    register_memory_system("registry-runtime-executing", || {
-        Box::new(RuntimeExecutingMemorySystem)
-    })
-    .expect("register runtime-executing memory system");
+    ensure_registry_runtime_executing_system_registered();
 
     let config = runtime_config::MemoryRuntimeConfig {
         resolved_system_id: Some("registry-runtime-executing".to_owned()),

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -371,7 +371,7 @@ fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
     let _durable_flush_guard = durable_flush_lock.blocking_lock();
     let _guard = core_dispatch_test_lock()
         .lock()
-        .expect("core dispatch test lock");
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -633,4 +633,133 @@ fn replace_session_turns_direct_requires_explicit_timestamps() {
 
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_dir(&tmp);
+}
+
+#[test]
+fn registry_selected_system_can_override_memory_runtime_execution() {
+    use async_trait::async_trait;
+
+    struct RuntimeExecutingMemorySystem;
+
+    struct RuntimeExecutingMemorySystemRuntime {
+        metadata: MemorySystemMetadata,
+    }
+
+    impl MemorySystem for RuntimeExecutingMemorySystem {
+        fn id(&self) -> &'static str {
+            "registry-runtime-executing"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-runtime-executing",
+                [MemorySystemCapability::PromptHydration],
+                "Registry runtime-executing test system",
+            )
+            .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve])
+        }
+
+        fn create_runtime(
+            &self,
+            _config: &runtime_config::MemoryRuntimeConfig,
+        ) -> crate::CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+            let metadata = self.metadata();
+            let runtime = RuntimeExecutingMemorySystemRuntime { metadata };
+            let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+            Ok(Some(boxed_runtime))
+        }
+    }
+
+    #[async_trait]
+    impl MemorySystemRuntime for RuntimeExecutingMemorySystemRuntime {
+        fn metadata(&self) -> &MemorySystemMetadata {
+            &self.metadata
+        }
+
+        fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
+            let operation = request.operation;
+            let payload = json!({
+                "adapter": "registry-runtime-executing",
+                "operation": operation,
+            });
+            let outcome = MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload,
+            };
+
+            Ok(outcome)
+        }
+
+        fn hydrate_stage_envelope(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+        ) -> Result<StageEnvelope, String> {
+            let diagnostics = MemoryDiagnostics {
+                system_id: self.metadata.id.to_owned(),
+                fail_open: true,
+                strict_mode_requested: false,
+                strict_mode_active: false,
+                degraded: false,
+                derivation_error: None,
+                retrieval_error: None,
+                rank_error: None,
+                recent_window_count: 0,
+                entry_count: 0,
+            };
+            let hydrated = HydratedMemoryContext {
+                entries: Vec::new(),
+                recent_window: Vec::new(),
+                diagnostics,
+            };
+            let envelope = StageEnvelope {
+                hydrated,
+                retrieval_request: None,
+                diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Retrieve)],
+            };
+
+            Ok(envelope)
+        }
+
+        async fn run_compact_stage(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+        ) -> Result<StageDiagnostics, String> {
+            let diagnostics = StageDiagnostics::succeeded(MemoryStageFamily::Compact);
+            Ok(diagnostics)
+        }
+    }
+
+    let _guard = core_dispatch_test_lock()
+        .lock()
+        .expect("core dispatch test lock");
+
+    register_memory_system("registry-runtime-executing", || {
+        Box::new(RuntimeExecutingMemorySystem)
+    })
+    .expect("register runtime-executing memory system");
+
+    let config = runtime_config::MemoryRuntimeConfig {
+        resolved_system_id: Some("registry-runtime-executing".to_owned()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    let request = MemoryCoreRequest {
+        operation: "noop".to_owned(),
+        payload: json!({}),
+    };
+    let outcome = execute_memory_core_with_config(request, &config)
+        .expect("registry runtime should handle memory core execution");
+
+    assert_eq!(outcome.payload["adapter"], "registry-runtime-executing");
+
+    let envelope = hydrate_stage_envelope("runtime-executing-session", &config)
+        .expect("registry runtime should handle stage envelope hydration");
+
+    assert_eq!(
+        envelope.hydrated.diagnostics.system_id,
+        "registry-runtime-executing"
+    );
 }

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -439,7 +439,7 @@ fn pre_compaction_durable_flush_skips_when_no_summary_checkpoint_exists() {
     let _durable_flush_guard = durable_flush_lock.blocking_lock();
     let _guard = core_dispatch_test_lock()
         .lock()
-        .expect("core dispatch test lock");
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,12 +1,12 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-08T09:47:32Z
+- Generated at: 2026-04-08T10:34:10Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
 - Boundary checks tracked: 5
-- SLO status: PASS
+- SLO status: FAIL
 
 ## Hotspot Metrics
 
@@ -15,10 +15,10 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 381 | 650 | 269 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 7.0% | PASS | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 395 | 650 | 255 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 11.0% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9446 | 10500 | 1054 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1786 | 6400 | 4614 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.4% | PASS | 0 |
@@ -44,9 +44,9 @@
 | spec_app_dependency | PASS | PASS | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
-- Hotspot growth SLO (>10% month-over-month): PASS
+- Hotspot growth SLO (>10% month-over-month): FAIL
 - Boundary ownership SLO (helpers stay behind their module boundaries): PASS
-- Overall architecture SLO status: PASS
+- Overall architecture SLO status: FAIL
 
 ## Refactor Budget Policy
 - Monthly drift report command: `scripts/generate_architecture_drift_report.sh`
@@ -61,10 +61,10 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=381 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=395 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
-<!-- arch-hotspot key=channel_registry lines=9446 functions=72 -->
+<!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1786 functions=0 -->


### PR DESCRIPTION
## Summary

- Problem: `memory.system` selection was largely metadata-only; core memory execution still hardcoded builtin SQLite behavior and non-builtin systems could not provide executable runtimes.
- Why it matters: future pluggable memory backends and memory-system evolution would require more hardcoded branching instead of using the registry as a real extension seam.
- What changed: added `MemorySystemRuntime`, routed memory core dispatch plus staged hydration/compaction through resolved runtimes, defaulted registry-selected systems onto system-backed runtimes so existing stage hooks still execute without extra boilerplate, let systems opt into custom runtime overrides when needed, and stabilized a Discord env-sensitive test.
- What did not change (scope boundary): no new external memory backend, no typed contract rewrite, no user-facing config expansion beyond making the existing runtime seam real.

## Linked Issues

- Closes #1102
- Related #421

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app memory::tests -- --nocapture
cargo test -p loongclaw-app orchestrator::tests -- --nocapture
cargo test -p loongclaw-app default_runtime_build_context_with_registry_selected_system_keeps_runtime_owned_summary_projection -- --nocapture
cargo test -p loongclaw-app registry_selected_system_skips_builtin_pre_assembly_execution -- --nocapture
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
```

Results: all commands above completed successfully on the isolated worktree branch.

## User-visible / Operator-visible Changes

- Memory system selection now resolves an executable runtime instead of only selecting metadata.
- Registry-selected systems keep runtime-owned prompt projection and now use system-backed runtimes by default, so stage-hook implementations remain effective without extra wiring.
- Systems that truly need custom runtime behavior can override `create_runtime(...)` explicitly.

## Failure Recovery

- Fast rollback or disable path: revert commit `e70174205`.
- Observable failure symptoms reviewers should watch for: missing summary/profile projection under registry-selected systems, compact stage unexpectedly succeeding for non-builtin systems, or stage-hook systems silently losing execution after runtime resolution.

## Reviewer Focus

- `crates/app/src/memory/system_runtime.rs`: new runtime seam, system-backed fallback, and builtin runtime behavior.
- `crates/app/src/memory/system.rs`: `create_runtime(...)` hook plus stage-hook systems remaining first-class.
- `crates/app/src/memory/system_registry.rs`: runtime resolution and fallback construction rules.
- `crates/app/src/memory/orchestrator.rs`: runtime resolution replacing direct system branching while preserving fallback semantics.
- `crates/app/src/memory/tests.rs`: registry-selected runtime override coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tests now avoid leaking a Discord bot token and tolerate a poisoned mutex to stabilize runs.

* **Chores**
  * Introduced a runtime abstraction for memory systems to centralize execution, hydration, and compact-stage handling.

* **New Features**
  * Registry can provide custom memory runtimes; runtime selection falls back to metadata-backed behavior and skips stages when execution adapters are missing.

* **Tests**
  * Added tests validating registry-provided runtimes control execution and hydration outcomes.

* **Documentation**
  * Architecture drift report updated (SLO/status and hotspot metrics).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->