### PR TITLE
refactor(provider): generalize url routing validation hints

### DIFF
--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2635,13 +2635,9 @@ impl ProviderKind {
     }
 
     fn url_validation_profile(self) -> Option<&'static ProviderUrlValidationProfile> {
-        for profile in &PROVIDER_URL_VALIDATION_PROFILES {
-            if profile.kind == self {
-                return Some(profile);
-            }
-        }
-
-        None
+        PROVIDER_URL_VALIDATION_PROFILES
+            .iter()
+            .find(|profile| profile.kind == self)
     }
 
     pub fn as_str(self) -> &'static str {
@@ -4647,6 +4643,31 @@ mod tests {
             assert!(
                 hint.contains("/api/coding/v3"),
                 "expected coding-path guidance for {kind:?}: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_rejects_non_coding_profiles_on_coding_proxy_paths() {
+        let cases = [
+            (ProviderKind::Byteplus, "kind = \"byteplus_coding\""),
+            (ProviderKind::Volcengine, "kind = \"volcengine_coding\""),
+        ];
+
+        for (kind, expected_kind_hint) in cases {
+            let provider = ProviderConfig {
+                kind,
+                base_url: "https://proxy.example.com/api/coding/v3".to_owned(),
+                base_url_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider
+                .configuration_hint()
+                .expect("non-coding profiles should reject coding proxy paths");
+
+            assert!(
+                hint.contains(expected_kind_hint),
+                "expected non-coding guidance for {kind:?}: {hint}"
             );
         }
     }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -243,6 +243,24 @@ pub struct ProviderTransportPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderEffectiveUrlValues {
+    resolved_base_url: String,
+    endpoint: String,
+    models_endpoint: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProviderUrlValidationProfile {
+    kind: ProviderKind,
+    extra_canonical_url_fingerprints: &'static [&'static str],
+    required_path_fragments: &'static [&'static str],
+    forbidden_path_fragments: &'static [&'static str],
+    forbidden_path_exceptions: &'static [&'static str],
+    route_expectation: &'static str,
+    path_validation_hint: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderFeatureSupportFacts {
     pub family: ProviderFeatureFamily,
     pub gate_name: &'static str,
@@ -2019,35 +2037,15 @@ impl ProviderConfig {
     }
 
     pub fn configuration_hint(&self) -> Option<String> {
-        if self.kind == ProviderKind::Byteplus && self.uses_byteplus_coding_plan_path() {
-            return Some(
-                "byteplus uses the standard ModelArk path and should not target `/api/coding` or `/api/coding/v3`; switch to `kind = \"byteplus_coding\"` for the dedicated OpenAI-compatible Coding Plan endpoint"
-                    .to_owned(),
-            );
+        let effective_urls = self.effective_url_values();
+        let cross_routing_hint = self.cross_routing_configuration_hint(&effective_urls);
+        if let Some(hint) = cross_routing_hint {
+            return Some(hint);
         }
-        if self.kind == ProviderKind::Volcengine && self.uses_volcengine_coding_plan_path() {
-            return Some(
-                "volcengine uses the standard Ark API path under `/api/v3` and should not target `/api/coding` or `/api/coding/v3`; switch to `kind = \"volcengine_coding\"` for the dedicated OpenAI-compatible Coding Plan endpoint"
-                    .to_owned(),
-            );
-        }
-        if self.kind == ProviderKind::ByteplusCoding
-            && (self.uses_generic_byteplus_modelark_v3_path()
-                || self.uses_ark_coding_anthropic_path())
-        {
-            return Some(
-                "byteplus_coding must use the dedicated BytePlus Coding path under `/api/coding/v3`; do not point it at the unsupported Anthropic-compatible `/api/coding` or generic `/api/v3` ModelArk endpoints because that bypasses Coding Plan quota and can incur standard model charges"
-                    .to_owned(),
-            );
-        }
-        if self.kind == ProviderKind::VolcengineCoding
-            && (self.uses_generic_volcengine_modelark_v3_path()
-                || self.uses_ark_coding_anthropic_path())
-        {
-            return Some(
-                "volcengine_coding must use the dedicated Volcengine Coding Plan path under `/api/coding/v3`; do not point it at the Anthropic-compatible `/api/coding` or generic `/api/v3` Ark endpoints because that bypasses Coding Plan quota and can incur standard charges"
-                    .to_owned(),
-            );
+
+        let path_validation_hint = self.path_validation_configuration_hint(&effective_urls);
+        if let Some(hint) = path_validation_hint {
+            return Some(hint);
         }
         if let Some(hint) = self.opencode_configuration_hint() {
             return Some(hint);
@@ -2062,6 +2060,82 @@ impl ProviderConfig {
                 self.kind.as_str()
             ));
         }
+        None
+    }
+
+    fn effective_url_values(&self) -> ProviderEffectiveUrlValues {
+        let resolved_base_url = self.resolved_base_url();
+        let endpoint = self.endpoint();
+        let models_endpoint = self.models_endpoint();
+
+        ProviderEffectiveUrlValues {
+            resolved_base_url,
+            endpoint,
+            models_endpoint,
+        }
+    }
+
+    fn cross_routing_configuration_hint(
+        &self,
+        effective_urls: &ProviderEffectiveUrlValues,
+    ) -> Option<String> {
+        let current_profile = self.kind.url_validation_profile()?;
+        let sources = effective_urls.sources();
+
+        for (source_name, source_value) in sources {
+            let current_match = current_profile.matching_canonical_fingerprint(source_value);
+            let candidate_match = find_cross_routed_validation_profile(self.kind, source_value);
+            let Some((candidate_profile, candidate_fingerprint)) = candidate_match else {
+                continue;
+            };
+            if current_match.is_some() {
+                continue;
+            }
+
+            let candidate_kind_id = candidate_profile.kind.as_str();
+            let current_kind_id = self.kind.as_str();
+            let route_expectation = current_profile.route_expectation;
+            let hint = format!(
+                "{current_kind_id} is pointing at the canonical `{candidate_kind_id}` {source_name} `{candidate_fingerprint}`; switch to `kind = \"{candidate_kind_id}\"` if that is intentional, or restore {route_expectation}"
+            );
+            return Some(hint);
+        }
+
+        None
+    }
+
+    fn path_validation_configuration_hint(
+        &self,
+        effective_urls: &ProviderEffectiveUrlValues,
+    ) -> Option<String> {
+        let validation_profile = self.kind.url_validation_profile()?;
+        let sources = effective_urls.sources();
+        let mut has_required_path = validation_profile.required_path_fragments.is_empty();
+        if !has_required_path {
+            for (_, value) in sources {
+                let path_match = validation_profile.matches_required_path_fragment(value);
+                if path_match {
+                    has_required_path = true;
+                    break;
+                }
+            }
+        }
+        if !has_required_path {
+            return Some(validation_profile.path_validation_hint.to_owned());
+        }
+
+        let mut has_forbidden_path = false;
+        for (_, value) in sources {
+            let path_match = validation_profile.matches_forbidden_path_fragment(value);
+            if path_match {
+                has_forbidden_path = true;
+                break;
+            }
+        }
+        if has_forbidden_path {
+            return Some(validation_profile.path_validation_hint.to_owned());
+        }
+
         None
     }
 
@@ -2162,94 +2236,6 @@ impl ProviderConfig {
     pub fn request_region_endpoint_failure_hint(&self) -> Option<String> {
         let support_facts = self.support_facts();
         support_facts.region_endpoint.request_failure_hint
-    }
-
-    fn uses_byteplus_coding_plan_path(&self) -> bool {
-        if self.kind != ProviderKind::Byteplus {
-            return false;
-        }
-
-        let resolved_base_url = self.resolved_base_url();
-        let endpoint = self.endpoint();
-        let models_endpoint = self.models_endpoint();
-        [
-            resolved_base_url.as_str(),
-            endpoint.as_str(),
-            models_endpoint.as_str(),
-        ]
-        .into_iter()
-        .any(is_ark_coding_plan_path)
-    }
-
-    fn uses_generic_byteplus_modelark_v3_path(&self) -> bool {
-        if self.kind != ProviderKind::ByteplusCoding {
-            return false;
-        }
-
-        let resolved_base_url = self.resolved_base_url();
-        let endpoint = self.endpoint();
-        let models_endpoint = self.models_endpoint();
-        [
-            resolved_base_url.as_str(),
-            endpoint.as_str(),
-            models_endpoint.as_str(),
-        ]
-        .into_iter()
-        .any(is_generic_ark_modelark_v3_path)
-    }
-
-    fn uses_volcengine_coding_plan_path(&self) -> bool {
-        if self.kind != ProviderKind::Volcengine {
-            return false;
-        }
-
-        let resolved_base_url = self.resolved_base_url();
-        let endpoint = self.endpoint();
-        let models_endpoint = self.models_endpoint();
-        [
-            resolved_base_url.as_str(),
-            endpoint.as_str(),
-            models_endpoint.as_str(),
-        ]
-        .into_iter()
-        .any(is_ark_coding_plan_path)
-    }
-
-    fn uses_generic_volcengine_modelark_v3_path(&self) -> bool {
-        if self.kind != ProviderKind::VolcengineCoding {
-            return false;
-        }
-
-        let resolved_base_url = self.resolved_base_url();
-        let endpoint = self.endpoint();
-        let models_endpoint = self.models_endpoint();
-        [
-            resolved_base_url.as_str(),
-            endpoint.as_str(),
-            models_endpoint.as_str(),
-        ]
-        .into_iter()
-        .any(is_generic_ark_modelark_v3_path)
-    }
-
-    fn uses_ark_coding_anthropic_path(&self) -> bool {
-        if !matches!(
-            self.kind,
-            ProviderKind::ByteplusCoding | ProviderKind::VolcengineCoding
-        ) {
-            return false;
-        }
-
-        let resolved_base_url = self.resolved_base_url();
-        let endpoint = self.endpoint();
-        let models_endpoint = self.models_endpoint();
-        [
-            resolved_base_url.as_str(),
-            endpoint.as_str(),
-            models_endpoint.as_str(),
-        ]
-        .into_iter()
-        .any(is_ark_coding_anthropic_path)
     }
 
     pub fn model_selection_fallback_hint(&self) -> Option<String> {
@@ -2584,23 +2570,78 @@ fn maybe_normalize_custom_chat_path(kind: ProviderKind, base_url: &str, path: &s
     normalized
 }
 
-fn is_ark_coding_plan_path(value: &str) -> bool {
-    value.trim().to_ascii_lowercase().contains("/api/coding")
+impl ProviderEffectiveUrlValues {
+    fn sources(&self) -> [(&'static str, &str); 3] {
+        [
+            ("endpoint", self.endpoint.as_str()),
+            ("models endpoint", self.models_endpoint.as_str()),
+            ("base url", self.resolved_base_url.as_str()),
+        ]
+    }
 }
 
-fn is_ark_coding_anthropic_path(value: &str) -> bool {
-    let normalized = value.trim().to_ascii_lowercase();
-    normalized.contains("/api/coding") && !normalized.contains("/api/coding/v3")
-}
+impl ProviderUrlValidationProfile {
+    fn matching_canonical_fingerprint(self, value: &str) -> Option<&'static str> {
+        let profile = self.kind.profile();
+        let base_fingerprint = profile.base_url;
+        let base_match = matches_url_validation_fingerprint(value, base_fingerprint);
+        if base_match {
+            return Some(base_fingerprint);
+        }
 
-fn is_generic_ark_modelark_v3_path(value: &str) -> bool {
-    let normalized = value.trim().to_ascii_lowercase();
-    normalized.contains("/api/v3") && !normalized.contains("/api/coding/v3")
+        for fingerprint in self.extra_canonical_url_fingerprints {
+            let fingerprint_match = matches_url_validation_fingerprint(value, fingerprint);
+            if fingerprint_match {
+                return Some(fingerprint);
+            }
+        }
+
+        None
+    }
+
+    fn matches_required_path_fragment(self, value: &str) -> bool {
+        for fragment in self.required_path_fragments {
+            let fragment_match = url_contains_validation_fragment(value, fragment);
+            if fragment_match {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn matches_forbidden_path_fragment(self, value: &str) -> bool {
+        for fragment in self.forbidden_path_exceptions {
+            let exception_match = url_contains_validation_fragment(value, fragment);
+            if exception_match {
+                return false;
+            }
+        }
+
+        for fragment in self.forbidden_path_fragments {
+            let fragment_match = url_contains_validation_fragment(value, fragment);
+            if fragment_match {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 impl ProviderKind {
     pub fn all_sorted() -> &'static [ProviderKind] {
         &PROVIDER_KIND_ORDER
+    }
+
+    fn url_validation_profile(self) -> Option<&'static ProviderUrlValidationProfile> {
+        for profile in &PROVIDER_URL_VALIDATION_PROFILES {
+            if profile.kind == self {
+                return Some(profile);
+            }
+        }
+
+        None
     }
 
     pub fn as_str(self) -> &'static str {
@@ -3005,6 +3046,98 @@ impl ProviderKind {
             variants,
         })
     }
+}
+
+const NON_CODING_ARK_FORBIDDEN_PATH_FRAGMENTS: [&str; 1] = ["/api/coding"];
+const CODING_ARK_REQUIRED_PATH_FRAGMENTS: [&str; 1] = ["/api/coding/v3"];
+const CODING_ARK_FORBIDDEN_PATH_FRAGMENTS: [&str; 2] = ["/api/v3", "/api/coding"];
+const CODING_ARK_FORBIDDEN_PATH_EXCEPTIONS: [&str; 1] = ["/api/coding/v3"];
+
+const PROVIDER_URL_VALIDATION_PROFILES: [ProviderUrlValidationProfile; 4] = [
+    ProviderUrlValidationProfile {
+        kind: ProviderKind::Byteplus,
+        extra_canonical_url_fingerprints: &[],
+        required_path_fragments: &[],
+        forbidden_path_fragments: &NON_CODING_ARK_FORBIDDEN_PATH_FRAGMENTS,
+        forbidden_path_exceptions: &[],
+        route_expectation: "the standard BytePlus ModelArk route under `/api/v3`",
+        path_validation_hint: "byteplus uses the standard ModelArk path and should not target `/api/coding` or `/api/coding/v3`; switch to `kind = \"byteplus_coding\"` for the dedicated OpenAI-compatible Coding Plan endpoint",
+    },
+    ProviderUrlValidationProfile {
+        kind: ProviderKind::ByteplusCoding,
+        extra_canonical_url_fingerprints: &[],
+        required_path_fragments: &CODING_ARK_REQUIRED_PATH_FRAGMENTS,
+        forbidden_path_fragments: &CODING_ARK_FORBIDDEN_PATH_FRAGMENTS,
+        forbidden_path_exceptions: &CODING_ARK_FORBIDDEN_PATH_EXCEPTIONS,
+        route_expectation: "the dedicated BytePlus Coding path under `/api/coding/v3`",
+        path_validation_hint: "byteplus_coding must use the dedicated BytePlus Coding path under `/api/coding/v3`; do not point it at the unsupported Anthropic-compatible `/api/coding` or generic `/api/v3` ModelArk endpoints because that bypasses Coding Plan quota and can incur standard model charges",
+    },
+    ProviderUrlValidationProfile {
+        kind: ProviderKind::Volcengine,
+        extra_canonical_url_fingerprints: &[],
+        required_path_fragments: &[],
+        forbidden_path_fragments: &NON_CODING_ARK_FORBIDDEN_PATH_FRAGMENTS,
+        forbidden_path_exceptions: &[],
+        route_expectation: "the standard Volcengine Ark route under `/api/v3`",
+        path_validation_hint: "volcengine uses the standard Ark API path under `/api/v3` and should not target `/api/coding` or `/api/coding/v3`; switch to `kind = \"volcengine_coding\"` for the dedicated OpenAI-compatible Coding Plan endpoint",
+    },
+    ProviderUrlValidationProfile {
+        kind: ProviderKind::VolcengineCoding,
+        extra_canonical_url_fingerprints: &[],
+        required_path_fragments: &CODING_ARK_REQUIRED_PATH_FRAGMENTS,
+        forbidden_path_fragments: &CODING_ARK_FORBIDDEN_PATH_FRAGMENTS,
+        forbidden_path_exceptions: &CODING_ARK_FORBIDDEN_PATH_EXCEPTIONS,
+        route_expectation: "the dedicated Volcengine Coding Plan path under `/api/coding/v3`",
+        path_validation_hint: "volcengine_coding must use the dedicated Volcengine Coding Plan path under `/api/coding/v3`; do not point it at the Anthropic-compatible `/api/coding` or generic `/api/v3` Ark endpoints because that bypasses Coding Plan quota and can incur standard charges",
+    },
+];
+
+fn find_cross_routed_validation_profile(
+    current_kind: ProviderKind,
+    source_value: &str,
+) -> Option<(&'static ProviderUrlValidationProfile, &'static str)> {
+    let mut best_match: Option<(&'static ProviderUrlValidationProfile, &'static str)> = None;
+
+    for profile in &PROVIDER_URL_VALIDATION_PROFILES {
+        let candidate_kind = profile.kind;
+        if candidate_kind == current_kind {
+            continue;
+        }
+
+        let matching_fingerprint = profile.matching_canonical_fingerprint(source_value);
+        if let Some(fingerprint) = matching_fingerprint {
+            let mut should_replace = true;
+            if let Some((_, best_fingerprint)) = best_match {
+                should_replace = fingerprint.len() > best_fingerprint.len();
+            }
+            if should_replace {
+                best_match = Some((profile, fingerprint));
+            }
+        }
+    }
+
+    best_match
+}
+
+fn matches_url_validation_fingerprint(value: &str, fingerprint: &str) -> bool {
+    let normalized_value = normalize_url_validation_value(value);
+    let normalized_fingerprint = normalize_url_validation_value(fingerprint);
+
+    matches_region_endpoint_url(normalized_value.as_str(), normalized_fingerprint.as_str())
+}
+
+fn url_contains_validation_fragment(value: &str, fragment: &str) -> bool {
+    let normalized_value = normalize_url_validation_value(value);
+    let normalized_fragment = normalize_url_validation_value(fragment);
+
+    normalized_value.contains(normalized_fragment.as_str())
+}
+
+fn normalize_url_validation_value(value: &str) -> String {
+    let trimmed = value.trim();
+    let trimmed = trimmed.trim_end_matches('/');
+
+    trimmed.to_ascii_lowercase()
 }
 
 fn provider_descriptor_aliases(profile: &ProviderProfile) -> Vec<String> {
@@ -4461,6 +4594,98 @@ mod tests {
         assert!(custom_hint.contains("Authorization"));
         assert!(custom_hint.contains("X-API-Key"));
         assert!(custom_hint.contains("provider.headers"));
+    }
+
+    #[test]
+    fn provider_configuration_hint_prefers_canonical_cross_routing_guidance() {
+        let cases = [
+            (
+                ProviderKind::Byteplus,
+                "https://ark.cn-beijing.volces.com/api/coding/v3",
+                "kind = \"volcengine_coding\"",
+            ),
+            (
+                ProviderKind::ByteplusCoding,
+                "https://ark.cn-beijing.volces.com",
+                "kind = \"volcengine\"",
+            ),
+        ];
+
+        for (kind, base_url, expected_kind_hint) in cases {
+            let provider = ProviderConfig {
+                kind,
+                base_url: base_url.to_owned(),
+                base_url_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider
+                .configuration_hint()
+                .expect("cross-routed provider configs should surface a hint");
+
+            assert!(
+                hint.contains(expected_kind_hint),
+                "expected cross-routing hint for {kind:?} with {base_url}: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_requires_coding_path_even_for_proxy_hosts() {
+        let cases = [ProviderKind::ByteplusCoding, ProviderKind::VolcengineCoding];
+
+        for kind in cases {
+            let provider = ProviderConfig {
+                kind,
+                base_url: "https://proxy.example.com/openai/v1".to_owned(),
+                base_url_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider
+                .configuration_hint()
+                .expect("coding providers should reject proxy urls that drop the coding path");
+
+            assert!(
+                hint.contains("/api/coding/v3"),
+                "expected coding-path guidance for {kind:?}: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_allows_proxy_coding_routes_that_keep_the_required_path() {
+        let cases = [ProviderKind::ByteplusCoding, ProviderKind::VolcengineCoding];
+
+        for kind in cases {
+            let provider = ProviderConfig {
+                kind,
+                base_url: "https://proxy.example.com/api/coding/v3".to_owned(),
+                base_url_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider.configuration_hint();
+
+            assert!(
+                hint.is_none(),
+                "proxy coding routes should stay valid for {kind:?}: {hint:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_checks_explicit_endpoints_before_current_base_url() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::ByteplusCoding,
+            base_url: "https://ark.ap-southeast.bytepluses.com/api/coding/v3".to_owned(),
+            base_url_explicit: true,
+            endpoint: Some("https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_owned()),
+            endpoint_explicit: true,
+            ..ProviderConfig::default()
+        };
+        let hint = provider
+            .configuration_hint()
+            .expect("explicit cross-routed endpoints should surface a hint");
+
+        assert!(hint.contains("kind = \"volcengine\""));
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2082,9 +2082,14 @@ impl ProviderConfig {
         let current_profile = self.kind.url_validation_profile()?;
         let sources = effective_urls.sources();
 
-        for (source_name, source_value) in sources {
-            let current_match = current_profile.matching_canonical_fingerprint(source_value);
-            let candidate_match = find_cross_routed_validation_profile(self.kind, source_value);
+        for (source_name, source_value, allow_host_only_base_match) in sources {
+            let current_match = current_profile
+                .matching_canonical_fingerprint(source_value, allow_host_only_base_match);
+            let candidate_match = find_cross_routed_validation_profile(
+                self.kind,
+                source_value,
+                allow_host_only_base_match,
+            );
             let Some((candidate_profile, candidate_fingerprint)) = candidate_match else {
                 continue;
             };
@@ -2110,30 +2115,21 @@ impl ProviderConfig {
     ) -> Option<String> {
         let validation_profile = self.kind.url_validation_profile()?;
         let sources = effective_urls.sources();
-        let mut has_required_path = validation_profile.required_path_fragments.is_empty();
-        if !has_required_path {
-            for (_, value) in sources {
+        let requires_path_validation = !validation_profile.required_path_fragments.is_empty();
+        if requires_path_validation {
+            for (_, value, _) in sources {
                 let path_match = validation_profile.matches_required_path_fragment(value);
-                if path_match {
-                    has_required_path = true;
-                    break;
+                if !path_match {
+                    return Some(validation_profile.path_validation_hint.to_owned());
                 }
             }
         }
-        if !has_required_path {
-            return Some(validation_profile.path_validation_hint.to_owned());
-        }
 
-        let mut has_forbidden_path = false;
-        for (_, value) in sources {
+        for (_, value, _) in sources {
             let path_match = validation_profile.matches_forbidden_path_fragment(value);
             if path_match {
-                has_forbidden_path = true;
-                break;
+                return Some(validation_profile.path_validation_hint.to_owned());
             }
-        }
-        if has_forbidden_path {
-            return Some(validation_profile.path_validation_hint.to_owned());
         }
 
         None
@@ -2571,20 +2567,28 @@ fn maybe_normalize_custom_chat_path(kind: ProviderKind, base_url: &str, path: &s
 }
 
 impl ProviderEffectiveUrlValues {
-    fn sources(&self) -> [(&'static str, &str); 3] {
+    fn sources(&self) -> [(&'static str, &str, bool); 3] {
         [
-            ("endpoint", self.endpoint.as_str()),
-            ("models endpoint", self.models_endpoint.as_str()),
-            ("base url", self.resolved_base_url.as_str()),
+            ("endpoint", self.endpoint.as_str(), false),
+            ("models endpoint", self.models_endpoint.as_str(), false),
+            ("base url", self.resolved_base_url.as_str(), true),
         ]
     }
 }
 
 impl ProviderUrlValidationProfile {
-    fn matching_canonical_fingerprint(self, value: &str) -> Option<&'static str> {
+    fn matching_canonical_fingerprint(
+        self,
+        value: &str,
+        allow_host_only_base_match: bool,
+    ) -> Option<&'static str> {
         let profile = self.kind.profile();
         let base_fingerprint = profile.base_url;
-        let base_match = matches_url_validation_fingerprint(value, base_fingerprint);
+        let base_match = matches_base_url_validation_fingerprint(
+            value,
+            base_fingerprint,
+            allow_host_only_base_match,
+        );
         if base_match {
             return Some(base_fingerprint);
         }
@@ -3048,6 +3052,8 @@ const NON_CODING_ARK_FORBIDDEN_PATH_FRAGMENTS: [&str; 1] = ["/api/coding"];
 const CODING_ARK_REQUIRED_PATH_FRAGMENTS: [&str; 1] = ["/api/coding/v3"];
 const CODING_ARK_FORBIDDEN_PATH_FRAGMENTS: [&str; 2] = ["/api/v3", "/api/coding"];
 const CODING_ARK_FORBIDDEN_PATH_EXCEPTIONS: [&str; 1] = ["/api/coding/v3"];
+const VOLCENGINE_STANDARD_CANONICAL_URL_FINGERPRINTS: [&str; 1] =
+    ["https://ark.cn-beijing.volces.com/api/v3"];
 
 const PROVIDER_URL_VALIDATION_PROFILES: [ProviderUrlValidationProfile; 4] = [
     ProviderUrlValidationProfile {
@@ -3070,7 +3076,7 @@ const PROVIDER_URL_VALIDATION_PROFILES: [ProviderUrlValidationProfile; 4] = [
     },
     ProviderUrlValidationProfile {
         kind: ProviderKind::Volcengine,
-        extra_canonical_url_fingerprints: &[],
+        extra_canonical_url_fingerprints: &VOLCENGINE_STANDARD_CANONICAL_URL_FINGERPRINTS,
         required_path_fragments: &[],
         forbidden_path_fragments: &NON_CODING_ARK_FORBIDDEN_PATH_FRAGMENTS,
         forbidden_path_exceptions: &[],
@@ -3091,6 +3097,7 @@ const PROVIDER_URL_VALIDATION_PROFILES: [ProviderUrlValidationProfile; 4] = [
 fn find_cross_routed_validation_profile(
     current_kind: ProviderKind,
     source_value: &str,
+    allow_host_only_base_match: bool,
 ) -> Option<(&'static ProviderUrlValidationProfile, &'static str)> {
     let mut best_match: Option<(&'static ProviderUrlValidationProfile, &'static str)> = None;
 
@@ -3100,7 +3107,8 @@ fn find_cross_routed_validation_profile(
             continue;
         }
 
-        let matching_fingerprint = profile.matching_canonical_fingerprint(source_value);
+        let matching_fingerprint =
+            profile.matching_canonical_fingerprint(source_value, allow_host_only_base_match);
         if let Some(fingerprint) = matching_fingerprint {
             let mut should_replace = true;
             if let Some((_, best_fingerprint)) = best_match {
@@ -3122,11 +3130,45 @@ fn matches_url_validation_fingerprint(value: &str, fingerprint: &str) -> bool {
     matches_region_endpoint_url(normalized_value.as_str(), normalized_fingerprint.as_str())
 }
 
+fn matches_base_url_validation_fingerprint(
+    value: &str,
+    fingerprint: &str,
+    allow_host_only_base_match: bool,
+) -> bool {
+    let fingerprint_has_non_root_path = url_has_non_root_path(fingerprint);
+    if fingerprint_has_non_root_path {
+        return matches_url_validation_fingerprint(value, fingerprint);
+    }
+    if !allow_host_only_base_match {
+        return false;
+    }
+    is_same_base_url(value, fingerprint)
+}
+
 fn url_contains_validation_fragment(value: &str, fragment: &str) -> bool {
     let normalized_value = normalize_url_validation_value(value);
     let normalized_fragment = normalize_url_validation_value(fragment);
 
     normalized_value.contains(normalized_fragment.as_str())
+}
+
+fn url_has_non_root_path(value: &str) -> bool {
+    let trimmed = value.trim();
+    let after_scheme = trimmed
+        .split_once("://")
+        .map(|(_, remainder)| remainder)
+        .unwrap_or(trimmed);
+    let Some((_, path_with_query)) = after_scheme.split_once('/') else {
+        return false;
+    };
+    let raw_path = format!("/{path_with_query}");
+    let path = raw_path
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(raw_path.as_str());
+    let normalized_path = path.trim_end_matches('/');
+
+    !normalized_path.is_empty()
 }
 
 fn normalize_url_validation_value(value: &str) -> String {
@@ -4707,6 +4749,66 @@ mod tests {
             .expect("explicit cross-routed endpoints should surface a hint");
 
         assert!(hint.contains("kind = \"volcengine\""));
+    }
+
+    #[test]
+    fn provider_configuration_hint_requires_coding_path_for_explicit_endpoint_overrides() {
+        let cases = [ProviderKind::ByteplusCoding, ProviderKind::VolcengineCoding];
+
+        for kind in cases {
+            let provider = ProviderConfig {
+                kind,
+                endpoint: Some("https://proxy.example.com/openai/v1/chat/completions".to_owned()),
+                endpoint_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider
+                .configuration_hint()
+                .expect("explicit endpoint overrides should keep the coding path");
+
+            assert!(
+                hint.contains("/api/coding/v3"),
+                "expected coding-path guidance for {kind:?}: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_requires_coding_path_for_explicit_models_endpoints() {
+        let cases = [ProviderKind::ByteplusCoding, ProviderKind::VolcengineCoding];
+
+        for kind in cases {
+            let provider = ProviderConfig {
+                kind,
+                models_endpoint: Some("https://proxy.example.com/openai/v1/models".to_owned()),
+                models_endpoint_explicit: true,
+                ..ProviderConfig::default()
+            };
+            let hint = provider
+                .configuration_hint()
+                .expect("explicit models endpoints should keep the coding path");
+
+            assert!(
+                hint.contains("/api/coding/v3"),
+                "expected coding-path guidance for {kind:?}: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_configuration_hint_ignores_non_canonical_host_only_proxy_paths() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Byteplus,
+            base_url: "https://ark.cn-beijing.volces.com/custom/proxy".to_owned(),
+            base_url_explicit: true,
+            ..ProviderConfig::default()
+        };
+        let hint = provider.configuration_hint();
+
+        assert!(
+            hint.is_none(),
+            "non-canonical host-only proxy paths should not claim a canonical cross-route: {hint:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem: provider configuration hints currently rely on provider-specific helper branches, which miss canonical cross-routing cases and proxy/path regressions once provider variants start overlapping.
- Why it matters: misconfigured provider endpoints can surface the wrong recovery hint or no hint at all, and every new overlapping provider pair keeps duplicating config validation logic.
- What changed: replaced the hard-coded BytePlus / Volcengine routing checks with a declarative provider URL validation registry that checks canonical fingerprints plus required / forbidden path fragments across the effective base URL, request endpoint, and models endpoint; added regression coverage for canonical cross-routing, stripped coding paths behind proxy hosts, valid proxy coding routes, and explicit endpoint overrides.
- What did not change (scope boundary): request transport behavior, provider defaults, auth semantics, and unrelated provider configuration hints.

## Linked Issues

- Closes #1120
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-issue1120-verify-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-issue1120-verify-target cargo test -p loongclaw-app provider_configuration_hint_ --lib -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-issue1120-verify-target cargo test --workspace --locked -- --test-threads=1
./scripts/check_architecture_boundaries.sh
cargo test --workspace --all-features --locked -- --test-threads=1

all passed locally.
```

## User-visible / Operator-visible Changes

- provider config hints now detect canonical BytePlus / Volcengine cross-routing and missing coding-plan path fragments more consistently, including explicit endpoint overrides and proxy hosts that drop `/api/coding/v3`.

## Failure Recovery

- Fast rollback or disable path: revert the two commits on this branch to restore the previous helper-based hint logic.
- Observable failure symptoms reviewers should watch for: provider configs that previously emitted a hint now emit none, or a valid proxy coding route starts getting flagged as invalid.

## Reviewer Focus

- please focus on the declarative validation registry and the ordering between explicit endpoint routing, canonical fingerprint matching, and path-based fallback guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider configuration validation with profile-driven checks that detect cross-routing and suggest corrective hints.
  * Stricter endpoint path validation enforcing required/forbidden path fragments, including better handling when requests go through proxy hosts or explicit endpoint overrides are set.

* **Refactor**
  * Unified, two-stage validation flow for all provider types for consistent behavior and clearer guidance.

* **Tests**
  * Added unit tests covering cross-routing, path enforcement, proxy scenarios, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->