### PR TITLE
Harden channel metadata invariants after PR #1105

### DIFF
--- a/crates/app/src/channel/sdk.rs
+++ b/crates/app/src/channel/sdk.rs
@@ -989,6 +989,39 @@ mod tests {
         assert_eq!(google_chat.surface_label, "google chat channel");
     }
 
+    #[test]
+    fn non_cli_integrations_resolve_catalog_entries() {
+        for integration in CHANNEL_INTEGRATIONS {
+            let channel_id = integration.channel_id;
+            if channel_id == "cli" {
+                continue;
+            }
+
+            let catalog_entry = super::super::registry::resolve_channel_catalog_entry(channel_id);
+            assert!(
+                catalog_entry.is_some(),
+                "missing catalog entry for integrated channel `{channel_id}`"
+            );
+        }
+    }
+
+    #[test]
+    fn background_runtime_integrations_resolve_command_family_descriptors() {
+        for integration in CHANNEL_INTEGRATIONS {
+            let channel_id = integration.channel_id;
+            if integration.background_runtime.is_none() {
+                continue;
+            }
+
+            let family_descriptor =
+                super::super::registry::resolve_channel_command_family_descriptor(channel_id);
+            assert!(
+                family_descriptor.is_some(),
+                "missing command family descriptor for background runtime channel `{channel_id}`"
+            );
+        }
+    }
+
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn feishu_background_surface_enablement_accepts_runtime_account_aliases() {


### PR DESCRIPTION
## Summary

- Problem:
  after PR #1105 and the follow-up fixes that have already landed on `dev`, the remaining unchecked gap is in the sdk layer: the declared channel integration list still only `debug_assert!`s that every non-`cli` integration resolves catalog metadata and every background-runtime integration resolves a command-family descriptor.
- Why it matters:
  those contracts can silently drift in release builds unless we lock them with dedicated regression coverage.
- What changed:
  added two focused sdk tests that iterate `CHANNEL_INTEGRATIONS` and fail if catalog-entry or background command-family metadata falls out of sync with the declared integrations.
- What did not change (scope boundary):
  no runtime behavior, channel ids, aliases, commands, or user-facing labels changed.

## Linked Issues

- Closes #1111
- Related #1104
- Related #1105

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1`
- [x] `cargo test --workspace --all-features --locked -- --test-threads=1`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-app non_cli_integrations_resolve_catalog_entries --all-features -- --nocapture
cargo test -p loongclaw-app background_runtime_integrations_resolve_command_family_descriptors --all-features -- --nocapture
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
scripts/check_architecture_boundaries.sh
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1

Result:
- all commands passed locally on the rebased branch
- the net diff is now limited to the remaining sdk invariant coverage that was still unique after `dev` absorbed the earlier registry-order and planned-surface fixes
```

## User-visible / Operator-visible Changes

- none intended. this is a metadata/invariant hardening follow-up.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `885d94e4c`.
- Observable failure symptoms reviewers should watch for:
  integrated channels losing catalog metadata coverage or background runtime integrations losing command-family descriptors without the test suite catching it.

## Reviewer Focus

- `crates/app/src/channel/sdk.rs`

Please focus on:
- whether iterating `CHANNEL_INTEGRATIONS` is the right invariant boundary for sdk/registry drift
- whether the new tests stay behavior-preserving while guarding the remaining release-build metadata gap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for channel integration registry resolution with new comprehensive unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->