### PR TITLE
Generalize memory system capabilities beyond pre-assembly hooks

### DIFF
--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -50,11 +50,12 @@ pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTes
 pub use protocol::{
     MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT,
     MEMORY_OP_READ_STAGE_ENVELOPE, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryContextEntry,
-    MemoryContextKind, WindowTurn, build_append_turn_request, build_read_context_request,
-    build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
-    build_replace_turns_request, build_replace_turns_request_with_expectation,
-    build_window_request, decode_memory_context_entries, decode_stage_envelope,
-    decode_window_turn_count, decode_window_turns, encode_stage_envelope_payload,
+    MemoryContextKind, MemoryCoreOperation, WindowTurn, build_append_turn_request,
+    build_read_context_request, build_read_stage_envelope_request,
+    build_read_stage_envelope_request_with_workspace_root, build_replace_turns_request,
+    build_replace_turns_request_with_expectation, build_window_request,
+    decode_memory_context_entries, decode_stage_envelope, decode_window_turn_count,
+    decode_window_turns, encode_stage_envelope_payload,
 };
 #[cfg(feature = "memory-sqlite")]
 pub(crate) use sqlite::CanonicalMemorySearchHit;
@@ -68,8 +69,9 @@ pub use stage::{
 };
 pub use system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
-    MemorySystemCapability, MemorySystemMetadata, RECALL_FIRST_MEMORY_SYSTEM_ID,
-    RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
+    MemorySystemCapability, MemorySystemMetadata, MemorySystemRuntimeFallbackKind,
+    RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+    WorkspaceRecallMemorySystem,
 };
 pub(crate) use system_registry::registered_memory_system_id;
 pub(crate) use system_registry::registered_memory_system_id_from_env;
@@ -106,6 +108,19 @@ pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutco
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
 }
 
+pub fn supported_memory_core_operations(backend: MemoryBackendKind) -> Vec<MemoryCoreOperation> {
+    match backend {
+        MemoryBackendKind::Sqlite => vec![
+            MemoryCoreOperation::AppendTurn,
+            MemoryCoreOperation::Window,
+            MemoryCoreOperation::ClearSession,
+            MemoryCoreOperation::ReadContext,
+            MemoryCoreOperation::ReplaceTurns,
+            MemoryCoreOperation::ReadStageEnvelope,
+        ],
+    }
+}
+
 pub fn execute_memory_core_with_config(
     request: MemoryCoreRequest,
     config: &runtime_config::MemoryRuntimeConfig,
@@ -122,14 +137,17 @@ pub(crate) fn execute_builtin_backend_memory_core(
     request: MemoryCoreRequest,
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
+    let parsed_operation = MemoryCoreOperation::parse_id(request.operation.as_str());
     match config.backend {
-        MemoryBackendKind::Sqlite => match request.operation.as_str() {
-            MEMORY_OP_APPEND_TURN => append_turn(request, config),
-            MEMORY_OP_WINDOW => load_window(request, config),
-            MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
-            MEMORY_OP_READ_CONTEXT => context::read_context(request, config),
-            MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
-            MEMORY_OP_READ_STAGE_ENVELOPE => context::read_stage_envelope(request, config),
+        MemoryBackendKind::Sqlite => match parsed_operation {
+            Some(MemoryCoreOperation::AppendTurn) => append_turn(request, config),
+            Some(MemoryCoreOperation::Window) => load_window(request, config),
+            Some(MemoryCoreOperation::ClearSession) => clear_session(request, config),
+            Some(MemoryCoreOperation::ReadContext) => context::read_context(request, config),
+            Some(MemoryCoreOperation::ReplaceTurns) => replace_turns(request, config),
+            Some(MemoryCoreOperation::ReadStageEnvelope) => {
+                context::read_stage_envelope(request, config)
+            }
             _ => Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -55,7 +55,7 @@ pub use protocol::{
     build_read_stage_envelope_request_with_workspace_root, build_replace_turns_request,
     build_replace_turns_request_with_expectation, build_window_request,
     decode_memory_context_entries, decode_stage_envelope, decode_window_turn_count,
-    decode_window_turns, encode_stage_envelope_payload,
+    decode_window_turns, encode_stage_envelope_payload, parse_exact_memory_core_operation,
 };
 #[cfg(feature = "memory-sqlite")]
 pub(crate) use sqlite::CanonicalMemorySearchHit;
@@ -110,14 +110,22 @@ pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutco
 
 pub fn supported_memory_core_operations(backend: MemoryBackendKind) -> Vec<MemoryCoreOperation> {
     match backend {
-        MemoryBackendKind::Sqlite => vec![
-            MemoryCoreOperation::AppendTurn,
-            MemoryCoreOperation::Window,
-            MemoryCoreOperation::ClearSession,
-            MemoryCoreOperation::ReadContext,
-            MemoryCoreOperation::ReplaceTurns,
-            MemoryCoreOperation::ReadStageEnvelope,
-        ],
+        MemoryBackendKind::Sqlite => {
+            let mut operations = Vec::new();
+
+            #[cfg(feature = "memory-sqlite")]
+            {
+                operations.push(MemoryCoreOperation::AppendTurn);
+                operations.push(MemoryCoreOperation::Window);
+                operations.push(MemoryCoreOperation::ClearSession);
+                operations.push(MemoryCoreOperation::ReplaceTurns);
+            }
+
+            operations.push(MemoryCoreOperation::ReadContext);
+            operations.push(MemoryCoreOperation::ReadStageEnvelope);
+
+            operations
+        }
     }
 }
 
@@ -137,7 +145,7 @@ pub(crate) fn execute_builtin_backend_memory_core(
     request: MemoryCoreRequest,
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
-    let parsed_operation = MemoryCoreOperation::parse_id(request.operation.as_str());
+    let parsed_operation = parse_exact_memory_core_operation(request.operation.as_str());
     match config.backend {
         MemoryBackendKind::Sqlite => match parsed_operation {
             Some(MemoryCoreOperation::AppendTurn) => append_turn(request, config),
@@ -148,7 +156,7 @@ pub(crate) fn execute_builtin_backend_memory_core(
             Some(MemoryCoreOperation::ReadStageEnvelope) => {
                 context::read_stage_envelope(request, config)
             }
-            _ => Ok(MemoryCoreOutcome {
+            None => Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
                     "adapter": "kv-core",

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1291,14 +1291,10 @@ mod tests {
                 .iter()
                 .map(|diag| (diag.family, diag.outcome))
                 .collect::<Vec<_>>(),
-            vec![
-                (MemoryStageFamily::Derive, StageOutcome::Skipped),
-                (MemoryStageFamily::Retrieve, StageOutcome::Skipped),
-                (MemoryStageFamily::Rank, StageOutcome::Skipped),
-            ]
+            vec![(MemoryStageFamily::Retrieve, StageOutcome::Skipped)]
         );
         assert_eq!(
-            envelope.diagnostics[1].message.as_deref(),
+            envelope.diagnostics[0].message.as_deref(),
             Some(
                 "memory system declares `retrieve` stage support but provides no execution adapter"
             )

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1291,10 +1291,14 @@ mod tests {
                 .iter()
                 .map(|diag| (diag.family, diag.outcome))
                 .collect::<Vec<_>>(),
-            vec![(MemoryStageFamily::Retrieve, StageOutcome::Skipped)]
+            vec![
+                (MemoryStageFamily::Derive, StageOutcome::Skipped),
+                (MemoryStageFamily::Retrieve, StageOutcome::Skipped),
+                (MemoryStageFamily::Rank, StageOutcome::Skipped),
+            ]
         );
         assert_eq!(
-            envelope.diagnostics[0].message.as_deref(),
+            envelope.diagnostics[1].message.as_deref(),
             Some(
                 "memory system declares `retrieve` stage support but provides no execution adapter"
             )

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -56,6 +56,17 @@ impl MemoryCoreOperation {
     }
 }
 
+pub fn parse_exact_memory_core_operation(raw: &str) -> Option<MemoryCoreOperation> {
+    let parsed_operation = MemoryCoreOperation::parse_id(raw)?;
+    let canonical_operation = parsed_operation.as_str();
+    let is_exact_match = raw == canonical_operation;
+    if !is_exact_match {
+        return None;
+    }
+
+    Some(parsed_operation)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowTurn {
     pub role: String,

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -19,6 +19,43 @@ pub const MEMORY_OP_READ_CONTEXT: &str = "read_context";
 pub const MEMORY_OP_REPLACE_TURNS: &str = "replace_turns";
 pub const MEMORY_OP_READ_STAGE_ENVELOPE: &str = "read_stage_envelope";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryCoreOperation {
+    AppendTurn,
+    Window,
+    ClearSession,
+    ReadContext,
+    ReplaceTurns,
+    ReadStageEnvelope,
+}
+
+impl MemoryCoreOperation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AppendTurn => MEMORY_OP_APPEND_TURN,
+            Self::Window => MEMORY_OP_WINDOW,
+            Self::ClearSession => MEMORY_OP_CLEAR_SESSION,
+            Self::ReadContext => MEMORY_OP_READ_CONTEXT,
+            Self::ReplaceTurns => MEMORY_OP_REPLACE_TURNS,
+            Self::ReadStageEnvelope => MEMORY_OP_READ_STAGE_ENVELOPE,
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        let normalized = raw.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            MEMORY_OP_APPEND_TURN => Some(Self::AppendTurn),
+            MEMORY_OP_WINDOW => Some(Self::Window),
+            MEMORY_OP_CLEAR_SESSION => Some(Self::ClearSession),
+            MEMORY_OP_READ_CONTEXT => Some(Self::ReadContext),
+            MEMORY_OP_REPLACE_TURNS => Some(Self::ReplaceTurns),
+            MEMORY_OP_READ_STAGE_ENVELOPE => Some(Self::ReadStageEnvelope),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowTurn {
     pub role: String,
@@ -581,5 +618,15 @@ mod tests {
         let rank_error = envelope.hydrated.diagnostics.rank_error;
 
         assert_eq!(rank_error.as_deref(), Some("rank stage timeout"));
+    }
+
+    #[test]
+    fn memory_core_operation_parse_and_render_are_stable() {
+        let operation = MemoryCoreOperation::parse_id(" read_stage_envelope ")
+            .expect("parse memory core operation");
+        let rendered = operation.as_str();
+
+        assert_eq!(operation, MemoryCoreOperation::ReadStageEnvelope);
+        assert_eq!(rendered, "read_stage_envelope");
     }
 }

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -99,15 +99,19 @@ impl MemorySystemMetadata {
         mut self,
         families: impl IntoIterator<Item = MemoryStageFamily>,
     ) -> Self {
-        let collected_families = families.into_iter().collect::<Vec<_>>();
-
-        for family in collected_families {
-            let already_present = self.supported_stage_families.contains(&family);
-            if already_present {
-                continue;
-            }
-
-            self.supported_stage_families.push(family);
+        let collected_families = dedupe_stage_families(families);
+        let pre_assembly_families = self.supported_pre_assembly_stage_families.clone();
+        let combined_families = pre_assembly_families
+            .into_iter()
+            .chain(collected_families)
+            .collect::<Vec<_>>();
+        let normalized_families = dedupe_stage_families(combined_families);
+        self.supported_stage_families = normalized_families;
+        let has_supported_stages = !self.supported_stage_families.is_empty();
+        if self.runtime_fallback_kind == MemorySystemRuntimeFallbackKind::MetadataOnly
+            && has_supported_stages
+        {
+            self.runtime_fallback_kind = MemorySystemRuntimeFallbackKind::SystemBacked;
         }
         self
     }
@@ -116,16 +120,27 @@ impl MemorySystemMetadata {
         mut self,
         families: impl IntoIterator<Item = MemoryStageFamily>,
     ) -> Self {
-        let collected_families = families.into_iter().collect::<Vec<_>>();
-        self.supported_pre_assembly_stage_families = collected_families.clone();
-
-        for family in collected_families {
-            let already_present = self.supported_stage_families.contains(&family);
-            if already_present {
-                continue;
-            }
-
-            self.supported_stage_families.push(family);
+        let collected_families = dedupe_stage_families(families);
+        let previous_pre_assembly_families = self.supported_pre_assembly_stage_families.clone();
+        let additional_stage_families = self
+            .supported_stage_families
+            .iter()
+            .copied()
+            .filter(|family| !previous_pre_assembly_families.contains(family))
+            .collect::<Vec<_>>();
+        let combined_families = collected_families
+            .iter()
+            .copied()
+            .chain(additional_stage_families)
+            .collect::<Vec<_>>();
+        let normalized_stage_families = dedupe_stage_families(combined_families);
+        self.supported_pre_assembly_stage_families = collected_families;
+        self.supported_stage_families = normalized_stage_families;
+        let has_supported_stages = !self.supported_stage_families.is_empty();
+        if self.runtime_fallback_kind == MemorySystemRuntimeFallbackKind::MetadataOnly
+            && has_supported_stages
+        {
+            self.runtime_fallback_kind = MemorySystemRuntimeFallbackKind::SystemBacked;
         }
         self
     }
@@ -156,6 +171,23 @@ impl MemorySystemMetadata {
     pub fn supports_stage_family(&self, family: MemoryStageFamily) -> bool {
         self.supported_stage_families.contains(&family)
     }
+}
+
+fn dedupe_stage_families(
+    families: impl IntoIterator<Item = MemoryStageFamily>,
+) -> Vec<MemoryStageFamily> {
+    let mut deduped_families = Vec::new();
+
+    for family in families {
+        let already_present = deduped_families.contains(&family);
+        if already_present {
+            continue;
+        }
+
+        deduped_families.push(family);
+    }
+
+    deduped_families
 }
 
 pub trait MemorySystem: Send + Sync {
@@ -1223,6 +1255,45 @@ mod tests {
                 MemoryRecallMode::PromptAssembly,
                 MemoryRecallMode::OperatorInspection
             ]
+        );
+    }
+
+    #[test]
+    fn supported_stage_families_replace_previous_explicit_stage_set() {
+        let metadata = MemorySystemMetadata::new(
+            "stage-reset",
+            [MemorySystemCapability::PromptHydration],
+            "Stage reset test system",
+        )
+        .with_supported_pre_assembly_stage_families([
+            MemoryStageFamily::Derive,
+            MemoryStageFamily::Retrieve,
+        ])
+        .with_supported_stage_families([MemoryStageFamily::Compact])
+        .with_supported_stage_families([MemoryStageFamily::AfterTurn]);
+
+        assert_eq!(
+            metadata.supported_stage_families,
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::AfterTurn,
+            ]
+        );
+    }
+
+    #[test]
+    fn supported_stage_builders_auto_promote_runtime_fallback_to_system_backed() {
+        let metadata = MemorySystemMetadata::new(
+            "auto-promote",
+            [MemorySystemCapability::PromptHydration],
+            "Auto promote test system",
+        )
+        .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve]);
+
+        assert_eq!(
+            metadata.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::SystemBacked
         );
     }
 

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -9,8 +9,8 @@ use super::{
     CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryAuthority,
     MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind,
     MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily,
-    MemoryTrustLevel, WindowTurn, builtin_pre_assembly_stage_families, durable_recall,
-    runtime_config::MemoryRuntimeConfig,
+    MemoryTrustLevel, StageDiagnostics, WindowTurn, builtin_pre_assembly_stage_families,
+    durable_recall, runtime_config::MemoryRuntimeConfig,
 };
 
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
@@ -42,12 +42,29 @@ impl MemorySystemCapability {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemorySystemRuntimeFallbackKind {
+    MetadataOnly,
+    SystemBacked,
+}
+
+impl MemorySystemRuntimeFallbackKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MetadataOnly => "metadata_only",
+            Self::SystemBacked => "system_backed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemorySystemMetadata {
     pub id: &'static str,
     pub api_version: u16,
     pub capabilities: BTreeSet<MemorySystemCapability>,
     pub summary: &'static str,
+    pub runtime_fallback_kind: MemorySystemRuntimeFallbackKind,
+    pub supported_stage_families: Vec<MemoryStageFamily>,
     pub supported_pre_assembly_stage_families: Vec<MemoryStageFamily>,
     pub supported_recall_modes: Vec<MemoryRecallMode>,
 }
@@ -63,16 +80,53 @@ impl MemorySystemMetadata {
             api_version: MEMORY_SYSTEM_API_VERSION,
             capabilities: capabilities.into_iter().collect(),
             summary,
+            runtime_fallback_kind: MemorySystemRuntimeFallbackKind::MetadataOnly,
+            supported_stage_families: Vec::new(),
             supported_pre_assembly_stage_families: Vec::new(),
             supported_recall_modes: Vec::new(),
         }
+    }
+
+    pub fn with_runtime_fallback_kind(
+        mut self,
+        runtime_fallback_kind: MemorySystemRuntimeFallbackKind,
+    ) -> Self {
+        self.runtime_fallback_kind = runtime_fallback_kind;
+        self
+    }
+
+    pub fn with_supported_stage_families(
+        mut self,
+        families: impl IntoIterator<Item = MemoryStageFamily>,
+    ) -> Self {
+        let collected_families = families.into_iter().collect::<Vec<_>>();
+
+        for family in collected_families {
+            let already_present = self.supported_stage_families.contains(&family);
+            if already_present {
+                continue;
+            }
+
+            self.supported_stage_families.push(family);
+        }
+        self
     }
 
     pub fn with_supported_pre_assembly_stage_families(
         mut self,
         families: impl IntoIterator<Item = MemoryStageFamily>,
     ) -> Self {
-        self.supported_pre_assembly_stage_families = families.into_iter().collect();
+        let collected_families = families.into_iter().collect::<Vec<_>>();
+        self.supported_pre_assembly_stage_families = collected_families.clone();
+
+        for family in collected_families {
+            let already_present = self.supported_stage_families.contains(&family);
+            if already_present {
+                continue;
+            }
+
+            self.supported_stage_families.push(family);
+        }
         self
     }
 
@@ -97,6 +151,10 @@ impl MemorySystemMetadata {
 
     pub fn supports_pre_assembly_stage_family(&self, family: MemoryStageFamily) -> bool {
         self.supported_pre_assembly_stage_families.contains(&family)
+    }
+
+    pub fn supports_stage_family(&self, family: MemoryStageFamily) -> bool {
+        self.supported_stage_families.contains(&family)
     }
 }
 
@@ -148,6 +206,15 @@ pub trait MemorySystem: Send + Sync {
         _entries: Vec<MemoryContextEntry>,
         _config: &MemoryRuntimeConfig,
     ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
+        Ok(None)
+    }
+
+    fn run_compact_stage(
+        &self,
+        _session_id: &str,
+        _workspace_root: Option<&Path>,
+        _config: &MemoryRuntimeConfig,
+    ) -> Result<Option<StageDiagnostics>, String> {
         Ok(None)
     }
 }
@@ -209,6 +276,16 @@ where
         config: &MemoryRuntimeConfig,
     ) -> Result<Option<Vec<MemoryContextEntry>>, String> {
         self.as_ref().run_rank_stage(entries, config)
+    }
+
+    fn run_compact_stage(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+    ) -> Result<Option<StageDiagnostics>, String> {
+        self.as_ref()
+            .run_compact_stage(session_id, workspace_root, config)
     }
 }
 
@@ -374,6 +451,8 @@ impl MemorySystem for BuiltinMemorySystem {
             "Built-in SQLite-backed canonical memory with deterministic prompt hydration.",
         )
         .with_supported_pre_assembly_stage_families(builtin_pre_assembly_stage_families())
+        .with_supported_stage_families([MemoryStageFamily::Compact])
+        .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::MetadataOnly)
         .with_supported_recall_modes([
             MemoryRecallMode::PromptAssembly,
             MemoryRecallMode::OperatorInspection,
@@ -818,6 +897,7 @@ impl MemorySystem for WorkspaceRecallMemorySystem {
             MemoryStageFamily::Retrieve,
             MemoryStageFamily::Rank,
         ])
+        .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
         .with_supported_recall_modes([
             MemoryRecallMode::PromptAssembly,
             MemoryRecallMode::OperatorInspection,
@@ -913,6 +993,7 @@ impl MemorySystem for RecallFirstMemorySystem {
             MemoryStageFamily::Retrieve,
             MemoryStageFamily::Rank,
         ])
+        .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
         .with_supported_recall_modes([MemoryRecallMode::PromptAssembly])
     }
 
@@ -982,6 +1063,7 @@ mod tests {
                 [MemorySystemCapability::PromptHydration],
                 "Registry stage-aware test system",
             )
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
             .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve])
         }
     }
@@ -991,6 +1073,10 @@ mod tests {
         let metadata = BuiltinMemorySystem.metadata();
         assert_eq!(metadata.id, DEFAULT_MEMORY_SYSTEM_ID);
         assert_eq!(metadata.api_version, MEMORY_SYSTEM_API_VERSION);
+        assert_eq!(
+            metadata.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::MetadataOnly
+        );
         assert_eq!(
             metadata.capability_names(),
             vec![
@@ -1017,6 +1103,15 @@ mod tests {
             metadata.supported_pre_assembly_stage_families,
             builtin_pre_assembly_stage_families()
         );
+        assert_eq!(
+            metadata.supported_stage_families,
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+                MemoryStageFamily::Compact,
+            ]
+        );
     }
 
     #[test]
@@ -1026,6 +1121,14 @@ mod tests {
         assert_eq!(
             custom.supported_pre_assembly_stage_families,
             vec![MemoryStageFamily::Retrieve]
+        );
+        assert_eq!(
+            custom.supported_stage_families,
+            vec![MemoryStageFamily::Retrieve]
+        );
+        assert_eq!(
+            custom.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::SystemBacked
         );
         assert!(custom.supported_recall_modes.is_empty());
     }
@@ -1057,11 +1160,23 @@ mod tests {
         assert_eq!(metadata.id, RECALL_FIRST_MEMORY_SYSTEM_ID);
         assert_eq!(metadata.api_version, MEMORY_SYSTEM_API_VERSION);
         assert_eq!(
+            metadata.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::SystemBacked
+        );
+        assert_eq!(
             metadata.capability_names(),
             vec!["prompt_hydration", "retrieval_provenance"]
         );
         assert_eq!(
             metadata.supported_pre_assembly_stage_families,
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
+        );
+        assert_eq!(
+            metadata.supported_stage_families,
             vec![
                 MemoryStageFamily::Derive,
                 MemoryStageFamily::Retrieve,
@@ -1079,11 +1194,23 @@ mod tests {
         let metadata = WorkspaceRecallMemorySystem.metadata();
         assert_eq!(metadata.id, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
         assert_eq!(
+            metadata.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::SystemBacked
+        );
+        assert_eq!(
             metadata.capability_names(),
             vec!["prompt_hydration", "retrieval_provenance"]
         );
         assert_eq!(
             metadata.supported_pre_assembly_stage_families,
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
+        );
+        assert_eq!(
+            metadata.supported_stage_families,
             vec![
                 MemoryStageFamily::Derive,
                 MemoryStageFamily::Retrieve,

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -222,9 +222,18 @@ pub fn resolve_memory_system_runtime(
     let metadata = system.metadata();
     let shared_system: Arc<dyn MemorySystem> = Arc::from(system);
     let runtime_fallback_kind = metadata.runtime_fallback_kind;
+    let has_supported_stages = !metadata.supported_stage_families.is_empty();
 
     let boxed_runtime: Box<dyn MemorySystemRuntime> = match runtime_fallback_kind {
         MemorySystemRuntimeFallbackKind::MetadataOnly => {
+            if has_supported_stages {
+                let error = format!(
+                    "memory system `{resolved_system_id}` declares stage families but still resolves as metadata_only; set runtime fallback to system_backed or provide create_runtime(...)"
+                );
+
+                return Err(error);
+            }
+
             let runtime_config = config.clone();
             let runtime = MetadataOnlyMemorySystemRuntime::new(runtime_config, metadata);
             let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
@@ -306,10 +315,11 @@ pub fn collect_memory_system_runtime_snapshot(
     config: &LoongClawConfig,
 ) -> CliResult<MemorySystemRuntimeSnapshot> {
     let selected = resolve_memory_system_selection(config);
-    let selected_metadata = describe_memory_system(Some(selected.id.as_str()))?;
-    let available = list_memory_system_metadata()?;
     let runtime = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let core_operations = super::supported_memory_core_operations(runtime.backend);
+    let selected_runtime = resolve_memory_system_runtime(&runtime)?;
+    let selected_metadata = selected_runtime.metadata().clone();
+    let core_operations = selected_runtime.supported_core_operations();
+    let available = list_memory_system_metadata()?;
     let policy = MemorySystemPolicySnapshot::from_runtime_config(&runtime);
 
     Ok(MemorySystemRuntimeSnapshot {
@@ -324,7 +334,10 @@ pub fn collect_memory_system_runtime_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::{BuiltinMemorySystemRuntime, MemorySystemRuntime};
+    use crate::memory::{
+        BuiltinMemorySystemRuntime, MemoryCoreOperation, MemorySystemRuntime,
+        MemorySystemRuntimeFallbackKind,
+    };
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemoryRecallMode, MemorySystemCapability};
     use crate::test_support::ScopedEnv;
 
@@ -458,6 +471,7 @@ mod tests {
                 "Registry compact system that should stay metadata-only",
             )
             .with_supported_stage_families([crate::memory::MemoryStageFamily::Compact])
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::MetadataOnly)
         }
 
         fn run_compact_stage(
@@ -501,6 +515,84 @@ mod tests {
             let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
 
             Ok(Some(boxed_runtime))
+        }
+    }
+
+    struct RuntimeMetadataOverrideRegistrySystem;
+
+    struct RuntimeMetadataOverrideRuntime {
+        metadata: MemorySystemMetadata,
+    }
+
+    impl MemorySystem for RuntimeMetadataOverrideRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-runtime-metadata-override"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-runtime-metadata-override",
+                [MemorySystemCapability::PromptHydration],
+                "Registry system whose runtime metadata differs from registry metadata",
+            )
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
+            .with_supported_stage_families([crate::memory::MemoryStageFamily::Compact])
+        }
+
+        fn create_runtime(
+            &self,
+            _config: &MemoryRuntimeConfig,
+        ) -> CliResult<Option<Box<dyn MemorySystemRuntime>>> {
+            let metadata = MemorySystemMetadata::new(
+                "registry-runtime-metadata-override",
+                [MemorySystemCapability::PromptHydration],
+                "Runtime override metadata",
+            )
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::MetadataOnly);
+            let runtime = RuntimeMetadataOverrideRuntime { metadata };
+            let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+
+            Ok(Some(boxed_runtime))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MemorySystemRuntime for RuntimeMetadataOverrideRuntime {
+        fn metadata(&self) -> &MemorySystemMetadata {
+            &self.metadata
+        }
+
+        fn supported_core_operations(&self) -> Vec<MemoryCoreOperation> {
+            vec![MemoryCoreOperation::ReadContext]
+        }
+
+        fn execute_core(
+            &self,
+            _request: loongclaw_contracts::MemoryCoreRequest,
+        ) -> Result<loongclaw_contracts::MemoryCoreOutcome, String> {
+            let error = "snapshot-only runtime should not execute core in this test".to_owned();
+
+            Err(error)
+        }
+
+        fn hydrate_stage_envelope(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+        ) -> Result<crate::memory::StageEnvelope, String> {
+            let error = "snapshot-only runtime should not hydrate in this test".to_owned();
+
+            Err(error)
+        }
+
+        async fn run_compact_stage(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+        ) -> Result<crate::memory::StageDiagnostics, String> {
+            let error = "snapshot-only runtime should not compact in this test".to_owned();
+
+            Err(error)
         }
     }
 
@@ -601,8 +693,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn metadata_only_runtime_fallback_does_not_infer_system_backed_execution_from_stage_list()
-    {
+    async fn metadata_only_runtime_fallback_rejects_stage_execution_trap() {
         register_memory_system("registry-metadata-only-compact", || {
             Box::new(MetadataOnlyCompactRegistrySystem)
         })
@@ -613,17 +704,15 @@ mod tests {
             ..MemoryRuntimeConfig::default()
         };
 
-        let runtime = resolve_memory_system_runtime(&config).expect("resolve memory runtime");
-        let diagnostics = runtime
-            .run_compact_stage("metadata-only-compact-session", None)
-            .await
-            .expect("run compact stage");
+        let error = match resolve_memory_system_runtime(&config) {
+            Ok(_runtime) => {
+                panic!("metadata-only fallback should reject stage execution trap")
+            }
+            Err(error) => error,
+        };
 
-        assert_eq!(
-            diagnostics.family,
-            crate::memory::MemoryStageFamily::Compact
-        );
-        assert_eq!(diagnostics.outcome, crate::memory::StageOutcome::Skipped);
+        assert!(error.contains("metadata_only"), "error: {error}");
+        assert!(error.contains("system_backed"), "error: {error}");
     }
 
     #[test]
@@ -857,6 +946,43 @@ mod tests {
                 .selected_metadata
                 .supported_pre_assembly_stage_families,
             vec![crate::memory::MemoryStageFamily::Retrieve]
+        );
+    }
+
+    #[test]
+    fn runtime_snapshot_prefers_resolved_runtime_metadata_and_core_operations() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+
+        register_memory_system("registry-runtime-metadata-override", || {
+            Box::new(RuntimeMetadataOverrideRegistrySystem)
+        })
+        .expect("register runtime metadata override system");
+
+        let config = LoongClawConfig {
+            memory: crate::config::MemoryConfig {
+                system_id: Some("registry-runtime-metadata-override".to_owned()),
+                ..crate::config::MemoryConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, "registry-runtime-metadata-override");
+        assert_eq!(
+            snapshot.selected_metadata.runtime_fallback_kind,
+            MemorySystemRuntimeFallbackKind::MetadataOnly
+        );
+        assert!(
+            snapshot
+                .selected_metadata
+                .supported_stage_families
+                .is_empty()
+        );
+        assert_eq!(
+            snapshot.core_operations,
+            vec![MemoryCoreOperation::ReadContext]
         );
     }
 

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -12,8 +12,8 @@ use crate::config::{
 use super::runtime_config::MemoryRuntimeConfig;
 use super::system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MemorySystem, MemorySystemMetadata,
-    RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
-    WorkspaceRecallMemorySystem,
+    MemorySystemRuntimeFallbackKind, RECALL_FIRST_MEMORY_SYSTEM_ID, RecallFirstMemorySystem,
+    WORKSPACE_RECALL_MEMORY_SYSTEM_ID, WorkspaceRecallMemorySystem,
 };
 use super::system_runtime::{
     MemorySystemRuntime, MetadataOnlyMemorySystemRuntime, SystemBackedMemorySystemRuntime,
@@ -56,6 +56,7 @@ pub struct MemorySystemRuntimeSnapshot {
     pub selected: MemorySystemSelection,
     pub selected_metadata: MemorySystemMetadata,
     pub available: Vec<MemorySystemMetadata>,
+    pub core_operations: Vec<super::MemoryCoreOperation>,
     pub policy: MemorySystemPolicySnapshot,
 }
 
@@ -219,20 +220,26 @@ pub fn resolve_memory_system_runtime(
     }
 
     let metadata = system.metadata();
-    let metadata_supports_stages = !metadata.supported_pre_assembly_stage_families.is_empty();
     let shared_system: Arc<dyn MemorySystem> = Arc::from(system);
+    let runtime_fallback_kind = metadata.runtime_fallback_kind;
 
-    if metadata_supports_stages {
-        let runtime_config = config.clone();
-        let runtime = SystemBackedMemorySystemRuntime::new(runtime_config, metadata, shared_system);
-        let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+    let boxed_runtime: Box<dyn MemorySystemRuntime> = match runtime_fallback_kind {
+        MemorySystemRuntimeFallbackKind::MetadataOnly => {
+            let runtime_config = config.clone();
+            let runtime = MetadataOnlyMemorySystemRuntime::new(runtime_config, metadata);
+            let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
 
-        return Ok(boxed_runtime);
-    }
+            boxed_runtime
+        }
+        MemorySystemRuntimeFallbackKind::SystemBacked => {
+            let runtime_config = config.clone();
+            let runtime =
+                SystemBackedMemorySystemRuntime::new(runtime_config, metadata, shared_system);
+            let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
 
-    let runtime_config = config.clone();
-    let runtime = MetadataOnlyMemorySystemRuntime::new(runtime_config, metadata);
-    let boxed_runtime: Box<dyn MemorySystemRuntime> = Box::new(runtime);
+            boxed_runtime
+        }
+    };
 
     Ok(boxed_runtime)
 }
@@ -302,12 +309,14 @@ pub fn collect_memory_system_runtime_snapshot(
     let selected_metadata = describe_memory_system(Some(selected.id.as_str()))?;
     let available = list_memory_system_metadata()?;
     let runtime = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let core_operations = super::supported_memory_core_operations(runtime.backend);
     let policy = MemorySystemPolicySnapshot::from_runtime_config(&runtime);
 
     Ok(MemorySystemRuntimeSnapshot {
         selected,
         selected_metadata,
         available,
+        core_operations,
         policy,
     })
 }
@@ -408,6 +417,7 @@ mod tests {
                 [MemorySystemCapability::PromptHydration],
                 "Registry snapshot system",
             )
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
             .with_supported_pre_assembly_stage_families([
                 crate::memory::MemoryStageFamily::Retrieve,
             ])
@@ -427,9 +437,41 @@ mod tests {
                 [MemorySystemCapability::PromptHydration],
                 "Registry config snapshot system",
             )
+            .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
             .with_supported_pre_assembly_stage_families([
                 crate::memory::MemoryStageFamily::Retrieve,
             ])
+        }
+    }
+
+    struct MetadataOnlyCompactRegistrySystem;
+
+    impl MemorySystem for MetadataOnlyCompactRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-metadata-only-compact"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-metadata-only-compact",
+                [MemorySystemCapability::PromptHydration],
+                "Registry compact system that should stay metadata-only",
+            )
+            .with_supported_stage_families([crate::memory::MemoryStageFamily::Compact])
+        }
+
+        fn run_compact_stage(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+            _config: &MemoryRuntimeConfig,
+        ) -> Result<Option<crate::memory::StageDiagnostics>, String> {
+            let diagnostics = crate::memory::StageDiagnostics::succeeded(
+                crate::memory::MemoryStageFamily::Compact,
+            );
+            let maybe_diagnostics = Some(diagnostics);
+
+            Ok(maybe_diagnostics)
         }
     }
 
@@ -556,6 +598,32 @@ mod tests {
             error.contains("registry-runtime-mismatch"),
             "error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn metadata_only_runtime_fallback_does_not_infer_system_backed_execution_from_stage_list()
+    {
+        register_memory_system("registry-metadata-only-compact", || {
+            Box::new(MetadataOnlyCompactRegistrySystem)
+        })
+        .expect("register metadata-only compact system");
+
+        let config = MemoryRuntimeConfig {
+            resolved_system_id: Some("registry-metadata-only-compact".to_owned()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let runtime = resolve_memory_system_runtime(&config).expect("resolve memory runtime");
+        let diagnostics = runtime
+            .run_compact_stage("metadata-only-compact-session", None)
+            .await
+            .expect("run compact stage");
+
+        assert_eq!(
+            diagnostics.family,
+            crate::memory::MemoryStageFamily::Compact
+        );
+        assert_eq!(diagnostics.outcome, crate::memory::StageOutcome::Skipped);
     }
 
     #[test]
@@ -707,6 +775,12 @@ mod tests {
 
         assert_eq!(snapshot.selected.id, DEFAULT_MEMORY_SYSTEM_ID);
         assert_eq!(snapshot.selected.source, MemorySystemSelectionSource::Env);
+        assert_eq!(
+            snapshot.core_operations,
+            crate::memory::supported_memory_core_operations(
+                crate::config::MemoryBackendKind::Sqlite
+            )
+        );
         assert_eq!(
             snapshot.policy.profile,
             crate::config::MemoryProfile::ProfilePlusWindow

--- a/crates/app/src/memory/system_runtime.rs
+++ b/crates/app/src/memory/system_runtime.rs
@@ -6,7 +6,7 @@ use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 
 use super::orchestrator::{
     BuiltinMemoryOrchestrator, hydrate_stage_envelope_without_execution_adapter,
-    skip_compact_stage_without_execution_adapter,
+    skip_compact_stage_without_execution_adapter, skipped_stage_diagnostics,
 };
 use super::runtime_config::MemoryRuntimeConfig;
 use super::{
@@ -84,13 +84,38 @@ impl MemorySystemRuntime for SystemBackedMemorySystemRuntime {
 
     async fn run_compact_stage(
         &self,
-        _session_id: &str,
-        _workspace_root: Option<&Path>,
+        session_id: &str,
+        workspace_root: Option<&Path>,
     ) -> Result<StageDiagnostics, String> {
         let family = MemoryStageFamily::Compact;
-        let diagnostics = skip_compact_stage_without_execution_adapter(family);
+        let supports_compact_stage = self.metadata.supports_stage_family(family);
+        if !supports_compact_stage {
+            let diagnostics = skipped_stage_diagnostics(family, None);
+            return Ok(diagnostics);
+        }
 
-        Ok(diagnostics)
+        let compact_stage_result =
+            self.system
+                .run_compact_stage(session_id, workspace_root, &self.config);
+        match compact_stage_result {
+            Ok(Some(diagnostics)) => Ok(diagnostics),
+            Ok(None) => {
+                let diagnostics = skip_compact_stage_without_execution_adapter(family);
+                Ok(diagnostics)
+            }
+            Err(error) if self.config.effective_fail_open() => {
+                let diagnostics = StageDiagnostics {
+                    family,
+                    outcome: super::StageOutcome::Fallback,
+                    budget_ms: None,
+                    elapsed_ms: None,
+                    fallback_activated: true,
+                    message: Some(error),
+                };
+                Ok(diagnostics)
+            }
+            Err(error) => Err(format!("memory compact stage failed: {error}")),
+        }
     }
 }
 
@@ -201,8 +226,13 @@ impl MemorySystemRuntime for MetadataOnlyMemorySystemRuntime {
         _workspace_root: Option<&Path>,
     ) -> Result<StageDiagnostics, String> {
         let family = MemoryStageFamily::Compact;
-        let diagnostics = skip_compact_stage_without_execution_adapter(family);
+        let supports_compact_stage = self.metadata.supports_stage_family(family);
+        if !supports_compact_stage {
+            let diagnostics = skipped_stage_diagnostics(family, None);
+            return Ok(diagnostics);
+        }
 
+        let diagnostics = skip_compact_stage_without_execution_adapter(family);
         Ok(diagnostics)
     }
 }

--- a/crates/app/src/memory/system_runtime.rs
+++ b/crates/app/src/memory/system_runtime.rs
@@ -10,12 +10,15 @@ use super::orchestrator::{
 };
 use super::runtime_config::MemoryRuntimeConfig;
 use super::{
-    MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics, StageEnvelope,
+    MemoryCoreOperation, MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics,
+    StageEnvelope,
 };
 
 #[async_trait]
 pub trait MemorySystemRuntime: Send + Sync {
     fn metadata(&self) -> &MemorySystemMetadata;
+
+    fn supported_core_operations(&self) -> Vec<MemoryCoreOperation>;
 
     fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String>;
 
@@ -56,6 +59,10 @@ impl SystemBackedMemorySystemRuntime {
 impl MemorySystemRuntime for SystemBackedMemorySystemRuntime {
     fn metadata(&self) -> &MemorySystemMetadata {
         &self.metadata
+    }
+
+    fn supported_core_operations(&self) -> Vec<MemoryCoreOperation> {
+        super::supported_memory_core_operations(self.config.backend)
     }
 
     fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
@@ -145,6 +152,10 @@ impl MemorySystemRuntime for BuiltinMemorySystemRuntime {
         &self.metadata
     }
 
+    fn supported_core_operations(&self) -> Vec<MemoryCoreOperation> {
+        super::supported_memory_core_operations(self.config.backend)
+    }
+
     fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
         super::execute_builtin_backend_memory_core(request, &self.config)
     }
@@ -200,6 +211,10 @@ impl MetadataOnlyMemorySystemRuntime {
 impl MemorySystemRuntime for MetadataOnlyMemorySystemRuntime {
     fn metadata(&self) -> &MemorySystemMetadata {
         &self.metadata
+    }
+
+    fn supported_core_operations(&self) -> Vec<MemoryCoreOperation> {
+        super::supported_memory_core_operations(self.config.backend)
     }
 
     fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -43,6 +43,27 @@ fn fallback_memory_operation_stays_compatible() {
     assert_eq!(outcome.payload["adapter"], "kv-core");
 }
 
+#[test]
+fn supported_memory_core_operations_for_sqlite_are_stable() {
+    let operations = supported_memory_core_operations(crate::config::MemoryBackendKind::Sqlite);
+    let operation_names = operations
+        .into_iter()
+        .map(MemoryCoreOperation::as_str)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        operation_names,
+        vec![
+            "append_turn",
+            "window",
+            "clear_session",
+            "read_context",
+            "replace_turns",
+            "read_stage_envelope",
+        ]
+    );
+}
+
 #[tokio::test]
 async fn mvp_memory_adapter_routes_through_kernel() {
     use std::collections::{BTreeMap, BTreeSet};
@@ -769,4 +790,62 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
         envelope.hydrated.diagnostics.system_id,
         "registry-runtime-executing"
     );
+}
+
+#[tokio::test]
+async fn registry_selected_system_can_use_compact_stage_hook_without_custom_runtime() {
+    struct CompactHookMemorySystem;
+
+    impl MemorySystem for CompactHookMemorySystem {
+        fn id(&self) -> &'static str {
+            "registry-compact-hook"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-compact-hook",
+                [MemorySystemCapability::PromptHydration],
+                "Registry compact hook test system",
+            )
+            .with_runtime_fallback_kind(
+                crate::memory::MemorySystemRuntimeFallbackKind::SystemBacked,
+            )
+            .with_supported_stage_families([MemoryStageFamily::Compact])
+        }
+
+        fn run_compact_stage(
+            &self,
+            _session_id: &str,
+            _workspace_root: Option<&std::path::Path>,
+            _config: &runtime_config::MemoryRuntimeConfig,
+        ) -> Result<Option<StageDiagnostics>, String> {
+            let diagnostics = StageDiagnostics::succeeded(MemoryStageFamily::Compact);
+
+            Ok(Some(diagnostics))
+        }
+    }
+
+    fn ensure_registry_compact_hook_system_registered() {
+        static REGISTRY_COMPACT_HOOK_SYSTEM: OnceLock<()> = OnceLock::new();
+        REGISTRY_COMPACT_HOOK_SYSTEM.get_or_init(|| {
+            register_memory_system("registry-compact-hook", || {
+                Box::new(CompactHookMemorySystem)
+            })
+            .expect("register compact-hook memory system");
+        });
+    }
+
+    ensure_registry_compact_hook_system_registered();
+
+    let config = runtime_config::MemoryRuntimeConfig {
+        resolved_system_id: Some("registry-compact-hook".to_owned()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+    let diagnostics = run_compact_stage("compact-hook-session", None, &config)
+        .await
+        .expect("compact stage should run through system-backed runtime");
+
+    assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
+    assert_eq!(diagnostics.outcome, StageOutcome::Succeeded);
+    assert!(!diagnostics.fallback_activated);
 }

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -57,8 +57,8 @@ fn supported_memory_core_operations_for_sqlite_are_stable() {
             "append_turn",
             "window",
             "clear_session",
-            "read_context",
             "replace_turns",
+            "read_context",
             "read_stage_envelope",
         ]
     );
@@ -698,6 +698,10 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
             &self.metadata
         }
 
+        fn supported_core_operations(&self) -> Vec<MemoryCoreOperation> {
+            vec![MemoryCoreOperation::ReadContext]
+        }
+
         fn execute_core(&self, request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
             let operation = request.operation;
             let payload = json!({
@@ -796,6 +800,9 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
 async fn registry_selected_system_can_use_compact_stage_hook_without_custom_runtime() {
     struct CompactHookMemorySystem;
 
+    static EXPECTED_COMPACT_HOOK_SESSION_ID: OnceLock<String> = OnceLock::new();
+    static EXPECTED_COMPACT_HOOK_WORKSPACE_ROOT: OnceLock<std::path::PathBuf> = OnceLock::new();
+
     impl MemorySystem for CompactHookMemorySystem {
         fn id(&self) -> &'static str {
             "registry-compact-hook"
@@ -815,10 +822,33 @@ async fn registry_selected_system_can_use_compact_stage_hook_without_custom_runt
 
         fn run_compact_stage(
             &self,
-            _session_id: &str,
-            _workspace_root: Option<&std::path::Path>,
+            session_id: &str,
+            workspace_root: Option<&std::path::Path>,
             _config: &runtime_config::MemoryRuntimeConfig,
         ) -> Result<Option<StageDiagnostics>, String> {
+            let expected_session_id = EXPECTED_COMPACT_HOOK_SESSION_ID
+                .get()
+                .expect("expected compact-hook session id");
+            let expected_workspace_root = EXPECTED_COMPACT_HOOK_WORKSPACE_ROOT
+                .get()
+                .expect("expected compact-hook workspace root");
+            let actual_workspace_root = workspace_root.map(|path| path.to_path_buf());
+            let expected_workspace_root = Some(expected_workspace_root.clone());
+            if session_id != expected_session_id {
+                let error = format!(
+                    "expected compact hook session id `{expected_session_id}`, got `{session_id}`"
+                );
+
+                return Err(error);
+            }
+            if actual_workspace_root != expected_workspace_root {
+                let error = format!(
+                    "expected compact hook workspace root `{:?}`, got `{:?}`",
+                    expected_workspace_root, actual_workspace_root
+                );
+
+                return Err(error);
+            }
             let diagnostics = StageDiagnostics::succeeded(MemoryStageFamily::Compact);
 
             Ok(Some(diagnostics))
@@ -837,13 +867,26 @@ async fn registry_selected_system_can_use_compact_stage_hook_without_custom_runt
 
     ensure_registry_compact_hook_system_registered();
 
+    let workspace_root = crate::test_support::unique_temp_dir("compact-hook-workspace");
+    std::fs::create_dir_all(&workspace_root).expect("create compact hook workspace");
+    EXPECTED_COMPACT_HOOK_SESSION_ID
+        .set("compact-hook-session".to_owned())
+        .ok();
+    EXPECTED_COMPACT_HOOK_WORKSPACE_ROOT
+        .set(workspace_root.clone())
+        .ok();
+
     let config = runtime_config::MemoryRuntimeConfig {
         resolved_system_id: Some("registry-compact-hook".to_owned()),
         ..runtime_config::MemoryRuntimeConfig::default()
     };
-    let diagnostics = run_compact_stage("compact-hook-session", None, &config)
-        .await
-        .expect("compact stage should run through system-backed runtime");
+    let diagnostics = run_compact_stage(
+        "compact-hook-session",
+        Some(workspace_root.as_path()),
+        &config,
+    )
+    .await
+    .expect("compact stage should run through system-backed runtime");
 
     assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
     assert_eq!(diagnostics.outcome, StageOutcome::Succeeded);

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5840,6 +5840,12 @@ pub fn memory_system_metadata_json(
     metadata: &mvp::memory::MemorySystemMetadata,
     source: Option<&str>,
 ) -> Value {
+    let supported_stage_families = metadata
+        .supported_stage_families
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryStageFamily::as_str)
+        .collect::<Vec<_>>();
     let supported_pre_assembly_stage_families = metadata
         .supported_pre_assembly_stage_families
         .iter()
@@ -5858,6 +5864,14 @@ pub fn memory_system_metadata_json(
     payload.insert(
         "capabilities".to_owned(),
         json!(metadata.capability_names()),
+    );
+    payload.insert(
+        "runtime_fallback_kind".to_owned(),
+        json!(metadata.runtime_fallback_kind.as_str()),
+    );
+    payload.insert(
+        "supported_stage_families".to_owned(),
+        json!(supported_stage_families),
     );
     payload.insert(
         "supported_pre_assembly_stage_families".to_owned(),
@@ -5892,6 +5906,15 @@ fn format_memory_recall_mode_names(recall_modes: &[mvp::memory::MemoryRecallMode
     render_string_list(names)
 }
 
+fn format_memory_core_operation_names(operations: &[mvp::memory::MemoryCoreOperation]) -> String {
+    let names = operations
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryCoreOperation::as_str)
+        .collect::<Vec<_>>();
+    render_string_list(names)
+}
+
 pub fn memory_system_policy_json(policy: &mvp::memory::MemorySystemPolicySnapshot) -> Value {
     json!({
         "backend": policy.backend.as_str(),
@@ -5920,6 +5943,12 @@ pub fn build_memory_systems_cli_json_payload(
             .iter()
             .map(|metadata| memory_system_metadata_json(metadata, None))
             .collect::<Vec<_>>(),
+        "core_operations": snapshot
+            .core_operations
+            .iter()
+            .copied()
+            .map(mvp::memory::MemoryCoreOperation::as_str)
+            .collect::<Vec<_>>(),
         "policy": memory_system_policy_json(&snapshot.policy),
     })
 }
@@ -5929,6 +5958,8 @@ pub fn render_memory_system_snapshot_text(
     snapshot: &mvp::memory::MemorySystemRuntimeSnapshot,
 ) -> String {
     let selected_capabilities = snapshot.selected_metadata.capability_names();
+    let selected_stage_families =
+        format_memory_stage_family_names(&snapshot.selected_metadata.supported_stage_families);
     let selected_pre_assembly_stages = format_memory_stage_family_names(
         &snapshot
             .selected_metadata
@@ -5936,16 +5967,20 @@ pub fn render_memory_system_snapshot_text(
     );
     let selected_recall_modes =
         format_memory_recall_mode_names(&snapshot.selected_metadata.supported_recall_modes);
+    let core_operations = format_memory_core_operation_names(&snapshot.core_operations);
     let mut lines = vec![
         format!("config={config_path}"),
         format!(
-            "selected={} source={} api_version={} capabilities={} pre_assembly_stages={} recall_modes={} summary={}",
+            "selected={} source={} api_version={} capabilities={} runtime_fallback_kind={} stages={} pre_assembly_stages={} recall_modes={} core_operations={} summary={}",
             snapshot.selected_metadata.id,
             snapshot.selected.source.as_str(),
             snapshot.selected_metadata.api_version,
             format_capability_names(&selected_capabilities),
+            snapshot.selected_metadata.runtime_fallback_kind.as_str(),
+            selected_stage_families,
             selected_pre_assembly_stages,
             selected_recall_modes,
+            core_operations,
             snapshot.selected_metadata.summary
         ),
         format!(
@@ -5964,14 +5999,17 @@ pub fn render_memory_system_snapshot_text(
 
     for metadata in &snapshot.available {
         let capabilities = metadata.capability_names();
+        let stage_families = format_memory_stage_family_names(&metadata.supported_stage_families);
         let pre_assembly_stages =
             format_memory_stage_family_names(&metadata.supported_pre_assembly_stage_families);
         let recall_modes = format_memory_recall_mode_names(&metadata.supported_recall_modes);
         lines.push(format!(
-            "- {} api_version={} capabilities={} pre_assembly_stages={} recall_modes={} summary={}",
+            "- {} api_version={} capabilities={} runtime_fallback_kind={} stages={} pre_assembly_stages={} recall_modes={} summary={}",
             metadata.id,
             metadata.api_version,
             format_capability_names(&capabilities),
+            metadata.runtime_fallback_kind.as_str(),
+            stage_families,
             pre_assembly_stages,
             recall_modes,
             metadata.summary

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1422,6 +1422,11 @@ fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
             .iter()
             .any(|entry| entry == "canonical_store")
     );
+    assert_eq!(payload["runtime_fallback_kind"], "metadata_only");
+    assert_eq!(
+        payload["supported_stage_families"],
+        json!(["derive", "retrieve", "rank", "compact"])
+    );
     assert_eq!(
         payload["supported_pre_assembly_stage_families"],
         json!(["derive", "retrieve", "rank"])
@@ -1452,12 +1457,31 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
     assert_eq!(payload["selected"]["id"], "builtin");
     assert_eq!(payload["selected"]["source"], "default");
     assert_eq!(
+        payload["selected"]["runtime_fallback_kind"],
+        "metadata_only"
+    );
+    assert_eq!(
+        payload["selected"]["supported_stage_families"],
+        json!(["derive", "retrieve", "rank", "compact"])
+    );
+    assert_eq!(
         payload["selected"]["supported_pre_assembly_stage_families"],
         json!(["derive", "retrieve", "rank"])
     );
     assert_eq!(
         payload["selected"]["supported_recall_modes"],
         json!(["prompt_assembly", "operator_inspection"])
+    );
+    assert_eq!(
+        payload["core_operations"],
+        json!([
+            "append_turn",
+            "window",
+            "clear_session",
+            "read_context",
+            "replace_turns",
+            "read_stage_envelope"
+        ])
     );
     assert_eq!(payload["policy"]["backend"], "sqlite");
     assert_eq!(payload["policy"]["profile"], "window_plus_summary");
@@ -1487,14 +1511,14 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains(
-        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
+        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance runtime_fallback_kind=metadata_only stages=derive,retrieve,rank,compact pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection core_operations=append_turn,window,clear_session,read_context,replace_turns,read_stage_envelope"
     ));
     assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
     assert!(rendered.contains(
-        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
+        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance runtime_fallback_kind=metadata_only stages=derive,retrieve,rank,compact pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection"
     ));
     assert!(rendered.contains(
-        "- recall_first api_version=1 capabilities=prompt_hydration,retrieval_provenance pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
+        "- recall_first api_version=1 capabilities=prompt_hydration,retrieval_provenance runtime_fallback_kind=system_backed stages=derive,retrieve,rank pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly"
     ));
 }
 

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1478,8 +1478,8 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
             "append_turn",
             "window",
             "clear_session",
-            "read_context",
             "replace_turns",
+            "read_context",
             "read_stage_envelope"
         ])
     );
@@ -1511,7 +1511,7 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains(
-        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance runtime_fallback_kind=metadata_only stages=derive,retrieve,rank,compact pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection core_operations=append_turn,window,clear_session,read_context,replace_turns,read_stage_envelope"
+        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance runtime_fallback_kind=metadata_only stages=derive,retrieve,rank,compact pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection core_operations=append_turn,window,clear_session,replace_turns,read_context,read_stage_envelope"
     ));
     assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
     assert!(rendered.contains(

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-08T12:02:32Z
+- Generated at: 2026-04-08T15:21:23Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 430 | 650 | 220 | 15 | 16 | 1 | 93.8% | WATCH | 356 | 20.8% | BREACH | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 448 | 650 | 202 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 25.8% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
@@ -24,13 +24,13 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1786 | 6400 | 4614 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.4% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10094 | 11200 | 1106 | 83 | 120 | 37 | 90.1% | WATCH | 10831 | -6.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 55 | 70 | 15 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6447 | 6500 | 53 | 200 | 210 | 10 | 99.2% | TIGHT | 6324 | 1.9% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6485 | 6500 | 15 | 201 | 210 | 9 | 99.8% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (100.0%), daemon_lib (99.2%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (93.8%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (100.0%), tools_mod (100.0%), daemon_lib (99.8%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -61,7 +61,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=430 functions=15 -->
+<!-- arch-hotspot key=memory_mod lines=448 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->
@@ -70,7 +70,7 @@
 <!-- arch-hotspot key=channel_mod lines=1786 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10094 functions=83 -->
 <!-- arch-hotspot key=tools_mod lines=14999 functions=55 -->
-<!-- arch-hotspot key=daemon_lib lines=6447 functions=200 -->
+<!-- arch-hotspot key=daemon_lib lines=6485 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-08T15:21:23Z
+- Generated at: 2026-04-08T16:50:04Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 448 | 650 | 202 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 25.8% | BREACH | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
@@ -61,7 +61,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=448 functions=16 -->
+<!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->


### PR DESCRIPTION
## Summary

- Problem: memory-system metadata still under-described stage and fallback behavior, so compact-stage participation stayed effectively builtin-special-cased and memory runtime snapshots could not fully explain what a selected system was capable of.
- Why it matters: future memory backends and runtime debugging need explicit, inspectable capability semantics instead of relying on partial pre-assembly conventions or ad-hoc compact branching.
- What changed: added typed `MemoryCoreOperation` ids, introduced explicit `MemorySystemRuntimeFallbackKind`, generalized memory metadata to track full supported stage families, taught system-backed runtimes to execute `run_compact_stage(...)`, and surfaced the richer metadata in daemon memory-system JSON/text snapshots.
- What did not change (scope boundary): no new external memory backend, no new user-facing memory profile/config surface, and no full public protocol rewrite.

## Linked Issues

- Closes #1121
- Related #1102

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app memory::tests -- --nocapture
cargo test -p loongclaw-app orchestrator::tests -- --nocapture
cargo test -p loongclaw-app registry_selected_system_can_use_compact_stage_hook_without_custom_runtime -- --nocapture
cargo test -p loongclaw --test integration memory_system_metadata_json_includes_stage_families_summary_and_source -- --nocapture
cargo test -p loongclaw --test integration build_memory_systems_cli_json_payload_includes_runtime_policy -- --nocapture
cargo test -p loongclaw --test integration render_memory_system_snapshot_text_reports_fail_open_policy -- --nocapture
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
```

Results: all commands above completed successfully in the isolated worktree using the shared target cache.

## User-visible / Operator-visible Changes

- `loongclaw list-memory-systems` / memory runtime snapshots now expose `runtime_fallback_kind` and full `supported_stage_families` in addition to pre-assembly stages.
- System-backed memory systems can now implement compact-stage behavior without a bespoke runtime implementation.
- Internal memory core dispatch uses a typed `MemoryCoreOperation` enum instead of matching only raw string literals.

## Failure Recovery

- Fast rollback or disable path: revert commit `fbe845b6f`.
- Observable failure symptoms reviewers should watch for: compact-stage hooks on registry-selected systems being ignored, memory-system snapshots omitting stage/fallback metadata, or memory core operations failing to parse canonical operation ids.

## Reviewer Focus

- `crates/app/src/memory/system.rs`: metadata contract expansion and new compact-stage hook.
- `crates/app/src/memory/system_runtime.rs`: system-backed compact-stage execution path.
- `crates/app/src/memory/system_registry.rs`: fallback-kind based runtime resolution.
- `crates/app/src/memory/protocol.rs` and `crates/app/src/memory/mod.rs`: typed memory core operations and dispatch.
- `crates/daemon/src/lib.rs`: memory-system JSON/text snapshot exposure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory systems can run a "compact" stage with configurable fallback modes (metadata-only or system-backed).
  * Clients can query the exact set of supported memory core operations for each backend.

* **Improvements**
  * Runtime now enforces consistency between declared stage support and fallback mode, rejecting invalid configurations.
  * CLI/snapshot outputs now include runtime fallback mode, supported stage families, and core operations.

* **Tests & Docs**
  * Integration and unit tests updated; release docs timestamped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->