### PR TITLE
Replace chat REPL with a fullscreen session surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1057,27 +1057,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f248321c6a7d4de5dcf2939368e96a397ad3f53b6a076e38d0104d1da326d37"
+checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6d78ff1f7d9bf8b7e1afbedbf78ba49e38e9da479d4c8a2db094e22f64e2bc"
+checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6005ba640213a5b95382aeaf6b82bf028309581c8d7349778d66f27dc1180b"
+checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb5b134a12b559ff0c0f5af0fcd755ad380723b5016c4e0d36f74d39485340"
+checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85837de8be7f17a4034a6b08816f05a3144345d2091937b39d415990daca28f4"
+checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e433faa87d38e5b8ff469e44a26fea4f93e58abd7a7c10bad9810056139700c9"
+checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1137,24 +1137,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5397ba61976e13944ca71230775db13ee1cb62849701ed35b753f4761ed0a9b7"
+checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc81c88765580720eb30f4fc2c1bfdb75fcbf3094f87b3cd69cecca79d77a245"
+checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463feed5d46cf8763f3ba3045284cf706dd161496e20ec9c14afbb4ba09b9e66"
+checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c5eca7696c1c04ab4c7ed8d18eadbb47d6cc9f14ec86fe0881bf1d7e97e261"
+checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1176,15 +1176,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
+checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
+checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8594dc6bb4860fa8292f1814c76459dbfb933e1978d8222de6380efce45c7cee"
+checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
 
 [[package]]
 name = "crc32fast"
@@ -1629,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2365,7 +2365,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2931,7 +2931,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3275,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7975f0975fa2c047bf47d617bdf716689e42ee82b159bd000ead7330d7697a1b"
+checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3287,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
+checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3671,7 +3671,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4126,7 +4126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4382,7 +4382,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5184,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fa9f298901a64ed3eae16b130f0b30c80dbb74a9e7f129a791f4e74649b917"
+checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a3aaaa3a522f443af67a7ed8d4efa20b0c3784e1031980537fbfcb497f70a7"
+checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
  "cranelift-bforest",
@@ -5248,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e671917bb6856ae360cb59d7aaf26f1cfd042c7b924319dd06fd380739fc0b2e"
+checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -5259,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dfd752e1dcf79eeeadc6f2681e2fb4a9f0b5534d18c5b9b93faccd0de2c80c"
+checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5286,9 +5286,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e9171af643316c11d6ebe52f31f6e2a5d6d1d270de9167a7b7b6f0e3f72982"
+checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5301,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe23134536b9883ffc2afcffae23f7ffbcb1791e2d9fac6d6464a37ea4c8fdd"
+checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -5311,9 +5311,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3112806515fac8495883885eb8dbdde849988ae91fe6beb544c0d7c0f4c9aa"
+checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5323,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dafc29c6e538273fda8409335137654751bdf24beab65702b7866b0a85ee108a"
+checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5336,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772f2b105b7fdd3dfb2cdf70c297baaeb96fe76a95cdc6fa516f713f04090c73"
+checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5439,7 +5439,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.22"
 bech32 = "0.11"
 ed25519-dalek = "2.2"
 secp256k1 = "0.31"
-wasmtime = { version = "43.0.0", default-features = false, features = ["std", "runtime", "cranelift"] }
+wasmtime = { version = "43.0.1", default-features = false, features = ["std", "runtime", "cranelift"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -98,7 +98,7 @@ use super::session::LATEST_SESSION_SELECTOR;
 use super::session::latest_resumable_root_session_id;
 use super::tui_surface::{
     TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec, TuiHeaderStyle,
-    TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec, render_tui_message_spec,
+    TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec, render_tui_message_body_spec,
     render_tui_screen_spec,
 };
 
@@ -777,69 +777,106 @@ async fn process_cli_chat_input(
         }
         ChatCommandMatchResult::NotMatched => {}
     }
-    if let Some(limit) = parse_fast_lane_summary_limit(input, runtime.config.memory.sliding_window)?
-    {
-        #[cfg(feature = "memory-sqlite")]
-        print_fast_lane_summary(
-            &runtime.session_id,
-            limit,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            &runtime.memory_config,
-        )
-        .await?;
-        #[cfg(not(feature = "memory-sqlite"))]
-        print_fast_lane_summary(
-            &runtime.session_id,
-            limit,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await?;
-        return Ok(CliChatLoopControl::Continue);
+    let fast_lane_limit_result =
+        parse_fast_lane_summary_limit(input, runtime.config.memory.sliding_window);
+    match fast_lane_limit_result {
+        Ok(Some(limit)) => {
+            #[cfg(feature = "memory-sqlite")]
+            print_fast_lane_summary(
+                &runtime.session_id,
+                limit,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                &runtime.memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_fast_lane_summary(
+                &runtime.session_id,
+                limit,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            )
+            .await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        Ok(None) => {}
+        Err(error) => {
+            if let Some(usage_lines) = maybe_render_nonfatal_usage_error(error.as_str()) {
+                print_rendered_cli_chat_lines(&usage_lines);
+                return Ok(CliChatLoopControl::Continue);
+            }
+
+            return Err(error);
+        }
     }
-    if let Some(limit) = parse_safe_lane_summary_limit(input, runtime.config.memory.sliding_window)?
-    {
-        #[cfg(feature = "memory-sqlite")]
-        print_safe_lane_summary(
-            &runtime.session_id,
-            limit,
-            &runtime.config.conversation,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            &runtime.memory_config,
-        )
-        .await?;
-        #[cfg(not(feature = "memory-sqlite"))]
-        print_safe_lane_summary(
-            &runtime.session_id,
-            limit,
-            &runtime.config.conversation,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await?;
-        return Ok(CliChatLoopControl::Continue);
+
+    let safe_lane_limit_result =
+        parse_safe_lane_summary_limit(input, runtime.config.memory.sliding_window);
+    match safe_lane_limit_result {
+        Ok(Some(limit)) => {
+            #[cfg(feature = "memory-sqlite")]
+            print_safe_lane_summary(
+                &runtime.session_id,
+                limit,
+                &runtime.config.conversation,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                &runtime.memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_safe_lane_summary(
+                &runtime.session_id,
+                limit,
+                &runtime.config.conversation,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            )
+            .await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        Ok(None) => {}
+        Err(error) => {
+            if let Some(usage_lines) = maybe_render_nonfatal_usage_error(error.as_str()) {
+                print_rendered_cli_chat_lines(&usage_lines);
+                return Ok(CliChatLoopControl::Continue);
+            }
+
+            return Err(error);
+        }
     }
-    if let Some(limit) =
-        parse_turn_checkpoint_summary_limit(input, runtime.config.memory.sliding_window)?
-    {
-        #[cfg(feature = "memory-sqlite")]
-        print_turn_checkpoint_summary(
-            &runtime.turn_coordinator,
-            &runtime.config,
-            &runtime.session_id,
-            limit,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            &runtime.memory_config,
-        )
-        .await?;
-        #[cfg(not(feature = "memory-sqlite"))]
-        print_turn_checkpoint_summary(
-            &runtime.turn_coordinator,
-            &runtime.config,
-            &runtime.session_id,
-            limit,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await?;
-        return Ok(CliChatLoopControl::Continue);
+
+    let turn_checkpoint_limit_result =
+        parse_turn_checkpoint_summary_limit(input, runtime.config.memory.sliding_window);
+    match turn_checkpoint_limit_result {
+        Ok(Some(limit)) => {
+            #[cfg(feature = "memory-sqlite")]
+            print_turn_checkpoint_summary(
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
+                limit,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                &runtime.memory_config,
+            )
+            .await?;
+            #[cfg(not(feature = "memory-sqlite"))]
+            print_turn_checkpoint_summary(
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
+                limit,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            )
+            .await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        Ok(None) => {}
+        Err(error) => {
+            if let Some(usage_lines) = maybe_render_nonfatal_usage_error(error.as_str()) {
+                print_rendered_cli_chat_lines(&usage_lines);
+                return Ok(CliChatLoopControl::Continue);
+            }
+
+            return Err(error);
+        }
     }
     match classify_chat_command_match_result(is_turn_checkpoint_repair_command(input))? {
         ChatCommandMatchResult::Matched => {
@@ -916,6 +953,18 @@ fn render_cli_chat_command_usage_lines_with_width(usage: &str, width: usize) -> 
     };
 
     render_cli_chat_message_spec_with_width(&message_spec, width)
+}
+
+fn maybe_render_nonfatal_usage_error(error: &str) -> Option<Vec<String>> {
+    let usage_error = error.contains("usage:");
+    if !usage_error {
+        return None;
+    }
+
+    let render_width = detect_cli_chat_render_width();
+    let usage_lines = render_cli_chat_command_usage_lines_with_width(error, render_width);
+
+    Some(usage_lines)
 }
 
 fn build_cli_chat_assistant_message_spec(assistant_text: &str) -> TuiMessageSpec {
@@ -1039,7 +1088,7 @@ fn render_cli_chat_message_card_lines(
 }
 
 fn render_cli_chat_message_spec_with_width(spec: &TuiMessageSpec, width: usize) -> Vec<String> {
-    let body_lines = render_tui_message_spec(spec, cli_chat_card_inner_width(width));
+    let body_lines = render_tui_message_body_spec(spec, cli_chat_card_inner_width(width));
     render_cli_chat_message_card_lines(
         spec.role.as_str(),
         spec.caption.as_deref(),
@@ -1051,12 +1100,10 @@ fn render_cli_chat_message_spec_with_width(spec: &TuiMessageSpec, width: usize) 
 fn render_cli_chat_card_lines(title: &str, body_lines: &[String], width: usize) -> Vec<String> {
     let inner_width = cli_chat_card_inner_width(width);
     let mut lines = vec![format!("╭─ {title}")];
-    let content_lines = body_lines.get(1..).unwrap_or(&[]);
-
-    if content_lines.is_empty() {
+    if body_lines.is_empty() {
         lines.push("│".to_owned());
     } else {
-        for line in content_lines {
+        for line in body_lines {
             if line.is_empty() {
                 lines.push("│".to_owned());
             } else {
@@ -1530,7 +1577,7 @@ fn render_cli_chat_live_surface_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_live_surface_message_spec(snapshot);
-    let body_lines = render_tui_message_spec(&message_spec, cli_chat_card_inner_width(width));
+    let body_lines = render_tui_message_body_spec(&message_spec, cli_chat_card_inner_width(width));
     let title = build_cli_chat_live_surface_card_title(snapshot);
     render_cli_chat_card_lines(title.as_str(), &body_lines, width)
 }
@@ -6509,6 +6556,20 @@ allowed_decisions: yes / auto / full / esc";
         let not_matched_result =
             classify_chat_command_match_result(Ok(false)).expect("classify non-match");
         assert_eq!(not_matched_result, ChatCommandMatchResult::NotMatched);
+    }
+
+    #[test]
+    fn maybe_render_nonfatal_usage_error_accepts_embedded_usage_text() {
+        let error = "invalid fast lane summary limit `nope`; usage: /fast_lane_summary [limit]";
+        let usage_lines =
+            maybe_render_nonfatal_usage_error(error).expect("usage should render non-fatally");
+
+        assert!(
+            usage_lines
+                .iter()
+                .any(|line| line.contains("/fast_lane_summary [limit]")),
+            "embedded usage text should still render the usage card: {usage_lines:#?}"
+        );
     }
 
     #[test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -18,6 +18,7 @@ mod cli_input;
 #[allow(clippy::expect_used)]
 mod latest_session_selector_tests;
 mod operator_surfaces;
+mod session_surface;
 
 use self::cli_input::ConcurrentCliInputReader;
 #[cfg(test)]
@@ -115,6 +116,7 @@ const CLI_CHAT_STATUS_COMMAND: &str = "/status";
 const CLI_CHAT_HISTORY_COMMAND: &str = "/history";
 const CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND: &str = "/turn_checkpoint_repair";
 const CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND_ALIAS: &str = "/turn-checkpoint-repair";
+const CLI_CHAT_COMPOSER_PROMPT: &str = "╰─ you · compose › ";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CliChatOptions {
@@ -330,6 +332,19 @@ pub async fn run_cli_chat(
     session_hint: Option<&str>,
     options: &CliChatOptions,
 ) -> CliResult<()> {
+    if session_surface::terminal_surface_supported() {
+        return session_surface::run_cli_chat_surface(config_path, session_hint, options).await;
+    }
+
+    run_cli_chat_repl(config_path, session_hint, options).await
+}
+
+#[allow(clippy::print_stdout)] // CLI REPL output
+async fn run_cli_chat_repl(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+) -> CliResult<()> {
     let resolved_config_path = config_path
         .map(config::expand_path)
         .unwrap_or_else(config::default_config_path);
@@ -385,7 +400,7 @@ pub async fn run_cli_chat(
         .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
 
     loop {
-        print!("you> ");
+        print!("{CLI_CHAT_COMPOSER_PROMPT}");
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
@@ -452,6 +467,14 @@ pub async fn run_cli_ask(
 }
 
 pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<()> {
+    if session_surface::terminal_surface_supported() {
+        return session_surface::run_concurrent_cli_host_surface(options);
+    }
+
+    run_concurrent_cli_host_repl(options)
+}
+
+fn run_concurrent_cli_host_repl(options: &ConcurrentCliHostOptions) -> CliResult<()> {
     let chat_options = CliChatOptions::default();
     let runtime = initialize_cli_turn_runtime_with_loaded_config(
         options.resolved_path.clone(),
@@ -623,7 +646,7 @@ async fn run_concurrent_cli_host_loop(
             break;
         }
 
-        print!("you> ");
+        print!("{CLI_CHAT_COMPOSER_PROMPT}");
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
@@ -682,7 +705,10 @@ async fn process_cli_chat_input(
             return Ok(CliChatLoopControl::Continue);
         }
         ChatCommandMatchResult::UsageError(usage) => {
-            let usage_lines = vec![usage];
+            let usage_lines = render_cli_chat_command_usage_lines_with_width(
+                &usage,
+                detect_cli_chat_render_width(),
+            );
             print_rendered_cli_chat_lines(&usage_lines);
             return Ok(CliChatLoopControl::Continue);
         }
@@ -694,7 +720,10 @@ async fn process_cli_chat_input(
             return Ok(CliChatLoopControl::Continue);
         }
         ChatCommandMatchResult::UsageError(usage) => {
-            let usage_lines = vec![usage];
+            let usage_lines = render_cli_chat_command_usage_lines_with_width(
+                &usage,
+                detect_cli_chat_render_width(),
+            );
             print_rendered_cli_chat_lines(&usage_lines);
             return Ok(CliChatLoopControl::Continue);
         }
@@ -706,7 +735,10 @@ async fn process_cli_chat_input(
             return Ok(CliChatLoopControl::Continue);
         }
         ChatCommandMatchResult::UsageError(usage) => {
-            let usage_lines = vec![usage];
+            let usage_lines = render_cli_chat_command_usage_lines_with_width(
+                &usage,
+                detect_cli_chat_render_width(),
+            );
             print_rendered_cli_chat_lines(&usage_lines);
             return Ok(CliChatLoopControl::Continue);
         }
@@ -736,7 +768,10 @@ async fn process_cli_chat_input(
             return Ok(CliChatLoopControl::Continue);
         }
         ChatCommandMatchResult::UsageError(usage) => {
-            let usage_lines = vec![usage];
+            let usage_lines = render_cli_chat_command_usage_lines_with_width(
+                &usage,
+                detect_cli_chat_render_width(),
+            );
             print_rendered_cli_chat_lines(&usage_lines);
             return Ok(CliChatLoopControl::Continue);
         }
@@ -856,7 +891,22 @@ fn render_cli_chat_assistant_lines_with_width(assistant_text: &str, width: usize
         return render_tui_screen_spec(&screen_spec, width, false);
     }
     let message_spec = build_cli_chat_assistant_message_spec(assistant_text);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
+}
+
+fn render_cli_chat_command_usage_lines_with_width(usage: &str, width: usize) -> Vec<String> {
+    let message_spec = TuiMessageSpec {
+        role: "chat".to_owned(),
+        caption: Some("command".to_owned()),
+        sections: vec![TuiSectionSpec::Callout {
+            tone: TuiCalloutTone::Warning,
+            title: Some("usage".to_owned()),
+            lines: vec![usage.to_owned()],
+        }],
+        footer_lines: vec!["Use /help to inspect the available command surface.".to_owned()],
+    };
+
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_cli_chat_assistant_message_spec(assistant_text: &str) -> TuiMessageSpec {
@@ -866,11 +916,11 @@ fn build_cli_chat_assistant_message_spec(assistant_text: &str) -> TuiMessageSpec
         role: config::CLI_COMMAND_NAME.to_owned(),
         caption: Some("reply".to_owned()),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec!["/help commands · /status runtime · /history transcript".to_owned()],
     }
 }
 
-fn build_cli_chat_approval_screen_spec(assistant_text: &str) -> Option<TuiScreenSpec> {
+pub(super) fn build_cli_chat_approval_screen_spec(assistant_text: &str) -> Option<TuiScreenSpec> {
     let parsed = parse_approval_prompt_view(assistant_text)?;
     let mut intro_lines = Vec::new();
     if let Some(preface) = parsed
@@ -947,6 +997,71 @@ fn build_cli_chat_approval_screen_spec(assistant_text: &str) -> Option<TuiScreen
         choices,
         footer_lines,
     })
+}
+
+fn cli_chat_card_inner_width(width: usize) -> usize {
+    width.saturating_sub(2).max(24)
+}
+
+fn build_cli_chat_message_card_title(role: &str, caption: Option<&str>) -> String {
+    let trimmed_role = role.trim();
+    let trimmed_caption = caption.map(str::trim).unwrap_or("");
+    let role_label = if trimmed_role.is_empty() {
+        "message"
+    } else {
+        trimmed_role
+    };
+
+    if trimmed_caption.is_empty() {
+        return role_label.to_owned();
+    }
+
+    format!("{role_label} · {trimmed_caption}")
+}
+
+fn render_cli_chat_message_card_lines(
+    role: &str,
+    caption: Option<&str>,
+    rendered_message_lines: &[String],
+    width: usize,
+) -> Vec<String> {
+    let title = build_cli_chat_message_card_title(role, caption);
+    render_cli_chat_card_lines(title.as_str(), rendered_message_lines, width)
+}
+
+fn render_cli_chat_message_spec_with_width(spec: &TuiMessageSpec, width: usize) -> Vec<String> {
+    let body_lines = render_tui_message_spec(spec, cli_chat_card_inner_width(width));
+    render_cli_chat_message_card_lines(
+        spec.role.as_str(),
+        spec.caption.as_deref(),
+        &body_lines,
+        width,
+    )
+}
+
+fn render_cli_chat_card_lines(title: &str, body_lines: &[String], width: usize) -> Vec<String> {
+    let inner_width = cli_chat_card_inner_width(width);
+    let mut lines = vec![format!("╭─ {title}")];
+    let content_lines = body_lines.get(1..).unwrap_or(&[]);
+
+    if content_lines.is_empty() {
+        lines.push("│".to_owned());
+    } else {
+        for line in content_lines {
+            if line.is_empty() {
+                lines.push("│".to_owned());
+            } else {
+                for wrapped_line in
+                    crate::presentation::render_wrapped_display_line(line.as_str(), inner_width)
+                {
+                    lines.push(format!("│ {wrapped_line}"));
+                }
+            }
+        }
+    }
+
+    lines.push("╰─".to_owned());
+    lines
 }
 
 fn build_cli_chat_live_surface_observer(render_width: usize) -> ConversationTurnObserverHandle {
@@ -1406,7 +1521,9 @@ fn render_cli_chat_live_surface_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_live_surface_message_spec(snapshot);
-    render_tui_message_spec(&message_spec, width)
+    let body_lines = render_tui_message_spec(&message_spec, cli_chat_card_inner_width(width));
+    let title = build_cli_chat_live_surface_card_title(snapshot);
+    render_cli_chat_card_lines(title.as_str(), &body_lines, width)
 }
 
 fn build_cli_chat_live_surface_message_spec(
@@ -1448,8 +1565,31 @@ fn build_cli_chat_live_surface_message_spec(
         role: config::CLI_COMMAND_NAME.to_owned(),
         caption: Some("live".to_owned()),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Streaming turn state · /status runtime · /compact checkpoint".to_owned(),
+        ],
     }
+}
+
+fn build_cli_chat_live_surface_card_title(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    let mut segments = vec![build_cli_chat_message_card_title(
+        config::CLI_COMMAND_NAME,
+        Some("live"),
+    )];
+
+    if let Some(provider_round) = snapshot.provider_round {
+        segments.push(format!("round {provider_round}"));
+    }
+
+    if let Some(message_count) = snapshot.message_count {
+        segments.push(format!("{message_count} msgs"));
+    }
+
+    if let Some(estimated_tokens) = snapshot.estimated_tokens {
+        segments.push(format!("~{estimated_tokens} tok"));
+    }
+
+    segments.join(" · ")
 }
 
 fn cli_chat_live_surface_tone(phase: ConversationTurnPhase) -> TuiCalloutTone {
@@ -1875,7 +2015,72 @@ fn parse_cli_chat_markdown_sections(text: &str) -> Vec<TuiSectionSpec> {
         });
     }
 
+    refine_cli_chat_sections(sections)
+}
+
+fn refine_cli_chat_sections(sections: Vec<TuiSectionSpec>) -> Vec<TuiSectionSpec> {
     sections
+        .into_iter()
+        .map(|section| match section {
+            TuiSectionSpec::Narrative {
+                title: Some(title),
+                lines,
+            } if is_reasoning_section_title(title.as_str()) && !lines.is_empty() => {
+                TuiSectionSpec::Callout {
+                    tone: TuiCalloutTone::Info,
+                    title: Some("reasoning".to_owned()),
+                    lines,
+                }
+            }
+            TuiSectionSpec::Preformatted {
+                title,
+                language: Some(language),
+                lines,
+            } if is_diff_language(language.as_str()) => TuiSectionSpec::Preformatted {
+                title: Some(title.unwrap_or_else(|| "diff".to_owned())),
+                language: Some(language),
+                lines,
+            },
+            TuiSectionSpec::Narrative {
+                title: Some(title),
+                lines,
+            } if is_tool_activity_section_title(title.as_str()) && !lines.is_empty() => {
+                TuiSectionSpec::Callout {
+                    tone: TuiCalloutTone::Info,
+                    title: Some("tool activity".to_owned()),
+                    lines,
+                }
+            }
+            other @ TuiSectionSpec::Narrative { .. }
+            | other @ TuiSectionSpec::KeyValues { .. }
+            | other @ TuiSectionSpec::ActionGroup { .. }
+            | other @ TuiSectionSpec::Checklist { .. }
+            | other @ TuiSectionSpec::Callout { .. }
+            | other @ TuiSectionSpec::Preformatted { .. } => other,
+        })
+        .collect()
+}
+
+fn is_reasoning_section_title(title: &str) -> bool {
+    let normalized = title.trim().to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "reasoning" | "analysis" | "thinking" | "thought process"
+    )
+}
+
+fn is_diff_language(language: &str) -> bool {
+    matches!(
+        language.trim().to_ascii_lowercase().as_str(),
+        "diff" | "patch"
+    )
+}
+
+fn is_tool_activity_section_title(title: &str) -> bool {
+    matches!(
+        title.trim().to_ascii_lowercase().as_str(),
+        "tool activity" | "tools" | "tool calls"
+    )
 }
 
 fn push_narrative_section(
@@ -2261,7 +2466,7 @@ fn render_cli_chat_feature_unavailable_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_feature_unavailable_message_spec(role, detail);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
@@ -2276,7 +2481,9 @@ fn build_cli_chat_feature_unavailable_message_spec(role: &str, detail: &str) -> 
         role: role.to_owned(),
         caption: Some("unavailable".to_owned()),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Feature gated in this build; /help shows the available chat surface.".to_owned(),
+        ],
     }
 }
 
@@ -2342,7 +2549,7 @@ fn render_turn_checkpoint_health_error_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_turn_checkpoint_health_error_message_spec(session_id, error);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -2370,7 +2577,10 @@ fn build_turn_checkpoint_health_error_message_spec(
         role: "checkpoint".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Durability state is unavailable until the next successful checkpoint sample."
+                .to_owned(),
+        ],
     }
 }
 
@@ -2396,7 +2606,7 @@ fn render_fast_lane_summary_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_fast_lane_summary_message_spec(session_id, limit, summary);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -2581,7 +2791,10 @@ fn build_fast_lane_summary_message_spec(
         role: "fast-lane".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Use /fast_lane_summary after tool-heavy turns to inspect concurrency behavior."
+                .to_owned(),
+        ],
     }
 }
 
@@ -2635,7 +2848,7 @@ fn render_safe_lane_summary_lines_with_width(
 ) -> Vec<String> {
     let message_spec =
         build_safe_lane_summary_message_spec(session_id, limit, conversation_config, summary);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -2942,7 +3155,9 @@ fn build_safe_lane_summary_message_spec(
         role: "safe-lane".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Use /safe_lane_summary when verify/replan behavior needs inspection.".to_owned(),
+        ],
     }
 }
 
@@ -2972,7 +3187,7 @@ fn render_turn_checkpoint_summary_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_turn_checkpoint_summary_message_spec(session_id, limit, diagnostics);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -3092,7 +3307,9 @@ fn build_turn_checkpoint_summary_message_spec(
         role: "checkpoint".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Use /turn_checkpoint_repair when the latest durable state needs repair.".to_owned(),
+        ],
     }
 }
 
@@ -3122,7 +3339,7 @@ fn render_turn_checkpoint_repair_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_turn_checkpoint_repair_message_spec(session_id, outcome);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -3183,7 +3400,9 @@ fn build_turn_checkpoint_repair_message_spec(
         role: "repair".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Re-run /status after repair to confirm the checkpoint state.".to_owned(),
+        ],
     }
 }
 
@@ -4912,23 +5131,25 @@ mod tests {
             "chat startup should keep the usage hint, but under the assistant-first opening block: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "session details"),
+            lines.iter().any(|line| line.contains("session details")),
             "chat startup should keep session/config facts in a structured key-value section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "runtime details"),
+            lines.iter().any(|line| line.contains("runtime details")),
             "chat startup should still preserve runtime context in a compact secondary section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "continuity maintenance"),
+            lines
+                .iter()
+                .any(|line| line.contains("continuity maintenance")),
             "chat startup should show compaction maintenance settings in a dedicated section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "- session: default"),
+            lines.iter().any(|line| line.contains("- session: default")),
             "chat startup should continue to show session identity after the handoff block: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "- compaction: true"),
+            lines.iter().any(|line| line.contains("- compaction: true")),
             "chat startup should show whether automatic compaction is enabled: {lines:#?}"
         );
     }
@@ -4962,19 +5183,21 @@ mod tests {
         );
 
         assert!(
-            lines.iter().any(|line| { line == "note: acp overrides" }),
+            lines
+                .iter()
+                .any(|line| line.contains("note: acp overrides")),
             "chat startup should group ACP overrides under a dedicated callout heading: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- bootstrap MCP servers: filesystem"),
+                .any(|line| line.contains("- bootstrap MCP servers: filesystem")),
             "chat startup should still surface the bootstrap MCP override details: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- working directory: /workspace/project"),
+                .any(|line| line.contains("- working directory: /workspace/project")),
             "chat startup should still surface the working directory override: {lines:#?}"
         );
     }
@@ -5007,21 +5230,25 @@ mod tests {
             80,
         );
 
-        assert_eq!(lines[0], "status: session=default");
+        assert_eq!(lines[0], "╭─ status · session=default");
         assert!(
-            lines.iter().any(|line| line == "session details"),
+            lines.iter().any(|line| line.contains("session details")),
             "status output should keep session facts grouped under a section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "runtime details"),
+            lines.iter().any(|line| line.contains("runtime details")),
             "status output should keep runtime facts grouped under a section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "continuity maintenance"),
+            lines
+                .iter()
+                .any(|line| line.contains("continuity maintenance")),
             "status output should surface compaction maintenance settings: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: operator controls"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: operator controls")),
             "status output should include the operator control callout: {lines:#?}"
         );
         assert!(
@@ -5108,23 +5335,27 @@ mod tests {
         )
         .expect("startup health surface");
 
-        assert_eq!(lines[0], "checkpoint: session=session-health");
+        assert_eq!(lines[0], "╭─ checkpoint · session=session-health");
         assert!(
-            lines.iter().any(|line| line == "durability status"),
+            lines.iter().any(|line| line.contains("durability status")),
             "startup health should group durability facts under a shared key-value section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "attention: recovery"),
+            lines
+                .iter()
+                .any(|line| line.contains("attention: recovery")),
             "startup health should surface pending recovery as a warning callout: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- action: inspect_manually"),
+                .any(|line| line.contains("- action: inspect_manually")),
             "startup health should preserve the concrete recovery action in the callout: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: runtime probe"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: runtime probe")),
             "startup health should surface runtime probe context as a secondary structured callout: {lines:#?}"
         );
     }
@@ -5192,7 +5423,7 @@ mod tests {
             80,
         );
 
-        assert_eq!(lines[0], "checkpoint: session=session-health");
+        assert_eq!(lines[0], "╭─ checkpoint · session=session-health");
         assert!(
             lines.iter().any(|line| line.contains("state: not_durable")),
             "status health should surface non-durable sessions explicitly: {lines:#?}"
@@ -5249,18 +5480,20 @@ mod tests {
 
         let lines = render_fast_lane_summary_lines_with_width("session-fast", 64, &summary, 80);
 
-        assert_eq!(lines[0], "fast-lane: session=session-fast limit=64");
+        assert_eq!(lines[0], "╭─ fast-lane · session=session-fast limit=64");
         assert!(
-            lines.iter().any(|line| line == "intent mix"),
+            lines.iter().any(|line| line.contains("intent mix")),
             "fast-lane summary should promote aggregate intent counters into a titled section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "latest segments"),
+            lines.iter().any(|line| line.contains("latest segments")),
             "fast-lane summary should keep the latest segment narrative visible: {lines:#?}"
         );
         assert!(
             lines.iter().any(|line| {
-                line == "- segment 0: class=parallel_safe mode=parallel intents=2 peak=3 wall_ms=120"
+                line.contains(
+                    "- segment 0: class=parallel_safe mode=parallel intents=2 peak=3 wall_ms=120",
+                )
             }),
             "fast-lane summary should render latest segment details as readable surface lines: {lines:#?}"
         );
@@ -5309,17 +5542,19 @@ mod tests {
         let lines =
             render_safe_lane_summary_lines_with_width("session-safe", 32, &config, &summary, 80);
 
-        assert_eq!(lines[0], "safe-lane: session=session-safe limit=32");
+        assert_eq!(lines[0], "╭─ safe-lane · session=session-safe limit=32");
         assert!(
-            lines.iter().any(|line| line == "attention: health"),
+            lines.iter().any(|line| line.contains("attention: health")),
             "safe-lane summary should surface warning health as a structured callout: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "- severity: critical"),
+            lines
+                .iter()
+                .any(|line| line.contains("- severity: critical")),
             "safe-lane health callout should preserve the derived severity: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "rollups"),
+            lines.iter().any(|line| line.contains("rollups")),
             "safe-lane summary should keep the route and failure rollups in a dedicated section: {lines:#?}"
         );
     }
@@ -5356,13 +5591,15 @@ mod tests {
             80,
         );
 
-        assert_eq!(lines[0], "checkpoint: session=session-summary limit=64");
+        assert_eq!(lines[0], "╭─ checkpoint · session=session-summary limit=64");
         assert!(
-            lines.iter().any(|line| line == "summary"),
+            lines.iter().any(|line| line.contains("summary")),
             "turn checkpoint summary should group the latest durability state in a titled section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: runtime probe"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: runtime probe")),
             "turn checkpoint summary should append runtime probe context as a structured callout: {lines:#?}"
         );
     }
@@ -5387,13 +5624,15 @@ mod tests {
         );
         let lines = render_turn_checkpoint_repair_lines_with_width("session-repair", &outcome, 80);
 
-        assert_eq!(lines[0], "repair: session=session-repair");
+        assert_eq!(lines[0], "╭─ repair · session=session-repair");
         assert!(
-            lines.iter().any(|line| line == "repair status"),
+            lines.iter().any(|line| line.contains("repair status")),
             "turn checkpoint repair should group repair facts in a structured key-value section: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "attention: repair result"),
+            lines
+                .iter()
+                .any(|line| line.contains("attention: repair result")),
             "manual repair outcomes should surface a warning callout: {lines:#?}"
         );
     }
@@ -5402,9 +5641,9 @@ mod tests {
     fn render_cli_chat_help_lines_promotes_commands_to_surface() {
         let lines = render_cli_chat_help_lines_with_width(72);
 
-        assert_eq!(lines[0], "chat: commands");
+        assert_eq!(lines[0], "╭─ chat · commands");
         assert!(
-            lines.iter().any(|line| line == "slash commands"),
+            lines.iter().any(|line| line.contains("slash commands")),
             "help output should keep a dedicated slash-command section: {lines:#?}"
         );
         assert!(
@@ -5424,8 +5663,23 @@ mod tests {
             "help output should surface the manual compaction command: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: usage notes"),
+            lines.iter().any(|line| line.contains("note: usage notes")),
             "help output should preserve operator guidance as a callout: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn render_cli_chat_command_usage_lines_wrap_usage_in_warning_card() {
+        let lines = render_cli_chat_command_usage_lines_with_width("usage: /history", 72);
+
+        assert_eq!(lines[0], "╭─ chat · command");
+        assert!(
+            lines.iter().any(|line| line.contains("attention: usage")),
+            "usage errors should render inside a warning pane: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("usage: /history")),
+            "usage pane should preserve the concrete command usage: {lines:#?}"
         );
     }
 
@@ -5456,9 +5710,11 @@ mod tests {
 
         let lines = render_cli_chat_status_lines_with_width(&summary, 80);
 
-        assert_eq!(lines[0], "status: session=session-status");
+        assert_eq!(lines[0], "╭─ status · session=session-status");
         assert!(
-            lines.iter().any(|line| line == "continuity maintenance"),
+            lines
+                .iter()
+                .any(|line| line.contains("continuity maintenance")),
             "status output should expose compaction settings as a dedicated section: {lines:#?}"
         );
         assert!(
@@ -5472,7 +5728,9 @@ mod tests {
             "status output should surface the compaction token trigger: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: operator controls"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: operator controls")),
             "status output should append the operator controls callout: {lines:#?}"
         );
         assert!(
@@ -5497,9 +5755,9 @@ mod tests {
 
         let lines = render_manual_compaction_lines_with_width("session-compact", &result, 80);
 
-        assert_eq!(lines[0], "compact: session=session-compact");
+        assert_eq!(lines[0], "╭─ compact · session=session-compact");
         assert!(
-            lines.iter().any(|line| line == "compaction result"),
+            lines.iter().any(|line| line.contains("compaction result")),
             "manual compaction should render a dedicated result section: {lines:#?}"
         );
         assert!(
@@ -5526,15 +5784,15 @@ mod tests {
         ];
         let lines = render_cli_chat_history_lines_with_width("session-7", 24, &history_lines, 72);
 
-        assert_eq!(lines[0], "history: session=session-7 limit=24");
+        assert_eq!(lines[0], "╭─ history · session=session-7 limit=24");
         assert!(
-            lines.iter().any(|line| line == "sliding window"),
+            lines.iter().any(|line| line.contains("sliding window")),
             "history output should keep a dedicated window section: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "user: summarize the current repo"),
+                .any(|line| line.contains("user: summarize the current repo")),
             "history output should still surface the original transcript entries: {lines:#?}"
         );
     }
@@ -5554,33 +5812,37 @@ println!(\"{value}\");
 ```";
         let lines = render_cli_chat_assistant_lines_with_width(assistant_text, 72);
 
-        assert_eq!(lines[0], "loong: reply");
+        assert_eq!(lines[0], "╭─ loong · reply");
         assert!(
-            lines.iter().any(|line| line == "Plan"),
+            lines.iter().any(|line| line.contains("Plan")),
             "markdown headings should become section titles: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- inspect the active config"),
+                .any(|line| line.contains("- inspect the active config")),
             "markdown list items should remain visible in the narrative block: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "- compare runtime state"),
+            lines
+                .iter()
+                .any(|line| line.contains("- compare runtime state")),
             "markdown star bullets should normalize into wrapped display bullets: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "note: quoted context"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: quoted context")),
             "markdown blockquotes should render as structured callouts: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "code [rust]"),
+            lines.iter().any(|line| line.contains("code [rust]")),
             "markdown fences should render as preformatted sections: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "    let value = input.trim();"),
+                .any(|line| line.contains("let value = input.trim();")),
             "preformatted sections should keep code indentation intact: {lines:#?}"
         );
     }
@@ -5595,19 +5857,41 @@ println!(\"{value}\");
         let lines = render_cli_chat_assistant_lines_with_width(assistant_text, 72);
 
         assert!(
-            lines.iter().any(|line| line == "note: Risks"),
+            lines.iter().any(|line| line.contains("note: Risks")),
             "headings should stay attached to quoted sections instead of falling back to a generic title: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "- keep credentials in env vars"),
+                .any(|line| line.contains("- keep credentials in env vars")),
             "quoted content should stay visible after preserving the heading: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "Next"),
+            lines.iter().any(|line| line.contains("Next")),
             "a trailing heading should still render even when it has no body lines yet: {lines:#?}"
         );
+    }
+
+    #[test]
+    fn parse_cli_chat_markdown_sections_promotes_reasoning_heading_to_callout() {
+        let sections = parse_cli_chat_markdown_sections(
+            "## Reasoning\nThe provider compared two options before choosing one.",
+        );
+        assert!(matches!(
+            sections.first(),
+            Some(TuiSectionSpec::Callout { title, .. }) if title.as_deref() == Some("reasoning")
+        ));
+    }
+
+    #[test]
+    fn parse_cli_chat_markdown_sections_promotes_tool_activity_heading_to_callout() {
+        let sections = parse_cli_chat_markdown_sections(
+            "## Tool Activity\nfile.read completed with 1 result line.",
+        );
+        assert!(matches!(
+            sections.first(),
+            Some(TuiSectionSpec::Callout { title, .. }) if title.as_deref() == Some("tool activity")
+        ));
     }
 
     #[test]
@@ -5657,19 +5941,20 @@ allowed_decisions: yes / auto / full / esc";
         };
         let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, 72);
 
-        assert_eq!(lines[0], "loong: live");
+        assert_eq!(lines[0], "╭─ loong · live · round 1 · 4 msgs · ~128 tok");
         assert!(
-            lines.iter().any(|line| line == "note: querying model"),
+            lines
+                .iter()
+                .any(|line| line.contains("note: querying model")),
             "live surface should explain the active phase through a callout: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "turn pipeline"),
+            lines.iter().any(|line| line.contains("turn pipeline")),
             "live surface should keep the pipeline checklist visible: {lines:#?}"
         );
         assert!(
             lines.iter().any(|line| {
-                line.starts_with("[WARN] call model")
-                    && line.contains("provider round 1 in progress")
+                line.contains("[WARN] call model") && line.contains("provider round 1 in progress")
             }),
             "live surface should keep the model step actively highlighted: {lines:#?}"
         );
@@ -5680,13 +5965,13 @@ allowed_decisions: yes / auto / full / esc";
             "live surface should avoid claiming streaming when the snapshot does not encode that capability: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "draft preview"),
+            lines.iter().any(|line| line.contains("draft preview")),
             "live surface should surface partial text as a dedicated preview block: {lines:#?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "Inspecting the repo layout..."),
+                .any(|line| line.contains("Inspecting the repo layout...")),
             "live surface should preserve the partial preview text: {lines:#?}"
         );
     }
@@ -5730,10 +6015,12 @@ allowed_decisions: yes / auto / full / esc";
 
         let preview_batch = batches
             .iter()
-            .find(|lines| lines.iter().any(|line| line == "draft preview"))
+            .find(|lines| lines.iter().any(|line| line.contains("draft preview")))
             .expect("preview batch");
         assert!(
-            preview_batch.iter().any(|line| line == "Draft response"),
+            preview_batch
+                .iter()
+                .any(|line| line.contains("Draft response")),
             "preview batch should include the streamed text: {preview_batch:#?}"
         );
     }
@@ -5792,7 +6079,7 @@ allowed_decisions: yes / auto / full / esc";
             .expect("captured batches lock should not be poisoned");
         let running_batch = batches
             .iter()
-            .find(|lines| lines.iter().any(|line| line == "tool activity"))
+            .find(|lines| lines.iter().any(|line| line.contains("tool activity")))
             .expect("running tool batch");
         let completed_batch = batches
             .iter()
@@ -5800,27 +6087,27 @@ allowed_decisions: yes / auto / full / esc";
             .find(|lines| {
                 lines
                     .iter()
-                    .any(|line| line == "[completed] file.read (id=call-tool-1) - ok")
+                    .any(|line| line.contains("[completed] file.read (id=call-tool-1) - ok"))
             })
             .expect("completed tool batch");
 
         assert!(
             running_batch
                 .iter()
-                .any(|line| line == "[running] file.read (id=call-tool-1)"),
+                .any(|line| line.contains("[running] file.read (id=call-tool-1)")),
             "tool batch should surface the running tool state: {running_batch:#?}"
         );
 
         assert!(
             completed_batch
                 .iter()
-                .any(|line| line == "[completed] file.read (id=call-tool-1) - ok"),
+                .any(|line| line.contains("[completed] file.read (id=call-tool-1) - ok")),
             "tool batch should surface the completed tool state: {completed_batch:#?}"
         );
         assert!(
             completed_batch
                 .iter()
-                .any(|line| line == "args: {\"path\":\"README.md\"}"),
+                .any(|line| line.contains("args: {\"path\":\"README.md\"}")),
             "tool batch should preserve streamed tool args: {completed_batch:#?}"
         );
     }
@@ -5888,15 +6175,17 @@ allowed_decisions: yes / auto / full / esc";
         let last_batch = batches.last().expect("follow-up request batch");
 
         assert!(
-            !last_batch.iter().any(|line| line == "draft preview"),
+            !last_batch.iter().any(|line| line.contains("draft preview")),
             "follow-up provider requests should reset the previous draft preview: {last_batch:#?}"
         );
         assert!(
-            !last_batch.iter().any(|line| line == "tool activity"),
+            !last_batch.iter().any(|line| line.contains("tool activity")),
             "follow-up provider requests should not reuse prior tool activity lines: {last_batch:#?}"
         );
         assert!(
-            !last_batch.iter().any(|line| line == "Draft response"),
+            !last_batch
+                .iter()
+                .any(|line| line.contains("Draft response")),
             "follow-up provider requests should not carry the previous request preview text: {last_batch:#?}"
         );
     }
@@ -5960,13 +6249,13 @@ allowed_decisions: yes / auto / full / esc";
         let last_batch = batches.last().expect("running-tools batch");
 
         assert!(
-            last_batch.iter().any(|line| line == "tool activity"),
+            last_batch.iter().any(|line| line.contains("tool activity")),
             "the tools phase should render the accumulated tool activity: {last_batch:#?}"
         );
         assert!(
             last_batch
                 .iter()
-                .any(|line| line == "[running] search (id=call_123)"),
+                .any(|line| line.contains("[running] search (id=call_123)")),
             "the tools phase should surface the streamed tool metadata: {last_batch:#?}"
         );
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -332,7 +332,7 @@ pub async fn run_cli_chat(
     session_hint: Option<&str>,
     options: &CliChatOptions,
 ) -> CliResult<()> {
-    if session_surface::terminal_surface_supported() {
+    if session_surface::interactive_terminal_surface_supported() {
         return session_surface::run_cli_chat_surface(config_path, session_hint, options).await;
     }
 
@@ -467,7 +467,7 @@ pub async fn run_cli_ask(
 }
 
 pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<()> {
-    if session_surface::terminal_surface_supported() {
+    if session_surface::interactive_terminal_surface_supported() {
         return session_surface::run_concurrent_cli_host_surface(options);
     }
 
@@ -841,15 +841,24 @@ async fn process_cli_chat_input(
         .await?;
         return Ok(CliChatLoopControl::Continue);
     }
-    if is_turn_checkpoint_repair_command(input)? {
-        print_turn_checkpoint_repair(
-            &runtime.turn_coordinator,
-            &runtime.config,
-            &runtime.session_id,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-        )
-        .await?;
-        return Ok(CliChatLoopControl::Continue);
+    match classify_chat_command_match_result(is_turn_checkpoint_repair_command(input))? {
+        ChatCommandMatchResult::Matched => {
+            print_turn_checkpoint_repair(
+                &runtime.turn_coordinator,
+                &runtime.config,
+                &runtime.session_id,
+                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            )
+            .await?;
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::UsageError(usage) => {
+            let render_width = detect_cli_chat_render_width();
+            let usage_lines = render_cli_chat_command_usage_lines_with_width(&usage, render_width);
+            print_rendered_cli_chat_lines(&usage_lines);
+            return Ok(CliChatLoopControl::Continue);
+        }
+        ChatCommandMatchResult::NotMatched => {}
     }
 
     Ok(CliChatLoopControl::AssistantText(

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -30,7 +30,6 @@ use crate::tui_surface::TuiKeyValueSpec;
 use crate::tui_surface::TuiMessageSpec;
 use crate::tui_surface::TuiScreenSpec;
 use crate::tui_surface::TuiSectionSpec;
-use crate::tui_surface::render_tui_message_spec;
 use crate::tui_surface::render_tui_screen_spec;
 
 use super::CLI_CHAT_COMPACT_COMMAND;
@@ -60,6 +59,7 @@ use super::print_rendered_cli_chat_lines;
 use super::recovery_callout_tone;
 #[cfg(not(feature = "memory-sqlite"))]
 use super::render_cli_chat_feature_unavailable_lines_with_width;
+use super::render_cli_chat_message_spec_with_width;
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::render_turn_checkpoint_health_error_lines_with_width;
 use super::tui_plain_item;
@@ -331,7 +331,7 @@ pub(super) fn render_cli_chat_missing_config_decline_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_missing_config_decline_message_spec(onboard_hint);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_cli_chat_missing_config_decline_message_spec(onboard_hint: &str) -> TuiMessageSpec {
@@ -356,7 +356,7 @@ fn build_cli_chat_missing_config_decline_message_spec(onboard_hint: &str) -> Tui
         role: "chat".to_owned(),
         caption: Some("setup required".to_owned()),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec!["Run setup now to unlock the full chat surface.".to_owned()],
     }
 }
 
@@ -373,7 +373,7 @@ pub(super) fn render_cli_chat_status_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_status_message_spec(summary);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScreenSpec {
@@ -402,7 +402,10 @@ fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScr
         intro_lines: Vec::new(),
         sections,
         choices: Vec::new(),
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Quick commands: /help · /status · /history · /compact".to_owned(),
+            "Type any request to start the transcript.".to_owned(),
+        ],
     }
 }
 
@@ -422,7 +425,7 @@ fn build_cli_chat_status_message_spec(summary: &CliChatStartupSummary) -> TuiMes
         role: "status".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec!["Quick commands: /history · /compact · /help".to_owned()],
     }
 }
 
@@ -512,7 +515,7 @@ fn build_cli_chat_runtime_sections(summary: &CliChatStartupSummary) -> Vec<TuiSe
 
 pub(super) fn render_cli_chat_help_lines_with_width(width: usize) -> Vec<String> {
     let message_spec = build_cli_chat_help_message_spec();
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
@@ -574,7 +577,10 @@ fn build_cli_chat_help_message_spec() -> TuiMessageSpec {
         role: "chat".to_owned(),
         caption: Some("commands".to_owned()),
         sections: vec![command_section, usage_section],
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Send normal text to continue the transcript.".to_owned(),
+            "Use /exit to leave chat.".to_owned(),
+        ],
     }
 }
 
@@ -585,7 +591,7 @@ pub(super) fn render_cli_chat_history_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_cli_chat_history_message_spec(session_id, limit, history_lines);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_cli_chat_history_message_spec(
@@ -603,7 +609,9 @@ fn build_cli_chat_history_message_spec(
         role: "history".to_owned(),
         caption: Some(caption),
         sections: vec![history_section],
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Use /status for runtime state or /compact before the next turn.".to_owned(),
+        ],
     }
 }
 
@@ -613,7 +621,7 @@ pub(super) fn render_manual_compaction_lines_with_width(
     width: usize,
 ) -> Vec<String> {
     let message_spec = build_manual_compaction_message_spec(session_id, result);
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 fn build_manual_compaction_message_spec(
@@ -652,7 +660,9 @@ fn build_manual_compaction_message_spec(
         role: "compact".to_owned(),
         caption: Some(caption),
         sections: vec![result_section, detail_section],
-        footer_lines: Vec::new(),
+        footer_lines: vec![
+            "Continue chatting, or run /status to inspect maintenance settings.".to_owned(),
+        ],
     }
 }
 
@@ -1105,7 +1115,7 @@ pub(super) fn render_turn_checkpoint_startup_health_lines_with_width(
         diagnostics,
         /*always_emit*/ false,
     )?;
-    let rendered_lines = render_tui_message_spec(&message_spec, width);
+    let rendered_lines = render_cli_chat_message_spec_with_width(&message_spec, width);
 
     Some(rendered_lines)
 }
@@ -1126,7 +1136,7 @@ pub(super) fn render_turn_checkpoint_status_health_lines_with_width(
         None => {
             let caption = format!("session={session_id}");
             let detail_line = "checkpoint diagnostics unavailable".to_owned();
-            return render_tui_message_spec(
+            return render_cli_chat_message_spec_with_width(
                 &TuiMessageSpec {
                     role: "checkpoint".to_owned(),
                     caption: Some(caption),
@@ -1135,14 +1145,16 @@ pub(super) fn render_turn_checkpoint_status_health_lines_with_width(
                         title: Some("durability status".to_owned()),
                         lines: vec![detail_line],
                     }],
-                    footer_lines: Vec::new(),
+                    footer_lines: vec![
+                        "Use /status to refresh runtime health after the next turn.".to_owned(),
+                    ],
                 },
                 width,
             );
         }
     };
 
-    render_tui_message_spec(&message_spec, width)
+    render_cli_chat_message_spec_with_width(&message_spec, width)
 }
 
 #[cfg(any(test, feature = "memory-sqlite"))]
@@ -1241,6 +1253,6 @@ fn build_turn_checkpoint_health_message_spec(
         role: "checkpoint".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: Vec::new(),
+        footer_lines: vec!["Use /turn_checkpoint_repair when recovery can run safely.".to_owned()],
     })
 }

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -64,6 +64,14 @@ use super::render_cli_chat_message_spec_with_width;
 use super::render_turn_checkpoint_health_error_lines_with_width;
 use super::tui_plain_item;
 
+const PRIMARY_QUICK_COMMANDS_HINT: &str = "Quick commands: /help · /status · /history · /compact";
+const STATUS_QUICK_COMMANDS_HINT: &str = "Quick commands: /history · /compact · /help";
+const TRANSCRIPT_START_HINT: &str = "Type any request to start the transcript.";
+const STATUS_OR_COMPACT_HINT: &str =
+    "Use /status for runtime state or /compact before the next turn.";
+const CONTINUE_OR_STATUS_HINT: &str =
+    "Continue chatting, or run /status to inspect maintenance settings.";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct CliChatStartupSummary {
     pub(super) config_path: String,
@@ -403,8 +411,8 @@ fn build_cli_chat_startup_screen_spec(summary: &CliChatStartupSummary) -> TuiScr
         sections,
         choices: Vec::new(),
         footer_lines: vec![
-            "Quick commands: /help · /status · /history · /compact".to_owned(),
-            "Type any request to start the transcript.".to_owned(),
+            PRIMARY_QUICK_COMMANDS_HINT.to_owned(),
+            TRANSCRIPT_START_HINT.to_owned(),
         ],
     }
 }
@@ -425,7 +433,7 @@ fn build_cli_chat_status_message_spec(summary: &CliChatStartupSummary) -> TuiMes
         role: "status".to_owned(),
         caption: Some(caption),
         sections,
-        footer_lines: vec!["Quick commands: /history · /compact · /help".to_owned()],
+        footer_lines: vec![STATUS_QUICK_COMMANDS_HINT.to_owned()],
     }
 }
 
@@ -609,9 +617,7 @@ fn build_cli_chat_history_message_spec(
         role: "history".to_owned(),
         caption: Some(caption),
         sections: vec![history_section],
-        footer_lines: vec![
-            "Use /status for runtime state or /compact before the next turn.".to_owned(),
-        ],
+        footer_lines: vec![STATUS_OR_COMPACT_HINT.to_owned()],
     }
 }
 
@@ -660,9 +666,7 @@ fn build_manual_compaction_message_spec(
         role: "compact".to_owned(),
         caption: Some(caption),
         sections: vec![result_section, detail_section],
-        footer_lines: vec![
-            "Continue chatting, or run /status to inspect maintenance settings.".to_owned(),
-        ],
+        footer_lines: vec![CONTINUE_OR_STATUS_HINT.to_owned()],
     }
 }
 

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -1,0 +1,2463 @@
+use std::cmp::min;
+use std::sync::{Arc, Mutex};
+
+use console::{Key, Term};
+
+use super::cli_input::ConcurrentCliInputReader;
+use super::*;
+
+const ALT_SCREEN_ENTER: &str = "\x1b[?1049h";
+const ALT_SCREEN_EXIT: &str = "\x1b[?1049l";
+const CLEAR_AND_HOME: &str = "\x1b[2J\x1b[H";
+const HEADER_GAP: usize = 1;
+const STATUS_BAR_HEIGHT: usize = 1;
+const COMPOSER_HEIGHT: usize = 4;
+const SIDEBAR_WIDTH: usize = 34;
+const MIN_SIDEBAR_TOTAL_WIDTH: usize = 110;
+const COMMAND_OVERLAY_WIDTH: usize = 52;
+
+pub(super) fn terminal_surface_supported() -> bool {
+    Term::stdout().is_term()
+}
+
+pub(super) async fn run_cli_chat_surface(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let runtime = initialize_cli_turn_runtime(config_path, session_hint, options, "cli-chat")?;
+    let surface = ChatSessionSurface::new(runtime, options.clone())?;
+    surface.run().await
+}
+
+pub(super) fn run_concurrent_cli_host_surface(options: &ConcurrentCliHostOptions) -> CliResult<()> {
+    let chat_options = CliChatOptions::default();
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        options.resolved_path.clone(),
+        options.config.clone(),
+        Some(options.session_id.as_str()),
+        &chat_options,
+        "cli-chat-concurrent",
+        CliSessionRequirement::RequireExplicit,
+        options.initialize_runtime_environment,
+    )?;
+    let host_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to initialize concurrent CLI host runtime: {error}"))?;
+    let surface = ChatSessionSurface::new(runtime, chat_options)?;
+    host_runtime.block_on(async {
+        surface
+            .run_with_shutdown(Some(options.shutdown.clone()))
+            .await
+    })
+}
+
+struct ChatSessionSurface {
+    runtime: CliTurnRuntime,
+    options: CliChatOptions,
+    term: Term,
+    state: Arc<Mutex<SurfaceState>>,
+}
+
+#[derive(Clone)]
+struct SurfaceEntry {
+    lines: Vec<String>,
+}
+
+#[derive(Clone, Default)]
+struct SurfaceState {
+    startup_summary: Option<operator_surfaces::CliChatStartupSummary>,
+    session_title_override: Option<String>,
+    transcript: Vec<SurfaceEntry>,
+    composer: String,
+    composer_cursor: usize,
+    history: Vec<String>,
+    history_index: Option<usize>,
+    scroll_offset: usize,
+    sticky_bottom: bool,
+    selected_entry: Option<usize>,
+    focus: SurfaceFocus,
+    sidebar_visible: bool,
+    sidebar_tab: SidebarTab,
+    command_palette: Option<CommandPaletteState>,
+    overlay: Option<SurfaceOverlay>,
+    live: LiveSurfaceModel,
+    footer_notice: String,
+    pending_turn: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+enum SidebarTab {
+    #[default]
+    Session,
+    Runtime,
+    Tools,
+    Help,
+}
+
+impl SidebarTab {
+    fn title(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Runtime => "runtime",
+            Self::Tools => "tools",
+            Self::Help => "help",
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            Self::Session => Self::Runtime,
+            Self::Runtime => Self::Tools,
+            Self::Tools => Self::Help,
+            Self::Help => Self::Session,
+        }
+    }
+
+    fn previous(self) -> Self {
+        match self {
+            Self::Session => Self::Help,
+            Self::Runtime => Self::Session,
+            Self::Tools => Self::Runtime,
+            Self::Help => Self::Tools,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct CommandPaletteState {
+    selected: usize,
+    query: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+enum SurfaceFocus {
+    Transcript,
+    #[default]
+    Composer,
+    Sidebar,
+    CommandPalette,
+}
+
+#[derive(Clone, Debug)]
+enum SurfaceOverlay {
+    EntryDetails {
+        entry_index: usize,
+    },
+    Timeline,
+    ConfirmExit,
+    InputPrompt {
+        kind: OverlayInputKind,
+        value: String,
+        cursor: usize,
+    },
+    ApprovalPrompt {
+        screen: TuiScreenSpec,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OverlayInputKind {
+    RenameSession,
+    ExportTranscript,
+}
+
+impl SurfaceFocus {
+    fn next(self, sidebar_visible: bool, palette_open: bool) -> Self {
+        if palette_open {
+            return Self::CommandPalette;
+        }
+
+        match self {
+            Self::Transcript => {
+                if sidebar_visible {
+                    Self::Sidebar
+                } else {
+                    Self::Composer
+                }
+            }
+            Self::Composer => Self::Transcript,
+            Self::Sidebar => Self::Composer,
+            Self::CommandPalette => Self::Composer,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Transcript => "transcript",
+            Self::Composer => "composer",
+            Self::Sidebar => "sidebar",
+            Self::CommandPalette => "palette",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommandPaletteAction {
+    Help,
+    Status,
+    History,
+    Compact,
+    Timeline,
+    RenameSession,
+    ExportTranscript,
+    JumpLatest,
+    ToggleSticky,
+    ToggleSidebar,
+    CycleSidebarTab,
+    ClearComposer,
+    Exit,
+}
+
+impl CommandPaletteAction {
+    fn items() -> &'static [(&'static str, &'static str, Self)] {
+        &[
+            ("Help", "Open slash command reference", Self::Help),
+            ("Status", "Show runtime/session status card", Self::Status),
+            ("History", "Show transcript window summary", Self::History),
+            ("Compact", "Run manual compaction summary", Self::Compact),
+            (
+                "Timeline",
+                "Open the transcript navigator overlay",
+                Self::Timeline,
+            ),
+            (
+                "Rename session",
+                "Set a local surface title for this session",
+                Self::RenameSession,
+            ),
+            (
+                "Export transcript",
+                "Write the current transcript to a text file",
+                Self::ExportTranscript,
+            ),
+            (
+                "Jump to latest",
+                "Select the newest transcript entry and stick to bottom",
+                Self::JumpLatest,
+            ),
+            (
+                "Toggle sticky scroll",
+                "Pin transcript to bottom or keep manual scroll position",
+                Self::ToggleSticky,
+            ),
+            (
+                "Toggle sidebar",
+                "Show or hide the right rail",
+                Self::ToggleSidebar,
+            ),
+            (
+                "Cycle rail tab",
+                "Move the right rail to the next tab",
+                Self::CycleSidebarTab,
+            ),
+            (
+                "Clear composer",
+                "Clear the current draft",
+                Self::ClearComposer,
+            ),
+            ("Exit", "Leave the session surface", Self::Exit),
+        ]
+    }
+}
+
+fn filtered_command_palette_items(
+    query: &str,
+) -> Vec<(&'static str, &'static str, CommandPaletteAction)> {
+    let trimmed = query.trim().to_ascii_lowercase();
+    let mut items = CommandPaletteAction::items().to_vec();
+    if trimmed.is_empty() {
+        return items;
+    }
+    items.retain(|(label, detail, _)| {
+        label.to_ascii_lowercase().contains(trimmed.as_str())
+            || detail.to_ascii_lowercase().contains(trimmed.as_str())
+    });
+    items
+}
+
+#[derive(Clone, Default)]
+struct LiveSurfaceModel {
+    snapshot: Option<CliChatLiveSurfaceSnapshot>,
+    tool_lines: Vec<String>,
+    last_assistant_preview: Option<String>,
+    last_phase_label: String,
+}
+
+struct SurfaceGuard {
+    term: Term,
+}
+
+impl SurfaceGuard {
+    fn new(term: &Term) -> CliResult<Self> {
+        term.write_str(ALT_SCREEN_ENTER)
+            .map_err(|error| format!("failed to enter alternate screen: {error}"))?;
+        term.hide_cursor()
+            .map_err(|error| format!("failed to hide cursor: {error}"))?;
+        term.clear_screen()
+            .map_err(|error| format!("failed to clear screen: {error}"))?;
+        Ok(Self { term: term.clone() })
+    }
+}
+
+impl Drop for SurfaceGuard {
+    fn drop(&mut self) {
+        let _ = self.term.show_cursor();
+        let _ = self.term.write_str(ALT_SCREEN_EXIT);
+        let _ = self.term.flush();
+    }
+}
+
+impl ChatSessionSurface {
+    fn new(runtime: CliTurnRuntime, options: CliChatOptions) -> CliResult<Self> {
+        let term = Term::stdout();
+        let startup_summary =
+            operator_surfaces::build_cli_chat_startup_summary(&runtime, &options)?;
+        let mut state = SurfaceState {
+            startup_summary: Some(startup_summary.clone()),
+            session_title_override: None,
+            transcript: Vec::new(),
+            composer: String::new(),
+            composer_cursor: 0,
+            history: Vec::new(),
+            history_index: None,
+            scroll_offset: 0,
+            sticky_bottom: true,
+            selected_entry: None,
+            focus: SurfaceFocus::Composer,
+            sidebar_visible: true,
+            sidebar_tab: SidebarTab::Session,
+            command_palette: None,
+            overlay: None,
+            live: LiveSurfaceModel::default(),
+            footer_notice:
+                "Esc clear · ↑↓ history/scroll · PgUp/PgDn transcript · Tab focus · : commands"
+                    .to_owned(),
+            pending_turn: false,
+        };
+        let render_width = detect_cli_chat_render_width();
+        state.transcript.push(SurfaceEntry {
+            lines: operator_surfaces::render_cli_chat_startup_lines_with_width(
+                &startup_summary,
+                render_width,
+            ),
+        });
+        Ok(Self {
+            runtime,
+            options,
+            term,
+            state: Arc::new(Mutex::new(state)),
+        })
+    }
+
+    async fn run(self) -> CliResult<()> {
+        self.run_with_shutdown(None).await
+    }
+
+    async fn run_with_shutdown(self, shutdown: Option<ConcurrentCliShutdown>) -> CliResult<()> {
+        let _guard = SurfaceGuard::new(&self.term)?;
+        self.render()?;
+
+        if let Some(shutdown) = shutdown {
+            self.run_concurrent_loop(shutdown).await
+        } else {
+            self.run_interactive_loop().await
+        }
+    }
+
+    async fn run_interactive_loop(&self) -> CliResult<()> {
+        loop {
+            let key = self
+                .term
+                .read_key()
+                .map_err(|error| format!("failed to read terminal key: {error}"))?;
+            let action = self.handle_key(key)?;
+            match action {
+                SurfaceLoopAction::Continue => {}
+                SurfaceLoopAction::Submit => {
+                    let composer = self.lock_state().composer.clone();
+                    let action = self.submit_text(composer.as_str()).await?;
+                    if matches!(action, SurfaceLoopAction::Exit) {
+                        break;
+                    }
+                }
+                SurfaceLoopAction::RunCommand(command) => {
+                    let action = self.submit_text(command.as_str()).await?;
+                    if matches!(action, SurfaceLoopAction::Exit) {
+                        break;
+                    }
+                }
+                SurfaceLoopAction::Exit => break,
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_concurrent_loop(&self, shutdown: ConcurrentCliShutdown) -> CliResult<()> {
+        let mut stdin_reader = ConcurrentCliInputReader::new()?;
+        loop {
+            if shutdown.is_requested() {
+                break;
+            }
+
+            let next_line = tokio::select! {
+                _ = shutdown.wait() => None,
+                line = stdin_reader.next_line() => Some(line?),
+            };
+
+            let Some(line) = next_line else {
+                break;
+            };
+            let Some(line) = line else {
+                break;
+            };
+
+            let action = self.submit_text(line.trim()).await?;
+            if matches!(action, SurfaceLoopAction::Exit) {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn handle_key(&self, key: Key) -> CliResult<SurfaceLoopAction> {
+        match key {
+            Key::CtrlC => Ok(SurfaceLoopAction::Exit),
+            Key::Escape => {
+                let mut state = self.lock_state();
+                if matches!(state.overlay, Some(SurfaceOverlay::ConfirmExit)) {
+                    state.overlay = None;
+                    state.focus = SurfaceFocus::Composer;
+                    drop(state);
+                    self.render()?;
+                    return Ok(SurfaceLoopAction::Continue);
+                }
+                if state.overlay.is_some() {
+                    state.overlay = None;
+                    if state.command_palette.is_none() {
+                        state.focus = SurfaceFocus::Transcript;
+                    }
+                    drop(state);
+                    self.render()?;
+                    return Ok(SurfaceLoopAction::Continue);
+                }
+                if state.command_palette.is_some() {
+                    state.command_palette = None;
+                    state.focus = SurfaceFocus::Composer;
+                    state.composer.clear();
+                    drop(state);
+                    self.render()?;
+                    return Ok(SurfaceLoopAction::Continue);
+                }
+                if state.composer.is_empty() {
+                    state.overlay = Some(SurfaceOverlay::ConfirmExit);
+                    state.focus = SurfaceFocus::Composer;
+                    drop(state);
+                    self.render()?;
+                    return Ok(SurfaceLoopAction::Continue);
+                }
+                state.composer.clear();
+                state.composer_cursor = 0;
+                state.history_index = None;
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::Tab => {
+                let mut state = self.lock_state();
+                if state.command_palette.is_some() {
+                    state.command_palette = None;
+                    state.focus = SurfaceFocus::Composer;
+                } else {
+                    state.focus = state
+                        .focus
+                        .next(state.sidebar_visible, state.command_palette.is_some());
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::BackTab => {
+                let mut state = self.lock_state();
+                state.sidebar_tab = state.sidebar_tab.previous();
+                state.focus = SurfaceFocus::Sidebar;
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::ArrowUp => {
+                let mut state = self.lock_state();
+                if let Some(palette) = state.command_palette.as_mut() {
+                    palette.selected = palette.selected.saturating_sub(1);
+                } else if state.focus == SurfaceFocus::Composer
+                    && state.composer.contains('\n')
+                    && !state.composer.is_empty()
+                {
+                    state.composer_cursor =
+                        move_cursor_vertically(&state.composer, state.composer_cursor, -1);
+                } else if state.focus == SurfaceFocus::Transcript || state.composer.is_empty() {
+                    state.scroll_offset = state.scroll_offset.saturating_add(3);
+                    state.sticky_bottom = false;
+                    let selected = state
+                        .selected_entry
+                        .unwrap_or_else(|| state.transcript.len().saturating_sub(1));
+                    state.selected_entry = Some(selected.saturating_sub(1));
+                } else if !state.history.is_empty() {
+                    let next_index = match state.history_index {
+                        Some(index) => index.saturating_sub(1),
+                        None => state.history.len().saturating_sub(1),
+                    };
+                    state.history_index = Some(next_index);
+                    if let Some(entry) = state.history.get(next_index) {
+                        state.composer = entry.clone();
+                        state.composer_cursor = state.composer.chars().count();
+                    }
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::ArrowDown => {
+                let mut state = self.lock_state();
+                if let Some(palette) = state.command_palette.as_mut() {
+                    let max_index = filtered_command_palette_items(&palette.query)
+                        .len()
+                        .saturating_sub(1);
+                    palette.selected = min(palette.selected.saturating_add(1), max_index);
+                } else if state.focus == SurfaceFocus::Composer
+                    && state.composer.contains('\n')
+                    && !state.composer.is_empty()
+                {
+                    state.composer_cursor =
+                        move_cursor_vertically(&state.composer, state.composer_cursor, 1);
+                } else if state.focus == SurfaceFocus::Transcript || state.composer.is_empty() {
+                    state.scroll_offset = state.scroll_offset.saturating_sub(3);
+                    if state.scroll_offset == 0 {
+                        state.sticky_bottom = true;
+                    }
+                    let next_selected = state
+                        .selected_entry
+                        .unwrap_or_else(|| state.transcript.len().saturating_sub(1))
+                        .saturating_add(1);
+                    state.selected_entry =
+                        Some(min(next_selected, state.transcript.len().saturating_sub(1)));
+                } else if let Some(index) = state.history_index {
+                    let next_index = index.saturating_add(1);
+                    if next_index >= state.history.len() {
+                        state.history_index = None;
+                        state.composer.clear();
+                    } else {
+                        state.history_index = Some(next_index);
+                        if let Some(entry) = state.history.get(next_index) {
+                            state.composer = entry.clone();
+                            state.composer_cursor = state.composer.chars().count();
+                        }
+                    }
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::Home => {
+                let mut state = self.lock_state();
+                if state.focus == SurfaceFocus::Composer {
+                    state.composer_cursor = 0;
+                } else {
+                    state.sidebar_tab = state.sidebar_tab.previous();
+                    state.focus = SurfaceFocus::Sidebar;
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::End => {
+                let mut state = self.lock_state();
+                if state.focus == SurfaceFocus::Composer {
+                    state.composer_cursor = state.composer.chars().count();
+                } else {
+                    state.sidebar_tab = state.sidebar_tab.next();
+                    state.focus = SurfaceFocus::Sidebar;
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::PageUp => {
+                let mut state = self.lock_state();
+                state.scroll_offset = state.scroll_offset.saturating_add(10);
+                state.sticky_bottom = false;
+                state.focus = SurfaceFocus::Transcript;
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::PageDown => {
+                let mut state = self.lock_state();
+                state.scroll_offset = state.scroll_offset.saturating_sub(10);
+                if state.scroll_offset == 0 {
+                    state.sticky_bottom = true;
+                }
+                state.focus = SurfaceFocus::Transcript;
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::Backspace => {
+                let mut state = self.lock_state();
+                if let Some(SurfaceOverlay::InputPrompt { value, cursor, .. }) =
+                    state.overlay.as_mut()
+                {
+                    remove_char_before_cursor(value, cursor);
+                } else if let Some(palette) = state.command_palette.as_mut() {
+                    palette.query.pop();
+                    let max_index = filtered_command_palette_items(&palette.query)
+                        .len()
+                        .saturating_sub(1);
+                    palette.selected = min(palette.selected, max_index);
+                } else {
+                    let mut cursor = state.composer_cursor;
+                    remove_char_before_cursor(&mut state.composer, &mut cursor);
+                    state.composer_cursor = cursor;
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::ArrowLeft => {
+                let mut state = self.lock_state();
+                if let Some(SurfaceOverlay::InputPrompt { value, cursor, .. }) =
+                    state.overlay.as_mut()
+                {
+                    *cursor = cursor.saturating_sub(1).min(value.chars().count());
+                } else if state.command_palette.is_none() && state.focus == SurfaceFocus::Composer {
+                    state.composer_cursor = state.composer_cursor.saturating_sub(1);
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::ArrowRight => {
+                let mut state = self.lock_state();
+                if let Some(SurfaceOverlay::InputPrompt { value, cursor, .. }) =
+                    state.overlay.as_mut()
+                {
+                    *cursor = min(cursor.saturating_add(1), value.chars().count());
+                } else if state.command_palette.is_none() && state.focus == SurfaceFocus::Composer {
+                    state.composer_cursor = min(
+                        state.composer_cursor.saturating_add(1),
+                        state.composer.chars().count(),
+                    );
+                }
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::Enter => {
+                {
+                    let state = self.lock_state();
+                    if matches!(state.overlay, Some(SurfaceOverlay::ConfirmExit)) {
+                        return Ok(SurfaceLoopAction::Exit);
+                    }
+                }
+                {
+                    let overlay_input = {
+                        let state = self.lock_state();
+                        match state.overlay.as_ref() {
+                            Some(SurfaceOverlay::InputPrompt {
+                                kind,
+                                value,
+                                cursor: _,
+                            }) => Some((*kind, value.clone())),
+                            _ => None,
+                        }
+                    };
+                    if let Some((kind, value)) = overlay_input {
+                        self.submit_input_overlay(kind, value)?;
+                        return Ok(SurfaceLoopAction::Continue);
+                    }
+                }
+                {
+                    let mut state = self.lock_state();
+                    if matches!(state.overlay, Some(SurfaceOverlay::ApprovalPrompt { .. })) {
+                        let response = state.composer.trim().to_owned();
+                        if !response.is_empty() {
+                            state.transcript.push(SurfaceEntry {
+                                lines: render_cli_chat_message_spec_with_width(
+                                    &TuiMessageSpec {
+                                        role: "you".to_owned(),
+                                        caption: Some("approval response".to_owned()),
+                                        sections: vec![TuiSectionSpec::Narrative {
+                                            title: None,
+                                            lines: vec![response],
+                                        }],
+                                        footer_lines: vec![
+                                            "Approval response captured in surface history."
+                                                .to_owned(),
+                                        ],
+                                    },
+                                    self.content_width(),
+                                ),
+                            });
+                            state.overlay = None;
+                            state.composer.clear();
+                            state.composer_cursor = 0;
+                            state.selected_entry = Some(state.transcript.len().saturating_sub(1));
+                            state.focus = SurfaceFocus::Transcript;
+                            state.sticky_bottom = true;
+                            drop(state);
+                            self.render()?;
+                            return Ok(SurfaceLoopAction::Continue);
+                        }
+                    }
+                }
+                {
+                    let mut state = self.lock_state();
+                    if state.command_palette.is_none()
+                        && state.focus == SurfaceFocus::Composer
+                        && should_continue_multiline(&state.composer)
+                    {
+                        let mut cursor = state.composer_cursor;
+                        remove_char_before_cursor(&mut state.composer, &mut cursor);
+                        insert_char_at_cursor(&mut state.composer, &mut cursor, '\n');
+                        state.composer_cursor = cursor;
+                        drop(state);
+                        self.render()?;
+                        return Ok(SurfaceLoopAction::Continue);
+                    }
+                }
+                let maybe_action = self
+                    .lock_state()
+                    .command_palette
+                    .as_ref()
+                    .and_then(|palette| {
+                        filtered_command_palette_items(&palette.query)
+                            .get(palette.selected)
+                            .map(|item| item.2)
+                    });
+                if let Some(action) = maybe_action {
+                    return self.execute_palette_action(action);
+                }
+                {
+                    let mut state = self.lock_state();
+                    if matches!(state.overlay, Some(SurfaceOverlay::Timeline)) {
+                        let entry_index = state
+                            .selected_entry
+                            .or_else(|| state.transcript.len().checked_sub(1));
+                        if let Some(entry_index) = entry_index {
+                            state.overlay = Some(SurfaceOverlay::EntryDetails { entry_index });
+                            drop(state);
+                            self.render()?;
+                            return Ok(SurfaceLoopAction::Continue);
+                        }
+                    }
+                }
+                let maybe_overlay = {
+                    let state = self.lock_state();
+                    if state.focus == SurfaceFocus::Transcript {
+                        state
+                            .selected_entry
+                            .or_else(|| state.transcript.len().checked_sub(1))
+                    } else {
+                        None
+                    }
+                };
+                if let Some(entry_index) = maybe_overlay {
+                    let mut state = self.lock_state();
+                    state.overlay = Some(SurfaceOverlay::EntryDetails { entry_index });
+                    drop(state);
+                    self.render()?;
+                    return Ok(SurfaceLoopAction::Continue);
+                }
+                Ok(SurfaceLoopAction::Submit)
+            }
+            Key::Char(character) => {
+                let mut state = self.lock_state();
+                if character == ':' && state.composer.is_empty() {
+                    state.command_palette = Some(CommandPaletteState::default());
+                    state.focus = SurfaceFocus::CommandPalette;
+                } else if let Some(SurfaceOverlay::InputPrompt { value, cursor, .. }) =
+                    state.overlay.as_mut()
+                {
+                    if !character.is_control() {
+                        insert_char_at_cursor(value, cursor, character);
+                    }
+                } else if let Some(palette) = state.command_palette.as_mut() {
+                    if !character.is_control() {
+                        palette.query.push(character);
+                        let max_index = filtered_command_palette_items(&palette.query)
+                            .len()
+                            .saturating_sub(1);
+                        palette.selected = min(palette.selected, max_index);
+                    }
+                } else if character == ']' && state.composer.is_empty() {
+                    state.sidebar_tab = state.sidebar_tab.next();
+                    state.focus = SurfaceFocus::Sidebar;
+                } else if character == '[' && state.composer.is_empty() {
+                    state.sidebar_tab = state.sidebar_tab.previous();
+                    state.focus = SurfaceFocus::Sidebar;
+                } else if character == 't'
+                    && state.composer.is_empty()
+                    && state.command_palette.is_none()
+                {
+                    state.overlay = Some(SurfaceOverlay::Timeline);
+                    state.focus = SurfaceFocus::Transcript;
+                } else if matches!(state.overlay, Some(SurfaceOverlay::ApprovalPrompt { .. }))
+                    && matches!(character, '1'..='9' | 'y' | 'n')
+                {
+                    state.overlay = None;
+                    state.focus = SurfaceFocus::Composer;
+                } else if (character == 'j' || character == 'k')
+                    && state.focus == SurfaceFocus::Transcript
+                    && state.command_palette.is_none()
+                {
+                    let current = state
+                        .selected_entry
+                        .unwrap_or_else(|| state.transcript.len().saturating_sub(1));
+                    if character == 'j' {
+                        state.selected_entry = Some(min(
+                            current.saturating_add(1),
+                            state.transcript.len().saturating_sub(1),
+                        ));
+                        state.scroll_offset = state.scroll_offset.saturating_sub(1);
+                        if state.scroll_offset == 0 {
+                            state.sticky_bottom = true;
+                        }
+                    } else {
+                        state.selected_entry = Some(current.saturating_sub(1));
+                        state.scroll_offset = state.scroll_offset.saturating_add(1);
+                        state.sticky_bottom = false;
+                    }
+                } else if character == 'g'
+                    && state.focus == SurfaceFocus::Transcript
+                    && state.command_palette.is_none()
+                {
+                    state.selected_entry = Some(0);
+                    state.sticky_bottom = false;
+                } else if character == 'G'
+                    && state.focus == SurfaceFocus::Transcript
+                    && state.command_palette.is_none()
+                {
+                    state.selected_entry = state.transcript.len().checked_sub(1);
+                    state.scroll_offset = 0;
+                    state.sticky_bottom = true;
+                } else {
+                    let mut cursor = state.composer_cursor;
+                    insert_char_at_cursor(&mut state.composer, &mut cursor, character);
+                    state.composer_cursor = cursor;
+                    state.focus = SurfaceFocus::Composer;
+                }
+                state.history_index = None;
+                drop(state);
+                self.render()?;
+                Ok(SurfaceLoopAction::Continue)
+            }
+            Key::Unknown
+            | Key::UnknownEscSeq(_)
+            | Key::Alt
+            | Key::Del
+            | Key::Shift
+            | Key::Insert => Ok(SurfaceLoopAction::Continue),
+            _ => Ok(SurfaceLoopAction::Continue),
+        }
+    }
+
+    fn execute_palette_action(&self, action: CommandPaletteAction) -> CliResult<SurfaceLoopAction> {
+        let mut state = self.lock_state();
+        state.command_palette = None;
+        match action {
+            CommandPaletteAction::Help => {
+                return Ok(SurfaceLoopAction::RunCommand(
+                    CLI_CHAT_HELP_COMMAND.to_owned(),
+                ));
+            }
+            CommandPaletteAction::Status => {
+                return Ok(SurfaceLoopAction::RunCommand(
+                    CLI_CHAT_STATUS_COMMAND.to_owned(),
+                ));
+            }
+            CommandPaletteAction::History => {
+                return Ok(SurfaceLoopAction::RunCommand(
+                    CLI_CHAT_HISTORY_COMMAND.to_owned(),
+                ));
+            }
+            CommandPaletteAction::Compact => {
+                return Ok(SurfaceLoopAction::RunCommand(
+                    CLI_CHAT_COMPACT_COMMAND.to_owned(),
+                ));
+            }
+            CommandPaletteAction::Timeline => {
+                state.overlay = Some(SurfaceOverlay::Timeline);
+                state.focus = SurfaceFocus::Transcript;
+            }
+            CommandPaletteAction::RenameSession => {
+                let initial = state
+                    .session_title_override
+                    .clone()
+                    .unwrap_or_else(|| self.runtime.session_id.clone());
+                state.overlay = Some(SurfaceOverlay::InputPrompt {
+                    kind: OverlayInputKind::RenameSession,
+                    cursor: initial.chars().count(),
+                    value: initial,
+                });
+                state.focus = SurfaceFocus::Composer;
+            }
+            CommandPaletteAction::ExportTranscript => {
+                let initial = default_export_path(self.runtime.session_id.as_str());
+                state.overlay = Some(SurfaceOverlay::InputPrompt {
+                    kind: OverlayInputKind::ExportTranscript,
+                    cursor: initial.chars().count(),
+                    value: initial,
+                });
+                state.focus = SurfaceFocus::Composer;
+            }
+            CommandPaletteAction::JumpLatest => {
+                state.sticky_bottom = true;
+                state.scroll_offset = 0;
+                state.selected_entry = state.transcript.len().checked_sub(1);
+                state.focus = SurfaceFocus::Transcript;
+            }
+            CommandPaletteAction::ToggleSticky => {
+                state.sticky_bottom = !state.sticky_bottom;
+                if state.sticky_bottom {
+                    state.scroll_offset = 0;
+                    state.selected_entry = state.transcript.len().checked_sub(1);
+                }
+                state.focus = SurfaceFocus::Transcript;
+            }
+            CommandPaletteAction::ToggleSidebar => state.sidebar_visible = !state.sidebar_visible,
+            CommandPaletteAction::CycleSidebarTab => state.sidebar_tab = state.sidebar_tab.next(),
+            CommandPaletteAction::ClearComposer => {
+                state.composer.clear();
+                state.composer_cursor = 0;
+            }
+            CommandPaletteAction::Exit => return Ok(SurfaceLoopAction::Exit),
+        }
+        state.focus = SurfaceFocus::Composer;
+        drop(state);
+        self.render()?;
+        Ok(SurfaceLoopAction::Continue)
+    }
+
+    async fn submit_text(&self, text: &str) -> CliResult<SurfaceLoopAction> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Ok(SurfaceLoopAction::Continue);
+        }
+
+        if is_exit_command(&self.runtime.config, trimmed) {
+            return Ok(SurfaceLoopAction::Exit);
+        }
+
+        if trimmed.starts_with('/') {
+            {
+                let mut state = self.lock_state();
+                state.composer.clear();
+                state.composer_cursor = 0;
+                state.history_index = None;
+                state.focus = SurfaceFocus::Composer;
+            }
+            self.handle_command(trimmed).await?;
+            self.render()?;
+            return Ok(SurfaceLoopAction::Continue);
+        }
+
+        {
+            let mut state = self.lock_state();
+            state.transcript.push(SurfaceEntry {
+                lines: render_cli_chat_message_spec_with_width(
+                    &TuiMessageSpec {
+                        role: "you".to_owned(),
+                        caption: Some("prompt".to_owned()),
+                        sections: vec![TuiSectionSpec::Narrative {
+                            title: None,
+                            lines: vec![trimmed.to_owned()],
+                        }],
+                        footer_lines: vec!["Enter send · Esc clear · Tab sidebar".to_owned()],
+                    },
+                    self.content_width(),
+                ),
+            });
+            state.history.push(trimmed.to_owned());
+            state.composer.clear();
+            state.composer_cursor = 0;
+            state.history_index = None;
+            state.pending_turn = true;
+            state.scroll_offset = 0;
+            state.sticky_bottom = true;
+            state.selected_entry = Some(state.transcript.len().saturating_sub(1));
+            state.focus = SurfaceFocus::Transcript;
+        }
+        self.render()?;
+
+        let observer = build_surface_live_observer(self.state.clone(), self.term.clone());
+        let assistant_text = self
+            .runtime
+            .turn_coordinator
+            .handle_turn_with_address_and_acp_options_and_observer(
+                &reload_cli_turn_config(
+                    &self.runtime.config,
+                    self.runtime.resolved_path.as_path(),
+                )?,
+                &self.runtime.session_address,
+                trimmed,
+                ProviderErrorMode::InlineMessage,
+                &if self.runtime.explicit_acp_request {
+                    AcpConversationTurnOptions::explicit()
+                } else {
+                    AcpConversationTurnOptions::automatic()
+                }
+                .with_additional_bootstrap_mcp_servers(
+                    &self.runtime.effective_bootstrap_mcp_servers,
+                )
+                .with_working_directory(self.runtime.effective_working_directory.as_deref()),
+                crate::conversation::ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
+                Some(observer),
+            )
+            .await?;
+
+        {
+            let mut state = self.lock_state();
+            state.transcript.push(SurfaceEntry {
+                lines: render_cli_chat_assistant_lines_with_width(
+                    &assistant_text,
+                    self.content_width(),
+                ),
+            });
+            if let Some(screen) = build_cli_chat_approval_screen_spec(&assistant_text) {
+                state.overlay = Some(SurfaceOverlay::ApprovalPrompt { screen });
+            }
+            state.pending_turn = false;
+            state.live.last_assistant_preview = Some(assistant_text);
+            state.live.snapshot = None;
+            state.live.tool_lines.clear();
+            state.selected_entry = Some(state.transcript.len().saturating_sub(1));
+            state.sticky_bottom = true;
+        }
+        self.render()?;
+        Ok(SurfaceLoopAction::Continue)
+    }
+
+    async fn handle_command(&self, input: &str) -> CliResult<()> {
+        let width = self.content_width();
+        let lines = if input == CLI_CHAT_HELP_COMMAND {
+            operator_surfaces::render_cli_chat_help_lines_with_width(width)
+        } else if operator_surfaces::is_cli_chat_status_command(input)? {
+            operator_surfaces::render_cli_chat_status_lines_with_width(
+                &operator_surfaces::build_cli_chat_startup_summary(&self.runtime, &self.options)?,
+                width,
+            )
+        } else if operator_surfaces::is_manual_compaction_command(input)? {
+            #[cfg(feature = "memory-sqlite")]
+            {
+                let binding = ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx);
+                let result = operator_surfaces::load_manual_compaction_result(
+                    &self.runtime.config,
+                    &self.runtime.session_id,
+                    &self.runtime.turn_coordinator,
+                    binding,
+                )
+                .await?;
+                operator_surfaces::render_manual_compaction_lines_with_width(
+                    &self.runtime.session_id,
+                    &result,
+                    width,
+                )
+            }
+            #[cfg(not(feature = "memory-sqlite"))]
+            {
+                render_cli_chat_feature_unavailable_lines_with_width(
+                    "compact",
+                    "manual compaction unavailable: memory-sqlite feature disabled",
+                    width,
+                )
+            }
+        } else if matches!(
+            classify_chat_command_match_result(parse_exact_chat_command(
+                input,
+                &[CLI_CHAT_HISTORY_COMMAND],
+                "usage: /history",
+            ))?,
+            ChatCommandMatchResult::Matched
+        ) {
+            #[cfg(feature = "memory-sqlite")]
+            {
+                let history_lines = operator_surfaces::load_history_lines(
+                    &self.runtime.session_id,
+                    self.runtime.config.memory.sliding_window,
+                    ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
+                    &self.runtime.memory_config,
+                )
+                .await?;
+                operator_surfaces::render_cli_chat_history_lines_with_width(
+                    &self.runtime.session_id,
+                    self.runtime.config.memory.sliding_window,
+                    &history_lines,
+                    width,
+                )
+            }
+            #[cfg(not(feature = "memory-sqlite"))]
+            {
+                render_cli_chat_feature_unavailable_lines_with_width(
+                    "history",
+                    "history unavailable: memory-sqlite feature disabled",
+                    width,
+                )
+            }
+        } else {
+            render_cli_chat_command_usage_lines_with_width(
+                "usage: /help | /status | /history | /compact | /exit",
+                width,
+            )
+        };
+
+        let mut state = self.lock_state();
+        state.transcript.push(SurfaceEntry { lines });
+        state.selected_entry = Some(state.transcript.len().saturating_sub(1));
+        state.sticky_bottom = true;
+        state.focus = SurfaceFocus::Transcript;
+        Ok(())
+    }
+
+    fn submit_input_overlay(&self, kind: OverlayInputKind, value: String) -> CliResult<()> {
+        let trimmed = value.trim();
+        let mut state = self.lock_state();
+        match kind {
+            OverlayInputKind::RenameSession => {
+                if trimmed.is_empty() {
+                    state.overlay = None;
+                    state.focus = SurfaceFocus::Composer;
+                    return Ok(());
+                }
+                state.session_title_override = Some(trimmed.to_owned());
+                state.transcript.push(SurfaceEntry {
+                    lines: render_cli_chat_message_spec_with_width(
+                        &TuiMessageSpec {
+                            role: "system".to_owned(),
+                            caption: Some("session".to_owned()),
+                            sections: vec![TuiSectionSpec::Callout {
+                                tone: TuiCalloutTone::Success,
+                                title: Some("session renamed".to_owned()),
+                                lines: vec![format!("Session title updated to `{trimmed}`.")],
+                            }],
+                            footer_lines: vec![
+                                "This rename is local to the current surface.".to_owned(),
+                            ],
+                        },
+                        self.content_width(),
+                    ),
+                });
+            }
+            OverlayInputKind::ExportTranscript => {
+                if trimmed.is_empty() {
+                    state.overlay = None;
+                    state.focus = SurfaceFocus::Composer;
+                    return Ok(());
+                }
+                let export_text = format_transcript_export(&state.transcript);
+                std::fs::write(trimmed, export_text).map_err(|error| {
+                    format!("failed to export transcript to `{trimmed}`: {error}")
+                })?;
+                state.transcript.push(SurfaceEntry {
+                    lines: render_cli_chat_message_spec_with_width(
+                        &TuiMessageSpec {
+                            role: "system".to_owned(),
+                            caption: Some("export".to_owned()),
+                            sections: vec![TuiSectionSpec::Callout {
+                                tone: TuiCalloutTone::Success,
+                                title: Some("transcript exported".to_owned()),
+                                lines: vec![format!("Saved transcript to `{trimmed}`.")],
+                            }],
+                            footer_lines: vec![
+                                "Use the exported text file for external review or sharing."
+                                    .to_owned(),
+                            ],
+                        },
+                        self.content_width(),
+                    ),
+                });
+            }
+        }
+        state.overlay = None;
+        state.focus = SurfaceFocus::Transcript;
+        state.selected_entry = Some(state.transcript.len().saturating_sub(1));
+        state.sticky_bottom = true;
+        Ok(())
+    }
+
+    fn render(&self) -> CliResult<()> {
+        let (height_u16, width_u16) = self.term.size();
+        let total_height = usize::from(height_u16);
+        let total_width = usize::from(width_u16);
+        let state = self.lock_state().clone();
+
+        let header_lines = crate::presentation::render_compact_brand_header(
+            total_width.saturating_sub(2),
+            &crate::presentation::BuildVersionInfo::current(),
+            Some(session_surface_subtitle(&state)),
+        )
+        .into_iter()
+        .map(|line| line.text)
+        .collect::<Vec<_>>();
+
+        let sidebar_visible = state.sidebar_visible && total_width >= MIN_SIDEBAR_TOTAL_WIDTH;
+        let sidebar_width = if sidebar_visible { SIDEBAR_WIDTH } else { 0 };
+        let content_width = total_width
+            .saturating_sub(sidebar_width)
+            .saturating_sub(if sidebar_visible { 3 } else { 2 })
+            .max(24);
+
+        let reserved_height =
+            header_lines.len() + HEADER_GAP + COMPOSER_HEIGHT + STATUS_BAR_HEIGHT + 1;
+        let transcript_height = total_height.saturating_sub(reserved_height).max(5);
+        let transcript_lines =
+            self.build_transcript_lines(&state, content_width, transcript_height);
+        let sidebar_lines = self.build_sidebar_lines(&state, sidebar_width, transcript_height);
+        let composer_lines = self.build_composer_lines(&state, total_width.saturating_sub(2));
+        let status_line = self.build_status_line(&state, total_width.saturating_sub(2));
+        let overlay_lines =
+            self.build_command_palette_lines(&state, total_width, total_height, transcript_height);
+        let detail_overlay =
+            self.build_entry_detail_overlay_lines(&state, total_width, total_height);
+        let timeline_overlay = self.build_timeline_overlay_lines(&state, total_width, total_height);
+        let prompt_overlay = self.build_prompt_overlay_lines(&state, total_width, total_height);
+
+        let mut output = String::from(CLEAR_AND_HOME);
+        for line in &header_lines {
+            output.push_str(line);
+            output.push('\n');
+        }
+        output.push('\n');
+
+        for row in 0..transcript_height {
+            let main_line = transcript_lines.get(row).map(String::as_str).unwrap_or("");
+            output.push_str(&pad_and_clip(main_line, content_width));
+            if sidebar_visible {
+                output.push_str(" │ ");
+                let side_line = sidebar_lines.get(row).map(String::as_str).unwrap_or("");
+                output.push_str(&pad_and_clip(side_line, sidebar_width));
+            }
+            output.push('\n');
+        }
+
+        for line in &composer_lines {
+            output.push_str(line);
+            output.push('\n');
+        }
+        output.push_str(&status_line);
+        if let Some(overlay) = overlay_lines {
+            output.push_str(overlay.as_str());
+        }
+        if let Some(overlay) = detail_overlay {
+            output.push_str(overlay.as_str());
+        }
+        if let Some(overlay) = timeline_overlay {
+            output.push_str(overlay.as_str());
+        }
+        if let Some(overlay) = prompt_overlay {
+            output.push_str(overlay.as_str());
+        }
+
+        self.term
+            .write_str(output.as_str())
+            .map_err(|error| format!("failed to render chat surface: {error}"))?;
+        self.term
+            .flush()
+            .map_err(|error| format!("failed to flush chat surface: {error}"))?;
+        Ok(())
+    }
+
+    fn build_transcript_lines(
+        &self,
+        state: &SurfaceState,
+        width: usize,
+        height: usize,
+    ) -> Vec<String> {
+        let mut lines = Vec::new();
+        for (entry_index, entry) in state.transcript.iter().enumerate() {
+            if !lines.is_empty() {
+                lines.push(String::new());
+            }
+            for (line_index, line) in entry.lines.iter().enumerate() {
+                let clipped = clipped_display_line(line, width.saturating_sub(2));
+                if line_index == 0 && state.selected_entry == Some(entry_index) {
+                    lines.push(format!("▶ {clipped}"));
+                } else {
+                    lines.push(clipped);
+                }
+            }
+        }
+
+        if state.pending_turn && !lines.is_empty() {
+            lines.push(String::new());
+        }
+
+        if state.pending_turn {
+            let live_lines = render_cli_chat_live_surface_lines_with_width(
+                &state
+                    .live
+                    .snapshot
+                    .clone()
+                    .unwrap_or(CliChatLiveSurfaceSnapshot {
+                        phase: ConversationTurnPhase::Preparing,
+                        provider_round: None,
+                        lane: None,
+                        tool_call_count: 0,
+                        message_count: None,
+                        estimated_tokens: None,
+                        draft_preview: None,
+                        tool_activity_lines: state.live.tool_lines.clone(),
+                    }),
+                width,
+            );
+            lines.extend(
+                live_lines
+                    .into_iter()
+                    .map(|line| clipped_display_line(&line, width)),
+            );
+        }
+
+        if state.sticky_bottom {
+            if lines.len() <= height {
+                return lines;
+            }
+
+            let start = lines.len().saturating_sub(height);
+            return lines.into_iter().skip(start).collect();
+        }
+
+        if lines.len() <= height {
+            return lines;
+        }
+
+        let max_offset = lines.len().saturating_sub(height);
+        let scroll_offset = min(state.scroll_offset, max_offset);
+        let start = lines.len().saturating_sub(height + scroll_offset);
+        lines.into_iter().skip(start).take(height).collect()
+    }
+
+    fn build_sidebar_lines(
+        &self,
+        state: &SurfaceState,
+        width: usize,
+        height: usize,
+    ) -> Vec<String> {
+        if width == 0 {
+            return Vec::new();
+        }
+
+        let startup_summary = state
+            .startup_summary
+            .clone()
+            .unwrap_or_else(|| fallback_startup_summary(self.runtime.session_id.as_str()));
+        let mut lines = vec![
+            format!("right rail · {}", state.sidebar_tab.title()),
+            format!("session {}", startup_summary.session_id),
+        ];
+        lines.push(format!("focus: {}", state.focus.label()));
+        let tab_label = format!(
+            "tabs: {} | {} | {} | {}",
+            if state.sidebar_tab == SidebarTab::Session {
+                "[session]"
+            } else {
+                "session"
+            },
+            if state.sidebar_tab == SidebarTab::Runtime {
+                "[runtime]"
+            } else {
+                "runtime"
+            },
+            if state.sidebar_tab == SidebarTab::Tools {
+                "[tools]"
+            } else {
+                "tools"
+            },
+            if state.sidebar_tab == SidebarTab::Help {
+                "[help]"
+            } else {
+                "help"
+            },
+        );
+        lines.extend(crate::presentation::render_wrapped_display_line(
+            &tab_label, width,
+        ));
+        lines.push(String::new());
+
+        match state.sidebar_tab {
+            SidebarTab::Session => {
+                lines.push(format!("session: {}", startup_summary.session_id));
+                lines.push(format!("config: {}", startup_summary.config_path));
+                lines.push(format!("memory: {}", startup_summary.memory_label));
+                lines.push(format!("context: {}", startup_summary.context_engine_id));
+                lines.push(format!(
+                    "context src: {}",
+                    startup_summary.context_engine_source
+                ));
+                lines.push(format!("acp backend: {}", startup_summary.acp_backend_id));
+                lines.push(format!("routing: {}", startup_summary.conversation_routing));
+                lines.push(format!("sticky: {}", state.sticky_bottom));
+                lines.push(format!("entries: {}", state.transcript.len()));
+                lines.push(format!(
+                    "channels: {}",
+                    if startup_summary.allowed_channels.is_empty() {
+                        "-".to_owned()
+                    } else {
+                        startup_summary.allowed_channels.join(", ")
+                    }
+                ));
+            }
+            SidebarTab::Runtime => {
+                lines.push(format!("acp: {}", startup_summary.acp_enabled));
+                lines.push(format!("dispatch: {}", startup_summary.dispatch_enabled));
+                lines.push(format!(
+                    "event stream: {}",
+                    startup_summary.event_stream_enabled
+                ));
+                let working_directory = startup_summary
+                    .working_directory
+                    .unwrap_or_else(|| "-".to_owned());
+                lines.push(format!("cwd: {}", working_directory));
+                lines.push(format!(
+                    "phase: {}",
+                    state
+                        .live
+                        .snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.phase.as_str())
+                        .unwrap_or("idle")
+                ));
+                lines.push(format!(
+                    "round: {}",
+                    state
+                        .live
+                        .snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.provider_round)
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned())
+                ));
+                lines.push(format!(
+                    "messages: {}",
+                    state
+                        .live
+                        .snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.message_count)
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned())
+                ));
+                lines.push(format!(
+                    "tokens: {}",
+                    state
+                        .live
+                        .snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.estimated_tokens)
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_owned())
+                ));
+            }
+            SidebarTab::Tools => {
+                lines.push(format!(
+                    "tool calls: {}",
+                    state
+                        .live
+                        .snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.tool_call_count)
+                        .unwrap_or(0)
+                ));
+                if state.live.tool_lines.is_empty() {
+                    lines.push("no tool activity recorded".to_owned());
+                } else {
+                    lines.extend(state.live.tool_lines.iter().take(10).cloned());
+                }
+            }
+            SidebarTab::Help => {
+                lines.push("shortcuts".to_owned());
+                lines.push("Enter send".to_owned());
+                lines.push("Esc clear / exit".to_owned());
+                lines.push("Tab cycle focus".to_owned());
+                lines.push("[ ] / Home End switch rail tab".to_owned());
+                lines.push("PgUp / PgDn transcript scroll".to_owned());
+                lines.push("j / k transcript move".to_owned());
+                lines.push("Enter on transcript → detail".to_owned());
+                lines.push("g / G transcript jump".to_owned());
+                lines.push("t timeline overlay".to_owned());
+                lines.push("← / → / Home / End composer cursor".to_owned());
+                lines.push("↑ / ↓ composer multiline move".to_owned());
+                lines.push(": command palette".to_owned());
+                lines.push("/help /status /history /compact".to_owned());
+            }
+        }
+
+        if let Some(preview) = state.live.last_assistant_preview.as_deref() {
+            lines.push(String::new());
+            lines.push("last reply".to_owned());
+            lines.extend(
+                crate::presentation::render_wrapped_display_line(preview, width)
+                    .into_iter()
+                    .take(8),
+            );
+        }
+
+        if let Some(selected) = state.selected_entry
+            && let Some(entry) = state.transcript.get(selected)
+        {
+            lines.push(String::new());
+            lines.push(format!("selected entry: {}", selected + 1));
+            lines.extend(
+                entry
+                    .lines
+                    .iter()
+                    .flat_map(|line| crate::presentation::render_wrapped_display_line(line, width))
+                    .take(6),
+            );
+        }
+
+        lines.truncate(height);
+        lines
+    }
+
+    fn build_composer_lines(&self, state: &SurfaceState, width: usize) -> Vec<String> {
+        let draft_lines = composer_display_lines(
+            &composer_text_with_cursor(&state.composer, state.composer_cursor),
+            width.saturating_sub(2),
+            2,
+        );
+        let prompt_line = if state.composer.is_empty() {
+            format!("╭─ compose · focus={}", state.focus.label())
+        } else {
+            format!(
+                "╭─ compose · {} chars · focus={}",
+                state.composer.chars().count(),
+                state.focus.label()
+            )
+        };
+        let body_line = format!("│ {}", draft_lines.first().cloned().unwrap_or_default());
+        let second_line = if draft_lines.len() > 1 {
+            format!("│ {}", draft_lines.get(1).cloned().unwrap_or_default())
+        } else if let Some(hint) = slash_command_hint(&state.composer) {
+            format!("│ {hint}")
+        } else {
+            "│".to_owned()
+        };
+        let hint = if state.command_palette.is_some() {
+            "╰─ command palette active · type filter · ↑↓ choose · Enter run · Esc close"
+        } else if state.composer.starts_with('/') {
+            "╰─ slash mode · Enter send command · : open command palette"
+        } else if should_continue_multiline(&state.composer) {
+            "╰─ multiline compose · trailing \\ inserts newline on Enter"
+        } else {
+            "╰─ Enter send · : command palette · /help for commands"
+        };
+        vec![prompt_line, body_line, second_line, hint.to_owned()]
+    }
+
+    fn build_status_line(&self, state: &SurfaceState, width: usize) -> String {
+        let mut status = format!(
+            "{} · focus={} · rail={} · entries={} · scroll={} · sticky={} · overlay={}",
+            state.footer_notice,
+            state.focus.label(),
+            state.sidebar_tab.title(),
+            state.transcript.len(),
+            state.scroll_offset,
+            state.sticky_bottom,
+            current_overlay_label(state)
+        );
+        if state.pending_turn {
+            status.push_str(" · turn running");
+        }
+        clipped_display_line(&status, width)
+    }
+
+    fn build_command_palette_lines(
+        &self,
+        state: &SurfaceState,
+        total_width: usize,
+        _total_height: usize,
+        transcript_height: usize,
+    ) -> Option<String> {
+        let palette = state.command_palette.as_ref()?;
+        let filtered_items = filtered_command_palette_items(&palette.query);
+        let overlay_width = COMMAND_OVERLAY_WIDTH
+            .min(total_width.saturating_sub(4))
+            .max(24);
+        let x = total_width.saturating_sub(overlay_width + 2);
+        let y = transcript_height.saturating_sub(8).max(2);
+        let header = if palette.query.is_empty() {
+            "╭─ commands".to_owned()
+        } else {
+            format!("╭─ commands · query={}", palette.query)
+        };
+        let mut lines = vec![format!("\x1b[{};{}H{}", y + 1, x + 1, header)];
+        for (index, (label, detail, _)) in filtered_items.iter().enumerate() {
+            let marker = if index == palette.selected { '>' } else { ' ' };
+            let row = y + 2 + index;
+            lines.push(format!(
+                "\x1b[{};{}H│ {} {}",
+                row + 1,
+                x + 1,
+                marker,
+                pad_and_clip(label, overlay_width.saturating_sub(4))
+            ));
+            let detail_row = row + 1;
+            lines.push(format!(
+                "\x1b[{};{}H│   {}",
+                detail_row + 1,
+                x + 1,
+                pad_and_clip(detail, overlay_width.saturating_sub(4))
+            ));
+        }
+        if filtered_items.is_empty() {
+            lines.push(format!(
+                "\x1b[{};{}H│ {}",
+                y + 2,
+                x + 1,
+                pad_and_clip(
+                    "no commands match the current query",
+                    overlay_width.saturating_sub(4)
+                )
+            ));
+        }
+        let bottom_row = y + 2 + filtered_items.len().max(1) * 2;
+        lines.push(format!(
+            "\x1b[{};{}H╰─ type to filter · Enter run · Esc close",
+            bottom_row + 1,
+            x + 1
+        ));
+        Some(lines.join(""))
+    }
+
+    fn build_entry_detail_overlay_lines(
+        &self,
+        state: &SurfaceState,
+        total_width: usize,
+        total_height: usize,
+    ) -> Option<String> {
+        let SurfaceOverlay::EntryDetails { entry_index } = state.overlay.as_ref()?.clone() else {
+            return None;
+        };
+        let entry = state.transcript.get(entry_index)?;
+        let overlay_width = min(total_width.saturating_sub(6), 80).max(28);
+        let overlay_height = min(total_height.saturating_sub(6), 18).max(8);
+        let x = (total_width.saturating_sub(overlay_width)) / 2;
+        let y = (total_height.saturating_sub(overlay_height)) / 2;
+        let mut lines = vec![format!(
+            "\x1b[{};{}H╭─ entry details · #{}",
+            y + 1,
+            x + 1,
+            entry_index + 1
+        )];
+
+        let body_width = overlay_width.saturating_sub(4);
+        let mut rendered = Vec::new();
+        for line in &entry.lines {
+            let wrapped = crate::presentation::render_wrapped_display_line(line, body_width);
+            if wrapped.is_empty() {
+                rendered.push(String::new());
+            } else {
+                rendered.extend(wrapped);
+            }
+        }
+
+        let visible_rows = overlay_height.saturating_sub(3);
+        for row in 0..visible_rows {
+            let rendered_line = rendered.get(row).cloned().unwrap_or_default();
+            lines.push(format!(
+                "\x1b[{};{}H│ {}",
+                y + 2 + row,
+                x + 1,
+                pad_and_clip(rendered_line.as_str(), body_width)
+            ));
+        }
+        lines.push(format!(
+            "\x1b[{};{}H╰─ Esc close · j/k move · g/G jump",
+            y + overlay_height - 1,
+            x + 1
+        ));
+        Some(lines.join(""))
+    }
+
+    fn build_timeline_overlay_lines(
+        &self,
+        state: &SurfaceState,
+        total_width: usize,
+        total_height: usize,
+    ) -> Option<String> {
+        if !matches!(state.overlay, Some(SurfaceOverlay::Timeline)) {
+            return None;
+        }
+        let overlay_width = min(total_width.saturating_sub(8), 72).max(32);
+        let overlay_height = min(total_height.saturating_sub(8), 18).max(8);
+        let x = (total_width.saturating_sub(overlay_width)) / 2;
+        let y = (total_height.saturating_sub(overlay_height)) / 2;
+        let mut lines = vec![format!("\x1b[{};{}H╭─ timeline", y + 1, x + 1)];
+        let body_rows = overlay_height.saturating_sub(3);
+        let selected = state
+            .selected_entry
+            .unwrap_or_else(|| state.transcript.len().saturating_sub(1));
+        let start_index = selected.saturating_sub(body_rows / 2);
+
+        for row in 0..body_rows {
+            let entry_index = start_index.saturating_add(row);
+            let label = if let Some(entry) = state.transcript.get(entry_index) {
+                let title = entry
+                    .lines
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "(empty entry)".to_owned());
+                let prefix = if entry_index == selected { '>' } else { ' ' };
+                format!("{prefix} {:>3}. {}", entry_index + 1, title)
+            } else {
+                String::new()
+            };
+            lines.push(format!(
+                "\x1b[{};{}H│ {}",
+                y + 2 + row,
+                x + 1,
+                pad_and_clip(label.as_str(), overlay_width.saturating_sub(4))
+            ));
+        }
+        lines.push(format!(
+            "\x1b[{};{}H╰─ j/k move · Enter open · Esc close",
+            y + overlay_height - 1,
+            x + 1
+        ));
+        Some(lines.join(""))
+    }
+
+    fn build_prompt_overlay_lines(
+        &self,
+        state: &SurfaceState,
+        total_width: usize,
+        total_height: usize,
+    ) -> Option<String> {
+        match state.overlay.as_ref()? {
+            SurfaceOverlay::ConfirmExit => {
+                let overlay_width = min(total_width.saturating_sub(12), 56).max(28);
+                let x = (total_width.saturating_sub(overlay_width)) / 2;
+                let y = (total_height.saturating_sub(6)) / 2;
+                Some(
+                    [
+                        format!("\x1b[{};{}H╭─ confirm exit", y + 1, x + 1),
+                        format!(
+                            "\x1b[{};{}H│ {}",
+                            y + 2,
+                            x + 1,
+                            pad_and_clip(
+                                "Press Enter to leave the session surface, or Esc to continue.",
+                                overlay_width.saturating_sub(4),
+                            )
+                        ),
+                        format!("\x1b[{};{}H╰─ Enter confirm · Esc cancel", y + 3, x + 1),
+                    ]
+                    .join(""),
+                )
+            }
+            SurfaceOverlay::InputPrompt {
+                kind,
+                value,
+                cursor,
+            } => {
+                let overlay_width = min(total_width.saturating_sub(10), 72).max(32);
+                let x = (total_width.saturating_sub(overlay_width)) / 2;
+                let y = (total_height.saturating_sub(8)) / 2;
+                let title = match kind {
+                    OverlayInputKind::RenameSession => "rename session",
+                    OverlayInputKind::ExportTranscript => "export transcript",
+                };
+                let hint = match kind {
+                    OverlayInputKind::RenameSession => {
+                        "Set a local session title for this fullscreen surface."
+                    }
+                    OverlayInputKind::ExportTranscript => {
+                        "Choose a file path to write the current transcript."
+                    }
+                };
+                let input = composer_text_with_cursor(value, *cursor);
+                Some(
+                    [
+                        format!("\x1b[{};{}H╭─ {}", y + 1, x + 1, title),
+                        format!(
+                            "\x1b[{};{}H│ {}",
+                            y + 2,
+                            x + 1,
+                            pad_and_clip(hint, overlay_width.saturating_sub(4))
+                        ),
+                        format!(
+                            "\x1b[{};{}H│ {}",
+                            y + 3,
+                            x + 1,
+                            pad_and_clip(input.as_str(), overlay_width.saturating_sub(4))
+                        ),
+                        format!("\x1b[{};{}H╰─ Enter save · Esc cancel", y + 4, x + 1),
+                    ]
+                    .join(""),
+                )
+            }
+            SurfaceOverlay::ApprovalPrompt { screen } => {
+                let overlay_width = min(total_width.saturating_sub(10), 88).max(36);
+                let x = (total_width.saturating_sub(overlay_width)) / 2;
+                let y = (total_height.saturating_sub(14)) / 2;
+                let lines = render_tui_screen_spec(screen, overlay_width.saturating_sub(4), false);
+                let mut rendered = vec![format!("\x1b[{};{}H╭─ approval required", y + 1, x + 1)];
+                for (offset, line) in lines.into_iter().take(10).enumerate() {
+                    rendered.push(format!(
+                        "\x1b[{};{}H│ {}",
+                        y + 2 + offset,
+                        x + 1,
+                        pad_and_clip(line.as_str(), overlay_width.saturating_sub(4))
+                    ));
+                }
+                rendered.push(format!(
+                    "\x1b[{};{}H╰─ Type approval response in composer · Esc close",
+                    y + 12,
+                    x + 1
+                ));
+                Some(rendered.join(""))
+            }
+            SurfaceOverlay::EntryDetails { .. } | SurfaceOverlay::Timeline => None,
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, SurfaceState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        }
+    }
+
+    fn content_width(&self) -> usize {
+        let (_height, width) = self.term.size();
+        let width = usize::from(width);
+        let sidebar_visible = self.lock_state().sidebar_visible && width >= MIN_SIDEBAR_TOTAL_WIDTH;
+        width
+            .saturating_sub(if sidebar_visible {
+                SIDEBAR_WIDTH + 3
+            } else {
+                2
+            })
+            .max(24)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SurfaceLoopAction {
+    Continue,
+    Submit,
+    RunCommand(String),
+    Exit,
+}
+
+struct SurfaceLiveObserver {
+    state: Arc<Mutex<SurfaceState>>,
+    term: Term,
+}
+
+impl ConversationTurnObserver for SurfaceLiveObserver {
+    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        };
+        state.live.snapshot = Some(CliChatLiveSurfaceSnapshot {
+            phase: event.phase,
+            provider_round: event.provider_round,
+            lane: event.lane,
+            tool_call_count: event.tool_call_count,
+            message_count: event.message_count,
+            estimated_tokens: event.estimated_tokens,
+            draft_preview: state
+                .live
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.draft_preview.clone()),
+            tool_activity_lines: state.live.tool_lines.clone(),
+        });
+        state.live.last_phase_label = event.phase.as_str().to_owned();
+        drop(state);
+        let _ = render_live_update(self.term.clone(), self.state.clone());
+    }
+
+    fn on_tool(&self, event: ConversationTurnToolEvent) {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        };
+        let detail = event.detail.unwrap_or_else(|| "-".to_owned());
+        state.live.tool_lines.push(format!(
+            "[{}] {} - {}",
+            event.state.as_str(),
+            event.tool_name,
+            detail
+        ));
+        let tool_lines = state.live.tool_lines.clone();
+        if let Some(snapshot) = state.live.snapshot.as_mut() {
+            snapshot.tool_activity_lines = tool_lines;
+        }
+        drop(state);
+        let _ = render_live_update(self.term.clone(), self.state.clone());
+    }
+
+    fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        };
+        if let Some(text) = event.delta.text {
+            let preview = state
+                .live
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.draft_preview.clone())
+                .unwrap_or_default();
+            let updated = format!("{preview}{text}");
+            if let Some(snapshot) = state.live.snapshot.as_mut() {
+                snapshot.draft_preview = Some(updated);
+            } else {
+                state.live.snapshot = Some(CliChatLiveSurfaceSnapshot {
+                    phase: ConversationTurnPhase::RequestingProvider,
+                    provider_round: None,
+                    lane: None,
+                    tool_call_count: 0,
+                    message_count: None,
+                    estimated_tokens: None,
+                    draft_preview: Some(updated),
+                    tool_activity_lines: state.live.tool_lines.clone(),
+                });
+            }
+        }
+        drop(state);
+        let _ = render_live_update(self.term.clone(), self.state.clone());
+    }
+}
+
+fn build_surface_live_observer(
+    state: Arc<Mutex<SurfaceState>>,
+    term: Term,
+) -> ConversationTurnObserverHandle {
+    Arc::new(SurfaceLiveObserver { state, term })
+}
+
+fn render_live_update(term: Term, state: Arc<Mutex<SurfaceState>>) -> CliResult<()> {
+    let snapshot_state = match state.lock() {
+        Ok(state) => state.clone(),
+        Err(poisoned_state) => poisoned_state.into_inner().clone(),
+    };
+    let (height_u16, width_u16) = term.size();
+    let total_height = usize::from(height_u16);
+    let total_width = usize::from(width_u16);
+    let header_lines = crate::presentation::render_compact_brand_header(
+        total_width.saturating_sub(2),
+        &crate::presentation::BuildVersionInfo::current(),
+        Some(session_surface_subtitle(&snapshot_state)),
+    )
+    .into_iter()
+    .map(|line| line.text)
+    .collect::<Vec<_>>();
+    let sidebar_visible = snapshot_state.sidebar_visible && total_width >= MIN_SIDEBAR_TOTAL_WIDTH;
+    let sidebar_width = if sidebar_visible { SIDEBAR_WIDTH } else { 0 };
+    let content_width = total_width
+        .saturating_sub(sidebar_width)
+        .saturating_sub(if sidebar_visible { 3 } else { 2 })
+        .max(24);
+    let reserved_height = header_lines.len() + HEADER_GAP + COMPOSER_HEIGHT + STATUS_BAR_HEIGHT + 1;
+    let transcript_height = total_height.saturating_sub(reserved_height).max(5);
+    let transcript_lines =
+        {
+            let mut lines = Vec::new();
+            for (entry_index, entry) in snapshot_state.transcript.iter().enumerate() {
+                if !lines.is_empty() {
+                    lines.push(String::new());
+                }
+                for (line_index, line) in entry.lines.iter().enumerate() {
+                    let clipped = clipped_display_line(line, content_width.saturating_sub(2));
+                    if line_index == 0 && snapshot_state.selected_entry == Some(entry_index) {
+                        lines.push(format!("▶ {clipped}"));
+                    } else {
+                        lines.push(clipped);
+                    }
+                }
+            }
+            if snapshot_state.pending_turn {
+                if !lines.is_empty() {
+                    lines.push(String::new());
+                }
+                lines.extend(
+                    render_cli_chat_live_surface_lines_with_width(
+                        &snapshot_state.live.snapshot.clone().unwrap_or(
+                            CliChatLiveSurfaceSnapshot {
+                                phase: ConversationTurnPhase::Preparing,
+                                provider_round: None,
+                                lane: None,
+                                tool_call_count: 0,
+                                message_count: None,
+                                estimated_tokens: None,
+                                draft_preview: None,
+                                tool_activity_lines: snapshot_state.live.tool_lines.clone(),
+                            },
+                        ),
+                        content_width,
+                    )
+                    .into_iter()
+                    .map(|line| clipped_display_line(&line, content_width)),
+                );
+            }
+            if lines.len() > transcript_height {
+                let start = lines.len().saturating_sub(transcript_height);
+                lines.into_iter().skip(start).collect()
+            } else {
+                lines
+            }
+        };
+
+    let startup_summary = snapshot_state
+        .startup_summary
+        .clone()
+        .unwrap_or_else(|| fallback_startup_summary("default"));
+    let mut sidebar_lines = vec![
+        format!("right rail · {}", snapshot_state.sidebar_tab.title()),
+        format!("session {}", startup_summary.session_id),
+        format!("focus: {}", snapshot_state.focus.label()),
+        format!("sticky: {}", snapshot_state.sticky_bottom),
+    ];
+    if let Some(preview) = snapshot_state.live.last_assistant_preview.as_deref() {
+        sidebar_lines.push(String::new());
+        sidebar_lines.push("last reply".to_owned());
+        sidebar_lines.extend(
+            crate::presentation::render_wrapped_display_line(preview, sidebar_width)
+                .into_iter()
+                .take(8),
+        );
+    }
+
+    let draft_lines = composer_display_lines(
+        &composer_text_with_cursor(&snapshot_state.composer, snapshot_state.composer_cursor),
+        total_width.saturating_sub(4),
+        2,
+    );
+    let composer_lines = vec![
+        format!("╭─ compose · focus={}", snapshot_state.focus.label()),
+        format!("│ {}", draft_lines.first().cloned().unwrap_or_default()),
+        if draft_lines.len() > 1 {
+            format!("│ {}", draft_lines.get(1).cloned().unwrap_or_default())
+        } else if let Some(hint) = slash_command_hint(&snapshot_state.composer) {
+            format!("│ {hint}")
+        } else {
+            "│ turn running…".to_owned()
+        },
+        "╰─ Enter send · : command palette · /help for commands".to_owned(),
+    ];
+    let mut status_text = format!(
+        "Esc clear · ↑↓ history/scroll · PgUp/PgDn transcript · Tab focus · : commands · focus={} · rail={} · sticky={}",
+        snapshot_state.focus.label(),
+        snapshot_state.sidebar_tab.title(),
+        snapshot_state.sticky_bottom
+    );
+    if snapshot_state.pending_turn {
+        status_text.push_str(" · turn running");
+    }
+    let status_line = clipped_display_line(&status_text, total_width.saturating_sub(2));
+    let mut output = String::from(CLEAR_AND_HOME);
+    for line in header_lines {
+        output.push_str(&line);
+        output.push('\n');
+    }
+    output.push('\n');
+    for row in 0..transcript_height {
+        let line = transcript_lines.get(row).map(String::as_str).unwrap_or("");
+        output.push_str(&pad_and_clip(line, content_width));
+        if sidebar_visible {
+            output.push_str(" │ ");
+            let side_line = sidebar_lines.get(row).map(String::as_str).unwrap_or("");
+            output.push_str(&pad_and_clip(side_line, sidebar_width));
+        }
+        output.push('\n');
+    }
+    for line in composer_lines {
+        output.push_str(&line);
+        output.push('\n');
+    }
+    output.push_str(&status_line);
+    term.write_str(output.as_str())
+        .map_err(|error| format!("failed to refresh live surface: {error}"))?;
+    term.flush()
+        .map_err(|error| format!("failed to flush live surface: {error}"))?;
+    Ok(())
+}
+
+fn pad_and_clip(line: &str, width: usize) -> String {
+    let clipped = clipped_display_line(line, width);
+    let clipped_len = clipped.chars().count();
+    if clipped_len >= width {
+        return clipped;
+    }
+    format!("{clipped}{}", " ".repeat(width - clipped_len))
+}
+
+fn clipped_display_line(line: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let char_count = line.chars().count();
+    if char_count <= width {
+        return line.to_owned();
+    }
+    let mut result = line
+        .chars()
+        .take(width.saturating_sub(1))
+        .collect::<String>();
+    result.push('…');
+    result
+}
+
+fn fallback_startup_summary(session_id: &str) -> operator_surfaces::CliChatStartupSummary {
+    operator_surfaces::CliChatStartupSummary {
+        config_path: "-".to_owned(),
+        memory_label: "-".to_owned(),
+        session_id: session_id.to_owned(),
+        context_engine_id: "-".to_owned(),
+        context_engine_source: "-".to_owned(),
+        compaction_enabled: false,
+        compaction_min_messages: None,
+        compaction_trigger_estimated_tokens: None,
+        compaction_preserve_recent_turns: 0,
+        compaction_fail_open: false,
+        acp_enabled: false,
+        dispatch_enabled: false,
+        conversation_routing: "-".to_owned(),
+        allowed_channels: Vec::new(),
+        acp_backend_id: "-".to_owned(),
+        acp_backend_source: "-".to_owned(),
+        explicit_acp_request: false,
+        event_stream_enabled: false,
+        bootstrap_mcp_servers: Vec::new(),
+        working_directory: None,
+    }
+}
+
+fn session_surface_subtitle(state: &SurfaceState) -> &str {
+    state
+        .session_title_override
+        .as_deref()
+        .unwrap_or("interactive session surface")
+}
+
+fn default_export_path(session_id: &str) -> String {
+    let sanitized = session_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("/tmp/loongclaw-{sanitized}-transcript.txt")
+}
+
+fn format_transcript_export(entries: &[SurfaceEntry]) -> String {
+    let mut rendered = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        rendered.push(format!("## Entry {}", index + 1));
+        rendered.extend(entry.lines.iter().cloned());
+        rendered.push(String::new());
+    }
+    rendered.join("\n")
+}
+
+fn current_overlay_label(state: &SurfaceState) -> &'static str {
+    match state.overlay.as_ref() {
+        Some(SurfaceOverlay::EntryDetails { .. }) => "entry",
+        Some(SurfaceOverlay::Timeline) => "timeline",
+        Some(SurfaceOverlay::ConfirmExit) => "confirm-exit",
+        Some(SurfaceOverlay::InputPrompt { kind, .. }) => match kind {
+            OverlayInputKind::RenameSession => "rename",
+            OverlayInputKind::ExportTranscript => "export",
+        },
+        Some(SurfaceOverlay::ApprovalPrompt { .. }) => "approval",
+        None => "none",
+    }
+}
+
+fn composer_display_lines(value: &str, width: usize, max_lines: usize) -> Vec<String> {
+    let mut wrapped = crate::presentation::render_wrapped_display_line(value, width);
+    if wrapped.is_empty() {
+        wrapped.push(String::new());
+    }
+    if wrapped.len() > max_lines {
+        wrapped.truncate(max_lines);
+    }
+    wrapped
+}
+
+fn composer_text_with_cursor(value: &str, cursor: usize) -> String {
+    let mut rendered = String::new();
+    let mut inserted = false;
+    for (index, character) in value.chars().enumerate() {
+        if index == cursor {
+            rendered.push('▏');
+            inserted = true;
+        }
+        rendered.push(character);
+    }
+    if !inserted {
+        rendered.push('▏');
+    }
+    rendered
+}
+
+fn insert_char_at_cursor(value: &mut String, cursor: &mut usize, character: char) {
+    let mut chars = value.chars().collect::<Vec<_>>();
+    let insert_at = min(*cursor, chars.len());
+    chars.insert(insert_at, character);
+    *value = chars.into_iter().collect();
+    *cursor = insert_at.saturating_add(1);
+}
+
+fn remove_char_before_cursor(value: &mut String, cursor: &mut usize) {
+    if *cursor == 0 {
+        return;
+    }
+    let mut chars = value.chars().collect::<Vec<_>>();
+    let remove_at = cursor.saturating_sub(1);
+    if remove_at < chars.len() {
+        chars.remove(remove_at);
+        *value = chars.into_iter().collect();
+        *cursor = remove_at;
+    }
+}
+
+fn move_cursor_vertically(value: &str, cursor: usize, direction: isize) -> usize {
+    let chars = value.chars().collect::<Vec<_>>();
+    let cursor = min(cursor, chars.len());
+    let mut current_line_start = 0;
+    let mut index = 0;
+    while index < cursor {
+        if chars.get(index).is_some_and(|character| *character == '\n') {
+            current_line_start = index.saturating_add(1);
+        }
+        index = index.saturating_add(1);
+    }
+    let current_column = cursor.saturating_sub(current_line_start);
+    let mut current_line_end = chars.len();
+    let mut forward_index = cursor;
+    while forward_index < chars.len() {
+        if chars
+            .get(forward_index)
+            .is_some_and(|character| *character == '\n')
+        {
+            current_line_end = forward_index;
+            break;
+        }
+        forward_index = forward_index.saturating_add(1);
+    }
+
+    if direction < 0 {
+        if current_line_start == 0 {
+            return cursor;
+        }
+        let prev_line_end = current_line_start.saturating_sub(1);
+        let mut prev_line_start = 0;
+        let mut reverse_index = 0;
+        while reverse_index < prev_line_end {
+            if chars
+                .get(reverse_index)
+                .is_some_and(|character| *character == '\n')
+            {
+                prev_line_start = reverse_index.saturating_add(1);
+            }
+            reverse_index = reverse_index.saturating_add(1);
+        }
+        let prev_len = prev_line_end.saturating_sub(prev_line_start);
+        return prev_line_start + min(current_column, prev_len);
+    }
+
+    if current_line_end >= chars.len() {
+        return cursor;
+    }
+    let next_line_start = current_line_end.saturating_add(1);
+    let mut next_line_end = chars.len();
+    let mut next_index = next_line_start;
+    while next_index < chars.len() {
+        if chars
+            .get(next_index)
+            .is_some_and(|character| *character == '\n')
+        {
+            next_line_end = next_index;
+            break;
+        }
+        next_index = next_index.saturating_add(1);
+    }
+    let next_len = next_line_end.saturating_sub(next_line_start);
+    next_line_start + min(current_column, next_len)
+}
+
+fn slash_command_hint(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+
+    let known = [
+        CLI_CHAT_HELP_COMMAND,
+        CLI_CHAT_STATUS_COMMAND,
+        CLI_CHAT_HISTORY_COMMAND,
+        CLI_CHAT_COMPACT_COMMAND,
+        CLI_CHAT_TURN_CHECKPOINT_REPAIR_COMMAND,
+    ];
+    let matches = known
+        .into_iter()
+        .filter(|candidate| candidate.starts_with(trimmed))
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        return Some("unknown slash command".to_owned());
+    }
+
+    Some(format!("matches: {}", matches.join(" · ")))
+}
+
+fn should_continue_multiline(value: &str) -> bool {
+    value.ends_with('\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidebar_tab_cycles_forward_and_backward() {
+        assert_eq!(SidebarTab::Session.next(), SidebarTab::Runtime);
+        assert_eq!(SidebarTab::Runtime.next(), SidebarTab::Tools);
+        assert_eq!(SidebarTab::Tools.next(), SidebarTab::Help);
+        assert_eq!(SidebarTab::Help.next(), SidebarTab::Session);
+        assert_eq!(SidebarTab::Session.previous(), SidebarTab::Help);
+    }
+
+    #[test]
+    fn clipped_display_line_adds_ellipsis_when_needed() {
+        assert_eq!(clipped_display_line("abcdef", 4), "abc…");
+        assert_eq!(clipped_display_line("abc", 4), "abc");
+    }
+
+    #[test]
+    fn composer_display_lines_wraps_and_limits_rows() {
+        let lines = composer_display_lines("alpha beta gamma delta", 10, 2);
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("alpha"));
+    }
+
+    #[test]
+    fn command_palette_items_have_stable_default_selection() {
+        let palette = CommandPaletteState::default();
+        let items = CommandPaletteAction::items();
+        assert_eq!(palette.selected, 0);
+        assert_eq!(palette.query, "");
+        assert_eq!(items[0].0, "Help");
+        assert!(items.iter().any(|item| item.0 == "Jump to latest"));
+    }
+
+    #[test]
+    fn surface_focus_cycles_without_palette() {
+        assert_eq!(
+            SurfaceFocus::Composer.next(true, false),
+            SurfaceFocus::Transcript
+        );
+        assert_eq!(
+            SurfaceFocus::Transcript.next(true, false),
+            SurfaceFocus::Sidebar
+        );
+        assert_eq!(
+            SurfaceFocus::Sidebar.next(true, false),
+            SurfaceFocus::Composer
+        );
+    }
+
+    #[test]
+    fn slash_command_hint_surfaces_matches() {
+        let hint = slash_command_hint("/hi").expect("hint");
+        assert!(hint.contains("/history"));
+        assert!(slash_command_hint("hello").is_none());
+    }
+
+    #[test]
+    fn should_continue_multiline_detects_trailing_backslash() {
+        assert!(should_continue_multiline("hello\\"));
+        assert!(!should_continue_multiline("hello"));
+    }
+
+    #[test]
+    fn composer_text_with_cursor_inserts_marker() {
+        assert_eq!(composer_text_with_cursor("abc", 1), "a▏bc");
+        assert_eq!(composer_text_with_cursor("", 0), "▏");
+    }
+
+    #[test]
+    fn insert_and_remove_char_at_cursor_updates_cursor_position() {
+        let mut value = "ac".to_owned();
+        let mut cursor = 1;
+        insert_char_at_cursor(&mut value, &mut cursor, 'b');
+        assert_eq!(value, "abc");
+        assert_eq!(cursor, 2);
+        remove_char_before_cursor(&mut value, &mut cursor);
+        assert_eq!(value, "ac");
+        assert_eq!(cursor, 1);
+    }
+
+    #[test]
+    fn move_cursor_vertically_preserves_column_when_possible() {
+        let value = "abc\ndefg\nxy";
+        assert_eq!(move_cursor_vertically(value, 5, -1), 1);
+        assert_eq!(move_cursor_vertically(value, 1, 1), 5);
+        assert_eq!(move_cursor_vertically(value, 7, 1), 11);
+    }
+
+    #[test]
+    fn command_palette_items_include_jump_and_sticky_actions() {
+        let labels = CommandPaletteAction::items()
+            .iter()
+            .map(|item| item.0)
+            .collect::<Vec<_>>();
+        assert!(labels.contains(&"Jump to latest"));
+        assert!(labels.contains(&"Toggle sticky scroll"));
+        assert!(labels.contains(&"Timeline"));
+    }
+
+    #[test]
+    fn filtered_command_palette_items_respects_query() {
+        let filtered = filtered_command_palette_items("time");
+        assert!(filtered.iter().any(|item| item.0 == "Timeline"));
+        assert!(!filtered.iter().any(|item| item.0 == "Compact"));
+    }
+
+    #[test]
+    fn current_overlay_label_reports_overlay_kind() {
+        let mut state = SurfaceState {
+            startup_summary: None,
+            session_title_override: None,
+            transcript: Vec::new(),
+            composer: String::new(),
+            composer_cursor: 0,
+            history: Vec::new(),
+            history_index: None,
+            scroll_offset: 0,
+            sticky_bottom: true,
+            selected_entry: None,
+            focus: SurfaceFocus::Composer,
+            sidebar_visible: true,
+            sidebar_tab: SidebarTab::Session,
+            command_palette: None,
+            overlay: None,
+            live: LiveSurfaceModel::default(),
+            footer_notice: String::new(),
+            pending_turn: false,
+        };
+        assert_eq!(current_overlay_label(&state), "none");
+        state.overlay = Some(SurfaceOverlay::Timeline);
+        assert_eq!(current_overlay_label(&state), "timeline");
+    }
+}

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -2311,9 +2311,7 @@ fn sanitize_session_id_for_export(session_id: &str) -> String {
 
 fn loongclaw_exports_dir() -> PathBuf {
     let loongclaw_home = crate::config::default_loongclaw_home();
-    let exports_dir = loongclaw_home.join("exports");
-
-    exports_dir
+    loongclaw_home.join("exports")
 }
 
 fn ensure_parent_directory_exists(path: &Path) -> CliResult<()> {
@@ -2537,10 +2535,7 @@ fn viewport_start_for_scroll_offset(
 
     let max_scroll_offset = total_lines.saturating_sub(viewport_height);
     let clamped_scroll_offset = min(scroll_offset, max_scroll_offset);
-    let viewport_start =
-        total_lines.saturating_sub(viewport_height.saturating_add(clamped_scroll_offset));
-
-    viewport_start
+    total_lines.saturating_sub(viewport_height.saturating_add(clamped_scroll_offset))
 }
 
 fn scroll_offset_for_viewport_start(
@@ -2554,10 +2549,7 @@ fn scroll_offset_for_viewport_start(
 
     let max_viewport_start = total_lines.saturating_sub(viewport_height);
     let clamped_viewport_start = min(viewport_start, max_viewport_start);
-    let scroll_offset =
-        total_lines.saturating_sub(viewport_height.saturating_add(clamped_viewport_start));
-
-    scroll_offset
+    total_lines.saturating_sub(viewport_height.saturating_add(clamped_viewport_start))
 }
 
 fn align_scroll_offset_to_selected_entry(

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -1,4 +1,8 @@
 use std::cmp::min;
+use std::io::IsTerminal;
+use std::ops::Range;
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use console::{Key, Term};
@@ -18,6 +22,29 @@ const COMMAND_OVERLAY_WIDTH: usize = 52;
 
 pub(super) fn terminal_surface_supported() -> bool {
     Term::stdout().is_term()
+}
+
+pub(super) fn stdin_is_tty() -> bool {
+    std::io::stdin().is_terminal()
+}
+
+fn terminal_surface_allowed(stdout_is_tty: bool, stdin_is_tty: bool) -> bool {
+    if !stdout_is_tty {
+        return false;
+    }
+
+    if !stdin_is_tty {
+        return false;
+    }
+
+    true
+}
+
+pub(super) fn interactive_terminal_surface_supported() -> bool {
+    let stdout_is_tty = terminal_surface_supported();
+    let stdin_is_tty = stdin_is_tty();
+
+    terminal_surface_allowed(stdout_is_tty, stdin_is_tty)
 }
 
 pub(super) async fn run_cli_chat_surface(
@@ -684,32 +711,9 @@ impl ChatSessionSurface {
                     if matches!(state.overlay, Some(SurfaceOverlay::ApprovalPrompt { .. })) {
                         let response = state.composer.trim().to_owned();
                         if !response.is_empty() {
-                            state.transcript.push(SurfaceEntry {
-                                lines: render_cli_chat_message_spec_with_width(
-                                    &TuiMessageSpec {
-                                        role: "you".to_owned(),
-                                        caption: Some("approval response".to_owned()),
-                                        sections: vec![TuiSectionSpec::Narrative {
-                                            title: None,
-                                            lines: vec![response],
-                                        }],
-                                        footer_lines: vec![
-                                            "Approval response captured in surface history."
-                                                .to_owned(),
-                                        ],
-                                    },
-                                    self.content_width(),
-                                ),
-                            });
                             state.overlay = None;
-                            state.composer.clear();
-                            state.composer_cursor = 0;
-                            state.selected_entry = Some(state.transcript.len().saturating_sub(1));
-                            state.focus = SurfaceFocus::Transcript;
-                            state.sticky_bottom = true;
-                            drop(state);
-                            self.render()?;
-                            return Ok(SurfaceLoopAction::Continue);
+                            state.focus = SurfaceFocus::Composer;
+                            return Ok(SurfaceLoopAction::Submit);
                         }
                     }
                 }
@@ -717,7 +721,10 @@ impl ChatSessionSurface {
                     let mut state = self.lock_state();
                     if state.command_palette.is_none()
                         && state.focus == SurfaceFocus::Composer
-                        && should_continue_multiline(&state.composer)
+                        && should_continue_multiline_at_cursor(
+                            &state.composer,
+                            state.composer_cursor,
+                        )
                     {
                         let mut cursor = state.composer_cursor;
                         remove_char_before_cursor(&mut state.composer, &mut cursor);
@@ -804,38 +811,77 @@ impl ChatSessionSurface {
                 {
                     state.overlay = Some(SurfaceOverlay::Timeline);
                     state.focus = SurfaceFocus::Transcript;
-                } else if matches!(state.overlay, Some(SurfaceOverlay::ApprovalPrompt { .. }))
-                    && matches!(character, '1'..='9' | 'y' | 'n')
-                {
-                    state.overlay = None;
-                    state.focus = SurfaceFocus::Composer;
+                } else if matches!(state.overlay, Some(SurfaceOverlay::ApprovalPrompt { .. })) {
+                    let quick_response = character.to_string();
+                    let quick_response_action =
+                        crate::conversation::parse_approval_prompt_action_input(
+                            quick_response.as_str(),
+                        );
+
+                    if quick_response_action.is_some() {
+                        let mut cursor = state.composer_cursor;
+                        insert_char_at_cursor(&mut state.composer, &mut cursor, character);
+                        state.composer_cursor = cursor;
+                        state.overlay = None;
+                        state.focus = SurfaceFocus::Composer;
+                        drop(state);
+                        self.render()?;
+                        return Ok(SurfaceLoopAction::Submit);
+                    }
                 } else if (character == 'j' || character == 'k')
                     && state.focus == SurfaceFocus::Transcript
                     && state.command_palette.is_none()
                 {
-                    let current = state
-                        .selected_entry
-                        .unwrap_or_else(|| state.transcript.len().saturating_sub(1));
-                    if character == 'j' {
-                        state.selected_entry = Some(min(
-                            current.saturating_add(1),
-                            state.transcript.len().saturating_sub(1),
-                        ));
-                        state.scroll_offset = state.scroll_offset.saturating_sub(1);
-                        if state.scroll_offset == 0 {
-                            state.sticky_bottom = true;
-                        }
+                    if state.transcript.is_empty() {
+                        state.selected_entry = None;
+                        state.scroll_offset = 0;
+                        state.sticky_bottom = true;
                     } else {
-                        state.selected_entry = Some(current.saturating_sub(1));
-                        state.scroll_offset = state.scroll_offset.saturating_add(1);
-                        state.sticky_bottom = false;
+                        let transcript_height = self.transcript_viewport_height_for_state(&state);
+                        let current = state
+                            .selected_entry
+                            .unwrap_or_else(|| state.transcript.len().saturating_sub(1));
+                        if character == 'j' {
+                            let next_selected = min(
+                                current.saturating_add(1),
+                                state.transcript.len().saturating_sub(1),
+                            );
+                            state.selected_entry = Some(next_selected);
+                        } else {
+                            let next_selected = current.saturating_sub(1);
+                            state.selected_entry = Some(next_selected);
+                        }
+                        if let Some(selected_entry) = state.selected_entry {
+                            let aligned_offset = align_scroll_offset_to_selected_entry(
+                                &state.transcript,
+                                selected_entry,
+                                transcript_height,
+                                state.scroll_offset,
+                            );
+                            state.scroll_offset = aligned_offset;
+                        }
+                        state.sticky_bottom = state.scroll_offset == 0;
                     }
                 } else if character == 'g'
                     && state.focus == SurfaceFocus::Transcript
                     && state.command_palette.is_none()
                 {
-                    state.selected_entry = Some(0);
-                    state.sticky_bottom = false;
+                    if state.transcript.is_empty() {
+                        state.selected_entry = None;
+                        state.scroll_offset = 0;
+                        state.sticky_bottom = true;
+                    } else {
+                        state.selected_entry = Some(0);
+                        state.sticky_bottom = false;
+                        let transcript_height = self.transcript_viewport_height_for_state(&state);
+                        let aligned_offset = align_scroll_offset_to_selected_entry(
+                            &state.transcript,
+                            0,
+                            transcript_height,
+                            state.scroll_offset,
+                        );
+                        state.scroll_offset = aligned_offset;
+                    }
                 } else if character == 'G'
                     && state.focus == SurfaceFocus::Transcript
                     && state.command_palette.is_none()
@@ -927,15 +973,25 @@ impl ChatSessionSurface {
                 }
                 state.focus = SurfaceFocus::Transcript;
             }
-            CommandPaletteAction::ToggleSidebar => state.sidebar_visible = !state.sidebar_visible,
-            CommandPaletteAction::CycleSidebarTab => state.sidebar_tab = state.sidebar_tab.next(),
+            CommandPaletteAction::ToggleSidebar => {
+                state.sidebar_visible = !state.sidebar_visible;
+                state.focus = if state.sidebar_visible {
+                    SurfaceFocus::Sidebar
+                } else {
+                    SurfaceFocus::Composer
+                };
+            }
+            CommandPaletteAction::CycleSidebarTab => {
+                state.sidebar_tab = state.sidebar_tab.next();
+                state.focus = SurfaceFocus::Sidebar;
+            }
             CommandPaletteAction::ClearComposer => {
                 state.composer.clear();
                 state.composer_cursor = 0;
+                state.focus = SurfaceFocus::Composer;
             }
             CommandPaletteAction::Exit => return Ok(SurfaceLoopAction::Exit),
         }
-        state.focus = SurfaceFocus::Composer;
         drop(state);
         self.render()?;
         Ok(SurfaceLoopAction::Continue)
@@ -1042,75 +1098,141 @@ impl ChatSessionSurface {
 
     async fn handle_command(&self, input: &str) -> CliResult<()> {
         let width = self.content_width();
-        let lines = if input == CLI_CHAT_HELP_COMMAND {
-            operator_surfaces::render_cli_chat_help_lines_with_width(width)
-        } else if operator_surfaces::is_cli_chat_status_command(input)? {
-            operator_surfaces::render_cli_chat_status_lines_with_width(
-                &operator_surfaces::build_cli_chat_startup_summary(&self.runtime, &self.options)?,
-                width,
-            )
-        } else if operator_surfaces::is_manual_compaction_command(input)? {
-            #[cfg(feature = "memory-sqlite")]
-            {
-                let binding = ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx);
-                let result = operator_surfaces::load_manual_compaction_result(
-                    &self.runtime.config,
-                    &self.runtime.session_id,
-                    &self.runtime.turn_coordinator,
-                    binding,
-                )
-                .await?;
-                operator_surfaces::render_manual_compaction_lines_with_width(
-                    &self.runtime.session_id,
-                    &result,
-                    width,
-                )
+        let help_match = classify_chat_command_match_result(parse_exact_chat_command(
+            input,
+            &[CLI_CHAT_HELP_COMMAND],
+            "usage: /help",
+        ))?;
+
+        let status_match = classify_chat_command_match_result(
+            operator_surfaces::is_cli_chat_status_command(input),
+        )?;
+
+        let compact_match = classify_chat_command_match_result(
+            operator_surfaces::is_manual_compaction_command(input),
+        )?;
+
+        let history_match = classify_chat_command_match_result(parse_exact_chat_command(
+            input,
+            &[CLI_CHAT_HISTORY_COMMAND],
+            "usage: /history",
+        ))?;
+
+        let turn_checkpoint_repair_match = classify_chat_command_match_result(
+            operator_surfaces::is_turn_checkpoint_repair_command(input),
+        )?;
+
+        let lines = match help_match {
+            ChatCommandMatchResult::Matched => {
+                operator_surfaces::render_cli_chat_help_lines_with_width(width)
             }
-            #[cfg(not(feature = "memory-sqlite"))]
-            {
-                render_cli_chat_feature_unavailable_lines_with_width(
-                    "compact",
-                    "manual compaction unavailable: memory-sqlite feature disabled",
-                    width,
-                )
+            ChatCommandMatchResult::UsageError(usage) => {
+                render_cli_chat_command_usage_lines_with_width(&usage, width)
             }
-        } else if matches!(
-            classify_chat_command_match_result(parse_exact_chat_command(
-                input,
-                &[CLI_CHAT_HISTORY_COMMAND],
-                "usage: /history",
-            ))?,
-            ChatCommandMatchResult::Matched
-        ) {
-            #[cfg(feature = "memory-sqlite")]
-            {
-                let history_lines = operator_surfaces::load_history_lines(
-                    &self.runtime.session_id,
-                    self.runtime.config.memory.sliding_window,
-                    ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
-                    &self.runtime.memory_config,
-                )
-                .await?;
-                operator_surfaces::render_cli_chat_history_lines_with_width(
-                    &self.runtime.session_id,
-                    self.runtime.config.memory.sliding_window,
-                    &history_lines,
-                    width,
-                )
-            }
-            #[cfg(not(feature = "memory-sqlite"))]
-            {
-                render_cli_chat_feature_unavailable_lines_with_width(
-                    "history",
-                    "history unavailable: memory-sqlite feature disabled",
-                    width,
-                )
-            }
-        } else {
-            render_cli_chat_command_usage_lines_with_width(
-                "usage: /help | /status | /history | /compact | /exit",
-                width,
-            )
+            ChatCommandMatchResult::NotMatched => match status_match {
+                ChatCommandMatchResult::Matched => {
+                    let summary = operator_surfaces::build_cli_chat_startup_summary(
+                        &self.runtime,
+                        &self.options,
+                    )?;
+                    operator_surfaces::render_cli_chat_status_lines_with_width(&summary, width)
+                }
+                ChatCommandMatchResult::UsageError(usage) => {
+                    render_cli_chat_command_usage_lines_with_width(&usage, width)
+                }
+                ChatCommandMatchResult::NotMatched => match compact_match {
+                    ChatCommandMatchResult::Matched => {
+                        #[cfg(feature = "memory-sqlite")]
+                        {
+                            let binding =
+                                ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx);
+                            let result = operator_surfaces::load_manual_compaction_result(
+                                &self.runtime.config,
+                                &self.runtime.session_id,
+                                &self.runtime.turn_coordinator,
+                                binding,
+                            )
+                            .await?;
+                            operator_surfaces::render_manual_compaction_lines_with_width(
+                                &self.runtime.session_id,
+                                &result,
+                                width,
+                            )
+                        }
+                        #[cfg(not(feature = "memory-sqlite"))]
+                        {
+                            render_cli_chat_feature_unavailable_lines_with_width(
+                                "compact",
+                                "manual compaction unavailable: memory-sqlite feature disabled",
+                                width,
+                            )
+                        }
+                    }
+                    ChatCommandMatchResult::UsageError(usage) => {
+                        render_cli_chat_command_usage_lines_with_width(&usage, width)
+                    }
+                    ChatCommandMatchResult::NotMatched => match history_match {
+                        ChatCommandMatchResult::Matched => {
+                            #[cfg(feature = "memory-sqlite")]
+                            {
+                                let history_lines = operator_surfaces::load_history_lines(
+                                    &self.runtime.session_id,
+                                    self.runtime.config.memory.sliding_window,
+                                    ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
+                                    &self.runtime.memory_config,
+                                )
+                                .await?;
+                                operator_surfaces::render_cli_chat_history_lines_with_width(
+                                    &self.runtime.session_id,
+                                    self.runtime.config.memory.sliding_window,
+                                    &history_lines,
+                                    width,
+                                )
+                            }
+                            #[cfg(not(feature = "memory-sqlite"))]
+                            {
+                                render_cli_chat_feature_unavailable_lines_with_width(
+                                    "history",
+                                    "history unavailable: memory-sqlite feature disabled",
+                                    width,
+                                )
+                            }
+                        }
+                        ChatCommandMatchResult::UsageError(usage) => {
+                            render_cli_chat_command_usage_lines_with_width(&usage, width)
+                        }
+                        ChatCommandMatchResult::NotMatched => match turn_checkpoint_repair_match {
+                            ChatCommandMatchResult::Matched => {
+                                let outcome = self
+                                    .runtime
+                                    .turn_coordinator
+                                    .repair_turn_checkpoint_tail(
+                                        &self.runtime.config,
+                                        &self.runtime.session_id,
+                                        ConversationRuntimeBinding::kernel(
+                                            &self.runtime.kernel_ctx,
+                                        ),
+                                    )
+                                    .await?;
+                                render_turn_checkpoint_repair_lines_with_width(
+                                    &self.runtime.session_id,
+                                    &outcome,
+                                    width,
+                                )
+                            }
+                            ChatCommandMatchResult::UsageError(usage) => {
+                                render_cli_chat_command_usage_lines_with_width(&usage, width)
+                            }
+                            ChatCommandMatchResult::NotMatched => {
+                                render_cli_chat_command_usage_lines_with_width(
+                                    "usage: /help | /status | /history | /compact | /turn_checkpoint_repair | /exit",
+                                    width,
+                                )
+                            }
+                        },
+                    },
+                },
+            },
         };
 
         let mut state = self.lock_state();
@@ -1156,10 +1278,14 @@ impl ChatSessionSurface {
                     state.focus = SurfaceFocus::Composer;
                     return Ok(());
                 }
+                let export_path = PathBuf::from(trimmed);
+                ensure_parent_directory_exists(export_path.as_path())?;
                 let export_text = format_transcript_export(&state.transcript);
-                std::fs::write(trimmed, export_text).map_err(|error| {
-                    format!("failed to export transcript to `{trimmed}`: {error}")
+                std::fs::write(export_path.as_path(), export_text).map_err(|error| {
+                    let display_path = export_path.display();
+                    format!("failed to export transcript to `{display_path}`: {error}")
                 })?;
+                let exported_path = export_path.display().to_string();
                 state.transcript.push(SurfaceEntry {
                     lines: render_cli_chat_message_spec_with_width(
                         &TuiMessageSpec {
@@ -1168,7 +1294,7 @@ impl ChatSessionSurface {
                             sections: vec![TuiSectionSpec::Callout {
                                 tone: TuiCalloutTone::Success,
                                 title: Some("transcript exported".to_owned()),
-                                lines: vec![format!("Saved transcript to `{trimmed}`.")],
+                                lines: vec![format!("Saved transcript to `{exported_path}`.")],
                             }],
                             footer_lines: vec![
                                 "Use the exported text file for external review or sharing."
@@ -1842,6 +1968,21 @@ impl ChatSessionSurface {
             })
             .max(24)
     }
+
+    fn transcript_viewport_height_for_state(&self, state: &SurfaceState) -> usize {
+        let (height, width) = self.term.size();
+        let total_height = usize::from(height);
+        let total_width = usize::from(width);
+        let header_lines = crate::presentation::render_compact_brand_header(
+            total_width.saturating_sub(2),
+            &crate::presentation::BuildVersionInfo::current(),
+            Some(session_surface_subtitle(state)),
+        );
+        let header_height = header_lines.len();
+        let reserved_height = header_height + HEADER_GAP + COMPOSER_HEIGHT + STATUS_BAR_HEIGHT + 1;
+
+        total_height.saturating_sub(reserved_height).max(5)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2147,17 +2288,47 @@ fn session_surface_subtitle(state: &SurfaceState) -> &str {
 }
 
 fn default_export_path(session_id: &str) -> String {
-    let sanitized = session_id
+    let sanitized_session_id = sanitize_session_id_for_export(session_id);
+    let file_name = format!("loongclaw-{sanitized_session_id}-transcript.txt");
+    let exports_dir = loongclaw_exports_dir();
+    let export_path = exports_dir.join(file_name);
+
+    export_path.display().to_string()
+}
+
+fn sanitize_session_id_for_export(session_id: &str) -> String {
+    session_id
         .chars()
         .map(|character| {
             if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
-                character
-            } else {
-                '_'
+                return character;
             }
+
+            '_'
         })
-        .collect::<String>();
-    format!("/tmp/loongclaw-{sanitized}-transcript.txt")
+        .collect()
+}
+
+fn loongclaw_exports_dir() -> PathBuf {
+    let loongclaw_home = crate::config::default_loongclaw_home();
+    let exports_dir = loongclaw_home.join("exports");
+
+    exports_dir
+}
+
+fn ensure_parent_directory_exists(path: &Path) -> CliResult<()> {
+    let Some(parent_dir) = path.parent() else {
+        return Ok(());
+    };
+
+    if parent_dir.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(parent_dir).map_err(|error| {
+        let display_path = parent_dir.display();
+        format!("failed to create transcript export directory `{display_path}`: {error}")
+    })
 }
 
 fn format_transcript_export(entries: &[SurfaceEntry]) -> String {
@@ -2325,6 +2496,108 @@ fn should_continue_multiline(value: &str) -> bool {
     value.ends_with('\\')
 }
 
+fn should_continue_multiline_at_cursor(value: &str, cursor: usize) -> bool {
+    let total_chars = value.chars().count();
+    if cursor != total_chars {
+        return false;
+    }
+
+    should_continue_multiline(value)
+}
+
+fn flattened_entry_line_ranges(entries: &[SurfaceEntry]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut next_line_index: usize = 0;
+
+    for (entry_index, entry) in entries.iter().enumerate() {
+        if entry_index > 0 {
+            next_line_index = next_line_index.saturating_add(1);
+        }
+
+        let line_count = entry.lines.len().max(1);
+        let start_line_index = next_line_index;
+        let end_line_index = start_line_index.saturating_add(line_count);
+        let entry_range = start_line_index..end_line_index;
+
+        ranges.push(entry_range);
+        next_line_index = end_line_index;
+    }
+
+    ranges
+}
+
+fn viewport_start_for_scroll_offset(
+    total_lines: usize,
+    viewport_height: usize,
+    scroll_offset: usize,
+) -> usize {
+    if total_lines <= viewport_height {
+        return 0;
+    }
+
+    let max_scroll_offset = total_lines.saturating_sub(viewport_height);
+    let clamped_scroll_offset = min(scroll_offset, max_scroll_offset);
+    let viewport_start =
+        total_lines.saturating_sub(viewport_height.saturating_add(clamped_scroll_offset));
+
+    viewport_start
+}
+
+fn scroll_offset_for_viewport_start(
+    total_lines: usize,
+    viewport_height: usize,
+    viewport_start: usize,
+) -> usize {
+    if total_lines <= viewport_height {
+        return 0;
+    }
+
+    let max_viewport_start = total_lines.saturating_sub(viewport_height);
+    let clamped_viewport_start = min(viewport_start, max_viewport_start);
+    let scroll_offset =
+        total_lines.saturating_sub(viewport_height.saturating_add(clamped_viewport_start));
+
+    scroll_offset
+}
+
+fn align_scroll_offset_to_selected_entry(
+    entries: &[SurfaceEntry],
+    selected_entry: usize,
+    viewport_height: usize,
+    scroll_offset: usize,
+) -> usize {
+    let entry_ranges = flattened_entry_line_ranges(entries);
+    let Some(selected_range) = entry_ranges.get(selected_entry) else {
+        return scroll_offset;
+    };
+
+    let total_lines = entry_ranges.last().map(|range| range.end).unwrap_or(0);
+
+    if total_lines <= viewport_height {
+        return 0;
+    }
+
+    let viewport_start =
+        viewport_start_for_scroll_offset(total_lines, viewport_height, scroll_offset);
+    let viewport_end = viewport_start.saturating_add(viewport_height);
+
+    if selected_range.start < viewport_start {
+        return scroll_offset_for_viewport_start(
+            total_lines,
+            viewport_height,
+            selected_range.start,
+        );
+    }
+
+    if selected_range.end > viewport_end {
+        let next_viewport_start = selected_range.end.saturating_sub(viewport_height);
+
+        return scroll_offset_for_viewport_start(total_lines, viewport_height, next_viewport_start);
+    }
+
+    scroll_offset
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2388,6 +2661,21 @@ mod tests {
     fn should_continue_multiline_detects_trailing_backslash() {
         assert!(should_continue_multiline("hello\\"));
         assert!(!should_continue_multiline("hello"));
+    }
+
+    #[test]
+    fn should_continue_multiline_at_cursor_requires_cursor_at_end() {
+        assert!(should_continue_multiline_at_cursor("hello\\", 6));
+        assert!(!should_continue_multiline_at_cursor("hello\\", 3));
+        assert!(!should_continue_multiline_at_cursor("hello", 5));
+    }
+
+    #[test]
+    fn terminal_surface_allowed_requires_interactive_stdin_and_stdout() {
+        assert!(terminal_surface_allowed(true, true));
+        assert!(!terminal_surface_allowed(true, false));
+        assert!(!terminal_surface_allowed(false, true));
+        assert!(!terminal_surface_allowed(false, false));
     }
 
     #[test]
@@ -2459,5 +2747,55 @@ mod tests {
         assert_eq!(current_overlay_label(&state), "none");
         state.overlay = Some(SurfaceOverlay::Timeline);
         assert_eq!(current_overlay_label(&state), "timeline");
+    }
+
+    #[test]
+    fn align_scroll_offset_to_selected_entry_keeps_entry_visible() {
+        let entries = vec![
+            SurfaceEntry {
+                lines: vec!["entry 1".to_owned()],
+            },
+            SurfaceEntry {
+                lines: vec!["entry 2".to_owned(), "entry 2 detail".to_owned()],
+            },
+            SurfaceEntry {
+                lines: vec!["entry 3".to_owned()],
+            },
+        ];
+        let viewport_height = 2;
+        let current_scroll_offset = 0;
+        let aligned_offset = align_scroll_offset_to_selected_entry(
+            &entries,
+            1,
+            viewport_height,
+            current_scroll_offset,
+        );
+
+        assert_eq!(aligned_offset, 2);
+    }
+
+    #[test]
+    fn default_export_path_uses_loongclaw_exports_directory() {
+        let export_path = PathBuf::from(default_export_path("session:/bad"));
+        let file_name = export_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("export file name");
+        let parent_dir = export_path
+            .parent()
+            .and_then(|value| value.file_name())
+            .and_then(|value| value.to_str())
+            .expect("export parent directory");
+
+        assert_eq!(parent_dir, "exports");
+        assert_eq!(file_name, "loongclaw-session__bad-transcript.txt");
+    }
+
+    #[test]
+    fn ensure_parent_directory_exists_ignores_relative_files_without_parent() {
+        let path = Path::new("transcript.txt");
+        let result = ensure_parent_directory_exists(path);
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/app/src/tui_surface.rs
+++ b/crates/app/src/tui_surface.rs
@@ -168,6 +168,14 @@ pub fn render_onboard_screen_spec(
 
 pub fn render_tui_message_spec(spec: &TuiMessageSpec, width: usize) -> Vec<String> {
     let mut lines = vec![render_message_heading(spec)];
+    let body_lines = render_tui_message_body_spec(spec, width);
+
+    lines.extend(body_lines);
+    lines
+}
+
+pub fn render_tui_message_body_spec(spec: &TuiMessageSpec, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
 
     for section in &spec.sections {
         append_section_lines(&mut lines, section, width);

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -29,6 +29,30 @@ fn render_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
 }
 
+fn compact_cli_output_for_assertion(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| {
+            if character.is_whitespace() {
+                return false;
+            }
+
+            !matches!(character, '│' | '╭' | '╰' | '─')
+        })
+        .collect()
+}
+
+fn stdout_contains_compacted_hint(stdout: &str, expected_hint: &str) -> bool {
+    let compacted_stdout = compact_cli_output_for_assertion(stdout);
+    let compacted_expected_hint = compact_cli_output_for_assertion(expected_hint);
+    let bulleted_expected_hint = format!("-{compacted_expected_hint}");
+
+    let matches_plain_hint = compacted_stdout.contains(&compacted_expected_hint);
+    let matches_bulleted_hint = compacted_stdout.contains(&bulleted_expected_hint);
+
+    matches_plain_hint || matches_bulleted_hint
+}
+
 fn invoked_chat_cli_command_name() -> &'static str {
     mvp::config::detect_invoked_cli_command_name_from_arg0(Some(OsStr::new(env!(
         "CARGO_BIN_EXE_loongclaw"
@@ -234,8 +258,6 @@ fn chat_without_config_decline_hint_preserves_explicit_config_path() {
         invoked_chat_cli_command_name(),
         explicit_config.display()
     );
-    let compacted_stdout = stdout.split_whitespace().collect::<String>();
-    let compacted_expected_hint = expected_hint.split_whitespace().collect::<String>();
 
     assert!(
         output.status.success(),
@@ -247,7 +269,7 @@ fn chat_without_config_decline_hint_preserves_explicit_config_path() {
         fixture.onboard_log()
     );
     assert!(
-        compacted_stdout.contains(&compacted_expected_hint),
+        stdout_contains_compacted_hint(&stdout, &expected_hint),
         "decline hint should preserve the explicit config path: {stdout:?}"
     );
 }
@@ -263,8 +285,6 @@ fn chat_without_config_treats_explicit_no_as_decline() {
         "You can run '{} onboard' later to get started.",
         invoked_chat_cli_command_name()
     );
-    let compacted_stdout = stdout.split_whitespace().collect::<String>();
-    let compacted_expected_hint = expected_hint.split_whitespace().collect::<String>();
 
     assert!(
         output.status.success(),
@@ -276,7 +296,7 @@ fn chat_without_config_treats_explicit_no_as_decline() {
         fixture.onboard_log()
     );
     assert!(
-        compacted_stdout.contains(&compacted_expected_hint),
+        stdout_contains_compacted_hint(&stdout, &expected_hint),
         "explicit no should leave a follow-up hint: {stdout:?}"
     );
 }
@@ -292,8 +312,6 @@ fn chat_without_config_treats_eof_as_decline() {
         "You can run '{} onboard' later to get started.",
         invoked_chat_cli_command_name()
     );
-    let compacted_stdout = stdout.split_whitespace().collect::<String>();
-    let compacted_expected_hint = expected_hint.split_whitespace().collect::<String>();
 
     assert!(
         output.status.success(),
@@ -305,7 +323,7 @@ fn chat_without_config_treats_eof_as_decline() {
         fixture.onboard_log()
     );
     assert!(
-        compacted_stdout.contains(&compacted_expected_hint),
+        stdout_contains_compacted_hint(&stdout, &expected_hint),
         "eof should still leave the follow-up hint: {stdout:?}"
     );
 }

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T02:45:41Z
+- Generated at: 2026-04-10T02:47:02Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,7 +20,7 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7146 | 7300 | 154 | 135 | 160 | 25 | 97.9% | TIGHT | 6936 | 3.0% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7207 | 7300 | 93 | 136 | 160 | 24 | 98.7% | TIGHT | 6936 | 3.9% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10254 | 11200 | 946 | 86 | 120 | 34 | 91.6% | WATCH | 10831 | -5.3% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14711 | 15000 | 289 | 61 | 70 | 9 | 98.1% | TIGHT | 14472 | 1.7% | PASS | 54 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (97.9%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (98.7%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.6%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -66,7 +66,7 @@
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
-<!-- arch-hotspot key=chat_runtime lines=7146 functions=135 -->
+<!-- arch-hotspot key=chat_runtime lines=7207 functions=136 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10254 functions=86 -->
 <!-- arch-hotspot key=tools_mod lines=14711 functions=61 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T01:06:38Z
+- Generated at: 2026-04-10T02:45:41Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,7 +20,7 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7146 | 7300 | 154 | 135 | 160 | 25 | 97.9% | TIGHT | 6936 | 3.0% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10254 | 11200 | 946 | 86 | 120 | 34 | 91.6% | WATCH | 10831 | -5.3% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14711 | 15000 | 289 | 61 | 70 | 9 | 98.1% | TIGHT | 14472 | 1.7% | PASS | 54 |
@@ -29,8 +29,8 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (91.6%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (97.9%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.6%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,7 +66,7 @@
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
-<!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
+<!-- arch-hotspot key=chat_runtime lines=7146 functions=135 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10254 functions=86 -->
 <!-- arch-hotspot key=tools_mod lines=14711 functions=61 -->


### PR DESCRIPTION
## Summary

- Problem: The interactive chat CLI was still centered on line-oriented REPL output, which made it hard to align with a modern fullscreen terminal session workflow.
- Why it matters: Transcript navigation, approval handling, operator actions, and live turn visibility were all constrained by append-only rendering.
- What changed: Added a fullscreen chat session surface runtime for TTY use, including transcript navigation, right rail, command palette, overlays, and a cursor-aware composer; preserved non-TTY fallback.
- What did not change (scope boundary): Provider/runtime orchestration semantics, non-interactive ask mode, and non-chat docs/workflow surfaces.

## Linked Issues

- Closes #1147
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: The primary TTY chat path now enters a fullscreen session runtime instead of a line-oriented REPL.
- Rollout / guardrails: Non-TTY fallback remains on the legacy path; session actions stay local to the runtime surface.
- Rollback path: Repoint `run_cli_chat` / concurrent host to the previous REPL path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo check -p loongclaw-app --lib
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
./scripts/check_architecture_boundaries.sh
cargo test -p loongclaw-app chat::session_surface::tests --lib -- --test-threads=1
cargo test -p loongclaw-app --lib -- --test-threads=1
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
```

## User-visible / Operator-visible Changes

- Interactive TTY chat now runs inside a fullscreen session surface with transcript navigation, command palette filtering, overlays, right-rail diagnostics, and a cursor-aware composer.

## Failure Recovery

- Fast rollback or disable path: Restore the legacy REPL as the TTY primary path.
- Observable failure symptoms reviewers should watch for: Input focus getting stuck, overlays failing to dismiss, or transcript navigation failing to keep the selected entry visible.

## Reviewer Focus

- `crates/app/src/chat.rs`
- `crates/app/src/chat/operator_surfaces.rs`
- `crates/app/src/chat/session_surface.rs`
- Focus on TTY entry-path switching, overlay interactions, transcript navigation, and fallback safety.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive terminal chat surface with richer navigation, overlays, multiline composer, export, and concurrent-host mode.

* **Improvements**
  * Unified CLI prompt and REPL fallbacks for non-interactive terminals.
  * Usage errors now show width-aware, non-fatal warning cards so sessions continue.
  * Card-style message rendering with contextual footer hints and quick-command guidance.

* **Parsing**
  * Smarter markdown promotion for reasoning/tool-activity and default diff/patch titles.

* **Refactor**
  * Message rendering split into heading/body composition for cleaner output assembly.

* **Tests / Docs**
  * Updated tests and docs to match new card headers, hints, and compacted CLI output checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->