### PR TITLE
Keep background task creation alive after one-shot CLI exit

### DIFF
--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -81,7 +81,8 @@ pub use runtime::{
     ContextEngineRuntimeSnapshot, ContextEngineSelection, ContextEngineSelectionSource,
     ConversationRuntime, DefaultConversationRuntime, SessionContext, TurnMiddlewareRuntimeSnapshot,
     TurnMiddlewareSelection, TurnMiddlewareSelectionSource,
-    collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
+    async_delegate_spawn_request_from_serialized_parts, collect_context_engine_runtime_snapshot,
+    execute_async_delegate_spawn_request, resolve_context_engine_selection,
     resolve_turn_middleware_selection,
 };
 pub use runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -693,6 +693,51 @@ pub struct AsyncDelegateSpawnRequest {
     pub binding: OwnedConversationRuntimeBinding,
 }
 
+impl AsyncDelegateSpawnRequest {
+    pub fn runtime_self_continuity_json(&self) -> Result<Option<Value>, String> {
+        let continuity = self.runtime_self_continuity.as_ref();
+        let encoded_continuity =
+            continuity
+                .map(serde_json::to_value)
+                .transpose()
+                .map_err(|error| {
+                    format!("serialize async delegate runtime-self continuity failed: {error}")
+                })?;
+
+        Ok(encoded_continuity)
+    }
+}
+
+pub fn async_delegate_spawn_request_from_serialized_parts(
+    child_session_id: String,
+    parent_session_id: String,
+    task: String,
+    label: Option<String>,
+    profile: Option<DelegateBuiltinProfile>,
+    execution: ConstrainedSubagentExecution,
+    runtime_self_continuity_json: Option<Value>,
+    timeout_seconds: u64,
+    binding: OwnedConversationRuntimeBinding,
+) -> Result<AsyncDelegateSpawnRequest, String> {
+    let runtime_self_continuity = runtime_self_continuity_json
+        .map(serde_json::from_value::<RuntimeSelfContinuity>)
+        .transpose()
+        .map_err(|error| format!("parse async delegate runtime-self continuity failed: {error}"))?;
+    let request = AsyncDelegateSpawnRequest {
+        child_session_id,
+        parent_session_id,
+        task,
+        label,
+        profile,
+        execution,
+        runtime_self_continuity,
+        timeout_seconds,
+        binding,
+    };
+
+    Ok(request)
+}
+
 #[async_trait]
 pub trait AsyncDelegateSpawner: Send + Sync {
     async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String>;
@@ -717,84 +762,99 @@ impl DefaultAsyncDelegateSpawner {
 #[async_trait]
 impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
     async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
-        let AsyncDelegateSpawnRequest {
-            child_session_id,
-            parent_session_id,
-            task,
-            label,
-            profile,
-            execution,
-            runtime_self_continuity,
-            timeout_seconds,
-            binding,
-        } = request;
-
-        let execution_timeout_seconds = execution.timeout_seconds;
-        if timeout_seconds != execution_timeout_seconds {
-            return Err(format!(
-                "async_delegate_timeout_mismatch: request timeout {} != execution timeout {}",
-                timeout_seconds, execution_timeout_seconds
-            ));
-        }
-
-        let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(
-            &self.config.memory,
-        ))?;
-        let runtime = DefaultConversationRuntime::from_config_or_env(self.config.as_ref())?;
-        let runtime_ref = &runtime;
-        let child_session_id_for_spawn = child_session_id.clone();
-        let parent_session_id_for_spawn = parent_session_id.clone();
-        let borrowed_binding = binding.as_borrowed();
-        let child_binding = binding.clone();
-        super::delegate_support::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
-            runtime_ref,
-            &parent_session_id,
-            &child_session_id,
-            borrowed_binding,
-            move || async move {
-                let started = repo.transition_session_with_event_if_current(
-                    &child_session_id_for_spawn,
-                    TransitionSessionWithEventIfCurrentRequest {
-                        expected_state: SessionState::Ready,
-                        next_state: SessionState::Running,
-                        last_error: None,
-                        event_kind: "delegate_started".to_owned(),
-                        actor_session_id: Some(parent_session_id_for_spawn.clone()),
-                        event_payload_json: execution
-                            .spawn_payload_with_profile_and_runtime_self_continuity(
-                                &task,
-                                label.as_deref(),
-                                profile,
-                                runtime_self_continuity.as_ref(),
-                            ),
-                    },
-                )?;
-                if started.is_none() {
-                    return Err(format!(
-                        "async_delegate_spawn_skipped: session `{}` was not in Ready state",
-                        child_session_id_for_spawn
-                    ));
-                }
-
-                let _ = super::turn_coordinator::run_started_delegate_child_turn_with_runtime(
-                    self.config.as_ref(),
-                    runtime_ref,
-                    &child_session_id_for_spawn,
-                    &parent_session_id_for_spawn,
-                    label,
-                    &task,
-                    profile,
-                    execution,
-                    execution_timeout_seconds,
-                    child_binding.as_borrowed(),
-                )
-                .await;
-                Ok(())
-            },
-        )
-        .await?;
+        execute_async_delegate_spawn_request(self.config.as_ref(), request).await?;
         Ok(())
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn execute_async_delegate_spawn_request(
+    config: &LoongClawConfig,
+    request: AsyncDelegateSpawnRequest,
+) -> Result<(), String> {
+    let AsyncDelegateSpawnRequest {
+        child_session_id,
+        parent_session_id,
+        task,
+        label,
+        profile,
+        execution,
+        runtime_self_continuity,
+        timeout_seconds,
+        binding,
+    } = request;
+
+    let execution_timeout_seconds = execution.timeout_seconds;
+
+    if timeout_seconds != execution_timeout_seconds {
+        return Err(format!(
+            "async_delegate_timeout_mismatch: request timeout {} != execution timeout {}",
+            timeout_seconds, execution_timeout_seconds
+        ));
+    }
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config)?;
+    let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+    let runtime_ref = &runtime;
+    let child_session_id_for_spawn = child_session_id.clone();
+    let parent_session_id_for_spawn = parent_session_id.clone();
+    let borrowed_binding = binding.as_borrowed();
+    let child_binding = binding.clone();
+
+    super::delegate_support::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
+        runtime_ref,
+        &parent_session_id,
+        &child_session_id,
+        borrowed_binding,
+        move || async move {
+            let event_payload_json = execution
+                .spawn_payload_with_profile_and_runtime_self_continuity(
+                    &task,
+                    label.as_deref(),
+                    profile,
+                    runtime_self_continuity.as_ref(),
+                );
+            let transition_request = TransitionSessionWithEventIfCurrentRequest {
+                expected_state: SessionState::Ready,
+                next_state: SessionState::Running,
+                last_error: None,
+                event_kind: "delegate_started".to_owned(),
+                actor_session_id: Some(parent_session_id_for_spawn.clone()),
+                event_payload_json,
+            };
+            let started = repo.transition_session_with_event_if_current(
+                &child_session_id_for_spawn,
+                transition_request,
+            )?;
+
+            if started.is_none() {
+                return Err(format!(
+                    "async_delegate_spawn_skipped: session `{}` was not in Ready state",
+                    child_session_id_for_spawn
+                ));
+            }
+
+            let _ = super::turn_coordinator::run_started_delegate_child_turn_with_runtime(
+                config,
+                runtime_ref,
+                &child_session_id_for_spawn,
+                &parent_session_id_for_spawn,
+                label,
+                &task,
+                profile,
+                execution,
+                execution_timeout_seconds,
+                child_binding.as_borrowed(),
+            )
+            .await;
+
+            Ok(())
+        },
+    )
+    .await?;
+
+    Ok(())
 }
 
 pub struct DefaultConversationRuntime<E = DefaultContextEngine> {
@@ -1248,6 +1308,14 @@ pub trait ConversationRuntime: Send + Sync {
         config: &LoongClawConfig,
     ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
         Some(Arc::new(DefaultAsyncDelegateSpawner::new(config)))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn background_task_spawner(
+        &self,
+        _config: &LoongClawConfig,
+    ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
+        None
     }
 
     async fn bootstrap(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1487,6 +1487,14 @@ impl ConversationRuntime for FakeRuntime {
         self.async_delegate_spawner_override.clone()
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    fn background_task_spawner(
+        &self,
+        _config: &LoongClawConfig,
+    ) -> Option<Arc<dyn crate::conversation::AsyncDelegateSpawner>> {
+        self.async_delegate_spawner_override.clone()
+    }
+
     async fn bootstrap(
         &self,
         _config: &LoongClawConfig,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -46,7 +46,9 @@ use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 #[cfg(feature = "memory-sqlite")]
 use super::delegate_support::{
-    finalize_and_announce_delegate_child_terminal, format_delegate_child_panic,
+    enqueue_delegate_result_announce_with_memory_config,
+    finalize_and_announce_delegate_child_terminal,
+    finalize_async_delegate_spawn_failure_with_recovery, format_delegate_child_panic,
     next_delegate_child_depth_for_delegate, spawn_async_delegate_detached,
 };
 use super::ingress::ConversationIngressContext;
@@ -4079,6 +4081,111 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
     let spawner = runtime
         .async_delegate_spawner(config)
         .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
+    let delegate_request = build_delegate_async_enqueue_request(
+        config,
+        runtime,
+        session_context,
+        delegate_request,
+        binding,
+    )
+    .await?;
+    let detached_config = std::sync::Arc::new(config.clone());
+    spawn_async_delegate_detached(
+        runtime_handle,
+        detached_config,
+        delegate_request.memory_config,
+        spawner,
+        delegate_request.request,
+        config.tools.delegate.max_frozen_bytes,
+        DelegateAnnounceSettings::from_config(config),
+    );
+
+    Ok(delegate_request.outcome)
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn enqueue_background_task_with_runtime<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_context: &SessionContext,
+    delegate_request: crate::tools::delegate::DelegateRequest,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    if !config.tools.delegate.enabled {
+        return Err("app_tool_disabled: delegate is disabled by config".to_owned());
+    }
+
+    let spawner = runtime
+        .background_task_spawner(config)
+        .ok_or_else(|| {
+            "background_task_host_unavailable: current runtime does not provide a durable async background-task host"
+                .to_owned()
+        })?;
+    let delegate_request = build_delegate_async_enqueue_request(
+        config,
+        runtime,
+        session_context,
+        delegate_request,
+        binding,
+    )
+    .await?;
+    let spawn_result = spawner.spawn(delegate_request.request.clone()).await;
+
+    if let Err(error) = spawn_result {
+        finalize_async_delegate_spawn_failure_with_recovery(
+            &delegate_request.memory_config,
+            &delegate_request.request.child_session_id,
+            &delegate_request.request.parent_session_id,
+            delegate_request.request.label.clone(),
+            delegate_request.request.profile,
+            &delegate_request.request.execution,
+            config.tools.delegate.max_frozen_bytes,
+            error.clone(),
+        )?;
+        enqueue_delegate_result_announce_with_memory_config(
+            delegate_request.memory_config.clone(),
+            delegate_request.request.parent_session_id.clone(),
+            delegate_request.request.child_session_id.clone(),
+            DelegateAnnounceSettings::from_config(config),
+        );
+        emit_async_delegate_child_terminal_event(
+            runtime,
+            &delegate_request.request.parent_session_id,
+            &delegate_request.request.child_session_id,
+            delegate_request.request.label.as_deref(),
+            delegate_request.request.profile,
+            "failed",
+            delegate_request.request.execution.isolation,
+            0,
+            None,
+            Some(error.as_str()),
+            None,
+            delegate_request.request.execution.workspace_root.as_deref(),
+            None,
+            binding,
+        )
+        .await;
+        return Err(error);
+    }
+
+    Ok(delegate_request.outcome)
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct PreparedAsyncDelegateEnqueue {
+    memory_config: MemoryRuntimeConfig,
+    request: AsyncDelegateSpawnRequest,
+    outcome: loongclaw_contracts::ToolCoreOutcome,
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_context: &SessionContext,
+    delegate_request: crate::tools::delegate::DelegateRequest,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<PreparedAsyncDelegateEnqueue, String> {
     let delegate_policy =
         crate::tools::delegate::resolve_delegate_policy(&delegate_request, &config.tools.delegate);
     let child_session_id = crate::tools::delegate::next_delegate_session_id();
@@ -4147,26 +4254,17 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         binding,
     )
     .await;
-    let detached_config = std::sync::Arc::new(config.clone());
-    spawn_async_delegate_detached(
-        runtime_handle,
-        detached_config,
-        memory_config,
-        spawner,
-        AsyncDelegateSpawnRequest {
-            child_session_id: child_session_id.clone(),
-            parent_session_id: session_context.session_id.clone(),
-            task: delegate_request.task,
-            label: child_label,
-            profile: delegate_policy.profile,
-            execution: queued_execution,
-            runtime_self_continuity,
-            timeout_seconds: delegate_policy.timeout_seconds,
-            binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
-        },
-        config.tools.delegate.max_frozen_bytes,
-        DelegateAnnounceSettings::from_config(config),
-    );
+    let request = AsyncDelegateSpawnRequest {
+        child_session_id: child_session_id.clone(),
+        parent_session_id: session_context.session_id.clone(),
+        task: delegate_request.task,
+        label: child_label,
+        profile: delegate_policy.profile,
+        execution: queued_execution,
+        runtime_self_continuity,
+        timeout_seconds: delegate_policy.timeout_seconds,
+        binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
+    };
 
     let mut outcome = crate::tools::delegate::delegate_async_queued_outcome(
         child_session_id,
@@ -4176,7 +4274,12 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         delegate_policy.timeout_seconds,
     );
     inject_delegate_workspace_metadata(&mut outcome, &execution, None, None);
-    Ok(outcome)
+
+    Ok(PreparedAsyncDelegateEnqueue {
+        memory_config,
+        request,
+        outcome,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4211,7 +4314,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     }
     let delegate_request =
         crate::tools::delegate::parse_delegate_request_with_default_timeout(&delegate_payload)?;
-    enqueue_delegate_async_with_runtime(
+    enqueue_background_task_with_runtime(
         config,
         runtime,
         &session_context,

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -58,6 +58,7 @@ libc = "0.2"
 
 
 [dependencies]
+async-trait.workspace = true
 axum = { workspace = true, features = ["query"] }
 clap.workspace = true
 clap_complete = "4.5"

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -25,6 +25,7 @@ impl Commands {
             Self::Audit { .. } => "audit",
             Self::Skills { .. } => "skills",
             Self::Tasks { .. } => "tasks",
+            Self::DelegateChildRun { .. } => "delegate_child_run",
             Self::Sessions { .. } => "sessions",
             Self::Plugins { .. } => "plugins",
             Self::Channels { .. } => "channels",

--- a/crates/daemon/src/delegate_child_cli.rs
+++ b/crates/daemon/src/delegate_child_cli.rs
@@ -108,19 +108,15 @@ pub(crate) fn spawn_detached_delegate_child_process(
 
             if let Some(exit_status) = startup_status {
                 let stderr = read_detached_delegate_child_stderr(&mut child);
-                let status_code = exit_status
-                    .code()
-                    .map(|code| code.to_string())
-                    .unwrap_or_else(|| "signal".to_owned());
-                let detail = if stderr.trim().is_empty() {
-                    "(empty stderr)".to_owned()
-                } else {
-                    stderr.trim().to_owned()
-                };
                 remove_detached_delegate_child_payload_file(payload_path.as_path());
-                return Err(format!(
-                    "delegate_async_process_spawn_failed: detached delegate child exited during startup with status {status_code}: {detail}"
-                ));
+                let startup_failure =
+                    detached_delegate_child_startup_failure(&exit_status, stderr.as_str());
+
+                if let Some(startup_failure) = startup_failure {
+                    return Err(startup_failure);
+                }
+
+                return Ok(());
             }
 
             Ok(())
@@ -144,6 +140,33 @@ fn read_detached_delegate_child_stderr(child: &mut std::process::Child) -> Strin
     let _ = stderr.read_to_string(&mut buffer);
 
     buffer
+}
+
+fn detached_delegate_child_startup_failure(
+    exit_status: &std::process::ExitStatus,
+    stderr: &str,
+) -> Option<String> {
+    let exited_successfully = exit_status.success();
+
+    if exited_successfully {
+        return None;
+    }
+
+    let status_code = exit_status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "signal".to_owned());
+    let trimmed_stderr = stderr.trim();
+    let detail = if trimmed_stderr.is_empty() {
+        "(empty stderr)".to_owned()
+    } else {
+        trimmed_stderr.to_owned()
+    };
+    let failure = format!(
+        "delegate_async_process_spawn_failed: detached delegate child exited during startup with status {status_code}: {detail}"
+    );
+
+    Some(failure)
 }
 
 pub async fn run_detached_delegate_child_cli(
@@ -274,5 +297,54 @@ fn owned_binding_from_detached_payload(
             let owned_binding = mvp::conversation::OwnedConversationRuntimeBinding::direct();
             Ok(owned_binding)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detached_delegate_child_startup_failure;
+
+    #[cfg(unix)]
+    fn exit_status_for(command: &str) -> std::process::ExitStatus {
+        std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(command)
+            .status()
+            .expect("spawn shell command")
+    }
+
+    #[cfg(windows)]
+    fn exit_status_for(command: &str) -> std::process::ExitStatus {
+        std::process::Command::new("cmd")
+            .args(["/C", command])
+            .status()
+            .expect("spawn cmd command")
+    }
+
+    #[test]
+    fn detached_delegate_child_startup_failure_ignores_fast_success_with_warning_stderr() {
+        #[cfg(unix)]
+        let exit_status = exit_status_for("exit 0");
+        #[cfg(windows)]
+        let exit_status = exit_status_for("exit 0");
+
+        let warning_output = "WARN optional runtime-self source missing";
+        let failure = detached_delegate_child_startup_failure(&exit_status, warning_output);
+
+        assert_eq!(failure, None);
+    }
+
+    #[test]
+    fn detached_delegate_child_startup_failure_surfaces_non_zero_exit() {
+        #[cfg(unix)]
+        let exit_status = exit_status_for("exit 7");
+        #[cfg(windows)]
+        let exit_status = exit_status_for("exit 7");
+
+        let failure = detached_delegate_child_startup_failure(&exit_status, "spawn failure");
+
+        let failure = failure.expect("non-zero exit should be reported");
+        assert!(failure.contains("status 7"), "failure={failure}");
+        assert!(failure.contains("spawn failure"), "failure={failure}");
     }
 }

--- a/crates/daemon/src/delegate_child_cli.rs
+++ b/crates/daemon/src/delegate_child_cli.rs
@@ -1,0 +1,278 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use wait_timeout::ChildExt;
+
+use crate::CliResult;
+use crate::mvp;
+
+const DETACHED_DELEGATE_CHILD_COMMAND: &str = "delegate-child-run";
+const DETACHED_DELEGATE_CHILD_CONFIG_ARG: &str = "--config-path";
+const DETACHED_DELEGATE_CHILD_PAYLOAD_ARG: &str = "--payload-file";
+const DETACHED_DELEGATE_CHILD_EXECUTABLE_ENV: &str = "CARGO_BIN_EXE_loong";
+const DETACHED_DELEGATE_CHILD_KERNEL_SCOPE: &str = "delegate-child-worker";
+const DETACHED_DELEGATE_CHILD_PASSTHROUGH_ENV_KEYS: &[&str] =
+    &["LOONGCLAW_CONFIG_PATH", "LOONG_HOME", "LOONGCLAW_HOME"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DetachedDelegateChildBinding {
+    Kernel,
+    Direct,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DetachedDelegateChildPayload {
+    child_session_id: String,
+    parent_session_id: String,
+    task: String,
+    label: Option<String>,
+    profile: Option<mvp::conversation::DelegateBuiltinProfile>,
+    execution: mvp::conversation::ConstrainedSubagentExecution,
+    runtime_self_continuity: Option<serde_json::Value>,
+    timeout_seconds: u64,
+    binding: DetachedDelegateChildBinding,
+}
+
+impl DetachedDelegateChildPayload {
+    fn from_request(request: &mvp::conversation::AsyncDelegateSpawnRequest) -> Self {
+        let binding = if request.binding.is_kernel_bound() {
+            DetachedDelegateChildBinding::Kernel
+        } else {
+            DetachedDelegateChildBinding::Direct
+        };
+
+        Self {
+            child_session_id: request.child_session_id.clone(),
+            parent_session_id: request.parent_session_id.clone(),
+            task: request.task.clone(),
+            label: request.label.clone(),
+            profile: request.profile,
+            execution: request.execution.clone(),
+            runtime_self_continuity: request
+                .runtime_self_continuity_json()
+                .expect("delegate payload serialization should succeed"),
+            timeout_seconds: request.timeout_seconds,
+            binding,
+        }
+    }
+
+    fn into_spawn_request(
+        self,
+        binding: mvp::conversation::OwnedConversationRuntimeBinding,
+    ) -> CliResult<mvp::conversation::AsyncDelegateSpawnRequest> {
+        mvp::conversation::async_delegate_spawn_request_from_serialized_parts(
+            self.child_session_id,
+            self.parent_session_id,
+            self.task,
+            self.label,
+            self.profile,
+            self.execution,
+            self.runtime_self_continuity,
+            self.timeout_seconds,
+            binding,
+        )
+    }
+}
+
+pub(crate) fn spawn_detached_delegate_child_process(
+    request: &mvp::conversation::AsyncDelegateSpawnRequest,
+) -> CliResult<()> {
+    let executable_path = resolve_detached_delegate_child_executable_path()?;
+    let config_path = resolve_detached_delegate_child_config_path()?;
+    let payload = DetachedDelegateChildPayload::from_request(request);
+    let payload_path = materialize_detached_delegate_child_payload_file(&payload)?;
+
+    let mut command = std::process::Command::new(&executable_path);
+    command.arg(DETACHED_DELEGATE_CHILD_COMMAND);
+    command.arg(DETACHED_DELEGATE_CHILD_CONFIG_ARG);
+    command.arg(config_path.as_os_str());
+    command.arg(DETACHED_DELEGATE_CHILD_PAYLOAD_ARG);
+    command.arg(payload_path.as_os_str());
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::piped());
+    propagate_detached_delegate_child_environment(&mut command);
+
+    let spawn_result = command.spawn();
+
+    match spawn_result {
+        Ok(mut child) => {
+            let startup_timeout = std::time::Duration::from_millis(500);
+            let startup_status = child.wait_timeout(startup_timeout).map_err(|error| {
+                format!("wait for detached delegate child startup failed: {error}")
+            })?;
+
+            if let Some(exit_status) = startup_status {
+                let stderr = read_detached_delegate_child_stderr(&mut child);
+                let status_code = exit_status
+                    .code()
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "signal".to_owned());
+                let detail = if stderr.trim().is_empty() {
+                    "(empty stderr)".to_owned()
+                } else {
+                    stderr.trim().to_owned()
+                };
+                remove_detached_delegate_child_payload_file(payload_path.as_path());
+                return Err(format!(
+                    "delegate_async_process_spawn_failed: detached delegate child exited during startup with status {status_code}: {detail}"
+                ));
+            }
+
+            Ok(())
+        }
+        Err(error) => {
+            remove_detached_delegate_child_payload_file(payload_path.as_path());
+            Err(format!(
+                "delegate_async_process_spawn_failed: could not launch detached delegate child via `{}`: {error}",
+                executable_path.display()
+            ))
+        }
+    }
+}
+
+fn read_detached_delegate_child_stderr(child: &mut std::process::Child) -> String {
+    let Some(mut stderr) = child.stderr.take() else {
+        return String::new();
+    };
+
+    let mut buffer = String::new();
+    let _ = stderr.read_to_string(&mut buffer);
+
+    buffer
+}
+
+pub async fn run_detached_delegate_child_cli(
+    config_path: &str,
+    payload_file: &str,
+) -> CliResult<()> {
+    let payload_path = PathBuf::from(payload_file);
+    let payload = read_detached_delegate_child_payload_file(payload_path.as_path())?;
+    remove_detached_delegate_child_payload_file(payload_path.as_path());
+
+    let (resolved_path, config) = mvp::config::load(Some(config_path))?;
+    mvp::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+
+    let binding = owned_binding_from_detached_payload(payload.binding, &config)?;
+    let spawn_request = payload.into_spawn_request(binding)?;
+
+    mvp::conversation::execute_async_delegate_spawn_request(&config, spawn_request).await?;
+
+    Ok(())
+}
+
+fn resolve_detached_delegate_child_executable_path() -> CliResult<PathBuf> {
+    let env_path = std::env::var_os(DETACHED_DELEGATE_CHILD_EXECUTABLE_ENV);
+
+    if let Some(env_path) = env_path {
+        let candidate_path = PathBuf::from(env_path);
+        return Ok(candidate_path);
+    }
+
+    let executable_path = std::env::current_exe()
+        .map_err(|error| format!("resolve detached delegate executable failed: {error}"))?;
+
+    Ok(executable_path)
+}
+
+fn resolve_detached_delegate_child_config_path() -> CliResult<PathBuf> {
+    let config_path = std::env::var_os("LOONGCLAW_CONFIG_PATH")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            "delegate_async_process_spawn_failed: LOONGCLAW_CONFIG_PATH is not set for detached delegate child startup"
+                .to_owned()
+        })?;
+
+    Ok(config_path)
+}
+
+fn materialize_detached_delegate_child_payload_file(
+    payload: &DetachedDelegateChildPayload,
+) -> CliResult<PathBuf> {
+    let payload_directory = std::env::temp_dir()
+        .join("loongclaw")
+        .join("delegate-child-payloads");
+    std::fs::create_dir_all(&payload_directory)
+        .map_err(|error| format!("create detached delegate payload directory failed: {error}"))?;
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            format!("read system clock for detached delegate payload failed: {error}")
+        })?;
+    let payload_file_name = format!(
+        "delegate-child-{}-{}.json",
+        std::process::id(),
+        timestamp.as_nanos()
+    );
+    let payload_path = payload_directory.join(payload_file_name);
+    let payload_bytes = serde_json::to_vec(payload)
+        .map_err(|error| format!("serialize detached delegate payload failed: {error}"))?;
+    std::fs::write(&payload_path, payload_bytes)
+        .map_err(|error| format!("write detached delegate payload failed: {error}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = std::fs::metadata(&payload_path)
+            .map_err(|error| format!("stat detached delegate payload failed: {error}"))?;
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(&payload_path, permissions)
+            .map_err(|error| format!("chmod detached delegate payload failed: {error}"))?;
+    }
+
+    Ok(payload_path)
+}
+
+fn read_detached_delegate_child_payload_file(
+    payload_path: &Path,
+) -> CliResult<DetachedDelegateChildPayload> {
+    let payload_bytes = std::fs::read(payload_path)
+        .map_err(|error| format!("read detached delegate payload failed: {error}"))?;
+    let payload = serde_json::from_slice::<DetachedDelegateChildPayload>(&payload_bytes)
+        .map_err(|error| format!("parse detached delegate payload failed: {error}"))?;
+
+    Ok(payload)
+}
+
+fn remove_detached_delegate_child_payload_file(payload_path: &Path) {
+    let _ = std::fs::remove_file(payload_path);
+}
+
+fn propagate_detached_delegate_child_environment(command: &mut std::process::Command) {
+    for env_key in DETACHED_DELEGATE_CHILD_PASSTHROUGH_ENV_KEYS {
+        let env_value = std::env::var_os(env_key);
+
+        if let Some(env_value) = env_value {
+            command.env(env_key, env_value);
+        }
+    }
+}
+
+fn owned_binding_from_detached_payload(
+    binding: DetachedDelegateChildBinding,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<mvp::conversation::OwnedConversationRuntimeBinding> {
+    match binding {
+        DetachedDelegateChildBinding::Kernel => {
+            let kernel_context = mvp::context::bootstrap_kernel_context_with_config(
+                DETACHED_DELEGATE_CHILD_KERNEL_SCOPE,
+                mvp::context::DEFAULT_TOKEN_TTL_S,
+                config,
+            )?;
+            let owned_binding =
+                mvp::conversation::OwnedConversationRuntimeBinding::kernel(kernel_context);
+            Ok(owned_binding)
+        }
+        DetachedDelegateChildBinding::Direct => {
+            let owned_binding = mvp::conversation::OwnedConversationRuntimeBinding::direct();
+            Ok(owned_binding)
+        }
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -37,6 +37,7 @@ pub use self::channel_send_target_kind::{
     default_twitch_send_target_kind, parse_twitch_send_target_kind,
 };
 pub use self::cli_json::build_runtime_snapshot_cli_json_payload;
+pub use self::delegate_child_cli::run_detached_delegate_child_cli;
 pub use self::env_compat::make_env_compatible;
 pub use self::mcp_cli::{
     build_mcp_server_detail_cli_json_payload, build_mcp_servers_cli_json_payload,
@@ -98,6 +99,7 @@ mod command_kind;
 pub mod completions_cli;
 mod control_plane_server;
 mod copilot_onboarding;
+mod delegate_child_cli;
 pub mod doctor_cli;
 pub mod doctor_security_cli;
 mod env_compat;
@@ -681,6 +683,13 @@ pub enum Commands {
         session: String,
         #[command(subcommand)]
         command: tasks_cli::TasksCommands,
+    },
+    #[command(hide = true)]
+    DelegateChildRun {
+        #[arg(long)]
+        config_path: String,
+        #[arg(long)]
+        payload_file: String,
     },
     #[command(
         about = "Inspect and manage persisted runtime sessions through an operator-facing session shell",

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -348,6 +348,10 @@ async fn main() {
             })
             .await
         }
+        Commands::DelegateChildRun {
+            config_path,
+            payload_file,
+        } => run_detached_delegate_child_cli(&config_path, &payload_file).await,
         Commands::Sessions {
             config,
             json,

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
 use clap::Subcommand;
 use kernel::ToolCoreRequest;
 use loongclaw_app as mvp;
@@ -74,6 +76,145 @@ pub struct TasksCommandExecution {
     pub resolved_config_path: String,
     pub current_session_id: String,
     pub payload: Value,
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct DetachedTasksRuntime {
+    inner: mvp::conversation::DefaultConversationRuntime<
+        Box<dyn mvp::conversation::ConversationContextEngine>,
+    >,
+    background_task_spawner: Arc<dyn mvp::conversation::AsyncDelegateSpawner>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl DetachedTasksRuntime {
+    fn from_config(config: &mvp::config::LoongClawConfig) -> CliResult<Self> {
+        let inner = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+        let background_task_spawner = Arc::new(DetachedTasksSpawner);
+
+        Ok(Self {
+            inner,
+            background_task_spawner,
+        })
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl mvp::conversation::ConversationRuntime for DetachedTasksRuntime {
+    fn session_context(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        session_id: &str,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<mvp::conversation::SessionContext> {
+        self.inner.session_context(config, session_id, binding)
+    }
+
+    fn tool_view(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        session_id: &str,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<mvp::tools::ToolView> {
+        self.inner.tool_view(config, session_id, binding)
+    }
+
+    fn background_task_spawner(
+        &self,
+        _config: &mvp::config::LoongClawConfig,
+    ) -> Option<Arc<dyn mvp::conversation::AsyncDelegateSpawner>> {
+        Some(self.background_task_spawner.clone())
+    }
+
+    async fn build_messages(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        tool_view: &mvp::tools::ToolView,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<Vec<Value>> {
+        self.inner
+            .build_messages(
+                config,
+                session_id,
+                include_system_prompt,
+                tool_view,
+                binding,
+            )
+            .await
+    }
+
+    async fn request_completion(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        messages: &[Value],
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<String> {
+        self.inner
+            .request_completion(config, messages, binding)
+            .await
+    }
+
+    async fn request_turn(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &mvp::tools::ToolView,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<mvp::conversation::ProviderTurn> {
+        self.inner
+            .request_turn(config, session_id, turn_id, messages, tool_view, binding)
+            .await
+    }
+
+    async fn request_turn_streaming(
+        &self,
+        config: &mvp::config::LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &mvp::tools::ToolView,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+        on_token: mvp::provider::StreamingTokenCallback,
+    ) -> CliResult<mvp::conversation::ProviderTurn> {
+        self.inner
+            .request_turn_streaming(
+                config, session_id, turn_id, messages, tool_view, binding, on_token,
+            )
+            .await
+    }
+
+    async fn persist_turn(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
+    ) -> CliResult<()> {
+        self.inner
+            .persist_turn(session_id, role, content, binding)
+            .await
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Clone)]
+struct DetachedTasksSpawner;
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl mvp::conversation::AsyncDelegateSpawner for DetachedTasksSpawner {
+    async fn spawn(
+        &self,
+        request: mvp::conversation::AsyncDelegateSpawnRequest,
+    ) -> Result<(), String> {
+        crate::delegate_child_cli::spawn_detached_delegate_child_process(&request)?;
+        Ok(())
+    }
 }
 
 pub async fn run_tasks_cli(options: TasksCommandOptions) -> CliResult<()> {
@@ -212,7 +353,7 @@ async fn execute_create_command(
     label: Option<String>,
     timeout_seconds: Option<u64>,
 ) -> CliResult<Value> {
-    let runtime = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+    let runtime = build_tasks_create_runtime(config)?;
     let kernel_context = mvp::context::bootstrap_kernel_context_with_config(
         "cli-tasks",
         mvp::context::DEFAULT_TOKEN_TTL_S,
@@ -246,6 +387,22 @@ async fn execute_create_command(
         "next_steps": next_steps,
     });
     Ok(payload)
+}
+
+fn build_tasks_create_runtime(
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<impl mvp::conversation::ConversationRuntime> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let runtime = DetachedTasksRuntime::from_config(config)?;
+        Ok(runtime)
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let runtime = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+        Ok(runtime)
+    }
 }
 
 fn execute_list_command(

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -47,6 +47,12 @@ pub(super) struct TasksCliEnvironmentGuard {
 }
 
 const TASKS_RUNTIME_ENV_KEYS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GEMINI_API_KEY",
     "LOONGCLAW_BROWSER_COMPANION_COMMAND",
     "LOONGCLAW_BROWSER_COMPANION_ENABLED",
     "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
@@ -83,6 +89,8 @@ const TASKS_RUNTIME_ENV_KEYS: &[&str] = &[
     "LOONGCLAW_WEB_FETCH_MAX_BYTES",
     "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
     "LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
 ];
 
 impl TasksCliEnvironmentGuard {
@@ -148,6 +156,20 @@ impl Drop for TasksCliEnvironmentGuard {
             }
         }
     }
+}
+
+fn tasks_cli_create_environment_guard() -> TasksCliEnvironmentGuard {
+    let current_executable = std::env::current_exe().expect("current test executable");
+    let deps_directory = current_executable.parent().expect("deps directory");
+    let target_directory = deps_directory.parent().expect("target directory");
+    let detached_delegate_binary = target_directory.join("loong");
+    let detached_delegate_binary = detached_delegate_binary
+        .to_str()
+        .expect("detached delegate binary path should be utf-8")
+        .to_owned();
+    let seeded_pairs = [("CARGO_BIN_EXE_loong", detached_delegate_binary.as_str())];
+
+    TasksCliEnvironmentGuard::set_with_seeded_env(&seeded_pairs, &[])
 }
 
 pub(super) fn write_tasks_config_with(
@@ -530,7 +552,7 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
 #[tokio::test]
 async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes() {
     let root = TempDirGuard::new("loongclaw-tasks-cli-create");
-    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let _env = tasks_cli_create_environment_guard();
     let config_path = write_tasks_config(root.path());
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -605,7 +627,7 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
 #[tokio::test]
 async fn execute_tasks_command_create_returns_queued_outcome_when_task_hydration_fails() {
     let root = TempDirGuard::new("loongclaw-tasks-cli-create-best-effort");
-    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let _env = tasks_cli_create_environment_guard();
     let config_path = write_tasks_config_with(root.path(), |config| {
         config.tools.sessions.enabled = false;
     });
@@ -651,7 +673,7 @@ async fn execute_tasks_command_create_returns_queued_outcome_when_task_hydration
 #[tokio::test]
 async fn execute_tasks_command_create_latest_session_selector_resolves_newest_resumable_root() {
     let root = TempDirGuard::new("loongclaw-tasks-cli-create-latest");
-    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let _env = tasks_cli_create_environment_guard();
     let config_path = write_tasks_config(root.path());
     let repo = load_session_repository(&config_path);
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-09T12:25:27Z
+- Generated at: 2026-04-10T01:06:38Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6848 | 7300 | 452 | 123 | 160 | 37 | 93.8% | WATCH | 6936 | -1.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10151 | 11200 | 1049 | 84 | 120 | 36 | 90.6% | WATCH | 10831 | -6.3% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10254 | 11200 | 946 | 86 | 120 | 34 | 91.6% | WATCH | 10831 | -5.3% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14711 | 15000 | 289 | 61 | 70 | 9 | 98.1% | TIGHT | 14472 | 1.7% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6485 | 6500 | 15 | 201 | 210 | 9 | 99.8% | TIGHT | 6324 | 2.5% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6494 | 6500 | 6 | 201 | 210 | 9 | 99.9% | TIGHT | 6324 | 2.7% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.1%), daemon_lib (99.8%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (90.6%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.1%), daemon_lib (99.9%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (93.8%), turn_coordinator (91.6%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,9 +68,9 @@
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
 <!-- arch-hotspot key=chat_runtime lines=6848 functions=123 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10151 functions=84 -->
+<!-- arch-hotspot key=turn_coordinator lines=10254 functions=86 -->
 <!-- arch-hotspot key=tools_mod lines=14711 functions=61 -->
-<!-- arch-hotspot key=daemon_lib lines=6485 functions=201 -->
+<!-- arch-hotspot key=daemon_lib lines=6494 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - `loong tasks create` could claim success before any durable worker actually owned the async child session.
  - Even after the detached-worker handoff landed, real `tasks cancel` / `session_cancel` operations could still look successful while a live detached worker kept running.
  - Queued children cancelled before their detached worker claimed the session could still surface as detached spawn failures.
  - Detached-task validation also surfaced noisy runtime-self `file.read` warnings for missing optional files such as `TOOLS.md` and `SOUL.md`.
- Why it matters:
  - Operators saw false success, stale `ready` / `queued` / `running` sessions, and misleading task/runtime state.
  - The tasks surface violated its own product contract by pretending detached work had crossed a durable ownership or cancellation boundary when it had not.
  - Detached terminal events could attribute cancellation to the parent session instead of the actual canceller.
  - Optional runtime-self guidance files looked like failures even when nothing was wrong.
- What changed:
  - Added a dedicated hidden `delegate-child-run` CLI path that executes one async delegate child inside a separate OS process.
  - Added a detached background-task spawner path for `tasks create`, while keeping the existing process-local async delegate spawner for non-task conversation paths.
  - Added serialized async delegate handoff helpers so the daemon can pass child-session execution state safely across the process boundary.
  - Added startup failure detection so `tasks create` fails fast if the detached worker exits before it can claim the child session.
  - Exposed detached owner metadata in the session/task read model.
  - On Unix, `session_cancel` / `tasks cancel` now use the recorded detached-process owner to terminate and terminalize a live detached worker immediately instead of only writing a cancel-request event.
  - Detached cancel terminal events now preserve the true canceller identity.
  - Queued children that were already terminalized as cancelled before the detached worker started are now treated as benign exits instead of spawn failures.
  - Filtered missing optional runtime-self sources before they cross into `file.read`, removing warning noise during detached task startup.
- What did not change (scope boundary):
  - This slice still does not redesign general `delegate_async` behavior for every surface.
  - It does not add a new scheduler or control-plane task queue.
  - Non-Unix detached-owner cancellation still falls back to the existing request-only flow.

## Linked Issues

- Closes #1163
- Related #656

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - The tasks surface now crosses a real process boundary instead of relying on the parent CLI runtime.
  - Unix cancellation now depends on recorded detached-process ownership and terminalizes from the operator surface.
- Rollout / guardrails:
  - `tasks create` now waits for immediate startup failure and surfaces that error instead of silently queuing a zombie session.
  - Detached owner metadata is visible in task/session status so operator actions can be audited.
  - Unix cancellation keeps the existing cancel-request event and immediately writes the terminal cancel event after owner termination.
  - Optional runtime-self files are filtered before tool dispatch, so only real readable files hit `file.read`.
- Rollback path:
  - Revert commits `17d7e46cc`, `3740ae0e8`, and `acc1e817c` to restore the old detached-worker/task-cancel behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
cargo test -p loongclaw --test integration execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes -- --nocapture
cargo test -p loongclaw --test integration execute_tasks_command_cancel_apply_terminates_detached_owner -- --nocapture
cargo test -p loongclaw-app session_cancel_terminates_running_detached_owner --lib -- --nocapture
cargo test -p loongclaw-app execute_async_delegate_spawn_request_returns_ok_when_session_was_cancelled_before_start --lib -- --nocapture
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
Manual: built the current debug binary, cloned a temp config/store under /tmp, ran `loong tasks create 'Write a detailed 1500-word analysis of three approaches to agent runtime governance, with sections and bullet points.' --json`, confirmed the task exposed `delegate_runtime_owner_bound`, ran `loong tasks cancel <task-id> --json`, and verified the task moved to `failed` with `delegate_cancel_requested` and `delegate_cancelled` events plus a terminal `delegate_cancelled: operator_requested` outcome.
```

Test env note:
- The tasks CLI integration fixture seeds `CARGO_BIN_EXE_loong` to the current target's `debug/loong` binary so detached-worker subprocesses use the same build artifact instead of the test harness executable.

## User-visible / Operator-visible Changes

- `loong tasks create` now only reports success after a detached worker process has been launched successfully.
- If the detached worker dies during startup, the command now fails immediately with a concrete `delegate_async_process_spawn_failed` error instead of leaving a misleading queued task behind.
- On Unix, `loong tasks cancel` now terminates and terminalizes a live detached worker instead of only recording a cancel request.
- Detached-task startup no longer emits warning noise for missing optional runtime-self guidance files.

## Failure Recovery

- Fast rollback or disable path:
  - Revert the three commits above or stop using `tasks create` / `tasks cancel` and fall back to foreground chat/ask surfaces while investigating.
- Observable failure symptoms reviewers should watch for:
  - `tasks create` returning `delegate_async_process_spawn_failed`
  - missing `delegate_started` / `delegate_completed` events after a successful create
  - `tasks cancel` leaving a detached task in `running` on Unix
  - detached worker startup failures tied to config path handoff

## Reviewer Focus

- `crates/app/src/conversation/runtime.rs`
  - queued-cancel benign exit handling during detached worker startup
- `crates/app/src/tools/session.rs`
  - detached owner detection, Unix termination path, and terminalization semantics
- `crates/daemon/src/delegate_child_cli.rs`
  - detached cancel attribution and fallback behavior
- `crates/daemon/tests/integration/tasks_cli.rs`
  - operator-surface regression coverage for detached cancel
- `crates/app/src/runtime_self.rs`
  - optional runtime-self source filtering before `file.read`
