### PR TITLE
Unify gateway ACP persistence and localhost operator views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,6 +2594,7 @@ dependencies = [
 name = "loongclaw"
 version = "0.1.0-alpha.3"
 dependencies = [
+ "async-trait",
  "axum",
  "base64",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ The current gateway slice now includes:
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
 - a localhost-only authenticated control surface that publishes status,
-  channel inventory, runtime snapshot, operator summary, and cooperative stop
-  endpoints from the same `gateway run` owner
+  channel inventory, runtime snapshot, ACP session/operator views, operator
+  summary, and cooperative stop endpoints from the same `gateway run` owner
 
 `gateway run` starts headless by default. Pass `--session` when you want the
 concurrent CLI host attached to the same runtime owner.
@@ -587,8 +587,9 @@ without introducing a second service lifecycle.
 
 The daemon now also carries a reusable localhost gateway client/discovery layer
 that centralizes loopback validation, bearer-token loading, and route helpers
-for `status`, `channels`, `runtime-snapshot`, `operator-summary`, and `stop`.
-That keeps dashboard and Web UI bootstrap logic out of ad-hoc file reads.
+for `status`, `channels`, `runtime-snapshot`, `acp/sessions`, `acp/status`,
+`acp/observability`, `operator-summary`, and `stop`. That keeps dashboard,
+ACP inspection, and Web UI bootstrap logic out of ad-hoc file reads.
 
 ```bash
 loongclaw gateway run --config ~/.loongclaw/config.toml

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -99,6 +99,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec", features = ["test-hooks"] }
+async-trait.workspace = true
 sha2.workspace = true
 syn = { version = "2", features = ["full", "visit"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -15,6 +15,22 @@ use super::{
     state::{GatewayOwnerStatus, default_gateway_runtime_state_dir, load_gateway_owner_status},
 };
 
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GatewayAcpSessionsRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GatewayAcpStatusRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route_session_id: Option<&'a str>,
+}
+
 #[derive(Debug, Clone)]
 pub struct GatewayLocalDiscovery {
     runtime_dir: PathBuf,
@@ -128,6 +144,23 @@ impl GatewayLocalClient {
         self.request_json(Method::GET, path).await
     }
 
+    pub async fn acp_sessions(&self, request: &GatewayAcpSessionsRequest) -> CliResult<Value> {
+        let path = "/api/gateway/acp/sessions";
+        self.request_json_with_query(Method::GET, path, request)
+            .await
+    }
+
+    pub async fn acp_status(&self, request: &GatewayAcpStatusRequest<'_>) -> CliResult<Value> {
+        let path = "/api/gateway/acp/status";
+        self.request_json_with_query(Method::GET, path, request)
+            .await
+    }
+
+    pub async fn acp_observability(&self) -> CliResult<Value> {
+        let path = "/api/gateway/acp/observability";
+        self.request_json(Method::GET, path).await
+    }
+
     pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
         let path = "/api/gateway/stop";
         self.request_json(Method::POST, path).await
@@ -169,12 +202,58 @@ impl GatewayLocalClient {
         let method_name = method.as_str().to_owned();
         let request_builder = self.http_client.request(method, endpoint.as_str());
         let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), method_name.as_str(), path)
+            .await
+    }
+
+    async fn request_json_with_query<T, Q>(
+        &self,
+        method: Method,
+        path: &str,
+        query: &Q,
+    ) -> CliResult<T>
+    where
+        T: DeserializeOwned,
+        Q: Serialize + ?Sized,
+    {
+        let endpoint = self.endpoint_url(path)?;
+        let method_name = method.as_str().to_owned();
+        let request_builder = self.http_client.request(method, endpoint.as_str());
+        let request_builder = request_builder.query(query);
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), method_name.as_str(), path)
+            .await
+    }
+
+    async fn send_gateway_request(
+        &self,
+        request_builder: reqwest::RequestBuilder,
+        endpoint: &str,
+    ) -> CliResult<Response> {
         let response = request_builder
             .send()
             .await
             .map_err(|error| format!("send gateway request failed for {endpoint}: {error}"))?;
-        let status = response.status();
+        Ok(response)
+    }
 
+    async fn decode_gateway_json_response<T>(
+        &self,
+        response: Response,
+        endpoint: &str,
+        method_name: &str,
+        path: &str,
+    ) -> CliResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let status = response.status();
         if !status.is_success() {
             let error_message = decode_gateway_error_message(response).await;
             let error = format!(

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -9,12 +9,12 @@ use std::{
 
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{Query, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
     routing::{get, post},
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::{
     net::TcpListener,
@@ -35,8 +35,9 @@ use super::api_turn::handle_turn;
 use super::event_bus::GatewayEventBus;
 use super::read_models::{
     GatewayChannelInventoryReadModel, GatewayOperatorSummaryReadModel,
-    GatewayRuntimeSnapshotReadModel, build_operator_summary_read_model,
-    build_runtime_snapshot_read_model,
+    GatewayRuntimeSnapshotReadModel, build_acp_observability_read_model,
+    build_acp_session_list_read_model, build_acp_status_read_model,
+    build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use super::state::{
     GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
@@ -45,13 +46,28 @@ use super::state::{
 
 const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
 const GATEWAY_CONTROL_RUNTIME_DIR_MODE: u32 = 0o700;
+const GATEWAY_ACP_SESSION_LIST_DEFAULT_LIMIT: usize = 50;
+const GATEWAY_ACP_SESSION_LIST_MAX_LIMIT: usize = 200;
 
 type GatewayControlJsonResponse = (StatusCode, Json<Value>);
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayAcpSessionsQuery {
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayAcpStatusQuery {
+    session: Option<String>,
+    conversation_id: Option<String>,
+    route_session_id: Option<String>,
+}
 
 #[derive(Clone)]
 pub(crate) struct GatewayControlAppState {
     pub(crate) runtime_dir: PathBuf,
     pub(crate) bearer_token: String,
+    pub(crate) config_path: String,
     pub(crate) channel_inventory: Arc<GatewayChannelInventoryReadModel>,
     pub(crate) runtime_snapshot: Arc<GatewayRuntimeSnapshotReadModel>,
     pub(crate) event_bus: Option<GatewayEventBus>,
@@ -107,6 +123,7 @@ impl GatewayControlAppState {
         Self {
             runtime_dir: PathBuf::from("/tmp/test"),
             bearer_token,
+            config_path: String::new(),
             channel_inventory: Arc::new(channel_inventory),
             runtime_snapshot: Arc::new(runtime_snapshot),
             event_bus: None,
@@ -239,6 +256,7 @@ pub async fn start_gateway_control_surface(
     let app_state = GatewayControlAppState {
         runtime_dir: runtime_dir.to_path_buf(),
         bearer_token,
+        config_path: loaded_config.resolved_path.display().to_string(),
         channel_inventory: Arc::new(channel_inventory),
         runtime_snapshot: Arc::new(runtime_snapshot),
         event_bus,
@@ -287,6 +305,15 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route(
             "/api/gateway/operator-summary",
             get(handle_gateway_operator_summary),
+        )
+        .route(
+            "/api/gateway/acp/sessions",
+            get(handle_gateway_acp_sessions),
+        )
+        .route("/api/gateway/acp/status", get(handle_gateway_acp_status))
+        .route(
+            "/api/gateway/acp/observability",
+            get(handle_gateway_acp_observability),
         )
         .route("/api/gateway/stop", post(handle_gateway_stop))
         .route("/v1/events", get(handle_events))
@@ -400,6 +427,200 @@ async fn handle_gateway_operator_summary(
     }
 }
 
+async fn handle_gateway_acp_sessions(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Query(query): Query<GatewayAcpSessionsQuery>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let sessions_result = manager.list_sessions();
+    let mut sessions = match sessions_result {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "acp_sessions_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    sort_gateway_acp_sessions(sessions.as_mut_slice());
+    let matched_count = sessions.len();
+    let limit = gateway_acp_session_list_limit(query.limit);
+    sessions.truncate(limit);
+
+    let payload = build_acp_session_list_read_model(
+        app_state.config_path.as_str(),
+        matched_count,
+        sessions.as_slice(),
+    );
+    let payload = match serialize_json_value(&payload, "gateway ACP sessions payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_acp_status(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Query(query): Query<GatewayAcpStatusQuery>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let config = match gateway_control_config(app_state.as_ref()) {
+        Ok(config) => config,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let resolved_session_key = crate::resolve_acp_status_session_key(
+        config,
+        query.session.as_deref(),
+        query.conversation_id.as_deref(),
+        query.route_session_id.as_deref(),
+    );
+    let resolved_session_key = match resolved_session_key {
+        Ok(resolved_session_key) => resolved_session_key,
+        Err(error) => {
+            return json_error(StatusCode::BAD_REQUEST, "invalid_selector", error.as_str());
+        }
+    };
+
+    let status_result = manager
+        .get_status(config, resolved_session_key.as_str())
+        .await;
+    let status = match status_result {
+        Ok(status) => status,
+        Err(error) if error.contains("is not registered") => {
+            return json_error(StatusCode::NOT_FOUND, "not_found", error.as_str());
+        }
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "acp_status_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let payload = build_acp_status_read_model(
+        app_state.config_path.as_str(),
+        query.session.as_deref(),
+        query.conversation_id.as_deref(),
+        query.route_session_id.as_deref(),
+        resolved_session_key.as_str(),
+        &status,
+    );
+    let payload = match serialize_json_value(&payload, "gateway ACP status payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_acp_observability(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let config = match gateway_control_config(app_state.as_ref()) {
+        Ok(config) => config,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let snapshot_result = manager.observability_snapshot(config).await;
+    let snapshot = match snapshot_result {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "acp_observability_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let payload = build_acp_observability_read_model(app_state.config_path.as_str(), &snapshot);
+    let payload = match serialize_json_value(&payload, "gateway ACP observability payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
 async fn handle_gateway_stop(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
@@ -492,6 +713,39 @@ fn build_gateway_operator_summary_read_model(
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
 ) -> GatewayOperatorSummaryReadModel {
     build_operator_summary_read_model(status, channel_inventory, runtime_snapshot)
+}
+
+fn gateway_control_config(app_state: &GatewayControlAppState) -> CliResult<&LoongClawConfig> {
+    let config = app_state
+        .config
+        .as_ref()
+        .ok_or_else(|| "gateway ACP config is unavailable".to_owned())?;
+    Ok(config)
+}
+
+fn gateway_control_acp_manager(
+    app_state: &GatewayControlAppState,
+) -> CliResult<&AcpSessionManager> {
+    let manager = app_state
+        .acp_manager
+        .as_deref()
+        .ok_or_else(|| "gateway ACP session manager is unavailable".to_owned())?;
+    Ok(manager)
+}
+
+fn gateway_acp_session_list_limit(requested_limit: Option<usize>) -> usize {
+    let requested_limit = requested_limit.unwrap_or(GATEWAY_ACP_SESSION_LIST_DEFAULT_LIMIT);
+    requested_limit.clamp(1, GATEWAY_ACP_SESSION_LIST_MAX_LIMIT)
+}
+
+fn sort_gateway_acp_sessions(sessions: &mut [crate::mvp::acp::AcpSessionMetadata]) {
+    sessions.sort_by(|left, right| {
+        let activity_order = right.last_activity_ms.cmp(&left.last_activity_ms);
+        if activity_order == std::cmp::Ordering::Equal {
+            return left.session_key.cmp(&right.session_key);
+        }
+        activity_order
+    });
 }
 
 fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -521,6 +521,9 @@ async fn handle_gateway_acp_status(
     );
     let resolved_session_key = match resolved_session_key {
         Ok(resolved_session_key) => resolved_session_key,
+        Err(error) if is_gateway_acp_not_found_error(error.as_str()) => {
+            return json_error(StatusCode::NOT_FOUND, "not_found", error.as_str());
+        }
         Err(error) => {
             return json_error(StatusCode::BAD_REQUEST, "invalid_selector", error.as_str());
         }
@@ -531,7 +534,7 @@ async fn handle_gateway_acp_status(
         .await;
     let status = match status_result {
         Ok(status) => status,
-        Err(error) if error.contains("is not registered") => {
+        Err(error) if is_gateway_acp_not_found_error(error.as_str()) => {
             return json_error(StatusCode::NOT_FOUND, "not_found", error.as_str());
         }
         Err(error) => {
@@ -648,6 +651,15 @@ async fn handle_gateway_stop(
         "message": response_message,
     });
     json_response(response_status, payload)
+}
+
+fn is_gateway_acp_not_found_error(error: &str) -> bool {
+    let is_session_error = error.starts_with("ACP session `");
+    let is_conversation_error = error.starts_with("ACP conversation `");
+    let is_route_error = error.starts_with("ACP route session `");
+    let has_registration_marker = error.contains(" is not registered");
+    let is_lookup_error = is_session_error || is_conversation_error || is_route_error;
+    is_lookup_error && has_registration_marker
 }
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -59,6 +59,32 @@ pub struct GatewayAcpSessionActivationProvenanceReadModel {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpSessionMetadataReadModel {
+    pub session_key: String,
+    pub conversation_id: Option<String>,
+    pub binding: Option<GatewayAcpBindingScopeReadModel>,
+    pub activation_origin: Option<&'static str>,
+    pub provenance: GatewayAcpSessionActivationProvenanceReadModel,
+    pub backend_id: String,
+    pub runtime_session_name: String,
+    pub working_directory: Option<String>,
+    pub backend_session_id: Option<String>,
+    pub agent_session_id: Option<String>,
+    pub mode: Option<&'static str>,
+    pub state: &'static str,
+    pub last_activity_ms: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpSessionListReadModel {
+    pub config: String,
+    pub matched_count: usize,
+    pub returned_count: usize,
+    pub sessions: Vec<GatewayAcpSessionMetadataReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct GatewayAcpSessionStatusReadModel {
     pub session_key: String,
     pub backend_id: String,
@@ -320,6 +346,26 @@ fn build_channel_surface_read_model(
     }
 }
 
+pub fn build_acp_session_list_read_model(
+    config_path: &str,
+    matched_count: usize,
+    sessions: &[mvp::acp::AcpSessionMetadata],
+) -> GatewayAcpSessionListReadModel {
+    let config = config_path.to_owned();
+    let returned_count = sessions.len();
+    let sessions = sessions
+        .iter()
+        .map(build_acp_session_metadata_read_model)
+        .collect();
+
+    GatewayAcpSessionListReadModel {
+        config,
+        matched_count,
+        returned_count,
+        sessions,
+    }
+}
+
 pub fn build_acp_status_read_model(
     config_path: &str,
     requested_session: Option<&str>,
@@ -467,6 +513,50 @@ fn build_acp_session_activation_provenance_read_model(
     GatewayAcpSessionActivationProvenanceReadModel {
         surface,
         activation_origin,
+    }
+}
+
+fn build_acp_session_metadata_read_model(
+    metadata: &mvp::acp::AcpSessionMetadata,
+) -> GatewayAcpSessionMetadataReadModel {
+    let session_key = metadata.session_key.clone();
+    let conversation_id = metadata.conversation_id.clone();
+    let binding = metadata
+        .binding
+        .as_ref()
+        .map(build_acp_binding_scope_read_model);
+    let activation_origin = metadata
+        .activation_origin
+        .map(mvp::acp::AcpRoutingOrigin::as_str);
+    let provenance = build_acp_session_activation_provenance_read_model(metadata.activation_origin);
+    let backend_id = metadata.backend_id.clone();
+    let runtime_session_name = metadata.runtime_session_name.clone();
+    let working_directory = metadata
+        .working_directory
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let backend_session_id = metadata.backend_session_id.clone();
+    let agent_session_id = metadata.agent_session_id.clone();
+    let mode = metadata.mode.map(crate::acp_session_mode_label);
+    let state = crate::acp_session_state_label(metadata.state);
+    let last_activity_ms = metadata.last_activity_ms;
+    let last_error = metadata.last_error.clone();
+
+    GatewayAcpSessionMetadataReadModel {
+        session_key,
+        conversation_id,
+        binding,
+        activation_origin,
+        provenance,
+        backend_id,
+        runtime_session_name,
+        working_directory,
+        backend_session_id,
+        agent_session_id,
+        mode,
+        state,
+        last_activity_ms,
+        last_error,
     }
 }
 

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -114,7 +114,11 @@ async fn run_gateway_runtime_with_hooks_for_test(
         spec.surfaces.len(),
     )?);
     let owner_token = tracker.owner_token().to_owned();
-    let acp_manager = build_gateway_acp_session_manager(&loaded_config.config)?;
+    let acp_manager = acquire_gateway_acp_session_manager(
+        tracker.as_ref(),
+        &loaded_config.config,
+        build_gateway_acp_session_manager,
+    )?;
     let control_surface_result =
         start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager)).await;
     let control_surface = match control_surface_result {
@@ -331,6 +335,22 @@ fn build_gateway_acp_session_manager(
     Ok(manager)
 }
 
+fn acquire_gateway_acp_session_manager(
+    tracker: &GatewayOwnerTracker,
+    config: &crate::mvp::config::LoongClawConfig,
+    builder: impl FnOnce(&crate::mvp::config::LoongClawConfig) -> CliResult<Arc<AcpSessionManager>>,
+) -> CliResult<Arc<AcpSessionManager>> {
+    let manager_result = builder(config);
+    let manager = match manager_result {
+        Ok(manager) => manager,
+        Err(error) => {
+            tracker.finalize_with_error(error.as_str())?;
+            return Err(error);
+        }
+    };
+    Ok(manager)
+}
+
 fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
     let pid = status
         .pid
@@ -387,4 +407,70 @@ fn merge_gateway_runtime_errors(primary_error: String, secondary_error: Option<S
     };
 
     format!("{primary_error}; {secondary_error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    fn unique_runtime_dir(label: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be monotonic")
+            .as_nanos();
+        let process_id = std::process::id();
+        let runtime_dir = std::env::temp_dir().join(format!(
+            "loongclaw-gateway-service-{label}-{process_id}-{timestamp}"
+        ));
+        fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
+        runtime_dir
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_manager_init_failure_marks_gateway_owner_failed() {
+        let runtime_dir = unique_runtime_dir("acp-manager-init-failure");
+        let config_path = runtime_dir.join("gateway-config.toml");
+        let tracker = GatewayOwnerTracker::acquire(
+            runtime_dir.as_path(),
+            GatewayOwnerMode::GatewayHeadless,
+            config_path.as_path(),
+            None,
+            1,
+        )
+        .expect("acquire gateway owner tracker");
+        let config = crate::mvp::config::LoongClawConfig::default();
+        let expected_error = "simulated ACP manager init failure".to_owned();
+        let builder = |_config: &crate::mvp::config::LoongClawConfig| Err(expected_error.clone());
+
+        let manager_result = acquire_gateway_acp_session_manager(&tracker, &config, builder);
+        let error = match manager_result {
+            Ok(_) => panic!("ACP manager init should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error, expected_error);
+
+        let status = load_gateway_owner_status(runtime_dir.as_path())
+            .expect("gateway owner status should be persisted");
+
+        assert_eq!(status.phase, "failed");
+        assert!(!status.running);
+        assert_eq!(
+            status.shutdown_reason.as_deref(),
+            Some(expected_error.as_str())
+        );
+        assert_eq!(status.last_error.as_deref(), Some(expected_error.as_str()));
+        assert_eq!(
+            request_gateway_stop(runtime_dir.as_path()).expect("query gateway stop outcome"),
+            GatewayStopRequestOutcome::AlreadyStopped
+        );
+
+        let _ = fs::remove_dir_all(runtime_dir.as_path());
+    }
 }

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -114,7 +114,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
         spec.surfaces.len(),
     )?);
     let owner_token = tracker.owner_token().to_owned();
-    let acp_manager = Arc::new(AcpSessionManager::default());
+    let acp_manager = build_gateway_acp_session_manager(&loaded_config.config)?;
     let control_surface_result =
         start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager)).await;
     let control_surface = match control_surface_result {
@@ -322,6 +322,13 @@ fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerStatus {
         port: None,
         token_path: None,
     }
+}
+
+fn build_gateway_acp_session_manager(
+    config: &crate::mvp::config::LoongClawConfig,
+) -> CliResult<Arc<AcpSessionManager>> {
+    let manager = crate::mvp::acp::shared_acp_session_manager(config)?;
+    Ok(manager)
 }
 
 fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -20,7 +20,7 @@ use axum::{
 use loongclaw_daemon::{
     CliResult,
     gateway::{
-        client::GatewayLocalClient,
+        client::{GatewayAcpSessionsRequest, GatewayAcpStatusRequest, GatewayLocalClient},
         service::run_gateway_run_with_hooks_for_test,
         state::{load_gateway_owner_status, request_gateway_stop},
     },
@@ -379,6 +379,109 @@ async fn gateway_run_turn_persists_acp_session_metadata_into_configured_sqlite_s
         persisted.conversation_id.as_deref(),
         Some("gateway-session")
     );
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+
+    let supervisor = timeout(GATEWAY_TURN_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_acp_operator_endpoints_surface_shared_session_truth() {
+    let backend_id = register_gateway_echo_backend("gateway-acp-surface");
+    let sqlite_path = unique_sqlite_path("gateway-acp-surface-store");
+    let runtime_dir = super::unique_temp_dir("gateway-acp-surface-runtime");
+    let runtime_dir_for_run = runtime_dir.clone();
+    let sqlite_path_for_config = sqlite_path.clone();
+    let backend_id_for_config = backend_id.to_owned();
+
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let config = gateway_turn_loaded_config_fixture(
+                sqlite_path_for_config.as_path(),
+                backend_id_for_config.as_str(),
+            );
+            Ok(config)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+
+    let client_result = GatewayLocalClient::discover(runtime_dir.as_path());
+    let client = client_result.expect("discover gateway client");
+    let turn_result = client
+        .turn("gateway-session", "operator truth")
+        .await
+        .expect("gateway turn should succeed");
+
+    assert_eq!(turn_result["output_text"], "echo: operator truth");
+
+    let sessions_request = GatewayAcpSessionsRequest { limit: Some(10) };
+    let sessions = client
+        .acp_sessions(&sessions_request)
+        .await
+        .expect("read gateway ACP sessions");
+
+    assert_eq!(sessions["matched_count"].as_u64(), Some(1));
+    assert_eq!(sessions["returned_count"].as_u64(), Some(1));
+    let sessions_array = sessions["sessions"]
+        .as_array()
+        .expect("gateway ACP sessions array");
+    assert_eq!(sessions_array.len(), 1);
+    let session = sessions_array.first().expect("gateway ACP session");
+    assert_eq!(session["session_key"], "agent:codex:gateway-session");
+    assert_eq!(session["backend_id"], backend_id);
+    assert_eq!(session["conversation_id"], "gateway-session");
+
+    let status_request = GatewayAcpStatusRequest {
+        session: None,
+        conversation_id: Some("gateway-session"),
+        route_session_id: None,
+    };
+    let status = client
+        .acp_status(&status_request)
+        .await
+        .expect("read gateway ACP status");
+
+    assert_eq!(
+        status["resolved_session_key"],
+        "agent:codex:gateway-session"
+    );
+    assert_eq!(status["status"]["backend_id"], backend_id);
+    assert_eq!(status["status"]["state"], "ready");
+
+    let observability = client
+        .acp_observability()
+        .await
+        .expect("read gateway ACP observability");
+
+    assert_eq!(observability["config"], "/tmp/loongclaw-gateway-acp.toml");
+    let active_sessions = observability["snapshot"]["runtime_cache"]["active_sessions"].as_u64();
+    assert!(active_sessions.is_some());
+    let errors_by_code = observability["snapshot"]["errors_by_code"].as_object();
+    assert!(errors_by_code.is_some());
 
     request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
 

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -41,6 +41,8 @@ use tower::ServiceExt;
 type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
 
 const GATEWAY_TURN_TEST_TIMEOUT: Duration = Duration::from_secs(2);
+const GATEWAY_CONTROL_SURFACE_WAIT_ATTEMPTS: usize = 400;
+const GATEWAY_CONTROL_SURFACE_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 struct GatewayEchoBackend {
     id: &'static str,
@@ -155,6 +157,14 @@ fn unique_sqlite_path(label: &str) -> PathBuf {
     sqlite_dir.join("gateway.sqlite3")
 }
 
+fn gateway_config_path(sqlite_path: &Path) -> PathBuf {
+    let parent_directory = sqlite_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir);
+    parent_directory.join("loongclaw-gateway-acp.toml")
+}
+
 fn gateway_turn_loaded_config_fixture(
     sqlite_path: &Path,
     backend_id: &str,
@@ -167,18 +177,27 @@ fn gateway_turn_loaded_config_fixture(
         backend: Some(backend_id.to_owned()),
         ..AcpConfig::default()
     };
+    let resolved_path = gateway_config_path(sqlite_path);
 
     LoadedSupervisorConfig {
-        resolved_path: PathBuf::from("/tmp/loongclaw-gateway-acp.toml"),
+        resolved_path,
         config,
     }
 }
 
 async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
-    for _ in 0..200 {
+    for _ in 0..GATEWAY_CONTROL_SURFACE_WAIT_ATTEMPTS {
         let maybe_status = load_gateway_owner_status(runtime_dir);
 
         if let Some(status) = maybe_status {
+            let failed_phase = status.phase == "failed";
+            if failed_phase {
+                let error_message = status
+                    .last_error
+                    .unwrap_or_else(|| "unknown gateway owner failure".to_owned());
+                panic!("gateway owner failed before control surface binding: {error_message}");
+            }
+
             let has_bind_address = status.bind_address.is_some();
             let has_port = status.port.is_some();
             let has_token_path = status.token_path.is_some();
@@ -188,7 +207,7 @@ async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
             }
         }
 
-        sleep(Duration::from_millis(5)).await;
+        sleep(GATEWAY_CONTROL_SURFACE_WAIT_INTERVAL).await;
     }
 
     panic!("timed out waiting for gateway control surface binding");
@@ -394,6 +413,7 @@ async fn gateway_run_turn_persists_acp_session_metadata_into_configured_sqlite_s
 async fn gateway_acp_operator_endpoints_surface_shared_session_truth() {
     let backend_id = register_gateway_echo_backend("gateway-acp-surface");
     let sqlite_path = unique_sqlite_path("gateway-acp-surface-store");
+    let config_path = gateway_config_path(sqlite_path.as_path());
     let runtime_dir = super::unique_temp_dir("gateway-acp-surface-runtime");
     let runtime_dir_for_run = runtime_dir.clone();
     let sqlite_path_for_config = sqlite_path.clone();
@@ -477,7 +497,7 @@ async fn gateway_acp_operator_endpoints_surface_shared_session_truth() {
         .await
         .expect("read gateway ACP observability");
 
-    assert_eq!(observability["config"], "/tmp/loongclaw-gateway-acp.toml");
+    assert_eq!(observability["config"], config_path.display().to_string());
     let active_sessions = observability["snapshot"]["runtime_cache"]["active_sessions"].as_u64();
     assert!(active_sessions.is_some());
     let errors_by_code = observability["snapshot"]["errors_by_code"].as_object();

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -1,3 +1,15 @@
+use super::*;
+
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
 use axum::{
     body::Body,
     http::{
@@ -5,8 +17,182 @@ use axum::{
         header::{AUTHORIZATION, CONTENT_TYPE},
     },
 };
+use loongclaw_daemon::{
+    CliResult,
+    gateway::{
+        client::GatewayLocalClient,
+        service::run_gateway_run_with_hooks_for_test,
+        state::{load_gateway_owner_status, request_gateway_stop},
+    },
+    mvp::{
+        acp::{
+            AcpBackendMetadata, AcpCapability, AcpRuntimeBackend, AcpSessionBootstrap,
+            AcpSessionHandle, AcpSessionState, AcpSessionStore, AcpSqliteSessionStore,
+            AcpTurnRequest, AcpTurnResult, AcpTurnStopReason, register_acp_backend,
+        },
+        config::{AcpConfig, LoongClawConfig},
+    },
+    supervisor::{LoadedSupervisorConfig, SupervisorRuntimeHooks},
+};
 use serde_json::json;
+use tokio::time::{sleep, timeout};
 use tower::ServiceExt;
+
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
+
+const GATEWAY_TURN_TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+struct GatewayEchoBackend {
+    id: &'static str,
+}
+
+#[async_trait]
+impl AcpRuntimeBackend for GatewayEchoBackend {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+
+    fn metadata(&self) -> AcpBackendMetadata {
+        let capabilities = [
+            AcpCapability::SessionLifecycle,
+            AcpCapability::TurnExecution,
+        ];
+        let description = "Gateway integration echo backend";
+        AcpBackendMetadata::new(self.id(), capabilities, description)
+    }
+
+    async fn ensure_session(
+        &self,
+        _config: &LoongClawConfig,
+        request: &AcpSessionBootstrap,
+    ) -> CliResult<AcpSessionHandle> {
+        let session_key = request.session_key.clone();
+        let backend_id = self.id().to_owned();
+        let runtime_session_name = format!("runtime-{session_key}");
+        let working_directory = request.working_directory.clone();
+        let backend_session_id = Some(format!("backend-{session_key}"));
+        let agent_session_id = Some(format!("agent-{session_key}"));
+        let binding = request.binding.clone();
+
+        Ok(AcpSessionHandle {
+            session_key,
+            backend_id,
+            runtime_session_name,
+            working_directory,
+            backend_session_id,
+            agent_session_id,
+            binding,
+        })
+    }
+
+    async fn run_turn(
+        &self,
+        _config: &LoongClawConfig,
+        _session: &AcpSessionHandle,
+        request: &AcpTurnRequest,
+    ) -> CliResult<AcpTurnResult> {
+        let output_text = format!("echo: {}", request.input);
+        let state = AcpSessionState::Ready;
+        let usage = None;
+        let events = Vec::new();
+        let stop_reason = Some(AcpTurnStopReason::Completed);
+
+        Ok(AcpTurnResult {
+            output_text,
+            state,
+            usage,
+            events,
+            stop_reason,
+        })
+    }
+
+    async fn cancel(
+        &self,
+        _config: &LoongClawConfig,
+        _session: &AcpSessionHandle,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn close(&self, _config: &LoongClawConfig, _session: &AcpSessionHandle) -> CliResult<()> {
+        Ok(())
+    }
+}
+
+fn pending_shutdown_future() -> BoxedShutdownFuture {
+    Box::pin(async move {
+        std::future::pending::<()>().await;
+        Ok(String::new())
+    })
+}
+
+fn register_gateway_echo_backend(prefix: &str) -> &'static str {
+    let temp_dir = super::unique_temp_dir(prefix);
+    let directory_name = temp_dir
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(prefix);
+    let backend_name = format!("{prefix}-{directory_name}");
+    let backend_id: &'static str = Box::leak(backend_name.into_boxed_str());
+    let backend_id_for_factory = backend_id;
+    let backend_factory = move || {
+        let backend = GatewayEchoBackend {
+            id: backend_id_for_factory,
+        };
+        let backend = Box::new(backend);
+        backend as Box<dyn AcpRuntimeBackend>
+    };
+    let register_result = register_acp_backend(backend_id, backend_factory);
+    register_result.expect("register gateway echo backend");
+
+    backend_id
+}
+
+fn unique_sqlite_path(label: &str) -> PathBuf {
+    let sqlite_dir = super::unique_temp_dir(label);
+    let create_dir_result = std::fs::create_dir_all(sqlite_dir.as_path());
+    create_dir_result.expect("create sqlite temp dir");
+    sqlite_dir.join("gateway.sqlite3")
+}
+
+fn gateway_turn_loaded_config_fixture(
+    sqlite_path: &Path,
+    backend_id: &str,
+) -> LoadedSupervisorConfig {
+    let mut config = LoongClawConfig::default();
+    let sqlite_path_text = sqlite_path.display().to_string();
+    config.memory.sqlite_path = sqlite_path_text;
+    config.acp = AcpConfig {
+        enabled: true,
+        backend: Some(backend_id.to_owned()),
+        ..AcpConfig::default()
+    };
+
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw-gateway-acp.toml"),
+        config,
+    }
+}
+
+async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
+    for _ in 0..200 {
+        let maybe_status = load_gateway_owner_status(runtime_dir);
+
+        if let Some(status) = maybe_status {
+            let has_bind_address = status.bind_address.is_some();
+            let has_port = status.port.is_some();
+            let has_token_path = status.token_path.is_some();
+
+            if status.running && has_bind_address && has_port && has_token_path {
+                return;
+            }
+        }
+
+        sleep(Duration::from_millis(5)).await;
+    }
+
+    panic!("timed out waiting for gateway control surface binding");
+}
 
 #[tokio::test]
 async fn gateway_turn_rejects_missing_auth() {
@@ -130,4 +316,76 @@ async fn gateway_turn_accepts_structured_session_scope_before_backend_check() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_run_turn_persists_acp_session_metadata_into_configured_sqlite_store() {
+    let backend_id = register_gateway_echo_backend("gateway-turn");
+    let sqlite_path = unique_sqlite_path("gateway-turn-store");
+    let runtime_dir = super::unique_temp_dir("gateway-turn-runtime");
+    let runtime_dir_for_run = runtime_dir.clone();
+    let sqlite_path_for_config = sqlite_path.clone();
+    let backend_id_for_config = backend_id.to_owned();
+
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let config = gateway_turn_loaded_config_fixture(
+                sqlite_path_for_config.as_path(),
+                backend_id_for_config.as_str(),
+            );
+            Ok(config)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+
+    let client_result = GatewayLocalClient::discover(runtime_dir.as_path());
+    let client = client_result.expect("discover gateway client");
+    let turn_response = client
+        .turn("gateway-session", "hello through gateway")
+        .await
+        .expect("gateway turn should succeed");
+
+    assert_eq!(turn_response["output_text"], "echo: hello through gateway");
+
+    let store = AcpSqliteSessionStore::new(Some(sqlite_path.clone()));
+    let session_key = "agent:codex:gateway-session";
+    let persisted_result = AcpSessionStore::get(&store, session_key);
+    let persisted_option = persisted_result.expect("read persisted ACP session metadata");
+    let persisted =
+        persisted_option.expect("gateway ACP session metadata should persist into sqlite");
+
+    assert_eq!(persisted.session_key, "agent:codex:gateway-session");
+    assert_eq!(persisted.backend_id, backend_id);
+    assert_eq!(
+        persisted.conversation_id.as_deref(),
+        Some("gateway-session")
+    );
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+
+    let supervisor = timeout(GATEWAY_TURN_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
 }

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -510,6 +510,66 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
             .is_some()
     );
 
+    let unauthorized_acp_sessions_response = client
+        .get(format!("{base_url}/api/gateway/acp/sessions"))
+        .send()
+        .await
+        .expect("send unauthorized gateway ACP sessions request");
+    assert_eq!(
+        unauthorized_acp_sessions_response.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+
+    let authorized_acp_sessions_response = client
+        .get(format!("{base_url}/api/gateway/acp/sessions"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send gateway ACP sessions request");
+    assert_eq!(
+        authorized_acp_sessions_response.status(),
+        reqwest::StatusCode::OK
+    );
+    let authorized_acp_sessions_json: Value = authorized_acp_sessions_response
+        .json()
+        .await
+        .expect("decode gateway ACP sessions response");
+    assert_eq!(
+        authorized_acp_sessions_json["returned_count"].as_u64(),
+        Some(0)
+    );
+
+    let authorized_acp_observability_response = client
+        .get(format!("{base_url}/api/gateway/acp/observability"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send gateway ACP observability request");
+    assert_eq!(
+        authorized_acp_observability_response.status(),
+        reqwest::StatusCode::OK
+    );
+    let authorized_acp_observability_json: Value = authorized_acp_observability_response
+        .json()
+        .await
+        .expect("decode gateway ACP observability response");
+    assert_eq!(
+        authorized_acp_observability_json["snapshot"]["runtime_cache"]["active_sessions"].as_u64(),
+        Some(0)
+    );
+
+    let missing_status_response = client
+        .get(format!("{base_url}/api/gateway/acp/status"))
+        .bearer_auth(token.as_str())
+        .query(&[("session", "missing-session")])
+        .send()
+        .await
+        .expect("send missing gateway ACP status request");
+    assert_eq!(
+        missing_status_response.status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+
     let stop_response = client
         .post(format!("{base_url}/api/gateway/stop"))
         .bearer_auth(token.as_str())

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -569,6 +569,71 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
         missing_status_response.status(),
         reqwest::StatusCode::NOT_FOUND
     );
+    let missing_status_json: Value = missing_status_response
+        .json()
+        .await
+        .expect("decode missing gateway ACP status response");
+    assert_eq!(missing_status_json["error"]["code"], "not_found");
+
+    let missing_conversation_status_response = client
+        .get(format!("{base_url}/api/gateway/acp/status"))
+        .bearer_auth(token.as_str())
+        .query(&[("conversation_id", "missing-conversation")])
+        .send()
+        .await
+        .expect("send missing gateway ACP conversation status request");
+    assert_eq!(
+        missing_conversation_status_response.status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    let missing_conversation_status_json: Value = missing_conversation_status_response
+        .json()
+        .await
+        .expect("decode missing gateway ACP conversation status response");
+    assert_eq!(
+        missing_conversation_status_json["error"]["code"],
+        "not_found"
+    );
+
+    let missing_route_status_response = client
+        .get(format!("{base_url}/api/gateway/acp/status"))
+        .bearer_auth(token.as_str())
+        .query(&[("route_session_id", "missing-route-session")])
+        .send()
+        .await
+        .expect("send missing gateway ACP route status request");
+    assert_eq!(
+        missing_route_status_response.status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    let missing_route_status_json: Value = missing_route_status_response
+        .json()
+        .await
+        .expect("decode missing gateway ACP route status response");
+    assert_eq!(missing_route_status_json["error"]["code"], "not_found");
+
+    let conflicting_selector_response = client
+        .get(format!("{base_url}/api/gateway/acp/status"))
+        .bearer_auth(token.as_str())
+        .query(&[
+            ("session", "missing-session"),
+            ("conversation_id", "missing-conversation"),
+        ])
+        .send()
+        .await
+        .expect("send conflicting gateway ACP selector request");
+    assert_eq!(
+        conflicting_selector_response.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let conflicting_selector_json: Value = conflicting_selector_response
+        .json()
+        .await
+        .expect("decode conflicting gateway ACP selector response");
+    assert_eq!(
+        conflicting_selector_json["error"]["code"],
+        "invalid_selector"
+    );
 
     let stop_response = client
         .post(format!("{base_url}/api/gateway/stop"))

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -62,6 +62,25 @@ fn legacy_acp_status_payload_json(
     })
 }
 
+fn legacy_acp_session_list_payload_json(
+    config_path: &str,
+    matched_count: usize,
+    sessions: &[mvp::acp::AcpSessionMetadata],
+) -> Value {
+    let returned_count = sessions.len();
+    let sessions = sessions
+        .iter()
+        .map(acp_session_metadata_json)
+        .collect::<Vec<_>>();
+
+    serde_json::json!({
+        "config": config_path,
+        "matched_count": matched_count,
+        "returned_count": returned_count,
+        "sessions": sessions,
+    })
+}
+
 fn legacy_acp_observability_payload_json(
     config_path: &str,
     snapshot: &mvp::acp::AcpManagerObservabilitySnapshot,
@@ -179,6 +198,66 @@ fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
         "telegram:bot_123456:42"
     );
     assert_eq!(encoded["status"]["last_error"], "permission denied");
+}
+
+#[test]
+fn gateway_read_model_acp_session_list_keeps_metadata_and_counts() {
+    let sessions = vec![
+        mvp::acp::AcpSessionMetadata {
+            session_key: "agent:codex:telegram:42".to_owned(),
+            conversation_id: Some("telegram:42".to_owned()),
+            binding: Some(mvp::acp::AcpSessionBindingScope {
+                route_session_id: "telegram:bot_123456:42".to_owned(),
+                channel_id: Some("telegram".to_owned()),
+                account_id: Some("bot_123456".to_owned()),
+                conversation_id: Some("42".to_owned()),
+                thread_id: None,
+            }),
+            activation_origin: Some(mvp::acp::AcpRoutingOrigin::AutomaticDispatch),
+            backend_id: "acpx".to_owned(),
+            runtime_session_name: "runtime-telegram-42".to_owned(),
+            working_directory: Some(PathBuf::from("/tmp/runtime-telegram-42")),
+            backend_session_id: Some("backend-42".to_owned()),
+            agent_session_id: Some("agent-42".to_owned()),
+            mode: Some(mvp::acp::AcpSessionMode::Interactive),
+            state: mvp::acp::AcpSessionState::Ready,
+            last_activity_ms: 1234,
+            last_error: None,
+        },
+        mvp::acp::AcpSessionMetadata {
+            session_key: "agent:codex:feishu:ops".to_owned(),
+            conversation_id: Some("feishu:ops".to_owned()),
+            binding: None,
+            activation_origin: Some(mvp::acp::AcpRoutingOrigin::ExplicitRequest),
+            backend_id: "acpx".to_owned(),
+            runtime_session_name: "runtime-feishu-ops".to_owned(),
+            working_directory: None,
+            backend_session_id: Some("backend-ops".to_owned()),
+            agent_session_id: Some("agent-ops".to_owned()),
+            mode: Some(mvp::acp::AcpSessionMode::Interactive),
+            state: mvp::acp::AcpSessionState::Error,
+            last_activity_ms: 5678,
+            last_error: Some("transport failed".to_owned()),
+        },
+    ];
+
+    let payload = gateway::read_models::build_acp_session_list_read_model(
+        "/tmp/loongclaw.toml",
+        9,
+        &sessions,
+    );
+    let encoded = serde_json::to_value(&payload).expect("serialize ACP session list read model");
+    let legacy = legacy_acp_session_list_payload_json("/tmp/loongclaw.toml", 9, &sessions);
+
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
+    assert_eq!(payload.matched_count, 9);
+    assert_eq!(payload.returned_count, sessions.len());
+    assert_eq!(encoded, legacy);
+    assert_eq!(encoded["sessions"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        encoded["sessions"][0]["provenance"]["surface"],
+        "session_activation"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Problem: `gateway run` originally kept ACP session state in a private in-memory manager, so gateway-owned turns did not persist into the configured sqlite-backed ACP store, and localhost gateway clients still had no gateway-native way to inspect ACP sessions, per-session status, or ACP observability.
- Why it matters: gateway-owned ACP state diverged from the daemon's shared ACP truth, and future localhost operator clients / Web UI bootstrap paths would still need to mix gateway discovery with out-of-band CLI ACP inspection.
- What changed: gateway startup now reuses the shared ACP session-manager selection path; the localhost gateway control surface now exposes ACP session list, ACP status, and ACP observability endpoints; the localhost gateway client helper now covers those ACP endpoints; integration/read-model coverage was added for the full flow; and the README gateway section now documents the expanded ACP operator surface.
- What did not change (scope boundary): this does not replace `/v1/turn`, does not introduce a remote/public ACP API, and does not redesign the broader control-plane server.

## Linked Issues

- Closes #1115
- Closes #1128
- Related #217
- Related #293

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw gateway_ -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-gateway-acp-operator-verify-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-gateway-acp-operator-verify-target cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-gateway-acp-operator-verify-target cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
./scripts/check-docs.sh
python3 scripts/sync_github_labels.py --check
bash scripts/test_sync_github_labels.sh
cargo deny check advisories bans licenses sources
```

All commands passed.

`check-docs.sh` reported the existing non-blocking release-artifact warnings already present in the repository.

`task check:conventions` could not be executed in this environment because the required helper (`~/.claude/skills/convention-engineering/scripts/main.go`) is not installed.

## User-visible / Operator-visible Changes

- Gateway-owned ACP turns now persist session metadata into the configured ACP/sqlite store instead of staying in a gateway-private in-memory manager.
- The localhost gateway control surface now exposes ACP session list, ACP per-session status, and ACP observability endpoints.
- The localhost gateway client/discovery helper now includes route helpers for those ACP operator endpoints.
- The README gateway section now documents the expanded ACP operator surface.

## Failure Recovery

- Fast rollback or disable path: revert commits `3fbae8d3c` and/or `606af181e`, or stop calling the new gateway ACP endpoints.
- Observable failure symptoms reviewers should watch for: gateway turns succeed but ACP sqlite state remains empty, or the new gateway ACP endpoints return stale/empty data after a successful gateway-owned ACP turn.

## Reviewer Focus

- `crates/daemon/src/gateway/service.rs`: confirm gateway startup now reuses the shared ACP manager selection path.
- `crates/daemon/src/gateway/control.rs`: confirm the new ACP route/auth wiring stays on the shared manager/store truth.
- `crates/daemon/src/gateway/client.rs`: confirm the localhost client helper covers the new ACP endpoints without ad-hoc file/token handling.
- `crates/daemon/tests/integration/gateway_api_turn.rs`, `gateway_owner_state.rs`, and `gateway_read_models.rs`: confirm the regression and operator-surface tests exercise a real `gateway run` owner end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ACP inspection endpoints (sessions, status, observability), client APIs, and gateway read models for ACP session data.
* **Improvements**
  * Gateway ACP initialization now uses configuration-driven acquisition and reports clearer availability/error states.
* **Tests**
  * Added broad integration and unit tests for ACP lifecycle, persistence, operator endpoints, observability, and error handling.
* **Documentation**
  * README updated to list ACP session/operator views and new control-surface routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->