### PR TITLE
Reduce channel query indirection between config and sdk

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -115,7 +115,11 @@ use runtime::state::ChannelOperationRuntimeTracker;
     feature = "channel-whatsapp"
 ))]
 pub use runtime::turn_feedback::ChannelTurnFeedbackPolicy;
-pub use sdk::{background_channel_runtime_descriptors, is_background_channel_surface_enabled};
+pub use sdk::{
+    ChannelDescriptor, ChannelRuntimeKind, background_channel_runtime_descriptors,
+    channel_descriptor, is_background_channel_surface_enabled, service_channel_descriptors,
+};
+pub(crate) use sdk::{collect_channel_validation_issues, enabled_channel_ids};
 pub use tlon_command::run_tlon_send;
 
 mod types;

--- a/crates/app/src/channel/sdk.rs
+++ b/crates/app/src/channel/sdk.rs
@@ -430,7 +430,7 @@ fn channel_serve_subcommand(
     Some(serve_command)
 }
 
-pub(crate) fn channel_descriptor(id: &str) -> Option<&'static ChannelDescriptor> {
+pub fn channel_descriptor(id: &str) -> Option<&'static ChannelDescriptor> {
     let integration = find_channel_integration(id)?;
     let descriptor_id = integration.channel_id;
     let descriptors = channel_descriptors();
@@ -468,7 +468,7 @@ fn channel_integration_order_key(
     (runtime_group, selection_order, channel_id)
 }
 
-pub(crate) fn service_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
+pub fn service_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
     ordered_channel_integrations()
         .into_iter()
         .filter_map(|integration| channel_descriptor(integration.channel_id))

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -4,8 +4,6 @@ use loongclaw_contracts::SecretRef;
 use serde::{Deserialize, Serialize};
 
 use crate::CliResult;
-use crate::channel::sdk;
-pub use crate::channel::sdk::{ChannelDescriptor, ChannelRuntimeKind};
 use crate::prompt::{
     DEFAULT_PROMPT_PACK_ID, PromptPersonality, PromptRenderInput, render_default_system_prompt,
     render_system_prompt,
@@ -16,7 +14,6 @@ use super::irc::{
     default_irc_password_env, default_irc_server_env, validate_irc_env_pointer,
     validate_irc_nickname_field, validate_irc_secret_ref_env_pointer, validate_irc_server_field,
 };
-use super::runtime::LoongClawConfig;
 use super::shared::{
     ConfigValidationCode, ConfigValidationIssue, ConfigValidationSeverity,
     EnvPointerValidationHint, validate_env_pointer_field, validate_secret_ref_env_pointer_field,
@@ -129,35 +126,6 @@ impl WebhookPayloadFormat {
 pub(crate) enum EmailSmtpEndpoint {
     RelayHost(String),
     ConnectionUrl(String),
-}
-
-pub fn channel_descriptor(id: &str) -> Option<&'static ChannelDescriptor> {
-    sdk::channel_descriptor(id)
-}
-
-pub fn service_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
-    sdk::service_channel_descriptors()
-}
-
-pub(super) fn enabled_channel_ids(config: &LoongClawConfig) -> Vec<String> {
-    enabled_channel_ids_for_runtime_kind(config, None)
-}
-
-pub(super) fn enabled_service_channel_ids(config: &LoongClawConfig) -> Vec<String> {
-    enabled_channel_ids_for_runtime_kind(config, Some(ChannelRuntimeKind::Service))
-}
-
-fn enabled_channel_ids_for_runtime_kind(
-    config: &LoongClawConfig,
-    runtime_kind: Option<ChannelRuntimeKind>,
-) -> Vec<String> {
-    sdk::enabled_channel_ids(config, runtime_kind)
-}
-
-pub(super) fn collect_channel_validation_issues(
-    config: &LoongClawConfig,
-) -> Vec<ConfigValidationIssue> {
-    sdk::collect_channel_validation_issues(config)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -12,6 +12,10 @@ mod tools;
 
 pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
+pub use crate::channel::{ChannelDescriptor, ChannelRuntimeKind};
+#[allow(unused_imports)]
+pub use crate::channel::{channel_descriptor, service_channel_descriptors};
+#[allow(unused_imports)]
 pub use audit::{AuditConfig, AuditMode};
 #[allow(unused_imports)]
 pub use channels::bridge::{
@@ -22,28 +26,28 @@ pub use channels::bridge::{
 #[allow(unused_imports)]
 pub use channels::{
     ChannelAccountIdentity, ChannelAccountIdentitySource, ChannelAcpConfig,
-    ChannelDefaultAccountSelection, ChannelDefaultAccountSelectionSource, ChannelDescriptor,
-    ChannelResolvedAccountRoute, ChannelRuntimeKind, CliChannelConfig, DingtalkAccountConfig,
-    DingtalkChannelConfig, DiscordAccountConfig, DiscordChannelConfig, EmailAccountConfig,
-    EmailChannelConfig, FeishuAccountConfig, FeishuChannelConfig, FeishuChannelServeMode,
-    FeishuDomain, GoogleChatAccountConfig, GoogleChatChannelConfig, ImessageAccountConfig,
-    ImessageChannelConfig, IrcAccountConfig, IrcChannelConfig, LineAccountConfig,
-    LineChannelConfig, MatrixAccountConfig, MatrixChannelConfig, MattermostAccountConfig,
-    MattermostChannelConfig, NextcloudTalkAccountConfig, NextcloudTalkChannelConfig,
-    NostrAccountConfig, NostrChannelConfig, ResolvedDingtalkChannelConfig,
-    ResolvedDiscordChannelConfig, ResolvedEmailChannelConfig, ResolvedFeishuChannelConfig,
-    ResolvedGoogleChatChannelConfig, ResolvedImessageChannelConfig, ResolvedIrcChannelConfig,
-    ResolvedLineChannelConfig, ResolvedMatrixChannelConfig, ResolvedMattermostChannelConfig,
-    ResolvedNextcloudTalkChannelConfig, ResolvedNostrChannelConfig, ResolvedSignalChannelConfig,
-    ResolvedSlackChannelConfig, ResolvedSynologyChatChannelConfig, ResolvedTeamsChannelConfig,
-    ResolvedTelegramChannelConfig, ResolvedTlonChannelConfig, ResolvedTwitchChannelConfig,
-    ResolvedWebhookChannelConfig, ResolvedWecomChannelConfig, ResolvedWhatsappChannelConfig,
-    SignalAccountConfig, SignalChannelConfig, SlackAccountConfig, SlackChannelConfig,
-    SynologyChatAccountConfig, SynologyChatChannelConfig, TeamsAccountConfig, TeamsChannelConfig,
-    TelegramAccountConfig, TelegramChannelConfig, TelegramStreamingMode, TlonAccountConfig,
-    TlonChannelConfig, TwitchAccountConfig, TwitchChannelConfig, WebhookAccountConfig,
-    WebhookChannelConfig, WebhookPayloadFormat, WecomAccountConfig, WecomChannelConfig,
-    WhatsappAccountConfig, WhatsappChannelConfig, channel_descriptor, service_channel_descriptors,
+    ChannelDefaultAccountSelection, ChannelDefaultAccountSelectionSource,
+    ChannelResolvedAccountRoute, CliChannelConfig, DingtalkAccountConfig, DingtalkChannelConfig,
+    DiscordAccountConfig, DiscordChannelConfig, EmailAccountConfig, EmailChannelConfig,
+    FeishuAccountConfig, FeishuChannelConfig, FeishuChannelServeMode, FeishuDomain,
+    GoogleChatAccountConfig, GoogleChatChannelConfig, ImessageAccountConfig, ImessageChannelConfig,
+    IrcAccountConfig, IrcChannelConfig, LineAccountConfig, LineChannelConfig, MatrixAccountConfig,
+    MatrixChannelConfig, MattermostAccountConfig, MattermostChannelConfig,
+    NextcloudTalkAccountConfig, NextcloudTalkChannelConfig, NostrAccountConfig, NostrChannelConfig,
+    ResolvedDingtalkChannelConfig, ResolvedDiscordChannelConfig, ResolvedEmailChannelConfig,
+    ResolvedFeishuChannelConfig, ResolvedGoogleChatChannelConfig, ResolvedImessageChannelConfig,
+    ResolvedIrcChannelConfig, ResolvedLineChannelConfig, ResolvedMatrixChannelConfig,
+    ResolvedMattermostChannelConfig, ResolvedNextcloudTalkChannelConfig,
+    ResolvedNostrChannelConfig, ResolvedSignalChannelConfig, ResolvedSlackChannelConfig,
+    ResolvedSynologyChatChannelConfig, ResolvedTeamsChannelConfig, ResolvedTelegramChannelConfig,
+    ResolvedTlonChannelConfig, ResolvedTwitchChannelConfig, ResolvedWebhookChannelConfig,
+    ResolvedWecomChannelConfig, ResolvedWhatsappChannelConfig, SignalAccountConfig,
+    SignalChannelConfig, SlackAccountConfig, SlackChannelConfig, SynologyChatAccountConfig,
+    SynologyChatChannelConfig, TeamsAccountConfig, TeamsChannelConfig, TelegramAccountConfig,
+    TelegramChannelConfig, TelegramStreamingMode, TlonAccountConfig, TlonChannelConfig,
+    TwitchAccountConfig, TwitchChannelConfig, WebhookAccountConfig, WebhookChannelConfig,
+    WebhookPayloadFormat, WecomAccountConfig, WecomChannelConfig, WhatsappAccountConfig,
+    WhatsappChannelConfig,
 };
 #[allow(unused_imports)]
 pub(crate) use channels::{

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -10,11 +10,11 @@ mod runtime;
 mod shared;
 mod tools;
 
-pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
 pub use crate::channel::{ChannelDescriptor, ChannelRuntimeKind};
 #[allow(unused_imports)]
 pub use crate::channel::{channel_descriptor, service_channel_descriptors};
+pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
 pub use audit::{AuditConfig, AuditMode};
 #[allow(unused_imports)]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -1573,7 +1573,7 @@ impl LoongClawConfig {
         if let Some(report) = selection_report {
             issues.extend(report.validation_issues());
         }
-        issues.extend(super::channels::collect_channel_validation_issues(self));
+        issues.extend(crate::channel::collect_channel_validation_issues(self));
         issues.extend(self.feishu_integration.validate());
         issues.extend(self.memory.validate());
         issues.extend(self.tools.validate());
@@ -1623,11 +1623,11 @@ impl LoongClawConfig {
     }
 
     pub fn enabled_channel_ids(&self) -> Vec<String> {
-        super::channels::enabled_channel_ids(self)
+        crate::channel::enabled_channel_ids(self, None)
     }
 
     pub fn enabled_service_channel_ids(&self) -> Vec<String> {
-        super::channels::enabled_service_channel_ids(self)
+        crate::channel::enabled_channel_ids(self, Some(crate::channel::ChannelRuntimeKind::Service))
     }
 
     pub fn active_provider_id(&self) -> Option<&str> {

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-08T16:50:04Z
+- Generated at: 2026-04-09T10:23:46Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -19,9 +19,9 @@
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1786 | 6400 | 4614 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.4% | PASS | 0 |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 55 | 70 | 15 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6485 | 6500 | 15 | 201 | 210 | 9 | 99.8% | TIGHT | 6324 | 2.5% | PASS | 210 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (100.0%), daemon_lib (99.8%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (98.8%), tools_mod (100.0%), daemon_lib (99.8%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -65,9 +65,9 @@
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->
-<!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
+<!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
-<!-- arch-hotspot key=channel_mod lines=1786 functions=0 -->
+<!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14999 functions=55 -->
 <!-- arch-hotspot key=daemon_lib lines=6485 functions=201 -->


### PR DESCRIPTION
## Summary

- Problem:
  `config/channels.rs` still acted as a thin forwarding layer for channel descriptor lookup,
  service-channel listing, enabled-channel queries, and channel validation dispatch even though
  channel-surface ownership had already moved under `crate::channel`.
- Why it matters:
  That extra forwarding layer kept source-of-truth ownership split across `config` and `channel`,
  which made the code harder to audit and easier to drift during future channel changes.
- What changed:
  Moved channel-surface query ownership to `crate::channel`, re-exported the public descriptor
  helpers from there through `config/mod.rs`, and routed `LoongClawConfig` runtime methods
  directly through the channel owner instead of bouncing through `config/channels.rs`.
- What did not change (scope boundary):
  No channel ids, aliases, selection ordering, command names, or config-facing API names were
  intentionally changed.

## Linked Issues

- Closes #1110
- Related #1105

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo check -p loongclaw-app --all-features
cargo test -p loongclaw-app channel_descriptor_lookup_reports_shared_metadata --all-features
cargo test -p loongclaw-app enabled_channel_views_follow_shared_catalog_order --all-features
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
scripts/check_architecture_boundaries.sh
cargo test --workspace --all-features --locked

Result:
- All commands passed
- config::tests::channel_descriptor_lookup_reports_shared_metadata passed
- config::tests::enabled_channel_views_follow_shared_catalog_order passed
- crates/app/src/config/channels.rs shrank from 9759 to 9684 lines on the rebased dev baseline
```

## User-visible / Operator-visible Changes

- None intended. This is a behavior-preserving ownership cleanup.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `86ea72978b53d2fd135ecf3c8f94d8472af3dc8c`.
- Observable failure symptoms reviewers should watch for:
  Missing descriptor lookup through `mvp::config::*`, service-channel ordering drift, or runtime
  methods returning different enabled-channel sets than before.

## Reviewer Focus

- `crates/app/src/channel/mod.rs`
- `crates/app/src/config/channels.rs`
- `crates/app/src/config/mod.rs`
- `crates/app/src/config/runtime.rs`

Please focus on:
- whether config-facing helper names remained stable
- whether query ownership moved cleanly to `crate::channel`
- whether `config/channels.rs` is now materially closer to a schema-only role


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized channel-related API surface and internal exports to consolidate channel metadata and selection logic; no changes to user-facing behavior or configuration semantics.
* **Documentation**
  * Updated architecture drift report with refreshed timestamp and adjusted channel-related hotspot metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->