### PR TITLE
Add local product control-plane turn submit/result/stream routes

### DIFF
--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -286,6 +286,7 @@ impl ControlPlaneTurnRegistry {
             let Some(record) = turns.get_mut(turn_id) else {
                 return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
             };
+            Self::ensure_turn_mutable(record, turn_id)?;
             record.snapshot.status = terminal_status;
             record.snapshot.completed_at_ms = Some(completed_at_ms);
             record.snapshot.output_text = Some(output_text.to_owned());
@@ -319,6 +320,7 @@ impl ControlPlaneTurnRegistry {
             let Some(record) = turns.get_mut(turn_id) else {
                 return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
             };
+            Self::ensure_turn_mutable(record, turn_id)?;
             record.snapshot.status = ControlPlaneTurnStatus::Failed;
             record.snapshot.completed_at_ms = Some(completed_at_ms);
             record.snapshot.error = Some(error.to_owned());
@@ -348,6 +350,7 @@ impl ControlPlaneTurnRegistry {
             let Some(record) = turns.get_mut(turn_id) else {
                 return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
             };
+            Self::ensure_turn_mutable(record, turn_id)?;
             Self::push_event_locked(record, terminal, payload)
         };
         let send_result = self.sender.send(event.clone());
@@ -406,6 +409,16 @@ impl ControlPlaneTurnRegistry {
         for (_, _, turn_id) in removal_candidates.into_iter().take(overflow_count) {
             turns.remove(turn_id.as_str());
         }
+    }
+
+    fn ensure_turn_mutable(
+        record: &ControlPlaneTurnStateRecord,
+        turn_id: &str,
+    ) -> Result<(), String> {
+        if !record.snapshot.status.is_terminal() {
+            return Ok(());
+        }
+        Err(format!("control_plane_turn_already_terminal: `{turn_id}`"))
     }
 }
 
@@ -1982,6 +1995,23 @@ mod tests {
             retained_terminal_count,
             CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT
         );
+    }
+
+    #[test]
+    fn turn_registry_rejects_mutation_after_terminal_completion() {
+        let registry = ControlPlaneTurnRegistry::new();
+        let turn = registry.issue_turn("session-1");
+        registry
+            .complete_success(turn.turn_id.as_str(), "done", Some("completed"), None)
+            .expect("complete turn");
+        let runtime_event_error = registry
+            .record_runtime_event(turn.turn_id.as_str(), json!({ "type": "late" }))
+            .expect_err("late runtime event should be rejected");
+        let completion_error = registry
+            .complete_failure(turn.turn_id.as_str(), "late failure")
+            .expect_err("late completion should be rejected");
+        assert!(runtime_event_error.contains("control_plane_turn_already_terminal"));
+        assert!(completion_error.contains("control_plane_turn_already_terminal"));
     }
 
     #[test]

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -34,6 +34,7 @@ const CONTROL_PLANE_MAX_WAIT_TIMEOUT_MS: u64 = 30_000;
 const CONTROL_PLANE_EVENT_CHANNEL_CAPACITY: usize = 256;
 const CONTROL_PLANE_TURN_EVENT_CHANNEL_CAPACITY: usize = 256;
 const CONTROL_PLANE_TURN_RECENT_EVENT_LIMIT: usize = 256;
+const CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT: usize = 256;
 #[cfg(feature = "memory-sqlite")]
 const DEFAULT_CONTROL_PLANE_SESSION_ID: &str = "default";
 #[cfg(feature = "memory-sqlite")]
@@ -270,26 +271,33 @@ impl ControlPlaneTurnRegistry {
             Some("cancelled") => ControlPlaneTurnStatus::Cancelled,
             _ => ControlPlaneTurnStatus::Completed,
         };
+        let usage_payload = usage.clone();
         let payload = json!({
             "event_type": "turn.completed",
             "output_text": output_text,
             "stop_reason": stop_reason,
-            "usage": usage,
+            "usage": usage_payload,
         });
-        let event = self.push_event(turn_id, true, payload)?;
-        let mut turns = self
-            .turns
-            .write()
-            .unwrap_or_else(|error| error.into_inner());
-        let Some(record) = turns.get_mut(turn_id) else {
-            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        let event = {
+            let mut turns = self
+                .turns
+                .write()
+                .unwrap_or_else(|error| error.into_inner());
+            let Some(record) = turns.get_mut(turn_id) else {
+                return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+            };
+            record.snapshot.status = terminal_status;
+            record.snapshot.completed_at_ms = Some(completed_at_ms);
+            record.snapshot.output_text = Some(output_text.to_owned());
+            record.snapshot.stop_reason = stop_reason.map(ToOwned::to_owned);
+            record.snapshot.usage = usage;
+            record.snapshot.error = None;
+            let event = Self::push_event_locked(record, true, payload);
+            Self::prune_terminal_turns_locked(&mut turns);
+            event
         };
-        record.snapshot.status = terminal_status;
-        record.snapshot.completed_at_ms = Some(completed_at_ms);
-        record.snapshot.output_text = Some(output_text.to_owned());
-        record.snapshot.stop_reason = stop_reason.map(ToOwned::to_owned);
-        record.snapshot.usage = usage;
-        record.snapshot.error = None;
+        let send_result = self.sender.send(event.clone());
+        let _ = send_result;
         Ok(event)
     }
 
@@ -303,20 +311,26 @@ impl ControlPlaneTurnRegistry {
             "event_type": "turn.failed",
             "error": error,
         });
-        let event = self.push_event(turn_id, true, payload)?;
-        let mut turns = self
-            .turns
-            .write()
-            .unwrap_or_else(|error| error.into_inner());
-        let Some(record) = turns.get_mut(turn_id) else {
-            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        let event = {
+            let mut turns = self
+                .turns
+                .write()
+                .unwrap_or_else(|error| error.into_inner());
+            let Some(record) = turns.get_mut(turn_id) else {
+                return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+            };
+            record.snapshot.status = ControlPlaneTurnStatus::Failed;
+            record.snapshot.completed_at_ms = Some(completed_at_ms);
+            record.snapshot.error = Some(error.to_owned());
+            record.snapshot.output_text = None;
+            record.snapshot.stop_reason = None;
+            record.snapshot.usage = None;
+            let event = Self::push_event_locked(record, true, payload);
+            Self::prune_terminal_turns_locked(&mut turns);
+            event
         };
-        record.snapshot.status = ControlPlaneTurnStatus::Failed;
-        record.snapshot.completed_at_ms = Some(completed_at_ms);
-        record.snapshot.error = Some(error.to_owned());
-        record.snapshot.output_text = None;
-        record.snapshot.stop_reason = None;
-        record.snapshot.usage = None;
+        let send_result = self.sender.send(event.clone());
+        let _ = send_result;
         Ok(event)
     }
 
@@ -326,13 +340,26 @@ impl ControlPlaneTurnRegistry {
         terminal: bool,
         payload: Value,
     ) -> Result<ControlPlaneTurnEventRecord, String> {
-        let mut turns = self
-            .turns
-            .write()
-            .unwrap_or_else(|error| error.into_inner());
-        let Some(record) = turns.get_mut(turn_id) else {
-            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        let event = {
+            let mut turns = self
+                .turns
+                .write()
+                .unwrap_or_else(|error| error.into_inner());
+            let Some(record) = turns.get_mut(turn_id) else {
+                return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+            };
+            Self::push_event_locked(record, terminal, payload)
         };
+        let send_result = self.sender.send(event.clone());
+        let _ = send_result;
+        Ok(event)
+    }
+
+    fn push_event_locked(
+        record: &mut ControlPlaneTurnStateRecord,
+        terminal: bool,
+        payload: Value,
+    ) -> ControlPlaneTurnEventRecord {
         let event = ControlPlaneTurnEventRecord {
             turn_id: record.snapshot.turn_id.clone(),
             session_id: record.snapshot.session_id.clone(),
@@ -346,10 +373,39 @@ impl ControlPlaneTurnRegistry {
         while record.recent_events.len() > CONTROL_PLANE_TURN_RECENT_EVENT_LIMIT {
             record.recent_events.pop_front();
         }
-        drop(turns);
-        let send_result = self.sender.send(event.clone());
-        let _ = send_result;
-        Ok(event)
+        event
+    }
+
+    fn prune_terminal_turns_locked(turns: &mut BTreeMap<String, ControlPlaneTurnStateRecord>) {
+        let terminal_count = turns
+            .values()
+            .filter(|record| record.snapshot.status.is_terminal())
+            .count();
+        if terminal_count <= CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT {
+            return;
+        }
+        let overflow_count = terminal_count - CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT;
+        let mut removal_candidates = turns
+            .iter()
+            .filter(|(_, record)| record.snapshot.status.is_terminal())
+            .map(|(turn_id, record)| {
+                let completed_at_ms = record
+                    .snapshot
+                    .completed_at_ms
+                    .unwrap_or(record.snapshot.submitted_at_ms);
+                let submitted_at_ms = record.snapshot.submitted_at_ms;
+                (completed_at_ms, submitted_at_ms, turn_id.clone())
+            })
+            .collect::<Vec<_>>();
+        removal_candidates.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.1.cmp(&right.1))
+                .then_with(|| left.2.cmp(&right.2))
+        });
+        for (_, _, turn_id) in removal_candidates.into_iter().take(overflow_count) {
+            turns.remove(turn_id.as_str());
+        }
     }
 }
 
@@ -1519,6 +1575,15 @@ impl ControlPlaneRepositoryView {
         )
     }
 
+    pub fn ensure_visible_session_id(&self, target_session_id: &str) -> Result<(), String> {
+        let target_session_id = target_session_id.trim();
+        if target_session_id.is_empty() {
+            return Err("control_plane_session_id_missing".to_owned());
+        }
+        let repo = self.open_repo()?;
+        self.ensure_visible_session(&repo, target_session_id)
+    }
+
     pub fn list_approvals(
         &self,
         session_id: Option<&str>,
@@ -1865,6 +1930,58 @@ mod tests {
         assert!(event.targeted);
         assert_eq!(event.state_version.sessions, 1);
         assert_eq!(manager.snapshot().session_count, 5);
+    }
+
+    #[test]
+    fn turn_registry_prunes_oldest_terminal_turns() {
+        let registry = ControlPlaneTurnRegistry::new();
+        let first_turn = registry.issue_turn("session-0");
+        let first_output = "output-0".to_owned();
+        registry
+            .complete_success(
+                first_turn.turn_id.as_str(),
+                first_output.as_str(),
+                Some("completed"),
+                None,
+            )
+            .expect("complete first turn");
+        let mut newest_turn_id = first_turn.turn_id.clone();
+        for index in 1..=CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT {
+            let session_id = format!("session-{index}");
+            let output_text = format!("output-{index}");
+            let turn = registry.issue_turn(session_id.as_str());
+            registry
+                .complete_success(
+                    turn.turn_id.as_str(),
+                    output_text.as_str(),
+                    Some("completed"),
+                    None,
+                )
+                .expect("complete retained turn");
+            newest_turn_id = turn.turn_id;
+        }
+        let removed_turn = registry
+            .read_turn(first_turn.turn_id.as_str())
+            .expect("read pruned turn");
+        let retained_turn = registry
+            .read_turn(newest_turn_id.as_str())
+            .expect("read retained turn");
+        let retained_terminal_count = {
+            let turns = registry
+                .turns
+                .read()
+                .unwrap_or_else(|error| error.into_inner());
+            turns
+                .values()
+                .filter(|record| record.snapshot.status.is_terminal())
+                .count()
+        };
+        assert!(removed_turn.is_none());
+        assert!(retained_turn.is_some());
+        assert_eq!(
+            retained_terminal_count,
+            CONTROL_PLANE_TURN_TERMINAL_RETENTION_LIMIT
+        );
     }
 
     #[test]

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::sync::{Notify, broadcast};
 use tokio::time::{Duration, Instant, timeout};
@@ -32,6 +32,8 @@ const CONTROL_PLANE_CONNECTION_TTL_MS: u64 = 15 * 60 * 1000;
 const CONTROL_PLANE_CHALLENGE_TTL_MS: u64 = 60 * 1000;
 const CONTROL_PLANE_MAX_WAIT_TIMEOUT_MS: u64 = 30_000;
 const CONTROL_PLANE_EVENT_CHANNEL_CAPACITY: usize = 256;
+const CONTROL_PLANE_TURN_EVENT_CHANNEL_CAPACITY: usize = 256;
+const CONTROL_PLANE_TURN_RECENT_EVENT_LIMIT: usize = 256;
 #[cfg(feature = "memory-sqlite")]
 const DEFAULT_CONTROL_PLANE_SESSION_ID: &str = "default";
 #[cfg(feature = "memory-sqlite")]
@@ -108,6 +110,247 @@ pub struct ControlPlaneEventRecord {
     pub state_version: ControlPlaneStateVersion,
     pub payload: Value,
     pub targeted: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlPlaneTurnStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ControlPlaneTurnStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ControlPlaneTurnEventRecord {
+    pub turn_id: String,
+    pub session_id: String,
+    pub seq: u64,
+    pub terminal: bool,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ControlPlaneTurnSnapshot {
+    pub turn_id: String,
+    pub session_id: String,
+    pub status: ControlPlaneTurnStatus,
+    pub submitted_at_ms: u64,
+    pub completed_at_ms: Option<u64>,
+    pub event_count: usize,
+    pub output_text: Option<String>,
+    pub stop_reason: Option<String>,
+    pub usage: Option<Value>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ControlPlaneTurnStateRecord {
+    snapshot: ControlPlaneTurnSnapshot,
+    recent_events: VecDeque<ControlPlaneTurnEventRecord>,
+    next_seq: u64,
+}
+
+#[derive(Debug)]
+pub struct ControlPlaneTurnRegistry {
+    nonce: AtomicU64,
+    turns: RwLock<BTreeMap<String, ControlPlaneTurnStateRecord>>,
+    sender: broadcast::Sender<ControlPlaneTurnEventRecord>,
+}
+
+impl Default for ControlPlaneTurnRegistry {
+    fn default() -> Self {
+        let channel = broadcast::channel(CONTROL_PLANE_TURN_EVENT_CHANNEL_CAPACITY);
+        let sender = channel.0;
+        Self {
+            nonce: AtomicU64::new(0),
+            turns: RwLock::new(BTreeMap::new()),
+            sender,
+        }
+    }
+}
+
+impl ControlPlaneTurnRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn issue_turn(&self, session_id: &str) -> ControlPlaneTurnSnapshot {
+        let issued_at_ms = current_time_ms();
+        let sequence = self.nonce.fetch_add(1, Ordering::Relaxed) + 1;
+        let random_component = rand::random::<u64>();
+        let turn_id = format!("cpt-turn-{sequence:016x}-{random_component:016x}");
+        let snapshot = ControlPlaneTurnSnapshot {
+            turn_id: turn_id.clone(),
+            session_id: session_id.to_owned(),
+            status: ControlPlaneTurnStatus::Running,
+            submitted_at_ms: issued_at_ms,
+            completed_at_ms: None,
+            event_count: 0,
+            output_text: None,
+            stop_reason: None,
+            usage: None,
+            error: None,
+        };
+        let record = ControlPlaneTurnStateRecord {
+            snapshot: snapshot.clone(),
+            recent_events: VecDeque::new(),
+            next_seq: 1,
+        };
+        let mut turns = self
+            .turns
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        turns.insert(turn_id, record);
+        snapshot
+    }
+
+    pub fn read_turn(&self, turn_id: &str) -> Result<Option<ControlPlaneTurnSnapshot>, String> {
+        let turns = self.turns.read().unwrap_or_else(|error| error.into_inner());
+        let snapshot = turns.get(turn_id).map(|record| record.snapshot.clone());
+        Ok(snapshot)
+    }
+
+    pub fn recent_events_after(
+        &self,
+        turn_id: &str,
+        after_seq: u64,
+        limit: usize,
+    ) -> Result<Vec<ControlPlaneTurnEventRecord>, String> {
+        let bounded_limit = limit.clamp(1, CONTROL_PLANE_TURN_RECENT_EVENT_LIMIT);
+        let turns = self.turns.read().unwrap_or_else(|error| error.into_inner());
+        let Some(record) = turns.get(turn_id) else {
+            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        };
+        let events = record
+            .recent_events
+            .iter()
+            .filter(|event| event.seq > after_seq)
+            .take(bounded_limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        Ok(events)
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ControlPlaneTurnEventRecord> {
+        self.sender.subscribe()
+    }
+
+    pub fn record_runtime_event(
+        &self,
+        turn_id: &str,
+        payload: Value,
+    ) -> Result<ControlPlaneTurnEventRecord, String> {
+        self.push_event(turn_id, false, payload)
+    }
+
+    pub fn complete_success(
+        &self,
+        turn_id: &str,
+        output_text: &str,
+        stop_reason: Option<&str>,
+        usage: Option<Value>,
+    ) -> Result<ControlPlaneTurnEventRecord, String> {
+        let completed_at_ms = current_time_ms();
+        let terminal_status = match stop_reason {
+            Some("cancelled") => ControlPlaneTurnStatus::Cancelled,
+            _ => ControlPlaneTurnStatus::Completed,
+        };
+        let payload = json!({
+            "event_type": "turn.completed",
+            "output_text": output_text,
+            "stop_reason": stop_reason,
+            "usage": usage,
+        });
+        let event = self.push_event(turn_id, true, payload)?;
+        let mut turns = self
+            .turns
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(record) = turns.get_mut(turn_id) else {
+            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        };
+        record.snapshot.status = terminal_status;
+        record.snapshot.completed_at_ms = Some(completed_at_ms);
+        record.snapshot.output_text = Some(output_text.to_owned());
+        record.snapshot.stop_reason = stop_reason.map(ToOwned::to_owned);
+        record.snapshot.usage = usage;
+        record.snapshot.error = None;
+        Ok(event)
+    }
+
+    pub fn complete_failure(
+        &self,
+        turn_id: &str,
+        error: &str,
+    ) -> Result<ControlPlaneTurnEventRecord, String> {
+        let completed_at_ms = current_time_ms();
+        let payload = json!({
+            "event_type": "turn.failed",
+            "error": error,
+        });
+        let event = self.push_event(turn_id, true, payload)?;
+        let mut turns = self
+            .turns
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(record) = turns.get_mut(turn_id) else {
+            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        };
+        record.snapshot.status = ControlPlaneTurnStatus::Failed;
+        record.snapshot.completed_at_ms = Some(completed_at_ms);
+        record.snapshot.error = Some(error.to_owned());
+        record.snapshot.output_text = None;
+        record.snapshot.stop_reason = None;
+        record.snapshot.usage = None;
+        Ok(event)
+    }
+
+    fn push_event(
+        &self,
+        turn_id: &str,
+        terminal: bool,
+        payload: Value,
+    ) -> Result<ControlPlaneTurnEventRecord, String> {
+        let mut turns = self
+            .turns
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(record) = turns.get_mut(turn_id) else {
+            return Err(format!("control_plane_turn_not_found: `{turn_id}`"));
+        };
+        let event = ControlPlaneTurnEventRecord {
+            turn_id: record.snapshot.turn_id.clone(),
+            session_id: record.snapshot.session_id.clone(),
+            seq: record.next_seq,
+            terminal,
+            payload,
+        };
+        record.next_seq += 1;
+        record.snapshot.event_count += 1;
+        record.recent_events.push_back(event.clone());
+        while record.recent_events.len() > CONTROL_PLANE_TURN_RECENT_EVENT_LIMIT {
+            record.recent_events.pop_front();
+        }
+        drop(turns);
+        let send_result = self.sender.send(event.clone());
+        let _ = send_result;
+        Ok(event)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -34,7 +34,9 @@ use loongclaw_protocol::{
     ControlPlaneSessionKind, ControlPlaneSessionListResponse, ControlPlaneSessionObservation,
     ControlPlaneSessionReadResponse, ControlPlaneSessionState, ControlPlaneSessionSummary,
     ControlPlaneSessionTerminalOutcome, ControlPlaneSnapshot, ControlPlaneSnapshotResponse,
-    ControlPlaneStateVersion, ProtocolRouter,
+    ControlPlaneStateVersion, ControlPlaneTurnEventEnvelope, ControlPlaneTurnResultResponse,
+    ControlPlaneTurnStatus, ControlPlaneTurnSubmitRequest, ControlPlaneTurnSubmitResponse,
+    ControlPlaneTurnSummary, ProtocolRouter,
 };
 use serde::Deserialize;
 
@@ -107,6 +109,7 @@ struct ControlPlaneHttpState {
     repository_view: Option<Arc<mvp::control_plane::ControlPlaneRepositoryView>>,
     #[cfg(feature = "memory-sqlite")]
     acp_view: Option<Arc<mvp::control_plane::ControlPlaneAcpView>>,
+    turn_runtime: Option<Arc<ControlPlaneTurnRuntime>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -177,12 +180,44 @@ struct SubscribeQuery {
     include_targeted: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct TurnResultQuery {
+    turn_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TurnStreamQuery {
+    turn_id: String,
+    #[serde(default)]
+    after_seq: Option<u64>,
+}
+
 struct ControlPlaneSubscribeStreamState {
     manager: Arc<mvp::control_plane::ControlPlaneManager>,
     pending_events: VecDeque<mvp::control_plane::ControlPlaneEventRecord>,
     receiver: tokio::sync::broadcast::Receiver<mvp::control_plane::ControlPlaneEventRecord>,
     last_seq: u64,
     include_targeted: bool,
+}
+
+struct ControlPlaneTurnStreamState {
+    turn_id: String,
+    registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
+    pending_events: VecDeque<mvp::control_plane::ControlPlaneTurnEventRecord>,
+    receiver: tokio::sync::broadcast::Receiver<mvp::control_plane::ControlPlaneTurnEventRecord>,
+    last_seq: u64,
+}
+
+struct ControlPlaneTurnRuntime {
+    config: mvp::config::LoongClawConfig,
+    acp_manager: Arc<mvp::acp::AcpSessionManager>,
+    registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
+}
+
+struct ControlPlaneTurnEventForwarder {
+    manager: Arc<mvp::control_plane::ControlPlaneManager>,
+    registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
+    turn_id: String,
 }
 
 impl ControlPlaneKernelAuthority {
@@ -748,6 +783,14 @@ fn parse_pairing_status(
     }
 }
 
+fn normalize_required_text(value: &str, field_name: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{field_name} is required"));
+    }
+    Ok(trimmed.to_owned())
+}
+
 fn initial_subscribe_state(
     manager: Arc<mvp::control_plane::ControlPlaneManager>,
     after_seq: u64,
@@ -844,6 +887,236 @@ fn control_plane_subscribe_stream(
 ) -> impl Stream<Item = Result<Event, Infallible>> {
     let initial_state = initial_subscribe_state(manager, after_seq, include_targeted);
     stream::unfold(initial_state, next_control_plane_sse_item)
+}
+
+impl ControlPlaneTurnRuntime {
+    fn new(config: mvp::config::LoongClawConfig) -> Result<Self, String> {
+        let acp_manager = mvp::acp::shared_acp_session_manager(&config)?;
+        Ok(Self::with_manager(config, acp_manager))
+    }
+
+    fn with_manager(
+        config: mvp::config::LoongClawConfig,
+        acp_manager: Arc<mvp::acp::AcpSessionManager>,
+    ) -> Self {
+        Self {
+            config,
+            acp_manager,
+            registry: Arc::new(mvp::control_plane::ControlPlaneTurnRegistry::new()),
+        }
+    }
+}
+
+impl mvp::acp::AcpTurnEventSink for ControlPlaneTurnEventForwarder {
+    fn on_event(&self, event: &serde_json::Value) -> CliResult<()> {
+        let recorded_event = self
+            .registry
+            .record_runtime_event(self.turn_id.as_str(), event.clone())?;
+        let payload = map_turn_event_payload(&recorded_event);
+        let _ = self.manager.record_acp_turn_event(payload, true);
+        Ok(())
+    }
+}
+
+fn extend_turn_metadata(
+    target: &mut std::collections::BTreeMap<String, String>,
+    extra: &std::collections::BTreeMap<String, String>,
+) {
+    for (key, value) in extra {
+        let normalized_key = key.trim();
+        let normalized_value = value.trim();
+        if normalized_key.is_empty() {
+            continue;
+        }
+        if normalized_value.is_empty() {
+            continue;
+        }
+
+        let normalized_key = normalized_key.to_owned();
+        let normalized_value = normalized_value.to_owned();
+        target.entry(normalized_key).or_insert(normalized_value);
+    }
+}
+
+fn map_turn_status(status: mvp::control_plane::ControlPlaneTurnStatus) -> ControlPlaneTurnStatus {
+    match status {
+        mvp::control_plane::ControlPlaneTurnStatus::Running => ControlPlaneTurnStatus::Running,
+        mvp::control_plane::ControlPlaneTurnStatus::Completed => ControlPlaneTurnStatus::Completed,
+        mvp::control_plane::ControlPlaneTurnStatus::Failed => ControlPlaneTurnStatus::Failed,
+        mvp::control_plane::ControlPlaneTurnStatus::Cancelled => ControlPlaneTurnStatus::Cancelled,
+    }
+}
+
+fn map_turn_summary(
+    snapshot: &mvp::control_plane::ControlPlaneTurnSnapshot,
+) -> ControlPlaneTurnSummary {
+    ControlPlaneTurnSummary {
+        turn_id: snapshot.turn_id.clone(),
+        session_id: snapshot.session_id.clone(),
+        status: map_turn_status(snapshot.status),
+        submitted_at_ms: snapshot.submitted_at_ms,
+        completed_at_ms: snapshot.completed_at_ms,
+        event_count: snapshot.event_count,
+    }
+}
+
+fn map_turn_result(
+    snapshot: &mvp::control_plane::ControlPlaneTurnSnapshot,
+) -> ControlPlaneTurnResultResponse {
+    ControlPlaneTurnResultResponse {
+        turn: map_turn_summary(snapshot),
+        output_text: snapshot.output_text.clone(),
+        stop_reason: snapshot.stop_reason.clone(),
+        usage: snapshot.usage.clone(),
+        error: snapshot.error.clone(),
+    }
+}
+
+fn map_turn_event_payload(
+    record: &mvp::control_plane::ControlPlaneTurnEventRecord,
+) -> serde_json::Value {
+    serde_json::json!({
+        "turn_id": record.turn_id,
+        "session_id": record.session_id,
+        "seq": record.seq,
+        "terminal": record.terminal,
+        "payload": record.payload,
+    })
+}
+
+fn map_turn_event(
+    record: mvp::control_plane::ControlPlaneTurnEventRecord,
+) -> ControlPlaneTurnEventEnvelope {
+    ControlPlaneTurnEventEnvelope {
+        turn_id: record.turn_id,
+        session_id: record.session_id,
+        seq: record.seq,
+        terminal: record.terminal,
+        payload: record.payload,
+    }
+}
+
+fn sse_event_from_turn_record(
+    record: mvp::control_plane::ControlPlaneTurnEventRecord,
+) -> Result<Event, String> {
+    let seq = record.seq;
+    let terminal = record.terminal;
+    let envelope = map_turn_event(record);
+    let event_name = if terminal {
+        "turn.terminal"
+    } else {
+        "turn.event"
+    };
+    let event_id = seq.to_string();
+    let base_event = Event::default();
+    let named_event = base_event.event(event_name);
+    let identified_event = named_event.id(event_id);
+    identified_event
+        .json_data(&envelope)
+        .map_err(|error| format!("control-plane turn SSE event encoding failed: {error}"))
+}
+
+fn fallback_turn_sse_error_event(message: &str) -> Event {
+    let error_message = format!("{{\"error\":\"{message}\"}}");
+    let base_event = Event::default();
+    let named_event = base_event.event("turn.error");
+    named_event.data(error_message)
+}
+
+fn initial_turn_stream_state(
+    registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
+    turn_id: &str,
+    after_seq: u64,
+) -> Result<ControlPlaneTurnStreamState, String> {
+    let receiver = registry.subscribe();
+    let pending_events =
+        registry.recent_events_after(turn_id, after_seq, CONTROL_PLANE_DEFAULT_EVENT_LIMIT)?;
+    let pending_events = VecDeque::from(pending_events);
+    Ok(ControlPlaneTurnStreamState {
+        turn_id: turn_id.to_owned(),
+        registry,
+        pending_events,
+        receiver,
+        last_seq: after_seq,
+    })
+}
+
+async fn next_turn_sse_item(
+    mut state: ControlPlaneTurnStreamState,
+) -> Option<(Result<Event, Infallible>, ControlPlaneTurnStreamState)> {
+    loop {
+        let pending_event = state.pending_events.pop_front();
+        if let Some(record) = pending_event {
+            let terminal = record.terminal;
+            state.last_seq = record.seq;
+            let event = match sse_event_from_turn_record(record) {
+                Ok(event) => event,
+                Err(error) => fallback_turn_sse_error_event(error.as_str()),
+            };
+            if terminal {
+                return Some((Ok(event), state));
+            }
+            return Some((Ok(event), state));
+        }
+
+        let snapshot_result = state.registry.read_turn(state.turn_id.as_str());
+        let snapshot_result = snapshot_result.ok().flatten();
+        if let Some(snapshot) = snapshot_result
+            && snapshot.status.is_terminal()
+        {
+            return None;
+        }
+
+        let receive_result = state.receiver.recv().await;
+        match receive_result {
+            Ok(record) => {
+                if record.turn_id != state.turn_id {
+                    continue;
+                }
+                if record.seq <= state.last_seq {
+                    continue;
+                }
+                let terminal = record.terminal;
+                state.last_seq = record.seq;
+                let event = match sse_event_from_turn_record(record) {
+                    Ok(event) => event,
+                    Err(error) => fallback_turn_sse_error_event(error.as_str()),
+                };
+                if terminal {
+                    return Some((Ok(event), state));
+                }
+                return Some((Ok(event), state));
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                let refill_result = state.registry.recent_events_after(
+                    state.turn_id.as_str(),
+                    state.last_seq,
+                    CONTROL_PLANE_DEFAULT_EVENT_LIMIT,
+                );
+                let refill = refill_result.unwrap_or_default();
+                state.pending_events = VecDeque::from(refill);
+                continue;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}
+
+fn control_plane_turn_stream(
+    registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
+    turn_id: String,
+    after_seq: u64,
+) -> Result<impl Stream<Item = Result<Event, Infallible>>, String> {
+    let initial_state = initial_turn_stream_state(registry, turn_id.as_str(), after_seq)?;
+    Ok(stream::unfold(initial_state, next_turn_sse_item))
+}
+
+fn stop_reason_label(stop_reason: Option<mvp::acp::AcpTurnStopReason>) -> Option<&'static str> {
+    match stop_reason {
+        Some(mvp::acp::AcpTurnStopReason::Completed) => Some("completed"),
+        Some(mvp::acp::AcpTurnStopReason::Cancelled) => Some("cancelled"),
+        None => None,
+    }
 }
 
 fn connection_principal_from_connect(
@@ -1797,11 +2070,214 @@ async fn acp_session_read(
     }
 }
 
+async fn turn_submit(
+    headers: HeaderMap,
+    State(state): State<ControlPlaneHttpState>,
+    Json(request): Json<ControlPlaneTurnSubmitRequest>,
+) -> Response {
+    if let Err(response) = authorize_control_plane_request(&state, "turn/submit", &headers) {
+        return *response;
+    }
+
+    let Some(turn_runtime) = state.turn_runtime.as_ref() else {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "turn/submit requires control-plane-serve --config <path>",
+        );
+    };
+
+    if !turn_runtime.config.acp.enabled {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "turn/submit requires ACP to be enabled (`acp.enabled=true`)",
+        );
+    }
+
+    let session_id = match normalize_required_text(request.session_id.as_str(), "session_id") {
+        Ok(session_id) => session_id,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+    let input = match normalize_required_text(request.input.as_str(), "input") {
+        Ok(input) => input,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+
+    let turn_address = match crate::build_acp_dispatch_address(
+        session_id.as_str(),
+        request.channel_id.as_deref(),
+        request.conversation_id.as_deref(),
+        request.account_id.as_deref(),
+        request.thread_id.as_deref(),
+    ) {
+        Ok(turn_address) => turn_address,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+
+    let working_directory = request
+        .working_directory
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from);
+    let turn_options = mvp::acp::AcpConversationTurnOptions::explicit();
+    let turn_options = turn_options.with_working_directory(working_directory.as_deref());
+    let prepared_turn = mvp::acp::prepare_acp_conversation_turn_for_address(
+        &turn_runtime.config,
+        &turn_address,
+        input.as_str(),
+        &turn_options,
+    );
+    let prepared_turn = match prepared_turn {
+        Ok(prepared_turn) => prepared_turn,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+
+    let turn_snapshot = turn_runtime.registry.issue_turn(session_id.as_str());
+    let turn_id = turn_snapshot.turn_id.clone();
+    let mut bootstrap = prepared_turn.bootstrap;
+    let mut acp_request = prepared_turn.request;
+    extend_turn_metadata(&mut bootstrap.metadata, &request.metadata);
+    extend_turn_metadata(&mut acp_request.metadata, &request.metadata);
+    acp_request
+        .metadata
+        .insert("control_plane.turn_id".to_owned(), turn_id.clone());
+
+    let config = turn_runtime.config.clone();
+    let acp_manager = turn_runtime.acp_manager.clone();
+    let turn_registry = turn_runtime.registry.clone();
+    let manager = state.manager.clone();
+    let spawned_turn_id = turn_id;
+
+    tokio::spawn(async move {
+        let event_forwarder = ControlPlaneTurnEventForwarder {
+            manager: manager.clone(),
+            registry: turn_registry.clone(),
+            turn_id: spawned_turn_id.clone(),
+        };
+        let execution_result = acp_manager
+            .run_turn_with_sink(&config, &bootstrap, &acp_request, Some(&event_forwarder))
+            .await;
+
+        match execution_result {
+            Ok(result) => {
+                let stop_reason = stop_reason_label(result.stop_reason);
+                let completion = turn_registry.complete_success(
+                    spawned_turn_id.as_str(),
+                    result.output_text.as_str(),
+                    stop_reason,
+                    result.usage.clone(),
+                );
+                if let Ok(record) = completion {
+                    let payload = map_turn_event_payload(&record);
+                    let _ = manager.record_acp_turn_event(payload, true);
+                }
+            }
+            Err(error) => {
+                let completion = turn_registry.complete_failure(spawned_turn_id.as_str(), &error);
+                if let Ok(record) = completion {
+                    let payload = map_turn_event_payload(&record);
+                    let _ = manager.record_acp_turn_event(payload, true);
+                }
+            }
+        }
+    });
+
+    let response = ControlPlaneTurnSubmitResponse {
+        turn: map_turn_summary(&turn_snapshot),
+    };
+    (StatusCode::ACCEPTED, Json(response)).into_response()
+}
+
+async fn turn_result(
+    headers: HeaderMap,
+    State(state): State<ControlPlaneHttpState>,
+    Query(query): Query<TurnResultQuery>,
+) -> Response {
+    if let Err(response) = authorize_control_plane_request(&state, "turn/result", &headers) {
+        return *response;
+    }
+
+    let Some(turn_runtime) = state.turn_runtime.as_ref() else {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "turn/result requires control-plane-serve --config <path>",
+        );
+    };
+
+    let turn_id = match normalize_required_text(query.turn_id.as_str(), "turn_id") {
+        Ok(turn_id) => turn_id,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+
+    let snapshot = match turn_runtime.registry.read_turn(turn_id.as_str()) {
+        Ok(Some(snapshot)) => snapshot,
+        Ok(None) => {
+            let message = format!("turn `{}` not found", turn_id);
+            return error_response(StatusCode::NOT_FOUND, message);
+        }
+        Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
+    };
+
+    Json(map_turn_result(&snapshot)).into_response()
+}
+
+async fn turn_stream(
+    headers: HeaderMap,
+    State(state): State<ControlPlaneHttpState>,
+    Query(query): Query<TurnStreamQuery>,
+) -> Response {
+    if let Err(response) = authorize_control_plane_request(&state, "turn/stream", &headers) {
+        return *response;
+    }
+
+    let Some(turn_runtime) = state.turn_runtime.as_ref() else {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "turn/stream requires control-plane-serve --config <path>",
+        );
+    };
+
+    let turn_id = match normalize_required_text(query.turn_id.as_str(), "turn_id") {
+        Ok(turn_id) => turn_id,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+
+    let snapshot = match turn_runtime.registry.read_turn(turn_id.as_str()) {
+        Ok(Some(snapshot)) => snapshot,
+        Ok(None) => {
+            let message = format!("turn `{}` not found", turn_id);
+            return error_response(StatusCode::NOT_FOUND, message);
+        }
+        Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
+    };
+    if snapshot.status.is_terminal() && snapshot.event_count == 0 {
+        return error_response(
+            StatusCode::CONFLICT,
+            format!("turn `{}` completed without any streamable events", turn_id),
+        );
+    }
+
+    let after_seq = query.after_seq.unwrap_or(0);
+    let stream_result =
+        control_plane_turn_stream(turn_runtime.registry.clone(), turn_id, after_seq);
+    let stream = match stream_result {
+        Ok(stream) => stream,
+        Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
+    };
+    let keep_alive = KeepAlive::new()
+        .interval(std::time::Duration::from_millis(
+            CONTROL_PLANE_TICK_INTERVAL_MS,
+        ))
+        .text(CONTROL_PLANE_KEEPALIVE_TEXT);
+    Sse::new(stream).keep_alive(keep_alive).into_response()
+}
+
 #[cfg(feature = "memory-sqlite")]
 fn build_control_plane_router_with_runtime(
     manager: Arc<mvp::control_plane::ControlPlaneManager>,
     repository_view: Option<Arc<mvp::control_plane::ControlPlaneRepositoryView>>,
     acp_view: Option<Arc<mvp::control_plane::ControlPlaneAcpView>>,
+    turn_runtime: Option<Arc<ControlPlaneTurnRuntime>>,
     pairing_registry: Arc<mvp::control_plane::ControlPlanePairingRegistry>,
     exposure_policy: ControlPlaneExposurePolicy,
 ) -> Result<Router, String> {
@@ -1816,6 +2292,7 @@ fn build_control_plane_router_with_runtime(
         exposure_policy: Arc::new(exposure_policy),
         repository_view,
         acp_view,
+        turn_runtime,
     };
 
     let router = Router::new()
@@ -1829,6 +2306,9 @@ fn build_control_plane_router_with_runtime(
         .route("/control/events", get(control_events))
         .route("/session/list", get(session_list))
         .route("/session/read", get(session_read))
+        .route("/turn/submit", post(turn_submit))
+        .route("/turn/result", get(turn_result))
+        .route("/turn/stream", get(turn_stream))
         .route("/approval/list", get(approval_list))
         .route("/pairing/list", get(pairing_list))
         .route("/pairing/resolve", post(pairing_resolve))
@@ -1850,6 +2330,7 @@ fn build_control_plane_router_with_views(
         manager,
         repository_view,
         acp_view,
+        None,
         pairing_registry,
         exposure_policy,
     )
@@ -1869,6 +2350,7 @@ fn build_control_plane_router_without_repository(
         pairing_registry: Arc::new(mvp::control_plane::ControlPlanePairingRegistry::new()),
         kernel_authority,
         exposure_policy: Arc::new(exposure_policy),
+        turn_runtime: None,
     };
 
     let router = Router::new()
@@ -1882,6 +2364,9 @@ fn build_control_plane_router_without_repository(
         .route("/control/events", get(control_events))
         .route("/session/list", get(session_list))
         .route("/session/read", get(session_read))
+        .route("/turn/submit", post(turn_submit))
+        .route("/turn/result", get(turn_result))
+        .route("/turn/stream", get(turn_stream))
         .route("/approval/list", get(approval_list))
         .route("/pairing/list", get(pairing_list))
         .route("/pairing/resolve", post(pairing_resolve))
@@ -1928,6 +2413,10 @@ pub async fn run_control_plane_serve_cli(
     )?;
     let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
     manager.set_runtime_ready(true);
+    let turn_runtime = match loaded_config.as_ref() {
+        Some((_, config)) => Some(Arc::new(ControlPlaneTurnRuntime::new(config.clone())?)),
+        None => None,
+    };
     #[cfg(feature = "memory-sqlite")]
     let (repository_view, acp_view) = match loaded_config.as_ref() {
         Some((resolved_path, config)) => {
@@ -1973,6 +2462,7 @@ pub async fn run_control_plane_serve_cli(
         manager,
         repository_view,
         acp_view,
+        turn_runtime,
         pairing_registry,
         exposure_policy,
     )?;
@@ -2011,6 +2501,212 @@ mod tests {
             .expect("router")
     }
 
+    fn build_control_plane_router_with_turn_runtime(
+        manager: Arc<mvp::control_plane::ControlPlaneManager>,
+        turn_runtime: Arc<ControlPlaneTurnRuntime>,
+    ) -> Router {
+        let pairing_registry = Arc::new(mvp::control_plane::ControlPlanePairingRegistry::new());
+        let exposure_policy = default_loopback_exposure_policy();
+        super::build_control_plane_router_with_runtime(
+            manager,
+            None,
+            None,
+            Some(turn_runtime),
+            pairing_registry,
+            exposure_policy,
+        )
+        .expect("router")
+    }
+
+    #[derive(Default)]
+    struct TestTurnBackendState {
+        sink_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    struct TestTurnBackend {
+        id: &'static str,
+        state: Arc<TestTurnBackendState>,
+    }
+
+    impl mvp::acp::AcpRuntimeBackend for TestTurnBackend {
+        fn id(&self) -> &'static str {
+            self.id
+        }
+
+        fn metadata(&self) -> mvp::acp::AcpBackendMetadata {
+            mvp::acp::AcpBackendMetadata::new(
+                self.id(),
+                [
+                    mvp::acp::AcpCapability::SessionLifecycle,
+                    mvp::acp::AcpCapability::TurnExecution,
+                    mvp::acp::AcpCapability::TurnEventStreaming,
+                ],
+                "Control-plane turn backend for daemon tests",
+            )
+        }
+
+        fn ensure_session<'life0, 'life1, 'life2, 'async_trait>(
+            &'life0 self,
+            _config: &'life1 mvp::config::LoongClawConfig,
+            request: &'life2 mvp::acp::AcpSessionBootstrap,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = CliResult<mvp::acp::AcpSessionHandle>>
+                    + Send
+                    + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                Ok(mvp::acp::AcpSessionHandle {
+                    session_key: request.session_key.clone(),
+                    backend_id: self.id().to_owned(),
+                    runtime_session_name: format!("test-runtime-{}", request.session_key),
+                    working_directory: request.working_directory.clone(),
+                    backend_session_id: Some(format!("backend-{}", request.session_key)),
+                    agent_session_id: Some(format!("agent-{}", request.session_key)),
+                    binding: request.binding.clone(),
+                })
+            })
+        }
+
+        fn run_turn<'life0, 'life1, 'life2, 'life3, 'async_trait>(
+            &'life0 self,
+            _config: &'life1 mvp::config::LoongClawConfig,
+            _session: &'life2 mvp::acp::AcpSessionHandle,
+            request: &'life3 mvp::acp::AcpTurnRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = CliResult<mvp::acp::AcpTurnResult>>
+                    + Send
+                    + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            'life3: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                Ok(mvp::acp::AcpTurnResult {
+                    output_text: format!("echo: {}", request.input),
+                    state: mvp::acp::AcpSessionState::Ready,
+                    usage: None,
+                    events: Vec::new(),
+                    stop_reason: Some(mvp::acp::AcpTurnStopReason::Completed),
+                })
+            })
+        }
+
+        fn run_turn_with_sink<'life0, 'life1, 'life2, 'life3, 'life5, 'async_trait>(
+            &'life0 self,
+            _config: &'life1 mvp::config::LoongClawConfig,
+            _session: &'life2 mvp::acp::AcpSessionHandle,
+            request: &'life3 mvp::acp::AcpTurnRequest,
+            _abort: Option<mvp::acp::AcpAbortSignal>,
+            sink: Option<&'life5 dyn mvp::acp::AcpTurnEventSink>,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = CliResult<mvp::acp::AcpTurnResult>>
+                    + Send
+                    + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            'life3: 'async_trait,
+            'life5: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let Some(sink) = sink {
+                    sink.on_event(&serde_json::json!({
+                        "type": "text",
+                        "content": format!("chunk:{}", request.input),
+                    }))?;
+                    sink.on_event(&serde_json::json!({
+                        "type": "done",
+                        "stopReason": "completed",
+                    }))?;
+                }
+                self.state
+                    .sink_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(mvp::acp::AcpTurnResult {
+                    output_text: format!("streamed: {}", request.input),
+                    state: mvp::acp::AcpSessionState::Ready,
+                    usage: Some(serde_json::json!({
+                        "total_tokens": 7
+                    })),
+                    events: Vec::new(),
+                    stop_reason: Some(mvp::acp::AcpTurnStopReason::Completed),
+                })
+            })
+        }
+
+        fn cancel<'life0, 'life1, 'life2, 'async_trait>(
+            &'life0 self,
+            _config: &'life1 mvp::config::LoongClawConfig,
+            _session: &'life2 mvp::acp::AcpSessionHandle,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<()>> + Send + 'async_trait>>
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn close<'life0, 'life1, 'life2, 'async_trait>(
+            &'life0 self,
+            _config: &'life1 mvp::config::LoongClawConfig,
+            _session: &'life2 mvp::acp::AcpSessionHandle,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<()>> + Send + 'async_trait>>
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move { Ok(()) })
+        }
+    }
+
+    fn turn_runtime_test_config(backend_id: &str) -> mvp::config::LoongClawConfig {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.acp.enabled = true;
+        config.acp.backend = Some(backend_id.to_owned());
+        config
+    }
+
+    fn seeded_turn_runtime(
+        backend_id: &'static str,
+        state: Arc<TestTurnBackendState>,
+    ) -> Arc<ControlPlaneTurnRuntime> {
+        mvp::acp::register_acp_backend(backend_id, {
+            move || {
+                Box::new(TestTurnBackend {
+                    id: backend_id,
+                    state: state.clone(),
+                })
+            }
+        })
+        .expect("register control-plane turn backend");
+        let config = turn_runtime_test_config(backend_id);
+        let acp_manager = Arc::new(mvp::acp::AcpSessionManager::default());
+        Arc::new(ControlPlaneTurnRuntime::with_manager(config, acp_manager))
+    }
+
     fn remote_control_plane_config(shared_token: &str) -> mvp::config::LoongClawConfig {
         let mut config = mvp::config::LoongClawConfig::default();
         config.control_plane.allow_remote = true;
@@ -2033,6 +2729,7 @@ mod tests {
         let pairing_registry = Arc::new(mvp::control_plane::ControlPlanePairingRegistry::new());
         super::build_control_plane_router_with_runtime(
             manager,
+            None,
             None,
             None,
             pairing_registry,
@@ -3764,6 +4461,260 @@ mod tests {
             .await
             .expect("snapshot response");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn turn_submit_returns_service_unavailable_without_runtime() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let router = build_control_plane_router(manager);
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorAdmin]),
+        )
+        .await;
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "session-1".to_owned(),
+            input: "hello".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn turn_submit_rejects_insufficient_scope() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str =
+            Box::leak(format!("control-plane-turn-scope-{}", current_time_ms()).into_boxed_str());
+        let turn_runtime = seeded_turn_runtime(backend_id, state);
+        let router = build_control_plane_router_with_turn_runtime(manager, turn_runtime);
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        )
+        .await;
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "session-1".to_owned(),
+            input: "hello".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn turn_submit_and_result_fetch_complete_with_streamed_backend() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str =
+            Box::leak(format!("control-plane-turn-success-{}", current_time_ms()).into_boxed_str());
+        let turn_runtime = seeded_turn_runtime(backend_id, state.clone());
+        let router = build_control_plane_router_with_turn_runtime(manager, turn_runtime);
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorAdmin]),
+        )
+        .await;
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "session-1".to_owned(),
+            input: "hello".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let submit_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        assert_eq!(submit_response.status(), StatusCode::ACCEPTED);
+        let submit_body = to_bytes(submit_response.into_body(), usize::MAX)
+            .await
+            .expect("submit body");
+        let submit: ControlPlaneTurnSubmitResponse =
+            serde_json::from_slice(&submit_body).expect("submit json");
+        assert_eq!(submit.turn.status, ControlPlaneTurnStatus::Running);
+
+        let turn_id = submit.turn.turn_id.clone();
+        let mut final_result = None;
+        for _ in 0..20 {
+            let result_response = router
+                .clone()
+                .oneshot(bearer_request(
+                    "GET",
+                    format!("/turn/result?turn_id={turn_id}").as_str(),
+                    &token,
+                ))
+                .await
+                .expect("turn result response");
+            assert_eq!(result_response.status(), StatusCode::OK);
+            let result_body = to_bytes(result_response.into_body(), usize::MAX)
+                .await
+                .expect("result body");
+            let result: ControlPlaneTurnResultResponse =
+                serde_json::from_slice(&result_body).expect("result json");
+            if result.turn.status.is_terminal() {
+                final_result = Some(result);
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        let final_result = final_result.expect("turn should reach a terminal state");
+        assert_eq!(final_result.turn.status, ControlPlaneTurnStatus::Completed);
+        assert_eq!(final_result.output_text.as_deref(), Some("streamed: hello"));
+        assert_eq!(final_result.stop_reason.as_deref(), Some("completed"));
+        assert_eq!(
+            final_result
+                .usage
+                .as_ref()
+                .and_then(|usage| usage.get("total_tokens")),
+            Some(&serde_json::json!(7))
+        );
+        assert!(
+            final_result.turn.event_count >= 3,
+            "expected runtime events plus terminal event"
+        );
+        assert_eq!(
+            state.sink_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_stream_replays_buffered_runtime_and_terminal_events() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str =
+            Box::leak(format!("control-plane-turn-stream-{}", current_time_ms()).into_boxed_str());
+        let turn_runtime = seeded_turn_runtime(backend_id, state);
+        let router = build_control_plane_router_with_turn_runtime(manager, turn_runtime);
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorAdmin]),
+        )
+        .await;
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "session-stream".to_owned(),
+            input: "stream me".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let submit_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        let submit_body = to_bytes(submit_response.into_body(), usize::MAX)
+            .await
+            .expect("submit body");
+        let submit: ControlPlaneTurnSubmitResponse =
+            serde_json::from_slice(&submit_body).expect("submit json");
+        let turn_id = submit.turn.turn_id;
+
+        for _ in 0..20 {
+            let result_response = router
+                .clone()
+                .oneshot(bearer_request(
+                    "GET",
+                    format!("/turn/result?turn_id={turn_id}").as_str(),
+                    &token,
+                ))
+                .await
+                .expect("turn result response");
+            let result_body = to_bytes(result_response.into_body(), usize::MAX)
+                .await
+                .expect("result body");
+            let result: ControlPlaneTurnResultResponse =
+                serde_json::from_slice(&result_body).expect("result json");
+            if result.turn.status.is_terminal() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        let stream_response = router
+            .oneshot(bearer_request(
+                "GET",
+                format!("/turn/stream?turn_id={turn_id}").as_str(),
+                &token,
+            ))
+            .await
+            .expect("turn stream response");
+        assert_eq!(stream_response.status(), StatusCode::OK);
+        let stream_body = to_bytes(stream_response.into_body(), usize::MAX)
+            .await
+            .expect("stream body");
+        let stream_text = String::from_utf8(stream_body.to_vec()).expect("utf8 stream body");
+        assert!(stream_text.contains("event: turn.event"));
+        assert!(stream_text.contains("event: turn.terminal"));
+        assert!(stream_text.contains("\"type\":\"text\""));
+        assert!(stream_text.contains("chunk:stream me"));
+        assert!(stream_text.contains("\"event_type\":\"turn.completed\""));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -1081,15 +1081,11 @@ async fn next_turn_sse_item(
     loop {
         let pending_event = state.pending_events.pop_front();
         if let Some(record) = pending_event {
-            let terminal = record.terminal;
             state.last_seq = record.seq;
             let event = match sse_event_from_turn_record(record) {
                 Ok(event) => event,
                 Err(error) => fallback_turn_sse_error_event(error.as_str()),
             };
-            if terminal {
-                return Some((Ok(event), state));
-            }
             return Some((Ok(event), state));
         }
 
@@ -1110,15 +1106,11 @@ async fn next_turn_sse_item(
                 if record.seq <= state.last_seq {
                     continue;
                 }
-                let terminal = record.terminal;
                 state.last_seq = record.seq;
                 let event = match sse_event_from_turn_record(record) {
                     Ok(event) => event,
                     Err(error) => fallback_turn_sse_error_event(error.as_str()),
                 };
-                if terminal {
-                    return Some((Ok(event), state));
-                }
                 return Some((Ok(event), state));
             }
             Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -791,6 +791,40 @@ fn normalize_required_text(value: &str, field_name: &str) -> Result<String, Stri
     Ok(trimmed.to_owned())
 }
 
+fn require_nonempty_text(value: &str, field_name: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{field_name} is required"));
+    }
+    Ok(value.to_owned())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_turn_session_visible(
+    state: &ControlPlaneHttpState,
+    session_id: &str,
+) -> Option<Response> {
+    let repository_view = state.repository_view.as_ref()?;
+    match repository_view.ensure_visible_session_id(session_id) {
+        Ok(()) => None,
+        Err(error) if error == "control_plane_session_id_missing" => {
+            Some(error_response(StatusCode::BAD_REQUEST, error))
+        }
+        Err(error) if error.starts_with("visibility_denied:") => {
+            Some(error_response(StatusCode::FORBIDDEN, error))
+        }
+        Err(error) => Some(error_response(StatusCode::INTERNAL_SERVER_ERROR, error)),
+    }
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+fn ensure_turn_session_visible(
+    _state: &ControlPlaneHttpState,
+    _session_id: &str,
+) -> Option<Response> {
+    None
+}
+
 fn initial_subscribe_state(
     manager: Arc<mvp::control_plane::ControlPlaneManager>,
     after_seq: u64,
@@ -2097,7 +2131,10 @@ async fn turn_submit(
         Ok(session_id) => session_id,
         Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
     };
-    let input = match normalize_required_text(request.input.as_str(), "input") {
+    if let Some(response) = ensure_turn_session_visible(&state, session_id.as_str()) {
+        return response;
+    }
+    let input = match require_nonempty_text(request.input.as_str(), "input") {
         Ok(input) => input,
         Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
     };
@@ -2217,6 +2254,9 @@ async fn turn_result(
         }
         Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
     };
+    if let Some(response) = ensure_turn_session_visible(&state, snapshot.session_id.as_str()) {
+        return response;
+    }
 
     Json(map_turn_result(&snapshot)).into_response()
 }
@@ -2250,6 +2290,9 @@ async fn turn_stream(
         }
         Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
     };
+    if let Some(response) = ensure_turn_session_visible(&state, snapshot.session_id.as_str()) {
+        return response;
+    }
     if snapshot.status.is_terminal() && snapshot.event_count == 0 {
         return error_response(
             StatusCode::CONFLICT,
@@ -2511,6 +2554,26 @@ mod tests {
             manager,
             None,
             None,
+            Some(turn_runtime),
+            pairing_registry,
+            exposure_policy,
+        )
+        .expect("router")
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn build_control_plane_router_with_turn_runtime_and_views(
+        manager: Arc<mvp::control_plane::ControlPlaneManager>,
+        repository_view: Arc<mvp::control_plane::ControlPlaneRepositoryView>,
+        acp_view: Arc<mvp::control_plane::ControlPlaneAcpView>,
+        turn_runtime: Arc<ControlPlaneTurnRuntime>,
+    ) -> Router {
+        let pairing_registry = Arc::new(mvp::control_plane::ControlPlanePairingRegistry::new());
+        let exposure_policy = default_loopback_exposure_policy();
+        super::build_control_plane_router_with_runtime(
+            manager,
+            Some(repository_view),
+            Some(acp_view),
             Some(turn_runtime),
             pairing_registry,
             exposure_policy,
@@ -4539,6 +4602,97 @@ mod tests {
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn turn_submit_rejects_hidden_session_visibility() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let backend_state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str =
+            Box::leak(format!("control-plane-turn-hidden-{}", current_time_ms()).into_boxed_str());
+        let turn_runtime = seeded_turn_runtime(backend_id, backend_state);
+        let (repository_view, acp_view) = seeded_control_plane_views("turn-hidden-session");
+        let router = build_control_plane_router_with_turn_runtime_and_views(
+            manager,
+            repository_view,
+            acp_view,
+            turn_runtime,
+        );
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorAdmin]),
+        )
+        .await;
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "hidden-root".to_owned(),
+            input: "hello".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn turn_result_and_stream_reject_hidden_session_visibility() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let backend_state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str = Box::leak(
+            format!("control-plane-turn-hidden-result-{}", current_time_ms()).into_boxed_str(),
+        );
+        let turn_runtime = seeded_turn_runtime(backend_id, backend_state);
+        let turn_snapshot = turn_runtime.registry.issue_turn("hidden-root");
+        let turn_id = turn_snapshot.turn_id.clone();
+        let (repository_view, acp_view) = seeded_control_plane_views("turn-hidden-result");
+        let result_router = build_control_plane_router_with_turn_runtime_and_views(
+            manager,
+            repository_view,
+            acp_view,
+            turn_runtime.clone(),
+        );
+        let token = connect_token(
+            &result_router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        )
+        .await;
+        let result_response = result_router
+            .clone()
+            .oneshot(bearer_request(
+                "GET",
+                format!("/turn/result?turn_id={turn_id}").as_str(),
+                &token,
+            ))
+            .await
+            .expect("turn result response");
+        assert_eq!(result_response.status(), StatusCode::FORBIDDEN);
+        let stream_response = result_router
+            .oneshot(bearer_request(
+                "GET",
+                format!("/turn/stream?turn_id={turn_id}").as_str(),
+                &token,
+            ))
+            .await
+            .expect("turn stream response");
+        assert_eq!(stream_response.status(), StatusCode::FORBIDDEN);
+    }
+
     #[tokio::test]
     async fn turn_submit_and_result_fetch_complete_with_streamed_backend() {
         let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
@@ -4740,6 +4894,83 @@ mod tests {
             .await
             .expect("approval list response");
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn turn_submit_preserves_input_whitespace() {
+        let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
+        let state = Arc::new(TestTurnBackendState::default());
+        let backend_id: &'static str = Box::leak(
+            format!("control-plane-turn-whitespace-{}", current_time_ms()).into_boxed_str(),
+        );
+        let turn_runtime = seeded_turn_runtime(backend_id, state);
+        let router = build_control_plane_router_with_turn_runtime(manager, turn_runtime);
+        let token = connect_token(
+            &router,
+            std::collections::BTreeSet::from([ControlPlaneScope::OperatorAdmin]),
+        )
+        .await;
+        let input = "  hello\n\n```rust\nfn main() {}\n```\n".to_owned();
+        let request = ControlPlaneTurnSubmitRequest {
+            session_id: "session-whitespace".to_owned(),
+            input: input.clone(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        let submit_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/turn/submit")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode turn submit request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("turn submit response");
+        assert_eq!(submit_response.status(), StatusCode::ACCEPTED);
+        let submit_body = to_bytes(submit_response.into_body(), usize::MAX)
+            .await
+            .expect("submit body");
+        let submit: ControlPlaneTurnSubmitResponse =
+            serde_json::from_slice(&submit_body).expect("submit json");
+        let turn_id = submit.turn.turn_id;
+        let mut final_result = None;
+        for _ in 0..20 {
+            let result_response = router
+                .clone()
+                .oneshot(bearer_request(
+                    "GET",
+                    format!("/turn/result?turn_id={turn_id}").as_str(),
+                    &token,
+                ))
+                .await
+                .expect("turn result response");
+            let result_body = to_bytes(result_response.into_body(), usize::MAX)
+                .await
+                .expect("result body");
+            let result: ControlPlaneTurnResultResponse =
+                serde_json::from_slice(&result_body).expect("result json");
+            if result.turn.status.is_terminal() {
+                final_result = Some(result);
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let final_result = final_result.expect("turn should reach a terminal state");
+        let expected_output = format!("streamed: {input}");
+        assert_eq!(
+            final_result.output_text.as_deref(),
+            Some(expected_output.as_str())
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -1089,11 +1089,12 @@ async fn next_turn_sse_item(
             return Some((Ok(event), state));
         }
 
-        let snapshot_result = state.registry.read_turn(state.turn_id.as_str());
-        let snapshot_result = snapshot_result.ok().flatten();
-        if let Some(snapshot) = snapshot_result
-            && snapshot.status.is_terminal()
-        {
+        let snapshot = match state.registry.read_turn(state.turn_id.as_str()) {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) => return None,
+            Err(_) => return None,
+        };
+        if snapshot.status.is_terminal() {
             return None;
         }
 
@@ -4963,6 +4964,33 @@ mod tests {
             final_result.output_text.as_deref(),
             Some(expected_output.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn turn_stream_stops_when_retention_prunes_completed_turn() {
+        let registry = Arc::new(mvp::control_plane::ControlPlaneTurnRegistry::new());
+        let turn = registry.issue_turn("session-pruned");
+        let turn_id = turn.turn_id.clone();
+        registry
+            .complete_success(turn_id.as_str(), "done", Some("completed"), None)
+            .expect("complete pruned turn");
+        let initial_state =
+            initial_turn_stream_state(registry.clone(), turn_id.as_str(), 1).expect("state");
+        for index in 0..300 {
+            let session_id = format!("session-retained-{index}");
+            let output_text = format!("output-{index}");
+            let retained_turn = registry.issue_turn(session_id.as_str());
+            registry
+                .complete_success(
+                    retained_turn.turn_id.as_str(),
+                    output_text.as_str(),
+                    Some("completed"),
+                    None,
+                )
+                .expect("complete retained turn");
+        }
+        let next_item = next_turn_sse_item(initial_state).await;
+        assert!(next_item.is_none());
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/protocol/src/control_plane.rs
+++ b/crates/protocol/src/control_plane.rs
@@ -660,6 +660,86 @@ pub struct ControlPlaneAcpSessionReadResponse {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum ControlPlaneTurnStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ControlPlaneTurnStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlPlaneTurnSubmitRequest {
+    pub session_id: String,
+    pub input: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlPlaneTurnSummary {
+    pub turn_id: String,
+    pub session_id: String,
+    pub status: ControlPlaneTurnStatus,
+    pub submitted_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at_ms: Option<u64>,
+    pub event_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlPlaneTurnSubmitResponse {
+    pub turn: ControlPlaneTurnSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ControlPlaneTurnResultResponse {
+    pub turn: ControlPlaneTurnSummary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ControlPlaneTurnEventEnvelope {
+    pub turn_id: String,
+    pub session_id: String,
+    pub seq: u64,
+    pub terminal: bool,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ControlPlaneEventName {
     PresenceChanged,
     HealthChanged,

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -12,6 +12,7 @@ mod control_plane;
 
 pub const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_READ_CAPABILITY: &str = "control_read";
+const CONTROL_WRITE_CAPABILITY: &str = "control_write";
 const CONTROL_APPROVALS_CAPABILITY: &str = "control_approvals";
 const CONTROL_PAIRING_CAPABILITY: &str = "control_pairing";
 const CONTROL_ACP_CAPABILITY: &str = "control_acp";
@@ -32,7 +33,9 @@ pub use control_plane::{
     ControlPlaneSessionEvent, ControlPlaneSessionKind, ControlPlaneSessionListResponse,
     ControlPlaneSessionObservation, ControlPlaneSessionReadResponse, ControlPlaneSessionState,
     ControlPlaneSessionSummary, ControlPlaneSessionTerminalOutcome, ControlPlaneSnapshot,
-    ControlPlaneSnapshotResponse, ControlPlaneStateVersion,
+    ControlPlaneSnapshotResponse, ControlPlaneStateVersion, ControlPlaneTurnEventEnvelope,
+    ControlPlaneTurnResultResponse, ControlPlaneTurnStatus, ControlPlaneTurnSubmitRequest,
+    ControlPlaneTurnSubmitResponse, ControlPlaneTurnSummary,
 };
 
 fn default_frame_version() -> u32 {
@@ -77,6 +80,9 @@ pub enum ProtocolRoute {
     HealthRead,
     SessionList,
     SessionRead,
+    TurnSubmit,
+    TurnResult,
+    TurnStream,
     ApprovalList,
     ApprovalResolve,
     PairingList,
@@ -100,6 +106,9 @@ impl ProtocolRoute {
             "health/read" => Self::HealthRead,
             "session/list" => Self::SessionList,
             "session/read" => Self::SessionRead,
+            "turn/submit" => Self::TurnSubmit,
+            "turn/result" => Self::TurnResult,
+            "turn/stream" => Self::TurnStream,
             "approval/list" => Self::ApprovalList,
             "approval/resolve" => Self::ApprovalResolve,
             "pairing/list" => Self::PairingList,
@@ -123,6 +132,9 @@ impl ProtocolRoute {
             Self::HealthRead => "health/read",
             Self::SessionList => "session/list",
             Self::SessionRead => "session/read",
+            Self::TurnSubmit => "turn/submit",
+            Self::TurnResult => "turn/result",
+            Self::TurnStream => "turn/stream",
             Self::ApprovalList => "approval/list",
             Self::ApprovalResolve => "approval/resolve",
             Self::PairingList => "pairing/list",
@@ -147,6 +159,9 @@ impl ProtocolRoute {
                 | Self::HealthRead
                 | Self::SessionList
                 | Self::SessionRead
+                | Self::TurnSubmit
+                | Self::TurnResult
+                | Self::TurnStream
                 | Self::ApprovalList
                 | Self::ApprovalResolve
                 | Self::PairingList
@@ -249,11 +264,20 @@ impl ProtocolRouter {
             | ProtocolRoute::PresenceRead
             | ProtocolRoute::HealthRead
             | ProtocolRoute::SessionList
-            | ProtocolRoute::SessionRead => Ok(ResolvedRoute {
+            | ProtocolRoute::SessionRead
+            | ProtocolRoute::TurnResult
+            | ProtocolRoute::TurnStream => Ok(ResolvedRoute {
                 route,
                 policy: RoutePolicy {
                     allow_anonymous: false,
                     required_capability: Some(CONTROL_READ_CAPABILITY.to_owned()),
+                },
+            }),
+            ProtocolRoute::TurnSubmit => Ok(ResolvedRoute {
+                route,
+                policy: RoutePolicy {
+                    allow_anonymous: false,
+                    required_capability: Some(CONTROL_WRITE_CAPABILITY.to_owned()),
                 },
             }),
             ProtocolRoute::ApprovalList | ProtocolRoute::ApprovalResolve => Ok(ResolvedRoute {

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -33,7 +33,9 @@ The current localhost control-plane slice now includes:
 
 Turn execution still reuses the existing ACP conversation preparation path and
 the current session/runtime addressing model. The first turn-result cache stays
-runtime-local; it does not introduce a second durable session authority.
+runtime-local; it does not introduce a second durable session authority. The
+runtime-local turn registry only retains a bounded recent window of completed
+turns for replay and final-result fetch.
 
 ## Acceptance Criteria
 

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -21,6 +21,20 @@ It is a local product substrate.
 It is not a hosted control panel, a public admin API, or a second assistant
 runtime.
 
+## Current shipped slice
+
+The current localhost control-plane slice now includes:
+
+- authenticated runtime snapshot and event feeds
+- session, approval, pairing, and ACP session observation routes
+- authenticated turn submission
+- SSE turn-event streaming for submitted turns
+- non-streaming final turn-result fetch for submitted turns
+
+Turn execution still reuses the existing ACP conversation preparation path and
+the current session/runtime addressing model. The first turn-result cache stays
+runtime-local; it does not introduce a second durable session authority.
+
 ## Acceptance Criteria
 
 - [ ] LoongClaw defines one localhost-only product control plane that future


### PR DESCRIPTION
## Summary

- Problem:
  The localhost product control plane exposed snapshot, session, approval, pairing, and ACP visibility, but it still had no turn resource group. Local clients could inspect runtime state through the control plane but still needed a separate turn path.
- Why it matters:
  Future launcher and Web UI clients need one shared local product seam for turn execution instead of pressure to add parallel runtime-facing paths.
- What changed:
  Added authenticated `turn/submit`, `turn/result`, and `turn/stream` routes; introduced protocol types for the new turn resource group; added a runtime-local turn registry for streamed-event replay and final result fetch; documented the shipped control-plane slice.
- What did not change (scope boundary):
  This does not add a second durable session store, WebSocket transport, remote exposure, or a browser-only execution path.

## Linked Issues

- Closes #1133
- Related #217
- Related #403

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The change expands the authenticated localhost control-plane surface with turn execution routes. Route authorization, ACP reuse, and stream/result semantics must stay aligned with the existing token-scope and session/runtime model.
- Rollout / guardrails:
  Keep the slice localhost-only, require `operator.write` for submit and `operator.read` for result/stream, and keep turn-result storage runtime-local instead of introducing a second durable authority.
- Rollback path:
  Revert the new turn routes and turn-registry plumbing while leaving the existing snapshot/session/approval/pairing/ACP surfaces intact.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-protocol --lib --quiet
cargo test -p loongclaw-app control_plane --quiet
cargo test -p loongclaw --lib control_plane_server --quiet
cargo test --workspace --locked
cargo test --workspace --all-features --locked
```

Additional scenario coverage in `crates/daemon/src/control_plane_server.rs`:
- unavailable runtime returns 503 for `turn/submit`
- insufficient scope rejects `turn/submit`
- successful turn submit/result completes through a streamed backend
- SSE turn stream replays buffered runtime events plus terminal completion

The touched tests do not mutate process-global env. Backend registration in the new control-plane tests uses unique backend ids per test to avoid shared registry collisions.

## User-visible / Operator-visible Changes

- `control-plane-serve` now exposes a turn resource group:
  - `POST /turn/submit`
  - `GET /turn/result?turn_id=...`
  - `GET /turn/stream?turn_id=...`
- The product spec for the local product control plane now reflects the shipped turn slice.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR, or run the control plane without `--config` so the turn routes remain unavailable and return service-unavailable instead of executing turns.
- Observable failure symptoms reviewers should watch for:
  Incorrect scope enforcement, missing terminal stream event, result fetch never reaching terminal state, or turn execution diverging from current ACP conversation addressing.

## Reviewer Focus

- `crates/daemon/src/control_plane_server.rs`
  - route auth requirements (`turn/submit` vs `turn/result` / `turn/stream`)
  - runtime-local turn registry semantics
  - terminal SSE close behavior and event replay
- `crates/app/src/control_plane.rs`
  - turn registry lifecycle and event buffering
- `crates/protocol/src/lib.rs`
  - method routing and capability policy for the new protocol routes
- `crates/protocol/src/control_plane.rs`
  - turn resource group wire contract


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit turns with immediate acceptance; per-turn tracking (status, timestamps, output, stop reason, usage, error), event sequencing, and SSE replay/live streaming until terminal.
  * New HTTP endpoints for submit/result/stream with authorization, visibility checks, and explicit error responses (503/404/409). Preserves submitted input whitespace and prunes older completed turns when retention exceeded.

* **Documentation**
  * Updated control-plane product spec describing shipped turn capabilities, streaming behavior, and retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->