### PR TITLE
Prevent ACPX MCP proxy drift from bypassing the shared runtime contract

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -15,6 +14,12 @@ use tokio::time::{Duration, Instant, sleep, sleep_until, timeout};
 use crate::CliResult;
 use crate::config::{AcpxMcpServerConfig, LoongClawConfig};
 
+#[cfg(test)]
+pub(crate) use super::acpx_mcp::probe_mcp_proxy_support_with_runtime;
+pub(crate) use super::acpx_mcp::{
+    AcpxMcpServerEntry, AcpxMcpServerEnvEntry, build_mcp_proxy_agent_command,
+    probe_mcp_proxy_support,
+};
 use super::backend::{
     AcpAbortSignal, AcpBackendMetadata, AcpCapability, AcpConfigPatch, AcpDoctorReport,
     AcpRuntimeBackend, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMode, AcpSessionState,
@@ -32,10 +37,6 @@ const ACPX_DEFAULT_QUEUE_OWNER_TTL_SECONDS: f64 = 0.1;
 const ACPX_PERMISSION_DENIED_EXIT_CODE: i32 = 5;
 const ACPX_SPAWN_RETRY_ATTEMPTS: usize = 5;
 const ACPX_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(25);
-const ACPX_MCP_PROXY_NODE_COMMAND: &str = "node";
-const ACPX_MCP_PROXY_SCRIPT_NAME: &str = "loongclaw-acpx-mcp-proxy.mjs";
-const ACPX_MCP_PROXY_SCRIPT_SOURCE: &str = include_str!("assets/acpx-mcp-proxy.mjs");
-static ACPX_MCP_PROXY_SCRIPT_PATH: OnceLock<Result<String, String>> = OnceLock::new();
 
 mod command_probe;
 
@@ -80,22 +81,6 @@ struct AcpxIdentifiers {
     acpx_record_id: Option<String>,
     backend_session_id: Option<String>,
     agent_session_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct AcpxMcpServerEntry {
-    name: String,
-    command: String,
-    args: Vec<String>,
-    env: Vec<AcpxMcpServerEnvEntry>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    cwd: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct AcpxMcpServerEnvEntry {
-    name: String,
-    value: String,
 }
 
 #[derive(Default)]
@@ -922,126 +907,6 @@ fn resolve_selected_mcp_server_entries(
             })
         })
         .collect()
-}
-
-fn build_mcp_proxy_agent_command(
-    target_command: &str,
-    mcp_servers: &[AcpxMcpServerEntry],
-) -> CliResult<String> {
-    let script_path = ensure_mcp_proxy_script_path()?;
-    let payload = serde_json::to_vec(&json!({
-        "targetCommand": target_command,
-        "mcpServers": mcp_servers,
-    }))
-    .map_err(|error| format!("serialize ACPX MCP proxy payload failed: {error}"))?;
-    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
-    Ok(join_command_line(&[
-        ACPX_MCP_PROXY_NODE_COMMAND.to_owned(),
-        script_path,
-        "--payload".to_owned(),
-        encoded,
-    ]))
-}
-
-fn ensure_mcp_proxy_script_path() -> CliResult<String> {
-    ACPX_MCP_PROXY_SCRIPT_PATH
-        .get_or_init(materialize_mcp_proxy_script)
-        .clone()
-}
-
-fn materialize_mcp_proxy_script() -> Result<String, String> {
-    let path = std::env::temp_dir()
-        .join("loongclaw")
-        .join(ACPX_MCP_PROXY_SCRIPT_NAME);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("create ACPX MCP proxy directory failed: {error}"))?;
-    }
-    std::fs::write(&path, ACPX_MCP_PROXY_SCRIPT_SOURCE)
-        .map_err(|error| format!("write ACPX MCP proxy script failed: {error}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let mut permissions = std::fs::metadata(&path)
-            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions)
-            .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
-    }
-    Ok(path.display().to_string())
-}
-
-async fn probe_mcp_proxy_support(
-    cwd: Option<&str>,
-    timeout_duration: Duration,
-) -> CliResult<(String, String)> {
-    let script_path = ensure_mcp_proxy_script_path()?;
-    let mut probe = Command::new(ACPX_MCP_PROXY_NODE_COMMAND);
-    probe.arg("--version");
-    if let Some(cwd) = cwd {
-        probe.current_dir(cwd);
-    }
-    let output = wait_for_command_output(&mut probe, timeout_duration)
-        .await
-        .map_err(|error| match error {
-            CommandOutputError::TimedOut => {
-                "embedded ACPX MCP proxy runtime probe timed out".to_owned()
-            }
-            CommandOutputError::Io(error) => {
-                if error.kind() == ErrorKind::NotFound {
-                    format!(
-                        "embedded ACPX MCP proxy requires `{ACPX_MCP_PROXY_NODE_COMMAND}` on PATH"
-                    )
-                } else {
-                    format!("probe embedded ACPX MCP proxy runtime failed: {error}")
-                }
-            }
-        })?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let observed = match (stdout.is_empty(), stderr.is_empty()) {
-        (false, true) => stdout,
-        (true, false) => stderr,
-        (false, false) => format!("{stdout} | {stderr}"),
-        (true, true) => "(empty)".to_owned(),
-    };
-    if !output.status.success() {
-        return Err(format!(
-            "embedded ACPX MCP proxy runtime probe exited with code {}: {observed}",
-            output
-                .status
-                .code()
-                .map_or_else(|| "unknown".to_owned(), |code| code.to_string())
-        ));
-    }
-    Ok((script_path, observed))
-}
-
-fn join_command_line(parts: &[String]) -> String {
-    parts
-        .iter()
-        .map(|part| quote_command_part(part.as_str()))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn quote_command_part(value: &str) -> String {
-    if value.is_empty() {
-        return "\"\"".to_owned();
-    }
-    if value.chars().all(|ch| {
-        ch.is_ascii_alphanumeric()
-            || matches!(
-                ch,
-                '_' | '.' | '/' | ':' | '@' | '%' | '+' | '=' | ',' | '-'
-            )
-    }) {
-        return value.to_owned();
-    }
-    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("\"{escaped}\"")
 }
 
 fn resolve_effective_cwd(
@@ -2371,8 +2236,8 @@ exit 0
             "expected --agent proxy flag in log: {log}"
         );
         assert!(
-            log.contains("--payload"),
-            "expected MCP proxy payload flag in log: {log}"
+            log.contains("--payload-file"),
+            "expected MCP proxy payload file flag in log: {log}"
         );
         assert!(
             log.contains("sessions ensure --name session-proxy"),

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -9,10 +9,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tokio::time::{Duration, Instant, sleep, sleep_until, timeout};
+use tokio::time::{Duration, Instant, sleep_until, timeout};
 
 use crate::CliResult;
 use crate::config::{AcpxMcpServerConfig, LoongClawConfig};
+use crate::process_launch::retry_executable_file_busy_async;
+#[cfg(test)]
+use crate::process_launch::retry_executable_file_busy_blocking as retry_spawn_blocking;
 
 #[cfg(test)]
 pub(crate) use super::acpx_mcp::probe_mcp_proxy_support_with_runtime;
@@ -1367,48 +1370,21 @@ async fn spawn_acpx_child(
     .map_err(|error| map_spawn_error(command, cwd, error))
 }
 
-async fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
+async fn retry_executable_file_busy<T, F>(operation: F) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
 {
-    let mut attempt = 0;
-    loop {
-        attempt += 1;
-        match operation() {
-            Ok(value) => return Ok(value),
-            Err(error)
-                if should_retry_spawn_error(&error) && attempt < ACPX_SPAWN_RETRY_ATTEMPTS =>
-            {
-                sleep(ACPX_SPAWN_RETRY_DELAY).await;
-            }
-            Err(error) => return Err(error),
-        }
-    }
+    retry_executable_file_busy_async(operation, ACPX_SPAWN_RETRY_ATTEMPTS, ACPX_SPAWN_RETRY_DELAY)
+        .await
 }
 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
-fn retry_executable_file_busy_blocking<T, F>(mut operation: F) -> std::io::Result<T>
+fn retry_executable_file_busy_blocking<T, F>(operation: F) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
 {
-    let mut attempt = 0;
-    loop {
-        attempt += 1;
-        match operation() {
-            Ok(value) => return Ok(value),
-            Err(error)
-                if should_retry_spawn_error(&error) && attempt < ACPX_SPAWN_RETRY_ATTEMPTS =>
-            {
-                std::thread::sleep(ACPX_SPAWN_RETRY_DELAY);
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-fn should_retry_spawn_error(error: &std::io::Error) -> bool {
-    error.kind() == ErrorKind::ExecutableFileBusy
+    retry_spawn_blocking(operation, ACPX_SPAWN_RETRY_ATTEMPTS, ACPX_SPAWN_RETRY_DELAY)
 }
 
 fn parse_json_lines(stdout: &str) -> Vec<Value> {

--- a/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
+++ b/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
@@ -16,6 +16,23 @@ fn decode_quoted_command_part(value: &str) -> String {
     unescaped_backslashes.replace("\\\"", "\"")
 }
 
+fn decode_script_path_from_proxy_command(command: &str) -> String {
+    let payload_marker = " --payload-file ";
+    let payload_index = command.find(payload_marker).expect("payload marker");
+    let prefix = &command[..payload_index];
+    let mut prefix_parts = prefix.splitn(2, ' ');
+    let _node_command = prefix_parts.next().expect("node command");
+    let script_part = prefix_parts.next().expect("script path");
+    decode_quoted_command_part(script_part)
+}
+
+fn decode_payload_path_from_proxy_command(command: &str) -> String {
+    let payload_marker = "--payload-file ";
+    let payload_index = command.find(payload_marker).expect("payload marker");
+    let payload_path = &command[payload_index + payload_marker.len()..];
+    decode_quoted_command_part(payload_path)
+}
+
 #[cfg(unix)]
 #[test]
 fn fake_acpx_script_helpers_work_with_empty_path() {
@@ -85,17 +102,47 @@ fn build_mcp_proxy_agent_command_preserves_server_cwd() {
 
     let command = build_mcp_proxy_agent_command("npx @zed-industries/codex-acp", &[server])
         .expect("proxy command");
-    let payload_marker = "--payload-file ";
-    let payload_index = command.find(payload_marker).expect("payload marker");
-    let payload_path = &command[payload_index + payload_marker.len()..];
-    let payload_path = decode_quoted_command_part(payload_path);
+    let script_path = decode_script_path_from_proxy_command(command.as_str());
+    let payload_path = decode_payload_path_from_proxy_command(command.as_str());
     let payload_bytes = std::fs::read(&payload_path).expect("read payload file");
     let payload: Value = serde_json::from_slice(payload_bytes.as_slice()).expect("parse payload");
 
+    assert!(
+        script_path.contains("loongclaw-acpx-mcp-proxy-"),
+        "expected versioned script path, got: {script_path}"
+    );
+    let script_file_name = std::path::Path::new(script_path.as_str())
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("script file name");
+    assert!(
+        script_file_name != "loongclaw-acpx-mcp-proxy.mjs",
+        "expected hashed script file name, got: {script_file_name}"
+    );
+    assert!(
+        std::path::Path::new(script_path.as_str()).exists(),
+        "expected materialized script path to exist: {script_path}"
+    );
     assert_eq!(
         payload["mcpServers"][0]["cwd"],
         Value::String("/workspace/docs".to_owned())
     );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let payload_metadata = std::fs::metadata(payload_path.as_str()).expect("payload metadata");
+        let payload_mode = payload_metadata.permissions().mode() & 0o777;
+        let payload_parent = std::path::Path::new(payload_path.as_str())
+            .parent()
+            .expect("payload parent");
+        let parent_metadata = std::fs::metadata(payload_parent).expect("payload parent metadata");
+        let parent_mode = parent_metadata.permissions().mode() & 0o777;
+
+        assert_eq!(payload_mode, 0o600);
+        assert_eq!(parent_mode, 0o700);
+    }
 
     std::fs::remove_file(payload_path).ok();
 }
@@ -145,5 +192,68 @@ fn probe_mcp_proxy_support_invokes_script_runtime() {
     assert!(
         logged_args.contains("--version"),
         "probe should pass --version to the embedded proxy script, got: {logged_args}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn probe_mcp_proxy_support_kills_timed_out_runtime() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create test runtime");
+    let _guard = runtime.block_on(lock_acpx_runtime_tests());
+    let temp_dir = unique_temp_dir("loongclaw-acpx-mcp-probe-timeout");
+    let pid_path = temp_dir.join("node.pid");
+    let node_script_path = temp_dir.join("fake-node-timeout.sh");
+    let node_script = format!(
+        "#!/bin/sh\necho $$ > '{}'\nexec sleep 30\n",
+        pid_path.display()
+    );
+    write_executable_script_atomically(&node_script_path, node_script.as_str())
+        .expect("write fake node timeout script");
+
+    let embedded_script_path = temp_dir.join("embedded-proxy.mjs");
+    write_executable_script_atomically(&embedded_script_path, "#!/bin/sh\nexit 0\n")
+        .expect("write embedded proxy script");
+
+    let error = runtime
+        .block_on(probe_mcp_proxy_support_with_runtime(
+            node_script_path.to_string_lossy().as_ref(),
+            embedded_script_path.to_string_lossy().as_ref(),
+            Some(temp_dir.to_string_lossy().as_ref()),
+            Duration::from_secs(5),
+        ))
+        .expect_err("probe should time out");
+
+    assert_eq!(error, "embedded ACPX MCP proxy runtime probe timed out");
+
+    for _ in 0..100 {
+        let pid_file_exists = pid_path.exists();
+
+        if pid_file_exists {
+            break;
+        }
+
+        runtime.block_on(async {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+    }
+
+    runtime.block_on(async {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    let pid_text = std::fs::read_to_string(&pid_path).expect("read timed out probe pid");
+    let pid = pid_text.trim().to_owned();
+    let status = std::process::Command::new("kill")
+        .args(["-0", pid.as_str()])
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("check fake node liveness");
+
+    assert!(
+        !status.success(),
+        "timed out probe process should be terminated: pid={pid}"
     );
 }

--- a/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
+++ b/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
@@ -16,21 +16,72 @@ fn decode_quoted_command_part(value: &str) -> String {
     unescaped_backslashes.replace("\\\"", "\"")
 }
 
+fn tokenize_proxy_command(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escaped = false;
+
+    for character in command.chars() {
+        if escaped {
+            current.push('\\');
+            current.push(character);
+            escaped = false;
+            continue;
+        }
+
+        let is_escaped_character = in_quotes && character == '\\';
+        if is_escaped_character {
+            escaped = true;
+            continue;
+        }
+
+        let is_quote = character == '"';
+        if is_quote {
+            in_quotes = !in_quotes;
+            current.push(character);
+            continue;
+        }
+
+        let is_separator = character.is_whitespace() && !in_quotes;
+        if is_separator {
+            if !current.is_empty() {
+                let token = decode_quoted_command_part(current.as_str());
+                tokens.push(token);
+                current.clear();
+            }
+            continue;
+        }
+
+        current.push(character);
+    }
+
+    if escaped {
+        current.push('\\');
+    }
+
+    if !current.is_empty() {
+        let token = decode_quoted_command_part(current.as_str());
+        tokens.push(token);
+    }
+
+    tokens
+}
+
 fn decode_script_path_from_proxy_command(command: &str) -> String {
-    let payload_marker = " --payload-file ";
-    let payload_index = command.find(payload_marker).expect("payload marker");
-    let prefix = &command[..payload_index];
-    let mut prefix_parts = prefix.splitn(2, ' ');
-    let _node_command = prefix_parts.next().expect("node command");
-    let script_part = prefix_parts.next().expect("script path");
-    decode_quoted_command_part(script_part)
+    let tokens = tokenize_proxy_command(command);
+    let script_path = tokens.get(1).expect("script path");
+    script_path.to_owned()
 }
 
 fn decode_payload_path_from_proxy_command(command: &str) -> String {
-    let payload_marker = "--payload-file ";
-    let payload_index = command.find(payload_marker).expect("payload marker");
-    let payload_path = &command[payload_index + payload_marker.len()..];
-    decode_quoted_command_part(payload_path)
+    let tokens = tokenize_proxy_command(command);
+    let payload_index = tokens
+        .iter()
+        .position(|token| token == "--payload-file")
+        .expect("payload marker");
+    let payload_path = tokens.get(payload_index + 1).expect("payload path");
+    payload_path.to_owned()
 }
 
 #[cfg(unix)]
@@ -102,6 +153,12 @@ fn build_mcp_proxy_agent_command_preserves_server_cwd() {
 
     let command = build_mcp_proxy_agent_command("npx @zed-industries/codex-acp", &[server])
         .expect("proxy command");
+    let tokens = tokenize_proxy_command(command.as_str());
+    let has_legacy_payload_flag = tokens.iter().any(|token| token == "--payload");
+    assert!(
+        !has_legacy_payload_flag,
+        "legacy inline payload flag should not be present: {command}"
+    );
     let script_path = decode_script_path_from_proxy_command(command.as_str());
     let payload_path = decode_payload_path_from_proxy_command(command.as_str());
     let payload_bytes = std::fs::read(&payload_path).expect("read payload file");

--- a/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
+++ b/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
@@ -1,7 +1,20 @@
-use base64::Engine;
+use std::time::Duration;
+
 use serde_json::Value;
 
 use super::*;
+
+fn decode_quoted_command_part(value: &str) -> String {
+    let trimmed = value.trim();
+    let quoted = trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2;
+    if !quoted {
+        return trimmed.to_owned();
+    }
+
+    let inner = &trimmed[1..trimmed.len() - 1];
+    let unescaped_backslashes = inner.replace("\\\\", "\\");
+    unescaped_backslashes.replace("\\\"", "\"")
+}
 
 #[cfg(unix)]
 #[test]
@@ -59,18 +72,6 @@ exit 0
 
 #[test]
 fn build_mcp_proxy_agent_command_preserves_server_cwd() {
-    fn decode_quoted_command_part(value: &str) -> String {
-        let trimmed = value.trim();
-        let quoted = trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2;
-        if !quoted {
-            return trimmed.to_owned();
-        }
-
-        let inner = &trimmed[1..trimmed.len() - 1];
-        let unescaped_backslashes = inner.replace("\\\\", "\\");
-        unescaped_backslashes.replace("\\\"", "\"")
-    }
-
     let server = AcpxMcpServerEntry {
         name: "docs".to_owned(),
         command: "uvx".to_owned(),
@@ -84,17 +85,65 @@ fn build_mcp_proxy_agent_command_preserves_server_cwd() {
 
     let command = build_mcp_proxy_agent_command("npx @zed-industries/codex-acp", &[server])
         .expect("proxy command");
-    let payload_marker = "--payload ";
+    let payload_marker = "--payload-file ";
     let payload_index = command.find(payload_marker).expect("payload marker");
-    let encoded_payload = &command[payload_index + payload_marker.len()..];
-    let encoded_payload = decode_quoted_command_part(encoded_payload);
-    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(encoded_payload)
-        .expect("decode payload");
-    let payload: Value = serde_json::from_slice(&payload_bytes).expect("parse payload");
+    let payload_path = &command[payload_index + payload_marker.len()..];
+    let payload_path = decode_quoted_command_part(payload_path);
+    let payload_bytes = std::fs::read(&payload_path).expect("read payload file");
+    let payload: Value = serde_json::from_slice(payload_bytes.as_slice()).expect("parse payload");
 
     assert_eq!(
         payload["mcpServers"][0]["cwd"],
         Value::String("/workspace/docs".to_owned())
+    );
+
+    std::fs::remove_file(payload_path).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn probe_mcp_proxy_support_invokes_script_runtime() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create test runtime");
+    let _guard = runtime.block_on(lock_acpx_runtime_tests());
+    let temp_dir = unique_temp_dir("loongclaw-acpx-mcp-probe-runtime");
+    let node_log_path = temp_dir.join("node-args.log");
+    let node_script_path = temp_dir.join("fake-node.sh");
+    let node_script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" > '{}'\nprintf 'fake-node 1\\n'\nexit 0\n",
+        node_log_path.display()
+    );
+    write_executable_script_atomically(&node_script_path, node_script.as_str())
+        .expect("write fake node script");
+
+    let embedded_script_path = temp_dir.join("embedded-proxy.mjs");
+    write_executable_script_atomically(&embedded_script_path, "#!/bin/sh\nexit 0\n")
+        .expect("write embedded proxy script");
+
+    let (reported_script_path, observed) = runtime
+        .block_on(probe_mcp_proxy_support_with_runtime(
+            node_script_path.to_string_lossy().as_ref(),
+            embedded_script_path.to_string_lossy().as_ref(),
+            Some(temp_dir.to_string_lossy().as_ref()),
+            Duration::from_secs(30),
+        ))
+        .expect("probe should succeed with fake runtime");
+
+    let logged_args = std::fs::read_to_string(&node_log_path).expect("read fake node log");
+
+    assert_eq!(
+        reported_script_path,
+        embedded_script_path.display().to_string()
+    );
+    assert_eq!(observed, "fake-node 1");
+    assert!(
+        logged_args.contains(embedded_script_path.to_string_lossy().as_ref()),
+        "probe should execute the embedded proxy script, got: {logged_args}"
+    );
+    assert!(
+        logged_args.contains("--version"),
+        "probe should pass --version to the embedded proxy script, got: {logged_args}"
     );
 }

--- a/crates/app/src/acp/acpx_mcp.rs
+++ b/crates/app/src/acp/acpx_mcp.rs
@@ -1,16 +1,13 @@
 use std::io::ErrorKind;
 use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::process::Command;
+use tokio::time::timeout;
 
 use crate::CliResult;
-use crate::config::LoongClawConfig;
-use crate::mcp::{McpRegistry, McpStdioServerLaunchSpec};
-
-use super::backend::AcpSessionBootstrap;
 
 const ACPX_MCP_PROXY_NODE_COMMAND: &str = "node";
 const ACPX_MCP_PROXY_SCRIPT_NAME: &str = "loongclaw-acpx-mcp-proxy.mjs";
@@ -23,7 +20,7 @@ pub(crate) struct AcpxMcpServerEntry {
     pub(crate) command: String,
     pub(crate) args: Vec<String>,
     pub(crate) env: Vec<AcpxMcpServerEnvEntry>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) cwd: Option<String>,
 }
 
@@ -31,42 +28,6 @@ pub(crate) struct AcpxMcpServerEntry {
 pub(crate) struct AcpxMcpServerEnvEntry {
     pub(crate) name: String,
     pub(crate) value: String,
-}
-
-pub(crate) fn validate_requested_mcp_servers(
-    config: &LoongClawConfig,
-    request: &AcpSessionBootstrap,
-) -> CliResult<Vec<String>> {
-    if request.mcp_servers.is_empty() {
-        return Ok(Vec::new());
-    }
-    if !config.acp.allow_mcp_server_injection {
-        return Err(
-            "ACPX bootstrap requested MCP server injection but acp.allow_mcp_server_injection=false"
-                .to_owned(),
-        );
-    }
-
-    let registry = McpRegistry::from_config(config)?;
-    let selected = registry.resolve_selected_server_names(&request.mcp_servers)?;
-    let _launch_specs = registry.resolve_injectable_stdio_launch_specs(&selected)?;
-
-    Ok(selected)
-}
-
-pub(crate) fn injectable_mcp_server_count(config: &LoongClawConfig) -> CliResult<usize> {
-    let registry = McpRegistry::from_config(config)?;
-    let count = registry.injectable_stdio_server_count();
-    Ok(count)
-}
-
-pub(crate) fn build_mcp_proxy_agent_command_for_selection(
-    config: &LoongClawConfig,
-    target_command: &str,
-    selected_mcp_servers: &[String],
-) -> CliResult<String> {
-    let mcp_servers = resolve_selected_mcp_server_entries(config, selected_mcp_servers)?;
-    build_mcp_proxy_agent_command(target_command, &mcp_servers)
 }
 
 pub(crate) fn build_mcp_proxy_agent_command(
@@ -80,81 +41,91 @@ pub(crate) fn build_mcp_proxy_agent_command(
     }))
     .map_err(|error| format!("serialize ACPX MCP proxy payload failed: {error}"))?;
     let payload_path = materialize_mcp_proxy_payload_path(payload.as_slice())?;
-    Ok(join_command_line(&[
+    let command_parts = vec![
         ACPX_MCP_PROXY_NODE_COMMAND.to_owned(),
         script_path,
         "--payload-file".to_owned(),
         payload_path,
-    ]))
+    ];
+    let command_line = join_command_line(command_parts.as_slice());
+    Ok(command_line)
 }
 
-pub(crate) async fn probe_mcp_proxy_support(cwd: Option<&str>) -> CliResult<(String, String)> {
+pub(crate) async fn probe_mcp_proxy_support(
+    cwd: Option<&str>,
+    timeout_duration: Duration,
+) -> CliResult<(String, String)> {
     let script_path = ensure_mcp_proxy_script_path()?;
-    let mut probe = Command::new(ACPX_MCP_PROXY_NODE_COMMAND);
-    probe.arg(script_path.as_str());
+    probe_mcp_proxy_support_with_runtime(
+        ACPX_MCP_PROXY_NODE_COMMAND,
+        script_path.as_str(),
+        cwd,
+        timeout_duration,
+    )
+    .await
+}
+
+pub(crate) async fn probe_mcp_proxy_support_with_runtime(
+    node_command: &str,
+    script_path: &str,
+    cwd: Option<&str>,
+    timeout_duration: Duration,
+) -> CliResult<(String, String)> {
+    let mut probe = Command::new(node_command);
+    probe.arg(script_path);
     probe.arg("--version");
+
     if let Some(cwd) = cwd {
         probe.current_dir(cwd);
     }
-    let output = probe.output().await.map_err(|error| {
+
+    let timed_output = timeout(timeout_duration, probe.output())
+        .await
+        .map_err(|_timeout_error| "embedded ACPX MCP proxy runtime probe timed out".to_owned())?;
+    let output = timed_output.map_err(|error| {
         if error.kind() == ErrorKind::NotFound {
-            format!("embedded ACPX MCP proxy requires `{ACPX_MCP_PROXY_NODE_COMMAND}` on PATH")
+            format!("embedded ACPX MCP proxy requires `{node_command}` on PATH")
         } else {
             format!("probe embedded ACPX MCP proxy runtime failed: {error}")
         }
     })?;
+
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let observed = match (stdout.is_empty(), stderr.is_empty()) {
-        (false, true) => stdout,
-        (true, false) => stderr,
-        (false, false) => format!("{stdout} | {stderr}"),
-        (true, true) => "(empty)".to_owned(),
-    };
+    let observed = observed_command_output(stdout.as_str(), stderr.as_str());
+
     if !output.status.success() {
-        return Err(format!(
-            "embedded ACPX MCP proxy runtime probe exited with code {}: {observed}",
-            output
-                .status
-                .code()
-                .map_or_else(|| "unknown".to_owned(), |code| code.to_string())
-        ));
+        let exit_code = output
+            .status
+            .code()
+            .map_or_else(|| "unknown".to_owned(), |code| code.to_string());
+        let message = format!(
+            "embedded ACPX MCP proxy runtime probe exited with code {exit_code}: {observed}"
+        );
+        return Err(message);
     }
+
+    let script_path = script_path.to_owned();
     Ok((script_path, observed))
 }
 
-fn resolve_selected_mcp_server_entries(
-    config: &LoongClawConfig,
-    selected_mcp_servers: &[String],
-) -> CliResult<Vec<AcpxMcpServerEntry>> {
-    let registry = McpRegistry::from_config(config)?;
-    let resolved_servers = registry.resolve_injectable_stdio_launch_specs(selected_mcp_servers)?;
+fn observed_command_output(stdout: &str, stderr: &str) -> String {
+    let stdout_empty = stdout.is_empty();
+    let stderr_empty = stderr.is_empty();
 
-    let mut entries = Vec::new();
-    for server in resolved_servers {
-        let entry = acpx_mcp_server_entry_from_registry_server(server);
-        entries.push(entry);
+    if !stdout_empty && stderr_empty {
+        return stdout.to_owned();
     }
 
-    Ok(entries)
-}
-
-fn acpx_mcp_server_entry_from_registry_server(
-    server: McpStdioServerLaunchSpec,
-) -> AcpxMcpServerEntry {
-    let mut env_entries = Vec::new();
-    for (name, value) in server.env {
-        let env_entry = AcpxMcpServerEnvEntry { name, value };
-        env_entries.push(env_entry);
+    if stdout_empty && !stderr_empty {
+        return stderr.to_owned();
     }
 
-    AcpxMcpServerEntry {
-        name: server.name,
-        command: server.command,
-        args: server.args,
-        env: env_entries,
-        cwd: server.cwd,
+    if !stdout_empty && !stderr_empty {
+        return format!("{stdout} | {stderr}");
     }
+
+    "(empty)".to_owned()
 }
 
 fn ensure_mcp_proxy_script_path() -> CliResult<String> {
@@ -164,81 +135,94 @@ fn ensure_mcp_proxy_script_path() -> CliResult<String> {
 }
 
 fn materialize_mcp_proxy_script() -> Result<String, String> {
-    let path = std::env::temp_dir()
-        .join("loongclaw")
-        .join(ACPX_MCP_PROXY_SCRIPT_NAME);
+    let temp_dir = std::env::temp_dir();
+    let loongclaw_dir = temp_dir.join("loongclaw");
+    let path = loongclaw_dir.join(ACPX_MCP_PROXY_SCRIPT_NAME);
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("create ACPX MCP proxy directory failed: {error}"))?;
     }
+
     std::fs::write(&path, ACPX_MCP_PROXY_SCRIPT_SOURCE)
         .map_err(|error| format!("write ACPX MCP proxy script failed: {error}"))?;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let mut permissions = std::fs::metadata(&path)
-            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?
-            .permissions();
+        let metadata = std::fs::metadata(&path)
+            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?;
+        let mut permissions = metadata.permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&path, permissions)
             .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
     }
-    Ok(path.display().to_string())
+
+    let script_path = path.display().to_string();
+    Ok(script_path)
 }
 
 fn materialize_mcp_proxy_payload_path(payload: &[u8]) -> CliResult<String> {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|error| format!("read system time for ACPX MCP payload failed: {error}"))?;
+    let process_id = std::process::id();
     let payload_file_name = format!(
-        "acpx-mcp-payload-{}-{}.json",
-        std::process::id(),
+        "acpx-mcp-payload-{process_id}-{}.json",
         timestamp.as_nanos()
     );
-    let payload_path = std::env::temp_dir()
-        .join("loongclaw")
-        .join("acpx-mcp-payloads")
-        .join(payload_file_name);
+    let temp_dir = std::env::temp_dir();
+    let loongclaw_dir = temp_dir.join("loongclaw");
+    let payload_dir = loongclaw_dir.join("acpx-mcp-payloads");
+    let payload_path = payload_dir.join(payload_file_name);
+
     if let Some(parent) = payload_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("create ACPX MCP payload directory failed: {error}"))?;
     }
+
     std::fs::write(&payload_path, payload)
         .map_err(|error| format!("write ACPX MCP payload failed: {error}"))?;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let mut permissions = std::fs::metadata(&payload_path)
-            .map_err(|error| format!("stat ACPX MCP payload failed: {error}"))?
-            .permissions();
+        let metadata = std::fs::metadata(&payload_path)
+            .map_err(|error| format!("stat ACPX MCP payload failed: {error}"))?;
+        let mut permissions = metadata.permissions();
         permissions.set_mode(0o600);
         std::fs::set_permissions(&payload_path, permissions)
             .map_err(|error| format!("chmod ACPX MCP payload failed: {error}"))?;
     }
-    Ok(payload_path.display().to_string())
+
+    let payload_path = payload_path.display().to_string();
+    Ok(payload_path)
 }
 
 fn join_command_line(parts: &[String]) -> String {
-    parts
+    let quoted_parts = parts
         .iter()
         .map(|part| quote_command_part(part.as_str()))
-        .collect::<Vec<_>>()
-        .join(" ")
+        .collect::<Vec<_>>();
+    quoted_parts.join(" ")
 }
 
 fn quote_command_part(value: &str) -> String {
     if value.is_empty() {
         return "\"\"".to_owned();
     }
-    if value
+
+    let is_simple = value
         .chars()
-        .all(|character| character.is_ascii_alphanumeric() || "-_./:@".contains(character))
-    {
+        .all(|character| character.is_ascii_alphanumeric() || "-_./:@".contains(character));
+    if is_simple {
         return value.to_owned();
     }
 
-    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("\"{escaped}\"")
+    let escaped_backslashes = value.replace('\\', "\\\\");
+    let escaped_value = escaped_backslashes.replace('"', "\\\"");
+    let quoted_value = format!("\"{escaped_value}\"");
+    quoted_value
 }

--- a/crates/app/src/acp/acpx_mcp.rs
+++ b/crates/app/src/acp/acpx_mcp.rs
@@ -1,17 +1,26 @@
 use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::OnceLock;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
+use tempfile::NamedTempFile;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::CliResult;
 
 const ACPX_MCP_PROXY_NODE_COMMAND: &str = "node";
-const ACPX_MCP_PROXY_SCRIPT_NAME: &str = "loongclaw-acpx-mcp-proxy.mjs";
+const ACPX_MCP_PROXY_SCRIPT_STEM: &str = "loongclaw-acpx-mcp-proxy";
+const ACPX_MCP_PROXY_SCRIPT_EXTENSION: &str = "mjs";
+const ACPX_MCP_PROXY_SCRIPT_HASH_PREFIX_LENGTH: usize = 12;
 const ACPX_MCP_PROXY_SCRIPT_SOURCE: &str = include_str!("assets/acpx-mcp-proxy.mjs");
+const LOONGCLAW_TEMP_DIR_NAME: &str = "loongclaw";
+const ACPX_MCP_PAYLOAD_DIR_NAME: &str = "acpx-mcp-payloads";
 static ACPX_MCP_PROXY_SCRIPT_PATH: OnceLock<Result<String, String>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,29 +83,59 @@ pub(crate) async fn probe_mcp_proxy_support_with_runtime(
     let mut probe = Command::new(node_command);
     probe.arg(script_path);
     probe.arg("--version");
+    probe.kill_on_drop(true);
+    probe.stdout(Stdio::piped());
+    probe.stderr(Stdio::piped());
 
     if let Some(cwd) = cwd {
         probe.current_dir(cwd);
     }
 
-    let timed_output = timeout(timeout_duration, probe.output())
-        .await
-        .map_err(|_timeout_error| "embedded ACPX MCP proxy runtime probe timed out".to_owned())?;
-    let output = timed_output.map_err(|error| {
+    let mut child = probe.spawn().map_err(|error| {
         if error.kind() == ErrorKind::NotFound {
             format!("embedded ACPX MCP proxy requires `{node_command}` on PATH")
         } else {
             format!("probe embedded ACPX MCP proxy runtime failed: {error}")
         }
     })?;
+    let stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| "capture embedded ACPX MCP proxy stdout failed".to_owned())?;
+    let stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| "capture embedded ACPX MCP proxy stderr failed".to_owned())?;
+    let stdout_task = tokio::spawn(read_probe_pipe(stdout_pipe, "stdout"));
+    let stderr_task = tokio::spawn(read_probe_pipe(stderr_pipe, "stderr"));
 
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let output_status = timeout(timeout_duration, child.wait())
+        .await
+        .map_err(|_timeout_error| "embedded ACPX MCP proxy runtime probe timed out".to_owned());
+
+    let output_status = match output_status {
+        Ok(wait_result) => wait_result
+            .map_err(|error| format!("wait for embedded ACPX MCP proxy runtime failed: {error}"))?,
+        Err(timeout_message) => {
+            terminate_probe_child_process(&mut child).await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(timeout_message);
+        }
+    };
+    let stdout_bytes = await_probe_pipe(stdout_task, "stdout").await?;
+    let stderr_bytes = await_probe_pipe(stderr_task, "stderr").await?;
+
+    let stdout = String::from_utf8_lossy(stdout_bytes.as_slice())
+        .trim()
+        .to_owned();
+    let stderr = String::from_utf8_lossy(stderr_bytes.as_slice())
+        .trim()
+        .to_owned();
     let observed = observed_command_output(stdout.as_str(), stderr.as_str());
 
-    if !output.status.success() {
-        let exit_code = output
-            .status
+    if !output_status.success() {
+        let exit_code = output_status
             .code()
             .map_or_else(|| "unknown".to_owned(), |code| code.to_string());
         let message = format!(
@@ -135,70 +174,159 @@ fn ensure_mcp_proxy_script_path() -> CliResult<String> {
 }
 
 fn materialize_mcp_proxy_script() -> Result<String, String> {
-    let temp_dir = std::env::temp_dir();
-    let loongclaw_dir = temp_dir.join("loongclaw");
-    let path = loongclaw_dir.join(ACPX_MCP_PROXY_SCRIPT_NAME);
+    let loongclaw_dir = loongclaw_temp_dir();
+    ensure_private_directory(loongclaw_dir.as_path(), "ACPX MCP proxy directory")?;
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("create ACPX MCP proxy directory failed: {error}"))?;
+    let script_file_name = versioned_mcp_proxy_script_file_name();
+    let path = loongclaw_dir.join(script_file_name);
+    let path_exists = path.exists();
+
+    if !path_exists {
+        persist_named_file(
+            path.as_path(),
+            ACPX_MCP_PROXY_SCRIPT_SOURCE.as_bytes(),
+            0o755,
+            "ACPX MCP proxy script",
+        )?;
     }
-
-    std::fs::write(&path, ACPX_MCP_PROXY_SCRIPT_SOURCE)
-        .map_err(|error| format!("write ACPX MCP proxy script failed: {error}"))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let metadata = std::fs::metadata(&path)
-            .map_err(|error| format!("stat ACPX MCP proxy script failed: {error}"))?;
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions)
-            .map_err(|error| format!("chmod ACPX MCP proxy script failed: {error}"))?;
-    }
+    set_path_permissions(path.as_path(), 0o755, "ACPX MCP proxy script")?;
 
     let script_path = path.display().to_string();
     Ok(script_path)
 }
 
 fn materialize_mcp_proxy_payload_path(payload: &[u8]) -> CliResult<String> {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| format!("read system time for ACPX MCP payload failed: {error}"))?;
-    let process_id = std::process::id();
-    let payload_file_name = format!(
-        "acpx-mcp-payload-{process_id}-{}.json",
-        timestamp.as_nanos()
-    );
-    let temp_dir = std::env::temp_dir();
-    let loongclaw_dir = temp_dir.join("loongclaw");
-    let payload_dir = loongclaw_dir.join("acpx-mcp-payloads");
-    let payload_path = payload_dir.join(payload_file_name);
+    let loongclaw_dir = loongclaw_temp_dir();
+    ensure_private_directory(loongclaw_dir.as_path(), "ACPX MCP payload root directory")?;
+    let payload_dir = loongclaw_dir.join(ACPX_MCP_PAYLOAD_DIR_NAME);
+    ensure_private_directory(payload_dir.as_path(), "ACPX MCP payload directory")?;
 
-    if let Some(parent) = payload_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("create ACPX MCP payload directory failed: {error}"))?;
-    }
+    let mut payload_file = tempfile::Builder::new()
+        .prefix("acpx-mcp-payload-")
+        .suffix(".json")
+        .tempfile_in(payload_dir.as_path())
+        .map_err(|error| format!("create ACPX MCP payload temp file failed: {error}"))?;
+    write_temp_file_bytes(&mut payload_file, payload, "ACPX MCP payload")?;
+    set_path_permissions(payload_file.path(), 0o600, "ACPX MCP payload")?;
 
-    std::fs::write(&payload_path, payload)
-        .map_err(|error| format!("write ACPX MCP payload failed: {error}"))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let metadata = std::fs::metadata(&payload_path)
-            .map_err(|error| format!("stat ACPX MCP payload failed: {error}"))?;
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o600);
-        std::fs::set_permissions(&payload_path, permissions)
-            .map_err(|error| format!("chmod ACPX MCP payload failed: {error}"))?;
-    }
-
+    let keep_result = payload_file.keep();
+    let (_file, payload_path) =
+        keep_result.map_err(|error| format!("persist ACPX MCP payload failed: {}", error.error))?;
     let payload_path = payload_path.display().to_string();
     Ok(payload_path)
+}
+
+fn loongclaw_temp_dir() -> PathBuf {
+    let temp_dir = std::env::temp_dir();
+    temp_dir.join(LOONGCLAW_TEMP_DIR_NAME)
+}
+
+fn versioned_mcp_proxy_script_file_name() -> String {
+    let digest = Sha256::digest(ACPX_MCP_PROXY_SCRIPT_SOURCE.as_bytes());
+    let digest_hex = hex::encode(digest);
+    let digest_prefix = digest_hex
+        .chars()
+        .take(ACPX_MCP_PROXY_SCRIPT_HASH_PREFIX_LENGTH)
+        .collect::<String>();
+    let file_name =
+        format!("{ACPX_MCP_PROXY_SCRIPT_STEM}-{digest_prefix}.{ACPX_MCP_PROXY_SCRIPT_EXTENSION}");
+    file_name
+}
+
+fn ensure_private_directory(path: &Path, subject: &str) -> Result<(), String> {
+    std::fs::create_dir_all(path).map_err(|error| format!("create {subject} failed: {error}"))?;
+    set_path_permissions(path, 0o700, subject)?;
+    Ok(())
+}
+
+fn persist_named_file(
+    target_path: &Path,
+    contents: &[u8],
+    mode: u32,
+    subject: &str,
+) -> Result<(), String> {
+    let parent_dir = target_path.parent().ok_or_else(|| {
+        format!(
+            "{subject} path `{}` has no parent directory",
+            target_path.display()
+        )
+    })?;
+    let mut staged_file = NamedTempFile::new_in(parent_dir)
+        .map_err(|error| format!("create staged {subject} failed: {error}"))?;
+
+    write_temp_file_bytes(&mut staged_file, contents, subject)?;
+    set_path_permissions(staged_file.path(), mode, subject)?;
+
+    let persist_result = staged_file.persist_noclobber(target_path);
+
+    match persist_result {
+        Ok(_) => Ok(()),
+        Err(error) if error.error.kind() == ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(format!("persist {subject} failed: {}", error.error)),
+    }
+}
+
+fn write_temp_file_bytes(
+    temp_file: &mut NamedTempFile,
+    contents: &[u8],
+    subject: &str,
+) -> Result<(), String> {
+    use std::io::Write;
+
+    temp_file
+        .write_all(contents)
+        .map_err(|error| format!("write {subject} failed: {error}"))?;
+    temp_file
+        .flush()
+        .map_err(|error| format!("flush {subject} failed: {error}"))?;
+    temp_file
+        .as_file()
+        .sync_all()
+        .map_err(|error| format!("sync {subject} failed: {error}"))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_path_permissions(path: &Path, mode: u32, subject: &str) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata =
+        std::fs::metadata(path).map_err(|error| format!("stat {subject} failed: {error}"))?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(mode);
+    std::fs::set_permissions(path, permissions)
+        .map_err(|error| format!("chmod {subject} failed: {error}"))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_path_permissions(_path: &Path, _mode: u32, _subject: &str) -> Result<(), String> {
+    Ok(())
+}
+
+async fn read_probe_pipe<T>(mut pipe: T, stream_name: &str) -> Result<Vec<u8>, String>
+where
+    T: tokio::io::AsyncRead + Unpin,
+{
+    let mut bytes = Vec::new();
+    pipe.read_to_end(&mut bytes)
+        .await
+        .map_err(|error| format!("read embedded ACPX MCP proxy {stream_name} failed: {error}"))?;
+    Ok(bytes)
+}
+
+async fn await_probe_pipe(
+    task: tokio::task::JoinHandle<Result<Vec<u8>, String>>,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    task.await.map_err(|error| {
+        format!("join embedded ACPX MCP proxy {stream_name} reader failed: {error}")
+    })?
+}
+
+async fn terminate_probe_child_process(child: &mut tokio::process::Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
 }
 
 fn join_command_line(parts: &[String]) -> String {

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -1,6 +1,7 @@
 mod acpx;
 #[cfg(test)]
 mod acpx_doctor_tests;
+mod acpx_mcp;
 mod analytics;
 mod backend;
 mod binding;

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -27,6 +27,11 @@ pub async fn retry_executable_file_busy_async<T, F>(
 where
     F: FnMut() -> io::Result<T>,
 {
+    if max_attempts == 0 {
+        let error = io::Error::new(io::ErrorKind::InvalidInput, "max_attempts must be > 0");
+        return Err(error);
+    }
+
     let mut attempt = 0;
 
     loop {
@@ -60,6 +65,11 @@ where
     F: FnMut() -> io::Result<T>,
     P: FnMut() -> io::Result<()>,
 {
+    if max_attempts == 0 {
+        let error = io::Error::new(io::ErrorKind::InvalidInput, "max_attempts must be > 0");
+        return Err(error);
+    }
+
     let mut attempt = 0;
 
     loop {
@@ -360,6 +370,16 @@ mod tests {
         assert_eq!(total_attempts, 3);
     }
 
+    #[tokio::test]
+    async fn retry_executable_file_busy_async_rejects_zero_attempt_budget() {
+        let result =
+            retry_executable_file_busy_async(|| Ok::<_, Error>("spawned"), 0, Duration::ZERO).await;
+
+        let error = result.expect_err("zero-attempt budget should be rejected");
+
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    }
+
     #[test]
     fn retry_executable_file_busy_with_pause_records_retry_boundaries() {
         let attempts = AtomicUsize::new(0);
@@ -389,6 +409,16 @@ mod tests {
         assert_eq!(result, "spawned");
         assert_eq!(total_attempts, 3);
         assert_eq!(total_pauses, 2);
+    }
+
+    #[test]
+    fn retry_executable_file_busy_with_pause_rejects_zero_attempt_budget() {
+        let result =
+            retry_executable_file_busy_with_pause(|| Ok::<_, Error>("spawned"), 0, || Ok(()));
+
+        let error = result.expect_err("zero-attempt budget should be rejected");
+
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -1,14 +1,105 @@
 use std::ffi::OsString;
+use std::io;
 #[cfg(unix)]
 use std::io::Read;
 #[cfg(unix)]
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[doc(hidden)]
 pub struct ResolvedCommandInvocation {
     pub program: OsString,
     pub args: Vec<OsString>,
+}
+
+#[doc(hidden)]
+pub fn should_retry_executable_file_busy(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::ExecutableFileBusy
+}
+
+#[doc(hidden)]
+pub async fn retry_executable_file_busy_async<T, F>(
+    mut operation: F,
+    max_attempts: usize,
+    delay: Duration,
+) -> io::Result<T>
+where
+    F: FnMut() -> io::Result<T>,
+{
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+        let result = operation();
+
+        match result {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let retryable = should_retry_executable_file_busy(&error);
+                let within_retry_budget = attempt < max_attempts;
+
+                if retryable && within_retry_budget {
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                return Err(error);
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn retry_executable_file_busy_with_pause<T, F, P>(
+    mut operation: F,
+    max_attempts: usize,
+    mut pause: P,
+) -> io::Result<T>
+where
+    F: FnMut() -> io::Result<T>,
+    P: FnMut() -> io::Result<()>,
+{
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+        let result = operation();
+
+        match result {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let retryable = should_retry_executable_file_busy(&error);
+                let within_retry_budget = attempt < max_attempts;
+
+                if retryable && within_retry_budget {
+                    pause()?;
+                    continue;
+                }
+
+                return Err(error);
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+pub fn retry_executable_file_busy_blocking<T, F>(
+    operation: F,
+    max_attempts: usize,
+    delay: Duration,
+) -> io::Result<T>
+where
+    F: FnMut() -> io::Result<T>,
+{
+    let pause = || {
+        std::thread::sleep(delay);
+        Ok(())
+    };
+
+    retry_executable_file_busy_with_pause(operation, max_attempts, pause)
 }
 
 #[doc(hidden)]
@@ -99,12 +190,19 @@ fn read_shebang(path: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Error, ErrorKind};
     #[cfg(unix)]
     use std::path::Path;
     #[cfg(unix)]
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
-    use super::resolve_command_invocation;
+    use super::{
+        resolve_command_invocation, retry_executable_file_busy_async,
+        retry_executable_file_busy_blocking, retry_executable_file_busy_with_pause,
+        should_retry_executable_file_busy,
+    };
 
     #[cfg(unix)]
     #[test]
@@ -225,5 +323,91 @@ mod tests {
                 std::ffi::OsString::from("--flag"),
             ]
         );
+    }
+
+    #[test]
+    fn should_retry_executable_file_busy_matches_executable_file_busy() {
+        let busy_error = Error::from(ErrorKind::ExecutableFileBusy);
+        let missing_error = Error::from(ErrorKind::NotFound);
+
+        assert!(should_retry_executable_file_busy(&busy_error));
+        assert!(!should_retry_executable_file_busy(&missing_error));
+    }
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_async_retries_until_success() {
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_executable_file_busy_async(
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+
+                if attempt < 2 {
+                    return Err(Error::from(ErrorKind::ExecutableFileBusy));
+                }
+
+                Ok("spawned")
+            },
+            5,
+            Duration::ZERO,
+        )
+        .await
+        .expect("executable-file-busy errors should retry");
+
+        let total_attempts = attempts.load(Ordering::Relaxed);
+
+        assert_eq!(result, "spawned");
+        assert_eq!(total_attempts, 3);
+    }
+
+    #[test]
+    fn retry_executable_file_busy_with_pause_records_retry_boundaries() {
+        let attempts = AtomicUsize::new(0);
+        let pauses = AtomicUsize::new(0);
+
+        let result = retry_executable_file_busy_with_pause(
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+
+                if attempt < 2 {
+                    return Err(Error::from(ErrorKind::ExecutableFileBusy));
+                }
+
+                Ok("spawned")
+            },
+            5,
+            || {
+                pauses.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .expect("retry helper should recover after retryable failures");
+
+        let total_attempts = attempts.load(Ordering::Relaxed);
+        let total_pauses = pauses.load(Ordering::Relaxed);
+
+        assert_eq!(result, "spawned");
+        assert_eq!(total_attempts, 3);
+        assert_eq!(total_pauses, 2);
+    }
+
+    #[test]
+    fn retry_executable_file_busy_blocking_stops_after_retry_budget() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = retry_executable_file_busy_blocking(
+            || {
+                attempts.fetch_add(1, Ordering::Relaxed);
+                Err::<(), Error>(Error::from(ErrorKind::ExecutableFileBusy))
+            },
+            4,
+            Duration::ZERO,
+        )
+        .expect_err("retry helper should stop after exhausting the retry budget");
+
+        let total_attempts = attempts.load(Ordering::Relaxed);
+
+        assert_eq!(error.kind(), ErrorKind::ExecutableFileBusy);
+        assert_eq!(total_attempts, 4);
     }
 }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::io::{ErrorKind, Write};
+use std::io::Write;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -11,6 +11,7 @@ use serde_json::{Map, Value, json};
 use wait_timeout::ChildExt;
 
 use crate::process_launch::resolve_command_invocation;
+use crate::process_launch::retry_executable_file_busy_with_pause as retry_spawn_with_pause;
 
 const DEFAULT_BROWSER_COMPANION_SCOPE_ID: &str = "__global";
 const BROWSER_COMPANION_PROTOCOL: &str = "loongclaw.browser_companion.v1";
@@ -174,37 +175,21 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
     }
 }
 
-fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
+fn retry_executable_file_busy<T, F>(operation: F) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
 {
-    retry_executable_file_busy_with_pause(&mut operation, || {
-        pause_before_browser_companion_spawn_retry(BROWSER_COMPANION_SPAWN_RETRY_DELAY)
-    })
+    let pause = || pause_before_browser_companion_spawn_retry(BROWSER_COMPANION_SPAWN_RETRY_DELAY);
+
+    retry_executable_file_busy_with_pause(operation, pause)
 }
 
-fn retry_executable_file_busy_with_pause<T, F, P>(
-    mut operation: F,
-    mut pause: P,
-) -> std::io::Result<T>
+fn retry_executable_file_busy_with_pause<T, F, P>(operation: F, pause: P) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
     P: FnMut() -> std::io::Result<()>,
 {
-    let mut attempt = 0;
-    loop {
-        attempt += 1;
-        match operation() {
-            Ok(value) => return Ok(value),
-            Err(error)
-                if should_retry_spawn_error(&error)
-                    && attempt < BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS =>
-            {
-                pause()?;
-            }
-            Err(error) => return Err(error),
-        }
-    }
+    retry_spawn_with_pause(operation, BROWSER_COMPANION_SPAWN_RETRY_ATTEMPTS, pause)
 }
 
 fn pause_before_browser_companion_spawn_retry(delay: Duration) -> std::io::Result<()> {
@@ -253,10 +238,6 @@ fn pause_before_browser_companion_spawn_retry(delay: Duration) -> std::io::Resul
             Ok(())
         }
     }
-}
-
-fn should_retry_spawn_error(error: &std::io::Error) -> bool {
-    error.kind() == ErrorKind::ExecutableFileBusy
 }
 
 fn write_browser_companion_request<W, C>(

--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -3,8 +3,6 @@ use std::ffi::OsStr;
 #[cfg(feature = "tool-shell")]
 use std::future::Future;
 #[cfg(feature = "tool-shell")]
-use std::io::ErrorKind;
-#[cfg(feature = "tool-shell")]
 use std::path::Path;
 #[cfg(feature = "tool-shell")]
 use std::process::{Output, Stdio};
@@ -16,6 +14,9 @@ use std::time::Duration;
 use tokio::io::AsyncReadExt;
 #[cfg(feature = "tool-shell")]
 use tokio::process::Command;
+
+#[cfg(feature = "tool-shell")]
+use crate::process_launch::retry_executable_file_busy_async;
 
 #[cfg(feature = "tool-shell")]
 pub(super) const DEFAULT_TIMEOUT_MS: u64 = 120_000;
@@ -92,31 +93,6 @@ where
 }
 
 #[cfg(feature = "tool-shell")]
-async fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
-where
-    F: FnMut() -> std::io::Result<T>,
-{
-    let mut attempt = 0;
-
-    loop {
-        attempt += 1;
-
-        match operation() {
-            Ok(value) => return Ok(value),
-            Err(error) if should_retry_spawn_error(&error) && attempt < SPAWN_RETRY_ATTEMPTS => {
-                tokio::time::sleep(SPAWN_RETRY_DELAY).await;
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-#[cfg(feature = "tool-shell")]
-fn should_retry_spawn_error(error: &std::io::Error) -> bool {
-    error.kind() == ErrorKind::ExecutableFileBusy
-}
-
-#[cfg(feature = "tool-shell")]
 pub(super) async fn run_process_with_timeout<P, S>(
     program: P,
     args: &[S],
@@ -140,9 +116,13 @@ where
     command.stdin(Stdio::null());
     command.kill_on_drop(true);
 
-    let mut child = retry_executable_file_busy(|| command.spawn())
-        .await
-        .map_err(|error| format!("{error_prefix} spawn failed: {error}"))?;
+    let mut child = retry_executable_file_busy_async(
+        || command.spawn(),
+        SPAWN_RETRY_ATTEMPTS,
+        SPAWN_RETRY_DELAY,
+    )
+    .await
+    .map_err(|error| format!("{error_prefix} spawn failed: {error}"))?;
 
     let duration = Duration::from_millis(timeout_ms.max(1));
     let stdout = child
@@ -200,32 +180,39 @@ where
 
 #[cfg(all(test, feature = "tool-shell"))]
 mod tests {
-    use super::{retry_executable_file_busy, should_retry_spawn_error};
     use std::io::{Error, ErrorKind};
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::process_launch::{
+        retry_executable_file_busy_async, should_retry_executable_file_busy,
+    };
 
     #[test]
     fn should_retry_spawn_error_matches_executable_file_busy() {
         let busy_error = Error::from(ErrorKind::ExecutableFileBusy);
         let missing_error = Error::from(ErrorKind::NotFound);
 
-        assert!(should_retry_spawn_error(&busy_error));
-        assert!(!should_retry_spawn_error(&missing_error));
+        assert!(should_retry_executable_file_busy(&busy_error));
+        assert!(!should_retry_executable_file_busy(&missing_error));
     }
 
     #[tokio::test]
     async fn retry_executable_file_busy_retries_until_success() {
         let attempts = AtomicUsize::new(0);
 
-        let result = retry_executable_file_busy(|| {
-            let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+        let result = retry_executable_file_busy_async(
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed);
 
-            if attempt < 2 {
-                return Err(Error::from(ErrorKind::ExecutableFileBusy));
-            }
+                if attempt < 2 {
+                    return Err(Error::from(ErrorKind::ExecutableFileBusy));
+                }
 
-            Ok("spawned")
-        })
+                Ok("spawned")
+            },
+            super::SPAWN_RETRY_ATTEMPTS,
+            super::SPAWN_RETRY_DELAY,
+        )
         .await
         .expect("executable-file-busy errors should retry");
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-09T10:23:46Z
+- Generated at: 2026-04-09T11:03:15Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 378 | 1000 | 622 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.8% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2800 | 2800 | 0 | 56 | 65 | 9 | 100.0% | TIGHT | 2698 | 3.8% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9450 | 10500 | 1050 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
@@ -29,8 +29,8 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), acpx_runtime (100.0%), channel_config (98.8%), tools_mod (100.0%), daemon_lib (99.8%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (100.0%), daemon_lib (99.8%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=provider_mod lines=378 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
-<!-- arch-hotspot key=acpx_runtime lines=2800 functions=56 -->
+<!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9450 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->


### PR DESCRIPTION
## Summary

- Problem:
  ACPX carried two competing MCP proxy helper paths, and its neighboring process-backed surfaces also duplicated low-level executable-busy retry logic. The active ACPX backend in `crates/app/src/acp/acpx.rs` still built inline `--payload` argv blobs and only probed `node --version`, even though a newer helper module already existed with file-backed payload handoff and embedded-script probing.
- Why it matters:
  This left ACPX on a drifted runtime contract and kept external-process harness primitives split across ACPX, browser companion, and shell/process helpers.
- What changed:
  Activated the shared `acpx_mcp` helper module, removed the stale duplicate MCP proxy implementation from `acpx.rs`, switched ACPX proxy command construction to `--payload-file`, added regression coverage that the probe actually executes the embedded proxy script contract, and centralized `ExecutableFileBusy` retry primitives in `crates/app/src/process_launch.rs` for ACPX, browser companion, and shell/process helpers to reuse.
- What did not change (scope boundary):
  This PR does not do the broader external-process harness unification across ACPX, browser companion, and shell tooling beyond the shared MCP proxy path and shared retry primitives.

## Linked Issues

- Closes #1123
- Related #221

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app process_launch -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app acpx_doctor -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app 'acp::acpx::tests::' -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app --all-features --locked
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked
```

All commands above passed in the isolated worktree except workspace-wide clippy, which is currently blocked on unrelated `runtime_capability_cli` all-features integration errors already present on the latest `origin/dev` tip.

## User-visible / Operator-visible Changes

- ACPX doctor now probes the embedded MCP proxy script path rather than only checking the Node binary.
- ACPX MCP-injected sessions now hand proxy payloads to the embedded runtime with `--payload-file` instead of embedding the full payload inline on argv.
- ACPX, browser companion, and shell/process surfaces now share one executable-busy retry primitive family instead of maintaining near-duplicate retry loops.

## Failure Recovery

- Fast rollback or disable path:
  Revert the two commits in this PR to restore the prior ACPX proxy helper path and local retry loops.
- Observable failure symptoms reviewers should watch for:
  ACPX doctor incorrectly reporting `mcp_runtime_proxy=unavailable`, MCP-injected ACPX sessions failing before prompt execution, or process-backed tools losing their expected executable-busy retry behavior.

## Reviewer Focus

- `crates/app/src/acp/acpx.rs`
- `crates/app/src/acp/acpx_mcp.rs`
- `crates/app/src/process_launch.rs`
- `crates/app/src/tools/process_exec.rs`
- `crates/app/src/tools/browser_companion.rs`
- `crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs`

Please focus on:
- whether the active ACPX backend now has a single MCP proxy helper path
- the switch from inline payload argv to `--payload-file`
- the probe regression coverage proving we execute the embedded proxy script contract
- the shared executable-busy retry primitives and whether caller-specific retry semantics stayed stable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved MCP proxy internals into a dedicated submodule and re-exported key probe/command helpers.

* **New Features / Improvements**
  * Added a runtime-backed probe variant with configurable timeout.
  * Switched to payload-file handling and deterministic, versioned proxy script persistence with stricter temp-file permissions.

* **Bug Fixes**
  * Centralized retry behavior for “executable file busy” errors into shared retry helpers.

* **Tests**
  * Added end-to-end probe, permission, payload-file and timeout/termination tests.

* **Documentation**
  * Updated architecture hotspot/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->