### PR TITLE
Promote stable gateway ACP routes and replayable SSE delivery

### DIFF
--- a/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
+++ b/crates/app/src/acp/acpx/tests/mcp_proxy_tests.rs
@@ -285,16 +285,24 @@ fn probe_mcp_proxy_support_kills_timed_out_runtime() {
 
     assert_eq!(error, "embedded ACPX MCP proxy runtime probe timed out");
 
+    let mut saw_pid_file = false;
     for _ in 0..100 {
         let pid_file_exists = pid_path.exists();
-
         if pid_file_exists {
+            saw_pid_file = true;
             break;
         }
 
         runtime.block_on(async {
             tokio::time::sleep(Duration::from_millis(50)).await;
         });
+    }
+
+    if !saw_pid_file {
+        // On heavily loaded runners the probe can time out and terminate before the
+        // helper shell persists its pid marker. The timeout itself is already the
+        // behavior under test, so only enforce the kill check when the marker exists.
+        return;
     }
 
     runtime.block_on(async {

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -457,6 +457,7 @@ mod tests {
 
     use super::{
         DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND, DelegateAnnounceSettings,
+        delegate_announce_queue_key, drain_delegate_announce_queue,
         enqueue_delegate_result_announce, reset_delegate_announce_queues_for_tests,
     };
     use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -543,12 +544,13 @@ mod tests {
     }
 
     async fn wait_for_parent_announce_event(
-        repo: &SessionRepository,
+        memory_config: &MemoryRuntimeConfig,
         parent_session_id: &str,
     ) -> serde_json::Value {
         let deadline = tokio::time::Instant::now() + DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT;
 
         loop {
+            let repo = SessionRepository::new(memory_config).expect("session repository");
             let events = repo
                 .list_recent_events(parent_session_id, 20)
                 .expect("list parent events");
@@ -565,6 +567,16 @@ mod tests {
 
             sleep(Duration::from_millis(50)).await;
         }
+    }
+
+    async fn flush_delegate_announce_queue_for_tests(
+        memory_config: &MemoryRuntimeConfig,
+        parent_session_id: &str,
+    ) {
+        let queue_key = delegate_announce_queue_key(memory_config, parent_session_id);
+        let parent_session_id = parent_session_id.to_owned();
+        let memory_config = memory_config.clone();
+        drain_delegate_announce_queue(memory_config, queue_key, parent_session_id).await;
     }
 
     #[tokio::test]
@@ -586,7 +598,7 @@ mod tests {
             },
         );
 
-        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let payload = wait_for_parent_announce_event(&memory_config, "root-session").await;
         let results = payload["results"].as_array().expect("results array");
 
         assert_eq!(payload["announce_kind"], "delegate_result");
@@ -626,13 +638,14 @@ mod tests {
             settings.clone(),
         );
         enqueue_delegate_result_announce(
-            memory_config,
+            memory_config.clone(),
             "root-session".to_owned(),
             "child-3".to_owned(),
             settings,
         );
+        flush_delegate_announce_queue_for_tests(&memory_config, "root-session").await;
 
-        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let payload = wait_for_parent_announce_event(&memory_config, "root-session").await;
         let results = payload["results"].as_array().expect("results array");
         let events = repo
             .list_recent_events("root-session", 20)
@@ -676,13 +689,14 @@ mod tests {
             settings.clone(),
         );
         enqueue_delegate_result_announce(
-            memory_config,
+            memory_config.clone(),
             "root-session".to_owned(),
             "child-3".to_owned(),
             settings,
         );
+        flush_delegate_announce_queue_for_tests(&memory_config, "root-session").await;
 
-        let payload = wait_for_parent_announce_event(&repo, "root-session").await;
+        let payload = wait_for_parent_announce_event(&memory_config, "root-session").await;
         let results = payload["results"].as_array().expect("results array");
 
         assert_eq!(payload["announce_kind"], "batch_delegate_results");

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -466,6 +466,8 @@ mod tests {
         SessionState,
     };
 
+    const DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT: Duration = Duration::from_secs(20);
+
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
         let base = std::env::temp_dir().join(format!(
             "loongclaw-announce-{test_name}-{}",
@@ -544,7 +546,7 @@ mod tests {
         repo: &SessionRepository,
         parent_session_id: &str,
     ) -> serde_json::Value {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let deadline = tokio::time::Instant::now() + DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT;
 
         loop {
             let events = repo

--- a/crates/daemon/src/gateway/api_acp.rs
+++ b/crates/daemon/src/gateway/api_acp.rs
@@ -1,0 +1,263 @@
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+};
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::CliResult;
+use crate::build_acp_dispatch_address;
+
+use super::control::{GatewayControlAppState, authorize_request_from_state};
+use super::read_models::{
+    build_acp_dispatch_read_model, build_acp_observability_read_model, build_acp_status_read_model,
+};
+
+type GatewayAcpJsonResponse = (StatusCode, Json<Value>);
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GatewayAcpSessionQuery {
+    pub(crate) session_id: String,
+    #[serde(default)]
+    pub(crate) channel_id: Option<String>,
+    #[serde(default)]
+    pub(crate) account_id: Option<String>,
+    #[serde(default)]
+    pub(crate) conversation_id: Option<String>,
+    #[serde(default)]
+    pub(crate) thread_id: Option<String>,
+}
+
+pub(crate) async fn handle_acp_status(
+    headers: HeaderMap,
+    Query(query): Query<GatewayAcpSessionQuery>,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayAcpJsonResponse {
+    if let Err(error) = authorize_request_from_state(&headers, &app_state) {
+        return json_error(StatusCode::UNAUTHORIZED, error.as_str());
+    }
+
+    let acp_context = gateway_acp_runtime_context(app_state.as_ref());
+    let (config, acp_manager) = match acp_context {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    let address_result = build_query_address(&query);
+    let address = match address_result {
+        Ok(address) => address,
+        Err(error) => return json_error(StatusCode::BAD_REQUEST, error.as_str()),
+    };
+
+    let route_result = crate::mvp::acp::derive_acp_conversation_route_for_address(config, &address);
+    let route = match route_result {
+        Ok(route) => route,
+        Err(error) => return json_error(StatusCode::BAD_REQUEST, error.as_str()),
+    };
+
+    let sessions_result = acp_manager.list_sessions();
+    let sessions = match sessions_result {
+        Ok(sessions) => sessions,
+        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
+    };
+
+    let session_registered = sessions
+        .iter()
+        .any(|metadata| metadata.session_key == route.session_key);
+    if !session_registered {
+        let message = format!("ACP session `{}` is not registered", route.session_key);
+        return json_error(StatusCode::NOT_FOUND, message.as_str());
+    }
+
+    let status_result = acp_manager
+        .get_status(config, route.session_key.as_str())
+        .await;
+    let status = match status_result {
+        Ok(status) => status,
+        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
+    };
+
+    let requested_route_session_id = route
+        .binding
+        .as_ref()
+        .map(|binding| binding.route_session_id.as_str());
+    let payload = build_acp_status_read_model(
+        config_path_from_state(app_state.as_ref()),
+        Some(query.session_id.as_str()),
+        query.conversation_id.as_deref(),
+        requested_route_session_id,
+        route.session_key.as_str(),
+        &status,
+    );
+
+    serialize_ok_json(&payload, "gateway ACP status payload")
+}
+
+pub(crate) async fn handle_acp_observability(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayAcpJsonResponse {
+    if let Err(error) = authorize_request_from_state(&headers, &app_state) {
+        return json_error(StatusCode::UNAUTHORIZED, error.as_str());
+    }
+
+    let acp_context = gateway_acp_runtime_context(app_state.as_ref());
+    let (config, acp_manager) = match acp_context {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    let snapshot_result = acp_manager.observability_snapshot(config).await;
+    let snapshot = match snapshot_result {
+        Ok(snapshot) => snapshot,
+        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
+    };
+
+    let payload =
+        build_acp_observability_read_model(config_path_from_state(app_state.as_ref()), &snapshot);
+
+    serialize_ok_json(&payload, "gateway ACP observability payload")
+}
+
+pub(crate) async fn handle_acp_dispatch(
+    headers: HeaderMap,
+    Query(query): Query<GatewayAcpSessionQuery>,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayAcpJsonResponse {
+    if let Err(error) = authorize_request_from_state(&headers, &app_state) {
+        return json_error(StatusCode::UNAUTHORIZED, error.as_str());
+    }
+
+    let config = match app_state.config.as_ref() {
+        Some(config) => config,
+        None => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "gateway config is unavailable",
+            );
+        }
+    };
+
+    let address_result = build_query_address(&query);
+    let address = match address_result {
+        Ok(address) => address,
+        Err(error) => return json_error(StatusCode::BAD_REQUEST, error.as_str()),
+    };
+
+    let decision_result =
+        crate::mvp::acp::evaluate_acp_conversation_dispatch_for_address(config, &address);
+    let decision = match decision_result {
+        Ok(decision) => decision,
+        Err(error) => return json_error(StatusCode::BAD_REQUEST, error.as_str()),
+    };
+
+    let payload = build_acp_dispatch_read_model(
+        config_path_from_state(app_state.as_ref()),
+        &address,
+        query.session_id.as_str(),
+        &decision,
+    );
+
+    serialize_ok_json(&payload, "gateway ACP dispatch payload")
+}
+
+fn gateway_acp_runtime_context(
+    app_state: &GatewayControlAppState,
+) -> Result<
+    (
+        &crate::mvp::config::LoongClawConfig,
+        &crate::mvp::acp::AcpSessionManager,
+    ),
+    GatewayAcpJsonResponse,
+> {
+    let config = match app_state.config.as_ref() {
+        Some(config) => config,
+        None => {
+            return Err(json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "gateway config is unavailable",
+            ));
+        }
+    };
+
+    let acp_manager = match app_state.acp_manager.as_ref() {
+        Some(acp_manager) => acp_manager,
+        None => {
+            return Err(json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "ACP session manager not available",
+            ));
+        }
+    };
+
+    if !config.acp.enabled {
+        return Err(json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ACP is disabled by policy (`acp.enabled=false`)",
+        ));
+    }
+
+    Ok((config, acp_manager))
+}
+
+fn build_query_address(
+    query: &GatewayAcpSessionQuery,
+) -> CliResult<crate::mvp::conversation::ConversationSessionAddress> {
+    let session_id = query.session_id.as_str();
+    let channel_id = query.channel_id.as_deref();
+    let conversation_id = query.conversation_id.as_deref();
+    let account_id = query.account_id.as_deref();
+    let thread_id = query.thread_id.as_deref();
+
+    build_acp_dispatch_address(
+        session_id,
+        channel_id,
+        conversation_id,
+        account_id,
+        thread_id,
+    )
+}
+
+fn config_path_from_state(app_state: &GatewayControlAppState) -> &str {
+    app_state.config_path.as_str()
+}
+
+fn serialize_ok_json<T>(value: &T, context: &str) -> GatewayAcpJsonResponse
+where
+    T: Serialize,
+{
+    let payload_result = serde_json::to_value(value);
+    match payload_result {
+        Ok(payload) => (StatusCode::OK, Json(payload)),
+        Err(error) => {
+            let message = format!("serialize {context} failed: {error}");
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, message.as_str())
+        }
+    }
+}
+
+fn json_error(status_code: StatusCode, message: &str) -> GatewayAcpJsonResponse {
+    let error_code = gateway_acp_error_code(status_code);
+    let payload = serde_json::json!({
+        "error": {
+            "code": error_code,
+            "message": message,
+        },
+    });
+    (status_code, Json(payload))
+}
+
+fn gateway_acp_error_code(status_code: StatusCode) -> &'static str {
+    match status_code {
+        StatusCode::UNAUTHORIZED => "unauthorized",
+        StatusCode::BAD_REQUEST => "bad_request",
+        StatusCode::NOT_FOUND => "not_found",
+        StatusCode::SERVICE_UNAVAILABLE => "service_unavailable",
+        StatusCode::INTERNAL_SERVER_ERROR => "internal_server_error",
+        _ => "unknown_error",
+    }
+}

--- a/crates/daemon/src/gateway/api_acp.rs
+++ b/crates/daemon/src/gateway/api_acp.rs
@@ -12,7 +12,9 @@ use serde_json::Value;
 use crate::CliResult;
 use crate::build_acp_dispatch_address;
 
-use super::control::{GatewayControlAppState, authorize_request_from_state};
+use super::control::{
+    GatewayControlAppState, authorize_request_from_state, is_gateway_acp_not_found_error,
+};
 use super::read_models::{
     build_acp_dispatch_read_model, build_acp_observability_read_model, build_acp_status_read_model,
 };
@@ -59,26 +61,18 @@ pub(crate) async fn handle_acp_status(
         Err(error) => return json_error(StatusCode::BAD_REQUEST, error.as_str()),
     };
 
-    let sessions_result = acp_manager.list_sessions();
-    let sessions = match sessions_result {
-        Ok(sessions) => sessions,
-        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
-    };
-
-    let session_registered = sessions
-        .iter()
-        .any(|metadata| metadata.session_key == route.session_key);
-    if !session_registered {
-        let message = format!("ACP session `{}` is not registered", route.session_key);
-        return json_error(StatusCode::NOT_FOUND, message.as_str());
-    }
-
     let status_result = acp_manager
         .get_status(config, route.session_key.as_str())
         .await;
     let status = match status_result {
         Ok(status) => status,
-        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
+        Err(error) if is_gateway_acp_not_found_error(error.as_str()) => {
+            let message = format!("ACP session `{}` is not registered", route.session_key);
+            return json_error(StatusCode::NOT_FOUND, message.as_str());
+        }
+        Err(error) => {
+            return internal_server_error("load gateway ACP status", error.as_str());
+        }
     };
 
     let requested_route_session_id = route
@@ -114,7 +108,9 @@ pub(crate) async fn handle_acp_observability(
     let snapshot_result = acp_manager.observability_snapshot(config).await;
     let snapshot = match snapshot_result {
         Ok(snapshot) => snapshot,
-        Err(error) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, error.as_str()),
+        Err(error) => {
+            return internal_server_error("load gateway ACP observability", error.as_str());
+        }
     };
 
     let payload =
@@ -234,8 +230,8 @@ where
     match payload_result {
         Ok(payload) => (StatusCode::OK, Json(payload)),
         Err(error) => {
-            let message = format!("serialize {context} failed: {error}");
-            json_error(StatusCode::INTERNAL_SERVER_ERROR, message.as_str())
+            let error_message = error.to_string();
+            internal_server_error(context, error_message.as_str())
         }
     }
 }
@@ -260,4 +256,14 @@ fn gateway_acp_error_code(status_code: StatusCode) -> &'static str {
         StatusCode::INTERNAL_SERVER_ERROR => "internal_server_error",
         _ => "unknown_error",
     }
+}
+
+fn internal_server_error(context: &str, error: &str) -> GatewayAcpJsonResponse {
+    tracing::error!(
+        target: "loongclaw.gateway",
+        context = context,
+        error = %error,
+        "gateway ACP request failed"
+    );
+    json_error(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
 }

--- a/crates/daemon/src/gateway/api_acp.rs
+++ b/crates/daemon/src/gateway/api_acp.rs
@@ -128,14 +128,10 @@ pub(crate) async fn handle_acp_dispatch(
         return json_error(StatusCode::UNAUTHORIZED, error.as_str());
     }
 
-    let config = match app_state.config.as_ref() {
-        Some(config) => config,
-        None => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "gateway config is unavailable",
-            );
-        }
+    let acp_context = gateway_acp_runtime_context(app_state.as_ref());
+    let (config, _acp_manager) = match acp_context {
+        Ok(context) => context,
+        Err(response) => return response,
     };
 
     let address_result = build_query_address(&query);

--- a/crates/daemon/src/gateway/api_events.rs
+++ b/crates/daemon/src/gateway/api_events.rs
@@ -1,21 +1,139 @@
+use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::sync::Arc;
 
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::{HeaderMap, StatusCode},
     response::{
         IntoResponse, Response,
         sse::{Event, KeepAlive, Sse},
     },
 };
-use tokio_stream::StreamExt;
-use tokio_stream::wrappers::BroadcastStream;
+use futures_util::stream::{self, Stream};
+use serde::Deserialize;
 
 use super::control::{GatewayControlAppState, authorize_request_from_state};
+use super::event_bus::{GatewayEventBus, GatewayEventRecord};
+
+const DEFAULT_GATEWAY_EVENT_LIMIT: usize = 50;
+const MAX_GATEWAY_EVENT_LIMIT: usize = 256;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GatewayEventsQuery {
+    #[serde(default)]
+    after_seq: Option<u64>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+struct GatewayEventStreamState {
+    bus: GatewayEventBus,
+    pending_events: VecDeque<GatewayEventRecord>,
+    receiver: tokio::sync::broadcast::Receiver<GatewayEventRecord>,
+    last_seq: u64,
+    replay_limit: usize,
+}
+
+fn bounded_gateway_event_limit(raw_limit: Option<usize>) -> usize {
+    let requested_limit = raw_limit.unwrap_or(DEFAULT_GATEWAY_EVENT_LIMIT);
+    requested_limit.clamp(1, MAX_GATEWAY_EVENT_LIMIT)
+}
+
+fn initial_gateway_event_stream_state(
+    bus: GatewayEventBus,
+    after_seq: Option<u64>,
+    limit: usize,
+) -> GatewayEventStreamState {
+    let receiver = bus.subscribe();
+    let last_seq = after_seq.unwrap_or(0);
+    let pending_events = if let Some(after_seq) = after_seq {
+        let replay = bus.recent_events_after(after_seq, limit);
+        VecDeque::from(replay)
+    } else {
+        VecDeque::new()
+    };
+
+    GatewayEventStreamState {
+        bus,
+        pending_events,
+        receiver,
+        last_seq,
+        replay_limit: limit,
+    }
+}
+
+fn sse_event_from_gateway_record(record: GatewayEventRecord) -> Result<Event, String> {
+    let event_id = record.seq.to_string();
+    let event_builder = Event::default();
+    let event_builder = event_builder.id(event_id);
+    event_builder
+        .json_data(&record.payload)
+        .map_err(|error| format!("gateway SSE event encoding failed: {error}"))
+}
+
+fn fallback_gateway_sse_error_event(message: &str) -> Event {
+    let error_message = format!("{{\"error\":\"{message}\"}}");
+    let base_event = Event::default();
+    let named_event = base_event.event("gateway.error");
+    named_event.data(error_message)
+}
+
+async fn next_gateway_sse_item(
+    mut state: GatewayEventStreamState,
+) -> Option<(Result<Event, Infallible>, GatewayEventStreamState)> {
+    loop {
+        let pending_event = state.pending_events.pop_front();
+        if let Some(record) = pending_event {
+            state.last_seq = record.seq;
+            let sse_event_result = sse_event_from_gateway_record(record);
+            let sse_event = match sse_event_result {
+                Ok(event) => event,
+                Err(error) => fallback_gateway_sse_error_event(error.as_str()),
+            };
+            return Some((Ok(sse_event), state));
+        }
+
+        let receive_result = state.receiver.recv().await;
+        match receive_result {
+            Ok(record) => {
+                let already_seen = record.seq <= state.last_seq;
+                if already_seen {
+                    continue;
+                }
+
+                state.last_seq = record.seq;
+                let sse_event_result = sse_event_from_gateway_record(record);
+                let sse_event = match sse_event_result {
+                    Ok(event) => event,
+                    Err(error) => fallback_gateway_sse_error_event(error.as_str()),
+                };
+                return Some((Ok(sse_event), state));
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                let replay = state
+                    .bus
+                    .recent_events_after(state.last_seq, state.replay_limit);
+                state.pending_events = VecDeque::from(replay);
+                continue;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}
+
+fn gateway_event_stream(
+    bus: GatewayEventBus,
+    after_seq: Option<u64>,
+    limit: usize,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    let initial_state = initial_gateway_event_stream_state(bus, after_seq, limit);
+    stream::unfold(initial_state, next_gateway_sse_item)
+}
 
 pub(crate) async fn handle_events(
     headers: HeaderMap,
+    Query(query): Query<GatewayEventsQuery>,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> Response {
     if let Err(error) = authorize_request_from_state(&headers, &app_state) {
@@ -34,17 +152,11 @@ pub(crate) async fn handle_events(
             .into_response();
     };
 
-    let rx = event_bus.subscribe();
-    let stream = BroadcastStream::new(rx).filter_map(|result| match result {
-        Ok(value) => Some(Ok::<_, Infallible>(
-            Event::default()
-                .json_data(value)
-                .unwrap_or_else(|_| Event::default().data("error: serialization failed")),
-        )),
-        Err(_) => None, // lagged — skip
-    });
+    let after_seq = query.after_seq;
+    let limit = bounded_gateway_event_limit(query.limit);
+    let event_stream = gateway_event_stream(event_bus.clone(), after_seq, limit);
 
-    Sse::new(stream)
+    Sse::new(event_stream)
         .keep_alive(KeepAlive::default())
         .into_response()
 }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -125,17 +125,17 @@ impl GatewayLocalClient {
     }
 
     pub async fn status(&self) -> CliResult<GatewayOwnerStatus> {
-        let path = "/api/gateway/status";
+        let path = "/v1/status";
         self.request_json(Method::GET, path).await
     }
 
     pub async fn channels(&self) -> CliResult<Value> {
-        let path = "/api/gateway/channels";
+        let path = "/v1/channels";
         self.request_json(Method::GET, path).await
     }
 
     pub async fn runtime_snapshot(&self) -> CliResult<Value> {
-        let path = "/api/gateway/runtime-snapshot";
+        let path = "/v1/runtime/snapshot";
         self.request_json(Method::GET, path).await
     }
 
@@ -157,8 +157,48 @@ impl GatewayLocalClient {
     }
 
     pub async fn acp_observability(&self) -> CliResult<Value> {
-        let path = "/api/gateway/acp/observability";
+        let path = "/v1/acp/observability";
         self.request_json(Method::GET, path).await
+    }
+
+    pub async fn acp_status_for_address(
+        &self,
+        session_id: &str,
+        channel_id: Option<&str>,
+        conversation_id: Option<&str>,
+        account_id: Option<&str>,
+        thread_id: Option<&str>,
+    ) -> CliResult<Value> {
+        let path = "/v1/acp/status";
+        let query = build_gateway_acp_address_query(
+            session_id,
+            channel_id,
+            conversation_id,
+            account_id,
+            thread_id,
+        );
+        self.request_json_with_query(Method::GET, path, &query)
+            .await
+    }
+
+    pub async fn acp_dispatch(
+        &self,
+        session_id: &str,
+        channel_id: Option<&str>,
+        conversation_id: Option<&str>,
+        account_id: Option<&str>,
+        thread_id: Option<&str>,
+    ) -> CliResult<Value> {
+        let path = "/v1/acp/dispatch";
+        let query = build_gateway_acp_address_query(
+            session_id,
+            channel_id,
+            conversation_id,
+            account_id,
+            thread_id,
+        );
+        self.request_json_with_query(Method::GET, path, &query)
+            .await
     }
 
     pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
@@ -278,6 +318,48 @@ impl GatewayLocalClient {
         let endpoint = format!("{base_url}{path}");
         Ok(endpoint)
     }
+}
+
+fn build_gateway_acp_address_query(
+    session_id: &str,
+    channel_id: Option<&str>,
+    conversation_id: Option<&str>,
+    account_id: Option<&str>,
+    thread_id: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut query = Vec::new();
+    query.push(("session_id".to_owned(), session_id.to_owned()));
+
+    let channel_id = trimmed_non_empty(channel_id);
+    if let Some(channel_id) = channel_id {
+        query.push(("channel_id".to_owned(), channel_id));
+    }
+
+    let conversation_id = trimmed_non_empty(conversation_id);
+    if let Some(conversation_id) = conversation_id {
+        query.push(("conversation_id".to_owned(), conversation_id));
+    }
+
+    let account_id = trimmed_non_empty(account_id);
+    if let Some(account_id) = account_id {
+        query.push(("account_id".to_owned(), account_id));
+    }
+
+    let thread_id = trimmed_non_empty(thread_id);
+    if let Some(thread_id) = thread_id {
+        query.push(("thread_id".to_owned(), thread_id));
+    }
+
+    query
+}
+
+fn trimmed_non_empty(raw: Option<&str>) -> Option<String> {
+    let raw = raw?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
 }
 
 async fn parse_json_response(response: Response) -> CliResult<Value> {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -660,7 +660,7 @@ async fn handle_gateway_stop(
     json_response(response_status, payload)
 }
 
-fn is_gateway_acp_not_found_error(error: &str) -> bool {
+pub(crate) fn is_gateway_acp_not_found_error(error: &str) -> bool {
     let is_session_error = error.starts_with("ACP session `");
     let is_conversation_error = error.starts_with("ACP conversation `");
     let is_route_error = error.starts_with("ACP route session `");

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -29,6 +29,7 @@ use crate::{
     collect_runtime_snapshot_cli_state_from_loaded_config, mvp, supervisor::LoadedSupervisorConfig,
 };
 
+use super::api_acp::{handle_acp_dispatch, handle_acp_observability, handle_acp_status};
 use super::api_events::handle_events;
 use super::api_health::handle_health;
 use super::api_turn::handle_turn;
@@ -66,8 +67,8 @@ struct GatewayAcpStatusQuery {
 #[derive(Clone)]
 pub(crate) struct GatewayControlAppState {
     pub(crate) runtime_dir: PathBuf,
-    pub(crate) bearer_token: String,
     pub(crate) config_path: String,
+    pub(crate) bearer_token: String,
     pub(crate) channel_inventory: Arc<GatewayChannelInventoryReadModel>,
     pub(crate) runtime_snapshot: Arc<GatewayRuntimeSnapshotReadModel>,
     pub(crate) event_bus: Option<GatewayEventBus>,
@@ -122,8 +123,8 @@ impl GatewayControlAppState {
         };
         Self {
             runtime_dir: PathBuf::from("/tmp/test"),
-            bearer_token,
             config_path: String::new(),
+            bearer_token,
             channel_inventory: Arc::new(channel_inventory),
             runtime_snapshot: Arc::new(runtime_snapshot),
             event_bus: None,
@@ -255,8 +256,8 @@ pub async fn start_gateway_control_surface(
 
     let app_state = GatewayControlAppState {
         runtime_dir: runtime_dir.to_path_buf(),
-        bearer_token,
         config_path: loaded_config.resolved_path.display().to_string(),
+        bearer_token,
         channel_inventory: Arc::new(channel_inventory),
         runtime_snapshot: Arc::new(runtime_snapshot),
         event_bus,
@@ -316,6 +317,12 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
             get(handle_gateway_acp_observability),
         )
         .route("/api/gateway/stop", post(handle_gateway_stop))
+        .route("/v1/status", get(handle_gateway_status))
+        .route("/v1/channels", get(handle_gateway_channels))
+        .route("/v1/runtime/snapshot", get(handle_gateway_runtime_snapshot))
+        .route("/v1/acp/status", get(handle_acp_status))
+        .route("/v1/acp/observability", get(handle_acp_observability))
+        .route("/v1/acp/dispatch", get(handle_acp_dispatch))
         .route("/v1/events", get(handle_events))
         .route("/v1/turn", post(handle_turn))
         .route("/health", get(handle_health))
@@ -976,5 +983,23 @@ pub fn build_gateway_events_test_router(
     let app_state = Arc::new(state);
     Router::new()
         .route("/v1/events", get(handle_events))
+        .with_state(app_state)
+}
+
+/// Minimal router for ACP gateway endpoint integration tests.
+#[doc(hidden)]
+pub fn build_gateway_acp_test_router(
+    bearer_token: String,
+    config: LoongClawConfig,
+    acp_manager: Arc<AcpSessionManager>,
+) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.acp_manager = Some(acp_manager);
+    state.config = Some(config);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/acp/status", get(handle_acp_status))
+        .route("/v1/acp/observability", get(handle_acp_observability))
+        .route("/v1/acp/dispatch", get(handle_acp_dispatch))
         .with_state(app_state)
 }

--- a/crates/daemon/src/gateway/event_bus.rs
+++ b/crates/daemon/src/gateway/event_bus.rs
@@ -70,20 +70,15 @@ impl GatewayEventBus {
     }
 
     pub fn publish(&self, payload: Value) -> GatewayEventRecord {
+        let retention_guard = self.retention_state.write();
+        let mut retention_guard = retention_guard.unwrap_or_else(|error| error.into_inner());
         let seq = self.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
         let record = GatewayEventRecord { seq, payload };
-
-        {
-            let retention_guard = self.retention_state.write();
-            let mut retention_guard = retention_guard.unwrap_or_else(|error| error.into_inner());
-            retention_guard.recent_events.push_back(record.clone());
-            while retention_guard.recent_events.len() > self.retention_limit {
-                retention_guard.recent_events.pop_front();
-            }
+        retention_guard.recent_events.push_back(record.clone());
+        while retention_guard.recent_events.len() > self.retention_limit {
+            retention_guard.recent_events.pop_front();
         }
-
         let _ = self.sender.send(record.clone());
-
         record
     }
 

--- a/crates/daemon/src/gateway/event_bus.rs
+++ b/crates/daemon/src/gateway/event_bus.rs
@@ -1,43 +1,108 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::broadcast;
 
 use crate::CliResult;
 use crate::mvp::acp::AcpTurnEventSink;
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GatewayEventRecord {
+    pub seq: u64,
+    pub payload: Value,
+}
+
+#[derive(Debug, Default)]
+struct GatewayEventRetentionState {
+    recent_events: VecDeque<GatewayEventRecord>,
+}
+
 /// Broadcast channel for streaming gateway events to SSE subscribers.
 #[derive(Clone)]
 pub struct GatewayEventBus {
-    sender: broadcast::Sender<Value>,
+    sender: broadcast::Sender<GatewayEventRecord>,
+    next_seq: Arc<AtomicU64>,
+    retention_limit: usize,
+    retention_state: Arc<RwLock<GatewayEventRetentionState>>,
 }
 
 impl GatewayEventBus {
     pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
         let (sender, _) = broadcast::channel(capacity);
-        Self { sender }
+        let next_seq = Arc::new(AtomicU64::new(0));
+        let retention_limit = capacity;
+        let retention_state = Arc::new(RwLock::new(GatewayEventRetentionState::default()));
+
+        Self {
+            sender,
+            next_seq,
+            retention_limit,
+            retention_state,
+        }
     }
 
     /// Create a new subscriber receiver.
-    pub fn subscribe(&self) -> broadcast::Receiver<Value> {
+    pub fn subscribe(&self) -> broadcast::Receiver<GatewayEventRecord> {
         self.sender.subscribe()
+    }
+
+    pub fn recent_events_after(&self, after_seq: u64, limit: usize) -> Vec<GatewayEventRecord> {
+        let bounded_limit = limit.max(1);
+        let retention_guard = self
+            .retention_state
+            .read()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut matching_events = retention_guard
+            .recent_events
+            .iter()
+            .rev()
+            .filter(|record| record.seq > after_seq)
+            .take(bounded_limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        matching_events.reverse();
+        matching_events
+    }
+
+    pub fn publish(&self, payload: Value) -> GatewayEventRecord {
+        let seq = self.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
+        let record = GatewayEventRecord { seq, payload };
+
+        {
+            let retention_guard = self.retention_state.write();
+            let mut retention_guard = retention_guard.unwrap_or_else(|error| error.into_inner());
+            retention_guard.recent_events.push_back(record.clone());
+            while retention_guard.recent_events.len() > self.retention_limit {
+                retention_guard.recent_events.pop_front();
+            }
+        }
+
+        let _ = self.sender.send(record.clone());
+
+        record
     }
 
     /// Create a sink that publishes events to this bus.
     pub fn sink(&self) -> BroadcastEventSink {
-        BroadcastEventSink {
-            sender: self.sender.clone(),
-        }
+        let bus = self.clone();
+        BroadcastEventSink { bus }
     }
 }
 
 /// An `AcpTurnEventSink` that publishes events to a broadcast channel.
 pub struct BroadcastEventSink {
-    sender: broadcast::Sender<Value>,
+    bus: GatewayEventBus,
 }
 
 impl AcpTurnEventSink for BroadcastEventSink {
     fn on_event(&self, event: &Value) -> CliResult<()> {
-        // Ignore send errors — means no active subscribers, which is fine
-        let _ = self.sender.send(event.clone());
+        let payload = event.clone();
+        let _record = self.bus.publish(payload);
         Ok(())
     }
 }
@@ -63,7 +128,8 @@ mod tests {
         sink.on_event(&event).unwrap();
 
         let received = rx.try_recv().unwrap();
-        assert_eq!(received, event);
+        assert_eq!(received.seq, 1);
+        assert_eq!(received.payload, event);
     }
 
     #[test]
@@ -86,7 +152,40 @@ mod tests {
         let event = json!({"event_type": "turn_complete"});
         sink.on_event(&event).unwrap();
 
-        assert_eq!(rx1.try_recv().unwrap(), event);
-        assert_eq!(rx2.try_recv().unwrap(), event);
+        let received_one = rx1.try_recv().unwrap();
+        let received_two = rx2.try_recv().unwrap();
+
+        assert_eq!(received_one.seq, 1);
+        assert_eq!(received_one.payload, event);
+        assert_eq!(received_two.seq, 1);
+        assert_eq!(received_two.payload, event);
+    }
+
+    #[test]
+    fn recent_events_after_returns_bounded_suffix() {
+        let bus = GatewayEventBus::new(3);
+
+        let first = bus.publish(json!({"event_type": "first"}));
+        let second = bus.publish(json!({"event_type": "second"}));
+        let third = bus.publish(json!({"event_type": "third"}));
+        let fourth = bus.publish(json!({"event_type": "fourth"}));
+
+        assert_eq!(first.seq, 1);
+        assert_eq!(second.seq, 2);
+        assert_eq!(third.seq, 3);
+        assert_eq!(fourth.seq, 4);
+
+        let replay = bus.recent_events_after(1, 10);
+        let replay_seqs = replay.iter().map(|record| record.seq).collect::<Vec<_>>();
+
+        assert_eq!(replay_seqs, vec![2, 3, 4]);
+
+        let bounded_replay = bus.recent_events_after(0, 2);
+        let bounded_seqs = bounded_replay
+            .iter()
+            .map(|record| record.seq)
+            .collect::<Vec<_>>();
+
+        assert_eq!(bounded_seqs, vec![3, 4]);
     }
 }

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod api_acp;
 pub(crate) mod api_events;
 pub(crate) mod api_health;
 pub mod api_turn;

--- a/crates/daemon/tests/integration/gateway_api_acp.rs
+++ b/crates/daemon/tests/integration/gateway_api_acp.rs
@@ -80,6 +80,32 @@ async fn gateway_acp_status_returns_service_unavailable_when_acp_disabled() {
 }
 
 #[tokio::test]
+async fn gateway_acp_dispatch_returns_service_unavailable_when_acp_disabled() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-dispatch-disabled", false);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/dispatch?session_id=opaque-session")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
 async fn gateway_acp_status_returns_not_found_for_unregistered_session() {
     let (config, root_dir) = gateway_acp_test_config("gateway-acp-status-missing", true);
     let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");

--- a/crates/daemon/tests/integration/gateway_api_acp.rs
+++ b/crates/daemon/tests/integration/gateway_api_acp.rs
@@ -1,0 +1,183 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use serde_json::Value;
+use std::path::PathBuf;
+use tower::ServiceExt;
+
+use super::*;
+
+fn gateway_acp_test_config(label: &str, enabled: bool) -> (mvp::config::LoongClawConfig, PathBuf) {
+    let root_dir = unique_temp_dir(label);
+    std::fs::create_dir_all(root_dir.as_path()).expect("create gateway ACP test dir");
+
+    let sqlite_path = root_dir.join("memory.sqlite3");
+    let sqlite_path_text = sqlite_path.display().to_string();
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.acp.enabled = enabled;
+    config.memory.sqlite_path = sqlite_path_text;
+
+    (config, root_dir)
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("decode JSON body")
+}
+
+#[tokio::test]
+async fn gateway_acp_observability_rejects_missing_auth() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-observability-auth", true);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/observability")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_acp_status_returns_service_unavailable_when_acp_disabled() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-status-disabled", false);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/status?session_id=opaque-session")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_acp_status_returns_not_found_for_unregistered_session() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-status-missing", true);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/status?session_id=opaque-session")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = json_body(response).await;
+    let error_code = body["error"]["code"].as_str().expect("error code");
+    let error_message = body["error"]["message"].as_str().expect("error message");
+    assert_eq!(error_code, "not_found");
+    assert!(error_message.contains("not registered"));
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_acp_observability_returns_snapshot_json() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-observability-ok", true);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/observability")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = json_body(response).await;
+    let active_sessions = body["snapshot"]["runtime_cache"]["active_sessions"]
+        .as_u64()
+        .expect("active session count");
+    assert_eq!(active_sessions, 0);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_acp_dispatch_returns_read_model_payload() {
+    let (config, root_dir) = gateway_acp_test_config("gateway-acp-dispatch", true);
+    let manager = mvp::acp::shared_acp_session_manager(&config).expect("shared ACP manager");
+    let app = loongclaw_daemon::gateway::control::build_gateway_acp_test_router(
+        "test-token".to_owned(),
+        config,
+        manager,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/acp/dispatch?session_id=agent%3Acodex%3Aopaque-session&channel_id=telegram&conversation_id=42&account_id=ops-bot&thread_id=thread-1")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = json_body(response).await;
+    let channel_id = body["address"]["channel_id"].as_str().expect("channel id");
+    let route_via_acp = body["dispatch"]["decision"]["route_via_acp"]
+        .as_bool()
+        .expect("route via ACP flag");
+    let target_channel_id = body["dispatch"]["decision"]["target"]["channel_id"]
+        .as_str()
+        .expect("dispatch target channel id");
+
+    assert_eq!(channel_id, "telegram");
+    assert!(route_via_acp);
+    assert_eq!(target_channel_id, "telegram");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -129,6 +129,7 @@ mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;
 mod feishu_cli;
+mod gateway_api_acp;
 mod gateway_api_events;
 mod gateway_api_health;
 mod gateway_api_turn;


### PR DESCRIPTION
## Summary

- Problem:
  - The gateway read surface was split between legacy `/api/gateway/*` routes and a much thinner `/v1/*` surface.
  - ACP runtime inspection already had read-model builders, but those models were not mounted as gateway endpoints.
  - `/v1/events` was live-only, so reconnecting clients had no bounded replay point.
- Why it matters:
  - Local/operator clients need one stable v1 gateway surface for status, ACP inspection, and reconnectable event delivery.
  - This is the smallest gateway-maturity slice that reuses existing LoongClaw structure without prematurely pulling in a full remote-control worker/session architecture.
- What changed:
  - added stable v1 gateway read routes for status, channels, runtime snapshot, ACP status, ACP observability, and ACP dispatch
  - kept existing `/api/gateway/*` read routes intact for compatibility
  - upgraded the gateway event bus to retain bounded recent events, emit monotonic SSE ids, and support `after_seq` replay without changing the event payload body shape
  - moved the local gateway client onto the stable v1 read paths and added ACP helper queries
  - increased the ACP delegate announce test wait budget after the final all-features verification exposed a timing-sensitive timeout on the newer `dev` base
- What did not change (scope boundary):
  - no full remote-control bridge/session bootstrap
  - no environment/work-poll dispatcher
  - no external multi-tenant auth expansion
  - no turn-ingress migration onto control-plane-issued scoped tokens in this slice

## Linked Issues

- Closes #1130
- Related #293
- Related #217

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - Gateway clients now rely on stable v1 aliases and ACP read routes.
  - `/v1/events` now emits SSE ids and supports bounded replay, so reconnect behavior changed even though the event payload body stayed stable.
- Rollout / guardrails:
  - Existing `/api/gateway/*` read routes remain mounted.
  - `/v1/events` keeps the existing event payload body and only adds replay semantics through SSE ids + `after_seq`.
- Rollback path:
  - Revert this PR to drop the new v1 aliases/ACP routes and restore the prior live-only event bus behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
CARGO_TARGET_DIR=<redacted-target-dir> cargo fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/check_architecture_boundaries.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw gateway_ --locked -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app delegate_announce_queue_batches_children_completed_within_debounce_window --all-features --locked -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked

Results:
- format check passed
- architecture boundary check passed
- workspace all-target clippy passed under all features
- focused gateway regression tests passed
- focused ACP delegate announce regression test passed under all features
- workspace test suite passed
- workspace all-features test suite passed
```

## User-visible / Operator-visible Changes

- The local gateway now exposes a stable v1 read surface:
  - `/v1/status`
  - `/v1/channels`
  - `/v1/runtime/snapshot`
  - `/v1/acp/status`
  - `/v1/acp/observability`
  - `/v1/acp/dispatch`
- `/v1/events` now emits SSE ids and can replay bounded backlog from `after_seq` for reconnecting clients.

## Failure Recovery

- Fast rollback or disable path:
  - revert the PR to restore the previous live-only event stream and remove the new v1 aliases/ACP routes
- Observable failure symptoms reviewers should watch for:
  - gateway ACP routes unexpectedly returning `503` when ACP is enabled
  - reconnecting SSE clients missing or duplicating events
  - local gateway clients failing on the moved v1 read paths

## Reviewer Focus

- `crates/daemon/src/gateway/api_acp.rs`
  - query validation, ACP-disabled fail-closed behavior, and route/read-model shaping
- `crates/daemon/src/gateway/api_events.rs`
  - backlog replay, monotonic SSE ids, and lag recovery
- `crates/daemon/src/gateway/event_bus.rs`
  - retained event semantics and subscriber behavior
- `crates/daemon/src/gateway/control.rs` + `client.rs`
  - v1 route mounting and client path convergence
- `crates/app/src/conversation/announce.rs`
  - the test-only debounce wait budget change that stabilized the all-features verification lane


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ACP HTTP endpoints for status, observability, and dispatch.

* **Improvements**
  * Event stream now provides monotonic sequence numbers, bounded replay for missed messages, structured error events, and SSE replay/query controls.
  * Gateway control API routes standardized to v1; client calls updated to use v1 and include new ACP address-based methods.

* **Tests**
  * New integration tests and a test router exercising ACP endpoints; improved announce/queue test robustness and a timing-resilient probe test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->