### PR TITLE
fix: use $PSScriptRoot instead of MyCommand.Path in install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -105,7 +105,7 @@ function Install-Binary([string]$SourceBinary) {
 }
 
 function Install-FromSource {
-    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $scriptDir = $PSScriptRoot
     $repoRoot = Resolve-Path (Join-Path $scriptDir "..")
     $cargoToml = Join-Path $repoRoot "Cargo.toml"
     if (-not (Test-Path $cargoToml)) {


### PR DESCRIPTION
this fixes a powershell source install error where `$MyInvocation.MyCommand.Path` can be null in some environments.

using `$PSScriptRoot` is the standard and more reliable way to resolve the script directory on powershell 3.0+.

fixes the failure where `install.ps1 -Source` can raise:
`ParentContainsErrorRecordException: The property Path cannot be found`