### PR TITLE
add unified operator runtime status surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ slot and supervise the enabled runtime-backed service-channel subset.
 
 The current gateway slice now includes:
 
+- `loongclaw status` for one operator-readable summary across the gateway
+  owner, ACP runtime, and durable work-unit health
 - `loongclaw gateway run` for the owner lifecycle
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
@@ -627,6 +629,10 @@ that centralizes loopback validation, bearer-token loading, and route helpers
 for `status`, `channels`, `runtime-snapshot`, `acp/sessions`, `acp/status`,
 `acp/observability`, `operator-summary`, and `stop`. That keeps dashboard,
 ACP inspection, and Web UI bootstrap logic out of ad-hoc file reads.
+
+```bash
+loongclaw status --config ~/.loongclaw/config.toml --json
+```
 
 ```bash
 loongclaw gateway run --config ~/.loongclaw/config.toml

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use super::super::config::{
-    AutonomyProfile, LoongClawConfig, MemoryProfile, MemorySystemKind, ProviderConfig,
+    AuditMode, AutonomyProfile, LoongClawConfig, MemoryProfile, MemorySystemKind, ProviderConfig,
 };
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
@@ -1746,10 +1746,12 @@ impl ConversationRuntime for FakeRuntime {
 }
 
 fn test_config() -> LoongClawConfig {
-    LoongClawConfig {
+    let mut config = LoongClawConfig {
         provider: ProviderConfig::default(),
         ..LoongClawConfig::default()
-    }
+    };
+    config.audit.mode = AuditMode::InMemory;
+    config
 }
 
 fn enable_guided_autonomy(config: &mut LoongClawConfig) {

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -53,6 +53,38 @@ pub use shape::{
     extract_provider_turn_with_scope_and_messages,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderToolSchemaReadiness {
+    pub active_model: String,
+    pub structured_tool_schema_enabled: bool,
+    pub effective_tool_schema_mode: String,
+}
+
+pub fn provider_tool_schema_readiness(config: &LoongClawConfig) -> ProviderToolSchemaReadiness {
+    let provider = &config.provider;
+    let runtime_contract = provider_runtime_contract(provider);
+    let capability_profile = capability_profile_runtime::ProviderCapabilityProfile::from_provider(
+        provider,
+        runtime_contract,
+    );
+    let active_model = provider.model.clone();
+    let capability = capability_profile.resolve_for_model(active_model.as_str());
+    let effective_tool_schema_mode = match capability.tool_schema_mode {
+        contracts::ProviderToolSchemaMode::Disabled => "disabled",
+        contracts::ProviderToolSchemaMode::EnabledStrict => "enabled_strict",
+        contracts::ProviderToolSchemaMode::EnabledWithDowngradeOnUnsupported => {
+            "enabled_with_downgrade"
+        }
+    };
+    let structured_tool_schema_enabled = capability.turn_tool_schema_enabled();
+
+    ProviderToolSchemaReadiness {
+        active_model,
+        structured_tool_schema_enabled,
+        effective_tool_schema_mode: effective_tool_schema_mode.to_owned(),
+    }
+}
+
 pub fn is_auth_style_failure_message(message: &str) -> bool {
     matches!(
         profile_health_policy::classify_profile_failure_reason_from_message(message),

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -82,6 +82,48 @@ fn next_model_cooldown_test_namespace() -> String {
     format!("model-cooldown-test-{seed}")
 }
 
+#[test]
+fn provider_tool_schema_readiness_reports_default_structured_mode() {
+    let config = LoongClawConfig::default();
+
+    let readiness = provider_tool_schema_readiness(&config);
+
+    assert_eq!(readiness.active_model, config.provider.model);
+    assert!(readiness.structured_tool_schema_enabled);
+    assert_eq!(
+        readiness.effective_tool_schema_mode,
+        "enabled_with_downgrade"
+    );
+}
+
+#[test]
+fn provider_tool_schema_readiness_honors_disabled_mode_and_model_hints() {
+    let disabled_config = LoongClawConfig {
+        provider: ProviderConfig {
+            tool_schema_mode: crate::config::ProviderToolSchemaModeConfig::Disabled,
+            ..ProviderConfig::default()
+        },
+        ..LoongClawConfig::default()
+    };
+    let disabled_readiness = provider_tool_schema_readiness(&disabled_config);
+
+    assert!(!disabled_readiness.structured_tool_schema_enabled);
+    assert_eq!(disabled_readiness.effective_tool_schema_mode, "disabled");
+
+    let hinted_config = LoongClawConfig {
+        provider: ProviderConfig {
+            model: "gpt-no-tools-preview".to_owned(),
+            tool_schema_disabled_model_hints: vec!["no-tools".to_owned()],
+            ..ProviderConfig::default()
+        },
+        ..LoongClawConfig::default()
+    };
+    let hinted_readiness = provider_tool_schema_readiness(&hinted_config);
+
+    assert!(!hinted_readiness.structured_tool_schema_enabled);
+    assert_eq!(hinted_readiness.effective_tool_schema_mode, "disabled");
+}
+
 fn next_temp_path(prefix: &str, extension: &str) -> PathBuf {
     static NEXT_TEMP_PATH_SEED: AtomicUsize = AtomicUsize::new(1);
     let seed = NEXT_TEMP_PATH_SEED.fetch_add(1, Ordering::Relaxed);

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -24,6 +24,7 @@ impl Commands {
             Self::Doctor { .. } => "doctor",
             Self::Audit { .. } => "audit",
             Self::Skills { .. } => "skills",
+            Self::Status { .. } => "status",
             Self::Tasks { .. } => "tasks",
             Self::DelegateChildRun { .. } => "delegate_child_run",
             Self::Sessions { .. } => "sessions",
@@ -112,6 +113,14 @@ mod tests {
             }
             .command_kind_for_logging(),
             "validate_config"
+        );
+        assert_eq!(
+            Commands::Status {
+                config: None,
+                json: false,
+            }
+            .command_kind_for_logging(),
+            "status"
         );
         assert_eq!(
             Commands::WorkUnit {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -117,6 +117,13 @@ impl GatewayControlAppState {
                 visible_tool_names: vec![],
                 capability_snapshot_sha256: String::new(),
                 capability_snapshot: String::new(),
+                tool_calling: super::read_models::GatewayToolCallingReadModel {
+                    availability: "inactive".to_owned(),
+                    structured_tool_schema_enabled: false,
+                    effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                    active_model: String::new(),
+                    reason: "no runtime-visible tools are enabled".to_owned(),
+                },
             },
             runtime_plugins: json!({}),
             external_skills: json!({}),

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -234,6 +234,7 @@ pub struct GatewayRuntimeSnapshotToolsReadModel {
     pub visible_tool_names: Vec<String>,
     pub capability_snapshot_sha256: String,
     pub capability_snapshot: String,
+    pub tool_calling: GatewayToolCallingReadModel,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -294,6 +295,16 @@ pub struct GatewayOperatorRuntimeSummaryReadModel {
     pub capability_snapshot_sha256: String,
     pub active_provider_profile_id: Option<String>,
     pub active_provider_label: Option<String>,
+    pub tool_calling: GatewayToolCallingReadModel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayToolCallingReadModel {
+    pub availability: String,
+    pub structured_tool_schema_enabled: bool,
+    pub effective_tool_schema_mode: String,
+    pub active_model: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -444,11 +455,13 @@ pub fn build_runtime_snapshot_read_model(
     let visible_tool_names = snapshot.visible_tool_names.clone();
     let capability_snapshot_sha256 = snapshot.capability_snapshot_sha256.clone();
     let capability_snapshot = snapshot.capability_snapshot.clone();
+    let tool_calling = build_tool_calling_read_model(&snapshot.tool_calling);
     let tools = GatewayRuntimeSnapshotToolsReadModel {
         visible_tool_count,
         visible_tool_names,
         capability_snapshot_sha256,
         capability_snapshot,
+        tool_calling,
     };
     let runtime_plugins = crate::runtime_snapshot_runtime_plugins_json(&snapshot.runtime_plugins);
     let external_skills = crate::runtime_snapshot_external_skills_json(&snapshot.external_skills);
@@ -889,6 +902,7 @@ fn build_operator_runtime_summary_read_model(
     let active_provider_profile_id =
         json_string_field(&runtime_snapshot.provider, "active_profile_id");
     let active_provider_label = json_string_field(&runtime_snapshot.provider, "active_label");
+    let tool_calling = runtime_snapshot.tools.tool_calling.clone();
 
     GatewayOperatorRuntimeSummaryReadModel {
         enabled_channel_ids,
@@ -897,6 +911,19 @@ fn build_operator_runtime_summary_read_model(
         capability_snapshot_sha256,
         active_provider_profile_id,
         active_provider_label,
+        tool_calling,
+    }
+}
+
+fn build_tool_calling_read_model(
+    state: &crate::RuntimeSnapshotToolCallingState,
+) -> GatewayToolCallingReadModel {
+    GatewayToolCallingReadModel {
+        availability: state.availability.clone(),
+        structured_tool_schema_enabled: state.structured_tool_schema_enabled,
+        effective_tool_schema_mode: state.effective_tool_schema_mode.clone(),
+        active_model: state.active_model.clone(),
+        reason: state.reason.clone(),
     }
 }
 

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -304,7 +304,7 @@ fn gateway_owner_mode(
     }
 }
 
-fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerStatus {
+pub(crate) fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerStatus {
     GatewayOwnerStatus {
         runtime_dir: runtime_dir.display().to_string(),
         phase: "stopped".to_owned(),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -82,9 +82,7 @@ pub fn run_memory_context_benchmark_cli(
     Err("benchmark-memory-context requires the daemon `memory-sqlite` feature".to_owned())
 }
 
-pub use base64;
-pub use kernel;
-pub use sha2;
+pub use {base64, kernel, sha2};
 
 pub mod audit_cli;
 mod browser_companion_diagnostics;
@@ -144,6 +142,7 @@ pub mod supervisor;
 mod task_execution;
 pub mod tasks_cli;
 mod tlon_cli;
+mod tool_calling_readiness;
 pub mod trajectory_cli;
 pub mod work_unit_cli;
 
@@ -176,6 +175,9 @@ use task_execution::execute_daemon_task_with_supervisor;
 pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
+use tool_calling_readiness::{
+    RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state,
+};
 pub use trajectory_cli::{
     TRAJECTORY_EXPORT_ARTIFACT_JSON_SCHEMA_VERSION, TrajectoryExportArtifactDocument,
     TrajectoryExportArtifactSchema, TrajectoryExportEvent, TrajectoryExportSessionSummary,
@@ -2338,6 +2340,7 @@ pub struct RuntimeSnapshotCliState {
     pub visible_tool_names: Vec<String>,
     pub capability_snapshot: String,
     pub capability_snapshot_sha256: String,
+    pub tool_calling: RuntimeSnapshotToolCallingState,
     pub runtime_plugins: RuntimeSnapshotRuntimePluginsState,
     pub external_skills: RuntimeSnapshotExternalSkillsState,
     pub restore_spec: RuntimeSnapshotRestoreSpec,
@@ -2592,9 +2595,11 @@ fn collect_runtime_snapshot_cli_state_from_parts(
         .tool_names()
         .map(str::to_owned)
         .collect::<Vec<_>>();
+    let visible_tool_count = visible_tool_names.len();
     let capability_snapshot = mvp::tools::capability_snapshot_with_config(&snapshot_tool_runtime);
     let capability_snapshot_sha256 =
         runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
+    let tool_calling = collect_runtime_snapshot_tool_calling_state(config, visible_tool_count);
     let runtime_plugins = collect_runtime_snapshot_runtime_plugins_state(config);
     let restore_spec = build_runtime_snapshot_restore_spec(config, &external_skills);
 
@@ -2611,6 +2616,7 @@ fn collect_runtime_snapshot_cli_state_from_parts(
         visible_tool_names,
         capability_snapshot,
         capability_snapshot_sha256,
+        tool_calling,
         runtime_plugins,
         external_skills,
         restore_spec,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -139,6 +139,7 @@ pub mod session_cli;
 pub mod sessions_cli;
 pub mod skills_cli;
 pub mod source_presentation;
+pub mod status_cli;
 pub mod supervisor;
 mod task_execution;
 pub mod tasks_cli;
@@ -704,6 +705,13 @@ pub enum Commands {
         session: String,
         #[command(subcommand)]
         command: sessions_cli::SessionsCommands,
+    },
+    /// Print one operator-readable runtime summary over gateway, ACP, and durable work-unit health
+    Status {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     #[command(
         visible_alias = "plugin",

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -145,7 +145,6 @@ mod tlon_cli;
 mod tool_calling_readiness;
 pub mod trajectory_cli;
 pub mod work_unit_cli;
-
 use channel_bridge_render::{
     push_channel_surface_managed_plugin_bridge_discovery,
     push_channel_surface_plugin_bridge_contract,
@@ -175,9 +174,8 @@ use task_execution::execute_daemon_task_with_supervisor;
 pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
-use tool_calling_readiness::{
-    RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state,
-};
+#[rustfmt::skip]
+use tool_calling_readiness::{RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state};
 pub use trajectory_cli::{
     TRAJECTORY_EXPORT_ARTIFACT_JSON_SCHEMA_VERSION, TrajectoryExportArtifactDocument,
     TrajectoryExportArtifactSchema, TrajectoryExportEvent, TrajectoryExportSessionSummary,
@@ -185,7 +183,6 @@ pub use trajectory_cli::{
     format_trajectory_inspect_text, load_trajectory_export_artifact, run_trajectory_export_cli,
     run_trajectory_inspect_cli,
 };
-
 #[allow(
     clippy::expect_used,
     clippy::panic,
@@ -709,12 +706,8 @@ pub enum Commands {
         command: sessions_cli::SessionsCommands,
     },
     /// Print one operator-readable runtime summary over gateway, ACP, and durable work-unit health
-    Status {
-        #[arg(long)]
-        config: Option<String>,
-        #[arg(long, default_value_t = false)]
-        json: bool,
-    },
+    #[rustfmt::skip]
+    Status { #[arg(long)] config: Option<String>, #[arg(long, default_value_t = false)] json: bool },
     #[command(
         visible_alias = "plugin",
         about = "Author manifest-first plugin packages and inspect shared plugin governance truth",
@@ -2325,7 +2318,6 @@ pub async fn run_list_models_cli(config_path: Option<&str>, as_json: bool) -> Cl
 
 pub const RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION: u32 = 1;
 pub const RUNTIME_SNAPSHOT_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 2;
-
 #[derive(Debug, Clone)]
 pub struct RuntimeSnapshotCliState {
     pub config: String,
@@ -2591,18 +2583,16 @@ fn collect_runtime_snapshot_cli_state_from_parts(
     let (external_skills, snapshot_tool_runtime) =
         collect_runtime_snapshot_external_skills_state(&tool_runtime);
     let tool_view = mvp::tools::runtime_tool_view_for_runtime_config(&snapshot_tool_runtime);
-    let visible_tool_names = tool_view
+    let visible_tools = tool_view
         .tool_names()
         .map(str::to_owned)
         .collect::<Vec<_>>();
-    let visible_tool_count = visible_tool_names.len();
     let capability_snapshot = mvp::tools::capability_snapshot_with_config(&snapshot_tool_runtime);
     let capability_snapshot_sha256 =
-        runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
-    let tool_calling = collect_runtime_snapshot_tool_calling_state(config, visible_tool_count);
+        runtime_snapshot_tool_digest(&visible_tools, &capability_snapshot)?;
+    let tool_calling = collect_runtime_snapshot_tool_calling_state(config, visible_tools.len());
     let runtime_plugins = collect_runtime_snapshot_runtime_plugins_state(config);
     let restore_spec = build_runtime_snapshot_restore_spec(config, &external_skills);
-
     Ok(RuntimeSnapshotCliState {
         config: config_display,
         provider,
@@ -2613,7 +2603,7 @@ fn collect_runtime_snapshot_cli_state_from_parts(
         enabled_service_channel_ids,
         channels,
         tool_runtime: snapshot_tool_runtime,
-        visible_tool_names,
+        visible_tool_names: visible_tools,
         capability_snapshot,
         capability_snapshot_sha256,
         tool_calling,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -334,6 +334,9 @@ async fn main() {
             json,
             command,
         }),
+        Commands::Status { config, json } => {
+            status_cli::run_status_cli(config.as_deref(), json).await
+        }
         Commands::Tasks {
             config,
             json,

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -1,0 +1,496 @@
+use loongclaw_contracts::WorkRuntimeHealthSnapshot;
+use loongclaw_spec::CliResult;
+use serde::Serialize;
+
+use crate::gateway::read_models::{
+    GatewayAcpObservabilityReadModel, GatewayOperatorSummaryReadModel,
+    build_acp_observability_read_model, build_operator_summary_read_model,
+    build_runtime_snapshot_read_model,
+};
+use crate::gateway::service::default_gateway_owner_status;
+use crate::gateway::state::{default_gateway_runtime_state_dir, load_gateway_owner_status};
+use crate::mvp;
+use crate::supervisor::LoadedSupervisorConfig;
+
+const STATUS_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusCliJsonSchema {
+    pub version: u32,
+    pub surface: &'static str,
+    pub purpose: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusCliAcpReadModel {
+    pub enabled: bool,
+    pub availability: String,
+    pub error: Option<String>,
+    pub persisted_session_count: Option<usize>,
+    pub observability: Option<GatewayAcpObservabilityReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusCliWorkUnitReadModel {
+    pub availability: String,
+    pub error: Option<String>,
+    pub health: Option<WorkRuntimeHealthSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusCliReadModel {
+    pub config: String,
+    pub schema: StatusCliJsonSchema,
+    pub gateway: GatewayOperatorSummaryReadModel,
+    pub acp: StatusCliAcpReadModel,
+    pub work_units: StatusCliWorkUnitReadModel,
+    pub recipes: Vec<String>,
+}
+
+pub async fn run_status_cli(config_path: Option<&str>, as_json: bool) -> CliResult<()> {
+    let status = collect_status_cli_read_model(config_path).await?;
+
+    if as_json {
+        let pretty_result = serde_json::to_string_pretty(&status);
+        let pretty =
+            pretty_result.map_err(|error| format!("serialize status output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_status_cli_text(&status);
+    println!("{rendered}");
+    Ok(())
+}
+
+pub async fn collect_status_cli_read_model(
+    config_path: Option<&str>,
+) -> CliResult<StatusCliReadModel> {
+    let load_result = mvp::config::load(config_path);
+    let (resolved_path, config) = load_result?;
+    let resolved_path_ref = resolved_path.as_path();
+    mvp::runtime_env::initialize_runtime_environment(&config, Some(resolved_path_ref));
+
+    let loaded_config = LoadedSupervisorConfig {
+        resolved_path: resolved_path.clone(),
+        config: config.clone(),
+    };
+    let snapshot_result =
+        crate::collect_runtime_snapshot_cli_state_from_loaded_config(&loaded_config);
+    let snapshot = snapshot_result?;
+    let config_path_display = resolved_path.display().to_string();
+    let config_path_text = config_path_display.as_str();
+    let channel_inventory =
+        crate::build_channels_cli_json_payload(config_path_text, &snapshot.channels);
+    let runtime_snapshot = build_runtime_snapshot_read_model(&snapshot);
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let owner_status_option = load_gateway_owner_status(runtime_dir.as_path());
+    let owner_status = match owner_status_option {
+        Some(owner_status) => owner_status,
+        None => default_gateway_owner_status(runtime_dir.as_path()),
+    };
+    let gateway =
+        build_operator_summary_read_model(&owner_status, &channel_inventory, &runtime_snapshot);
+    let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
+    let work_units = collect_status_cli_work_unit_read_model(&config);
+    let recipes = build_status_cli_recipes(config_path_text);
+    let schema = StatusCliJsonSchema {
+        version: STATUS_CLI_JSON_SCHEMA_VERSION,
+        surface: "status",
+        purpose: "operator_runtime_summary",
+    };
+
+    Ok(StatusCliReadModel {
+        config: config_path_display,
+        schema,
+        gateway,
+        acp,
+        work_units,
+        recipes,
+    })
+}
+
+async fn collect_status_cli_acp_read_model(
+    config_path: &str,
+    config: &mvp::config::LoongClawConfig,
+) -> StatusCliAcpReadModel {
+    let enabled = config.acp.enabled;
+    let persisted_session_count = load_persisted_acp_session_count(config);
+
+    if !enabled {
+        return StatusCliAcpReadModel {
+            enabled,
+            availability: "disabled".to_owned(),
+            error: None,
+            persisted_session_count,
+            observability: None,
+        };
+    }
+
+    let manager_result = mvp::acp::shared_acp_session_manager(config);
+    let manager = match manager_result {
+        Ok(manager) => manager,
+        Err(error) => {
+            return StatusCliAcpReadModel {
+                enabled,
+                availability: "unavailable".to_owned(),
+                error: Some(error),
+                persisted_session_count,
+                observability: None,
+            };
+        }
+    };
+
+    let snapshot_result = manager.observability_snapshot(config).await;
+    let snapshot = match snapshot_result {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            return StatusCliAcpReadModel {
+                enabled,
+                availability: "unavailable".to_owned(),
+                error: Some(error),
+                persisted_session_count,
+                observability: None,
+            };
+        }
+    };
+
+    let observability = build_acp_observability_read_model(config_path, &snapshot);
+
+    StatusCliAcpReadModel {
+        enabled,
+        availability: "available".to_owned(),
+        error: None,
+        persisted_session_count,
+        observability: Some(observability),
+    }
+}
+
+fn collect_status_cli_work_unit_read_model(
+    config: &mvp::config::LoongClawConfig,
+) -> StatusCliWorkUnitReadModel {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = config;
+        StatusCliWorkUnitReadModel {
+            availability: "unavailable".to_owned(),
+            error: Some("work unit runtime requires feature `memory-sqlite`".to_owned()),
+            health: None,
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let repository_result = mvp::work::repository::WorkUnitRepository::new(&memory_config);
+        let repository = match repository_result {
+            Ok(repository) => repository,
+            Err(error) => {
+                return StatusCliWorkUnitReadModel {
+                    availability: "unavailable".to_owned(),
+                    error: Some(error),
+                    health: None,
+                };
+            }
+        };
+
+        let health_result = repository.load_runtime_health(None);
+        let health = match health_result {
+            Ok(health) => health,
+            Err(error) => {
+                return StatusCliWorkUnitReadModel {
+                    availability: "unavailable".to_owned(),
+                    error: Some(error),
+                    health: None,
+                };
+            }
+        };
+
+        StatusCliWorkUnitReadModel {
+            availability: "available".to_owned(),
+            error: None,
+            health: Some(health),
+        }
+    }
+}
+
+fn load_persisted_acp_session_count(config: &mvp::config::LoongClawConfig) -> Option<usize> {
+    #[cfg(not(any(feature = "memory-sqlite", feature = "mvp")))]
+    {
+        let _ = config;
+        None
+    }
+
+    #[cfg(any(feature = "memory-sqlite", feature = "mvp"))]
+    {
+        let sqlite_path = config.memory.resolved_sqlite_path();
+        let store = mvp::acp::AcpSqliteSessionStore::new(Some(sqlite_path));
+        let sessions_result = mvp::acp::AcpSessionStore::list(&store);
+        let sessions = match sessions_result {
+            Ok(sessions) => sessions,
+            Err(_) => {
+                return None;
+            }
+        };
+        Some(sessions.len())
+    }
+}
+
+fn build_status_cli_recipes(config_path: &str) -> Vec<String> {
+    let command_name = crate::active_cli_command_name();
+    let config_arg = crate::cli_handoff::shell_quote_argument(config_path);
+    let gateway_recipe = format!("{command_name} gateway status");
+    let channels_recipe = format!("{command_name} channels --config {config_arg} --json");
+    let acp_observability_recipe =
+        format!("{command_name} acp-observability --config {config_arg} --json");
+    let acp_sessions_recipe =
+        format!("{command_name} list-acp-sessions --config {config_arg} --json");
+    let work_units_recipe = format!("{command_name} work-unit health --config {config_arg} --json");
+
+    vec![
+        gateway_recipe,
+        channels_recipe,
+        acp_observability_recipe,
+        acp_sessions_recipe,
+        work_units_recipe,
+    ]
+}
+
+fn render_status_cli_text(status: &StatusCliReadModel) -> String {
+    let gateway = &status.gateway;
+    let owner = &gateway.owner;
+    let control_surface = &gateway.control_surface;
+    let channels = &gateway.channels;
+    let runtime = &gateway.runtime;
+    let base_url_option = control_surface.base_url.as_deref();
+    let base_url = base_url_option.unwrap_or("-");
+    let owner_pid = render_optional_u32(owner.pid);
+    let owner_session_option = owner.attached_cli_session.as_deref();
+    let owner_session = owner_session_option.unwrap_or("-");
+    let owner_error_option = owner.last_error.as_deref();
+    let owner_error = owner_error_option.unwrap_or("-");
+    let owner_shutdown_reason_option = owner.shutdown_reason.as_deref();
+    let owner_shutdown_reason = owner_shutdown_reason_option.unwrap_or("-");
+    let active_provider_profile_id_option = runtime.active_provider_profile_id.as_deref();
+    let active_provider_profile_id = active_provider_profile_id_option.unwrap_or("-");
+    let active_provider_label_option = runtime.active_provider_label.as_deref();
+    let active_provider_label = active_provider_label_option.unwrap_or("-");
+    let capability_snapshot_sha256 = runtime.capability_snapshot_sha256.as_str();
+
+    let mut lines = Vec::new();
+    lines.push(format!("config={}", status.config));
+    lines.push(format!(
+        "gateway phase={} running={} stale={} mode={} pid={} session={} control_base_url={} owner_config={} loopback_only={} surfaces_configured={} surfaces_running={}",
+        owner.phase,
+        owner.running,
+        owner.stale,
+        owner.mode.as_str(),
+        owner_pid,
+        owner_session,
+        base_url,
+        owner.config_path,
+        control_surface.loopback_only,
+        owner.configured_surface_count,
+        owner.running_surface_count,
+    ));
+    lines.push(format!(
+        "gateway_shutdown_reason={} gateway_last_error={}",
+        owner_shutdown_reason, owner_error,
+    ));
+    lines.push(format!(
+        "channels catalog={} configured={} enabled_accounts={} misconfigured_accounts={} runtime_backed={} enabled_service_channels={} ready_service_channels={}",
+        channels.catalog_channel_count,
+        channels.configured_account_count,
+        channels.enabled_account_count,
+        channels.misconfigured_account_count,
+        channels.runtime_backed_channel_count,
+        channels.enabled_service_channel_count,
+        channels.ready_service_channel_count,
+    ));
+    lines.push(format!(
+        "runtime provider_profile={} provider_label={} visible_tool_count={} capability_snapshot_sha256={}",
+        active_provider_profile_id,
+        active_provider_label,
+        runtime.visible_tool_count,
+        capability_snapshot_sha256,
+    ));
+    lines.push(render_status_cli_acp_text(&status.acp));
+    lines.push(render_status_cli_work_units_text(&status.work_units));
+
+    if !status.recipes.is_empty() {
+        lines.push("recipes:".to_owned());
+        for recipe in &status.recipes {
+            lines.push(format!("- {recipe}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn render_status_cli_acp_text(acp: &StatusCliAcpReadModel) -> String {
+    let persisted_session_count = render_optional_usize(acp.persisted_session_count);
+    let availability = acp.availability.as_str();
+
+    if let Some(observability) = &acp.observability {
+        let snapshot = &observability.snapshot;
+        let error_values = snapshot.errors_by_code.values();
+        let error_values = error_values.copied();
+        let error_total = error_values.sum::<usize>();
+        let line = format!(
+            "acp enabled={} availability={} persisted_sessions={} runtime_active_sessions={} bound_sessions={} unbound_sessions={} actor_queue_depth={} turn_queue_depth={} turn_failures={} error_total={}",
+            acp.enabled,
+            availability,
+            persisted_session_count,
+            snapshot.runtime_cache.active_sessions,
+            snapshot.sessions.bound,
+            snapshot.sessions.unbound,
+            snapshot.actors.queue_depth,
+            snapshot.turns.queue_depth,
+            snapshot.turns.failed,
+            error_total,
+        );
+        return line;
+    }
+
+    let error_option = acp.error.as_deref();
+    let error = error_option.unwrap_or("-");
+    format!(
+        "acp enabled={} availability={} persisted_sessions={} error={}",
+        acp.enabled, availability, persisted_session_count, error,
+    )
+}
+
+fn render_status_cli_work_units_text(work_units: &StatusCliWorkUnitReadModel) -> String {
+    let availability = work_units.availability.as_str();
+
+    if let Some(health) = &work_units.health {
+        let line = format!(
+            "work_units availability={} total_count={} ready_count={} leased_count={} running_count={} blocked_count={} retry_pending_count={} terminal_count={} archived_count={} expired_lease_count={}",
+            availability,
+            health.total_count,
+            health.ready_count,
+            health.leased_count,
+            health.running_count,
+            health.blocked_count,
+            health.retry_pending_count,
+            health.terminal_count,
+            health.archived_count,
+            health.expired_lease_count,
+        );
+        return line;
+    }
+
+    let error_option = work_units.error.as_deref();
+    let error = error_option.unwrap_or("-");
+    format!("work_units availability={} error={}", availability, error)
+}
+
+fn render_optional_u32(value: Option<u32>) -> String {
+    let value = value.map(|value| value.to_string());
+    value.unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_optional_usize(value: Option<usize>) -> String {
+    let value = value.map(|value| value.to_string());
+    value.unwrap_or_else(|| "-".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::read_models::{
+        GatewayOperatorChannelsSummaryReadModel, GatewayOperatorControlSurfaceReadModel,
+        GatewayOperatorRuntimeSummaryReadModel,
+    };
+    use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus};
+
+    #[test]
+    fn render_status_cli_text_surfaces_drill_down_recipes() {
+        let gateway = GatewayOperatorSummaryReadModel {
+            owner: GatewayOwnerStatus {
+                runtime_dir: "/tmp/runtime".to_owned(),
+                phase: "running".to_owned(),
+                running: true,
+                stale: false,
+                pid: Some(42),
+                mode: GatewayOwnerMode::GatewayHeadless,
+                version: "0.0.0-test".to_owned(),
+                config_path: "/tmp/config.toml".to_owned(),
+                attached_cli_session: None,
+                started_at_ms: 1,
+                last_heartbeat_at: 2,
+                stopped_at_ms: None,
+                shutdown_reason: None,
+                last_error: None,
+                configured_surface_count: 1,
+                running_surface_count: 1,
+                bind_address: Some("127.0.0.1".to_owned()),
+                port: Some(7777),
+                token_path: Some("/tmp/token".to_owned()),
+            },
+            control_surface: GatewayOperatorControlSurfaceReadModel {
+                base_url: Some("http://127.0.0.1:7777".to_owned()),
+                loopback_only: true,
+            },
+            channels: GatewayOperatorChannelsSummaryReadModel {
+                catalog_channel_count: 1,
+                configured_channel_count: 1,
+                configured_account_count: 1,
+                enabled_account_count: 1,
+                misconfigured_account_count: 0,
+                runtime_backed_channel_count: 1,
+                enabled_service_channel_count: 1,
+                ready_service_channel_count: 1,
+                surfaces: Vec::new(),
+            },
+            runtime: GatewayOperatorRuntimeSummaryReadModel {
+                enabled_channel_ids: vec!["telegram".to_owned()],
+                enabled_service_channel_ids: vec!["telegram".to_owned()],
+                visible_tool_count: 4,
+                capability_snapshot_sha256: "abc123".to_owned(),
+                active_provider_profile_id: Some("demo".to_owned()),
+                active_provider_label: Some("Demo".to_owned()),
+            },
+        };
+        let status = StatusCliReadModel {
+            config: "/tmp/config.toml".to_owned(),
+            schema: StatusCliJsonSchema {
+                version: STATUS_CLI_JSON_SCHEMA_VERSION,
+                surface: "status",
+                purpose: "operator_runtime_summary",
+            },
+            gateway,
+            acp: StatusCliAcpReadModel {
+                enabled: false,
+                availability: "disabled".to_owned(),
+                error: None,
+                persisted_session_count: Some(0),
+                observability: None,
+            },
+            work_units: StatusCliWorkUnitReadModel {
+                availability: "available".to_owned(),
+                error: None,
+                health: Some(WorkRuntimeHealthSnapshot {
+                    total_count: 0,
+                    ready_count: 0,
+                    leased_count: 0,
+                    running_count: 0,
+                    blocked_count: 0,
+                    retry_pending_count: 0,
+                    terminal_count: 0,
+                    archived_count: 0,
+                    expired_lease_count: 0,
+                }),
+            },
+            recipes: vec!["loong gateway status".to_owned()],
+        };
+
+        let rendered = render_status_cli_text(&status);
+
+        assert!(rendered.contains("gateway phase=running"));
+        assert!(rendered.contains("acp enabled=false availability=disabled"));
+        assert!(rendered.contains("work_units availability=available total_count=0"));
+        assert!(rendered.contains("recipes:\n- loong gateway status"));
+    }
+}

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -131,13 +131,7 @@ async fn collect_status_cli_acp_read_model(
     let manager = match manager_result {
         Ok(manager) => manager,
         Err(error) => {
-            return StatusCliAcpReadModel {
-                enabled,
-                availability: "unavailable".to_owned(),
-                error: Some(error),
-                persisted_session_count,
-                observability: None,
-            };
+            return build_unavailable_acp_read_model(enabled, error, persisted_session_count);
         }
     };
 
@@ -145,13 +139,7 @@ async fn collect_status_cli_acp_read_model(
     let snapshot = match snapshot_result {
         Ok(snapshot) => snapshot,
         Err(error) => {
-            return StatusCliAcpReadModel {
-                enabled,
-                availability: "unavailable".to_owned(),
-                error: Some(error),
-                persisted_session_count,
-                observability: None,
-            };
+            return build_unavailable_acp_read_model(enabled, error, persisted_session_count);
         }
     };
 
@@ -163,6 +151,20 @@ async fn collect_status_cli_acp_read_model(
         error: None,
         persisted_session_count,
         observability: Some(observability),
+    }
+}
+
+fn build_unavailable_acp_read_model(
+    enabled: bool,
+    error: String,
+    persisted_session_count: Option<usize>,
+) -> StatusCliAcpReadModel {
+    StatusCliAcpReadModel {
+        enabled,
+        availability: "unavailable".to_owned(),
+        error: Some(error),
+        persisted_session_count,
+        observability: None,
     }
 }
 
@@ -277,6 +279,7 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
     let active_provider_label_option = runtime.active_provider_label.as_deref();
     let active_provider_label = active_provider_label_option.unwrap_or("-");
     let capability_snapshot_sha256 = runtime.capability_snapshot_sha256.as_str();
+    let tool_calling = &runtime.tool_calling;
 
     let mut lines = Vec::new();
     lines.push(format!("config={}", status.config));
@@ -314,6 +317,14 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
         active_provider_label,
         runtime.visible_tool_count,
         capability_snapshot_sha256,
+    ));
+    lines.push(format!(
+        "tool_calling availability={} structured_tool_schema_enabled={} mode={} active_model={} reason={}",
+        tool_calling.availability,
+        tool_calling.structured_tool_schema_enabled,
+        tool_calling.effective_tool_schema_mode,
+        tool_calling.active_model,
+        tool_calling.reason,
     ));
     lines.push(render_status_cli_acp_text(&status.acp));
     lines.push(render_status_cli_work_units_text(&status.work_units));
@@ -451,6 +462,15 @@ mod tests {
                 capability_snapshot_sha256: "abc123".to_owned(),
                 active_provider_profile_id: Some("demo".to_owned()),
                 active_provider_label: Some("Demo".to_owned()),
+                tool_calling: crate::gateway::read_models::GatewayToolCallingReadModel {
+                    availability: "ready".to_owned(),
+                    structured_tool_schema_enabled: true,
+                    effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                    active_model: "gpt-4.1-mini".to_owned(),
+                    reason:
+                        "provider turns include structured tool definitions for the active model"
+                            .to_owned(),
+                },
             },
         };
         let status = StatusCliReadModel {
@@ -489,6 +509,7 @@ mod tests {
         let rendered = render_status_cli_text(&status);
 
         assert!(rendered.contains("gateway phase=running"));
+        assert!(rendered.contains("tool_calling availability=ready"));
         assert!(rendered.contains("acp enabled=false availability=disabled"));
         assert!(rendered.contains("work_units availability=available total_count=0"));
         assert!(rendered.contains("recipes:\n- loong gateway status"));

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -1,6 +1,7 @@
 use loongclaw_contracts::WorkRuntimeHealthSnapshot;
 use loongclaw_spec::CliResult;
 use serde::Serialize;
+use std::path::Path;
 
 use crate::gateway::read_models::{
     GatewayAcpObservabilityReadModel, GatewayOperatorSummaryReadModel,
@@ -85,10 +86,11 @@ pub async fn collect_status_cli_read_model(
     let runtime_snapshot = build_runtime_snapshot_read_model(&snapshot);
     let runtime_dir = default_gateway_runtime_state_dir();
     let owner_status_option = load_gateway_owner_status(runtime_dir.as_path());
-    let owner_status = match owner_status_option {
-        Some(owner_status) => owner_status,
-        None => default_gateway_owner_status(runtime_dir.as_path()),
-    };
+    let owner_status = select_gateway_owner_status_for_config(
+        runtime_dir.as_path(),
+        config_path_text,
+        owner_status_option,
+    );
     let gateway =
         build_operator_summary_read_model(&owner_status, &channel_inventory, &runtime_snapshot);
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
@@ -108,6 +110,26 @@ pub async fn collect_status_cli_read_model(
         work_units,
         recipes,
     })
+}
+
+fn select_gateway_owner_status_for_config(
+    runtime_dir: &Path,
+    config_path: &str,
+    owner_status: Option<crate::gateway::state::GatewayOwnerStatus>,
+) -> crate::gateway::state::GatewayOwnerStatus {
+    let Some(owner_status) = owner_status else {
+        return default_gateway_owner_status(runtime_dir);
+    };
+
+    let owner_config_path = Path::new(owner_status.config_path.as_str());
+    let requested_config_path = Path::new(config_path);
+    let matches_requested_config = owner_config_path == requested_config_path;
+
+    if matches_requested_config {
+        return owner_status;
+    }
+
+    default_gateway_owner_status(runtime_dir)
 }
 
 async fn collect_status_cli_acp_read_model(
@@ -513,5 +535,75 @@ mod tests {
         assert!(rendered.contains("acp enabled=false availability=disabled"));
         assert!(rendered.contains("work_units availability=available total_count=0"));
         assert!(rendered.contains("recipes:\n- loong gateway status"));
+    }
+
+    #[test]
+    fn select_gateway_owner_status_for_config_ignores_mismatched_gateway_owner() {
+        let runtime_dir = Path::new("/tmp/runtime");
+        let owner_status = GatewayOwnerStatus {
+            runtime_dir: runtime_dir.display().to_string(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: "0.0.0-test".to_owned(),
+            config_path: "/tmp/other-config.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1,
+            last_heartbeat_at: 2,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 1,
+            running_surface_count: 1,
+            bind_address: None,
+            port: None,
+            token_path: None,
+        };
+
+        let selected = select_gateway_owner_status_for_config(
+            runtime_dir,
+            "/tmp/requested-config.toml",
+            Some(owner_status),
+        );
+
+        assert_eq!(selected.phase, "stopped");
+        assert!(!selected.running);
+        assert_eq!(selected.config_path, "-");
+    }
+
+    #[test]
+    fn select_gateway_owner_status_for_config_keeps_matching_gateway_owner() {
+        let runtime_dir = Path::new("/tmp/runtime");
+        let owner_status = GatewayOwnerStatus {
+            runtime_dir: runtime_dir.display().to_string(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: "0.0.0-test".to_owned(),
+            config_path: "/tmp/requested-config.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1,
+            last_heartbeat_at: 2,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 1,
+            running_surface_count: 1,
+            bind_address: None,
+            port: None,
+            token_path: None,
+        };
+
+        let selected = select_gateway_owner_status_for_config(
+            runtime_dir,
+            "/tmp/requested-config.toml",
+            Some(owner_status.clone()),
+        );
+
+        assert_eq!(selected, owner_status);
     }
 }

--- a/crates/daemon/src/tool_calling_readiness.rs
+++ b/crates/daemon/src/tool_calling_readiness.rs
@@ -1,0 +1,82 @@
+use crate::mvp;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeSnapshotToolCallingState {
+    pub availability: String,
+    pub structured_tool_schema_enabled: bool,
+    pub effective_tool_schema_mode: String,
+    pub active_model: String,
+    pub reason: String,
+}
+
+pub fn collect_runtime_snapshot_tool_calling_state(
+    config: &mvp::config::LoongClawConfig,
+    visible_tool_count: usize,
+) -> RuntimeSnapshotToolCallingState {
+    let provider_readiness = mvp::provider::provider_tool_schema_readiness(config);
+    let no_visible_tools = visible_tool_count == 0;
+
+    if no_visible_tools {
+        return RuntimeSnapshotToolCallingState {
+            availability: "inactive".to_owned(),
+            structured_tool_schema_enabled: provider_readiness.structured_tool_schema_enabled,
+            effective_tool_schema_mode: provider_readiness.effective_tool_schema_mode,
+            active_model: provider_readiness.active_model,
+            reason: "no runtime-visible tools are enabled".to_owned(),
+        };
+    }
+
+    if provider_readiness.structured_tool_schema_enabled {
+        return RuntimeSnapshotToolCallingState {
+            availability: "ready".to_owned(),
+            structured_tool_schema_enabled: true,
+            effective_tool_schema_mode: provider_readiness.effective_tool_schema_mode,
+            active_model: provider_readiness.active_model,
+            reason: "provider turns include structured tool definitions for the active model"
+                .to_owned(),
+        };
+    }
+
+    RuntimeSnapshotToolCallingState {
+        availability: "degraded".to_owned(),
+        structured_tool_schema_enabled: false,
+        effective_tool_schema_mode: provider_readiness.effective_tool_schema_mode,
+        active_model: provider_readiness.active_model,
+        reason:
+            "provider turns omit structured tool definitions for the active model; tool use relies on prompt-visible guidance only"
+                .to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_runtime_snapshot_tool_calling_state;
+    use crate::mvp;
+
+    #[test]
+    fn tool_calling_state_is_inactive_when_no_tools_are_visible() {
+        let config = mvp::config::LoongClawConfig::default();
+
+        let state = collect_runtime_snapshot_tool_calling_state(&config, 0);
+
+        assert_eq!(state.availability, "inactive");
+        assert_eq!(state.reason, "no runtime-visible tools are enabled");
+    }
+
+    #[test]
+    fn tool_calling_state_is_degraded_when_tool_schema_is_disabled() {
+        let config = mvp::config::LoongClawConfig {
+            provider: mvp::config::ProviderConfig {
+                tool_schema_mode: mvp::config::ProviderToolSchemaModeConfig::Disabled,
+                ..mvp::config::ProviderConfig::default()
+            },
+            ..mvp::config::LoongClawConfig::default()
+        };
+
+        let state = collect_runtime_snapshot_tool_calling_state(&config, 2);
+
+        assert_eq!(state.availability, "degraded");
+        assert!(!state.structured_tool_schema_enabled);
+        assert_eq!(state.effective_tool_schema_mode, "disabled");
+    }
+}

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -813,6 +813,12 @@ async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stop
             .map(|value| value as usize)
             .unwrap_or_default()
     );
+    assert_eq!(
+        operator_summary.runtime.tool_calling.availability,
+        runtime_snapshot["tools"]["tool_calling"]["availability"]
+            .as_str()
+            .unwrap_or_default()
+    );
 
     let stop = client.stop().await.expect("request gateway stop");
     assert_eq!(stop.outcome, GatewayStopResponseOutcome::Requested);

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -412,6 +412,11 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
             .is_some_and(|value| value > 0),
         "runtime snapshot should advertise at least one visible tool"
     );
+    assert_eq!(encoded["tools"]["tool_calling"]["availability"], "ready");
+    assert_eq!(
+        encoded["tools"]["tool_calling"]["structured_tool_schema_enabled"],
+        true
+    );
 
     fs::remove_dir_all(&root).ok();
 }
@@ -489,6 +494,10 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
     assert_eq!(
         summary.runtime.active_provider_profile_id.as_deref(),
         runtime_snapshot.provider["active_profile_id"].as_str()
+    );
+    assert_eq!(
+        summary.runtime.tool_calling.availability,
+        runtime_snapshot.tools.tool_calling.availability
     );
     assert_eq!(
         encoded["control_surface"]["base_url"],

--- a/crates/daemon/tests/integration/managed_bridge_parity.rs
+++ b/crates/daemon/tests/integration/managed_bridge_parity.rs
@@ -54,6 +54,13 @@ fn runtime_snapshot_fixture(
             visible_tool_names: Vec::new(),
             capability_snapshot_sha256: String::new(),
             capability_snapshot: String::new(),
+            tool_calling: loongclaw_daemon::gateway::read_models::GatewayToolCallingReadModel {
+                availability: "inactive".to_owned(),
+                structured_tool_schema_enabled: true,
+                effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                active_model: "gpt-4.1-mini".to_owned(),
+                reason: "no runtime-visible tools are enabled".to_owned(),
+            },
         },
         runtime_plugins: serde_json::json!({}),
         external_skills: serde_json::json!({}),

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -159,6 +159,7 @@ mod sessions_cli;
 mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;
+mod status_cli;
 mod tasks_cli;
 pub(crate) use managed_bridge_fixtures::*;
 mod trajectory_export_cli;

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -20,7 +20,11 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"))
 }
 
-fn write_status_config(root: &Path, acp_enabled: bool) -> PathBuf {
+fn write_status_config(
+    root: &Path,
+    acp_enabled: bool,
+    tool_schema_mode: mvp::config::ProviderToolSchemaModeConfig,
+) -> PathBuf {
     fs::create_dir_all(root).expect("create fixture root");
 
     let sqlite_path = root.join("memory.sqlite3");
@@ -35,6 +39,7 @@ fn write_status_config(root: &Path, acp_enabled: bool) -> PathBuf {
                 kind: mvp::config::ProviderKind::Openai,
                 model: "gpt-4.1-mini".to_owned(),
                 api_key: Some(SecretRef::Inline("demo-token".to_owned())),
+                tool_schema_mode,
                 ..Default::default()
             },
         },
@@ -119,7 +124,11 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
     let root = unique_temp_dir("loongclaw-status-cli-json");
     let home_root = root.join("home");
     fs::create_dir_all(&home_root).expect("create home root");
-    let config_path = write_status_config(&root, true);
+    let config_path = write_status_config(
+        &root,
+        true,
+        mvp::config::ProviderToolSchemaModeConfig::EnabledWithDowngrade,
+    );
     let output =
         run_status_cli_process(&config_path, &home_root, &["--json"], "run status CLI json");
 
@@ -137,6 +146,14 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
 
     assert_eq!(payload["schema"]["surface"], "status");
     assert_eq!(payload["gateway"]["owner"]["phase"], "stopped");
+    assert_eq!(
+        payload["gateway"]["runtime"]["tool_calling"]["availability"],
+        "ready"
+    );
+    assert_eq!(
+        payload["gateway"]["runtime"]["tool_calling"]["structured_tool_schema_enabled"],
+        true
+    );
     assert_eq!(payload["acp"]["enabled"], true);
     let acp_availability = payload["acp"]["availability"]
         .as_str()
@@ -179,7 +196,11 @@ fn status_cli_text_surfaces_section_summaries_and_recipes() {
     let root = unique_temp_dir("loongclaw-status-cli-text");
     let home_root = root.join("home");
     fs::create_dir_all(&home_root).expect("create home root");
-    let config_path = write_status_config(&root, false);
+    let config_path = write_status_config(
+        &root,
+        false,
+        mvp::config::ProviderToolSchemaModeConfig::Disabled,
+    );
     let output = run_status_cli_process(&config_path, &home_root, &[], "run status CLI text");
 
     if !output.status.success() {
@@ -194,6 +215,8 @@ fn status_cli_text_surfaces_section_summaries_and_recipes() {
     let stdout = render_output(&output.stdout);
 
     assert!(stdout.contains("gateway phase=stopped"));
+    assert!(stdout.contains("tool_calling availability=degraded"));
+    assert!(stdout.contains("structured_tool_schema_enabled=false"));
     assert!(stdout.contains("acp enabled=false availability=disabled"));
     assert!(stdout.contains("work_units availability="));
     assert!(stdout.contains("recipes:"));

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -1,0 +1,202 @@
+use super::*;
+use loongclaw_contracts::SecretRef;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
+    let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let process_id = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"))
+}
+
+fn write_status_config(root: &Path, acp_enabled: bool) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let sqlite_path = root.join("memory.sqlite3");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.tools.file_root = Some(root.display().to_string());
+    config.set_active_provider_profile(
+        "demo-openai",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                api_key: Some(SecretRef::Inline("demo-token".to_owned())),
+                ..Default::default()
+            },
+        },
+    );
+
+    if acp_enabled {
+        config.acp.enabled = true;
+        config.acp.dispatch.enabled = true;
+        config.acp.default_agent = Some("codex".to_owned());
+        config.acp.allowed_agents = vec!["codex".to_owned()];
+    }
+
+    let config_path = root.join("loongclaw.toml");
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+    mvp::config::write(Some(config_path_text), &config, true).expect("write config fixture");
+    config_path
+}
+
+fn render_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn run_status_cli_process(
+    config_path: &Path,
+    home_root: &Path,
+    args: &[&str],
+    context: &str,
+) -> std::process::Output {
+    let home_root_text = home_root.to_str().expect("home root should be valid utf-8");
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .arg("status")
+        .arg("--config")
+        .arg(config_path_text)
+        .args(args)
+        .env("LOONG_HOME", home_root_text)
+        .output()
+        .expect(context)
+}
+
+#[test]
+fn cli_status_help_mentions_operator_runtime_summary() {
+    let help = render_cli_help(["status"]);
+
+    assert!(
+        help.contains("operator-readable runtime summary"),
+        "status help should explain the aggregated operator surface: {help}"
+    );
+    assert!(
+        help.contains("--json"),
+        "status help should surface machine-readable output: {help}"
+    );
+}
+
+#[test]
+fn cli_status_parse_accepts_config_and_json_flags() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "status",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--json",
+    ])
+    .expect("status CLI should parse");
+
+    let command = cli.command.expect("CLI should parse a subcommand");
+    let Commands::Status { config, json } = command else {
+        panic!("unexpected CLI parse result: {command:?}");
+    };
+
+    assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+    assert!(json);
+}
+
+#[test]
+fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
+    let root = unique_temp_dir("loongclaw-status-cli-json");
+    let home_root = root.join("home");
+    fs::create_dir_all(&home_root).expect("create home root");
+    let config_path = write_status_config(&root, true);
+    let output =
+        run_status_cli_process(&config_path, &home_root, &["--json"], "run status CLI json");
+
+    if !output.status.success() {
+        let stdout = render_output(&output.stdout);
+        let stderr = render_output(&output.stderr);
+        panic!(
+            "status CLI json should succeed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+            output.status.code()
+        );
+    }
+
+    let stdout = render_output(&output.stdout);
+    let payload: Value = serde_json::from_str(&stdout).expect("decode status json");
+
+    assert_eq!(payload["schema"]["surface"], "status");
+    assert_eq!(payload["gateway"]["owner"]["phase"], "stopped");
+    assert_eq!(payload["acp"]["enabled"], true);
+    let acp_availability = payload["acp"]["availability"]
+        .as_str()
+        .expect("acp availability string");
+    assert!(
+        matches!(acp_availability, "available" | "unavailable"),
+        "unexpected acp availability: {payload:#?}"
+    );
+    if acp_availability == "available" {
+        assert!(payload["acp"]["observability"].is_object());
+    } else {
+        assert!(payload["acp"]["error"].is_string());
+    }
+
+    let work_units_availability = payload["work_units"]["availability"]
+        .as_str()
+        .expect("work-unit availability string");
+    assert!(
+        matches!(work_units_availability, "available" | "unavailable"),
+        "unexpected work-unit availability: {payload:#?}"
+    );
+    if work_units_availability == "available" {
+        assert_eq!(payload["work_units"]["health"]["total_count"], 0);
+    } else {
+        assert!(payload["work_units"]["error"].is_string());
+    }
+    assert!(
+        payload["recipes"]
+            .as_array()
+            .map(|recipes| recipes.len() >= 4)
+            .unwrap_or(false),
+        "status JSON should include drill-down recipes: {payload:#?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn status_cli_text_surfaces_section_summaries_and_recipes() {
+    let root = unique_temp_dir("loongclaw-status-cli-text");
+    let home_root = root.join("home");
+    fs::create_dir_all(&home_root).expect("create home root");
+    let config_path = write_status_config(&root, false);
+    let output = run_status_cli_process(&config_path, &home_root, &[], "run status CLI text");
+
+    if !output.status.success() {
+        let stdout = render_output(&output.stdout);
+        let stderr = render_output(&output.stderr);
+        panic!(
+            "status CLI text should succeed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+            output.status.code()
+        );
+    }
+
+    let stdout = render_output(&output.stdout);
+
+    assert!(stdout.contains("gateway phase=stopped"));
+    assert!(stdout.contains("acp enabled=false availability=disabled"));
+    assert!(stdout.contains("work_units availability="));
+    assert!(stdout.contains("recipes:"));
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/docs/design-docs/local-product-control-plane.md
+++ b/docs/design-docs/local-product-control-plane.md
@@ -7,7 +7,7 @@ LoongClaw already has the hard parts of a kernel-first system:
 - a governed execution boundary in the kernel
 - a real ACP control plane for backend session lifecycle and routing
 - a durable `SessionRepository` for session lineage, events, approvals, and outcomes
-- operator-facing CLI surfaces such as `onboard`, `doctor`, `acp-status`, and `list-acp-sessions`
+- operator-facing CLI surfaces such as `onboard`, `doctor`, `status`, `acp-status`, and `list-acp-sessions`
 
 What it does not yet have is one written contract for how those pieces become a
 coherent local product platform.

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T04:48:26Z
+- Generated at: 2026-04-10T05:14:20Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -14,7 +14,7 @@
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 373 | 1000 | 627 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | -0.5% | PASS | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 405 | 1000 | 595 | 11 | 20 | 9 | 55.0% | HEALTHY | 375 | 8.0% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
@@ -24,12 +24,12 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10294 | 11200 | 906 | 86 | 120 | 34 | 91.9% | WATCH | 10831 | -5.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14777 | 15000 | 223 | 61 | 70 | 9 | 98.5% | TIGHT | 14472 | 2.1% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6494 | 6500 | 6 | 201 | 210 | 9 | 99.9% | TIGHT | 6324 | 2.7% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6498 | 6500 | 2 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (98.7%), tools_mod (98.5%), daemon_lib (99.9%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (98.7%), tools_mod (98.5%), daemon_lib (100.0%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.9%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -60,7 +60,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=373 functions=10 -->
+<!-- arch-hotspot key=provider_mod lines=405 functions=11 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
@@ -70,7 +70,7 @@
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10294 functions=86 -->
 <!-- arch-hotspot key=tools_mod lines=14777 functions=61 -->
-<!-- arch-hotspot key=daemon_lib lines=6494 functions=201 -->
+<!-- arch-hotspot key=daemon_lib lines=6498 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - #217 is still missing its smallest status-oriented first slice.
  - operators have to jump across `gateway status`, `acp-observability`, `list-acp-sessions`, `work-unit health`, and `channels` to reconstruct one runtime picture.
  - even after adding `loongclaw status`, the surface could still look healthier than reality when the active provider/model pair had structured tool calling disabled.
- Why it matters:
  - the runtime substrate already exists, but without one operator-readable summary surface the umbrella still lacks the agreed first status seam.
  - if the status surface hides tool-calling degradation, operators still cannot trust it for autonomy diagnosis.
- What changed:
  - added `loongclaw status` as a read-only operator rollup over existing gateway, ACP, and durable work-unit truth
  - wired the new command through the daemon CLI and command-kind logging surface
  - reused existing gateway read models, ACP observability, and work-unit health instead of adding a second runtime model
  - added shared provider/tool-calling readiness evaluation so status now tells operators whether the active model is actually on the structured tool-calling path, degraded to prompt-visible tool guidance, or inactive because no tools are visible
  - projected that readiness into runtime snapshot, gateway operator summary, status text/json output, and integration coverage
  - updated the public runtime/control-plane docs
- What did not change (scope boundary):
  - no scheduler, cron, heartbeat, or service-install behavior
  - no new gateway HTTP route family
  - no new turn execution surface
  - no new runtime authority or duplicate state store
  - no provider transport redesign or hardcoded provider matrix in daemon code

## Linked Issues

- Closes #1144
- Related #217

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo check -p loongclaw-app -p loongclaw --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app provider_tool_schema_readiness_reports_default_structured_mode --lib
cargo test -p loongclaw-app provider_tool_schema_readiness_honors_disabled_mode_and_model_hints --lib
cargo test -p loongclaw tool_calling_state_is_inactive_when_no_tools_are_visible --lib
cargo test -p loongclaw tool_calling_state_is_degraded_when_tool_schema_is_disabled --lib
cargo test -p loongclaw status_cli_json_rolls_up_gateway_acp_and_work_unit_sections --test integration
cargo test -p loongclaw status_cli_text_surfaces_section_summaries_and_recipes --test integration
cargo test -p loongclaw gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary --test integration
cargo test -p loongclaw gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups --test integration
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
```

Results:
- all listed commands passed in the isolated follow-up worktree
- the tool-calling readiness follow-up stayed additive and reused existing provider/runtime metadata instead of introducing daemon-local heuristics

## User-visible / Operator-visible Changes

- `loongclaw status` now reports one unified operator-facing summary over:
  - gateway owner lifecycle state
  - ACP availability / observability
  - durable work-unit runtime health
  - tool-calling readiness for the active provider/model
- the runtime snapshot and gateway operator summary now expose whether tool use is:
  - `ready` (structured tool schema enabled)
  - `degraded` (tool calls rely on prompt-visible guidance only)
  - `inactive` (no runtime-visible tools)
- text output includes explicit drill-down recipes back to narrower runtime commands

## Failure Recovery

- Fast rollback or disable path:
  - revert commit `8d3ea6921` for the initial status surface and/or `890d63243` for the tool-calling readiness follow-up
- Observable failure symptoms reviewers should watch for:
  - `status` diverges from `gateway status`, `acp-observability`, or `work-unit health`
  - tool-calling readiness reports `ready` when `provider.tool_schema_mode` or active model hints disable structured tool schema
  - gateway/runtime snapshot fixtures or read models drift on the new `tool_calling` field

## Reviewer Focus

- `crates/daemon/src/status_cli.rs`
  - confirm the surface stays read-only, aggregates existing truth only, and renders tool-calling degradation clearly
- `crates/daemon/src/tool_calling_readiness.rs`
  - confirm the readiness helper is metadata-driven and not daemon-local provider branching
- `crates/app/src/provider/mod.rs`
  - confirm provider capability resolution is reused correctly for the active model
- `crates/daemon/src/gateway/read_models.rs`
  - confirm runtime snapshot and operator summary stay schema-aligned with the new field
- `crates/daemon/tests/integration/status_cli.rs`
  - confirm disabled tool-schema vs ready structured-tool-schema cases are both covered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `loongclaw status` CLI: operator-readable runtime summary (pretty text or JSON) including gateway, ACP, work-unit health, tool-calling readiness, and suggested follow-up recipes.
  * Runtime summaries now surface provider tool-schema/readiness and tool-calling status.

* **Documentation**
  * README and design docs updated with `loongclaw status` examples and usage (`--config … --json`).

* **Tests**
  * New unit and integration tests covering status output, flag parsing, and tool-schema/tool-calling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->