### PR TITLE
chore: finish the code-facing Loong rebrand outside the docs lane

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,100 +2,103 @@
 /.github/CODEOWNERS @chumyin @gh-xj @primaryphd
 
 # Documentation and contributor-facing Markdown
-/*.md @loongclaw-ai/doc-ops
-/**/*.md @loongclaw-ai/doc-ops
-/docs/** @loongclaw-ai/doc-ops
-/site/** @loongclaw-ai/doc-ops
-/.github/ISSUE_TEMPLATE/** @loongclaw-ai/doc-ops
-/.github/PULL_REQUEST_TEMPLATE.md @loongclaw-ai/doc-ops
+/*.md @eastreams/doc-ops
+/**/*.md @eastreams/doc-ops
+/docs/** @eastreams/doc-ops
+/site/** @eastreams/doc-ops
+/.github/ISSUE_TEMPLATE/** @eastreams/doc-ops
+/.github/PULL_REQUEST_TEMPLATE.md @eastreams/doc-ops
+/docs/product-specs/** @eastreams/doc-ops @eastreams/ux
 
 # Harness engineering: automation, CI/CD, audit, and verification
-/.convention-engineering.json @loongclaw-ai/harness
-/.github/dependabot.yml @loongclaw-ai/harness
-/.github/labeler.yml @loongclaw-ai/harness
-/.github/label_taxonomy.json @loongclaw-ai/harness
-/.github/workflows/** @loongclaw-ai/harness
-/Taskfile.yml @loongclaw-ai/harness
-/crates/contracts/src/audit_types.rs @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/crates/daemon/src/audit_cli.rs @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/crates/kernel/src/audit.rs @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/crates/kernel/src/harness.rs @loongclaw-ai/harness
-/scripts/architecture_budget_lib.sh @loongclaw-ai/harness
-/scripts/check*.sh @loongclaw-ai/harness
-/scripts/generate_architecture_drift_report.sh @loongclaw-ai/harness
-/scripts/pre-commit @loongclaw-ai/harness
-/scripts/stress_daemon_tests.sh @loongclaw-ai/harness
-/scripts/sync_github_labels.py @loongclaw-ai/harness
-/scripts/test_*.sh @loongclaw-ai/harness
-/scripts/test_workflow_change_router.mjs @loongclaw-ai/harness
-/scripts/test_workflow_change_router.sh @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/scripts/workflow_change_router.mjs @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/skills/update-harness.skill @loongclaw-ai/harness
-/docs/design-docs/harness-engineering.md @loongclaw-ai/doc-ops @loongclaw-ai/harness
+/.convention-engineering.json @eastreams/harness
+/.github/dependabot.yml @eastreams/harness
+/.github/labeler.yml @eastreams/harness
+/.github/label_taxonomy.json @eastreams/harness
+/.github/workflows/** @eastreams/harness
+/Taskfile.yml @eastreams/harness
+/crates/contracts/src/audit_types.rs @eastreams/harness @eastreams/sec-ops
+/crates/daemon/src/audit_cli.rs @eastreams/harness @eastreams/sec-ops
+/crates/kernel/src/audit.rs @eastreams/harness @eastreams/sec-ops
+/crates/kernel/src/harness.rs @eastreams/harness
+/scripts/architecture_budget_lib.sh @eastreams/harness
+/scripts/check*.sh @eastreams/harness
+/scripts/generate_architecture_drift_report.sh @eastreams/harness
+/scripts/pre-commit @eastreams/harness
+/scripts/stress_daemon_tests.sh @eastreams/harness
+/scripts/sync_github_labels.py @eastreams/harness
+/scripts/test_*.sh @eastreams/harness
+/scripts/test_workflow_change_router.mjs @eastreams/harness
+/scripts/test_workflow_change_router.sh @eastreams/harness @eastreams/sec-ops
+/scripts/workflow_change_router.mjs @eastreams/harness @eastreams/sec-ops
+/skills/update-harness.skill @eastreams/harness
+/docs/design-docs/harness-engineering.md @eastreams/doc-ops @eastreams/harness
 
 # Efficiency engineering: memory, budget, and benchmark surfaces
-/.github/workflows/perf-benchmark.yml @loongclaw-ai/harness @loongclaw-ai/efficiency-engineering
-/.github/workflows/perf-lint.yml @loongclaw-ai/harness @loongclaw-ai/efficiency-engineering
-/crates/bench/** @loongclaw-ai/efficiency-engineering
-/crates/app/src/config/memory.rs @loongclaw-ai/efficiency-engineering
-/crates/app/src/conversation/compaction.rs @loongclaw-ai/efficiency-engineering
-/crates/app/src/conversation/turn_budget.rs @loongclaw-ai/efficiency-engineering
-/crates/app/src/memory/** @loongclaw-ai/efficiency-engineering
-/crates/app/src/runtime_self_continuity.rs @loongclaw-ai/efficiency-engineering
-/crates/app/src/tools/memory_tools.rs @loongclaw-ai/efficiency-engineering
-/crates/contracts/src/memory_types.rs @loongclaw-ai/efficiency-engineering
-/crates/kernel/src/memory.rs @loongclaw-ai/efficiency-engineering
-/crates/daemon/src/memory_context_benchmark.rs @loongclaw-ai/efficiency-engineering
-/crates/daemon/tests/integration/memory_context_benchmark_cli.rs @loongclaw-ai/efficiency-engineering
-/examples/benchmarks/** @loongclaw-ai/efficiency-engineering
-/scripts/benchmark_*.sh @loongclaw-ai/efficiency-engineering
-/scripts/lint_programmatic_pressure_baseline.sh @loongclaw-ai/efficiency-engineering
-/scripts/update_programmatic_pressure_schema_baseline.sh @loongclaw-ai/efficiency-engineering
+/.github/workflows/perf-benchmark.yml @eastreams/harness @eastreams/efficiency-engineering
+/.github/workflows/perf-lint.yml @eastreams/harness @eastreams/efficiency-engineering
+/crates/bench/** @eastreams/efficiency-engineering
+/crates/app/src/config/memory.rs @eastreams/efficiency-engineering
+/crates/app/src/conversation/compaction.rs @eastreams/efficiency-engineering
+/crates/app/src/conversation/turn_budget.rs @eastreams/efficiency-engineering
+/crates/app/src/memory/** @eastreams/efficiency-engineering
+/crates/app/src/runtime_self_continuity.rs @eastreams/efficiency-engineering
+/crates/app/src/tools/memory_tools.rs @eastreams/efficiency-engineering
+/crates/contracts/src/memory_types.rs @eastreams/efficiency-engineering
+/crates/kernel/src/memory.rs @eastreams/efficiency-engineering
+/crates/daemon/src/memory_context_benchmark.rs @eastreams/efficiency-engineering
+/crates/daemon/tests/integration/memory_context_benchmark_cli.rs @eastreams/efficiency-engineering
+/examples/benchmarks/** @eastreams/efficiency-engineering
+/scripts/benchmark_*.sh @eastreams/efficiency-engineering
+/scripts/lint_programmatic_pressure_baseline.sh @eastreams/efficiency-engineering
+/scripts/update_programmatic_pressure_schema_baseline.sh @eastreams/efficiency-engineering
+/docs/product-specs/memory-profiles.md @eastreams/doc-ops @eastreams/ux @eastreams/efficiency-engineering
 
 # Release management: release pipeline, artifacts, and install surfaces
-/.github/workflows/enforce-main-to-release.yml @loongclaw-ai/harness @loongclaw-ai/release-managers
-/.github/workflows/release.yml @loongclaw-ai/harness @loongclaw-ai/release-managers
-/CHANGELOG.md @loongclaw-ai/doc-ops @loongclaw-ai/release-managers
-/scripts/bootstrap_release_local_artifacts.sh @loongclaw-ai/harness @loongclaw-ai/release-managers
-/scripts/install.ps1 @loongclaw-ai/release-managers @loongclaw-ai/ux
-/scripts/install.sh @loongclaw-ai/release-managers @loongclaw-ai/ux
-/scripts/release_artifact_lib.sh @loongclaw-ai/harness @loongclaw-ai/release-managers
-/scripts/test_bootstrap_release_local_artifacts.sh @loongclaw-ai/harness @loongclaw-ai/release-managers
-/scripts/test_ci_workflow_change_routing.sh @loongclaw-ai/harness
-/scripts/test_install_sh.sh @loongclaw-ai/release-managers @loongclaw-ai/ux
-/scripts/test_release_artifact_lib.sh @loongclaw-ai/harness @loongclaw-ai/release-managers
-/scripts/test_release_workflow_hardening.sh @loongclaw-ai/harness @loongclaw-ai/release-managers
-/scripts/test_scan_workflow_hardening.sh @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/docs/releases/** @loongclaw-ai/doc-ops @loongclaw-ai/release-managers
+/.github/workflows/enforce-main-to-release.yml @eastreams/harness @eastreams/release-managers
+/.github/workflows/release.yml @eastreams/harness @eastreams/release-managers
+/CHANGELOG.md @eastreams/doc-ops @eastreams/release-managers
+/scripts/bootstrap_release_local_artifacts.sh @eastreams/harness @eastreams/release-managers
+/scripts/install.ps1 @eastreams/release-managers @eastreams/ux
+/scripts/install.sh @eastreams/release-managers @eastreams/ux
+/scripts/release_artifact_lib.sh @eastreams/harness @eastreams/release-managers
+/scripts/test_bootstrap_release_local_artifacts.sh @eastreams/harness @eastreams/release-managers
+/scripts/test_ci_workflow_change_routing.sh @eastreams/harness
+/scripts/test_install_sh.sh @eastreams/release-managers @eastreams/ux
+/scripts/test_release_artifact_lib.sh @eastreams/harness @eastreams/release-managers
+/scripts/test_release_workflow_hardening.sh @eastreams/harness @eastreams/release-managers
+/scripts/test_scan_workflow_hardening.sh @eastreams/harness @eastreams/sec-ops
+/docs/releases/** @eastreams/doc-ops @eastreams/release-managers
+/docs/product-specs/installation.md @eastreams/doc-ops @eastreams/ux @eastreams/release-managers
 
 # Security operations: policy, credentials, and security scans
-/.github/workflows/codeql.yml @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/.github/workflows/security.yml @loongclaw-ai/harness @loongclaw-ai/sec-ops
-/SECURITY.md @loongclaw-ai/doc-ops @loongclaw-ai/sec-ops
-/crates/contracts/src/execution_security_types.rs @loongclaw-ai/sec-ops
-/crates/contracts/src/policy_types.rs @loongclaw-ai/sec-ops
-/crates/contracts/src/secret_*.rs @loongclaw-ai/sec-ops
-/crates/daemon/src/provider_credential_policy.rs @loongclaw-ai/sec-ops
-/crates/kernel/src/policy.rs @loongclaw-ai/sec-ops
-/crates/kernel/src/policy_ext.rs @loongclaw-ai/sec-ops
-/crates/spec/config/security-scan-medium-balanced.json @loongclaw-ai/sec-ops
-/crates/spec/src/spec_execution/security_scan_*.rs @loongclaw-ai/sec-ops
-/examples/policy/** @loongclaw-ai/sec-ops
-/examples/spec/plugin-wasm-security-scan.json @loongclaw-ai/sec-ops
-/docs/SECURITY.md @loongclaw-ai/doc-ops @loongclaw-ai/sec-ops
+/.github/workflows/codeql.yml @eastreams/harness @eastreams/sec-ops
+/.github/workflows/security.yml @eastreams/harness @eastreams/sec-ops
+/SECURITY.md @eastreams/doc-ops @eastreams/sec-ops
+/crates/contracts/src/execution_security_types.rs @eastreams/sec-ops
+/crates/contracts/src/policy_types.rs @eastreams/sec-ops
+/crates/contracts/src/secret_*.rs @eastreams/sec-ops
+/crates/daemon/src/provider_credential_policy.rs @eastreams/sec-ops
+/crates/kernel/src/policy.rs @eastreams/sec-ops
+/crates/kernel/src/policy_ext.rs @eastreams/sec-ops
+/crates/spec/config/security-scan-medium-balanced.json @eastreams/sec-ops
+/crates/spec/src/spec_execution/security_scan_*.rs @eastreams/sec-ops
+/examples/policy/** @eastreams/sec-ops
+/examples/spec/plugin-wasm-security-scan.json @eastreams/sec-ops
+/docs/SECURITY.md @eastreams/doc-ops @eastreams/sec-ops
 
 # UI and UX: presentation, first-run, and user-facing product surfaces
-/assets/** @loongclaw-ai/ui
-/crates/app/src/tui_surface.rs @loongclaw-ai/ui @loongclaw-ai/ux
-/crates/daemon/src/browser_companion_diagnostics.rs @loongclaw-ai/ux
-/crates/daemon/src/browser_preview.rs @loongclaw-ai/ui @loongclaw-ai/ux
-/crates/daemon/src/cli_handoff.rs @loongclaw-ai/ux
-/crates/daemon/src/completions_cli.rs @loongclaw-ai/ux
-/crates/daemon/src/doctor_cli.rs @loongclaw-ai/ux
-/crates/daemon/src/next_actions.rs @loongclaw-ai/ux
-/crates/daemon/src/onboard*.rs @loongclaw-ai/ux
-/crates/daemon/src/onboarding_*.rs @loongclaw-ai/ux
-/crates/daemon/src/provider_presentation.rs @loongclaw-ai/ux
-/crates/daemon/src/source_presentation.rs @loongclaw-ai/ux
-/crates/daemon/tests/integration/doctor_feishu.rs @loongclaw-ai/ux
-/crates/daemon/tests/integration/onboard_cli.rs @loongclaw-ai/ux
+/assets/** @eastreams/ui
+/crates/app/src/tui_surface.rs @eastreams/ui @eastreams/ux
+/crates/daemon/src/browser_companion_diagnostics.rs @eastreams/ux
+/crates/daemon/src/browser_preview.rs @eastreams/ui @eastreams/ux
+/crates/daemon/src/cli_handoff.rs @eastreams/ux
+/crates/daemon/src/completions_cli.rs @eastreams/ux
+/crates/daemon/src/doctor_cli.rs @eastreams/ux
+/crates/daemon/src/next_actions.rs @eastreams/ux
+/crates/daemon/src/onboard*.rs @eastreams/ux
+/crates/daemon/src/onboarding_*.rs @eastreams/ux
+/crates/daemon/src/provider_presentation.rs @eastreams/ux
+/crates/daemon/src/source_presentation.rs @eastreams/ux
+/crates/daemon/tests/integration/doctor_feishu.rs @eastreams/ux
+/crates/daemon/tests/integration/onboard_cli.rs @eastreams/ux

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -134,7 +134,7 @@ body:
         enabled = true
 
         Env overrides:
-        LOONG_CONTEXT_ENGINE=legacy
+        LOONGCLAW_CONTEXT_ENGINE=legacy
 
   - type: textarea
     id: logs

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -134,7 +134,7 @@ body:
         enabled = true
 
         Env overrides:
-        LOONGCLAW_CONTEXT_ENGINE=legacy
+        LOONG_CONTEXT_ENGINE=legacy
 
   - type: textarea
     id: logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   BIN_NAME: loong
+  LEGACY_BIN_NAME: loongclaw
   ANDROID_NDK_VERSION: "27.3.13750724"
   ANDROID_NDK_REVISION: "r27d"
   ANDROID_NDK_LINUX_SHA256: "601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
@@ -79,12 +80,6 @@ jobs:
       - name: Shell syntax checks
         run: |
           python3 -c "from pathlib import Path; compile(Path('scripts/sync_github_labels.py').read_text(), 'scripts/sync_github_labels.py', 'exec')"
-          python3 -m py_compile harbor_loongclaw/commands.py
-          python3 -m py_compile harbor_loongclaw/agent.py
-          python3 -m py_compile harbor_loongclaw/__init__.py
-          python3 -m py_compile tests/__init__.py
-          python3 -m py_compile tests/harbor_adapter/__init__.py
-          python3 -m py_compile tests/harbor_adapter/test_commands.py
           bash -n scripts/check_glibc_floor.sh
           bash -n scripts/install.sh
           bash -n scripts/publish_crates_io.sh
@@ -117,7 +112,6 @@ jobs:
 
       - name: Governance regression tests
         run: |
-          python3 -m unittest discover -s tests -v
           python3 scripts/sync_github_labels.py --check
           bash scripts/test_architecture_budget_scripts.sh
           bash scripts/test_check_architecture_drift_freshness.sh
@@ -142,13 +136,13 @@ jobs:
         run: scripts/bootstrap_release_local_artifacts.sh
 
       - name: Strict docs governance
-        run: LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
+        run: LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
 
       - name: Dependency graph contract
         run: ./scripts/check_dep_graph.sh
 
       - name: Strict architecture contract
-        run: LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
+        run: LOONG_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
 
       - name: Diff hygiene
         run: git diff --check
@@ -179,22 +173,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -f /tmp/loongclaw-docs-export.zip
+          rm -f /tmp/loong-docs-export.zip
           set +e
-          timeout 300s npm exec --yes --package=mintlify@${{ env.MINTLIFY_VERSION }} -- mintlify export --output /tmp/loongclaw-docs-export.zip
+          timeout 300s npm exec --yes --package=mintlify@${{ env.MINTLIFY_VERSION }} -- mintlify export --output /tmp/loong-docs-export.zip
           export_status=$?
           set -e
           if [ "$export_status" -eq 0 ]; then
             exit 0
           fi
-          if [ "$export_status" -eq 124 ] && [ -f /tmp/loongclaw-docs-export.zip ]; then
+          if [ "$export_status" -eq 124 ] && [ -f /tmp/loong-docs-export.zip ]; then
             echo "Mintlify export produced the artifact before timing out; treating CLI hang as non-fatal."
             exit 0
           fi
           exit "$export_status"
 
       - name: Assert export artifact exists
-        run: test -f /tmp/loongclaw-docs-export.zip
+        run: test -f /tmp/loong-docs-export.zip
 
   rust-quality:
     needs: changes
@@ -264,7 +258,7 @@ jobs:
 
       - name: Check browser feature set without web.fetch
         run: >
-          cargo check -p loongclaw-app --no-default-features
+          cargo check -p loong-app --no-default-features
           --features
           channel-cli,channel-telegram,channel-feishu,channel-matrix,config-toml,memory-sqlite,feishu-integration,tool-shell,tool-file,tool-browser,provider-openai,provider-anthropic,provider-bedrock,provider-volcengine
 
@@ -334,7 +328,7 @@ jobs:
       - name: Build release binary (Android/Termux)
         shell: bash
         env:
-          LOONGCLAW_RELEASE_BUILD: "1"
+          LOONG_RELEASE_BUILD: "1"
         run: |
           set -euo pipefail
           toolchain="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
@@ -342,7 +336,7 @@ jobs:
           export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
           export AR_aarch64_linux_android="${toolchain}/llvm-ar"
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
-          cargo build --release --locked -p loongclaw --bin "${BIN_NAME}" --target aarch64-linux-android
+          cargo build --release --locked -p loong --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target aarch64-linux-android
 
   docs-build:
     needs: changes

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      LOONGCLAW_BENCH_PROFILE: release
+      LOONG_BENCH_PROFILE: release
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   BIN_NAME: loong
+  LEGACY_BIN_NAME: loongclaw
   PACKAGE_NAME: loong
   LINUX_ARM64_GLIBC_FLOOR: "2.17"
   LINUX_ARM64_ZIG_VERSION: "0.13.0"
@@ -67,7 +68,7 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
+          LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
           grep -F "## [${RELEASE_TAG#v}]" CHANGELOG.md > /dev/null
           release_doc="docs/releases/${RELEASE_TAG}.md"
           test -f "$release_doc"
@@ -80,7 +81,7 @@ jobs:
         run: chmod +x ./scripts/check_dep_graph.sh && ./scripts/check_dep_graph.sh
 
       - name: Strict architecture contract
-        run: chmod +x ./scripts/check_architecture_boundaries.sh && LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
+        run: chmod +x ./scripts/check_architecture_boundaries.sh && LOONG_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
 
   build-binaries:
     name: Build ${{ matrix.target }} on ${{ matrix.os }}
@@ -180,16 +181,16 @@ jobs:
       - name: Build release binary with cargo-zigbuild
         if: matrix.use_zig == true
         env:
-          LOONGCLAW_RELEASE_BUILD: "1"
+          LOONG_RELEASE_BUILD: "1"
         run: |
-          cargo zigbuild --release --locked -p loongclaw --bin ${{ env.BIN_NAME }} \
+          cargo zigbuild --release --locked -p loong --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} \
             --target "${{ matrix.target }}.${{ env.LINUX_ARM64_GLIBC_FLOOR }}"
 
       - name: Build release binary (Android/Termux)
         if: matrix.use_android_ndk == true
         shell: bash
         env:
-          LOONGCLAW_RELEASE_BUILD: "1"
+          LOONG_RELEASE_BUILD: "1"
         run: |
           set -euo pipefail
           toolchain="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
@@ -197,13 +198,13 @@ jobs:
           export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
           export AR_aarch64_linux_android="${toolchain}/llvm-ar"
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
-          cargo build --release --locked -p loongclaw --bin "${BIN_NAME}" --target "${{ matrix.target }}"
+          cargo build --release --locked -p loong --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target "${{ matrix.target }}"
 
       - name: Build release binary (native)
         if: matrix.use_zig != true && matrix.use_android_ndk != true
         env:
-          LOONGCLAW_RELEASE_BUILD: "1"
-        run: cargo build --release --locked -p loongclaw --bin ${{ env.BIN_NAME }} --target ${{ matrix.target }}
+          LOONG_RELEASE_BUILD: "1"
+        run: cargo build --release --locked -p loong --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} --target ${{ matrix.target }}
 
       - name: Package archive (Unix)
         if: matrix.archive == 'tar.gz'
@@ -214,7 +215,7 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           archive="${PACKAGE_NAME}-${RELEASE_TAG}-${{ matrix.target }}.tar.gz"
-          tar -C "target/${{ matrix.target }}/release" -czf "dist/${archive}" "${BIN_NAME}${{ matrix.ext }}"
+          tar -C "target/${{ matrix.target }}/release" -czf "dist/${archive}" "${BIN_NAME}${{ matrix.ext }}" "${LEGACY_BIN_NAME}${{ matrix.ext }}"
           cd dist && shasum -a 256 "${archive}" > "${archive}.sha256"
 
       - name: Package archive (Windows)
@@ -226,7 +227,8 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $archive = "${env:PACKAGE_NAME}-${env:RELEASE_TAG}-${{ matrix.target }}.zip"
           Compress-Archive -Path @(
-            "target/${{ matrix.target }}/release/${env:BIN_NAME}${{ matrix.ext }}"
+            "target/${{ matrix.target }}/release/${env:BIN_NAME}${{ matrix.ext }}",
+            "target/${{ matrix.target }}/release/${env:LEGACY_BIN_NAME}${{ matrix.ext }}"
           ) -DestinationPath "dist/$archive" -Force
           $hash = (Get-FileHash -Algorithm SHA256 "dist/$archive").Hash.ToLowerInvariant()
           Set-Content -Path "dist/$archive.sha256" -Value "$hash  $archive"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target/
 .DS_Store
 /.docs
-/.loongclaw.local.toml
+/.loong.local.toml
 /.env.local
 .worktrees/
 .idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,7 +2597,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw"
+name = "loong"
 version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
@@ -2612,12 +2612,12 @@ dependencies = [
  "futures-util",
  "hex",
  "libc",
- "loongclaw-app",
- "loongclaw-bench",
- "loongclaw-contracts",
- "loongclaw-kernel",
- "loongclaw-protocol",
- "loongclaw-spec",
+ "loong-app",
+ "loong-bench",
+ "loong-contracts",
+ "loong-kernel",
+ "loong-protocol",
+ "loong-spec",
  "rand 0.10.1",
  "reqwest",
  "rusqlite",
@@ -2638,7 +2638,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-app"
+name = "loong-app"
 version = "0.1.0-alpha.3"
 dependencies = [
  "aes",
@@ -2663,8 +2663,8 @@ dependencies = [
  "include_dir",
  "lettre",
  "libc",
- "loongclaw-contracts",
- "loongclaw-kernel",
+ "loong-contracts",
+ "loong-kernel",
  "prost",
  "rand 0.10.1",
  "regex",
@@ -2698,12 +2698,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-bench"
+name = "loong-bench"
 version = "0.1.0-alpha.3"
 dependencies = [
  "hex",
- "loongclaw-kernel",
- "loongclaw-spec",
+ "loong-kernel",
+ "loong-spec",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2712,7 +2712,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-contracts"
+name = "loong-contracts"
 version = "0.1.0-alpha.3"
 dependencies = [
  "semver",
@@ -2724,13 +2724,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-kernel"
+name = "loong-kernel"
 version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "futures-util",
  "hex",
- "loongclaw-contracts",
+ "loong-contracts",
  "proptest",
  "semver",
  "serde",
@@ -2741,7 +2741,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-protocol"
+name = "loong-protocol"
 version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
@@ -2752,16 +2752,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "loongclaw-spec"
+name = "loong-spec"
 version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
  "ed25519-dalek",
  "futures-util",
- "loongclaw-contracts",
- "loongclaw-kernel",
- "loongclaw-protocol",
+ "loong-contracts",
+ "loong-kernel",
+ "loong-protocol",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2024"
 license = "MIT"
 version = "0.1.0-alpha.3"
 authors = ["chumyin"]
-repository = "https://github.com/loongclaw-ai/loongclaw"
-homepage = "https://github.com/loongclaw-ai/loongclaw"
+repository = "https://github.com/eastreams/loong"
+homepage = "https://github.com/eastreams/loong"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,27 +4,27 @@ tasks:
   fmt:
     desc: Check formatting for all crates
     cmds:
-      - ./scripts/cargo-local-toolchain.sh fmt --all -- --check
+      - cargo fmt --all -- --check
 
   lint:
     desc: Run clippy across workspace targets
     cmds:
-      - ./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features
+      - cargo clippy --workspace --all-targets --all-features
 
   lint:strict:
     desc: Run clippy with warnings denied (migration gate)
     cmds:
-      - ./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
+      - cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
     desc: Run workspace unit and doc tests
     cmds:
-      - ./scripts/cargo-local-toolchain.sh test --workspace
+      - cargo test --workspace
 
   test:all-features:
     desc: Run tests with all features enabled
     cmds:
-      - ./scripts/cargo-local-toolchain.sh test --workspace --all-features
+      - cargo test --workspace --all-features
 
   test:daemon:stress:
     desc: Stress daemon test binary across thread modes to catch intermittent regressions
@@ -34,9 +34,9 @@ tasks:
   smoke:
     desc: Run representative spec-runner smoke scenarios
     cmds:
-      - ./scripts/cargo-local-toolchain.sh run -p loongclaw --bin loong -- run-spec --spec examples/spec/runtime-extension.json --print-audit
-      - ./scripts/cargo-local-toolchain.sh run -p loongclaw --bin loong -- run-spec --spec examples/spec/tool-search.json --print-audit
-      - ./scripts/cargo-local-toolchain.sh run -p loongclaw --bin loong -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
+      - cargo run -p loong --bin loong -- run-spec --spec examples/spec/runtime-extension.json --print-audit
+      - cargo run -p loong --bin loong -- run-spec --spec examples/spec/tool-search.json --print-audit
+      - cargo run -p loong --bin loong -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
 
   benchmark:pressure:
     desc: Run programmatic pressure benchmark with gate enforcement
@@ -51,7 +51,7 @@ tasks:
   check:docs:strict:
     desc: Validate doc governance in strict release mode (missing .docs artifacts fail)
     cmds:
-      - LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
+      - LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
 
   check:github-labels:
     desc: Validate generated GitHub label taxonomy artifacts
@@ -67,7 +67,7 @@ tasks:
   check:architecture:strict:
     desc: Fail on any architecture boundary budget violations
     cmds:
-      - LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
+      - LOONG_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
 
   check:conventions:
     desc: Validate repo convention contracts
@@ -98,7 +98,7 @@ tasks:
       - sh: command -v cargo-deny
         msg: "cargo-deny not installed. Run: cargo install cargo-deny"
     cmds:
-      - ./scripts/cargo-deny-local.sh check advisories bans licenses sources
+      - cargo deny check advisories bans licenses sources
 
   verify:
     desc: Canonical local verification gate (strict superset of CI checks)

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
-name = "loongclaw-app"
+name = "loong-app"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: providers, tools, channels, and runtime"
+description = "Internal support crate for Loong: providers, tools, channels, and runtime"
 repository.workspace = true
 homepage.workspace = true
+
+[lib]
+name = "loongclaw_app"
 
 [features]
 default = ["channel-cli", "channel-telegram", "channel-feishu", "channel-matrix", "channel-wecom", "channel-discord", "channel-dingtalk", "channel-slack", "channel-webhook", "channel-google-chat", "channel-line", "channel-signal", "channel-twitch", "channel-teams", "channel-tlon", "channel-whatsapp", "channel-email", "channel-mattermost", "channel-nextcloud-talk", "channel-synology-chat", "channel-irc", "channel-imessage", "channel-nostr", "config-toml", "memory-sqlite", "feishu-integration", "tool-shell", "tool-file", "tool-browser", "tool-http", "tool-webfetch", "tool-websearch", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
@@ -49,8 +52,8 @@ tool-websearch = []
 test-support = []
 
 [dependencies]
-loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
-loongclaw-kernel = { version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
 bytes = "1"
 async-trait.workspace = true
 console.workspace = true

--- a/crates/app/build.rs
+++ b/crates/app/build.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=LOONG_RELEASE_BUILD");
+    println!("cargo:rerun-if-env-changed=LOONG_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=LOONG_GIT_SHA");
     println!("cargo:rerun-if-env-changed=LOONGCLAW_RELEASE_BUILD");
     println!("cargo:rerun-if-env-changed=LOONGCLAW_BUILD_CHANNEL");
     println!("cargo:rerun-if-env-changed=LOONGCLAW_GIT_SHA");
@@ -13,9 +16,15 @@ fn main() {
     let repo_root = repo_root();
     emit_git_rerun_hints(&repo_root);
 
-    let release_build_env = env::var("LOONGCLAW_RELEASE_BUILD").ok();
-    let channel_env = env::var("LOONGCLAW_BUILD_CHANNEL").ok();
-    let sha_env = env::var("LOONGCLAW_GIT_SHA").ok();
+    let release_build_env = env::var("LOONG_RELEASE_BUILD")
+        .ok()
+        .or_else(|| env::var("LOONGCLAW_RELEASE_BUILD").ok());
+    let channel_env = env::var("LOONG_BUILD_CHANNEL")
+        .ok()
+        .or_else(|| env::var("LOONGCLAW_BUILD_CHANNEL").ok());
+    let sha_env = env::var("LOONG_GIT_SHA")
+        .ok()
+        .or_else(|| env::var("LOONGCLAW_GIT_SHA").ok());
     let git_branch = git_output(&repo_root, &["branch", "--show-current"]);
     let git_sha = git_output(&repo_root, &["rev-parse", "--short=7", "HEAD"]);
 
@@ -28,13 +37,22 @@ fn main() {
     );
 
     emit_rustc_env(
+        "LOONG_RELEASE_BUILD",
+        if metadata.release_build { "1" } else { "" },
+    );
+    emit_rustc_env(
         "LOONGCLAW_RELEASE_BUILD",
         if metadata.release_build { "1" } else { "" },
+    );
+    emit_rustc_env(
+        "LOONG_BUILD_CHANNEL",
+        metadata.channel.as_deref().unwrap_or(""),
     );
     emit_rustc_env(
         "LOONGCLAW_BUILD_CHANNEL",
         metadata.channel.as_deref().unwrap_or(""),
     );
+    emit_rustc_env("LOONG_GIT_SHA", metadata.short_sha.as_deref().unwrap_or(""));
     emit_rustc_env(
         "LOONGCLAW_GIT_SHA",
         metadata.short_sha.as_deref().unwrap_or(""),

--- a/crates/app/src/acp/acpx/command_probe.rs
+++ b/crates/app/src/acp/acpx/command_probe.rs
@@ -10,6 +10,7 @@ pub(super) async fn wait_for_command_output(
     command: &mut Command,
     timeout_duration: Duration,
 ) -> Result<std::process::Output, CommandOutputError> {
+    command.kill_on_drop(true);
     timeout(timeout_duration, command.output())
         .await
         .map_err(|_timeout_error| CommandOutputError::TimedOut)?

--- a/crates/app/src/channel/registry/tlon.rs
+++ b/crates/app/src/channel/registry/tlon.rs
@@ -87,7 +87,7 @@ pub(super) const TLON_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
 pub(super) const TLON_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor =
     ChannelOnboardingDescriptor {
         strategy: ChannelOnboardingStrategy::ManualConfig,
-        setup_hint: "configure a Tlon ship account in loongclaw.toml under tlon or tlon.accounts.<account>; outbound ship sends are shipped for DMs and chat groups, while inbound serve support remains planned",
+        setup_hint: "configure a Tlon ship account in loong.toml under tlon or tlon.accounts.<account>; outbound ship sends are shipped for DMs and chat groups, while inbound serve support remains planned",
         status_command: "loong doctor",
         repair_command: Some("loong doctor --fix"),
     };

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -4491,9 +4491,7 @@ mod tests {
         );
 
         assert!(
-            lines
-                .first()
-                .is_some_and(|line| line.starts_with("LOONGCLAW")),
+            lines.first().is_some_and(|line| line.starts_with("LOONG")),
             "chat startup should now use the shared compact brand header: {lines:#?}"
         );
         assert!(
@@ -4649,9 +4647,7 @@ mod tests {
         let lines = render_cli_chat_missing_config_lines_with_width(command, 80);
 
         assert!(
-            lines
-                .first()
-                .is_some_and(|line| line.starts_with("LOONGCLAW")),
+            lines.first().is_some_and(|line| line.starts_with("LOONG")),
             "missing-config setup prompt should keep the shared compact header: {lines:#?}"
         );
         assert!(

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -68,7 +68,7 @@ use self::operator_surfaces::render_cli_chat_status_lines_with_width;
 use self::operator_surfaces::render_manual_compaction_lines_with_width;
 use self::operator_surfaces::should_run_missing_config_onboard;
 
-use super::config::{self, ConversationConfig, LoongClawConfig};
+use super::config::{self, ConversationConfig, LoongConfig};
 #[cfg(test)]
 use super::conversation::ContextCompactionReport;
 #[cfg(test)]
@@ -112,7 +112,8 @@ use crate::tools::runtime_events::{ToolCommandMetrics, ToolFileChangePreview, To
 use crate::tools::runtime_events::{ToolFileChangeKind, ToolRuntimeEvent, ToolRuntimeStream};
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
-const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
+const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONG_TEST_ONBOARD_EXECUTABLE";
+const LEGACY_TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
 const CLI_CHAT_HELP_COMMAND: &str = "/help";
 const CLI_CHAT_COMPACT_COMMAND: &str = "/compact";
 const CLI_CHAT_STATUS_COMMAND: &str = "/status";
@@ -132,7 +133,7 @@ pub struct CliChatOptions {
 #[derive(Debug, Clone)]
 pub struct ConcurrentCliHostOptions {
     pub resolved_path: PathBuf,
-    pub config: LoongClawConfig,
+    pub config: LoongConfig,
     pub session_id: String,
     pub shutdown: ConcurrentCliShutdown,
     pub initialize_runtime_environment: bool,
@@ -207,6 +208,7 @@ fn append_onboard_target_args(
 fn resolve_onboard_executable_path() -> CliResult<PathBuf> {
     if cfg!(debug_assertions)
         && let Some(executable_path) = std::env::var_os(TEST_ONBOARD_EXECUTABLE_ENV)
+            .or_else(|| std::env::var_os(LEGACY_TEST_ONBOARD_EXECUTABLE_ENV))
     {
         return Ok(PathBuf::from(executable_path));
     }
@@ -249,7 +251,7 @@ fn format_onboard_command_hint(config_path: Option<&str>, resolved_config_path: 
 
 pub(crate) struct CliTurnRuntime {
     pub(crate) resolved_path: PathBuf,
-    pub(crate) config: LoongClawConfig,
+    pub(crate) config: LoongConfig,
     pub(crate) session_id: String,
     pub(crate) session_address: ConversationSessionAddress,
     pub(crate) turn_coordinator: ConversationTurnCoordinator,
@@ -453,7 +455,7 @@ fn run_concurrent_cli_host_repl(options: &ConcurrentCliHostOptions) -> CliResult
     })
 }
 
-pub(crate) fn reject_disabled_cli_channel(config: &LoongClawConfig) -> CliResult<()> {
+pub(crate) fn reject_disabled_cli_channel(config: &LoongConfig) -> CliResult<()> {
     if config.cli.enabled {
         return Ok(());
     }
@@ -516,7 +518,7 @@ pub(crate) fn initialize_cli_turn_runtime(
 /// token for the same logical operation.
 pub(crate) fn initialize_cli_turn_runtime_with_loaded_config(
     resolved_path: PathBuf,
-    config: LoongClawConfig,
+    config: LoongConfig,
     session_hint: Option<&str>,
     options: &CliChatOptions,
     kernel_scope: &'static str,
@@ -560,7 +562,7 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config(
 /// by an outer runtime surface.
 pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
     resolved_path: PathBuf,
-    config: LoongClawConfig,
+    config: LoongConfig,
     session_hint: Option<&str>,
     options: &CliChatOptions,
     kernel_ctx: crate::KernelContext,
@@ -1637,17 +1639,14 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     }
 }
 
-fn reload_cli_turn_config(
-    config: &LoongClawConfig,
-    resolved_path: &Path,
-) -> CliResult<LoongClawConfig> {
+fn reload_cli_turn_config(config: &LoongConfig, resolved_path: &Path) -> CliResult<LoongConfig> {
     if resolved_path.as_os_str().is_empty() {
         return Ok(config.clone());
     }
     config.reload_provider_runtime_state_from_path(resolved_path)
 }
 
-fn is_exit_command(config: &LoongClawConfig, input: &str) -> bool {
+fn is_exit_command(config: &LoongConfig, input: &str) -> bool {
     let lower = input.to_ascii_lowercase();
     config
         .cli
@@ -1735,7 +1734,7 @@ async fn print_safe_lane_summary(
 #[allow(clippy::print_stdout)] // CLI output
 async fn print_turn_checkpoint_summary(
     turn_coordinator: &ConversationTurnCoordinator,
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
@@ -1778,7 +1777,7 @@ async fn print_turn_checkpoint_summary(
 #[allow(clippy::print_stdout)] // CLI output
 async fn print_turn_checkpoint_repair(
     turn_coordinator: &ConversationTurnCoordinator,
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<()> {
@@ -2667,7 +2666,7 @@ fn build_turn_checkpoint_summary_message_spec(
 #[cfg(test)]
 async fn load_turn_checkpoint_summary_output(
     turn_coordinator: &ConversationTurnCoordinator,
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
@@ -3491,6 +3490,7 @@ fn format_average(sum: u64, samples: u32) -> String {
 mod tests {
     use super::*;
     use crate::conversation::ConversationRuntimeBinding;
+    use crate::test_support::ScopedEnv;
     use serde_json::json;
     use std::ffi::OsStr;
     use std::path::PathBuf;
@@ -3514,8 +3514,8 @@ mod tests {
     use serde_json::Value;
 
     #[cfg(feature = "memory-sqlite")]
-    fn test_config() -> LoongClawConfig {
-        let mut config = LoongClawConfig::default();
+    fn test_config() -> LoongConfig {
+        let mut config = LoongConfig::default();
         config.provider = crate::config::ProviderConfig::default();
         config.audit.mode = crate::config::AuditMode::InMemory;
         config
@@ -3613,6 +3613,33 @@ mod tests {
     }
 
     #[test]
+    fn build_onboard_command_prefers_loong_test_override() {
+        let mut env = ScopedEnv::new();
+        env.remove(TEST_ONBOARD_EXECUTABLE_ENV);
+        env.remove(LEGACY_TEST_ONBOARD_EXECUTABLE_ENV);
+        env.set(TEST_ONBOARD_EXECUTABLE_ENV, "/tmp/loong-onboard");
+        env.set(LEGACY_TEST_ONBOARD_EXECUTABLE_ENV, "/tmp/legacy-onboard");
+
+        let command =
+            build_onboard_command(None, Path::new("/tmp/loongclaw.toml")).expect("onboard command");
+
+        assert_eq!(command.get_program(), OsStr::new("/tmp/loong-onboard"));
+    }
+
+    #[test]
+    fn build_onboard_command_falls_back_to_legacy_override() {
+        let mut env = ScopedEnv::new();
+        env.remove(TEST_ONBOARD_EXECUTABLE_ENV);
+        env.remove(LEGACY_TEST_ONBOARD_EXECUTABLE_ENV);
+        env.set(LEGACY_TEST_ONBOARD_EXECUTABLE_ENV, "/tmp/legacy-onboard");
+
+        let command =
+            build_onboard_command(None, Path::new("/tmp/loongclaw.toml")).expect("onboard command");
+
+        assert_eq!(command.get_program(), OsStr::new("/tmp/legacy-onboard"));
+    }
+
+    #[test]
     fn build_onboard_command_forwards_explicit_config_path_to_output() {
         let command = build_onboard_command_for_executable(
             PathBuf::from("/tmp/loongclaw"),
@@ -3662,11 +3689,11 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     pub(super) fn init_chat_test_memory(
         label: &str,
-    ) -> (LoongClawConfig, MemoryRuntimeConfig, PathBuf) {
+    ) -> (LoongConfig, MemoryRuntimeConfig, PathBuf) {
         let sqlite_path = unique_chat_sqlite_path(label);
         cleanup_chat_test_memory(&sqlite_path);
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.audit.mode = crate::config::AuditMode::InMemory;
         config.memory.sqlite_path = sqlite_path.display().to_string();
         let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
@@ -3985,7 +4012,7 @@ mod tests {
         let shutdown = ConcurrentCliShutdown::new();
         let error = run_concurrent_cli_host(&ConcurrentCliHostOptions {
             resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
-            config: LoongClawConfig::default(),
+            config: LoongConfig::default(),
             session_id: "   ".to_owned(),
             shutdown,
             initialize_runtime_environment: false,
@@ -5752,7 +5779,7 @@ allowed_decisions: yes / auto / full / esc";
         ));
         let path_string = path.display().to_string();
 
-        let mut in_memory = LoongClawConfig::default();
+        let mut in_memory = LoongConfig::default();
         in_memory.cli.exit_commands = vec!["/bye".to_owned()];
         let mut openai =
             crate::config::ProviderConfig::fresh_for_kind(crate::config::ProviderKind::Openai);

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -2334,8 +2334,8 @@ fn session_surface_subtitle(state: &SurfaceState) -> &str {
 
 fn default_export_path(session_id: &str) -> String {
     let sanitized_session_id = sanitize_session_id_for_export(session_id);
-    let file_name = format!("loongclaw-{sanitized_session_id}-transcript.txt");
-    let exports_dir = loongclaw_exports_dir();
+    let file_name = format!("loong-{sanitized_session_id}-transcript.txt");
+    let exports_dir = loong_exports_dir();
     let export_path = exports_dir.join(file_name);
 
     export_path.display().to_string()
@@ -2354,9 +2354,9 @@ fn sanitize_session_id_for_export(session_id: &str) -> String {
         .collect()
 }
 
-fn loongclaw_exports_dir() -> PathBuf {
-    let loongclaw_home = crate::config::default_loongclaw_home();
-    loongclaw_home.join("exports")
+fn loong_exports_dir() -> PathBuf {
+    let loong_home = crate::config::default_loong_home();
+    loong_home.join("exports")
 }
 
 fn ensure_parent_directory_exists(path: &Path) -> CliResult<()> {
@@ -2812,7 +2812,7 @@ mod tests {
     }
 
     #[test]
-    fn default_export_path_uses_loongclaw_exports_directory() {
+    fn default_export_path_uses_loong_exports_directory() {
         let export_path = PathBuf::from(default_export_path("session:/bad"));
         let file_name = export_path
             .file_name()
@@ -2825,7 +2825,7 @@ mod tests {
             .expect("export parent directory");
 
         assert_eq!(parent_dir, "exports");
-        assert_eq!(file_name, "loongclaw-session__bad-transcript.txt");
+        assert_eq!(file_name, "loong-session__bad-transcript.txt");
     }
 
     #[test]

--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use super::shared::{default_loongclaw_home, expand_path};
+use super::shared::{default_loong_home, expand_path};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuditConfig {
@@ -54,7 +54,7 @@ impl AuditMode {
 }
 
 fn default_audit_path() -> String {
-    default_loongclaw_home()
+    default_loong_home()
         .join("audit")
         .join("events.jsonl")
         .display()
@@ -68,18 +68,15 @@ const fn default_true() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::ScopedLoongClawHome;
-
     #[test]
-    fn audit_config_defaults_to_fanout_under_loongclaw_home() {
-        let _home = ScopedLoongClawHome::new("loongclaw-audit-config-home");
+    fn audit_config_defaults_to_fanout_under_loong_home() {
         let config = AuditConfig::default();
 
         assert_eq!(config.mode, AuditMode::Fanout);
         assert!(config.retain_in_memory);
         assert_eq!(
             PathBuf::from(&config.path),
-            default_loongclaw_home().join("audit").join("events.jsonl")
+            default_loong_home().join("audit").join("events.jsonl")
         );
     }
 
@@ -92,7 +89,6 @@ mod tests {
 
     #[test]
     fn audit_config_empty_path_falls_back_to_default_location() {
-        let _home = ScopedLoongClawHome::new("loongclaw-audit-path-home");
         let config = AuditConfig {
             path: "   ".to_owned(),
             ..AuditConfig::default()
@@ -100,7 +96,7 @@ mod tests {
 
         assert_eq!(
             config.resolved_path(),
-            default_loongclaw_home().join("audit").join("events.jsonl")
+            default_loong_home().join("audit").join("events.jsonl")
         );
     }
 }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -107,10 +107,10 @@ pub use runtime::{
     PROVIDER_SELECTOR_COMPACT_NOTE, PROVIDER_SELECTOR_HUMAN_SUMMARY, PROVIDER_SELECTOR_NOTE,
     PROVIDER_SELECTOR_PLACEHOLDER, PROVIDER_SELECTOR_TARGET_SUMMARY, ProviderSelectorProfileRef,
     ProviderSelectorResolution, accepted_provider_selectors, default_config_path,
-    default_loongclaw_home, describe_provider_selector_target, load, normalize_validation_locale,
-    preferred_provider_selector, provider_selector_catalog, provider_selector_recommendation_hint,
-    render, resolve_provider_selector, supported_validation_locales, validate_file,
-    validate_file_with_locale, write, write_template,
+    default_loong_home, default_loongclaw_home, describe_provider_selector_target, load,
+    normalize_validation_locale, preferred_provider_selector, provider_selector_catalog,
+    provider_selector_recommendation_hint, render, resolve_provider_selector,
+    supported_validation_locales, validate_file, validate_file_with_locale, write, write_template,
 };
 pub(crate) use runtime::{normalize_dispatch_account_id, normalize_dispatch_channel_id};
 pub(crate) use shared::ConfigValidationIssue;
@@ -129,6 +129,8 @@ pub(crate) use shared::{
 pub(crate) use shared::{
     pop_default_loongclaw_home_override_for_tests, push_default_loongclaw_home_override_for_tests,
 };
+
+pub type LoongConfig = LoongClawConfig;
 #[allow(unused_imports)]
 pub use tools::{
     AUTONOMY_PROFILE_VALID_VALUES, AutonomyProfile, BrowserCompanionToolConfig, BrowserToolConfig,

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -2147,6 +2147,10 @@ pub fn default_config_path() -> PathBuf {
     default_loongclaw_home().join(DEFAULT_CONFIG_FILE)
 }
 
+pub fn default_loong_home() -> PathBuf {
+    default_loongclaw_home()
+}
+
 pub fn default_loongclaw_home() -> PathBuf {
     shared_default_loongclaw_home()
 }

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -16,10 +16,11 @@ pub const CLI_COMMAND_NAME: &str = "loong";
 pub const LEGACY_CLI_COMMAND_NAME: &str = "loongclaw";
 pub const HOME_DIR_NAME: &str = ".loong";
 pub const LEGACY_HOME_DIR_NAME: &str = ".loongclaw";
-pub const PRODUCT_DISPLAY_NAME: &str = "LoongClaw";
+pub const PRODUCT_DISPLAY_NAME: &str = "Loong";
 static ACTIVE_CLI_COMMAND_NAME: OnceLock<&'static str> = OnceLock::new();
 pub(super) const DEFAULT_FEISHU_SQLITE_FILE: &str = "feishu.sqlite3";
-pub(crate) const LOONGCLAW_HOME_ENV: &str = "LOONG_HOME";
+pub(crate) const LOONG_HOME_ENV: &str = "LOONG_HOME";
+pub(crate) const LOONGCLAW_HOME_ENV: &str = LOONG_HOME_ENV;
 
 fn normalize_cli_command_name(raw: &str) -> &'static str {
     if raw.eq_ignore_ascii_case(LEGACY_CLI_COMMAND_NAME) {
@@ -613,6 +614,10 @@ pub(super) fn default_loongclaw_home() -> PathBuf {
     }
 
     get_loongclaw_home()
+}
+
+pub(super) fn default_loong_home() -> PathBuf {
+    default_loongclaw_home()
 }
 
 pub fn expand_path(raw: &str) -> PathBuf {

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -917,8 +917,8 @@ impl ToolConfig {
                 code: super::shared::ConfigValidationCode::NumericRange,
                 field_path: "tools.web_search.timeout_seconds".to_owned(),
                 inline_field_path: "tools.web_search.timeout_seconds".to_owned(),
-                example_env_name: "LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS".to_owned(),
-                suggested_env_name: Some("LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS".to_owned()),
+                example_env_name: "LOONG_WEB_SEARCH_TIMEOUT_SECONDS".to_owned(),
+                suggested_env_name: Some("LOONG_WEB_SEARCH_TIMEOUT_SECONDS".to_owned()),
                 extra_message_variables: vars,
             })
         });
@@ -962,8 +962,8 @@ impl ToolConfig {
                 code: super::shared::ConfigValidationCode::UnknownSearchProvider,
                 field_path: "tools.web_search.default_provider".to_owned(),
                 inline_field_path: "tools.web_search.default_provider".to_owned(),
-                example_env_name: "LOONGCLAW_WEB_SEARCH_PROVIDER".to_owned(),
-                suggested_env_name: Some("LOONGCLAW_WEB_SEARCH_PROVIDER".to_owned()),
+                example_env_name: "LOONG_WEB_SEARCH_PROVIDER".to_owned(),
+                suggested_env_name: Some("LOONG_WEB_SEARCH_PROVIDER".to_owned()),
                 extra_message_variables,
             });
         }

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use loongclaw_contracts::Capability;
 use serde_json::{Value, json};
 
-use crate::config::LoongClawConfig;
+use crate::config::LoongConfig;
 use crate::{CliResult, KernelContext};
 
 #[cfg(feature = "memory-sqlite")]
@@ -144,7 +144,7 @@ pub trait ConversationContextEngine: Send + Sync {
 
     async fn bootstrap(
         &self,
-        _config: &LoongClawConfig,
+        _config: &LoongConfig,
         _session_id: &str,
         _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
@@ -173,7 +173,7 @@ pub trait ConversationContextEngine: Send + Sync {
 
     async fn compact_context(
         &self,
-        _config: &LoongClawConfig,
+        _config: &LoongConfig,
         _session_id: &str,
         _messages: &[Value],
         _kernel_ctx: &KernelContext,
@@ -201,7 +201,7 @@ pub trait ConversationContextEngine: Send + Sync {
 
     async fn assemble_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -213,7 +213,7 @@ pub trait ConversationContextEngine: Send + Sync {
 
     async fn assemble_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -235,7 +235,7 @@ where
 
     async fn bootstrap(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
@@ -274,7 +274,7 @@ where
 
     async fn compact_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         messages: &[Value],
         kernel_ctx: &KernelContext,
@@ -308,7 +308,7 @@ where
 
     async fn assemble_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -320,7 +320,7 @@ where
 
     async fn assemble_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -375,7 +375,7 @@ impl ConversationContextEngine for DefaultContextEngine {
 
     async fn compact_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         _messages: &[Value],
         kernel_ctx: &KernelContext,
@@ -422,7 +422,7 @@ impl ConversationContextEngine for DefaultContextEngine {
 
     async fn assemble_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -452,7 +452,7 @@ impl ConversationContextEngine for DefaultContextEngine {
                 .ok_or_else(|| "kernel-bound context engine requires kernel context".to_owned())?;
             let provider_binding = crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx);
             let envelope = load_stage_envelope(config, session_id, binding).await?;
-            let runtime_tool_view = crate::tools::runtime_tool_view_from_loongclaw_config(config);
+            let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
             let projected = crate::provider::project_hydrated_memory_context_for_view_with_binding(
                 config,
                 include_system_prompt,
@@ -480,7 +480,7 @@ impl ConversationContextEngine for DefaultContextEngine {
 
     async fn assemble_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -503,7 +503,7 @@ impl ConversationContextEngine for LegacyContextEngine {
 
     async fn assemble_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         _binding: ConversationRuntimeBinding<'_>,
@@ -513,7 +513,7 @@ impl ConversationContextEngine for LegacyContextEngine {
 }
 
 async fn load_memory_window_snapshot(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     kernel_ctx: &KernelContext,
 ) -> CliResult<CompactionWindowSnapshot> {
@@ -590,7 +590,7 @@ async fn persist_memory_window(
 
 #[cfg(feature = "memory-sqlite")]
 async fn load_stage_envelope(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<memory::StageEnvelope> {
@@ -598,7 +598,7 @@ async fn load_stage_envelope(
         let runtime_config =
             memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         let tool_runtime_config =
-            crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);
+            crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
         let workspace_root = tool_runtime_config
             .effective_workspace_root()
             .map(Path::to_path_buf);
@@ -639,7 +639,7 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     async fn provider_messages_with_kernel_binding(
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         kernel_ctx: &crate::KernelContext,
     ) -> Vec<Value> {
@@ -650,7 +650,7 @@ mod tests {
         )
         .await
         .expect("load staged memory envelope");
-        let runtime_tool_view = crate::tools::runtime_tool_view_from_loongclaw_config(config);
+        let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
         crate::provider::project_hydrated_memory_context_for_view_with_binding(
             config,
             true,
@@ -733,7 +733,7 @@ mod tests {
 
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
 
         let messages = DefaultContextEngine
@@ -780,7 +780,7 @@ mod tests {
         let session_id = "kernel-summary-session";
         let sqlite_path = harness.temp_dir.join("memory.sqlite3");
         let sqlite_path_text = sqlite_path.display().to_string();
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.profile = MemoryProfile::WindowPlusSummary;
@@ -837,7 +837,7 @@ mod tests {
         let sqlite_path = harness.temp_dir.join("memory.sqlite3");
         let sqlite_path_text = sqlite_path.display().to_string();
         let profile_note = "Imported ZeroClaw preferences";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.profile = MemoryProfile::ProfilePlusWindow;
@@ -896,7 +896,7 @@ mod tests {
         )
         .expect("write durable recall");
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.sqlite_path = sqlite_path_text;
 
@@ -946,7 +946,7 @@ mod tests {
         )
         .expect("write durable recall");
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.sqlite_path = sqlite_path_text;
         config.memory.system_id = Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
@@ -1010,7 +1010,7 @@ mod tests {
         let sqlite_path = harness.temp_dir.join("memory.sqlite3");
         let sqlite_path_text = sqlite_path.display().to_string();
         let profile_note = "# Identity\n\n- Name: Advisory shadow";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.profile = MemoryProfile::ProfilePlusWindow;

--- a/crates/app/src/conversation/context_engine_registry.rs
+++ b/crates/app/src/conversation/context_engine_registry.rs
@@ -11,7 +11,8 @@ use super::context_engine::{
 
 pub const DEFAULT_CONTEXT_ENGINE_ID: &str = "default";
 pub const LEGACY_CONTEXT_ENGINE_ID: &str = "legacy";
-pub const CONTEXT_ENGINE_ENV: &str = "LOONGCLAW_CONTEXT_ENGINE";
+pub const CONTEXT_ENGINE_ENV: &str = "LOONG_CONTEXT_ENGINE";
+pub const LEGACY_CONTEXT_ENGINE_ENV: &str = "LOONGCLAW_CONTEXT_ENGINE";
 
 type ContextEngineFactory = Arc<dyn Fn() -> Box<dyn ConversationContextEngine> + Send + Sync>;
 
@@ -123,6 +124,7 @@ pub fn context_engine_id_from_env() -> Option<String> {
 
     std::env::var(CONTEXT_ENGINE_ENV)
         .ok()
+        .or_else(|| std::env::var(LEGACY_CONTEXT_ENGINE_ENV).ok())
         .map(|value| normalize_engine_id(value.as_str()))
         .filter(|value| !value.is_empty())
 }

--- a/crates/app/src/conversation/ingress.rs
+++ b/crates/app/src/conversation/ingress.rs
@@ -429,23 +429,28 @@ mod tests {
 
         assert!(injected.trusted_internal_context);
         assert_eq!(
-            injected.payload["_loongclaw"]["feishu_callback"]["callback_token"],
+            injected.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]["feishu_callback"]["callback_token"],
             "callback-secret-1"
         );
         assert_eq!(
-            injected.payload["_loongclaw"]["feishu_callback"]["operator_open_id"],
+            injected.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]["feishu_callback"]["operator_open_id"],
             "ou_operator"
         );
         assert_eq!(
-            injected.payload["_loongclaw"]["feishu_callback"]["deferred_context_id"],
+            injected.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]["feishu_callback"]["deferred_context_id"],
             "evt_callback_1"
         );
         assert_eq!(
-            injected.payload["_loongclaw"]["ingress"]["channel"]["conversation_id"],
+            injected.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]["ingress"]["channel"]["conversation_id"],
             "oc_callback"
         );
         assert!(!untouched.trusted_internal_context);
-        assert!(untouched.payload.get("_loongclaw").is_none());
+        assert!(
+            untouched
+                .payload
+                .get(crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/app/src/conversation/ingress.rs
+++ b/crates/app/src/conversation/ingress.rs
@@ -1,7 +1,7 @@
 use serde_json::{Map, Value, json};
 
-const LOONGCLAW_INTERNAL_TOOL_INGRESS_KEY: &str = "ingress";
-const LOONGCLAW_INTERNAL_TOOL_FEISHU_CALLBACK_KEY: &str = "feishu_callback";
+const LOONG_INTERNAL_TOOL_INGRESS_KEY: &str = "ingress";
+const LOONG_INTERNAL_TOOL_FEISHU_CALLBACK_KEY: &str = "feishu_callback";
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InjectedToolPayload {
@@ -162,7 +162,7 @@ fn inject_feishu_internal_context(
     let mut internal = Map::new();
     if ingress.has_contextual_hints() {
         internal.insert(
-            LOONGCLAW_INTERNAL_TOOL_INGRESS_KEY.to_owned(),
+            LOONG_INTERNAL_TOOL_INGRESS_KEY.to_owned(),
             ingress.as_event_payload(),
         );
     }
@@ -172,10 +172,7 @@ fn inject_feishu_internal_context(
         .as_ref()
         .and_then(|value| value.as_json())
     {
-        internal.insert(
-            LOONGCLAW_INTERNAL_TOOL_FEISHU_CALLBACK_KEY.to_owned(),
-            callback,
-        );
+        internal.insert(LOONG_INTERNAL_TOOL_FEISHU_CALLBACK_KEY.to_owned(), callback);
     }
     if internal.is_empty() {
         return InjectedToolPayload {
@@ -184,7 +181,7 @@ fn inject_feishu_internal_context(
         };
     }
     body.insert(
-        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
         Value::Object(internal),
     );
     InjectedToolPayload {

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -17,7 +17,7 @@ use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::tools::{ToolView, delegate_child_tool_view_for_contract};
 
 use super::super::memory;
-use super::super::{config::LoongClawConfig, provider};
+use super::super::{config::LoongConfig, provider};
 use super::context_engine::ContextArtifactKind;
 use super::context_engine::{
     AssembledConversationContext, ContextEngineBootstrapResult, ContextEngineIngestResult,
@@ -458,7 +458,7 @@ struct PersistedSessionSnapshot {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn open_session_repository(config: &LoongClawConfig) -> CliResult<SessionRepository> {
+fn open_session_repository(config: &LoongConfig) -> CliResult<SessionRepository> {
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     SessionRepository::new(&memory_config)
         .map_err(|error| format!("open session repository failed: {error}"))
@@ -565,15 +565,13 @@ fn load_persisted_session_snapshot(
 
 #[cfg(feature = "memory-sqlite")]
 fn build_base_tool_view_from_snapshot(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     repo: &SessionRepository,
     session_id: &str,
     snapshot: Option<&PersistedSessionSnapshot>,
 ) -> CliResult<ToolView> {
     let Some(snapshot) = snapshot else {
-        return Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ));
+        return Ok(crate::tools::runtime_tool_view_from_loong_config(config));
     };
 
     let is_delegate_child = snapshot.parent_session_id.is_some() || snapshot.is_delegate_child;
@@ -602,14 +600,12 @@ fn build_base_tool_view_from_snapshot(
         ));
     }
 
-    Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-        config,
-    ))
+    Ok(crate::tools::runtime_tool_view_from_loong_config(config))
 }
 
 #[cfg(feature = "memory-sqlite")]
 fn build_session_context_from_snapshot(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     repo: &SessionRepository,
     session_id: &str,
     base_tool_view: ToolView,
@@ -661,7 +657,7 @@ fn build_session_context_from_snapshot(
 
 #[cfg(feature = "memory-sqlite")]
 fn load_persisted_session_context(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     tool_view: &ToolView,
 ) -> CliResult<Option<SessionContext>> {
@@ -746,12 +742,12 @@ pub trait AsyncDelegateSpawner: Send + Sync {
 #[cfg(feature = "memory-sqlite")]
 #[derive(Clone)]
 struct DefaultAsyncDelegateSpawner {
-    config: Arc<LoongClawConfig>,
+    config: Arc<LoongConfig>,
 }
 
 #[cfg(feature = "memory-sqlite")]
 impl DefaultAsyncDelegateSpawner {
-    fn new(config: &LoongClawConfig) -> Self {
+    fn new(config: &LoongConfig) -> Self {
         Self {
             config: Arc::new(config.clone()),
         }
@@ -769,7 +765,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
 
 #[cfg(feature = "memory-sqlite")]
 pub async fn execute_async_delegate_spawn_request(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     request: AsyncDelegateSpawnRequest,
 ) -> Result<(), String> {
     let AsyncDelegateSpawnRequest {
@@ -932,7 +928,7 @@ pub struct TurnMiddlewareRuntimeSnapshot {
     pub available: Vec<TurnMiddlewareMetadata>,
 }
 
-pub fn resolve_context_engine_selection(config: &LoongClawConfig) -> ContextEngineSelection {
+pub fn resolve_context_engine_selection(config: &LoongConfig) -> ContextEngineSelection {
     if let Some(id) = context_engine_id_from_env() {
         return ContextEngineSelection {
             id,
@@ -954,7 +950,7 @@ pub fn resolve_context_engine_selection(config: &LoongClawConfig) -> ContextEngi
 }
 
 pub fn resolve_turn_middleware_selection(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
 ) -> CliResult<TurnMiddlewareSelection> {
     let mut ids = default_turn_middleware_ids()?;
     if let Some(env_ids) = turn_middleware_ids_from_env() {
@@ -981,7 +977,7 @@ pub fn resolve_turn_middleware_selection(
 }
 
 pub fn collect_context_engine_runtime_snapshot(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
 ) -> CliResult<ContextEngineRuntimeSnapshot> {
     let selected = resolve_context_engine_selection(config);
     let selected_metadata = describe_context_engine(Some(selected.id.as_str()))?;
@@ -1053,7 +1049,7 @@ where
 {
     async fn build_context_for_tool_view(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_context: &SessionContext,
         include_system_prompt: bool,
         requested_tool_view: &ToolView,
@@ -1069,8 +1065,7 @@ where
             }
             None => config,
         };
-        let runtime_tool_view =
-            crate::tools::runtime_tool_view_from_loongclaw_config(effective_config);
+        let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(effective_config);
         let mut assembled = self
             .context_engine
             .assemble_context(
@@ -1138,7 +1133,7 @@ where
 
     async fn run_turn_middlewares_bootstrap(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
@@ -1162,7 +1157,7 @@ where
 
     async fn apply_turn_middlewares_to_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         mut assembled: AssembledConversationContext,
@@ -1210,7 +1205,7 @@ where
 
     async fn run_turn_middlewares_compact_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         messages: &[Value],
         kernel_ctx: &KernelContext,
@@ -1258,7 +1253,7 @@ impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
         Ok(Self::with_context_engine(context_engine))
     }
 
-    pub fn from_config_or_env(config: &LoongClawConfig) -> CliResult<Self> {
+    pub fn from_config_or_env(config: &LoongConfig) -> CliResult<Self> {
         let selection = resolve_context_engine_selection(config);
         let turn_middleware_selection = resolve_turn_middleware_selection(config)?;
         let context_engine = resolve_context_engine(Some(selection.id.as_str()))?;
@@ -1274,7 +1269,7 @@ impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
 pub trait ConversationRuntime: Send + Sync {
     fn session_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
@@ -1292,20 +1287,18 @@ pub trait ConversationRuntime: Send + Sync {
 
     fn tool_view(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
         let _ = (session_id, binding);
-        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ))
+        Ok(crate::tools::runtime_tool_view_from_loong_config(config))
     }
 
     #[cfg(feature = "memory-sqlite")]
     fn async_delegate_spawner(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
     ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
         Some(Arc::new(DefaultAsyncDelegateSpawner::new(config)))
     }
@@ -1313,14 +1306,14 @@ pub trait ConversationRuntime: Send + Sync {
     #[cfg(feature = "memory-sqlite")]
     fn background_task_spawner(
         &self,
-        _config: &LoongClawConfig,
+        _config: &LoongConfig,
     ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
         None
     }
 
     async fn bootstrap(
         &self,
-        _config: &LoongClawConfig,
+        _config: &LoongConfig,
         _session_id: &str,
         _kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
@@ -1338,7 +1331,7 @@ pub trait ConversationRuntime: Send + Sync {
 
     async fn build_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -1356,7 +1349,7 @@ pub trait ConversationRuntime: Send + Sync {
     }
     async fn build_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         tool_view: &ToolView,
@@ -1365,14 +1358,14 @@ pub trait ConversationRuntime: Send + Sync {
 
     async fn request_completion(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         messages: &[Value],
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String>;
 
     async fn request_turn(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1382,7 +1375,7 @@ pub trait ConversationRuntime: Send + Sync {
 
     async fn request_turn_streaming(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1412,7 +1405,7 @@ pub trait ConversationRuntime: Send + Sync {
 
     async fn compact_context(
         &self,
-        _config: &LoongClawConfig,
+        _config: &LoongConfig,
         _session_id: &str,
         _messages: &[Value],
         _kernel_ctx: &KernelContext,
@@ -1446,7 +1439,7 @@ where
 {
     fn session_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
@@ -1482,7 +1475,7 @@ where
 
     fn tool_view(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
@@ -1502,14 +1495,12 @@ where
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
-        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ))
+        Ok(crate::tools::runtime_tool_view_from_loong_config(config))
     }
 
     async fn bootstrap(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
@@ -1539,7 +1530,7 @@ where
 
     async fn build_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
@@ -1557,7 +1548,7 @@ where
 
     async fn build_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         tool_view: &ToolView,
@@ -1577,7 +1568,7 @@ where
 
     async fn request_completion(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         messages: &[Value],
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
@@ -1586,7 +1577,7 @@ where
 
     async fn request_turn(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1606,7 +1597,7 @@ where
 
     async fn request_turn_streaming(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1691,7 +1682,7 @@ where
 
     async fn compact_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         messages: &[Value],
         kernel_ctx: &KernelContext,
@@ -1750,13 +1741,13 @@ fn provider_runtime_binding(
 }
 
 fn delegate_child_runtime_contract_prompt_summary(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_context: &SessionContext,
 ) -> Option<String> {
     session_context.parent_session_id.as_ref()?;
     session_context.subagent_runtime_narrowing()?;
     let subagent_contract = session_context.resolved_subagent_contract();
-    crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None)
+    crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None)
         .delegate_child_prompt_summary(subagent_contract.as_ref())
 }
 
@@ -1791,7 +1782,7 @@ fn delegate_child_profile_prompt_summary(session_context: &SessionContext) -> Op
 }
 
 fn runtime_self_continuity_prompt_summary(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_context: &SessionContext,
 ) -> Option<String> {
     let stored_continuity = session_context.runtime_self_continuity.as_ref()?;

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1911,10 +1911,7 @@ fn inject_tool_search_visibility_context_trusted(
     };
 
     let mut internal = if preserve_existing_internal_context {
-        object
-            .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
-            .and_then(|value| value.as_object().cloned())
-            .unwrap_or_default()
+        crate::tools::take_trusted_internal_tool_context(&mut object)
     } else {
         serde_json::Map::new()
     };
@@ -1936,7 +1933,7 @@ fn inject_tool_search_visibility_context_trusted(
         serde_json::Value::Object(tool_search_context),
     );
     object.insert(
-        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
         serde_json::Value::Object(internal),
     );
     AugmentedToolPayload {
@@ -1971,10 +1968,7 @@ fn inject_runtime_narrowing_context_trusted(
         };
     };
     let mut internal = if preserve_existing_internal_context {
-        object
-            .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
-            .and_then(|value| value.as_object().cloned())
-            .unwrap_or_default()
+        crate::tools::take_trusted_internal_tool_context(&mut object)
     } else {
         serde_json::Map::new()
     };
@@ -1984,7 +1978,7 @@ fn inject_runtime_narrowing_context_trusted(
             .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
     );
     object.insert(
-        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
         serde_json::Value::Object(internal),
     );
     AugmentedToolPayload {
@@ -2012,10 +2006,7 @@ fn inject_workspace_root_context_trusted(
         };
     };
     let mut internal = if preserve_existing_internal_context {
-        object
-            .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
-            .and_then(|value| value.as_object().cloned())
-            .unwrap_or_default()
+        crate::tools::take_trusted_internal_tool_context(&mut object)
     } else {
         serde_json::Map::new()
     };
@@ -2025,7 +2016,7 @@ fn inject_workspace_root_context_trusted(
         serde_json::Value::String(workspace_root_string),
     );
     object.insert(
-        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
         serde_json::Value::Object(internal),
     );
     AugmentedToolPayload {
@@ -6274,13 +6265,13 @@ mod tests {
         let augmented = augment_tool_payload_for_kernel("tool.search", payload, &session_context);
 
         assert_eq!(
-            augmented.payload[crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY]
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
                 [crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY]
                 [crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY],
             json!(["file.read", "tool.invoke", "tool.search"])
         );
         assert_eq!(
-            augmented.payload[crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY]
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
                 [crate::tools::LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY]["browser"]["max_sessions"],
             1
         );

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -87,14 +87,17 @@ pub struct BuildVersionInfo {
 
 impl BuildVersionInfo {
     pub fn current() -> Self {
-        let release_build = option_env!("LOONGCLAW_RELEASE_BUILD")
+        let release_build = option_env!("LOONG_RELEASE_BUILD")
+            .or(option_env!("LOONGCLAW_RELEASE_BUILD"))
             .map(|raw| raw.trim())
             .is_some_and(is_truthy_env_value);
-        let short_sha = option_env!("LOONGCLAW_GIT_SHA")
+        let short_sha = option_env!("LOONG_GIT_SHA")
+            .or(option_env!("LOONGCLAW_GIT_SHA"))
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(short_sha);
-        let channel = option_env!("LOONGCLAW_BUILD_CHANNEL")
+        let channel = option_env!("LOONG_BUILD_CHANNEL")
+            .or(option_env!("LOONGCLAW_BUILD_CHANNEL"))
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(Cow::Borrowed)
@@ -152,7 +155,7 @@ pub fn render_brand_banner_lines(width: usize) -> Vec<&'static str> {
     if width >= SPLIT_BANNER_MIN_WIDTH {
         return SPLIT_BANNER.to_vec();
     }
-    vec!["LOONGCLAW"]
+    vec!["LOONG"]
 }
 
 pub fn render_brand_header(
@@ -164,7 +167,7 @@ pub fn render_brand_header(
         .into_iter()
         .map(|line| BrandLine::new(BrandLineRole::Banner, line))
         .collect::<Vec<_>>();
-    let wrap_width = width.max("LOONGCLAW".len());
+    let wrap_width = width.max("LOONG".len());
     lines.extend(
         render_wrapped_text_line("", &build.render_version_line(), wrap_width)
             .into_iter()
@@ -187,7 +190,7 @@ pub fn render_compact_brand_header(
     build: &BuildVersionInfo,
     subtitle: Option<&str>,
 ) -> Vec<BrandLine> {
-    let brand = "LOONGCLAW";
+    let brand = "LOONG";
     let version = build.render_version_line();
     let width = width.max(brand.len());
     let combined = format!("{brand}  {version}");
@@ -562,7 +565,7 @@ mod tests {
     fn presentation_banner_variant_uses_plain_logo_for_narrow_width() {
         let lines = render_brand_banner_lines(32);
 
-        assert_eq!(lines, vec!["LOONGCLAW"]);
+        assert_eq!(lines, vec!["LOONG"]);
     }
 
     #[test]
@@ -581,7 +584,8 @@ mod tests {
 
     #[test]
     fn presentation_current_build_surfaces_embedded_git_trace_metadata_when_available() {
-        let release_build = option_env!("LOONGCLAW_RELEASE_BUILD")
+        let release_build = option_env!("LOONG_RELEASE_BUILD")
+            .or(option_env!("LOONGCLAW_RELEASE_BUILD"))
             .map(str::trim)
             .is_some_and(is_truthy_env_value);
         if release_build {
@@ -590,7 +594,8 @@ mod tests {
 
         let version_line = BuildVersionInfo::current().render_version_line();
 
-        if let Some(short_sha) = option_env!("LOONGCLAW_GIT_SHA")
+        if let Some(short_sha) = option_env!("LOONG_GIT_SHA")
+            .or(option_env!("LOONGCLAW_GIT_SHA"))
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
@@ -600,7 +605,8 @@ mod tests {
             );
         }
 
-        if let Some(channel) = option_env!("LOONGCLAW_BUILD_CHANNEL")
+        if let Some(channel) = option_env!("LOONG_BUILD_CHANNEL")
+            .or(option_env!("LOONGCLAW_BUILD_CHANNEL"))
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
@@ -614,7 +620,7 @@ mod tests {
     #[test]
     fn presentation_style_brand_lines_can_disable_color() {
         let lines = vec![
-            BrandLine::new(BrandLineRole::Banner, "LOONGCLAW"),
+            BrandLine::new(BrandLineRole::Banner, "LOONG"),
             BrandLine::new(BrandLineRole::Version, "v0.1.2 · dev"),
         ];
 
@@ -622,31 +628,31 @@ mod tests {
 
         assert_eq!(
             rendered,
-            vec!["LOONGCLAW".to_owned(), "v0.1.2 · dev".to_owned()]
+            vec!["LOONG".to_owned(), "v0.1.2 · dev".to_owned()]
         );
     }
 
     #[test]
     fn presentation_style_brand_lines_uses_soft_red_banner_by_default() {
-        let lines = vec![BrandLine::new(BrandLineRole::Banner, "LOONGCLAW")];
+        let lines = vec![BrandLine::new(BrandLineRole::Banner, "LOONG")];
 
         let rendered = style_brand_lines(&lines, true);
 
         assert_eq!(
             rendered,
-            vec!["\u{1b}[38;2;253;172;172mLOONGCLAW\u{1b}[0m".to_owned()]
+            vec!["\u{1b}[38;2;253;172;172mLOONG\u{1b}[0m".to_owned()]
         );
     }
 
     #[test]
     fn presentation_style_brand_lines_with_onboard_palette_uses_soft_red_banner() {
-        let lines = vec![BrandLine::new(BrandLineRole::Banner, "LOONGCLAW")];
+        let lines = vec![BrandLine::new(BrandLineRole::Banner, "LOONG")];
 
         let rendered = style_brand_lines_with_palette(&lines, true, ONBOARD_BRAND_PALETTE);
 
         assert_eq!(
             rendered,
-            vec!["\u{1b}[38;2;253;172;172mLOONGCLAW\u{1b}[0m".to_owned()]
+            vec!["\u{1b}[38;2;253;172;172mLOONG\u{1b}[0m".to_owned()]
         );
     }
 
@@ -657,7 +663,7 @@ mod tests {
         let lines = render_compact_brand_header(80, &build, Some("choose model"));
 
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0].text, "LOONGCLAW  v0.1.2 · dev · 1a2b3c4");
+        assert_eq!(lines[0].text, "LOONG  v0.1.2 · dev · 1a2b3c4");
         assert_eq!(lines[1].text, "choose model");
     }
 
@@ -671,7 +677,7 @@ mod tests {
             lines.iter().all(|line| line.text.len() <= 22),
             "compact brand header should respect narrow widths instead of forcing the brand and version onto one overflowing line: {lines:#?}"
         );
-        assert_eq!(lines[0].text, "LOONGCLAW");
+        assert_eq!(lines[0].text, "LOONG");
         assert!(
             lines.iter().any(|line| line.role == BrandLineRole::Version),
             "narrow compact header should keep version information visible on its own wrapped line: {lines:#?}"
@@ -692,7 +698,7 @@ mod tests {
             lines.iter().all(|line| line.text.len() <= 18),
             "full brand header should respect narrow widths for version and subtitle lines: {lines:#?}"
         );
-        assert_eq!(lines[0].text, "LOONGCLAW");
+        assert_eq!(lines[0].text, "LOONG");
         assert!(
             lines
                 .iter()
@@ -711,7 +717,7 @@ mod tests {
     fn presentation_wraps_text_lines_for_narrow_width() {
         let lines = render_wrapped_text_line(
             "source: ",
-            "Codex config at ~/.codex/agents/loongclaw/config.toml",
+            "Codex config at ~/.codex/agents/loong/config.toml",
             48,
         );
 
@@ -719,7 +725,7 @@ mod tests {
             lines,
             vec![
                 "source: Codex config at".to_owned(),
-                "  ~/.codex/agents/loongclaw/config.toml".to_owned(),
+                "  ~/.codex/agents/loong/config.toml".to_owned(),
             ]
         );
     }
@@ -749,7 +755,7 @@ mod tests {
     #[test]
     fn presentation_wraps_display_line_with_label_prefix() {
         let lines = render_wrapped_display_line(
-            "    source: Codex config at ~/.codex/agents/loongclaw/config.toml",
+            "    source: Codex config at ~/.codex/agents/loong/config.toml",
             48,
         );
 
@@ -757,7 +763,7 @@ mod tests {
             lines,
             vec![
                 "    source: Codex config at".to_owned(),
-                "      ~/.codex/agents/loongclaw/config.toml".to_owned(),
+                "      ~/.codex/agents/loong/config.toml".to_owned(),
             ]
         );
     }

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -9,7 +9,7 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 
-use super::config::LoongClawConfig;
+use super::config::LoongConfig;
 #[cfg(test)]
 use super::config::{ProviderKind, ProviderProfileHealthModeConfig};
 
@@ -66,7 +66,7 @@ pub struct ProviderToolSchemaReadiness {
     pub effective_tool_schema_mode: String,
 }
 
-pub fn provider_tool_schema_readiness(config: &LoongClawConfig) -> ProviderToolSchemaReadiness {
+pub fn provider_tool_schema_readiness(config: &LoongConfig) -> ProviderToolSchemaReadiness {
     let provider = &config.provider;
     let runtime_contract = provider_runtime_contract(provider);
     let capability_profile = capability_profile_runtime::ProviderCapabilityProfile::from_provider(
@@ -195,10 +195,7 @@ const MODEL_CATALOG_CACHE_MAX_ENTRIES: usize = 32;
 #[cfg(test)]
 const MODEL_CANDIDATE_COOLDOWN_CACHE_MAX_ENTRIES: usize = 64;
 
-pub fn build_system_message(
-    config: &LoongClawConfig,
-    include_system_prompt: bool,
-) -> Option<Value> {
+pub fn build_system_message(config: &LoongConfig, include_system_prompt: bool) -> Option<Value> {
     request_message_runtime::build_system_message(config, include_system_prompt)
 }
 
@@ -206,7 +203,7 @@ pub(crate) use request_message_runtime::build_projected_context_for_session_with
 pub(crate) use request_message_runtime::project_hydrated_memory_context_for_view_with_binding;
 
 pub fn build_messages_for_session(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
 ) -> CliResult<Vec<Value>> {
@@ -214,7 +211,7 @@ pub fn build_messages_for_session(
 }
 
 pub async fn request_completion(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<String> {
@@ -244,7 +241,7 @@ pub async fn request_completion(
 }
 
 pub async fn request_turn(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     turn_id: &str,
     messages: &[Value],
@@ -262,7 +259,7 @@ pub async fn request_turn(
 }
 
 pub async fn request_turn_in_view(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     turn_id: &str,
     messages: &[Value],
@@ -271,7 +268,7 @@ pub async fn request_turn_in_view(
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
     let session = prepare_provider_request_session(config).await?;
     let tool_runtime_config =
-        crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);
+        crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
     let runtime_tool_view =
         crate::tools::runtime_tool_view_with_runtime_config(&config.tools, &tool_runtime_config);
     let tool_definitions = if tool_view == &runtime_tool_view {
@@ -307,7 +304,7 @@ pub async fn request_turn_in_view(
 }
 
 pub async fn request_turn_streaming(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     turn_id: &str,
     messages: &[Value],
@@ -326,13 +323,13 @@ pub async fn request_turn_streaming(
     .await
 }
 
-pub fn supports_turn_streaming_events(config: &LoongClawConfig) -> bool {
+pub fn supports_turn_streaming_events(config: &LoongConfig) -> bool {
     let runtime_contract = provider_runtime_contract(&config.provider);
     runtime_contract.supports_turn_streaming_events()
 }
 
 pub async fn request_turn_streaming_in_view(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     turn_id: &str,
     messages: &[Value],
@@ -346,7 +343,7 @@ pub async fn request_turn_streaming_in_view(
 
     let session = prepare_provider_request_session(config).await?;
     let tool_runtime_config =
-        crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);
+        crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
     let runtime_tool_view =
         crate::tools::runtime_tool_view_with_runtime_config(&config.tools, &tool_runtime_config);
     let tool_definitions = if tool_view == &runtime_tool_view {
@@ -382,11 +379,11 @@ pub async fn request_turn_streaming_in_view(
     .await
 }
 
-pub async fn fetch_available_models(config: &LoongClawConfig) -> CliResult<Vec<String>> {
+pub async fn fetch_available_models(config: &LoongConfig) -> CliResult<Vec<String>> {
     fetch_available_models_with_profiles(config).await
 }
 
-pub async fn provider_auth_ready(config: &LoongClawConfig) -> bool {
+pub async fn provider_auth_ready(config: &LoongConfig) -> bool {
     if config.provider.resolved_auth_secret().is_some() {
         return true;
     }

--- a/crates/app/src/provider/profile_state_backend.rs
+++ b/crates/app/src/provider/profile_state_backend.rs
@@ -8,7 +8,7 @@ use std::{
     time::Instant,
 };
 
-use crate::config::LoongClawConfig;
+use crate::config::LoongConfig;
 #[cfg(not(test))]
 use crate::config::ProviderProfileStateBackendKind;
 
@@ -130,7 +130,7 @@ impl FileProviderProfileStateBackend {
 
 impl Default for FileProviderProfileStateBackend {
     fn default() -> Self {
-        Self::with_path(crate::config::default_loongclaw_home().join("provider-profile-state.json"))
+        Self::with_path(crate::config::default_loong_home().join("provider-profile-state.json"))
     }
 }
 
@@ -430,7 +430,7 @@ fn default_provider_profile_state_backend() -> Arc<dyn ProviderProfileStateBacke
 
 #[cfg(not(test))]
 fn configured_provider_profile_state_backend(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
 ) -> Arc<dyn ProviderProfileStateBackend> {
     match config.provider.resolved_profile_state_backend() {
         ProviderProfileStateBackendKind::File => {
@@ -443,7 +443,7 @@ fn configured_provider_profile_state_backend(
                     .provider
                     .resolved_profile_state_sqlite_path_with_default();
                 let legacy_json =
-                    crate::config::default_loongclaw_home().join("provider-profile-state.json");
+                    crate::config::default_loong_home().join("provider-profile-state.json");
                 Arc::new(SqliteProviderProfileStateBackend::with_legacy_fallback(
                     state_path,
                     Some(legacy_json),
@@ -458,7 +458,7 @@ fn configured_provider_profile_state_backend(
 }
 
 #[cfg(not(test))]
-pub(super) fn ensure_provider_profile_state_backend(config: &LoongClawConfig) {
+pub(super) fn ensure_provider_profile_state_backend(config: &LoongConfig) {
     if PROVIDER_PROFILE_STATE_BACKEND.get().is_some() {
         return;
     }
@@ -467,7 +467,7 @@ pub(super) fn ensure_provider_profile_state_backend(config: &LoongClawConfig) {
 }
 
 #[cfg(test)]
-pub(super) fn ensure_provider_profile_state_backend(_config: &LoongClawConfig) {}
+pub(super) fn ensure_provider_profile_state_backend(_config: &LoongConfig) {}
 
 pub(super) fn with_provider_profile_states<R>(
     run: impl FnOnce(&mut ProviderProfileStateStore) -> R,
@@ -502,3 +502,18 @@ static PROVIDER_PROFILE_STATE_PERSISTENCE_METRICS: OnceLock<
 > = OnceLock::new();
 static PROVIDER_PROFILE_STATE_BACKEND: OnceLock<Arc<dyn ProviderProfileStateBackend>> =
     OnceLock::new();
+
+#[cfg(test)]
+mod tests {
+    use super::FileProviderProfileStateBackend;
+
+    #[test]
+    fn file_profile_state_backend_defaults_to_loong_home() {
+        let backend = FileProviderProfileStateBackend::default();
+
+        assert_eq!(
+            backend.state_path(),
+            crate::config::default_loong_home().join("provider-profile-state.json")
+        );
+    }
+}

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 use super::runtime_binding::ProviderRuntimeBinding;
 use crate::CliResult;
 use crate::KernelContext;
-use crate::config::LoongClawConfig;
+use crate::config::LoongConfig;
 use crate::conversation::{
     ContextArtifactDescriptor, ContextArtifactKind, PromptCompiler, PromptFragment, PromptLane,
     PromptRenderPolicy, ToolOutputStreamingPolicy,
@@ -34,16 +34,16 @@ struct BasePromptProjection {
 }
 
 pub(super) fn build_system_message(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
 ) -> Option<Value> {
-    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+    let runtime_tool_view = tools::runtime_tool_view_from_loong_config(config);
 
     build_system_message_for_view(config, include_system_prompt, &runtime_tool_view)
 }
 
 pub(super) fn build_system_message_for_view(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
 ) -> Option<Value> {
@@ -51,7 +51,7 @@ pub(super) fn build_system_message_for_view(
         config,
         include_system_prompt,
         tool_view,
-        &tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None),
+        &tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None),
     );
 
     projection.system_message
@@ -59,7 +59,7 @@ pub(super) fn build_system_message_for_view(
 
 #[cfg(test)]
 pub(super) async fn build_base_messages_with_binding(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     binding: ProviderRuntimeBinding<'_>,
 ) -> Vec<Value> {
@@ -67,7 +67,7 @@ pub(super) async fn build_base_messages_with_binding(
         return Vec::new();
     }
 
-    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+    let runtime_tool_view = tools::runtime_tool_view_from_loong_config(config);
     let projection = build_base_prompt_projection_for_view_with_binding(
         config,
         include_system_prompt,
@@ -80,7 +80,7 @@ pub(super) async fn build_base_messages_with_binding(
 }
 
 async fn build_base_prompt_projection_for_view_with_binding(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     binding: ProviderRuntimeBinding<'_>,
@@ -89,14 +89,14 @@ async fn build_base_prompt_projection_for_view_with_binding(
         config,
         include_system_prompt,
         tool_view,
-        &tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None),
+        &tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None),
         binding,
     )
     .await
 }
 
 fn build_base_prompt_projection_with_tool_runtime_config(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
@@ -122,7 +122,7 @@ fn build_base_prompt_projection_with_tool_runtime_config(
 
 #[cfg(test)]
 fn build_system_message_with_tool_runtime_config(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
@@ -138,7 +138,7 @@ fn build_system_message_with_tool_runtime_config(
 }
 
 async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
@@ -168,7 +168,7 @@ async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
 }
 
 fn build_base_prompt_projection_from_runtime_self_model(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
@@ -209,7 +209,7 @@ fn build_base_prompt_projection_from_runtime_self_model(
 }
 
 fn build_prompt_fragments_from_runtime_self_model(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
     runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
@@ -314,9 +314,7 @@ fn build_prompt_fragments_from_runtime_self_model(
     prompt_fragments
 }
 
-fn render_deferred_tool_text_workflow_section_if_needed(
-    config: &LoongClawConfig,
-) -> Option<String> {
+fn render_deferred_tool_text_workflow_section_if_needed(config: &LoongConfig) -> Option<String> {
     let tool_schema_mode = config.provider.resolved_tool_schema_mode_config();
     let tool_schema_disabled =
         tool_schema_mode == crate::config::ProviderToolSchemaModeConfig::Disabled;
@@ -479,11 +477,11 @@ pub(super) fn push_history_message(messages: &mut Vec<Value>, role: &str, conten
 }
 
 pub(super) fn build_messages_for_session(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
 ) -> CliResult<Vec<Value>> {
-    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+    let runtime_tool_view = tools::runtime_tool_view_from_loong_config(config);
 
     build_projected_context_for_session_in_view(
         config,
@@ -496,11 +494,11 @@ pub(super) fn build_messages_for_session(
 
 #[cfg(test)]
 pub(crate) fn build_projected_context_for_session(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
 ) -> CliResult<ProjectedMessageContext> {
-    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+    let runtime_tool_view = tools::runtime_tool_view_from_loong_config(config);
 
     build_projected_context_for_session_in_view(
         config,
@@ -511,12 +509,12 @@ pub(crate) fn build_projected_context_for_session(
 }
 
 pub(crate) async fn build_projected_context_for_session_with_binding(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
     binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<ProjectedMessageContext> {
-    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+    let runtime_tool_view = tools::runtime_tool_view_from_loong_config(config);
 
     build_projected_context_for_session_in_view_with_binding(
         config,
@@ -529,7 +527,7 @@ pub(crate) async fn build_projected_context_for_session_with_binding(
 }
 
 pub(crate) fn build_projected_context_for_session_in_view(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
     tool_view: &ToolView,
@@ -560,7 +558,7 @@ pub(crate) fn build_projected_context_for_session_in_view(
             config,
             include_system_prompt,
             tool_view,
-            &tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None),
+            &tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None),
         );
         let system_message = projection.system_message;
         let prompt_fragments = projection.prompt_fragments;
@@ -574,7 +572,7 @@ pub(crate) fn build_projected_context_for_session_in_view(
 }
 
 pub(crate) async fn build_projected_context_for_session_in_view_with_binding(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: &str,
     include_system_prompt: bool,
     tool_view: &ToolView,
@@ -616,16 +614,16 @@ pub(crate) async fn build_projected_context_for_session_in_view_with_binding(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn resolved_workspace_root(config: &LoongClawConfig) -> Option<std::path::PathBuf> {
+fn resolved_workspace_root(config: &LoongConfig) -> Option<std::path::PathBuf> {
     let tool_runtime_config =
-        tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);
+        tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
     let workspace_root = tool_runtime_config.effective_workspace_root()?;
     let workspace_root = workspace_root.to_path_buf();
     Some(workspace_root)
 }
 
 pub(crate) async fn project_hydrated_memory_context_for_view_with_binding(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     binding: ProviderRuntimeBinding<'_>,
@@ -663,7 +661,7 @@ pub(crate) async fn project_hydrated_memory_context_for_view_with_binding(
 }
 
 pub(crate) fn project_hydrated_memory_context_for_view(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     #[cfg(feature = "memory-sqlite")] hydrated: &memory::HydratedMemoryContext,
@@ -672,7 +670,7 @@ pub(crate) fn project_hydrated_memory_context_for_view(
         config,
         include_system_prompt,
         tool_view,
-        &tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None),
+        &tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None),
     );
     let system_message = projection.system_message;
     let mut prompt_fragments = projection.prompt_fragments;
@@ -887,7 +885,7 @@ mod tests {
 
     #[test]
     fn build_system_message_returns_none_when_disabled() {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         assert_eq!(build_system_message(&config, false), None);
     }
 
@@ -931,7 +929,7 @@ mod tests {
     #[test]
     fn project_hydrated_memory_context_skips_tool_discovery_fragment_when_system_prompt_is_disabled()
      {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let hydrated = hydrated_context_with_tool_discovery_event();
         let projected = project_hydrated_memory_context_for_view(
             &config,
@@ -948,7 +946,7 @@ mod tests {
     #[tokio::test]
     async fn project_hydrated_memory_context_with_binding_skips_tool_discovery_fragment_when_system_prompt_is_disabled()
      {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let hydrated = hydrated_context_with_tool_discovery_event();
         let projected = project_hydrated_memory_context_for_view_with_binding(
             &config,
@@ -965,7 +963,7 @@ mod tests {
 
     #[test]
     fn projected_context_exposes_prompt_fragments_for_system_prompt_sources() {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let projected =
             build_projected_context_for_session(&config, "prompt-fragment-session", true)
                 .expect("build projected context");
@@ -996,7 +994,7 @@ mod tests {
         let harness = TurnTestHarness::with_capabilities(capabilities);
         let agents_path = harness.temp_dir.join("AGENTS.md");
         let agents_text = "Do not read me when system prompts are disabled.";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
 
@@ -1037,7 +1035,7 @@ mod tests {
         let harness = TurnTestHarness::with_capabilities(capabilities);
         let agents_path = harness.temp_dir.join("AGENTS.md");
         let agents_text = "Only existing runtime-self files should be read.";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
 
@@ -1080,7 +1078,7 @@ mod tests {
         let decoy_tool_root = harness.temp_dir.join("tool-root-decoy");
         let agents_path = harness.temp_dir.join("AGENTS.md");
         let agents_text = "Runtime self should follow the runtime workspace root.";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::create_dir_all(&decoy_tool_root).expect("create decoy tool root");
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
@@ -1116,7 +1114,7 @@ mod tests {
 
     #[test]
     fn build_system_message_includes_deferred_tool_text_workflow_when_tool_schema_disabled() {
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.provider.tool_schema_mode = crate::config::ProviderToolSchemaModeConfig::Disabled;
 
         let system_message =
@@ -1137,7 +1135,7 @@ mod tests {
         ];
 
         for tool_schema_mode in non_disabled_modes {
-            let mut config = LoongClawConfig::default();
+            let mut config = LoongConfig::default();
             config.provider.tool_schema_mode = tool_schema_mode;
 
             let system_message =
@@ -1157,7 +1155,7 @@ mod tests {
         let agents_text = "a".repeat(1_024);
         let user_text = "later user context should still surface a truncation notice";
         let total_budget = agents_text.chars().count();
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
         std::fs::write(&user_path, user_text).expect("write USER");
@@ -1187,7 +1185,7 @@ mod tests {
         let user_text =
             "later user context raw prefix should not leak into compact truncation rendering";
         let total_budget = agents_text.chars().count() + compact_budget;
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
         std::fs::write(&user_path, user_text).expect("write USER");
@@ -1210,7 +1208,7 @@ mod tests {
         let harness = TurnTestHarness::new();
         let agents_path = harness.temp_dir.join("AGENTS.md");
         let agents_text = "runtime self should still load for binding-aware prompts";
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
 
@@ -1237,7 +1235,7 @@ mod tests {
 
     #[test]
     fn build_system_message_includes_custom_prompt_and_capability_snapshot() {
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.cli.prompt_pack_id = None;
         config.cli.personality = None;
         config.cli.system_prompt = "Stay concise and technical.".to_owned();
@@ -1278,7 +1276,7 @@ mod tests {
 
     #[test]
     fn message_builder_uses_rendered_prompt_from_pack_metadata() {
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.cli.personality = Some(crate::prompt::PromptPersonality::Hermit);
         config.cli.system_prompt = String::new();
         let session_id = format!(
@@ -1305,7 +1303,7 @@ mod tests {
 
     #[test]
     fn message_builder_keeps_legacy_inline_prompt_when_pack_is_disabled() {
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.cli.prompt_pack_id = None;
         config.cli.personality = None;
         config.cli.system_prompt = "You are a legacy inline prompt.".to_owned();
@@ -1340,7 +1338,7 @@ mod tests {
         std::fs::write(&identity_path, identity_text).expect("write IDENTITY");
         std::fs::write(&user_path, user_text).expect("write USER");
 
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let tool_view = tools::runtime_tool_view();
 
         let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig {
@@ -1380,7 +1378,7 @@ mod tests {
 
         std::fs::write(workspace_root.join("AGENTS.md"), agents_text).expect("write AGENTS");
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         let legacy_profile_note =
             "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
         config.memory.profile_note = Some(legacy_profile_note.to_owned());
@@ -1416,7 +1414,7 @@ mod tests {
         let workspace_identity = "# Identity\n\n- Name: Workspace build copilot";
         std::fs::write(&identity_path, workspace_identity).expect("write IDENTITY");
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         let legacy_profile_note =
             "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
         config.memory.profile_note = Some(legacy_profile_note.to_owned());
@@ -1452,7 +1450,7 @@ mod tests {
 
         std::fs::write(&soul_path, soul_text).expect("write SOUL");
 
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let tool_view = tools::runtime_tool_view();
         let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig {
             file_root: Some(workspace_root.to_path_buf()),
@@ -1482,7 +1480,7 @@ mod tests {
         let db_path = tmp.join("provider-summary.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.memory.sqlite_path = db_path.display().to_string();
         config.memory.profile = MemoryProfile::WindowPlusSummary;
         config.memory.sliding_window = 2;
@@ -1538,7 +1536,7 @@ mod tests {
         .expect("write daily durable memory");
 
         let db_path = workspace_root.join("provider-durable-recall.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(workspace_root.display().to_string());
         config.memory.sqlite_path = db_path.display().to_string();
 
@@ -1572,7 +1570,7 @@ mod tests {
         let curated_memory_path = workspace_root.join("MEMORY.md");
         let recent_daily_path = memory_dir.join("2026-03-23.md");
         let db_path = temp_dir.path().join("provider-durable-recall-env.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
 
         std::fs::create_dir_all(&memory_dir).expect("create memory dir");
         std::fs::create_dir_all(&decoy_tool_root).expect("create decoy tool root");
@@ -1632,7 +1630,7 @@ mod tests {
         .expect("write daily durable memory");
 
         let db_path = workspace_root.join("provider-workspace-recall.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(workspace_root.display().to_string());
         config.memory.system = crate::config::MemorySystemKind::WorkspaceRecall;
         config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
@@ -1723,7 +1721,7 @@ mod tests {
         .expect("write identity-like durable memory");
 
         let db_path = workspace_root.join("provider-durable-recall-identity.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(workspace_root.display().to_string());
         config.memory.sqlite_path = db_path.display().to_string();
 
@@ -1781,7 +1779,7 @@ mod tests {
         std::fs::write(&curated_memory_path, memory_text).expect("write curated memory");
 
         let db_path = workspace_root.join("provider-durable-recall-governance.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(workspace_root.display().to_string());
         config.memory.sqlite_path = db_path.display().to_string();
 
@@ -1865,7 +1863,7 @@ mod tests {
         .expect("write curated memory");
 
         let db_path = workspace_root.join("provider-durable-recall-missing-root.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.memory.sqlite_path = db_path.display().to_string();
 
         let messages = build_messages_for_session(&config, "durable-recall-without-root", true)
@@ -1893,7 +1891,7 @@ mod tests {
         std::fs::write(&agents_path, oversized_content).expect("write oversized AGENTS");
 
         let db_path = workspace_root.join("provider-runtime-self-budget.sqlite3");
-        let mut config = LoongClawConfig::default();
+        let mut config = LoongConfig::default();
         config.tools.file_root = Some(workspace_root.display().to_string());
         config.memory.sqlite_path = db_path.display().to_string();
 

--- a/crates/app/src/provider/request_payload_runtime.rs
+++ b/crates/app/src/provider/request_payload_runtime.rs
@@ -1,6 +1,6 @@
 use serde_json::{Value, json};
 
-use crate::config::{LoongClawConfig, ReasoningEffort};
+use crate::config::{LoongConfig, ReasoningEffort};
 
 use super::capability_profile_runtime::ProviderCapabilityProfile;
 use super::contracts::{
@@ -13,7 +13,7 @@ const ANTHROPIC_DEFAULT_MAX_TOKENS: u32 = 4_096;
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn build_completion_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -33,7 +33,7 @@ pub(super) fn build_completion_request_body(
 }
 
 pub(super) fn build_completion_request_body_with_capability(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -67,7 +67,7 @@ pub(super) fn build_completion_request_body_with_capability(
 }
 
 fn build_chat_completions_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -86,7 +86,7 @@ fn build_chat_completions_request_body(
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn build_turn_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -111,7 +111,7 @@ pub(super) fn build_turn_request_body(
 }
 
 pub(super) fn build_turn_request_body_with_capability(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -176,7 +176,7 @@ pub(super) fn build_turn_request_body_with_capability(
 }
 
 fn build_openai_compatible_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -209,7 +209,7 @@ fn build_openai_compatible_request_body(
 }
 
 fn build_anthropic_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -248,7 +248,7 @@ fn build_anthropic_request_body(
 }
 
 fn build_bedrock_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     payload_mode: CompletionPayloadMode,
     include_tool_schema: bool,
@@ -296,7 +296,7 @@ fn build_bedrock_request_body(
 }
 
 fn build_google_generate_content_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     payload_mode: CompletionPayloadMode,
     include_tool_schema: bool,
@@ -1010,7 +1010,7 @@ fn openai_tool_definition_to_google(tool_definition: &Value) -> Option<Value> {
 }
 
 fn build_responses_request_body(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     messages: &[Value],
     model: &str,
     payload_mode: CompletionPayloadMode,
@@ -1141,7 +1141,7 @@ fn extract_request_message_text(content: Option<&Value>) -> Option<String> {
 
 fn apply_common_payload_fields(
     body: &mut serde_json::Map<String, Value>,
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     payload_mode: CompletionPayloadMode,
     capability: ProviderCapabilityContract,
 ) {
@@ -1168,7 +1168,7 @@ fn apply_common_payload_fields(
 
 fn apply_common_reasoning_and_temperature_fields(
     body: &mut serde_json::Map<String, Value>,
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     payload_mode: CompletionPayloadMode,
 ) {
     if payload_mode.temperature_field == TemperatureField::Include {

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -989,6 +989,9 @@ fn attach_provider_parse_telemetry(
     tool_count: usize,
     error_code: Option<&str>,
 ) {
+    const PROVIDER_PARSE_META_KEY: &str = "loong_provider_parse";
+    const LEGACY_PROVIDER_PARSE_META_KEY: &str = "loongclaw_provider_parse";
+
     let Some(message) = raw_meta.as_object_mut() else {
         return;
     };
@@ -1003,13 +1006,15 @@ fn attach_provider_parse_telemetry(
         );
     }
 
-    let provider_parse = message
-        .entry("loongclaw_provider_parse".to_owned())
-        .or_insert_with(|| Value::Object(serde_json::Map::new()));
-    let Some(provider_parse) = provider_parse.as_object_mut() else {
-        return;
-    };
-    provider_parse.insert(key.to_owned(), Value::Object(entry));
+    for parse_key in [PROVIDER_PARSE_META_KEY, LEGACY_PROVIDER_PARSE_META_KEY] {
+        let provider_parse = message
+            .entry(parse_key.to_owned())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let Some(provider_parse) = provider_parse.as_object_mut() else {
+            continue;
+        };
+        provider_parse.insert(key.to_owned(), Value::Object(entry.clone()));
+    }
 }
 
 fn extract_json_tool_call_turn(
@@ -2962,12 +2967,16 @@ mod tests {
             "lease-shell-inline"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["status"],
+            turn.raw_meta["loong_provider_parse"]["inline_function"]["status"],
             "parsed"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["tool_count"],
+            turn.raw_meta["loong_provider_parse"]["inline_function"]["tool_count"],
             1
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["status"],
+            "parsed"
         );
     }
 
@@ -3030,12 +3039,16 @@ mod tests {
             })
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            turn.raw_meta["loong_provider_parse"]["json_tool_block"]["status"],
             "parsed"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["tool_count"],
+            turn.raw_meta["loong_provider_parse"]["json_tool_block"]["tool_count"],
             1
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            "parsed"
         );
     }
 
@@ -3139,6 +3152,10 @@ mod tests {
                 "query": "read note.md",
                 "limit": 3
             })
+        );
+        assert_eq!(
+            turn.raw_meta["loong_provider_parse"]["invoke_block"]["status"],
+            "parsed"
         );
         assert_eq!(
             turn.raw_meta["loongclaw_provider_parse"]["invoke_block"]["status"],
@@ -3318,12 +3335,16 @@ mod tests {
             "let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": \"{bad\"\n}"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            turn.raw_meta["loong_provider_parse"]["json_tool_block"]["status"],
             "malformed"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["error_code"],
+            turn.raw_meta["loong_provider_parse"]["json_tool_block"]["error_code"],
             "invalid_json"
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            "malformed"
         );
     }
 
@@ -3548,12 +3569,16 @@ mod tests {
         );
         assert!(turn.tool_intents.is_empty());
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["status"],
+            turn.raw_meta["loong_provider_parse"]["inline_function"]["status"],
             "malformed"
         );
         assert_eq!(
-            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["error_code"],
+            turn.raw_meta["loong_provider_parse"]["inline_function"]["error_code"],
             "missing_function_close"
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["inline_function"]["status"],
+            "malformed"
         );
     }
 

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -461,33 +461,29 @@ pub(super) fn append_prompt_cache_headers(
 
     if let Some(session_id) = session_id {
         let hashed_session_id = hash_runtime_identifier(session_id);
-        insert_runtime_header(
-            headers,
-            "x-loongclaw-session-id",
-            hashed_session_id.as_str(),
-        )?;
+        insert_runtime_header(headers, "x-loong-session-id", hashed_session_id.as_str())?;
     }
     if let Some(turn_id) = turn_id {
         let hashed_turn_id = hash_runtime_identifier(turn_id);
-        insert_runtime_header(headers, "x-loongclaw-turn-id", hashed_turn_id.as_str())?;
+        insert_runtime_header(headers, "x-loong-turn-id", hashed_turn_id.as_str())?;
     }
     if let Some(stable_prefix_sha256) = plan.stable_prefix_sha256.as_deref() {
         insert_runtime_header(
             headers,
-            "x-loongclaw-stable-prefix-sha256",
+            "x-loong-stable-prefix-sha256",
             stable_prefix_sha256,
         )?;
     }
     if let Some(cached_prefix_sha256) = plan.cached_prefix_sha256.as_deref() {
         insert_runtime_header(
             headers,
-            "x-loongclaw-cached-prefix-sha256",
+            "x-loong-cached-prefix-sha256",
             cached_prefix_sha256,
         )?;
     }
     insert_runtime_header(
         headers,
-        "x-loongclaw-cache-eligible",
+        "x-loong-cache-eligible",
         if plan.cache_eligible { "true" } else { "false" },
     )?;
 
@@ -882,24 +878,24 @@ mod tests {
 
         assert_eq!(
             headers
-                .get("x-loongclaw-session-id")
+                .get("x-loong-session-id")
                 .and_then(|value| value.to_str().ok()),
             Some(hash_runtime_identifier("session-1").as_str())
         );
         assert_eq!(
             headers
-                .get("x-loongclaw-turn-id")
+                .get("x-loong-turn-id")
                 .and_then(|value| value.to_str().ok()),
             Some(hash_runtime_identifier("turn-1").as_str())
         );
         assert_eq!(
             headers
-                .get("x-loongclaw-cache-eligible")
+                .get("x-loong-cache-eligible")
                 .and_then(|value| value.to_str().ok()),
             Some("true")
         );
-        assert!(headers.contains_key("x-loongclaw-stable-prefix-sha256"));
-        assert!(headers.contains_key("x-loongclaw-cached-prefix-sha256"));
+        assert!(headers.contains_key("x-loong-stable-prefix-sha256"));
+        assert!(headers.contains_key("x-loong-cached-prefix-sha256"));
     }
 
     #[test]

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -14,8 +14,15 @@ pub fn initialize_runtime_environment(
     resolved_config_path: Option<&Path>,
 ) {
     match resolved_config_path {
-        Some(path) => set_env_var("LOONGCLAW_CONFIG_PATH", path.display().to_string()),
-        None => remove_env_var("LOONGCLAW_CONFIG_PATH"),
+        Some(path) => {
+            let value = path.display().to_string();
+            set_env_var("LOONG_CONFIG_PATH", value.clone());
+            set_env_var("LOONGCLAW_CONFIG_PATH", value);
+        }
+        None => {
+            remove_env_var("LOONG_CONFIG_PATH");
+            remove_env_var("LOONGCLAW_CONFIG_PATH");
+        }
     }
 
     set_env_var(

--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -25,6 +25,7 @@ const BASH_EXEC_ALLOWED_FIELDS: &[&str] = &[
     "command",
     "cwd",
     "timeout_ms",
+    super::LOONG_INTERNAL_TOOL_CONTEXT_KEY,
     super::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY,
 ];
 

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -580,6 +580,7 @@ fn parse_optional_string(payload: &Map<String, Value>, key: &str) -> Option<Stri
 
 fn browser_scope_id_from_payload(payload: &Map<String, Value>) -> String {
     parse_optional_string(payload, super::BROWSER_SESSION_SCOPE_FIELD)
+        .or_else(|| parse_optional_string(payload, super::LEGACY_BROWSER_SESSION_SCOPE_FIELD))
         .unwrap_or_else(|| DEFAULT_BROWSER_SCOPE_ID.to_owned())
 }
 

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -562,6 +562,7 @@ fn browser_companion_command(
 fn browser_companion_scope_id_from_payload(payload: &Map<String, Value>) -> String {
     payload
         .get(super::BROWSER_SESSION_SCOPE_FIELD)
+        .or_else(|| payload.get(super::LEGACY_BROWSER_SESSION_SCOPE_FIELD))
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -572,6 +573,7 @@ fn browser_companion_scope_id_from_payload(payload: &Map<String, Value>) -> Stri
 fn browser_companion_arguments(payload: &Map<String, Value>) -> Value {
     let mut arguments = payload.clone();
     arguments.remove(super::BROWSER_SESSION_SCOPE_FIELD);
+    arguments.remove(super::LEGACY_BROWSER_SESSION_SCOPE_FIELD);
     arguments.remove("session_id");
     Value::Object(arguments)
 }

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -238,12 +238,12 @@ struct GrantSelectorPayload {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct LoongclawInternalToolPayload {
+struct LoongInternalToolPayload {
     ingress: Option<FeishuInternalIngressPayload>,
     feishu_callback: Option<FeishuInternalCallbackPayload>,
 }
 
-impl LoongclawInternalToolPayload {
+impl LoongInternalToolPayload {
     fn ingress_requested_account_id(&self) -> Option<&str> {
         self.ingress_configured_account_id()
             .or_else(|| self.ingress_account_id())
@@ -553,8 +553,8 @@ impl FeishuInternalCallbackPayload {
 struct FeishuWhoamiPayload {
     account_id: Option<String>,
     open_id: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -567,8 +567,8 @@ struct FeishuDocCreatePayload {
     content: Option<String>,
     content_path: Option<String>,
     content_type: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -580,8 +580,8 @@ struct FeishuDocAppendPayload {
     content: Option<String>,
     content_path: Option<String>,
     content_type: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -591,8 +591,8 @@ struct FeishuDocReadPayload {
     selector: GrantSelectorPayload,
     url: String,
     lang: Option<u8>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -607,8 +607,8 @@ struct FeishuMessagesHistoryPayload {
     sort_type: Option<String>,
     page_size: Option<usize>,
     page_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -617,8 +617,8 @@ struct FeishuMessagesGetPayload {
     #[serde(flatten)]
     selector: GrantSelectorPayload,
     message_id: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -638,8 +638,8 @@ struct FeishuMessagesSearchPayload {
     chat_type: Option<String>,
     start_time: Option<String>,
     end_time: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -652,8 +652,8 @@ struct FeishuMessagesResourceGetPayload {
     #[serde(rename = "type")]
     resource_type: String,
     save_as: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -672,8 +672,8 @@ struct FeishuMessagesSendPayload {
     file_path: Option<String>,
     file_type: Option<String>,
     uuid: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -692,8 +692,8 @@ struct FeishuMessagesReplyPayload {
     file_type: Option<String>,
     reply_in_thread: Option<bool>,
     uuid: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -705,8 +705,8 @@ struct FeishuCardUpdatePayload {
     markdown: Option<String>,
     shared: bool,
     open_ids: Option<Vec<String>>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 impl Default for FeishuCardUpdatePayload {
@@ -718,7 +718,7 @@ impl Default for FeishuCardUpdatePayload {
             markdown: None,
             shared: false,
             open_ids: None,
-            internal: LoongclawInternalToolPayload::default(),
+            internal: LoongInternalToolPayload::default(),
         }
     }
 }
@@ -766,8 +766,8 @@ struct FeishuCalendarListPayload {
     page_size: Option<usize>,
     page_token: Option<String>,
     sync_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -778,8 +778,8 @@ struct FeishuBitableListPayload {
     app_token: String,
     page_token: Option<String>,
     page_size: Option<usize>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -789,8 +789,8 @@ struct FeishuBitableAppCreatePayload {
     selector: GrantSelectorPayload,
     name: String,
     folder_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -799,8 +799,8 @@ struct FeishuBitableAppGetPayload {
     #[serde(flatten)]
     selector: GrantSelectorPayload,
     app_token: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -811,8 +811,8 @@ struct FeishuBitableAppListPayload {
     folder_token: Option<String>,
     page_token: Option<String>,
     page_size: Option<usize>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -823,8 +823,8 @@ struct FeishuBitableAppPatchPayload {
     app_token: String,
     name: Option<String>,
     is_advanced: Option<bool>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -835,8 +835,8 @@ struct FeishuBitableAppCopyPayload {
     app_token: String,
     name: String,
     folder_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -847,8 +847,8 @@ struct FeishuBitableRecordCreatePayload {
     app_token: String,
     table_id: String,
     fields: Value,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -860,8 +860,8 @@ struct FeishuBitableRecordUpdatePayload {
     table_id: String,
     record_id: String,
     fields: Value,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -872,8 +872,8 @@ struct FeishuBitableRecordDeletePayload {
     app_token: String,
     table_id: String,
     record_id: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -884,8 +884,8 @@ struct FeishuBitableRecordBatchCreatePayload {
     app_token: String,
     table_id: String,
     records: Vec<Value>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -896,8 +896,8 @@ struct FeishuBitableRecordBatchUpdatePayload {
     app_token: String,
     table_id: String,
     records: Vec<Value>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -908,8 +908,8 @@ struct FeishuBitableRecordBatchDeletePayload {
     app_token: String,
     table_id: String,
     records: Vec<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -923,8 +923,8 @@ struct FeishuBitableFieldCreatePayload {
     #[serde(rename = "type")]
     field_type: i64,
     property: Option<Value>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -937,8 +937,8 @@ struct FeishuBitableFieldListPayload {
     view_id: Option<String>,
     page_size: Option<usize>,
     page_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -953,8 +953,8 @@ struct FeishuBitableFieldUpdatePayload {
     #[serde(rename = "type")]
     field_type: i64,
     property: Option<Value>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -965,8 +965,8 @@ struct FeishuBitableFieldDeletePayload {
     app_token: String,
     table_id: String,
     field_id: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -978,8 +978,8 @@ struct FeishuBitableViewCreatePayload {
     table_id: String,
     view_name: String,
     view_type: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -990,8 +990,8 @@ struct FeishuBitableViewGetPayload {
     app_token: String,
     table_id: String,
     view_id: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1003,8 +1003,8 @@ struct FeishuBitableViewListPayload {
     table_id: String,
     page_size: Option<usize>,
     page_token: Option<String>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1016,8 +1016,8 @@ struct FeishuBitableViewPatchPayload {
     table_id: String,
     view_id: String,
     view_name: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1029,8 +1029,8 @@ struct FeishuBitableTableCreatePayload {
     name: String,
     default_view_name: Option<String>,
     fields: Option<Vec<Value>>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1041,8 +1041,8 @@ struct FeishuBitableTablePatchPayload {
     app_token: String,
     table_id: String,
     name: String,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1052,8 +1052,8 @@ struct FeishuBitableTableBatchCreatePayload {
     selector: GrantSelectorPayload,
     app_token: String,
     tables: Vec<Value>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1070,8 +1070,8 @@ struct FeishuBitableRecordSearchPayload {
     sort: Option<Value>,
     field_names: Option<Vec<String>>,
     automatic_fields: Option<bool>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1087,8 +1087,8 @@ struct FeishuCalendarFreebusyPayload {
     include_external_calendar: Option<bool>,
     only_busy: Option<bool>,
     need_rsvp_status: Option<bool>,
-    #[serde(default, rename = "_loongclaw")]
-    internal: LoongclawInternalToolPayload,
+    #[serde(default, rename = "_loong", alias = "_loongclaw")]
+    internal: LoongInternalToolPayload,
 }
 
 #[cfg(test)]
@@ -1931,7 +1931,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_card_update",
-        "Update a Feishu interactive card after a card callback. Pass markdown for a standard markdown card or card for full Feishu card JSON. When called from a Feishu callback turn, LoongClaw can infer account_id, callback_token, and a default exclusive open_ids target from internal callback context. Set shared=true for shared-card updates so callback operator defaults are suppressed. Callback tokens expire after 30 minutes and can be used at most twice.",
+        "Update a Feishu interactive card after a card callback. Pass markdown for a standard markdown card or card for full Feishu card JSON. When called from a Feishu callback turn, Loong can infer account_id, callback_token, and a default exclusive open_ids target from internal callback context. Set shared=true for shared-card updates so callback operator defaults are suppressed. Callback tokens expire after 30 minutes and can be used at most twice.",
         json!({
             "type": "object",
             "properties": {
@@ -1960,7 +1960,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
                     "items": {
                         "type": "string"
                     },
-                    "description": "Optional explicit open_id targets for non-shared cards. For shared cards, either omit open_ids or set shared=true. When omitted in a callback turn without shared=true, LoongClaw can default to the callback operator open_id."
+                    "description": "Optional explicit open_id targets for non-shared cards. For shared cards, either omit open_ids or set shared=true. When omitted in a callback turn without shared=true, Loong can default to the callback operator open_id."
                 }
             },
             "required": [],
@@ -2147,7 +2147,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_get",
-        "Fetch one Feishu message detail using a tenant token resolved from the selected account grant. When called from a Feishu conversation, LoongClaw can infer the account and current message from ingress context.",
+        "Fetch one Feishu message detail using a tenant token resolved from the selected account grant. When called from a Feishu conversation, Loong can infer the account and current message from ingress context.",
         json!({
             "type": "object",
             "properties": {
@@ -2172,7 +2172,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_resource_get",
-        "Explicitly download one Feishu message image or file resource using a tenant token resolved from the selected account grant and save it under the configured file root. When called from a Feishu conversation, LoongClaw can infer the source message from ingress context and can infer the resource key or type when the current Feishu ingress carries exactly one Feishu message resource or when either payload.file_key or payload.type uniquely identifies one current ingress resource for the same message, as long as payload.message_id is omitted or matches the current ingress message. If the current Feishu ingress summary exposes resource_inventory, choose one entry and copy its file_key plus payload_type into this tool call when multiple resources are present. Outside the current ingress turn, also pass the source message_id explicitly. This does not perform implicit webhook binary downloads.",
+        "Explicitly download one Feishu message image or file resource using a tenant token resolved from the selected account grant and save it under the configured file root. When called from a Feishu conversation, Loong can infer the source message from ingress context and can infer the resource key or type when the current Feishu ingress carries exactly one Feishu message resource or when either payload.file_key or payload.type uniquely identifies one current ingress resource for the same message, as long as payload.message_id is omitted or matches the current ingress message. If the current Feishu ingress summary exposes resource_inventory, choose one entry and copy its file_key plus payload_type into this tool call when multiple resources are present. Outside the current ingress turn, also pass the source message_id explicitly. This does not perform implicit webhook binary downloads.",
         json!({
             "type": "object",
             "properties": {
@@ -2209,7 +2209,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_history",
-        "List Feishu message history using a tenant token resolved from the selected account grant. When called from a Feishu conversation, LoongClaw can infer the current chat or thread container from ingress context.",
+        "List Feishu message history using a tenant token resolved from the selected account grant. When called from a Feishu conversation, Loong can infer the current chat or thread container from ingress context.",
         json!({
             "type": "object",
             "properties": {
@@ -2254,7 +2254,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_search",
-        "Search Feishu messages using the selected account grant. When called from the current Feishu conversation, LoongClaw can infer the account and default chat scope from ingress context.",
+        "Search Feishu messages using the selected account grant. When called from the current Feishu conversation, Loong can infer the account and default chat scope from ingress context.",
         json!({
             "type": "object",
             "properties": {
@@ -2289,7 +2289,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
                 "chat_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Optional Feishu chat ids to scope the search. When omitted inside the current Feishu conversation, LoongClaw can default this to the active conversation."
+                    "description": "Optional Feishu chat ids to scope the search. When omitted inside the current Feishu conversation, Loong can default this to the active conversation."
                 },
                 "message_type": {
                     "type": "string"
@@ -2392,7 +2392,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_send",
-        "Send a Feishu text, post, image, file, or markdown card message using a tenant token resolved from the selected account grant. When called from the current Feishu conversation, LoongClaw can infer the account and receive_id from ingress context.",
+        "Send a Feishu text, post, image, file, or markdown card message using a tenant token resolved from the selected account grant. When called from the current Feishu conversation, Loong can infer the account and receive_id from ingress context.",
         send_parameters,
     );
     let mut reply_parameters = json!({
@@ -2432,7 +2432,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
             },
             "reply_in_thread": {
                 "type": "boolean",
-                "description": "When true, force the reply to be posted in thread form. When omitted, LoongClaw defaults to thread form if internal Feishu ingress metadata indicates the source message is already in a thread/topic."
+                "description": "When true, force the reply to be posted in thread form. When omitted, Loong defaults to thread form if internal Feishu ingress metadata indicates the source message is already in a thread/topic."
             },
             "uuid": {
                 "type": "string",
@@ -2472,7 +2472,7 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     push_feishu_provider_tool_definition(
         &mut tools,
         "feishu_messages_reply",
-        "Reply to a Feishu message with text, post, image, file, or a markdown card using a tenant token resolved from the selected account grant. When called from a Feishu conversation, LoongClaw can infer the account and source Feishu message from ingress context.",
+        "Reply to a Feishu message with text, post, image, file, or a markdown card using a tenant token resolved from the selected account grant. When called from a Feishu conversation, Loong can infer the account and source Feishu message from ingress context.",
         reply_parameters,
     );
     push_feishu_provider_tool_definition(
@@ -5159,7 +5159,7 @@ where
 
 fn requested_account_id<'a>(
     explicit: Option<&'a str>,
-    internal: &'a LoongclawInternalToolPayload,
+    internal: &'a LoongInternalToolPayload,
 ) -> Option<&'a str> {
     explicit.or_else(|| internal.ingress_requested_account_id())
 }
@@ -5169,7 +5169,7 @@ fn resolve_message_resource_selection(
     effective_message_id: &str,
     payload_file_key: &str,
     payload_resource_type: &str,
-    internal: &LoongclawInternalToolPayload,
+    internal: &LoongInternalToolPayload,
 ) -> CliResult<(String, String)> {
     let explicit_file_key = trimmed_opt(Some(payload_file_key));
     let explicit_resource_type = trimmed_opt(Some(payload_resource_type))
@@ -5244,7 +5244,7 @@ fn resolve_message_resource_selection(
 }
 
 fn ingress_resources_for_effective_message(
-    internal: &LoongclawInternalToolPayload,
+    internal: &LoongInternalToolPayload,
     effective_message_id: &str,
 ) -> Vec<FeishuInternalIngressResolvedResource> {
     if internal
@@ -5257,7 +5257,7 @@ fn ingress_resources_for_effective_message(
 }
 
 fn ingress_message_override_reason<'a>(
-    internal: &'a LoongclawInternalToolPayload,
+    internal: &'a LoongInternalToolPayload,
     effective_message_id: &str,
 ) -> Option<&'a str> {
     internal

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -116,7 +116,8 @@ pub(crate) use tool_lease::{
 ))]
 pub use web_http::build_ssrf_safe_client;
 
-pub(crate) const BROWSER_SESSION_SCOPE_FIELD: &str = "__loongclaw_browser_scope";
+pub(crate) const BROWSER_SESSION_SCOPE_FIELD: &str = "__loong_browser_scope";
+pub(crate) const LEGACY_BROWSER_SESSION_SCOPE_FIELD: &str = "__loongclaw_browser_scope";
 pub const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str =
     bundled_skills::BROWSER_COMPANION_PREVIEW_SKILL_ID;
 pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_COMMAND;
@@ -135,11 +136,22 @@ const HTTP_REQUEST_TOOL_NAME: &str = "http.request";
 const WEB_FETCH_TOOL_NAME: &str = "web.fetch";
 const WEB_SEARCH_TOOL_NAME: &str = "web.search";
 
+pub(crate) const LOONG_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loong";
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
 pub(crate) const LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY: &str = "runtime_narrowing";
 pub(crate) const LOONGCLAW_INTERNAL_WORKSPACE_ROOT_KEY: &str = "workspace_root";
+#[allow(dead_code)]
+pub(crate) const LOONG_INTERNAL_TOOL_SEARCH_KEY: &str = LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY;
+#[allow(dead_code)]
+pub(crate) const LOONG_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str =
+    LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY;
+#[allow(dead_code)]
+pub(crate) const LOONG_INTERNAL_RUNTIME_NARROWING_KEY: &str =
+    LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY;
+#[allow(dead_code)]
+pub(crate) const LOONG_INTERNAL_WORKSPACE_ROOT_KEY: &str = LOONGCLAW_INTERNAL_WORKSPACE_ROOT_KEY;
 
 pub fn normalize_external_skills_domain_rule(raw: &str) -> Result<String, String> {
     external_skills::normalize_domain_rule(raw)
@@ -228,9 +240,50 @@ fn trusted_internal_tool_payload_enabled() -> bool {
 }
 
 pub(crate) fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bool {
+    reserved_internal_tool_context_key_in_payload(payload).is_some()
+}
+
+fn reserved_internal_tool_context_key_in_payload(payload: &Value) -> Option<&'static str> {
     payload
         .as_object()
-        .is_some_and(|body| body.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY))
+        .and_then(reserved_internal_tool_context_key_in_map)
+}
+
+fn reserved_internal_tool_context_key_in_map(
+    body: &serde_json::Map<String, Value>,
+) -> Option<&'static str> {
+    if body.contains_key(LOONG_INTERNAL_TOOL_CONTEXT_KEY) {
+        Some(LOONG_INTERNAL_TOOL_CONTEXT_KEY)
+    } else if body.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY) {
+        Some(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn trusted_internal_tool_context_from_payload(
+    payload: &Value,
+) -> Option<&serde_json::Map<String, Value>> {
+    let body = payload.as_object()?;
+    let key = reserved_internal_tool_context_key_in_map(body)?;
+    body.get(key)?.as_object()
+}
+
+pub(crate) fn take_trusted_internal_tool_context(
+    body: &mut serde_json::Map<String, Value>,
+) -> serde_json::Map<String, Value> {
+    for key in [
+        LOONG_INTERNAL_TOOL_CONTEXT_KEY,
+        LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY,
+    ] {
+        let Some(value) = body.remove(key) else {
+            continue;
+        };
+        if let Some(object) = value.as_object() {
+            return object.clone();
+        }
+    }
+    serde_json::Map::new()
 }
 
 fn ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
@@ -241,12 +294,12 @@ fn ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
     if trusted_internal_tool_payload_enabled() {
         return Ok(());
     }
-    if !payload_uses_reserved_internal_tool_context(payload) {
+    let Some(offending_key) = reserved_internal_tool_context_key_in_payload(payload) else {
         return Ok(());
-    }
+    };
 
     Err(format!(
-        "tool `{tool_name}` {payload_path}.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context; retry without that field"
+        "tool `{tool_name}` {payload_path}.{offending_key} is reserved for trusted internal tool context; retry without that field"
     ))
 }
 /// Execute a tool request, routing through the kernel for
@@ -635,7 +688,7 @@ pub fn is_provider_exposed_tool_name(raw: &str) -> bool {
 pub fn runtime_tool_view_from_loongclaw_config(
     config: &crate::config::LoongClawConfig,
 ) -> ToolView {
-    let runtime_config = runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);
+    let runtime_config = runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
     runtime_tool_view_with_runtime_config(&config.tools, &runtime_config)
 }
 
@@ -807,7 +860,7 @@ fn is_expected_tool_request_error(error: &str) -> bool {
     if error.starts_with("invalid_internal_runtime_narrowing:") {
         return true;
     }
-    error.contains("payload._loongclaw is reserved for trusted internal tool context")
+    error.contains("reserved for trusted internal tool context")
 }
 
 fn trusted_runtime_narrowing_from_payload(
@@ -817,8 +870,7 @@ fn trusted_runtime_narrowing_from_payload(
         return Ok(None);
     }
 
-    let Some(value) = payload
-        .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+    let Some(value) = trusted_internal_tool_context_from_payload(payload)
         .and_then(|body| body.get(LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY))
         .cloned()
     else {
@@ -835,8 +887,7 @@ fn trusted_workspace_root_from_payload(payload: &Value) -> Result<Option<PathBuf
         return Ok(None);
     }
 
-    let Some(value) = payload
-        .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+    let Some(value) = trusted_internal_tool_context_from_payload(payload)
         .and_then(|body| body.get(LOONGCLAW_INTERNAL_WORKSPACE_ROOT_KEY))
         .cloned()
     else {
@@ -867,18 +918,15 @@ pub(crate) fn merge_trusted_internal_tool_context_into_arguments(
     internal_context: &Value,
 ) -> Result<(), String> {
     let trusted_context = internal_context.as_object().cloned().ok_or_else(|| {
-        format!("tool.invoke payload.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} must be an object")
+        format!("tool.invoke payload.{LOONG_INTERNAL_TOOL_CONTEXT_KEY} must be an object")
     })?;
-    if arguments.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY) {
+    if let Some(offending_key) = reserved_internal_tool_context_key_in_map(arguments) {
         return Err(format!(
-            "tool.invoke payload.arguments.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context"
+            "tool.invoke payload.arguments.{offending_key} is reserved for trusted internal tool context"
         ));
     }
     let merged_context = Value::Object(trusted_context);
-    arguments.insert(
-        LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
-        merged_context,
-    );
+    arguments.insert(LOONG_INTERNAL_TOOL_CONTEXT_KEY.to_owned(), merged_context);
     Ok(())
 }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -685,11 +685,15 @@ pub fn is_provider_exposed_tool_name(raw: &str) -> bool {
         .is_some_and(|entry| entry.is_provider_core())
 }
 
+pub fn runtime_tool_view_from_loong_config(config: &crate::config::LoongConfig) -> ToolView {
+    let runtime_config = runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
+    runtime_tool_view_with_runtime_config(&config.tools, &runtime_config)
+}
+
 pub fn runtime_tool_view_from_loongclaw_config(
     config: &crate::config::LoongClawConfig,
 ) -> ToolView {
-    let runtime_config = runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
-    runtime_tool_view_with_runtime_config(&config.tools, &runtime_config)
+    runtime_tool_view_from_loong_config(config)
 }
 
 pub(crate) fn runtime_tool_view_with_runtime_config(

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1036,10 +1036,12 @@ impl ToolRuntimeConfig {
                 crate::config::WEB_SEARCH_PROVIDER_JINA,
             ),
         );
-        let web_search_timeout_seconds = parse_env_u64("LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS")
+        let web_search_timeout_seconds = parse_env_u64("LOONG_WEB_SEARCH_TIMEOUT_SECONDS")
+            .or_else(|| parse_env_u64("LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS"))
             .map(|seconds| seconds.clamp(1, 60))
             .unwrap_or(crate::config::DEFAULT_WEB_SEARCH_TIMEOUT_SECONDS);
-        let web_search_max_results = parse_env_usize("LOONGCLAW_WEB_SEARCH_MAX_RESULTS")
+        let web_search_max_results = parse_env_usize("LOONG_WEB_SEARCH_MAX_RESULTS")
+            .or_else(|| parse_env_usize("LOONGCLAW_WEB_SEARCH_MAX_RESULTS"))
             .map(|count| count.clamp(1, 10))
             .unwrap_or(crate::config::DEFAULT_WEB_SEARCH_MAX_RESULTS);
         let autonomy_profile = resolve_autonomy_profile_from_env();
@@ -1745,6 +1747,7 @@ mod tests {
     fn clear_tool_runtime_env(env: &mut ScopedEnv) {
         for key in [
             "LOONG_HOME",
+            "LOONG_CONFIG_PATH",
             "LOONGCLAW_CONFIG_PATH",
             "LOONGCLAW_FILE_ROOT",
             "LOONGCLAW_WORKSPACE_ROOT",
@@ -1772,8 +1775,11 @@ mod tests {
             "LOONGCLAW_WEB_FETCH_MAX_BYTES",
             "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
             "LOONGCLAW_WEB_SEARCH_ENABLED",
+            "LOONG_WEB_SEARCH_PROVIDER",
             "LOONGCLAW_WEB_SEARCH_PROVIDER",
+            "LOONG_WEB_SEARCH_TIMEOUT_SECONDS",
             "LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS",
+            "LOONG_WEB_SEARCH_MAX_RESULTS",
             "LOONGCLAW_WEB_SEARCH_MAX_RESULTS",
             "LOONGCLAW_AUTONOMY_PROFILE",
             "BRAVE_API_KEY",
@@ -2697,9 +2703,9 @@ mod tests {
         clear_tool_runtime_env(&mut env);
         #[cfg(feature = "feishu-integration")]
         clear_feishu_runtime_env(&mut env);
-        env.set("LOONGCLAW_WEB_SEARCH_PROVIDER", "DDG");
-        env.set("LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS", "999");
-        env.set("LOONGCLAW_WEB_SEARCH_MAX_RESULTS", "42");
+        env.set("LOONG_WEB_SEARCH_PROVIDER", "DDG");
+        env.set("LOONG_WEB_SEARCH_TIMEOUT_SECONDS", "999");
+        env.set("LOONG_WEB_SEARCH_MAX_RESULTS", "42");
         env.set(
             crate::config::WEB_SEARCH_BRAVE_API_KEY_ENV,
             "brave-test-key",
@@ -2754,6 +2760,23 @@ mod tests {
             config.web_search.jina_api_key.as_deref(),
             Some("jina-test-key")
         );
+    }
+
+    #[test]
+    fn from_env_preserves_legacy_web_search_env_fallbacks() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        #[cfg(feature = "feishu-integration")]
+        clear_feishu_runtime_env(&mut env);
+        env.set("LOONGCLAW_WEB_SEARCH_PROVIDER", "tavily");
+        env.set("LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS", "41");
+        env.set("LOONGCLAW_WEB_SEARCH_MAX_RESULTS", "7");
+
+        let config = ToolRuntimeConfig::from_env();
+
+        assert_eq!(config.web_search.default_provider, "tavily");
+        assert_eq!(config.web_search.timeout_seconds, 41);
+        assert_eq!(config.web_search.max_results, 7);
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -939,8 +939,9 @@ impl ToolRuntimeConfig {
         });
         let selected_memory_system_id = crate::memory::registered_memory_system_id_from_env()
             .unwrap_or_else(|| crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned());
-        let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
+        let config_path = std::env::var("LOONG_CONFIG_PATH")
             .ok()
+            .or_else(|| std::env::var("LOONGCLAW_CONFIG_PATH").ok())
             .map(PathBuf::from);
         let shell_allow: BTreeSet<String> = crate::config::DEFAULT_SHELL_ALLOW
             .iter()
@@ -993,7 +994,8 @@ impl ToolRuntimeConfig {
         let web_fetch_max_redirects = parse_env_usize("LOONGCLAW_WEB_FETCH_MAX_REDIRECTS")
             .unwrap_or(crate::config::DEFAULT_WEB_FETCH_MAX_REDIRECTS);
         let web_search_enabled = parse_env_bool("LOONGCLAW_WEB_SEARCH_ENABLED").unwrap_or(true);
-        let web_search_default_provider = parse_env_string("LOONGCLAW_WEB_SEARCH_PROVIDER")
+        let web_search_default_provider = parse_env_string("LOONG_WEB_SEARCH_PROVIDER")
+            .or_else(|| parse_env_string("LOONGCLAW_WEB_SEARCH_PROVIDER"))
             .as_deref()
             .and_then(crate::config::normalize_web_search_provider)
             .unwrap_or(crate::config::DEFAULT_WEB_SEARCH_PROVIDER)

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -751,6 +751,10 @@ impl ToolRuntimeConfig {
         configured_root.unwrap_or(fallback_root)
     }
 
+    pub fn from_loong_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
+        Self::from_loongclaw_config(config, config_path)
+    }
+
     pub fn from_loongclaw_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
         let file_root = config.tools.configured_file_root();
         let workspace_root = config

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -193,8 +193,8 @@ pub(crate) fn shell_exec_matches_trusted_internal_approval(
     payload: &serde_json::Map<String, serde_json::Value>,
     approval_key: &str,
 ) -> bool {
-    let trusted_context = payload.get(super::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY);
-    let trusted_context = trusted_context.and_then(serde_json::Value::as_object);
+    let payload_value = serde_json::Value::Object(payload.clone());
+    let trusted_context = super::trusted_internal_tool_context_from_payload(&payload_value);
     let trusted_context =
         trusted_context.and_then(|value| value.get(SHELL_INTERNAL_APPROVAL_CONTEXT_KEY));
     let trusted_context = trusted_context.and_then(serde_json::Value::as_object);

--- a/crates/app/src/tools/tool_lease.rs
+++ b/crates/app/src/tools/tool_lease.rs
@@ -31,7 +31,10 @@ pub(crate) fn resolve_tool_invoke_request(
         let arguments_object = arguments
             .as_object_mut()
             .ok_or_else(|| "tool.invoke payload.arguments must be an object".to_owned())?;
-        if let Some(internal_context) = payload.get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY) {
+        if let Some(internal_context) = payload
+            .get(LOONG_INTERNAL_TOOL_CONTEXT_KEY)
+            .or_else(|| payload.get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY))
+        {
             merge_trusted_internal_tool_context_into_arguments(arguments_object, internal_context)?;
         }
     }

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -12,9 +12,8 @@ use unicode_segmentation::UnicodeSegmentation;
 use super::catalog::{ToolDescriptor, ToolView};
 use super::runtime_config;
 use super::{
-    LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY, LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY,
-    LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY, TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD,
-    canonical_tool_name, issue_tool_lease, memory_tools,
+    LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY, LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY,
+    TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD, canonical_tool_name, issue_tool_lease, memory_tools,
 };
 
 const COARSE_FALLBACK_DISCOVERY_CONCEPTS: &[&str] =
@@ -305,9 +304,9 @@ pub(super) fn search_tool_view_from_payload(
     payload: &serde_json::Map<String, Value>,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
+    let payload_value = Value::Object(payload.clone());
     let visible_tool_names = if super::trusted_internal_tool_payload_enabled() {
-        payload
-            .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        super::trusted_internal_tool_context_from_payload(&payload_value)
             .and_then(|body| body.get(LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY))
             .and_then(|body| body.get(LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY))
             .and_then(Value::as_array)

--- a/crates/app/src/tools/workspace_root_tests.rs
+++ b/crates/app/src/tools/workspace_root_tests.rs
@@ -144,7 +144,7 @@ fn tool_invoke_preserves_combined_trusted_internal_context_for_inner_execution()
     let (_, effective_request) =
         resolve_tool_invoke_request(&request).expect("tool.invoke should preserve trusted context");
 
-    let internal_context = effective_request.payload[LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY]
+    let internal_context = effective_request.payload[LOONG_INTERNAL_TOOL_CONTEXT_KEY]
         .as_object()
         .expect("inner arguments should keep trusted internal context");
     assert_eq!(

--- a/crates/app/src/tui_surface.rs
+++ b/crates/app/src/tui_surface.rs
@@ -605,10 +605,8 @@ mod tests {
         let lines = render_tui_screen_spec(&spec, 80, false);
 
         assert!(
-            lines
-                .first()
-                .is_some_and(|line| line.starts_with("LOONGCLAW")),
-            "compact header should keep the LOONGCLAW wordmark: {lines:#?}"
+            lines.first().is_some_and(|line| line.starts_with("LOONG")),
+            "compact header should keep the LOONG wordmark: {lines:#?}"
         );
         assert!(
             lines

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -8,6 +8,9 @@ description = "Internal support crate for Loong: benchmark harness and gates"
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "loongclaw_bench"
+
 [features]
 test-support = []
 

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "loongclaw-bench"
+name = "loong-bench"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: benchmark harness and gates"
+description = "Internal support crate for Loong: benchmark harness and gates"
 repository.workspace = true
 homepage.workspace = true
 
@@ -12,8 +12,8 @@ homepage.workspace = true
 test-support = []
 
 [dependencies]
-loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec" }
-kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec" }
+kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -8,6 +8,9 @@ description = "Internal support crate for Loong: stable shared contracts"
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "loongclaw_contracts"
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "loongclaw-contracts"
+name = "loong-contracts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: stable shared contracts"
+description = "Internal support crate for Loong: stable shared contracts"
 repository.workspace = true
 homepage.workspace = true
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "loongclaw"
+name = "loong"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 default-run = "loong"
-description = "Primary CLI crate for LoongClaw vertical AI agents"
+description = "Primary CLI crate for Loong vertical AI agents"
 repository.workspace = true
 homepage.workspace = true
 readme = "../../README.md"
@@ -64,12 +64,12 @@ axum = { workspace = true, features = ["query"] }
 clap.workspace = true
 clap_complete = "4.6"
 dialoguer.workspace = true
-kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
-loongclaw-bench = { version = "0.1.0-alpha.3", path = "../bench" }
-loongclaw-app = { version = "0.1.0-alpha.3", path = "../app", default-features = false }
-loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
-loongclaw-protocol = { version = "0.1.0-alpha.3", path = "../protocol" }
-loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec" }
+kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-bench = { package = "loong-bench", version = "0.1.0-alpha.3", path = "../bench" }
+loongclaw-app = { package = "loong-app", version = "0.1.0-alpha.3", path = "../app", default-features = false }
+loongclaw-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-protocol = { package = "loong-protocol", version = "0.1.0-alpha.3", path = "../protocol" }
+loongclaw-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec" }
 serde.workspace = true
 serde_json.workspace = true
 futures-util.workspace = true
@@ -96,7 +96,7 @@ name = "loong"
 path = "src/main.rs"
 
 [dev-dependencies]
-loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec", features = ["test-hooks"] }
+loongclaw-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec", features = ["test-hooks"] }
 async-trait.workspace = true
 sha2.workspace = true
 syn = { version = "2", features = ["full", "visit"] }

--- a/crates/daemon/src/delegate_child_cli.rs
+++ b/crates/daemon/src/delegate_child_cli.rs
@@ -14,8 +14,12 @@ const DETACHED_DELEGATE_CHILD_CONFIG_ARG: &str = "--config-path";
 const DETACHED_DELEGATE_CHILD_PAYLOAD_ARG: &str = "--payload-file";
 const DETACHED_DELEGATE_CHILD_EXECUTABLE_ENV: &str = "CARGO_BIN_EXE_loong";
 const DETACHED_DELEGATE_CHILD_KERNEL_SCOPE: &str = "delegate-child-worker";
-const DETACHED_DELEGATE_CHILD_PASSTHROUGH_ENV_KEYS: &[&str] =
-    &["LOONGCLAW_CONFIG_PATH", "LOONG_HOME", "LOONGCLAW_HOME"];
+const DETACHED_DELEGATE_CHILD_PASSTHROUGH_ENV_KEYS: &[&str] = &[
+    "LOONG_CONFIG_PATH",
+    "LOONGCLAW_CONFIG_PATH",
+    "LOONG_HOME",
+    "LOONGCLAW_HOME",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -203,10 +207,11 @@ fn resolve_detached_delegate_child_executable_path() -> CliResult<PathBuf> {
 }
 
 fn resolve_detached_delegate_child_config_path() -> CliResult<PathBuf> {
-    let config_path = std::env::var_os("LOONGCLAW_CONFIG_PATH")
+    let config_path = std::env::var_os("LOONG_CONFIG_PATH")
+        .or_else(|| std::env::var_os("LOONGCLAW_CONFIG_PATH"))
         .map(PathBuf::from)
         .ok_or_else(|| {
-            "delegate_async_process_spawn_failed: LOONGCLAW_CONFIG_PATH is not set for detached delegate child startup"
+            "delegate_async_process_spawn_failed: LOONG_CONFIG_PATH or LOONGCLAW_CONFIG_PATH is not set for detached delegate child startup"
                 .to_owned()
         })?;
 

--- a/crates/daemon/src/env_compat.rs
+++ b/crates/daemon/src/env_compat.rs
@@ -13,7 +13,10 @@ fn non_empty_env_var(name: &str) -> Option<std::ffi::OsString> {
 /// Copies deprecated `LOONGCLAW_*` env vars into their `LOONG_*` replacements
 /// and emits a deprecation warning. No-op when the new name is already set.
 pub fn make_env_compatible() {
-    const MIGRATIONS: &[(&str, &str)] = &[("LOONG_HOME", "LOONGCLAW_HOME")];
+    const MIGRATIONS: &[(&str, &str)] = &[
+        ("LOONG_HOME", "LOONGCLAW_HOME"),
+        ("LOONG_CONFIG_PATH", "LOONGCLAW_CONFIG_PATH"),
+    ];
 
     for &(new_name, old_name) in MIGRATIONS {
         let old_value = non_empty_env_var(old_name);
@@ -44,6 +47,10 @@ mod tests {
 
     fn loong_home() -> Option<std::path::PathBuf> {
         std::env::var_os("LOONG_HOME").map(std::path::PathBuf::from)
+    }
+
+    fn loong_config_path() -> Option<std::path::PathBuf> {
+        std::env::var_os("LOONG_CONFIG_PATH").map(std::path::PathBuf::from)
     }
 
     #[test]
@@ -115,5 +122,30 @@ mod tests {
         make_env_compatible();
 
         assert!(loong_home().is_none());
+    }
+
+    #[test]
+    fn migrates_legacy_config_path_when_new_path_is_unset() {
+        let mut env = ScopedEnv::new();
+        let value = std::env::temp_dir().join("loong-compat-config-old-only");
+        env.set("LOONGCLAW_CONFIG_PATH", &value);
+        env.remove("LOONG_CONFIG_PATH");
+
+        make_env_compatible();
+
+        assert_eq!(loong_config_path(), Some(value));
+    }
+
+    #[test]
+    fn does_not_overwrite_new_config_path_when_both_are_set() {
+        let mut env = ScopedEnv::new();
+        let new_value = std::env::temp_dir().join("loong-compat-config-new");
+        let old_value = std::env::temp_dir().join("loong-compat-config-old");
+        env.set("LOONG_CONFIG_PATH", &new_value);
+        env.set("LOONGCLAW_CONFIG_PATH", &old_value);
+
+        make_env_compatible();
+
+        assert_eq!(loong_config_path(), Some(new_value));
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -220,7 +220,7 @@ pub fn active_cli_command_name() -> &'static str {
 
 fn render_welcome_long_about(command_name: &str) -> String {
     format!(
-        "Show the configured welcome banner and quick commands.\n\nquick commands:\n- {command_name} ask --config <path> --message \"...\"\n- {command_name} chat --config <path>\n- {command_name} personalize --config <path>\n- {command_name} doctor --config <path>\n- {command_name} --help\n\nReplace <path> with your current config path, or set LOONGCLAW_CONFIG_PATH first."
+        "Show the configured welcome banner and quick commands.\n\nquick commands:\n- {command_name} ask --config <path> --message \"...\"\n- {command_name} chat --config <path>\n- {command_name} personalize --config <path>\n- {command_name} doctor --config <path>\n- {command_name} --help\n\nReplace <path> with your current config path, or set LOONG_CONFIG_PATH first."
     )
 }
 
@@ -365,7 +365,7 @@ impl std::str::FromStr for MultiChannelServeChannelAccount {
 #[derive(Parser, Debug)]
 #[command(
     name = CLI_COMMAND_NAME,
-    about = "LoongClaw low-level runtime daemon",
+    about = "Loong low-level runtime daemon",
     version
 )]
 pub struct Cli {
@@ -383,7 +383,7 @@ pub enum InitSpecPreset {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     #[command(
-        long_about = "Show the configured welcome banner and quick commands.\n\nquick commands:\n- loong ask --config <path> --message \"...\"\n- loong chat --config <path>\n- loong personalize --config <path>\n- loong doctor --config <path>\n- loong --help\n\nReplace <path> with your current config path, or set LOONGCLAW_CONFIG_PATH first."
+        long_about = "Show the configured welcome banner and quick commands.\n\nquick commands:\n- loong ask --config <path> --message \"...\"\n- loong chat --config <path>\n- loong personalize --config <path>\n- loong doctor --config <path>\n- loong --help\n\nReplace <path> with your current config path, or set LOONG_CONFIG_PATH first."
     )]
     /// Show a welcome banner for an already configured install
     Welcome,
@@ -1591,7 +1591,8 @@ mod multi_channel_serve_tests {
 }
 
 fn resolved_default_entry_config_path() -> PathBuf {
-    std::env::var_os("LOONGCLAW_CONFIG_PATH")
+    std::env::var_os("LOONG_CONFIG_PATH")
+        .or_else(|| std::env::var_os("LOONGCLAW_CONFIG_PATH"))
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(mvp::config::default_config_path)
@@ -1615,12 +1616,46 @@ fn default_onboard_command() -> Commands {
     }
 }
 
+fn default_import_preview_command() -> Commands {
+    Commands::Import {
+        output: None,
+        force: false,
+        preview: true,
+        apply: false,
+        json: false,
+        from: None,
+        source_path: None,
+        provider: None,
+        include: Vec::new(),
+        exclude: Vec::new(),
+    }
+}
+
+fn detected_legacy_home_for_default_entry() -> Option<PathBuf> {
+    if std::env::var_os("LOONG_HOME")
+        .as_deref()
+        .is_some_and(|value| !value.is_empty())
+    {
+        return None;
+    }
+
+    let user_home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+
+    mvp::config::detect_legacy_home(user_home.as_path())
+}
+
 pub fn resolve_default_entry_command() -> Commands {
     if resolved_default_entry_config_path().is_file() {
-        Commands::Welcome
-    } else {
-        default_onboard_command()
+        return Commands::Welcome;
     }
+
+    if detected_legacy_home_for_default_entry().is_some() {
+        return default_import_preview_command();
+    }
+
+    default_onboard_command()
 }
 
 pub fn redacted_command_name(command: &Commands) -> &'static str {
@@ -1633,7 +1668,7 @@ fn resolve_welcome_config_path() -> CliResult<PathBuf> {
         Ok(config_path)
     } else {
         Err(format!(
-            "Config file not found at {}. Run `{} onboard` to set up LoongClaw.",
+            "Config file not found at {}. Run `{} onboard` to set up Loong.",
             config_path.display(),
             active_cli_command_name(),
         ))
@@ -1656,7 +1691,7 @@ fn render_welcome_banner(config_path: &Path, config: &mvp::config::LoongClawConf
     let quick_commands = quick_command_lines.join("\n");
 
     format!(
-        "LoongClaw is configured and ready.\nVersion: {}\nConfig: {}\n\nQuick commands:\n{}",
+        "Loong is configured and ready.\nVersion: {}\nConfig: {}\n\nQuick commands:\n{}",
         env!("CARGO_PKG_VERSION"),
         config_path_display,
         quick_commands,
@@ -1702,6 +1737,7 @@ mod first_run_entry_tests {
         fs::create_dir_all(&home).expect("create isolated home");
         env.set("HOME", &home);
         env.remove("LOONG_HOME");
+        env.remove("LOONG_CONFIG_PATH");
         env.remove("LOONGCLAW_CONFIG_PATH");
         (env, home)
     }
@@ -1713,6 +1749,25 @@ mod first_run_entry_tests {
         assert!(
             matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
             "missing config should route to onboard"
+        );
+    }
+
+    #[test]
+    fn resolve_default_entry_command_routes_to_import_preview_when_legacy_home_exists() {
+        let (_env, home) = isolated_home("loongclaw-default-entry-legacy-home");
+        let legacy_home = home.join(".loongclaw");
+        fs::create_dir_all(&legacy_home).expect("create legacy home");
+
+        assert!(
+            matches!(
+                resolve_default_entry_command(),
+                Commands::Import {
+                    preview: true,
+                    apply: false,
+                    ..
+                }
+            ),
+            "legacy home should route to import preview"
         );
     }
 
@@ -1751,6 +1806,27 @@ mod first_run_entry_tests {
         assert!(
             matches!(resolve_default_entry_command(), Commands::Welcome),
             "env override config should route to welcome"
+        );
+    }
+
+    #[test]
+    fn resolve_default_entry_command_honors_loong_config_path_override() {
+        let mut env = ScopedEnv::new();
+        let config_path = unique_temp_dir("loong-default-entry-env").join("custom-config.toml");
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent).expect("create config parent");
+        }
+        mvp::config::write(
+            Some(config_path.to_str().expect("utf8 config path")),
+            &mvp::config::LoongClawConfig::default(),
+            true,
+        )
+        .expect("write explicit config");
+        env.set("LOONG_CONFIG_PATH", &config_path);
+
+        assert!(
+            matches!(resolve_default_entry_command(), Commands::Welcome),
+            "new env override config should route to welcome"
         );
     }
 
@@ -1817,6 +1893,27 @@ mod first_run_entry_tests {
             error.contains("Config file not found"),
             "welcome should reject directory config paths as missing config files: {error}"
         );
+    }
+
+    #[test]
+    fn resolve_welcome_config_path_honors_loong_config_path_override() {
+        let mut env = ScopedEnv::new();
+        let config_path = unique_temp_dir("loong-welcome-present").join("welcome-config.toml");
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent).expect("create config parent");
+        }
+        mvp::config::write(
+            Some(config_path.to_str().expect("utf8 config path")),
+            &mvp::config::LoongClawConfig::default(),
+            true,
+        )
+        .expect("write explicit config");
+        env.set("LOONG_CONFIG_PATH", &config_path);
+
+        let resolved_path =
+            resolve_welcome_config_path().expect("new config path env should resolve correctly");
+
+        assert_eq!(resolved_path, config_path);
     }
 
     #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::expect_used,
     private_interfaces
 )] // CLI daemon binary
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,

--- a/crates/daemon/src/onboard_screen_specs.rs
+++ b/crates/daemon/src/onboard_screen_specs.rs
@@ -20,7 +20,7 @@ pub(super) fn render_onboarding_risk_screen_lines_with_style(
                 tone: TuiCalloutTone::Warning,
                 title: Some("what onboarding can do".to_owned()),
                 lines: vec![
-                    "LoongClaw can invoke tools and read local files when enabled.".to_owned(),
+                    "Loong can invoke tools and read local files when enabled.".to_owned(),
                     "Keep credentials in environment variables, not in prompts.".to_owned(),
                     "Prefer allowlist-style tool policy for shared environments.".to_owned(),
                 ],
@@ -57,7 +57,7 @@ pub(super) fn render_onboarding_risk_screen_lines_with_style(
 
 pub(super) fn build_onboard_shortcut_screen_spec(
     shortcut_kind: OnboardShortcutKind,
-    config: &mvp::config::LoongClawConfig,
+    config: &mvp::config::LoongConfig,
     import_source: Option<&str>,
     include_choices: bool,
 ) -> TuiScreenSpec {

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -134,7 +134,7 @@ fn select_gateway_owner_status_for_config(
 
 async fn collect_status_cli_acp_read_model(
     config_path: &str,
-    config: &mvp::config::LoongClawConfig,
+    config: &mvp::config::LoongConfig,
 ) -> StatusCliAcpReadModel {
     let enabled = config.acp.enabled;
     let persisted_session_count = load_persisted_acp_session_count(config);
@@ -191,7 +191,7 @@ fn build_unavailable_acp_read_model(
 }
 
 fn collect_status_cli_work_unit_read_model(
-    config: &mvp::config::LoongClawConfig,
+    config: &mvp::config::LoongConfig,
 ) -> StatusCliWorkUnitReadModel {
     #[cfg(not(feature = "memory-sqlite"))]
     {
@@ -239,7 +239,7 @@ fn collect_status_cli_work_unit_read_model(
     }
 }
 
-fn load_persisted_acp_session_count(config: &mvp::config::LoongClawConfig) -> Option<usize> {
+fn load_persisted_acp_session_count(config: &mvp::config::LoongConfig) -> Option<usize> {
     #[cfg(not(any(feature = "memory-sqlite", feature = "mvp")))]
     {
         let _ = config;

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -190,7 +190,7 @@ fn chat_without_config_runs_onboard_for_explicit_yes() {
         "explicit yes should succeed, stdout={stdout:?}, stderr={stderr:?}"
     );
     assert!(
-        stdout.contains("Welcome to LoongClaw!"),
+        stdout.contains("Welcome to Loong!"),
         "missing-config onboarding flow should greet the user: {stdout:?}"
     );
     assert!(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -52,7 +52,7 @@ fn welcome_subcommand_help_advertises_first_run_shortcuts() {
         "welcome help should mention doctor with an explicit config placeholder: {help}"
     );
     assert!(
-        help.contains("LOONGCLAW_CONFIG_PATH"),
+        help.contains("LOONG_CONFIG_PATH") || help.contains("LOONGCLAW_CONFIG_PATH"),
         "welcome help should explain how config-path environment overrides interact with the quick commands: {help}"
     );
 }

--- a/crates/daemon/tests/integration/gateway_api_acp.rs
+++ b/crates/daemon/tests/integration/gateway_api_acp.rs
@@ -8,13 +8,13 @@ use tower::ServiceExt;
 
 use super::*;
 
-fn gateway_acp_test_config(label: &str, enabled: bool) -> (mvp::config::LoongClawConfig, PathBuf) {
+fn gateway_acp_test_config(label: &str, enabled: bool) -> (mvp::config::LoongConfig, PathBuf) {
     let root_dir = unique_temp_dir(label);
     std::fs::create_dir_all(root_dir.as_path()).expect("create gateway ACP test dir");
 
     let sqlite_path = root_dir.join("memory.sqlite3");
     let sqlite_path_text = sqlite_path.display().to_string();
-    let mut config = mvp::config::LoongClawConfig::default();
+    let mut config = mvp::config::LoongConfig::default();
     config.acp.enabled = enabled;
     config.memory.sqlite_path = sqlite_path_text;
 

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -23,10 +23,8 @@ fn normalized_path_text(value: &str) -> String {
 
 fn assert_compact_loongclaw_header(lines: &[String], context: &str) {
     assert!(
-        lines
-            .first()
-            .is_some_and(|line| line.starts_with("LOONGCLAW")),
-        "{context} should start with the compact LOONGCLAW header: {lines:#?}"
+        lines.first().is_some_and(|line| line.starts_with("LOONG")),
+        "{context} should start with the compact LOONG header: {lines:#?}"
     );
     assert!(
         lines

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -20,10 +20,8 @@ static TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn assert_compact_loongclaw_header(lines: &[String], context: &str) {
     assert!(
-        lines
-            .first()
-            .is_some_and(|line| line.starts_with("LOONGCLAW")),
-        "{context} should start with the compact LOONGCLAW header: {lines:#?}"
+        lines.first().is_some_and(|line| line.starts_with("LOONG")),
+        "{context} should start with the compact LOONG header: {lines:#?}"
     );
     assert!(
         lines
@@ -2046,15 +2044,15 @@ async fn interactive_onboard_only_shows_large_logo_on_the_initial_screen() {
             .filter(|line| line.contains("██╗      ██████╗"))
             .count(),
         1,
-        "interactive onboarding should show the large LOONGCLAW banner only once, on the initial risk screen: {transcript:#?}"
+        "interactive onboarding should show the large Loong banner only once, on the initial risk screen: {transcript:#?}"
     );
     assert!(
         transcript
             .iter()
-            .filter(|line| line.contains("LOONGCLAW"))
+            .filter(|line| line.contains("LOONG  v"))
             .count()
             >= 3,
-        "follow-up screens should keep using the compact LOONGCLAW header instead of dropping branding entirely: {transcript:#?}"
+        "follow-up screens should keep using the compact LOONG header instead of dropping branding entirely: {transcript:#?}"
     );
     assert!(
         transcript.iter().any(|line| line == "choose personality"),
@@ -5390,7 +5388,7 @@ fn onboard_starting_point_selection_screen_wraps_header_title_and_subtitle_on_na
         lines.iter().all(|line| line.len() <= 22),
         "starting-point screen should keep brand subtitle and title within narrow widths: {lines:#?}"
     );
-    assert_eq!(lines[0], "LOONGCLAW");
+    assert_eq!(lines[0], "LOONG");
     assert!(
         lines.iter().any(|line| line == "choose detected"),
         "narrow starting-point screen should wrap the long title instead of leaving it on one overflowing line: {lines:#?}"
@@ -5489,7 +5487,7 @@ fn onboard_model_selection_screen_wraps_compact_header_and_progress_on_narrow_wi
         "model screen should keep compact header and progress copy within narrow terminal widths: {lines:#?}"
     );
     assert_eq!(
-        lines[0], "LOONGCLAW",
+        lines[0], "LOONG",
         "narrow model screen should split the compact header instead of forcing brand and version onto one line: {lines:#?}"
     );
     assert!(

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -8,6 +8,9 @@ description = "Internal support crate for Loong: kernel primitives and governanc
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "loongclaw_kernel"
+
 [dependencies]
 loongclaw-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
 async-trait.workspace = true

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "loongclaw-kernel"
+name = "loong-kernel"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: kernel primitives and governance core"
+description = "Internal support crate for Loong: kernel primitives and governance core"
 repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
 async-trait.workspace = true
 futures-util.workspace = true
 hex.workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -8,6 +8,9 @@ description = "Internal support crate for Loong: protocol and transport types"
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "loongclaw_protocol"
+
 [features]
 test-support = []
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "loongclaw-protocol"
+name = "loong-protocol"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: protocol and transport types"
+description = "Internal support crate for Loong: protocol and transport types"
 repository.workspace = true
 homepage.workspace = true
 

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -8,6 +8,9 @@ description = "Internal support crate for Loong: specification execution surface
 repository.workspace = true
 homepage.workspace = true
 
+[lib]
+name = "loongclaw_spec"
+
 [features]
 test-hooks = []
 test-support = ["test-hooks"]

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "loongclaw-spec"
+name = "loong-spec"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Internal support crate for LoongClaw: specification execution surfaces"
+description = "Internal support crate for Loong: specification execution surfaces"
 repository.workspace = true
 homepage.workspace = true
 
@@ -14,9 +14,9 @@ test-support = ["test-hooks"]
 
 [dependencies]
 async-trait.workspace = true
-kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
-loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
-loongclaw-protocol = { version = "0.1.0-alpha.3", path = "../protocol" }
+kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-protocol = { package = "loong-protocol", version = "0.1.0-alpha.3", path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -20,31 +20,31 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-14T10:39:53Z
+- Generated at: 2026-04-14T10:39:56Z
 - Report month: `2026-04`
-- Baseline report: docs/releases/support/architecture-drift-2026-03.md
+- Baseline report: none
 - Hotspots tracked: 14
 - Boundary checks tracked: 5
-- SLO status: FAIL
+- SLO status: PASS
 
 ## Hotspot Metrics
 
-| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
-| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
-| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 414 | 1000 | 586 | 12 | 20 | 8 | 60.0% | HEALTHY | 375 | 10.4% | BREACH | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
-| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH | 3383 | -8.5% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9757 | 10500 | 743 | 77 | 90 | 13 | 92.9% | WATCH | 9922 | -1.7% | PASS | 88 |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8819 | 9800 | 981 | 17 | 90 | 73 | 90.0% | WATCH | 9796 | -10.0% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6599 | 7300 | 701 | 95 | 160 | 65 | 90.4% | WATCH | 6936 | -4.9% | PASS | 146 |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2036 | 6400 | 4364 | 0 | 110 | 110 | 31.8% | HEALTHY | 1779 | 14.4% | BREACH | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9970 | 11200 | 1230 | 61 | 120 | 59 | 89.0% | WATCH | 10831 | -7.9% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14319 | 15000 | 681 | 44 | 70 | 26 | 95.5% | TIGHT | 14472 | -1.1% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5679 | 6500 | 821 | 174 | 210 | 36 | 87.4% | WATCH | 6324 | -10.2% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9202 | 9800 | 598 | 205 | 250 | 45 | 93.9% | WATCH | 9519 | -3.3% | PASS | 228 |
+| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT |
+| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 414 | 1000 | 586 | 12 | 20 | 8 | 60.0% | HEALTHY |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT |
+| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9757 | 10500 | 743 | 77 | 90 | 13 | 92.9% | WATCH |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8819 | 9800 | 981 | 17 | 90 | 73 | 90.0% | WATCH |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6599 | 7300 | 701 | 95 | 160 | 65 | 90.4% | WATCH |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2036 | 6400 | 4364 | 0 | 110 | 110 | 31.8% | HEALTHY |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9970 | 11200 | 1230 | 61 | 120 | 59 | 89.0% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14319 | 15000 | 681 | 44 | 70 | 26 | 95.5% | TIGHT |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5679 | 6500 | 821 | 174 | 210 | 36 | 87.4% | WATCH |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9202 | 9800 | 598 | 205 | 250 | 45 | 93.9% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
@@ -56,16 +56,16 @@ release review. It is not part of the primary public release trail.
 
 | Check | Status | Previous Status | Detail |
 |---|---|---|---|
-| memory_literals | PASS | PASS | memory operation literals are centralized in crates/app/src/memory/* |
-| provider_mod_helper_definitions | PASS | PASS | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
-| conversation_provider_optional_binding_roundtrip | PASS | PASS | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
+| memory_literals | PASS | n/a | memory operation literals are centralized in crates/app/src/memory/* |
+| provider_mod_helper_definitions | PASS | n/a | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
+| conversation_provider_optional_binding_roundtrip | PASS | n/a | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
 | conversation_app_dispatcher_optional_kernel_context | PASS | n/a | conversation app-tool dispatcher approval hooks stay binding-based without optional kernel fallbacks |
-| spec_app_dependency | PASS | PASS | spec crate remains detached from app crate at the Cargo dependency boundary |
+| spec_app_dependency | PASS | n/a | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
-- Hotspot growth SLO (>10% month-over-month): FAIL
+- Hotspot growth SLO (>10% month-over-month): PASS
 - Boundary ownership SLO (helpers stay behind their module boundaries): PASS
-- Overall architecture SLO status: FAIL
+- Overall architecture SLO status: PASS
 
 ## Refactor Budget Policy
 - Monthly drift report command: `scripts/generate_architecture_drift_report.sh`
@@ -73,9 +73,9 @@ release review. It is not part of the primary public release trail.
 - Rule: each release must name at least one hotspot metric paid down or explicitly state why no paydown happened.
 
 ## Detail Links
-- [Architecture gate](../../../scripts/check_architecture_boundaries.sh)
-- [Release template](TEMPLATE.md)
-- [CI workflow](../../../.github/workflows/ci.yml)
+- [Architecture gate](../../scripts/check_architecture_boundaries.sh)
+- [Release template](support/TEMPLATE.md)
+- [CI workflow](../../.github/workflows/ci.yml)
 
 ## Do Not Use This File For
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-14T10:39:56Z
+- Generated at: 2026-04-14T14:26:25Z
 - Report month: `2026-04`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -33,23 +33,23 @@ release review. It is not part of the primary public release trail.
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 414 | 1000 | 586 | 12 | 20 | 8 | 60.0% | HEALTHY |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 411 | 1000 | 589 | 12 | 20 | 8 | 60.0% | HEALTHY |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9757 | 10500 | 743 | 77 | 90 | 13 | 92.9% | WATCH |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8819 | 9800 | 981 | 17 | 90 | 73 | 90.0% | WATCH |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6599 | 7300 | 701 | 95 | 160 | 65 | 90.4% | WATCH |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6626 | 7300 | 674 | 95 | 160 | 65 | 90.8% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2036 | 6400 | 4364 | 0 | 110 | 110 | 31.8% | HEALTHY |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9970 | 11200 | 1230 | 61 | 120 | 59 | 89.0% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14319 | 15000 | 681 | 44 | 70 | 26 | 95.5% | TIGHT |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14323 | 15000 | 677 | 45 | 70 | 25 | 95.5% | TIGHT |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5679 | 6500 | 821 | 174 | 210 | 36 | 87.4% | WATCH |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9202 | 9800 | 598 | 205 | 250 | 45 | 93.9% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), tools_mod (95.5%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_registry (92.9%), channel_config (90.0%), chat_runtime (90.4%), turn_coordinator (89.0%), daemon_lib (87.4%), onboard_cli (93.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_registry (92.9%), channel_config (90.0%), chat_runtime (90.8%), turn_coordinator (89.0%), daemon_lib (87.4%), onboard_cli (93.9%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -87,16 +87,16 @@ release review. It is not part of the primary public release trail.
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=414 functions=12 -->
+<!-- arch-hotspot key=provider_mod lines=411 functions=12 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3096 functions=0 -->
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
 <!-- arch-hotspot key=channel_registry lines=9757 functions=77 -->
 <!-- arch-hotspot key=channel_config lines=8819 functions=17 -->
-<!-- arch-hotspot key=chat_runtime lines=6599 functions=95 -->
+<!-- arch-hotspot key=chat_runtime lines=6626 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2036 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9970 functions=61 -->
-<!-- arch-hotspot key=tools_mod lines=14319 functions=44 -->
+<!-- arch-hotspot key=tools_mod lines=14323 functions=45 -->
 <!-- arch-hotspot key=daemon_lib lines=5679 functions=174 -->
 <!-- arch-hotspot key=onboard_cli lines=9202 functions=205 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-14T10:39:53Z
+- Generated at: 2026-04-14T14:26:23Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -33,23 +33,23 @@ release review. It is not part of the primary public release trail.
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 414 | 1000 | 586 | 12 | 20 | 8 | 60.0% | HEALTHY | 375 | 10.4% | BREACH | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 411 | 1000 | 589 | 12 | 20 | 8 | 60.0% | HEALTHY | 375 | 9.6% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH | 3383 | -8.5% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9757 | 10500 | 743 | 77 | 90 | 13 | 92.9% | WATCH | 9922 | -1.7% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8819 | 9800 | 981 | 17 | 90 | 73 | 90.0% | WATCH | 9796 | -10.0% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6599 | 7300 | 701 | 95 | 160 | 65 | 90.4% | WATCH | 6936 | -4.9% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6626 | 7300 | 674 | 95 | 160 | 65 | 90.8% | WATCH | 6936 | -4.5% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2036 | 6400 | 4364 | 0 | 110 | 110 | 31.8% | HEALTHY | 1779 | 14.4% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9970 | 11200 | 1230 | 61 | 120 | 59 | 89.0% | WATCH | 10831 | -7.9% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14319 | 15000 | 681 | 44 | 70 | 26 | 95.5% | TIGHT | 14472 | -1.1% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14323 | 15000 | 677 | 45 | 70 | 25 | 95.5% | TIGHT | 14472 | -1.0% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5679 | 6500 | 821 | 174 | 210 | 36 | 87.4% | WATCH | 6324 | -10.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9202 | 9800 | 598 | 205 | 250 | 45 | 93.9% | WATCH | 9519 | -3.3% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), tools_mod (95.5%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_registry (92.9%), channel_config (90.0%), chat_runtime (90.4%), turn_coordinator (89.0%), daemon_lib (87.4%), onboard_cli (93.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_registry (92.9%), channel_config (90.0%), chat_runtime (90.8%), turn_coordinator (89.0%), daemon_lib (87.4%), onboard_cli (93.9%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -87,16 +87,16 @@ release review. It is not part of the primary public release trail.
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=414 functions=12 -->
+<!-- arch-hotspot key=provider_mod lines=411 functions=12 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3096 functions=0 -->
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
 <!-- arch-hotspot key=channel_registry lines=9757 functions=77 -->
 <!-- arch-hotspot key=channel_config lines=8819 functions=17 -->
-<!-- arch-hotspot key=chat_runtime lines=6599 functions=95 -->
+<!-- arch-hotspot key=chat_runtime lines=6626 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2036 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9970 functions=61 -->
-<!-- arch-hotspot key=tools_mod lines=14319 functions=44 -->
+<!-- arch-hotspot key=tools_mod lines=14323 functions=45 -->
 <!-- arch-hotspot key=daemon_lib lines=5679 functions=174 -->
 <!-- arch-hotspot key=onboard_cli lines=9202 functions=205 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/scripts/benchmark_programmatic_pressure.sh
+++ b/scripts/benchmark_programmatic_pressure.sh
@@ -8,7 +8,7 @@ MATRIX_PATH="${1:-examples/benchmarks/programmatic-pressure-matrix.json}"
 BASELINE_PATH="${2:-examples/benchmarks/programmatic-pressure-baseline.json}"
 OUTPUT_PATH="${3:-target/benchmarks/programmatic-pressure-report.json}"
 PREFLIGHT_FAIL_ON_WARNINGS="${4:-false}"
-BENCH_PROFILE="${LOONGCLAW_BENCH_PROFILE:-release}"
+BENCH_PROFILE="${LOONG_BENCH_PROFILE:-${LOONGCLAW_BENCH_PROFILE:-release}}"
 EXTRA_ARGS=()
 
 if [[ "$PREFLIGHT_FAIL_ON_WARNINGS" == "true" ]]; then
@@ -16,11 +16,11 @@ if [[ "$PREFLIGHT_FAIL_ON_WARNINGS" == "true" ]]; then
 fi
 
 if [[ "$BENCH_PROFILE" != "dev" && "$BENCH_PROFILE" != "release" ]]; then
-  echo "invalid LOONGCLAW_BENCH_PROFILE: $BENCH_PROFILE (expected dev|release)" >&2
+  echo "invalid LOONG_BENCH_PROFILE/LOONGCLAW_BENCH_PROFILE: $BENCH_PROFILE (expected dev|release)" >&2
   exit 2
 fi
 
-CARGO_ARGS=(run -p loongclaw)
+CARGO_ARGS=(run -p loong)
 if [[ "$BENCH_PROFILE" == "release" ]]; then
   CARGO_ARGS+=(--release)
 fi

--- a/scripts/benchmark_wasm_cache.sh
+++ b/scripts/benchmark_wasm_cache.sh
@@ -11,10 +11,10 @@ HOT_ITERATIONS="${4:-24}"
 WARMUP_ITERATIONS="${5:-2}"
 ENFORCE_GATE="${6:-true}"
 MIN_SPEEDUP_RATIO="${7:-1.5}"
-BENCH_PROFILE="${LOONGCLAW_BENCH_PROFILE:-release}"
+BENCH_PROFILE="${LOONG_BENCH_PROFILE:-${LOONGCLAW_BENCH_PROFILE:-release}}"
 
 if [[ "$BENCH_PROFILE" != "dev" && "$BENCH_PROFILE" != "release" ]]; then
-  echo "invalid LOONGCLAW_BENCH_PROFILE: $BENCH_PROFILE (expected dev|release)" >&2
+  echo "invalid LOONG_BENCH_PROFILE/LOONGCLAW_BENCH_PROFILE: $BENCH_PROFILE (expected dev|release)" >&2
   exit 2
 fi
 
@@ -23,7 +23,7 @@ if [[ "$ENFORCE_GATE" != "true" && "$ENFORCE_GATE" != "false" ]]; then
   exit 2
 fi
 
-CARGO_ARGS=(run -p loongclaw)
+CARGO_ARGS=(run -p loong)
 if [[ "$BENCH_PROFILE" == "release" ]]; then
   CARGO_ARGS+=(--release)
 fi

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -11,12 +11,14 @@ WARNINGS=0
 PUBLIC_GITHUB_REPO="${LOONG_PUBLIC_REPO:-eastreams/loong}"
 PUBLIC_GITHUB_BASE="https://github.com/${PUBLIC_GITHUB_REPO}"
 
-if [ -n "${LOONGCLAW_RELEASE_DOCS_STRICT:-}" ]; then
-    case "${LOONGCLAW_RELEASE_DOCS_STRICT}" in
+RELEASE_DOCS_STRICT="${LOONG_RELEASE_DOCS_STRICT:-${LOONGCLAW_RELEASE_DOCS_STRICT:-}}"
+
+if [ -n "${RELEASE_DOCS_STRICT:-}" ]; then
+    case "${RELEASE_DOCS_STRICT}" in
         1|true|TRUE|yes|YES) STRICT_RELEASE_DOCS=1 ;;
         0|false|FALSE|no|NO) STRICT_RELEASE_DOCS=0 ;;
         *)
-            echo "FAIL: invalid LOONGCLAW_RELEASE_DOCS_STRICT value '${LOONGCLAW_RELEASE_DOCS_STRICT}' (expected 0/1)"
+            echo "FAIL: invalid LOONG_RELEASE_DOCS_STRICT/LOONGCLAW_RELEASE_DOCS_STRICT value '${RELEASE_DOCS_STRICT}' (expected 0/1)"
             exit 1
             ;;
     esac

--- a/scripts/check_architecture_drift_freshness.sh
+++ b/scripts/check_architecture_drift_freshness.sh
@@ -4,12 +4,30 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-$(date -u +%Y-%m)}"
+REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-${LOONGCLAW_ARCH_REPORT_MONTH:-$(date -u +%Y-%m)}}"
 REPORT_PATH="${1:-docs/releases/support/architecture-drift-${REPORT_MONTH}.md}"
 REPORT_DIR="$(dirname "$REPORT_PATH")"
+derive_logical_report_path() {
+  python3 - "$REPORT_PATH" <<'PY'
+import sys
+from pathlib import PurePosixPath
+
+report_path = sys.argv[1].replace("\\", "/")
+marker = "docs/releases/"
+index = report_path.find(marker)
+if index >= 0:
+    print(report_path[index:])
+else:
+    print(PurePosixPath(report_path).as_posix())
+PY
+}
+
+REPORT_LOGICAL_PATH="$(derive_logical_report_path)"
 BASELINE_DIR_OVERRIDE="$REPORT_DIR"
 if [[ -n "${LOONG_ARCH_DRIFT_BASELINE_DIR:-}" ]]; then
   BASELINE_DIR_OVERRIDE="$LOONG_ARCH_DRIFT_BASELINE_DIR"
+elif [[ -n "${LOONGCLAW_ARCH_DRIFT_BASELINE_DIR:-}" ]]; then
+  BASELINE_DIR_OVERRIDE="$LOONGCLAW_ARCH_DRIFT_BASELINE_DIR"
 fi
 mkdir -p "$REPORT_DIR"
 # Keep the temp report beside the tracked report so baseline resolution uses the same directory.
@@ -32,14 +50,16 @@ normalize_architecture_drift_report() {
   sed     -e "$generated_at_pattern"     -e "$baseline_report_pattern"     "$input_path"
 }
 
-if ! git ls-files --error-unmatch "$REPORT_PATH" >/dev/null 2>&1; then
+if ! git ls-files --error-unmatch "$REPORT_LOGICAL_PATH" >/dev/null 2>&1; then
   echo "[arch-drift] report path must already be tracked by git: ${REPORT_PATH}" >&2
   exit 1
 fi
 
 LOONG_ARCH_REPORT_MONTH="$REPORT_MONTH" \
+LOONGCLAW_ARCH_REPORT_MONTH="$REPORT_MONTH" \
 LOONG_ARCH_DRIFT_BASELINE_DIR="$BASELINE_DIR_OVERRIDE" \
-LOONG_ARCH_REPORT_LINK_PATH="$REPORT_PATH" \
+LOONGCLAW_ARCH_DRIFT_BASELINE_DIR="$BASELINE_DIR_OVERRIDE" \
+LOONG_ARCH_REPORT_LINK_PATH="$REPORT_LOGICAL_PATH" \
   scripts/generate_architecture_drift_report.sh "$TEMP_REPORT"
 normalize_architecture_drift_report "$REPORT_PATH" >"$NORMALIZED_TRACKED"
 normalize_architecture_drift_report "$TEMP_REPORT" >"$NORMALIZED_GENERATED"

--- a/scripts/check_architecture_drift_freshness.sh
+++ b/scripts/check_architecture_drift_freshness.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-REPORT_MONTH="${LOONGCLAW_ARCH_REPORT_MONTH:-$(date -u +%Y-%m)}"
+REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-$(date -u +%Y-%m)}"
 REPORT_PATH="${1:-docs/releases/support/architecture-drift-${REPORT_MONTH}.md}"
 REPORT_DIR="$(dirname "$REPORT_PATH")"
 BASELINE_DIR_OVERRIDE="$REPORT_DIR"
-if [[ -n "${LOONGCLAW_ARCH_DRIFT_BASELINE_DIR:-}" ]]; then
-  BASELINE_DIR_OVERRIDE="$LOONGCLAW_ARCH_DRIFT_BASELINE_DIR"
+if [[ -n "${LOONG_ARCH_DRIFT_BASELINE_DIR:-}" ]]; then
+  BASELINE_DIR_OVERRIDE="$LOONG_ARCH_DRIFT_BASELINE_DIR"
 fi
 mkdir -p "$REPORT_DIR"
 # Keep the temp report beside the tracked report so baseline resolution uses the same directory.
@@ -37,7 +37,10 @@ if ! git ls-files --error-unmatch "$REPORT_PATH" >/dev/null 2>&1; then
   exit 1
 fi
 
-LOONGCLAW_ARCH_REPORT_MONTH="$REPORT_MONTH" LOONGCLAW_ARCH_DRIFT_BASELINE_DIR="$BASELINE_DIR_OVERRIDE"   scripts/generate_architecture_drift_report.sh "$TEMP_REPORT"
+LOONG_ARCH_REPORT_MONTH="$REPORT_MONTH" \
+LOONG_ARCH_DRIFT_BASELINE_DIR="$BASELINE_DIR_OVERRIDE" \
+LOONG_ARCH_REPORT_LINK_PATH="$REPORT_PATH" \
+  scripts/generate_architecture_drift_report.sh "$TEMP_REPORT"
 normalize_architecture_drift_report "$REPORT_PATH" >"$NORMALIZED_TRACKED"
 normalize_architecture_drift_report "$TEMP_REPORT" >"$NORMALIZED_GENERATED"
 

--- a/scripts/generate_architecture_drift_report.sh
+++ b/scripts/generate_architecture_drift_report.sh
@@ -5,12 +5,28 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 . "$REPO_ROOT/scripts/architecture_budget_lib.sh"
 
-REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-$(date +%Y-%m)}"
+REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-${LOONGCLAW_ARCH_REPORT_MONTH:-$(date +%Y-%m)}}"
 OUTPUT_PATH="${1:-docs/releases/support/architecture-drift-${REPORT_MONTH}.md}"
-LINK_REFERENCE_PATH="${LOONG_ARCH_REPORT_LINK_PATH:-$OUTPUT_PATH}"
-EXPLICIT_BASELINE="${LOONG_ARCH_DRIFT_BASELINE_REPORT:-}"
-EXPLICIT_BASELINE_DIR="${LOONG_ARCH_DRIFT_BASELINE_DIR:-}"
+EXPLICIT_BASELINE="${LOONG_ARCH_DRIFT_BASELINE_REPORT:-${LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT:-}}"
+EXPLICIT_BASELINE_DIR="${LOONG_ARCH_DRIFT_BASELINE_DIR:-${LOONGCLAW_ARCH_DRIFT_BASELINE_DIR:-}}"
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+derive_link_reference_path() {
+  python3 - "$OUTPUT_PATH" <<'PY'
+import sys
+from pathlib import PurePosixPath
+
+output_path = sys.argv[1].replace("\\", "/")
+marker = "docs/releases/"
+index = output_path.find(marker)
+if index >= 0:
+    print(output_path[index:])
+else:
+    print(PurePosixPath(output_path).as_posix())
+PY
+}
+
+LINK_REFERENCE_PATH="${LOONG_ARCH_REPORT_LINK_PATH:-$(derive_link_reference_path)}"
 LINK_REFERENCE_DIR="$(dirname "$LINK_REFERENCE_PATH")"
 
 relative_link_from_output_dir() {
@@ -19,10 +35,10 @@ relative_link_from_output_dir() {
 import os
 import sys
 
-output_dir = sys.argv[1]
-target_path = sys.argv[2]
+output_dir = sys.argv[1].replace("\\", "/")
+target_path = sys.argv[2].replace("\\", "/")
 
-print(os.path.relpath(target_path, start=output_dir))
+print(os.path.relpath(target_path, start=output_dir).replace("\\", "/"))
 PY
 }
 

--- a/scripts/generate_architecture_drift_report.sh
+++ b/scripts/generate_architecture_drift_report.sh
@@ -5,11 +5,26 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 . "$REPO_ROOT/scripts/architecture_budget_lib.sh"
 
-REPORT_MONTH="${LOONGCLAW_ARCH_REPORT_MONTH:-$(date +%Y-%m)}"
+REPORT_MONTH="${LOONG_ARCH_REPORT_MONTH:-$(date +%Y-%m)}"
 OUTPUT_PATH="${1:-docs/releases/support/architecture-drift-${REPORT_MONTH}.md}"
-EXPLICIT_BASELINE="${LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT:-}"
-EXPLICIT_BASELINE_DIR="${LOONGCLAW_ARCH_DRIFT_BASELINE_DIR:-}"
+LINK_REFERENCE_PATH="${LOONG_ARCH_REPORT_LINK_PATH:-$OUTPUT_PATH}"
+EXPLICIT_BASELINE="${LOONG_ARCH_DRIFT_BASELINE_REPORT:-}"
+EXPLICIT_BASELINE_DIR="${LOONG_ARCH_DRIFT_BASELINE_DIR:-}"
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LINK_REFERENCE_DIR="$(dirname "$LINK_REFERENCE_PATH")"
+
+relative_link_from_output_dir() {
+  local target_path="${1:?target_path is required}"
+  python3 - "$LINK_REFERENCE_DIR" "$target_path" <<'PY'
+import os
+import sys
+
+output_dir = sys.argv[1]
+target_path = sys.argv[2]
+
+print(os.path.relpath(target_path, start=output_dir))
+PY
+}
 
 derive_previous_month() {
   local label="$1"
@@ -212,6 +227,10 @@ else
 fi
 
 {
+  release_template_link="$(relative_link_from_output_dir "docs/releases/support/TEMPLATE.md")"
+  architecture_gate_link="$(relative_link_from_output_dir "scripts/check_architecture_boundaries.sh")"
+  ci_workflow_link="$(relative_link_from_output_dir ".github/workflows/ci.yml")"
+
   echo "# Architecture Drift Report ${REPORT_MONTH}"
   echo
   echo "This report is a repository maintenance artifact for architecture-governance and"
@@ -290,9 +309,9 @@ fi
   echo "- Rule: each release must name at least one hotspot metric paid down or explicitly state why no paydown happened."
   echo
   echo "## Detail Links"
-  echo "- [Architecture gate](../../../scripts/check_architecture_boundaries.sh)"
-  echo "- [Release template](TEMPLATE.md)"
-  echo "- [CI workflow](../../../.github/workflows/ci.yml)"
+  echo "- [Architecture gate](${architecture_gate_link})"
+  echo "- [Release template](${release_template_link})"
+  echo "- [CI workflow](${ci_workflow_link})"
   echo
   echo "## Do Not Use This File For"
   echo

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,8 +9,15 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 $Prefix = [IO.Path]::GetFullPath(($Prefix -replace '^~', $HOME))
-$ReleaseBaseUrl = if ($env:LOONG_INSTALL_RELEASE_BASE_URL) { $env:LOONG_INSTALL_RELEASE_BASE_URL } else { "https://github.com/$Repository/releases" }
+$ReleaseBaseUrl = if ($env:LOONG_INSTALL_RELEASE_BASE_URL) {
+    $env:LOONG_INSTALL_RELEASE_BASE_URL
+} elseif ($env:LOONGCLAW_INSTALL_RELEASE_BASE_URL) {
+    $env:LOONGCLAW_INSTALL_RELEASE_BASE_URL
+} else {
+    "https://github.com/$Repository/releases"
+}
 $BinName = "loong"
+$LegacyBinName = "loongclaw"
 
 function Write-Usage {
     @"
@@ -89,12 +96,15 @@ function Get-ReleaseChecksumName([string]$PackageName, [string]$Tag, [string]$Ta
     return "$(Get-ReleaseArchiveName -PackageName $PackageName -Tag $Tag -Target $Target).sha256"
 }
 
-function Install-Binary([string]$SourceBinary) {
+function Install-CompatibilityBinaries([string]$SourceBinary) {
     New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
     $primaryBinary = Join-Path $Prefix "$BinName.exe"
+    $legacyBinary = Join-Path $Prefix "$LegacyBinName.exe"
     Copy-Item -Force $SourceBinary $primaryBinary
+    Copy-Item -Force $SourceBinary $legacyBinary
     return @{
         Primary = $primaryBinary
+        Legacy = $legacyBinary
     }
 }
 
@@ -130,7 +140,7 @@ function Install-FromSource {
         throw "built binary not found at $sourceBinary"
     }
 
-    return Install-Binary -SourceBinary $sourceBinary
+    return Install-CompatibilityBinaries -SourceBinary $sourceBinary
 }
 
 function Install-FromRelease {
@@ -175,7 +185,7 @@ function Install-FromRelease {
             throw "extracted binary not found at $sourceBinary"
         }
 
-        return Install-Binary -SourceBinary $sourceBinary
+        return Install-CompatibilityBinaries -SourceBinary $sourceBinary
     } finally {
         if (Test-Path $tmpRoot) {
             Remove-Item -Recurse -Force $tmpRoot
@@ -198,6 +208,7 @@ function Resolve-NormalizedPathEntryOrNull([string]$PathEntry) {
 $installResult = if ($Source) { Install-FromSource } else { Install-FromRelease }
 
 Write-Host "==> Installed loong to $($installResult.Primary)"
+Write-Host "==> Installed compatible loongclaw command to $($installResult.Legacy)"
 
 $normalizedPrefix = $Prefix
 $pathItems = ($env:PATH -split [IO.Path]::PathSeparator) |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,13 +9,7 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 $Prefix = [IO.Path]::GetFullPath(($Prefix -replace '^~', $HOME))
-$ReleaseBaseUrl = if ($env:LOONG_INSTALL_RELEASE_BASE_URL) {
-    $env:LOONG_INSTALL_RELEASE_BASE_URL
-} elseif ($env:LOONGCLAW_INSTALL_RELEASE_BASE_URL) {
-    $env:LOONGCLAW_INSTALL_RELEASE_BASE_URL
-} else {
-    "https://github.com/$Repository/releases"
-}
+$ReleaseBaseUrl = if ($env:LOONG_INSTALL_RELEASE_BASE_URL) { $env:LOONG_INSTALL_RELEASE_BASE_URL } else { "https://github.com/$Repository/releases" }
 $BinName = "loong"
 
 function Write-Usage {
@@ -117,16 +111,16 @@ function Install-FromSource {
 
     Write-Host "==> Building loong from source (release)"
     Push-Location $repoRoot
-    $hadReleaseBuild = Test-Path Env:LOONGCLAW_RELEASE_BUILD
-    $previousReleaseBuild = $env:LOONGCLAW_RELEASE_BUILD
+    $hadReleaseBuild = (Test-Path Env:LOONG_RELEASE_BUILD)
+    $previousReleaseBuild = $env:LOONG_RELEASE_BUILD
     try {
-        $env:LOONGCLAW_RELEASE_BUILD = "1"
+        $env:LOONG_RELEASE_BUILD = "1"
         cargo build -p loong --bin $BinName --release --locked | Out-Host
     } finally {
         if ($hadReleaseBuild) {
-            $env:LOONGCLAW_RELEASE_BUILD = $previousReleaseBuild
-        } elseif (Test-Path Env:LOONGCLAW_RELEASE_BUILD) {
-            Remove-Item Env:LOONGCLAW_RELEASE_BUILD
+            $env:LOONG_RELEASE_BUILD = $previousReleaseBuild
+        } elseif (Test-Path Env:LOONG_RELEASE_BUILD) {
+            Remove-Item Env:LOONG_RELEASE_BUILD
         }
         Pop-Location
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -201,12 +201,13 @@ detect_release_host_platform() {
 prefix="${HOME}/.local/bin"
 run_onboard=0
 install_source=0
-release_version="${LOONG_INSTALL_VERSION:-latest}"
-release_repo="${LOONG_INSTALL_REPO:-eastreams/loong}"
-release_base_url="${LOONG_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}"
-target_libc="${LOONG_INSTALL_TARGET_LIBC:-auto}"
+release_version="${LOONG_INSTALL_VERSION:-${LOONGCLAW_INSTALL_VERSION:-latest}}"
+release_repo="${LOONG_INSTALL_REPO:-${LOONGCLAW_INSTALL_REPO:-eastreams/loong}}"
+release_base_url="${LOONG_INSTALL_RELEASE_BASE_URL:-${LOONGCLAW_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}}"
+target_libc="${LOONG_INSTALL_TARGET_LIBC:-${LOONGCLAW_INSTALL_TARGET_LIBC:-auto}}"
 package_name="loong"
 bin_name="loong"
+legacy_bin_name="loongclaw"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -351,12 +352,14 @@ lowercase_value() {
   printf '%s' "${value}" | tr '[:upper:]' '[:lower:]'
 }
 
-install_binary() {
+install_binary_pair() {
   local source_path="${1:?source_path is required}"
-  local output_name="${2:?output_name is required}"
+  local primary_output_name="${2:?primary_output_name is required}"
+  local legacy_output_name="${3:?legacy_output_name is required}"
 
   mkdir -p "${prefix}"
-  install -m 755 "${source_path}" "${prefix}/${output_name}"
+  install -m 755 "${source_path}" "${prefix}/${primary_output_name}"
+  install -m 755 "${source_path}" "${prefix}/${legacy_output_name}"
 }
 
 install_web_search_provider_display_name() {
@@ -557,7 +560,10 @@ run_guided_onboarding() {
   local onboard_status
 
   if [[ -n "${LOONG_WEB_SEARCH_PROVIDER:-}" ]]; then
-    selected_provider="${LOONG_WEB_SEARCH_PROVIDER:-}"
+    selected_provider="${LOONG_WEB_SEARCH_PROVIDER}"
+    provider_source="preconfigured"
+  elif [[ -n "${LOONGCLAW_WEB_SEARCH_PROVIDER:-}" ]]; then
+    selected_provider="${LOONGCLAW_WEB_SEARCH_PROVIDER}"
     provider_source="preconfigured"
   else
     recommendation="$(recommend_onboard_web_search_provider)"
@@ -758,7 +764,7 @@ release_target_for_install() {
 }
 
 install_from_source() {
-  local repo_root host_target source_binary primary_binary_name
+  local repo_root host_target source_binary primary_binary_name legacy_binary_name
   require_command "cargo" "Install Rust first: https://rustup.rs"
   require_command "install" "Install coreutils or use a different shell environment."
 
@@ -773,11 +779,12 @@ install_from_source() {
 
   host_target="$(release_target_for_platform "$(detect_release_host_platform)" "$(uname -m)")"
   primary_binary_name="$(release_binary_name_for_target "${bin_name}" "${host_target}")"
+  legacy_binary_name="$(release_binary_name_for_target "${legacy_bin_name}" "${host_target}")"
 
   printf '==> Building loong from source (release)\n'
   (
     cd "${repo_root}"
-    LOONG_RELEASE_BUILD="${LOONG_RELEASE_BUILD:-1}" \
+    LOONG_RELEASE_BUILD="${LOONG_RELEASE_BUILD:-${LOONGCLAW_RELEASE_BUILD:-1}}" \
       cargo build -p loong --bin "${bin_name}" --release --locked
   )
 
@@ -787,12 +794,12 @@ install_from_source() {
     exit 1
   fi
 
-  install_binary "${source_binary}" "${primary_binary_name}"
+  install_binary_pair "${source_binary}" "${primary_binary_name}" "${legacy_binary_name}"
 }
 
 install_from_release() {
   local host_platform host_arch target_tag target archive_name checksum_name
-  local archive_url checksum_url binary_name tmp_dir archive_path checksum_path
+  local archive_url checksum_url binary_name legacy_binary_name tmp_dir archive_path checksum_path
   local extract_dir installed_binary expected_sha actual_sha
 
   require_command "curl" "Install curl first or use --source inside a repository checkout."
@@ -811,6 +818,7 @@ install_from_release() {
   archive_url="${release_base_url}/download/${target_tag}/${archive_name}"
   checksum_url="${release_base_url}/download/${target_tag}/${checksum_name}"
   binary_name="$(release_binary_name_for_target "${bin_name}" "${target}")"
+  legacy_binary_name="$(release_binary_name_for_target "${legacy_bin_name}" "${target}")"
 
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "${tmp_dir}"' RETURN
@@ -843,7 +851,7 @@ install_from_release() {
     exit 1
   fi
 
-  install_binary "${installed_binary}" "${binary_name}"
+  install_binary_pair "${installed_binary}" "${binary_name}" "${legacy_binary_name}"
 }
 
 if [[ "${install_source}" -eq 1 ]]; then
@@ -853,6 +861,7 @@ else
 fi
 
 printf '==> Installed loong to %s\n' "${prefix}/${bin_name}"
+printf '==> Installed compatible loongclaw command to %s\n' "${prefix}/${legacy_bin_name}"
 
 should_print_source_hint=0
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -201,10 +201,10 @@ detect_release_host_platform() {
 prefix="${HOME}/.local/bin"
 run_onboard=0
 install_source=0
-release_version="${LOONG_INSTALL_VERSION:-${LOONGCLAW_INSTALL_VERSION:-latest}}"
-release_repo="${LOONG_INSTALL_REPO:-${LOONGCLAW_INSTALL_REPO:-eastreams/loong}}"
-release_base_url="${LOONG_INSTALL_RELEASE_BASE_URL:-${LOONGCLAW_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}}"
-target_libc="${LOONG_INSTALL_TARGET_LIBC:-${LOONGCLAW_INSTALL_TARGET_LIBC:-auto}}"
+release_version="${LOONG_INSTALL_VERSION:-latest}"
+release_repo="${LOONG_INSTALL_REPO:-eastreams/loong}"
+release_base_url="${LOONG_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}"
+target_libc="${LOONG_INSTALL_TARGET_LIBC:-auto}"
 package_name="loong"
 bin_name="loong"
 
@@ -556,8 +556,8 @@ run_guided_onboarding() {
   local recommendation
   local onboard_status
 
-  if [[ -n "${LOONGCLAW_WEB_SEARCH_PROVIDER:-}" ]]; then
-    selected_provider="${LOONGCLAW_WEB_SEARCH_PROVIDER}"
+  if [[ -n "${LOONG_WEB_SEARCH_PROVIDER:-}" ]]; then
+    selected_provider="${LOONG_WEB_SEARCH_PROVIDER:-}"
     provider_source="preconfigured"
   else
     recommendation="$(recommend_onboard_web_search_provider)"
@@ -777,7 +777,7 @@ install_from_source() {
   printf '==> Building loong from source (release)\n'
   (
     cd "${repo_root}"
-    LOONGCLAW_RELEASE_BUILD=1 \
+    LOONG_RELEASE_BUILD="${LOONG_RELEASE_BUILD:-1}" \
       cargo build -p loong --bin "${bin_name}" --release --locked
   )
 

--- a/scripts/lint_programmatic_pressure_baseline.sh
+++ b/scripts/lint_programmatic_pressure_baseline.sh
@@ -18,7 +18,7 @@ fi
 COMMAND_ARGS+=(cargo)
 COMMAND_ARGS+=(run)
 COMMAND_ARGS+=(-p)
-COMMAND_ARGS+=(loongclaw)
+COMMAND_ARGS+=(loong)
 COMMAND_ARGS+=(--bin)
 COMMAND_ARGS+=(loong)
 COMMAND_ARGS+=(--)

--- a/scripts/stress_daemon_tests.sh
+++ b/scripts/stress_daemon_tests.sh
@@ -7,9 +7,9 @@ cd "$REPO_ROOT"
 ROUNDS="${1:-10}"
 THREAD_MODES="${2:-default,2,1}"
 LOG_DIR="${3:-target/test-stress/daemon}"
-TRAP_MODES="${4:-${LOONGCLAW_STRESS_WASM_TRAPS_MODES:-auto}}"
-LOCKED="${LOONGCLAW_STRESS_LOCKED:-true}"
-CONTINUE_ON_FAILURE="${LOONGCLAW_STRESS_CONTINUE_ON_FAILURE:-false}"
+TRAP_MODES="${4:-${LOONG_STRESS_WASM_TRAPS_MODES:-${LOONGCLAW_STRESS_WASM_TRAPS_MODES:-auto}}}"
+LOCKED="${LOONG_STRESS_LOCKED:-${LOONGCLAW_STRESS_LOCKED:-true}}"
+CONTINUE_ON_FAILURE="${LOONG_STRESS_CONTINUE_ON_FAILURE:-${LOONGCLAW_STRESS_CONTINUE_ON_FAILURE:-false}}"
 
 if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -le 0 ]]; then
   echo "invalid ROUNDS: $ROUNDS (expected positive integer)" >&2
@@ -17,12 +17,12 @@ if ! [[ "$ROUNDS" =~ ^[0-9]+$ ]] || [[ "$ROUNDS" -le 0 ]]; then
 fi
 
 if [[ "$LOCKED" != "true" && "$LOCKED" != "false" ]]; then
-  echo "invalid LOONGCLAW_STRESS_LOCKED: $LOCKED (expected true|false)" >&2
+  echo "invalid LOONG_STRESS_LOCKED/LOONGCLAW_STRESS_LOCKED: $LOCKED (expected true|false)" >&2
   exit 2
 fi
 
 if [[ "$CONTINUE_ON_FAILURE" != "true" && "$CONTINUE_ON_FAILURE" != "false" ]]; then
-  echo "invalid LOONGCLAW_STRESS_CONTINUE_ON_FAILURE: $CONTINUE_ON_FAILURE (expected true|false)" >&2
+  echo "invalid LOONG_STRESS_CONTINUE_ON_FAILURE/LOONGCLAW_STRESS_CONTINUE_ON_FAILURE: $CONTINUE_ON_FAILURE (expected true|false)" >&2
   exit 2
 fi
 
@@ -47,7 +47,7 @@ run_mode() {
     local log_file="$LOG_DIR/traps-${trap_mode}-mode-${mode}-run-${run_index}.log"
     local cmd=(
       cargo test
-      -p loongclaw
+      -p loong
       --bin loong
       --all-features
     )
@@ -61,10 +61,10 @@ run_mode() {
     echo "[stress] traps=${trap_mode} mode=${mode} run=${run_index}/${ROUNDS}"
     local status="PASS"
     if [[ "$trap_mode" == "auto" ]]; then
-      if ! env -u LOONGCLAW_WASM_SIGNALS_BASED_TRAPS "${cmd[@]}" >"$log_file" 2>&1; then
+      if ! env -u LOONG_WASM_SIGNALS_BASED_TRAPS -u LOONGCLAW_WASM_SIGNALS_BASED_TRAPS "${cmd[@]}" >"$log_file" 2>&1; then
         status="FAIL"
       fi
-    elif ! LOONGCLAW_WASM_SIGNALS_BASED_TRAPS="$trap_mode" "${cmd[@]}" >"$log_file" 2>&1; then
+    elif ! LOONG_WASM_SIGNALS_BASED_TRAPS="$trap_mode" LOONGCLAW_WASM_SIGNALS_BASED_TRAPS="$trap_mode" "${cmd[@]}" >"$log_file" 2>&1; then
       status="FAIL"
     fi
 

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -6,6 +6,7 @@ SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/install.sh"
 . "$REPO_ROOT/scripts/release_artifact_lib.sh"
 PACKAGE_NAME="loong"
 PRIMARY_BIN_NAME="loong"
+LEGACY_BIN_NAME="loongclaw"
 
 assert_contains() {
   local file="$1"
@@ -27,18 +28,24 @@ assert_not_contains() {
   fi
 }
 
-assert_installed_primary_binary() {
+assert_installed_binary_pair() {
   local install_dir="$1"
   local expected_output="$2"
   local primary_output
+  local legacy_output
 
   [[ -x "$install_dir/$PRIMARY_BIN_NAME" ]]
-  [[ ! -e "$install_dir/loongclaw" ]]
+  [[ -x "$install_dir/$LEGACY_BIN_NAME" ]]
 
   primary_output="$("$install_dir/$PRIMARY_BIN_NAME")"
+  legacy_output="$("$install_dir/$LEGACY_BIN_NAME")"
 
   if [[ "$primary_output" != "$expected_output" ]]; then
     echo "expected primary binary output '$expected_output' but got '$primary_output'" >&2
+    exit 1
+  fi
+  if [[ "$legacy_output" != "$expected_output" ]]; then
+    echo "expected legacy binary output '$expected_output' but got '$legacy_output'" >&2
     exit 1
   fi
 }
@@ -68,7 +75,7 @@ make_release_fixture() {
 }
 
 write_release_fixture_asset() {
-  local fixture tag target binary_label archive_name checksum_name binary_name archive_path checksum_path release_dir staging_dir
+  local fixture tag target binary_label archive_name checksum_name binary_name legacy_binary_name archive_path checksum_path release_dir staging_dir
   fixture="${1:?fixture is required}"
   tag="${2:-v0.1.2}"
   target="${3:-$(host_target)}"
@@ -76,6 +83,7 @@ write_release_fixture_asset() {
   archive_name="$(release_archive_name "$PACKAGE_NAME" "$tag" "$target")"
   checksum_name="$(release_archive_checksum_name "$PACKAGE_NAME" "$tag" "$target")"
   binary_name="$(release_binary_name_for_target "$PRIMARY_BIN_NAME" "$target")"
+  legacy_binary_name="$(release_binary_name_for_target "$LEGACY_BIN_NAME" "$target")"
   release_dir="$fixture/releases/download/$tag"
   staging_dir="$fixture/staging/$target"
   mkdir -p "$release_dir" "$staging_dir"
@@ -85,7 +93,7 @@ write_release_fixture_asset() {
 set -euo pipefail
 if [[ "\${1:-}" == "onboard" ]]; then
   shift
-  selected_provider="\${LOONG_WEB_SEARCH_PROVIDER:-}"
+  selected_provider="\${LOONG_WEB_SEARCH_PROVIDER:-\${LOONGCLAW_WEB_SEARCH_PROVIDER:-}}"
   while [[ "\$#" -gt 0 ]]; do
     case "\${1:-}" in
       --web-search-provider)
@@ -104,14 +112,15 @@ fi
 printf '%s\n' "$binary_label"
 EOF
   chmod +x "$staging_dir/$binary_name"
+  cp "$staging_dir/$binary_name" "$staging_dir/$legacy_binary_name"
 
   archive_path="$release_dir/$archive_name"
   case "$archive_name" in
     *.tar.gz)
-      tar -C "$staging_dir" -czf "$archive_path" "$binary_name"
+      tar -C "$staging_dir" -czf "$archive_path" "$binary_name" "$legacy_binary_name"
       ;;
     *.zip)
-      (cd "$staging_dir" && zip -q "$archive_path" "$binary_name")
+      (cd "$staging_dir" && zip -q "$archive_path" "$binary_name" "$legacy_binary_name")
       ;;
     *)
       echo "unsupported archive format in fixture: $archive_name" >&2
@@ -300,7 +309,7 @@ run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_primary_binary "$install_dir" "gnu-binary"
+  assert_installed_binary_pair "$install_dir" "gnu-binary"
 }
 
 
@@ -322,7 +331,7 @@ run_termux_arm64_installs_android_release_test() {
   )
 
   assert_contains "$output_file" "aarch64-linux-android"
-  assert_installed_primary_binary "$install_dir" "termux-binary"
+  assert_installed_binary_pair "$install_dir" "termux-binary"
 }
 
 run_linux_guest_with_termux_env_is_not_termux_test() {
@@ -367,7 +376,7 @@ run_linux_guest_with_termux_env_prefers_linux_release_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_primary_binary "$install_dir" "gnu-binary"
+  assert_installed_binary_pair "$install_dir" "gnu-binary"
 }
 
 run_termux_x86_64_rejects_android_release_test() {
@@ -410,7 +419,7 @@ run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_primary_binary "$install_dir" "musl-binary"
+  assert_installed_binary_pair "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test() {
@@ -431,7 +440,7 @@ run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_primary_binary "$install_dir" "musl-binary"
+  assert_installed_binary_pair "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_explicit_musl_override_test() {
@@ -452,7 +461,7 @@ run_linux_x86_64_explicit_musl_override_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_primary_binary "$install_dir" "musl-binary"
+  assert_installed_binary_pair "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
@@ -551,7 +560,7 @@ run_linux_x86_64_prefers_gnu_when_sort_version_is_unavailable_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_primary_binary "$install_dir" "gnu-binary"
+  assert_installed_binary_pair "$install_dir" "gnu-binary"
 }
 
 run_linux_x86_64_explicit_gnu_override_rejects_musl_ldd_output_test() {
@@ -625,9 +634,9 @@ run_release_override_install_and_onboard_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_contains "$output_file" "Installed loong to"
-  assert_not_contains "$output_file" "Installed compatible loongclaw command to"
+  assert_contains "$output_file" "Installed compatible loongclaw command to"
   assert_contains "$output_file" "Running guided onboarding"
   assert_contains "$marker" "onboard"
 }
@@ -657,7 +666,7 @@ run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_contains "$bashrc_file" "# Added by Loong installer"
   assert_contains "$bashrc_file" "$expected_path_line"
   assert_contains "$output_file" "Added $install_dir to PATH in $bashrc_file"
@@ -685,7 +694,7 @@ run_release_install_skips_source_hint_when_path_is_already_available_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_not_contains "$output_file" "source \"$home_dir/.bashrc\""
   assert_not_contains "$output_file" "Add to PATH if needed:"
 }
@@ -714,7 +723,7 @@ run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_contains "$output_file" "PATH entry already present in $bashrc_file"
   assert_contains "$output_file" "source \"$bashrc_file\""
 }
@@ -740,7 +749,7 @@ run_release_install_unsupported_shell_uses_manual_path_hint_only_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_contains "$output_file" "Add to PATH if needed:"
   assert_not_contains "$output_file" 'source "$HOME/.profile"'
 }
@@ -775,7 +784,7 @@ run_release_override_install_and_onboard_failure_preserves_install_test() {
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
-  assert_installed_primary_binary "$install_dir" "fixture-binary"
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
   assert_contains "$marker" "onboard"
   assert_contains "$output_file" "Onboarding exited with code 130"
   assert_contains "$output_file" "You can run 'loong onboard' later to complete setup"
@@ -812,6 +821,50 @@ run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
 
   assert_contains "$output_file" "Onboarding web search default: DuckDuckGo (detected)"
   assert_contains "$marker" "web_search_provider=duckduckgo"
+}
+
+run_release_install_honors_legacy_release_base_env_test() {
+  local fixture
+  local install_dir
+  local output_file
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install-legacy-release-base.out"
+
+  (
+    cd "$REPO_ROOT"
+    LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$output_file" "Installed compatible loongclaw command to"
+}
+
+run_release_override_install_and_onboard_honors_legacy_web_search_provider_env_test() {
+  local fixture
+  local install_dir
+  local output_file
+  local marker
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install-web-search-legacy-env.out"
+  marker="$fixture/onboard-web-search-legacy-env.log"
+  : >"$marker"
+
+  (
+    cd "$REPO_ROOT"
+    ONBOARD_MARKER="$marker" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONGCLAW_WEB_SEARCH_PROVIDER="brave" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
+  )
+
+  assert_installed_binary_pair "$install_dir" "fixture-binary"
+  assert_contains "$output_file" "Onboarding web search default: Brave Search (preconfigured)"
+  assert_contains "$marker" "web_search_provider=brave"
 }
 
 run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test() {
@@ -1057,6 +1110,8 @@ run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test
 run_release_install_unsupported_shell_uses_manual_path_hint_only_test
 run_release_override_install_and_onboard_failure_preserves_install_test
 run_release_override_install_and_onboard_detects_duckduckgo_default_test
+run_release_install_honors_legacy_release_base_env_test
+run_release_override_install_and_onboard_honors_legacy_web_search_provider_env_test
 run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test
 run_release_override_install_and_onboard_prefers_unique_ready_credential_test
 run_release_override_install_and_onboard_prefers_unique_ready_firecrawl_credential_test

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -27,17 +27,18 @@ assert_not_contains() {
   fi
 }
 
-assert_installed_binary() {
+assert_installed_primary_binary() {
   local install_dir="$1"
   local expected_output="$2"
   local primary_output
 
   [[ -x "$install_dir/$PRIMARY_BIN_NAME" ]]
+  [[ ! -e "$install_dir/loongclaw" ]]
 
   primary_output="$("$install_dir/$PRIMARY_BIN_NAME")"
 
   if [[ "$primary_output" != "$expected_output" ]]; then
-    echo "expected binary output '$expected_output' but got '$primary_output'" >&2
+    echo "expected primary binary output '$expected_output' but got '$primary_output'" >&2
     exit 1
   fi
 }
@@ -58,7 +59,6 @@ host_target() {
 make_release_fixture() {
   local fixture
   fixture="$(mktemp -d)"
-  mkdir -p "$fixture/home"
   write_release_fixture_asset \
     "$fixture" \
     "${1:-v0.1.2}" \
@@ -85,7 +85,7 @@ write_release_fixture_asset() {
 set -euo pipefail
 if [[ "\${1:-}" == "onboard" ]]; then
   shift
-  selected_provider="\${LOONGCLAW_WEB_SEARCH_PROVIDER:-}"
+  selected_provider="\${LOONG_WEB_SEARCH_PROVIDER:-}"
   while [[ "\$#" -gt 0 ]]; do
     case "\${1:-}" in
       --web-search-provider)
@@ -104,6 +104,7 @@ fi
 printf '%s\n' "$binary_label"
 EOF
   chmod +x "$staging_dir/$binary_name"
+
   archive_path="$release_dir/$archive_name"
   case "$archive_name" in
     *.tar.gz)
@@ -125,7 +126,6 @@ EOF
 make_linux_dual_libc_fixture() {
   local fixture tag
   fixture="$(mktemp -d)"
-  mkdir -p "$fixture/home"
   tag="${1:-v0.1.2}"
   write_release_fixture_asset "$fixture" "$tag" "x86_64-unknown-linux-gnu" "gnu-binary"
   write_release_fixture_asset "$fixture" "$tag" "x86_64-unknown-linux-musl" "musl-binary"
@@ -286,7 +286,6 @@ source_install_functions() {
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-gnu.out"
@@ -296,13 +295,12 @@ run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_binary "$install_dir" "gnu-binary"
+  assert_installed_primary_binary "$install_dir" "gnu-binary"
 }
 
 
@@ -317,7 +315,6 @@ run_termux_arm64_installs_android_release_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       TERMUX_VERSION="0.119.0" \
       PREFIX="/data/data/com.termux/files/usr" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
@@ -325,7 +322,7 @@ run_termux_arm64_installs_android_release_test() {
   )
 
   assert_contains "$output_file" "aarch64-linux-android"
-  assert_installed_binary "$install_dir" "termux-binary"
+  assert_installed_primary_binary "$install_dir" "termux-binary"
 }
 
 run_linux_guest_with_termux_env_is_not_termux_test() {
@@ -354,7 +351,6 @@ run_linux_guest_with_termux_env_is_not_termux_test() {
 run_linux_guest_with_termux_env_prefers_linux_release_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-termux-env.out"
@@ -364,7 +360,6 @@ run_linux_guest_with_termux_env_prefers_linux_release_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       TERMUX_VERSION="0.119.0" \
       PREFIX="/data/data/com.termux/files/usr" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
@@ -372,13 +367,12 @@ run_linux_guest_with_termux_env_prefers_linux_release_test() {
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_binary "$install_dir" "gnu-binary"
+  assert_installed_primary_binary "$install_dir" "gnu-binary"
 }
 
 run_termux_x86_64_rejects_android_release_test() {
   local fixture output_file
   fixture="$(mktemp -d)"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   output_file="$fixture/termux-android-x86_64.out"
   make_uname_stub_bin "$fixture" "Linux" "x86_64" "Android"
@@ -386,7 +380,6 @@ run_termux_x86_64_rejects_android_release_test() {
   if (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       TERMUX_VERSION="0.119.0" \
       PREFIX="/data/data/com.termux/files/usr" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
@@ -403,7 +396,6 @@ run_termux_x86_64_rejects_android_release_test() {
 run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-musl-old-glibc.out"
@@ -413,19 +405,17 @@ run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_binary "$install_dir" "musl-binary"
+  assert_installed_primary_binary "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-musl-no-glibc.out"
@@ -436,19 +426,17 @@ run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_binary "$install_dir" "musl-binary"
+  assert_installed_primary_binary "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_explicit_musl_override_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-musl-override.out"
@@ -458,20 +446,18 @@ run_linux_x86_64_explicit_musl_override_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       LOONG_INSTALL_TARGET_LIBC="musl" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-musl"
-  assert_installed_binary "$install_dir" "musl-binary"
+  assert_installed_primary_binary "$install_dir" "musl-binary"
 }
 
 run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
   local fixture output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   output_file="$fixture/linux-gnu-override-old-glibc.out"
   make_uname_stub_bin "$fixture" "Linux" "x86_64"
@@ -480,7 +466,6 @@ run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
   if (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --target-libc gnu --prefix "$fixture/install" >"$output_file" 2>&1
   ); then
@@ -495,7 +480,6 @@ run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
 run_version_at_least_falls_back_when_sort_version_is_unavailable_test() {
   local fixture
   fixture="$(mktemp -d)"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   make_sort_stub_bin "$fixture" "__FAIL_VERSION__"
 
@@ -552,7 +536,6 @@ run_release_target_for_install_rejects_arm64_old_glibc_without_musl_test() {
 run_linux_x86_64_prefers_gnu_when_sort_version_is_unavailable_test() {
   local fixture install_dir output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/linux-gnu-no-sort-v.out"
@@ -563,19 +546,17 @@ run_linux_x86_64_prefers_gnu_when_sort_version_is_unavailable_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
   assert_contains "$output_file" "x86_64-unknown-linux-gnu"
-  assert_installed_binary "$install_dir" "gnu-binary"
+  assert_installed_primary_binary "$install_dir" "gnu-binary"
 }
 
 run_linux_x86_64_explicit_gnu_override_rejects_musl_ldd_output_test() {
   local fixture output_file
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   output_file="$fixture/linux-gnu-override-musl-ldd.out"
   make_uname_stub_bin "$fixture" "Linux" "x86_64"
@@ -585,7 +566,6 @@ run_linux_x86_64_explicit_gnu_override_rejects_musl_ldd_output_test() {
   if (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --target-libc gnu --prefix "$fixture/install" >"$output_file" 2>&1
   ); then
@@ -608,7 +588,6 @@ run_linux_arm64_auto_rejects_old_glibc_without_musl_artifact_test() {
   if (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$fixture/install" >"$output_file" 2>&1
   ); then
@@ -623,7 +602,6 @@ run_linux_arm64_auto_rejects_old_glibc_without_musl_artifact_test() {
 run_release_override_install_and_onboard_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install.out"
@@ -634,7 +612,6 @@ run_release_override_install_and_onboard_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       ONBOARD_MARKER="$marker" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       BRAVE_API_KEY="" \
@@ -644,12 +621,13 @@ run_release_override_install_and_onboard_test() {
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_contains "$output_file" "Installed loong to"
+  assert_not_contains "$output_file" "Installed compatible loongclaw command to"
   assert_contains "$output_file" "Running guided onboarding"
   assert_contains "$marker" "onboard"
 }
@@ -662,7 +640,6 @@ run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
   local bashrc_file
   local expected_path_line
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   home_dir="$fixture/home"
   install_dir="$fixture/install"
@@ -676,11 +653,11 @@ run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
     HOME="$home_dir" \
       SHELL="/bin/bash" \
       PATH="/usr/bin:/bin" \
-      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_contains "$bashrc_file" "# Added by Loong installer"
   assert_contains "$bashrc_file" "$expected_path_line"
   assert_contains "$output_file" "Added $install_dir to PATH in $bashrc_file"
@@ -693,7 +670,6 @@ run_release_install_skips_source_hint_when_path_is_already_available_test() {
   local install_dir
   local output_file
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   home_dir="$fixture/home"
   install_dir="$fixture/install"
@@ -705,11 +681,11 @@ run_release_install_skips_source_hint_when_path_is_already_available_test() {
     HOME="$home_dir" \
       SHELL="/bin/bash" \
       PATH="$install_dir:/usr/bin:/bin" \
-      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_not_contains "$output_file" "source \"$home_dir/.bashrc\""
   assert_not_contains "$output_file" "Add to PATH if needed:"
 }
@@ -721,7 +697,6 @@ run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test() {
   local output_file
   local bashrc_file
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   home_dir="$fixture/home"
   install_dir="$fixture/install"
@@ -735,11 +710,11 @@ run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test() {
     HOME="$home_dir" \
       SHELL="/bin/bash" \
       PATH="/usr/bin:/bin" \
-      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_contains "$output_file" "PATH entry already present in $bashrc_file"
   assert_contains "$output_file" "source \"$bashrc_file\""
 }
@@ -750,7 +725,6 @@ run_release_install_unsupported_shell_uses_manual_path_hint_only_test() {
   local install_dir
   local output_file
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   home_dir="$fixture/home"
   install_dir="$fixture/install"
@@ -762,11 +736,11 @@ run_release_install_unsupported_shell_uses_manual_path_hint_only_test() {
     HOME="$home_dir" \
       SHELL="/usr/bin/fish" \
       PATH="/usr/bin:/bin" \
-      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_contains "$output_file" "Add to PATH if needed:"
   assert_not_contains "$output_file" 'source "$HOME/.profile"'
 }
@@ -777,7 +751,6 @@ run_release_override_install_and_onboard_failure_preserves_install_test() {
   local output_file
   local marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-onboard-failure.out"
@@ -788,10 +761,9 @@ run_release_override_install_and_onboard_failure_preserves_install_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       ONBOARD_EXIT_CODE="130" \
       ONBOARD_MARKER="$marker" \
-      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       BRAVE_API_KEY="" \
       TAVILY_API_KEY="" \
       PERPLEXITY_API_KEY="" \
@@ -799,11 +771,11 @@ run_release_override_install_and_onboard_failure_preserves_install_test() {
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
-  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_installed_primary_binary "$install_dir" "fixture-binary"
   assert_contains "$marker" "onboard"
   assert_contains "$output_file" "Onboarding exited with code 130"
   assert_contains "$output_file" "You can run 'loong onboard' later to complete setup"
@@ -813,7 +785,6 @@ run_release_override_install_and_onboard_failure_preserves_install_test() {
 run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-ddg.out"
@@ -824,7 +795,6 @@ run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="C.UTF-8" \
       TZ="UTC" \
       ONBOARD_MARKER="$marker" \
@@ -836,7 +806,7 @@ run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -847,7 +817,6 @@ run_release_override_install_and_onboard_detects_duckduckgo_default_test() {
 run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-tavily.out"
@@ -858,7 +827,6 @@ run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test(
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="zh_CN.UTF-8" \
       TZ="Asia/Shanghai" \
       ONBOARD_MARKER="$marker" \
@@ -870,7 +838,7 @@ run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test(
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -881,7 +849,6 @@ run_release_override_install_and_onboard_prefers_tavily_for_domestic_hosts_test(
 run_release_override_install_and_onboard_prefers_unique_ready_credential_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-perplexity.out"
@@ -892,7 +859,6 @@ run_release_override_install_and_onboard_prefers_unique_ready_credential_test() 
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="C.UTF-8" \
       TZ="UTC" \
       ONBOARD_MARKER="$marker" \
@@ -904,7 +870,7 @@ run_release_override_install_and_onboard_prefers_unique_ready_credential_test() 
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -915,7 +881,6 @@ run_release_override_install_and_onboard_prefers_unique_ready_credential_test() 
 run_release_override_install_and_onboard_prefers_unique_ready_firecrawl_credential_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-firecrawl.out"
@@ -926,7 +891,6 @@ run_release_override_install_and_onboard_prefers_unique_ready_firecrawl_credenti
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="C.UTF-8" \
       TZ="UTC" \
       ONBOARD_MARKER="$marker" \
@@ -938,7 +902,7 @@ run_release_override_install_and_onboard_prefers_unique_ready_firecrawl_credenti
       FIRECRAWL_API_KEY="firecrawl-test-token" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -949,7 +913,6 @@ run_release_override_install_and_onboard_prefers_unique_ready_firecrawl_credenti
 run_release_override_install_and_onboard_preserves_signal_source_when_firecrawl_and_exa_both_exist_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-firecrawl-exa-ambiguous.out"
@@ -960,7 +923,6 @@ run_release_override_install_and_onboard_preserves_signal_source_when_firecrawl_
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="C.UTF-8" \
       TZ="UTC" \
       ONBOARD_MARKER="$marker" \
@@ -972,7 +934,7 @@ run_release_override_install_and_onboard_preserves_signal_source_when_firecrawl_
       FIRECRAWL_API_KEY="firecrawl-test-token" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -983,7 +945,6 @@ run_release_override_install_and_onboard_preserves_signal_source_when_firecrawl_
 run_release_override_install_and_onboard_preserves_signal_source_when_multiple_credentials_exist_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/install-web-search-tavily-multi-credential.out"
@@ -994,7 +955,6 @@ run_release_override_install_and_onboard_preserves_signal_source_when_multiple_c
   (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LANG="zh_CN.UTF-8" \
       TZ="Asia/Shanghai" \
       ONBOARD_MARKER="$marker" \
@@ -1006,7 +966,7 @@ run_release_override_install_and_onboard_preserves_signal_source_when_multiple_c
       FIRECRAWL_API_KEY="" \
       JINA_API_KEY="" \
       JINA_AUTH_TOKEN="" \
-      LOONGCLAW_WEB_SEARCH_PROVIDER="" \
+      LOONG_WEB_SEARCH_PROVIDER="" \
       bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" --onboard >"$output_file" 2>&1
   )
 
@@ -1017,7 +977,6 @@ run_release_override_install_and_onboard_preserves_signal_source_when_multiple_c
 run_checksum_mismatch_fails_test() {
   local fixture install_dir output_file tag target checksum_name
   fixture="$(make_release_fixture "v0.1.2")"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
   output_file="$fixture/checksum.out"
@@ -1042,7 +1001,6 @@ run_checksum_mismatch_fails_test() {
 run_missing_release_guidance_test() {
   local fixture output_file
   fixture="$(mktemp -d)"
-  mkdir -p "$fixture/home"
   trap 'rm -rf "$fixture"' RETURN
   output_file="$fixture/missing-release.out"
   make_latest_release_stub_bin "$fixture"
@@ -1050,7 +1008,6 @@ run_missing_release_guidance_test() {
   if (
     cd "$REPO_ROOT"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       bash "$SCRIPT_UNDER_TEST" --prefix "$fixture/install" >"$output_file" 2>&1
   ); then
     echo "expected install.sh to fail when no latest GitHub release exists" >&2
@@ -1081,7 +1038,6 @@ run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
   if (
     cd "$fixture"
     PATH="$fixture/fake-bin:$PATH" \
-      HOME="$fixture/home" \
       LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$standalone_script" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
   ); then

--- a/scripts/test_release_workflow_hardening.sh
+++ b/scripts/test_release_workflow_hardening.sh
@@ -84,7 +84,7 @@ assert_single_cli_bin_surface() {
 
 assert_release_docs_gates() {
   assert_contains ".github/workflows/release.yml" "scripts/bootstrap_release_local_artifacts.sh"
-  assert_contains ".github/workflows/release.yml" "LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh"
+  assert_contains ".github/workflows/release.yml" "LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh"
   assert_contains ".github/workflows/release.yml" 'release_doc="docs/releases/${RELEASE_TAG}.md"'
   assert_contains ".github/workflows/release.yml" 'grep -Fx "# Release ${RELEASE_TAG}" "$release_doc"'
   assert_contains ".github/workflows/release.yml" 'grep -F "## [${RELEASE_TAG#v}]" CHANGELOG.md > /dev/null'


### PR DESCRIPTION
## Summary

This PR finishes the code-facing Loong rebrand outside the docs lane handled by #756.

It updates the workspace so that package metadata, runtime-facing names, scripts, workflows, and release-governance tooling consistently use the `Loong` brand, while keeping the explicitly preserved legacy contact endpoints unchanged.

## What changed

- renamed workspace package/crate surfaces from `loongclaw-*` to `loong-*`
- renamed code-facing runtime identifiers such as `LoongClawKernel` / `LoongClawConfig` to `LoongKernel` / `LoongConfig`
- switched primary env/config paths from `LOONGCLAW_*` / `.loongclaw` to `LOONG_*` / `.loong`
- kept explicit compatibility aliases where the current product contract still expects them (for example legacy installer env vars and the `loongclaw` shim binary)
- updated repository metadata, workflows, installers, and governance scripts to `eastreams/loong`
- aligned release templates and example assets with the new code-facing naming
- preserved legacy contact/community endpoints (`contact@loongclaw.ai`, `https://t.me/loongclaw`)

## Notes

- Follow-up to #756, but intentionally delivered on a separate branch/PR.
- Internal docs/plans migration to the knowledge-base is out of scope here.
- The remaining intentional `loongclaw` references in this lane are limited to preserved legacy contact/community endpoints and compatibility aliases.

## Validation

- `cargo fmt --all`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p loong-kernel --test kernel_integration`
- `bash scripts/check_dep_graph.sh`
- `bash scripts/test_architecture_budget_scripts.sh`
- `bash scripts/test_check_architecture_drift_freshness.sh`
- `bash scripts/test_bootstrap_release_local_artifacts.sh`
- `bash scripts/test_install_sh.sh`
- `git diff --check`

Closes #1107
