### PR TITLE
Make MCP runtime snapshots truthful to local readiness and auth state

### DIFF
--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
 use std::path::Path;
 
 use crate::CliResult;
@@ -324,9 +325,9 @@ fn mcp_server_status_from_config(server: &McpServerConfig) -> McpServerStatus {
     }
 
     match &server.transport {
-        McpServerTransportConfig::Stdio { command, cwd, .. } => {
-            stdio_mcp_server_status(command.as_str(), cwd.as_deref())
-        }
+        McpServerTransportConfig::Stdio {
+            command, env, cwd, ..
+        } => stdio_mcp_server_status(command.as_str(), env, cwd.as_deref()),
         McpServerTransportConfig::StreamableHttp {
             url,
             bearer_token_env_var,
@@ -343,7 +344,8 @@ fn mcp_server_status_from_config(server: &McpServerConfig) -> McpServerStatus {
 
 fn mcp_server_status_from_acpx_profile(server: &AcpxMcpServerConfig) -> McpServerStatus {
     let command = server.command.as_str();
-    stdio_mcp_server_status(command, None)
+    let env = &server.env;
+    stdio_mcp_server_status(command, env, None)
 }
 
 fn disabled_mcp_server_status() -> McpServerStatus {
@@ -357,7 +359,11 @@ fn disabled_mcp_server_status() -> McpServerStatus {
     }
 }
 
-fn stdio_mcp_server_status(command: &str, cwd: Option<&Path>) -> McpServerStatus {
+fn stdio_mcp_server_status(
+    command: &str,
+    env: &BTreeMap<String, String>,
+    cwd: Option<&Path>,
+) -> McpServerStatus {
     let auth = McpAuthStatus::Unsupported;
 
     let cwd_result = validate_stdio_cwd(cwd);
@@ -370,7 +376,7 @@ fn stdio_mcp_server_status(command: &str, cwd: Option<&Path>) -> McpServerStatus
         return status;
     }
 
-    let command_result = validate_stdio_command(command, cwd);
+    let command_result = validate_stdio_command(command, env, cwd);
     if let Err(last_error) = command_result {
         let status = McpServerStatus {
             kind: McpServerStatusKind::Failed,
@@ -389,7 +395,11 @@ fn stdio_mcp_server_status(command: &str, cwd: Option<&Path>) -> McpServerStatus
     }
 }
 
-fn validate_stdio_command(command: &str, cwd: Option<&Path>) -> Result<(), String> {
+fn validate_stdio_command(
+    command: &str,
+    env: &BTreeMap<String, String>,
+    cwd: Option<&Path>,
+) -> Result<(), String> {
     let trimmed_command = command.trim();
     if trimmed_command.is_empty() {
         let error = "stdio_command_missing".to_owned();
@@ -430,7 +440,11 @@ fn validate_stdio_command(command: &str, cwd: Option<&Path>) -> Result<(), Strin
         return Err(error);
     }
 
-    let command_found = which::which(trimmed_command).is_ok();
+    let search_path = resolve_stdio_command_search_path(env);
+    let fallback_cwd = Path::new(".");
+    let search_cwd = cwd.unwrap_or(fallback_cwd);
+    let command_lookup = which::which_in(trimmed_command, search_path, search_cwd);
+    let command_found = command_lookup.is_ok();
     if command_found {
         return Ok(());
     }
@@ -464,6 +478,33 @@ fn validate_stdio_cwd(cwd: Option<&Path>) -> Result<(), String> {
     let rendered_cwd = cwd.display().to_string();
     let error = format!("stdio_cwd_not_directory: {rendered_cwd}");
     Err(error)
+}
+
+fn resolve_stdio_command_search_path(env: &BTreeMap<String, String>) -> Option<OsString> {
+    let path_override = find_env_value_ignore_case(env, "PATH");
+    if let Some(path_override) = path_override {
+        let path_override = OsString::from(path_override);
+        return Some(path_override);
+    }
+
+    std::env::var_os("PATH")
+}
+
+fn find_env_value_ignore_case<'a>(
+    env: &'a BTreeMap<String, String>,
+    expected_name: &str,
+) -> Option<&'a str> {
+    for (name, value) in env {
+        let is_match = name.eq_ignore_ascii_case(expected_name);
+        if !is_match {
+            continue;
+        }
+
+        let value = value.as_str();
+        return Some(value);
+    }
+
+    None
 }
 
 fn streamable_http_mcp_server_status(
@@ -1316,6 +1357,56 @@ mod tests {
             last_error.contains(missing_command.as_str()),
             "last_error={last_error}"
         );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_uses_configured_stdio_path_for_command_lookup() {
+        let mut scoped_env = ScopedEnv::new();
+        scoped_env.set("PATH", OsString::from(""));
+
+        let command_dir = unique_temp_dir("loongclaw-mcp-command-path-override");
+        std::fs::create_dir_all(&command_dir).expect("create command directory");
+
+        let source_executable = std::env::current_exe().expect("current executable path");
+        let command_file_name = source_executable
+            .file_name()
+            .expect("current executable file name");
+        let command_file_name = command_file_name.to_string_lossy();
+        let command_file_name = command_file_name.to_string();
+        let copied_command_path = command_dir.join(&command_file_name);
+        let copied_bytes = std::fs::copy(&source_executable, &copied_command_path)
+            .expect("copy executable into configured PATH");
+        assert!(copied_bytes > 0, "copied executable should not be empty");
+
+        let configured_path = command_dir.display().to_string();
+
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command: command_file_name,
+                args: Vec::new(),
+                env: BTreeMap::from([("PATH".to_owned(), configured_path)]),
+                cwd: None,
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert_eq!(server.status.last_error, None);
     }
 
     #[test]

--- a/crates/app/src/mcp/registry.rs
+++ b/crates/app/src/mcp/registry.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use crate::CliResult;
 use crate::config::{AcpxBackendConfig, AcpxMcpServerConfig, LoongClawConfig};
@@ -82,8 +83,13 @@ impl McpRegistry {
         for entry in self.servers.values() {
             let is_stdio = entry.stdio_launch_spec.is_some();
             let is_enabled = entry.snapshot.enabled;
+            let status_kind = entry.snapshot.status.kind;
+            let is_launchable = matches!(
+                status_kind,
+                McpServerStatusKind::Pending | McpServerStatusKind::Connected
+            );
 
-            if is_stdio && is_enabled {
+            if is_stdio && is_enabled && is_launchable {
                 count += 1;
             }
         }
@@ -151,6 +157,25 @@ impl McpRegistry {
             if !is_enabled {
                 let message = format!(
                     "ACPX requested mcp_server `{name}` exists, but it is disabled in the shared MCP registry"
+                );
+
+                return Err(message);
+            }
+
+            let status_kind = entry.snapshot.status.kind;
+            let launchable_status = matches!(
+                status_kind,
+                McpServerStatusKind::Pending | McpServerStatusKind::Connected
+            );
+            if !launchable_status {
+                let last_error = entry
+                    .snapshot
+                    .status
+                    .last_error
+                    .clone()
+                    .unwrap_or_else(|| "mcp_server_not_launchable".to_owned());
+                let message = format!(
+                    "ACPX requested mcp_server `{name}` exists, but it is not launchable in the shared MCP registry: {last_error}"
                 );
 
                 return Err(message);
@@ -224,11 +249,7 @@ fn registry_entry_from_config(
     origin: McpServerOrigin,
 ) -> McpRegistryEntry {
     let transport = transport_snapshot(&server.transport);
-    let status_kind = if server.enabled {
-        McpServerStatusKind::Pending
-    } else {
-        McpServerStatusKind::Disabled
-    };
+    let status = mcp_server_status_from_config(server);
 
     let snapshot = McpRuntimeServerSnapshot {
         name,
@@ -236,11 +257,7 @@ fn registry_entry_from_config(
         required: server.required,
         selected_for_acp_bootstrap: false,
         origins: vec![origin],
-        status: McpServerStatus {
-            kind: status_kind,
-            auth: McpAuthStatus::Unknown,
-            last_error: None,
-        },
+        status,
         transport,
         enabled_tools: server.enabled_tools.clone(),
         disabled_tools: server.disabled_tools.clone(),
@@ -276,11 +293,7 @@ fn registry_entry_from_acpx_profile(
             kind: McpServerOriginKind::AcpBackendProfile,
             source_id: Some("acpx".to_owned()),
         }],
-        status: McpServerStatus {
-            kind: McpServerStatusKind::Pending,
-            auth: McpAuthStatus::Unknown,
-            last_error: None,
-        },
+        status: mcp_server_status_from_acpx_profile(server),
         transport,
         enabled_tools: Vec::new(),
         disabled_tools: Vec::new(),
@@ -302,6 +315,315 @@ fn registry_entry_from_acpx_profile(
         snapshot,
         stdio_launch_spec: Some(stdio_launch_spec),
     }
+}
+
+fn mcp_server_status_from_config(server: &McpServerConfig) -> McpServerStatus {
+    if !server.enabled {
+        let status = disabled_mcp_server_status();
+        return status;
+    }
+
+    match &server.transport {
+        McpServerTransportConfig::Stdio { command, cwd, .. } => {
+            stdio_mcp_server_status(command.as_str(), cwd.as_deref())
+        }
+        McpServerTransportConfig::StreamableHttp {
+            url,
+            bearer_token_env_var,
+            http_headers,
+            env_http_headers,
+        } => streamable_http_mcp_server_status(
+            url.as_str(),
+            bearer_token_env_var.as_deref(),
+            http_headers,
+            env_http_headers,
+        ),
+    }
+}
+
+fn mcp_server_status_from_acpx_profile(server: &AcpxMcpServerConfig) -> McpServerStatus {
+    let command = server.command.as_str();
+    stdio_mcp_server_status(command, None)
+}
+
+fn disabled_mcp_server_status() -> McpServerStatus {
+    let kind = McpServerStatusKind::Disabled;
+    let auth = McpAuthStatus::Unknown;
+    let last_error = None;
+    McpServerStatus {
+        kind,
+        auth,
+        last_error,
+    }
+}
+
+fn stdio_mcp_server_status(command: &str, cwd: Option<&Path>) -> McpServerStatus {
+    let auth = McpAuthStatus::Unsupported;
+
+    let cwd_result = validate_stdio_cwd(cwd);
+    if let Err(last_error) = cwd_result {
+        let status = McpServerStatus {
+            kind: McpServerStatusKind::Failed,
+            auth,
+            last_error: Some(last_error),
+        };
+        return status;
+    }
+
+    let command_result = validate_stdio_command(command, cwd);
+    if let Err(last_error) = command_result {
+        let status = McpServerStatus {
+            kind: McpServerStatusKind::Failed,
+            auth,
+            last_error: Some(last_error),
+        };
+        return status;
+    }
+
+    let kind = McpServerStatusKind::Pending;
+    let last_error = None;
+    McpServerStatus {
+        kind,
+        auth,
+        last_error,
+    }
+}
+
+fn validate_stdio_command(command: &str, cwd: Option<&Path>) -> Result<(), String> {
+    let trimmed_command = command.trim();
+    if trimmed_command.is_empty() {
+        let error = "stdio_command_missing".to_owned();
+        return Err(error);
+    }
+
+    let command_path = Path::new(trimmed_command);
+    let is_path_like = command_path.components().count() > 1;
+
+    if command_path.is_absolute() {
+        let path_exists = command_path.is_file();
+        if path_exists {
+            return Ok(());
+        }
+
+        let rendered_command = command_path.display().to_string();
+        let error = format!("stdio_command_not_found: {rendered_command}");
+        return Err(error);
+    }
+
+    if is_path_like {
+        let Some(cwd) = cwd else {
+            return Ok(());
+        };
+
+        if !cwd.is_absolute() {
+            return Ok(());
+        }
+
+        let resolved_command = cwd.join(command_path);
+        let path_exists = resolved_command.is_file();
+        if path_exists {
+            return Ok(());
+        }
+
+        let rendered_command = resolved_command.display().to_string();
+        let error = format!("stdio_command_not_found: {rendered_command}");
+        return Err(error);
+    }
+
+    let command_found = which::which(trimmed_command).is_ok();
+    if command_found {
+        return Ok(());
+    }
+
+    let error = format!("stdio_command_not_found: {trimmed_command}");
+    Err(error)
+}
+
+fn validate_stdio_cwd(cwd: Option<&Path>) -> Result<(), String> {
+    let Some(cwd) = cwd else {
+        return Ok(());
+    };
+
+    let cwd_exists = cwd.exists();
+    if !cwd_exists {
+        let is_absolute = cwd.is_absolute();
+        if !is_absolute {
+            return Ok(());
+        }
+
+        let rendered_cwd = cwd.display().to_string();
+        let error = format!("stdio_cwd_not_found: {rendered_cwd}");
+        return Err(error);
+    }
+
+    let is_directory = cwd.is_dir();
+    if is_directory {
+        return Ok(());
+    }
+
+    let rendered_cwd = cwd.display().to_string();
+    let error = format!("stdio_cwd_not_directory: {rendered_cwd}");
+    Err(error)
+}
+
+fn streamable_http_mcp_server_status(
+    raw_url: &str,
+    bearer_token_env_var: Option<&str>,
+    http_headers: &BTreeMap<String, String>,
+    env_http_headers: &BTreeMap<String, String>,
+) -> McpServerStatus {
+    let auth_state =
+        resolve_streamable_http_auth_state(bearer_token_env_var, http_headers, env_http_headers);
+    let url_result = validate_streamable_http_url(raw_url);
+
+    if let Err(last_error) = url_result {
+        let status = McpServerStatus {
+            kind: McpServerStatusKind::Failed,
+            auth: auth_state.auth,
+            last_error: Some(last_error),
+        };
+        return status;
+    }
+
+    if let Some(last_error) = auth_state.last_error {
+        let status = McpServerStatus {
+            kind: McpServerStatusKind::NeedsAuth,
+            auth: auth_state.auth,
+            last_error: Some(last_error),
+        };
+        return status;
+    }
+
+    let kind = McpServerStatusKind::Pending;
+    let auth = auth_state.auth;
+    let last_error = None;
+    McpServerStatus {
+        kind,
+        auth,
+        last_error,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StreamableHttpAuthState {
+    auth: McpAuthStatus,
+    last_error: Option<String>,
+}
+
+fn resolve_streamable_http_auth_state(
+    bearer_token_env_var: Option<&str>,
+    http_headers: &BTreeMap<String, String>,
+    env_http_headers: &BTreeMap<String, String>,
+) -> StreamableHttpAuthState {
+    if let Some(env_var_name) = bearer_token_env_var {
+        let trimmed_name = env_var_name.trim();
+        let env_is_present = environment_variable_has_value(trimmed_name);
+        if env_is_present {
+            let auth = McpAuthStatus::BearerToken;
+            let state = StreamableHttpAuthState {
+                auth,
+                last_error: None,
+            };
+            return state;
+        }
+
+        let error = format!("streamable_http_bearer_token_env_missing: {trimmed_name}");
+        let state = StreamableHttpAuthState {
+            auth: McpAuthStatus::NotLoggedIn,
+            last_error: Some(error),
+        };
+        return state;
+    }
+
+    let env_auth_header = find_header_ignore_case(env_http_headers, "authorization");
+    if let Some(env_var_name) = env_auth_header {
+        let trimmed_name = env_var_name.trim();
+        let env_is_present = environment_variable_has_value(trimmed_name);
+        if env_is_present {
+            let auth = McpAuthStatus::Unknown;
+            let state = StreamableHttpAuthState {
+                auth,
+                last_error: None,
+            };
+            return state;
+        }
+
+        let error = format!("streamable_http_auth_header_env_missing: {trimmed_name}");
+        let state = StreamableHttpAuthState {
+            auth: McpAuthStatus::NotLoggedIn,
+            last_error: Some(error),
+        };
+        return state;
+    }
+
+    let static_auth_header = find_header_ignore_case(http_headers, "authorization");
+    if let Some(static_auth_header) = static_auth_header {
+        let trimmed_header = static_auth_header.trim();
+        let normalized_header = trimmed_header.to_ascii_lowercase();
+        let is_bearer_header = normalized_header.starts_with("bearer ");
+        let auth = if is_bearer_header {
+            McpAuthStatus::BearerToken
+        } else {
+            McpAuthStatus::Unknown
+        };
+        let state = StreamableHttpAuthState {
+            auth,
+            last_error: None,
+        };
+        return state;
+    }
+
+    StreamableHttpAuthState {
+        auth: McpAuthStatus::Unknown,
+        last_error: None,
+    }
+}
+
+fn validate_streamable_http_url(raw_url: &str) -> Result<(), String> {
+    let parsed_url = reqwest::Url::parse(raw_url);
+    let parsed_url = match parsed_url {
+        Ok(parsed_url) => parsed_url,
+        Err(_) => {
+            let error = "streamable_http_url_invalid: expected http:// or https:// URL".to_owned();
+            return Err(error);
+        }
+    };
+
+    let scheme = parsed_url.scheme();
+    let is_supported_scheme = matches!(scheme, "http" | "https");
+    if is_supported_scheme {
+        return Ok(());
+    }
+
+    let error = "streamable_http_url_invalid: expected http:// or https:// URL".to_owned();
+    Err(error)
+}
+
+fn environment_variable_has_value(name: &str) -> bool {
+    let value = std::env::var_os(name);
+    let Some(value) = value else {
+        return false;
+    };
+
+    let is_empty = value.to_string_lossy().trim().is_empty();
+    !is_empty
+}
+
+fn find_header_ignore_case<'a>(
+    headers: &'a BTreeMap<String, String>,
+    expected_name: &str,
+) -> Option<&'a str> {
+    for (name, value) in headers {
+        let is_match = name.eq_ignore_ascii_case(expected_name);
+        if !is_match {
+            continue;
+        }
+
+        let value = value.as_str();
+        return Some(value);
+    }
+
+    None
 }
 
 fn canonical_server_name(raw: &str) -> CliResult<String> {
@@ -553,20 +875,40 @@ fn stdio_launch_spec_from_config(
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
     use std::path::PathBuf;
 
     use crate::config::{AcpConfig, AcpxMcpServerConfig};
+    use crate::test_support::ScopedEnv;
+    use crate::test_support::unique_temp_dir;
 
     use super::*;
     use crate::mcp::config::{McpConfig, McpServerConfig, McpServerTransportConfig};
 
+    fn existing_test_command() -> String {
+        let current_executable = std::env::current_exe().expect("current executable path");
+        current_executable.display().to_string()
+    }
+
+    fn missing_test_command_path(label: &str) -> String {
+        let root = unique_temp_dir(label);
+        let missing_path = root.join("missing-command");
+        missing_path.display().to_string()
+    }
+
     fn configured_stdio_server() -> McpServerConfig {
+        let command = existing_test_command();
+        configured_stdio_server_with_command(command)
+    }
+
+    fn configured_stdio_server_with_command(command: String) -> McpServerConfig {
+        let cwd = std::env::temp_dir();
         McpServerConfig {
             transport: McpServerTransportConfig::Stdio {
-                command: "uvx".to_owned(),
+                command,
                 args: vec!["context7-mcp".to_owned()],
                 env: BTreeMap::from([("API_TOKEN".to_owned(), "secret".to_owned())]),
-                cwd: Some(PathBuf::from("/workspace/repo")),
+                cwd: Some(cwd),
             },
             enabled: true,
             required: false,
@@ -579,6 +921,8 @@ mod tests {
 
     #[test]
     fn collect_mcp_runtime_snapshot_includes_config_servers_and_bootstrap_selection() {
+        let expected_command = existing_test_command();
+        let expected_cwd = std::env::temp_dir().display().to_string();
         let config = LoongClawConfig {
             mcp: McpConfig {
                 servers: BTreeMap::from([("Docs".to_owned(), configured_stdio_server())]),
@@ -603,6 +947,7 @@ mod tests {
         assert_eq!(server.name, "docs");
         assert!(server.selected_for_acp_bootstrap);
         assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
         assert_eq!(server.enabled_tools, vec!["search".to_owned()]);
         assert_eq!(server.disabled_tools, vec!["write".to_owned()]);
 
@@ -619,9 +964,9 @@ mod tests {
         assert_eq!(
             server.transport,
             McpTransportSnapshot::Stdio {
-                command: "uvx".to_owned(),
+                command: expected_command,
                 args: vec!["context7-mcp".to_owned()],
-                cwd: Some("/workspace/repo".to_owned()),
+                cwd: Some(expected_cwd),
                 env_var_names: vec!["API_TOKEN".to_owned()],
             }
         );
@@ -629,6 +974,7 @@ mod tests {
 
     #[test]
     fn collect_mcp_runtime_snapshot_includes_acpx_profile_servers() {
+        let expected_command = existing_test_command();
         let config = LoongClawConfig {
             acp: AcpConfig {
                 backends: crate::config::AcpBackendProfilesConfig {
@@ -636,7 +982,7 @@ mod tests {
                         mcp_servers: BTreeMap::from([(
                             "filesystem".to_owned(),
                             AcpxMcpServerConfig {
-                                command: "npx".to_owned(),
+                                command: expected_command,
                                 args: vec![
                                     "-y".to_owned(),
                                     "@modelcontextprotocol/server-filesystem".to_owned(),
@@ -670,10 +1016,12 @@ mod tests {
 
         assert!(has_acpx_origin);
         assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
     }
 
     #[test]
     fn collect_mcp_runtime_snapshot_redacts_acpx_profile_servers() {
+        let expected_command = existing_test_command();
         let config = LoongClawConfig {
             acp: AcpConfig {
                 backends: crate::config::AcpBackendProfilesConfig {
@@ -681,7 +1029,7 @@ mod tests {
                         mcp_servers: BTreeMap::from([(
                             "filesystem".to_owned(),
                             AcpxMcpServerConfig {
-                                command: "npx".to_owned(),
+                                command: expected_command.clone(),
                                 args: vec![
                                     "--apiKey=secret".to_owned(),
                                     "-H".to_owned(),
@@ -712,7 +1060,7 @@ mod tests {
         assert_eq!(
             server.transport,
             McpTransportSnapshot::Stdio {
-                command: "npx".to_owned(),
+                command: expected_command,
                 args: vec![
                     "--apiKey=<redacted>".to_owned(),
                     "-H".to_owned(),
@@ -849,6 +1197,7 @@ mod tests {
 
     #[test]
     fn registry_resolves_injectable_stdio_launch_specs_from_shared_mcp_config() {
+        let expected_command = existing_test_command();
         let config = LoongClawConfig {
             mcp: McpConfig {
                 servers: BTreeMap::from([("Docs".to_owned(), configured_stdio_server())]),
@@ -868,7 +1217,7 @@ mod tests {
         assert_eq!(selected_names, vec!["docs".to_owned()]);
         assert_eq!(launch_specs.len(), 1);
         assert_eq!(launch_specs[0].name, "docs");
-        assert_eq!(launch_specs[0].command, "uvx");
+        assert_eq!(launch_specs[0].command, expected_command);
         assert_eq!(launch_specs[0].args, vec!["context7-mcp".to_owned()]);
         assert_eq!(
             launch_specs[0].env,
@@ -936,6 +1285,438 @@ mod tests {
             .expect_err("http server must be rejected for ACPX injection");
 
         assert!(error.contains("streamable_http"), "error={error}");
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_stdio_server_failed_when_command_missing() {
+        let missing_command = missing_test_command_path("loongclaw-mcp-missing-command");
+        let server = configured_stdio_server_with_command(missing_command.clone());
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert!(
+            last_error.contains("stdio_command_not_found"),
+            "last_error={last_error}"
+        );
+        assert!(
+            last_error.contains(missing_command.as_str()),
+            "last_error={last_error}"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_relative_stdio_command_pending_when_absolute_cwd_contains_command()
+     {
+        let cwd = unique_temp_dir("loongclaw-mcp-relative-command-cwd");
+        std::fs::create_dir_all(&cwd).expect("create command cwd");
+        let command_path = cwd.join("fake-mcp");
+        std::fs::write(&command_path, "#!/bin/sh\n").expect("write fake command");
+
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command: "./fake-mcp".to_owned(),
+                args: Vec::new(),
+                env: BTreeMap::new(),
+                cwd: Some(cwd),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert_eq!(server.status.last_error, None);
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_stdio_server_failed_when_absolute_cwd_missing() {
+        let command = existing_test_command();
+        let missing_cwd = unique_temp_dir("loongclaw-mcp-missing-cwd").join("missing-cwd");
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command,
+                args: Vec::new(),
+                env: BTreeMap::new(),
+                cwd: Some(missing_cwd.clone()),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+        let expected_cwd = missing_cwd.display().to_string();
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert!(
+            last_error.contains("stdio_cwd_not_found"),
+            "last_error={last_error}"
+        );
+        assert!(
+            last_error.contains(expected_cwd.as_str()),
+            "last_error={last_error}"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_prefers_stdio_cwd_error_for_relative_command_when_absolute_cwd_missing()
+     {
+        let missing_cwd =
+            unique_temp_dir("loongclaw-mcp-relative-command-missing-cwd").join("missing-cwd");
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command: "./fake-mcp".to_owned(),
+                args: Vec::new(),
+                env: BTreeMap::new(),
+                cwd: Some(missing_cwd),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert!(
+            last_error.contains("stdio_cwd_not_found"),
+            "last_error={last_error}"
+        );
+        assert!(
+            !last_error.contains("stdio_command_not_found"),
+            "last_error={last_error}"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_stdio_server_failed_when_absolute_cwd_is_not_directory() {
+        let cwd_root = unique_temp_dir("loongclaw-mcp-cwd-not-directory");
+        std::fs::create_dir_all(&cwd_root).expect("create cwd root");
+        let cwd_file = cwd_root.join("not-a-directory");
+        std::fs::write(&cwd_file, "not a directory").expect("write cwd file");
+        let command = existing_test_command();
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::Stdio {
+                command,
+                args: Vec::new(),
+                env: BTreeMap::new(),
+                cwd: Some(cwd_file.clone()),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("docs server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+        let expected_cwd = cwd_file.display().to_string();
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert!(
+            last_error.contains("stdio_cwd_not_directory"),
+            "last_error={last_error}"
+        );
+        assert!(
+            last_error.contains(expected_cwd.as_str()),
+            "last_error={last_error}"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_streamable_http_server_failed_for_invalid_url() {
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::StreamableHttp {
+                url: "ftp://mcp.example.com".to_owned(),
+                bearer_token_env_var: None,
+                http_headers: BTreeMap::new(),
+                env_http_headers: BTreeMap::new(),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("remote".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("remote server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unknown);
+        assert_eq!(
+            last_error,
+            "streamable_http_url_invalid: expected http:// or https:// URL"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_streamable_http_server_needs_auth_when_bearer_env_missing()
+     {
+        let mut scoped_env = ScopedEnv::new();
+        scoped_env.remove("LOONGCLAW_TEST_MCP_TOKEN_MISSING");
+
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::StreamableHttp {
+                url: "https://mcp.example.com".to_owned(),
+                bearer_token_env_var: Some("LOONGCLAW_TEST_MCP_TOKEN_MISSING".to_owned()),
+                http_headers: BTreeMap::new(),
+                env_http_headers: BTreeMap::new(),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("remote".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("remote server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("needs_auth server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::NeedsAuth);
+        assert_eq!(server.status.auth, McpAuthStatus::NotLoggedIn);
+        assert_eq!(
+            last_error,
+            "streamable_http_bearer_token_env_missing: LOONGCLAW_TEST_MCP_TOKEN_MISSING"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_streamable_http_server_needs_auth_when_bearer_env_blank()
+    {
+        let mut scoped_env = ScopedEnv::new();
+        scoped_env.set("LOONGCLAW_TEST_MCP_TOKEN_BLANK", OsString::from("   "));
+
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::StreamableHttp {
+                url: "https://mcp.example.com".to_owned(),
+                bearer_token_env_var: Some("LOONGCLAW_TEST_MCP_TOKEN_BLANK".to_owned()),
+                http_headers: BTreeMap::new(),
+                env_http_headers: BTreeMap::new(),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("remote".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("remote server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("needs_auth server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::NeedsAuth);
+        assert_eq!(server.status.auth, McpAuthStatus::NotLoggedIn);
+        assert_eq!(
+            last_error,
+            "streamable_http_bearer_token_env_missing: LOONGCLAW_TEST_MCP_TOKEN_BLANK"
+        );
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_streamable_http_server_ready_when_bearer_env_present() {
+        let mut scoped_env = ScopedEnv::new();
+        let token_value = OsString::from("test-token");
+        scoped_env.set("LOONGCLAW_TEST_MCP_TOKEN_PRESENT", token_value);
+
+        let server = McpServerConfig {
+            transport: McpServerTransportConfig::StreamableHttp {
+                url: "https://mcp.example.com".to_owned(),
+                bearer_token_env_var: Some("LOONGCLAW_TEST_MCP_TOKEN_PRESENT".to_owned()),
+                http_headers: BTreeMap::new(),
+                env_http_headers: BTreeMap::new(),
+            },
+            enabled: true,
+            required: false,
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+        };
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("remote".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("remote server");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Pending);
+        assert_eq!(server.status.auth, McpAuthStatus::BearerToken);
+        assert_eq!(server.status.last_error, None);
+    }
+
+    #[test]
+    fn collect_mcp_runtime_snapshot_marks_acpx_profile_server_failed_when_command_missing() {
+        let missing_command = missing_test_command_path("loongclaw-acpx-mcp-missing-command");
+        let config = LoongClawConfig {
+            acp: AcpConfig {
+                backends: crate::config::AcpBackendProfilesConfig {
+                    acpx: Some(crate::config::AcpxBackendConfig {
+                        mcp_servers: BTreeMap::from([(
+                            "filesystem".to_owned(),
+                            AcpxMcpServerConfig {
+                                command: missing_command,
+                                args: Vec::new(),
+                                env: BTreeMap::new(),
+                            },
+                        )]),
+                        ..crate::config::AcpxBackendConfig::default()
+                    }),
+                },
+                ..AcpConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let snapshot = collect_mcp_runtime_snapshot(&config).expect("collect MCP snapshot");
+        let server = snapshot.servers.first().expect("filesystem server");
+        let last_error = server
+            .status
+            .last_error
+            .as_deref()
+            .expect("failed server should expose last_error");
+
+        assert_eq!(server.status.kind, McpServerStatusKind::Failed);
+        assert_eq!(server.status.auth, McpAuthStatus::Unsupported);
+        assert!(
+            last_error.contains("stdio_command_not_found"),
+            "last_error={last_error}"
+        );
+    }
+
+    #[test]
+    fn registry_rejects_failed_stdio_servers_for_acpx_injection() {
+        let missing_command = missing_test_command_path("loongclaw-mcp-injection-missing-command");
+        let server = configured_stdio_server_with_command(missing_command);
+        let config = LoongClawConfig {
+            mcp: McpConfig {
+                servers: BTreeMap::from([("docs".to_owned(), server)]),
+            },
+            ..LoongClawConfig::default()
+        };
+
+        let registry = McpRegistry::from_config(&config).expect("registry");
+        let requested_names = vec!["docs".to_owned()];
+        let selected_names = registry
+            .resolve_selected_server_names(&requested_names)
+            .expect("selected names");
+        let error = registry
+            .resolve_injectable_stdio_launch_specs(&selected_names)
+            .expect_err("failed stdio servers must be rejected for ACPX injection");
+
+        assert!(error.contains("not launchable"), "error={error}");
+        assert!(error.contains("stdio_command_not_found"), "error={error}");
     }
 
     #[test]

--- a/crates/daemon/src/mcp_cli.rs
+++ b/crates/daemon/src/mcp_cli.rs
@@ -167,7 +167,7 @@ pub(crate) fn render_mcp_servers_snapshot_text(
                 .collect::<Vec<_>>()
                 .join(",");
             let transport = render_mcp_transport_summary(&server.transport);
-            lines.push(format!(
+            let mut line = format!(
                 "- {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
                 server.name,
                 mcp_server_status_kind_str(server.status.kind),
@@ -175,7 +175,12 @@ pub(crate) fn render_mcp_servers_snapshot_text(
                 server.selected_for_acp_bootstrap,
                 origins,
                 transport
-            ));
+            );
+            if let Some(last_error) = &server.status.last_error {
+                line.push_str(" last_error=");
+                line.push_str(last_error);
+            }
+            lines.push(line);
         }
     }
     if !snapshot.missing_selected_servers.is_empty() {
@@ -243,7 +248,7 @@ pub(crate) fn append_mcp_runtime_snapshot_lines(
                 .collect::<Vec<_>>()
                 .join(",");
             let transport = render_mcp_transport_summary(&server.transport);
-            lines.push(format!(
+            let mut line = format!(
                 "  acp_mcp {} status={} auth={} selected_for_acp_bootstrap={} origins={} transport={}",
                 server.name,
                 mcp_server_status_kind_str(server.status.kind),
@@ -251,7 +256,12 @@ pub(crate) fn append_mcp_runtime_snapshot_lines(
                 server.selected_for_acp_bootstrap,
                 origins,
                 transport
-            ));
+            );
+            if let Some(last_error) = &server.status.last_error {
+                line.push_str(" last_error=");
+                line.push_str(last_error);
+            }
+            lines.push(line);
         }
     }
 
@@ -376,4 +386,74 @@ pub(crate) fn normalize_mcp_server_name(raw: &str) -> CliResult<String> {
         return Err("MCP server name must not be empty".to_owned());
     }
     Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failed_stdio_server() -> mvp::mcp::McpRuntimeServerSnapshot {
+        mvp::mcp::McpRuntimeServerSnapshot {
+            name: "docs".to_owned(),
+            enabled: true,
+            required: false,
+            selected_for_acp_bootstrap: true,
+            origins: vec![mvp::mcp::McpServerOrigin {
+                kind: mvp::mcp::McpServerOriginKind::Config,
+                source_id: None,
+            }],
+            status: mvp::mcp::McpServerStatus {
+                kind: mvp::mcp::McpServerStatusKind::Failed,
+                auth: mvp::mcp::McpAuthStatus::Unsupported,
+                last_error: Some("stdio_command_not_found: /tmp/missing".to_owned()),
+            },
+            transport: mvp::mcp::McpTransportSnapshot::Stdio {
+                command: "/tmp/missing".to_owned(),
+                args: Vec::new(),
+                cwd: None,
+                env_var_names: Vec::new(),
+            },
+            enabled_tools: Vec::new(),
+            disabled_tools: Vec::new(),
+            startup_timeout_ms: None,
+            tool_timeout_ms: None,
+        }
+    }
+
+    #[test]
+    fn render_mcp_servers_snapshot_text_includes_last_error_for_failed_servers() {
+        let snapshot = mvp::mcp::McpRuntimeSnapshot {
+            servers: vec![failed_stdio_server()],
+            missing_selected_servers: Vec::new(),
+        };
+
+        let rendered = render_mcp_servers_snapshot_text("/tmp/loongclaw.toml", &snapshot);
+
+        assert!(rendered.contains("status=failed"), "rendered={rendered}");
+        assert!(
+            rendered.contains("last_error=stdio_command_not_found: /tmp/missing"),
+            "rendered={rendered}"
+        );
+    }
+
+    #[test]
+    fn append_mcp_runtime_snapshot_lines_includes_last_error_for_failed_servers() {
+        let snapshot = mvp::mcp::McpRuntimeSnapshot {
+            servers: vec![failed_stdio_server()],
+            missing_selected_servers: Vec::new(),
+        };
+        let mut lines = Vec::new();
+
+        append_mcp_runtime_snapshot_lines(&mut lines, &snapshot);
+
+        let rendered = lines.join("\n");
+        assert!(
+            rendered.contains("acp_mcp docs status=failed"),
+            "rendered={rendered}"
+        );
+        assert!(
+            rendered.contains("last_error=stdio_command_not_found: /tmp/missing"),
+            "rendered={rendered}"
+        );
+    }
 }

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -99,6 +99,12 @@ impl Drop for RuntimeSnapshotPolicyResetGuard {
 
 fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongClawConfig) {
     fs::create_dir_all(root).expect("create fixture root");
+    let workspace_root = root.join("workspace");
+    fs::create_dir_all(&workspace_root).expect("create workspace fixture root");
+    let mcp_command = std::env::current_exe()
+        .expect("current executable path for MCP fixture")
+        .display()
+        .to_string();
 
     let mut config = mvp::config::LoongClawConfig::default();
     config.tools.file_root = Some(root.display().to_string());
@@ -123,13 +129,13 @@ fn write_runtime_snapshot_config(root: &Path) -> (PathBuf, mvp::config::LoongCla
         "docs".to_owned(),
         mvp::mcp::McpServerConfig {
             transport: mvp::mcp::McpServerTransportConfig::Stdio {
-                command: "uvx".to_owned(),
+                command: mcp_command,
                 args: vec!["context7-mcp".to_owned()],
                 env: std::collections::BTreeMap::from([(
                     "API_TOKEN".to_owned(),
                     "secret".to_owned(),
                 )]),
-                cwd: Some(root.join("workspace")),
+                cwd: Some(workspace_root),
             },
             enabled: true,
             required: false,


### PR DESCRIPTION
## Summary

- Problem:
  MCP runtime snapshots and MCP CLI operator surfaces defaulted many enabled servers to `status=pending` and `auth=unknown` even when local config already proved the server could not launch or lacked explicit bearer auth.
- Why it matters:
  ACP bootstrap, `list-mcp-servers`, `show-mcp-server`, and runtime snapshot/operator surfaces should help operators catch local MCP misconfiguration before downstream failures, not hide it behind generic pending state.
- What changed:
  - derive deterministic MCP readiness/auth state from local config/runtime facts in `crates/app/src/mcp/registry.rs`
  - fail stdio snapshots for missing commands, invalid absolute `cwd`, and non-directory absolute `cwd`
  - resolve relative/path-like stdio commands against an existing absolute `cwd` instead of the inspector process cwd
  - fail streamable HTTP snapshots for invalid URLs and surface `needs_auth`/`not_logged_in` when explicit bearer auth env is missing or blank
  - reject failed stdio MCP entries for ACPX injection earlier via the shared MCP registry
  - include `last_error=` in MCP CLI/runtime-snapshot summary lines when a server is failed or needs auth
  - make the runtime-snapshot integration fixture use a real launchable command and existing workspace directory so the happy-path snapshot remains truthful and stable
- What did not change (scope boundary):
  - no live MCP health probes, background managers, or network connection attempts
  - no OAuth flows or token refresh behavior
  - no provider-specific auth heuristics beyond explicit bearer-env and authorization-header facts already present in config

## Linked Issues

- Closes #1153
- Related #221

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-app mcp::registry::tests:: --lib -- --test-threads=1
cargo test -p loongclaw mcp_cli::tests:: --lib -- --test-threads=1
cargo test -p loongclaw --test integration runtime_snapshot_text_highlights_experiment_relevant_sections -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-mcp-fullverify-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-mcp-fullverify-target cargo test --workspace --locked -q
CARGO_TARGET_DIR=/tmp/loongclaw-mcp-fullverify-target cargo test --workspace --all-features --locked -q
./scripts/check_architecture_boundaries.sh

Results:
- targeted MCP registry tests: 25 passed
- targeted MCP CLI tests: 2 passed
- targeted runtime snapshot integration test: 1 passed
- workspace locked tests: passed
- workspace all-features tests: passed
- architecture boundaries: passed
```

## User-visible / Operator-visible Changes

- `loong list-mcp-servers`, `loong show-mcp-server`, and runtime snapshot ACP MCP summaries now surface deterministic `failed` / `needs_auth` states and include the underlying `last_error` when local config proves a problem.
- Relative stdio commands such as `./server` remain valid when the configured absolute `cwd` contains the command, instead of being misclassified from the inspector's own cwd.
- Explicit bearer auth env vars that are unset or blank now show `needs_auth` / `not_logged_in` instead of a misleading ready state.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `979dc35dd` to restore the previous MCP snapshot inference and CLI summary rendering.
- Observable failure symptoms reviewers should watch for:
  Unexpected MCP servers changing from `pending` to `failed` because the local machine genuinely lacks the configured command or absolute `cwd`; if this looks too aggressive, inspect the surfaced `last_error` and the configured path/command first.

## Reviewer Focus

- `crates/app/src/mcp/registry.rs`: stdio path/cwd resolution order, streamable HTTP auth inference, and ACPX injection gating.
- `crates/daemon/src/mcp_cli.rs`: whether summary rendering exposes enough failure detail without over-noising healthy output.
- `crates/daemon/tests/integration/runtime_snapshot_cli.rs`: happy-path fixture realism after the snapshot truthfulness change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now includes per-server failure details (last_error) in status output.
  * Servers that require credentials are explicitly indicated.

* **Improvements**
  * More consistent and strict server status validation across sources.
  * Injection now rejects servers that are not launchable, reducing runtime surprises.
  * Clearer, specific failure reasons to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->