### PR TITLE
[Bug] Keep incomplete core-tool calls on the repairable follow-up path

### DIFF
--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -22,6 +22,7 @@ mod session_address;
 mod session_history;
 mod subagent;
 mod tool_discovery_state;
+mod tool_input_contract;
 mod tool_result_compaction;
 mod trust_projection;
 mod turn_budget;

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11416,6 +11416,98 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     assert_eq!(visible_turns[1].2, reply);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_request_context() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Trying to read the file now.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({}),
+                "session-file-read-followup",
+                "turn-file-read-followup",
+                "call-file-read-followup",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_FILE_READ_REPAIR_REPLY".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-file-read-followup",
+            "read the file",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("repairable file.read failure should still return completion fallback");
+
+    assert_eq!(reply, "MODEL_FILE_READ_REPAIR_REPLY");
+
+    let completion_requests = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion request lock")
+        .clone();
+    assert_eq!(completion_requests.len(), 1);
+
+    let followup_messages = &completion_requests[0];
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            let is_assistant = role == Some("assistant");
+            let has_request_marker =
+                content.is_some_and(|value| value.starts_with("[tool_request]\n"));
+            let mentions_file_read =
+                content.is_some_and(|value| value.contains("\"tool\":\"file.read\""));
+            let shows_empty_request = content.is_some_and(|value| value.contains("\"request\":{}"));
+            is_assistant && has_request_marker && mentions_file_read && shows_empty_request
+        }),
+        "completion followup should include the failed file.read request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            let is_assistant = role == Some("assistant");
+            let has_failure_marker =
+                content.is_some_and(|value| value.starts_with("[tool_failure]\n"));
+            let mentions_repair =
+                content.is_some_and(|value| value.contains("tool input needs repair"));
+            let mentions_required_path =
+                content.is_some_and(|value| value.contains("file.read payload.path is required"));
+            is_assistant && has_failure_marker && mentions_repair && mentions_required_path
+        }),
+        "completion followup should include the repairable file.read failure reason: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            let is_user = role == Some("user");
+            let has_guidance =
+                content.is_some_and(|value| value.contains("Repair guidance for file.read:"));
+            let mentions_path = content.is_some_and(|value| {
+                value.contains("Add required field `payload.path` as a string.")
+            });
+            let mentions_shape = content.is_some_and(|value| {
+                value.contains("Expected payload shape: path:string,max_bytes?:integer.")
+            });
+            is_user && has_guidance && mentions_path && mentions_shape
+        }),
+        "completion followup should include file.read repair guidance: {followup_messages:?}"
+    );
+}
+
 #[cfg(feature = "tool-shell")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_failed_request_context()

--- a/crates/app/src/conversation/tool_input_contract.rs
+++ b/crates/app/src/conversation/tool_input_contract.rs
@@ -63,9 +63,30 @@ pub(crate) fn render_tool_input_repair_guidance(
     let descriptor = catalog.resolve(tool_name)?;
     let request_value = request_summary?;
     let issue = detect_tool_input_contract_issue(descriptor, request_value)?;
-    Some(render_repair_guidance_for_issue(
+    Some(render_tool_input_repair_guidance_for_issue(
         tool_name, descriptor, &issue,
     ))
+}
+
+pub(crate) fn render_tool_input_repair_guidance_from_reason(
+    tool_name: &str,
+    tool_failure_reason: &str,
+) -> Option<String> {
+    let catalog = tools::tool_catalog();
+    let descriptor = catalog.resolve(tool_name)?;
+    render_tool_input_repair_guidance_from_reason_with_descriptor(
+        tool_name,
+        descriptor,
+        tool_failure_reason,
+    )
+}
+
+fn render_tool_input_repair_guidance_for_issue(
+    tool_name: &str,
+    descriptor: &tools::ToolDescriptor,
+    issue: &ToolInputContractIssue,
+) -> String {
+    render_repair_guidance_for_issue(tool_name, descriptor, issue)
 }
 
 fn effective_payload_for_descriptor(
@@ -84,16 +105,155 @@ fn effective_payload_for_descriptor(
         return None;
     }
 
-    let resolved = tools::resolve_tool_invoke_request(request).ok()?;
-    let (_, inner_request) = resolved;
-    let inner_tool_name = inner_request.tool_name.as_str();
+    let request_object = request.payload.as_object()?;
+    let inner_tool_name = request_object
+        .get("tool_id")
+        .or_else(|| request_object.get("tool_name"))
+        .and_then(Value::as_str)
+        .map(tools::canonical_tool_name)?;
 
     if inner_tool_name != descriptor_tool_name {
         return None;
     }
 
-    let payload = inner_request.payload;
+    let payload = request_object
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
     Some(payload)
+}
+
+fn render_tool_input_repair_guidance_from_reason_with_descriptor(
+    tool_name: &str,
+    descriptor: &tools::ToolDescriptor,
+    tool_failure_reason: &str,
+) -> Option<String> {
+    let issue = parse_tool_input_contract_issue_from_reason(descriptor, tool_failure_reason)?;
+    let guidance = render_tool_input_repair_guidance_for_issue(tool_name, descriptor, &issue);
+    Some(guidance)
+}
+
+fn strip_tool_input_reason_prefix(reason: &str) -> &str {
+    let trimmed_reason = reason.trim();
+    let tool_preflight_prefix = "tool_preflight_denied: tool input needs repair: ";
+
+    if let Some(stripped_reason) = trimmed_reason.strip_prefix(tool_preflight_prefix) {
+        return stripped_reason;
+    }
+
+    let followup_prefix = "tool input needs repair: ";
+    let stripped_followup_reason = trimmed_reason.strip_prefix(followup_prefix);
+    stripped_followup_reason.unwrap_or(trimmed_reason)
+}
+
+fn parse_tool_input_contract_issue_from_reason(
+    descriptor: &tools::ToolDescriptor,
+    tool_failure_reason: &str,
+) -> Option<ToolInputContractIssue> {
+    let tool_name = descriptor.name;
+    let reason = strip_tool_input_reason_prefix(tool_failure_reason);
+    let object_reason = format!("{tool_name} payload must be an object");
+
+    if reason == object_reason {
+        return Some(ToolInputContractIssue::PayloadMustBeObject);
+    }
+
+    let prefix = format!("{tool_name} payload.");
+    let suffix = reason.strip_prefix(prefix.as_str())?;
+    let missing_issue = parse_missing_required_field_issue(descriptor, suffix);
+
+    if missing_issue.is_some() {
+        return missing_issue;
+    }
+
+    parse_invalid_field_type_issue(descriptor, suffix)
+}
+
+fn parse_missing_required_field_issue(
+    descriptor: &tools::ToolDescriptor,
+    reason_suffix: &str,
+) -> Option<ToolInputContractIssue> {
+    let split = reason_suffix.split_once(" is required")?;
+    let field_name = split.0;
+    let type_suffix = split.1;
+    let field = descriptor_required_field_name(descriptor, field_name)?;
+    let expected_type = expected_type_for_field(descriptor, field);
+    let has_type_suffix = !type_suffix.is_empty();
+
+    if has_type_suffix {
+        let parsed_type = type_suffix.strip_prefix(" (")?;
+        let parsed_type = parsed_type.strip_suffix(')')?;
+        let expected_type_matches = expected_type == Some(parsed_type);
+
+        if !expected_type_matches {
+            return None;
+        }
+    }
+
+    let issue = ToolInputContractIssue::MissingRequiredField {
+        field,
+        expected_type,
+    };
+    Some(issue)
+}
+
+fn parse_invalid_field_type_issue(
+    descriptor: &tools::ToolDescriptor,
+    reason_suffix: &str,
+) -> Option<ToolInputContractIssue> {
+    let split = reason_suffix.split_once(" must be ")?;
+    let field_name = split.0;
+    let expected_type = split.1;
+    let field = descriptor_parameter_field_name(descriptor, field_name)?;
+    let descriptor_expected_type = expected_type_for_field(descriptor, field)?;
+    let expected_type_matches = descriptor_expected_type == expected_type;
+
+    if !expected_type_matches {
+        return None;
+    }
+
+    let issue = ToolInputContractIssue::InvalidFieldType {
+        field,
+        expected_type: descriptor_expected_type,
+    };
+    Some(issue)
+}
+
+fn descriptor_required_field_name(
+    descriptor: &tools::ToolDescriptor,
+    field_name: &str,
+) -> Option<&'static str> {
+    for required_field in descriptor.required_fields() {
+        let is_match = *required_field == field_name;
+
+        if is_match {
+            return Some(*required_field);
+        }
+    }
+
+    None
+}
+
+fn descriptor_parameter_field_name(
+    descriptor: &tools::ToolDescriptor,
+    field_name: &str,
+) -> Option<&'static str> {
+    for (candidate_field_name, _) in descriptor.parameter_types() {
+        let is_match = *candidate_field_name == field_name;
+
+        if is_match {
+            return Some(*candidate_field_name);
+        }
+    }
+
+    None
+}
+
+fn indefinite_article(expected_type: &str) -> &'static str {
+    match expected_type {
+        "array" | "integer" | "object" => "an",
+        _ => "a",
+    }
 }
 
 fn detect_tool_input_contract_issue(
@@ -208,7 +368,10 @@ fn render_repair_guidance_for_issue(
         } => {
             let field_path = format!("payload.{field}");
             let expected_suffix = expected_type
-                .map(|value| format!(" as a {value}"))
+                .map(|value| {
+                    let article = indefinite_article(value);
+                    format!(" as {article} {value}")
+                })
                 .unwrap_or_default();
             let line = format!("Add required field `{field_path}`{expected_suffix}.");
             lines.push(line);
@@ -218,7 +381,8 @@ fn render_repair_guidance_for_issue(
             expected_type,
         } => {
             let field_path = format!("payload.{field}");
-            let line = format!("Set `{field_path}` to a {expected_type} value.");
+            let article = indefinite_article(expected_type);
+            let line = format!("Set `{field_path}` to {article} {expected_type} value.");
             lines.push(line);
         }
     }
@@ -239,7 +403,7 @@ fn render_repair_guidance_for_issue(
 mod tests {
     use super::{
         ToolInputContractIssue, detect_repairable_tool_request_issue,
-        render_tool_input_repair_guidance,
+        render_tool_input_repair_guidance, render_tool_input_repair_guidance_from_reason,
     };
     use crate::tools;
     use loongclaw_contracts::ToolCoreRequest;
@@ -307,5 +471,39 @@ mod tests {
                 expected_type: "string",
             })
         );
+    }
+
+    #[test]
+    fn detect_repairable_tool_request_issue_marks_scalar_tool_invoke_arguments_repairable() {
+        let descriptor = tools::tool_catalog()
+            .resolve("file.read")
+            .expect("file.read descriptor");
+        let request = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "file.read",
+                "lease": "lease-a",
+                "arguments": "README.md"
+            }),
+        };
+
+        let issue = detect_repairable_tool_request_issue(descriptor, &request);
+
+        assert_eq!(issue, Some(ToolInputContractIssue::PayloadMustBeObject));
+    }
+
+    #[test]
+    fn render_tool_input_repair_guidance_from_reason_preserves_array_type_guidance() {
+        let guidance = render_tool_input_repair_guidance_from_reason(
+            "shell.exec",
+            "tool_preflight_denied: tool input needs repair: shell.exec payload.args must be array",
+        )
+        .expect("guidance");
+
+        assert!(guidance.contains("Repair guidance for shell.exec:"));
+        assert!(guidance.contains("Set `payload.args` to an array value."));
+        assert!(guidance.contains(
+            "Expected payload shape: command:string,args?:string[],timeout_ms?:integer,cwd?:string."
+        ));
     }
 }

--- a/crates/app/src/conversation/tool_input_contract.rs
+++ b/crates/app/src/conversation/tool_input_contract.rs
@@ -1,0 +1,311 @@
+use loongclaw_contracts::ToolCoreRequest;
+use serde_json::Value;
+
+use crate::tools;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ToolInputContractIssue {
+    PayloadMustBeObject,
+    MissingRequiredField {
+        field: &'static str,
+        expected_type: Option<&'static str>,
+    },
+    InvalidFieldType {
+        field: &'static str,
+        expected_type: &'static str,
+    },
+}
+
+impl ToolInputContractIssue {
+    pub(crate) fn reason(&self, tool_name: &str) -> String {
+        match self {
+            Self::PayloadMustBeObject => {
+                format!("{tool_name} payload must be an object")
+            }
+            Self::MissingRequiredField {
+                field,
+                expected_type,
+            } => {
+                let field_path = format!("payload.{field}");
+                let expected_suffix = expected_type
+                    .map(|value| format!(" ({value})"))
+                    .unwrap_or_default();
+                format!("{tool_name} {field_path} is required{expected_suffix}")
+            }
+            Self::InvalidFieldType {
+                field,
+                expected_type,
+            } => {
+                let field_path = format!("payload.{field}");
+                format!("{tool_name} {field_path} must be {expected_type}")
+            }
+        }
+    }
+}
+
+pub(crate) fn detect_repairable_tool_request_issue(
+    descriptor: &tools::ToolDescriptor,
+    request: &ToolCoreRequest,
+) -> Option<ToolInputContractIssue> {
+    if descriptor.execution_kind != tools::ToolExecutionKind::Core {
+        return None;
+    }
+
+    let effective_payload = effective_payload_for_descriptor(descriptor, request)?;
+    detect_tool_input_contract_issue(descriptor, &effective_payload)
+}
+
+pub(crate) fn render_tool_input_repair_guidance(
+    tool_name: &str,
+    request_summary: Option<&Value>,
+) -> Option<String> {
+    let catalog = tools::tool_catalog();
+    let descriptor = catalog.resolve(tool_name)?;
+    let request_value = request_summary?;
+    let issue = detect_tool_input_contract_issue(descriptor, request_value)?;
+    Some(render_repair_guidance_for_issue(
+        tool_name, descriptor, &issue,
+    ))
+}
+
+fn effective_payload_for_descriptor(
+    descriptor: &tools::ToolDescriptor,
+    request: &ToolCoreRequest,
+) -> Option<Value> {
+    let descriptor_tool_name = descriptor.name;
+    let request_tool_name = tools::canonical_tool_name(request.tool_name.as_str());
+
+    if request_tool_name == descriptor_tool_name {
+        let payload = request.payload.clone();
+        return Some(payload);
+    }
+
+    if request_tool_name != "tool.invoke" {
+        return None;
+    }
+
+    let resolved = tools::resolve_tool_invoke_request(request).ok()?;
+    let (_, inner_request) = resolved;
+    let inner_tool_name = inner_request.tool_name.as_str();
+
+    if inner_tool_name != descriptor_tool_name {
+        return None;
+    }
+
+    let payload = inner_request.payload;
+    Some(payload)
+}
+
+fn detect_tool_input_contract_issue(
+    descriptor: &tools::ToolDescriptor,
+    request_value: &Value,
+) -> Option<ToolInputContractIssue> {
+    let request_object = match request_value.as_object() {
+        Some(value) => value,
+        None => return Some(ToolInputContractIssue::PayloadMustBeObject),
+    };
+
+    for required_field in descriptor.required_fields() {
+        let expected_type = expected_type_for_field(descriptor, required_field);
+        let value = request_object.get(*required_field);
+        let missing = required_field_is_missing(value, expected_type);
+
+        if missing {
+            let issue = ToolInputContractIssue::MissingRequiredField {
+                field: required_field,
+                expected_type,
+            };
+            return Some(issue);
+        }
+    }
+
+    for (field_name, expected_type) in descriptor.parameter_types() {
+        let value = match request_object.get(*field_name) {
+            Some(value) => value,
+            None => continue,
+        };
+        let matches_expected_type = value_matches_expected_type(value, expected_type);
+
+        if !matches_expected_type {
+            let issue = ToolInputContractIssue::InvalidFieldType {
+                field: field_name,
+                expected_type,
+            };
+            return Some(issue);
+        }
+    }
+
+    None
+}
+
+fn expected_type_for_field(
+    descriptor: &tools::ToolDescriptor,
+    field_name: &str,
+) -> Option<&'static str> {
+    for (candidate_field_name, expected_type) in descriptor.parameter_types() {
+        let is_match = *candidate_field_name == field_name;
+
+        if is_match {
+            return Some(*expected_type);
+        }
+    }
+
+    None
+}
+
+fn required_field_is_missing(value: Option<&Value>, expected_type: Option<&str>) -> bool {
+    let value = match value {
+        Some(value) => value,
+        None => return true,
+    };
+
+    if value.is_null() {
+        return true;
+    }
+
+    let requires_non_empty_string = expected_type == Some("string");
+
+    if !requires_non_empty_string {
+        return false;
+    }
+
+    let string_value = match value.as_str() {
+        Some(value) => value,
+        None => return false,
+    };
+    let trimmed_value = string_value.trim();
+    trimmed_value.is_empty()
+}
+
+fn value_matches_expected_type(value: &Value, expected_type: &str) -> bool {
+    match expected_type {
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        _ => true,
+    }
+}
+
+fn render_repair_guidance_for_issue(
+    tool_name: &str,
+    descriptor: &tools::ToolDescriptor,
+    issue: &ToolInputContractIssue,
+) -> String {
+    let mut lines = Vec::new();
+    let heading = format!("Repair guidance for {tool_name}:");
+    lines.push(heading);
+
+    match issue {
+        ToolInputContractIssue::PayloadMustBeObject => {
+            let line = "Send a JSON object payload instead of a scalar or list.".to_owned();
+            lines.push(line);
+        }
+        ToolInputContractIssue::MissingRequiredField {
+            field,
+            expected_type,
+        } => {
+            let field_path = format!("payload.{field}");
+            let expected_suffix = expected_type
+                .map(|value| format!(" as a {value}"))
+                .unwrap_or_default();
+            let line = format!("Add required field `{field_path}`{expected_suffix}.");
+            lines.push(line);
+        }
+        ToolInputContractIssue::InvalidFieldType {
+            field,
+            expected_type,
+        } => {
+            let field_path = format!("payload.{field}");
+            let line = format!("Set `{field_path}` to a {expected_type} value.");
+            lines.push(line);
+        }
+    }
+
+    let argument_hint = descriptor.argument_hint();
+    let trimmed_hint = argument_hint.trim();
+    let has_argument_hint = !trimmed_hint.is_empty();
+
+    if has_argument_hint {
+        let line = format!("Expected payload shape: {trimmed_hint}.");
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ToolInputContractIssue, detect_repairable_tool_request_issue,
+        render_tool_input_repair_guidance,
+    };
+    use crate::tools;
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::json;
+
+    #[test]
+    fn detect_repairable_tool_request_issue_unwraps_tool_invoke_for_core_tools() {
+        let (tool_name, payload) = tools::synthesize_test_provider_tool_call_with_scope(
+            "file.read",
+            json!({}),
+            Some("session-a"),
+            Some("turn-a"),
+        );
+        let descriptor = tools::tool_catalog()
+            .resolve("file.read")
+            .expect("file.read descriptor");
+        let request = ToolCoreRequest { tool_name, payload };
+
+        let issue = detect_repairable_tool_request_issue(descriptor, &request);
+
+        assert_eq!(
+            issue,
+            Some(ToolInputContractIssue::MissingRequiredField {
+                field: "path",
+                expected_type: Some("string"),
+            })
+        );
+    }
+
+    #[test]
+    fn render_tool_input_repair_guidance_uses_descriptor_argument_hint() {
+        let summary = json!({
+            "tool": "file.read",
+            "request": {}
+        });
+        let guidance = render_tool_input_repair_guidance("file.read", summary.get("request"))
+            .expect("guidance");
+
+        assert!(guidance.contains("Repair guidance for file.read:"));
+        assert!(guidance.contains("Add required field `payload.path` as a string."));
+        assert!(guidance.contains("Expected payload shape: path:string,max_bytes?:integer."));
+    }
+
+    #[test]
+    fn detect_repairable_tool_request_issue_preserves_invalid_required_field_types() {
+        let (tool_name, payload) = tools::synthesize_test_provider_tool_call_with_scope(
+            "file.read",
+            json!({
+                "path": 7
+            }),
+            Some("session-a"),
+            Some("turn-a"),
+        );
+        let descriptor = tools::tool_catalog()
+            .resolve("file.read")
+            .expect("file.read descriptor");
+        let request = ToolCoreRequest { tool_name, payload };
+
+        let issue = detect_repairable_tool_request_issue(descriptor, &request);
+
+        assert_eq!(
+            issue,
+            Some(ToolInputContractIssue::InvalidFieldType {
+                field: "path",
+                expected_type: "string",
+            })
+        );
+    }
+}

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6659,6 +6659,46 @@ mod tests {
         assert_eq!(error.message, "no_kernel_context");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_single_tool_intent_marks_repairable_file_read_failure_retryable() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "file.read",
+            json!({}),
+            Some("root-session"),
+            Some("turn-file-read-plan-node"),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-file-read-plan-node".to_owned(),
+            tool_call_id: "call-file-read-plan-node".to_owned(),
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::planned_root_tool_view(),
+        );
+
+        let error = execute_single_tool_intent(
+            &intent,
+            &session_context,
+            &DefaultAppToolDispatcher::runtime(),
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+            None,
+            2_048,
+        )
+        .await
+        .expect_err("repairable file.read preflight should return a plan-node error");
+
+        assert_eq!(error.kind, PlanNodeErrorKind::Retryable);
+        assert!(error.message.contains("tool input needs repair"));
+        assert!(error.message.contains("file.read payload.path is required"));
+    }
+
     #[cfg(feature = "tool-shell")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_single_tool_intent_marks_repairable_shell_preflight_failure_retryable() {

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -45,6 +45,7 @@ use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary;
 
 use super::ingress::{ConversationIngressContext, inject_internal_tool_ingress};
+use super::tool_input_contract::detect_repairable_tool_request_issue;
 use super::turn_shared::effective_followup_tool_name;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1628,6 +1629,14 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         descriptor: &crate::tools::ToolDescriptor,
         binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolExecutionPreflight, String> {
+        let repairable_issue = detect_repairable_tool_request_issue(descriptor, &request);
+
+        if let Some(repairable_issue) = repairable_issue {
+            let repairable_reason = repairable_issue.reason(descriptor.name);
+            let encoded_reason = RepairableToolPreflight::encode(repairable_reason.as_str());
+            return Err(encoded_reason);
+        }
+
         #[cfg(not(feature = "memory-sqlite"))]
         {
             let _ = (session_context, intent, descriptor, binding);

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -3,7 +3,9 @@ use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
 use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
-use super::tool_input_contract::render_tool_input_repair_guidance;
+use super::tool_input_contract::{
+    render_tool_input_repair_guidance, render_tool_input_repair_guidance_from_reason,
+};
 use super::tool_result_compaction::compact_tool_search_payload_summary_str;
 use super::turn_engine::{
     ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolBatchExecutionIntentStatus,
@@ -1921,7 +1923,14 @@ fn render_tool_failure_repair_guidance(
         return shell_guidance;
     }
 
-    render_tool_input_repair_guidance(tool_name, request_summary_request)
+    let guidance_from_request =
+        render_tool_input_repair_guidance(tool_name, request_summary_request);
+
+    if guidance_from_request.is_some() {
+        return guidance_from_request;
+    }
+
+    render_tool_input_repair_guidance_from_reason(tool_name, tool_failure_reason)
 }
 
 fn render_shell_failure_repair_guidance(
@@ -3122,6 +3131,35 @@ mod tests {
         assert!(user_prompt.contains("Repair guidance for file.read"));
         assert!(user_prompt.contains("Add required field `payload.path` as a string."));
         assert!(user_prompt.contains("Expected payload shape: path:string,max_bytes?:integer."));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_uses_failure_reason_when_shell_summary_redacts_args_type() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.args must be array"
+                .to_owned(),
+        };
+        let tool_request_summary = r#"{"tool":"shell.exec","request":{"command":"echo"}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "run echo safely",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for shell.exec"));
+        assert!(user_prompt.contains("Set `payload.args` to an array value."));
+        assert!(user_prompt.contains(
+            "Expected payload shape: command:string,args?:string[],timeout_ms?:integer,cwd?:string."
+        ));
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -3,6 +3,7 @@ use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
 use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
+use super::tool_input_contract::render_tool_input_repair_guidance;
 use super::tool_result_compaction::compact_tool_search_payload_summary_str;
 use super::turn_engine::{
     ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolBatchExecutionIntentStatus,
@@ -1901,17 +1902,46 @@ fn render_tool_failure_repair_guidance(
     let tool_request_summary = tool_request_summary?;
     let request_summary_json = serde_json::from_str::<Value>(tool_request_summary).ok()?;
     let tool_name = request_summary_json.get("tool").and_then(Value::as_str)?;
+    let request_summary_request = request_summary_json.get("request");
+    let reason_mentions_repairable_shape = tool_failure_reason.contains("tool input needs repair")
+        || tool_failure_reason.contains("payload must be an object")
+        || tool_failure_reason.contains("payload.");
+
+    if !reason_mentions_repairable_shape {
+        return None;
+    }
+
+    let shell_guidance = render_shell_failure_repair_guidance(
+        tool_name,
+        request_summary_request,
+        tool_failure_reason,
+    );
+
+    if shell_guidance.is_some() {
+        return shell_guidance;
+    }
+
+    render_tool_input_repair_guidance(tool_name, request_summary_request)
+}
+
+fn render_shell_failure_repair_guidance(
+    tool_name: &str,
+    request_summary_request: Option<&Value>,
+    tool_failure_reason: &str,
+) -> Option<String> {
     if tool_name != "shell.exec" {
         return None;
     }
 
-    let request_object = request_summary_json.get("request")?.as_object()?;
+    let request_object = request_summary_request?.as_object()?;
     let command = request_object.get("command").and_then(Value::as_str)?;
     let has_path_separator = command.contains('/') || command.contains('\\');
     let mentions_payload_command = tool_failure_reason.contains("payload.command");
     let mentions_path_separator = tool_failure_reason.contains("path separators");
+    let should_render_guidance =
+        has_path_separator || mentions_payload_command || mentions_path_separator;
 
-    if !has_path_separator && !mentions_payload_command && !mentions_path_separator {
+    if !should_render_guidance {
         return None;
     }
 
@@ -3064,6 +3094,34 @@ mod tests {
 
         assert!(user_prompt.contains("Repair guidance for shell.exec"));
         assert!(user_prompt.contains("The failed request used `\"ls -la\" `; retry with `ls`"));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_renders_required_field_guidance_for_file_read() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason:
+                "tool_preflight_denied: tool input needs repair: file.read payload.path is required (string)"
+                    .to_owned(),
+        };
+        let tool_request_summary = r#"{"tool":"file.read","request":{}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "read the file",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for file.read"));
+        assert!(user_prompt.contains("Add required field `payload.path` as a string."));
+        assert!(user_prompt.contains("Expected payload shape: path:string,max_bytes?:integer."));
     }
 
     #[test]

--- a/crates/app/tests/conversation_integration.rs
+++ b/crates/app/tests/conversation_integration.rs
@@ -294,13 +294,16 @@ async fn integ_malformed_tool_args_returns_error() {
     #[allow(clippy::wildcard_enum_match_arm)]
     match result {
         TurnResult::ToolError(err) => {
+            let mentions_repairable_shape = err.contains("tool input needs repair");
+            let mentions_object_requirement =
+                err.contains("must be an object") || err.contains("must be object");
             assert!(
-                err.contains("must be an object"),
-                "expected 'must be an object' in error, got: {err}"
+                mentions_repairable_shape && mentions_object_requirement,
+                "expected repairable object-shape error, got: {err}"
             );
         }
         other => {
-            panic!("expected ToolError with 'must be an object', got: {other:?}");
+            panic!("expected ToolError with repairable object-shape guidance, got: {other:?}");
         }
     }
 }

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T02:47:02Z
+- Generated at: 2026-04-10T03:36:08Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,7 +22,7 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7207 | 7300 | 93 | 136 | 160 | 24 | 98.7% | TIGHT | 6936 | 3.9% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10254 | 11200 | 946 | 86 | 120 | 34 | 91.6% | WATCH | 10831 | -5.3% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10294 | 11200 | 906 | 86 | 120 | 34 | 91.9% | WATCH | 10831 | -5.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14711 | 15000 | 289 | 61 | 70 | 9 | 98.1% | TIGHT | 14472 | 1.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6494 | 6500 | 6 | 201 | 210 | 9 | 99.9% | TIGHT | 6324 | 2.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
@@ -30,7 +30,7 @@
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (98.7%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.6%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.9%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
 <!-- arch-hotspot key=chat_runtime lines=7207 functions=136 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10254 functions=86 -->
+<!-- arch-hotspot key=turn_coordinator lines=10294 functions=86 -->
 <!-- arch-hotspot key=tools_mod lines=14711 functions=61 -->
 <!-- arch-hotspot key=daemon_lib lines=6494 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->


### PR DESCRIPTION
## Summary

- Problem: wrapped core-tool calls could still fail hard after discovery succeeded when the provider omitted a required nested payload field (for example `tool.invoke` → `file.read` without `arguments.path`).
- Why it matters: the agent looked like it could not continue tool work even though the failure was only a repairable shape mistake.
- What changed: added metadata-driven core-tool payload-shape validation before execution, mapped those failures into the existing repairable preflight loop, and added generic field-level repair guidance in follow-up tails for core tools while preserving shell-specific guidance.
- What did not change (scope boundary): no provider protocol redesign, no hidden auto-install path, no broad mutation-policy redesign.

## Linked Issues

- Closes #1149
- Related #570

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-app execute_single_tool_intent_marks_repairable_file_read_failure_retryable --lib
cargo test -p loongclaw-app handle_turn_with_runtime_file_read_repair_followup_includes_failed_request_context --lib
cargo test -p loongclaw-app tool_failure_followup_tail_renders_required_field_guidance_for_file_read --lib
cargo test -p loongclaw-app render_tool_input_repair_guidance_uses_descriptor_argument_hint --lib
cargo test -p loongclaw audit_cli::tests::audit_discovery_filters_tool_search_events_and_rolls_up_trust_context --lib --exact --nocapture
cargo test -p loongclaw-app integ_malformed_tool_args_returns_error --test conversation_integration -- --exact --nocapture
cargo check -p loongclaw-app -p loongclaw --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
./scripts/check_architecture_boundaries.sh

Result: all commands passed in the isolated worktree using a private CARGO_HOME and worktree-local target cache.
```

## User-visible / Operator-visible Changes

- Repairable core-tool input mistakes now stay in the conversation repair loop instead of surfacing as hard terminal tool failures.
- Follow-up prompts can now tell the model which required core-tool field is missing or mistyped (for example `payload.path` for `file.read`).

## Failure Recovery

- Fast rollback or disable path: revert commit `f02a626bf`.
- Observable failure symptoms reviewers should watch for: unexpected repair guidance on non-shape failures, or core-tool calls being marked retryable when they should still be terminal runtime errors.

## Reviewer Focus

- `crates/app/src/conversation/tool_input_contract.rs` for metadata-driven payload-shape detection.
- `crates/app/src/conversation/turn_engine.rs` for the new repairable preflight hook.
- `crates/app/src/conversation/turn_shared.rs` for generic repair guidance gating.
- `crates/app/tests/conversation_integration.rs` for the updated repairable object-shape contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool input validation to detect malformed requests (missing required fields, invalid field types, incorrect payload format).
  * Enhanced error messages to include actionable repair guidance when tools receive invalid input.
  * Tool failures now indicate whether an issue is repairable and provide specific instructions for fixing the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->