### PR TITLE
Cache tool catalog lookup and stable lease digests

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 #[cfg(not(feature = "tool-file"))]
 use std::path::Path;
@@ -6,6 +7,7 @@ use std::sync::OnceLock;
 use loongclaw_kernel::ToolConcurrencyClass;
 use serde::Serialize;
 use serde_json::{Value, json};
+use sha2::Digest;
 
 use super::runtime_config::ToolRuntimeConfig;
 use crate::config::ToolConfig;
@@ -393,6 +395,18 @@ impl ToolView {
 #[derive(Debug, Clone)]
 pub struct ToolCatalog {
     descriptors: Vec<ToolDescriptor>,
+    descriptor_indices: BTreeMap<&'static str, usize>,
+    resolved_name_indices: BTreeMap<&'static str, usize>,
+    all_entries: Box<[ToolCatalogEntry]>,
+    provider_core_entries: Box<[ToolCatalogEntry]>,
+    discoverable_entries: Box<[ToolCatalogEntry]>,
+    catalog_digest: String,
+}
+
+struct ToolCatalogEntryCaches {
+    all_entries: Box<[ToolCatalogEntry]>,
+    provider_core_entries: Box<[ToolCatalogEntry]>,
+    discoverable_entries: Box<[ToolCatalogEntry]>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -431,19 +445,33 @@ const fn runtime_messaging_tool_availability() -> ToolAvailability {
 
 impl ToolCatalog {
     pub fn descriptor(&self, tool_name: &str) -> Option<&ToolDescriptor> {
-        self.descriptors
-            .iter()
-            .find(|descriptor| descriptor.name == tool_name)
+        let index = self.descriptor_indices.get(tool_name)?;
+        self.descriptors.get(*index)
     }
 
     pub fn resolve(&self, raw_tool_name: &str) -> Option<&ToolDescriptor> {
-        self.descriptors
-            .iter()
-            .find(|descriptor| descriptor.matches_name(raw_tool_name))
+        let index = self.resolved_name_indices.get(raw_tool_name)?;
+        self.descriptors.get(*index)
     }
 
     pub fn descriptors(&self) -> &[ToolDescriptor] {
         &self.descriptors
+    }
+
+    fn all_entries(&self) -> &[ToolCatalogEntry] {
+        &self.all_entries
+    }
+
+    fn provider_core_entries(&self) -> &[ToolCatalogEntry] {
+        &self.provider_core_entries
+    }
+
+    fn discoverable_entries(&self) -> &[ToolCatalogEntry] {
+        &self.discoverable_entries
+    }
+
+    fn catalog_digest(&self) -> &str {
+        self.catalog_digest.as_str()
     }
 }
 
@@ -1639,7 +1667,89 @@ fn build_tool_catalog() -> ToolCatalog {
 
     annotate_tool_concurrency_classes(&mut descriptors);
     descriptors.sort_by(|left, right| left.name.cmp(right.name));
-    ToolCatalog { descriptors }
+
+    let descriptor_indices = build_descriptor_indices(descriptors.as_slice());
+    let resolved_name_indices = build_resolved_name_indices(descriptors.as_slice());
+    let entry_caches = build_tool_catalog_entry_caches(descriptors.as_slice());
+    let all_entries = entry_caches.all_entries;
+    let provider_core_entries = entry_caches.provider_core_entries;
+    let discoverable_entries = entry_caches.discoverable_entries;
+    let catalog_digest = build_tool_catalog_digest(all_entries.as_ref());
+
+    ToolCatalog {
+        descriptors,
+        descriptor_indices,
+        resolved_name_indices,
+        all_entries,
+        provider_core_entries,
+        discoverable_entries,
+        catalog_digest,
+    }
+}
+
+fn build_descriptor_indices(descriptors: &[ToolDescriptor]) -> BTreeMap<&'static str, usize> {
+    let mut descriptor_indices = BTreeMap::new();
+
+    for (index, descriptor) in descriptors.iter().enumerate() {
+        descriptor_indices.insert(descriptor.name, index);
+    }
+
+    descriptor_indices
+}
+
+fn build_resolved_name_indices(descriptors: &[ToolDescriptor]) -> BTreeMap<&'static str, usize> {
+    let mut resolved_name_indices = BTreeMap::new();
+
+    for (index, descriptor) in descriptors.iter().enumerate() {
+        resolved_name_indices
+            .entry(descriptor.name)
+            .or_insert(index);
+        resolved_name_indices
+            .entry(descriptor.provider_name)
+            .or_insert(index);
+
+        for alias in descriptor.aliases {
+            resolved_name_indices.entry(*alias).or_insert(index);
+        }
+    }
+
+    resolved_name_indices
+}
+
+fn build_tool_catalog_entry_caches(descriptors: &[ToolDescriptor]) -> ToolCatalogEntryCaches {
+    let mut all_entries = Vec::new();
+    let mut provider_core_entries = Vec::new();
+    let mut discoverable_entries = Vec::new();
+
+    for descriptor in descriptors {
+        let entry = descriptor_to_entry(descriptor);
+
+        if descriptor.is_provider_core() {
+            provider_core_entries.push(entry);
+        }
+
+        if descriptor.is_discoverable() {
+            discoverable_entries.push(entry);
+        }
+
+        all_entries.push(entry);
+    }
+
+    ToolCatalogEntryCaches {
+        all_entries: all_entries.into_boxed_slice(),
+        provider_core_entries: provider_core_entries.into_boxed_slice(),
+        discoverable_entries: discoverable_entries.into_boxed_slice(),
+    }
+}
+
+fn build_tool_catalog_digest(entries: &[ToolCatalogEntry]) -> String {
+    let payload = serde_json::to_vec(entries).unwrap_or_default();
+    let digest = sha2::Sha256::digest(payload);
+    hex::encode(digest)
+}
+
+pub(crate) fn stable_tool_catalog_digest() -> &'static str {
+    tool_catalog().catalog_digest()
 }
 
 pub fn tool_catalog() -> &'static ToolCatalog {
@@ -1866,33 +1976,24 @@ fn tool_visibility_gate_enabled_for_delegate_child(
 }
 
 pub fn provider_core_tool_catalog() -> Vec<ToolCatalogEntry> {
-    tool_catalog()
-        .descriptors()
-        .iter()
-        .filter(|descriptor| descriptor.is_provider_core())
-        .map(descriptor_to_entry)
-        .collect()
+    tool_catalog().provider_core_entries().to_vec()
 }
 
 pub fn discoverable_tool_catalog() -> Vec<ToolCatalogEntry> {
-    tool_catalog()
-        .descriptors()
-        .iter()
-        .filter(|descriptor| descriptor.is_discoverable())
-        .map(descriptor_to_entry)
-        .collect()
+    tool_catalog().discoverable_entries().to_vec()
 }
 
 pub fn all_tool_catalog() -> Vec<ToolCatalogEntry> {
-    tool_catalog()
-        .descriptors()
-        .iter()
-        .map(descriptor_to_entry)
-        .collect()
+    tool_catalog().all_entries().to_vec()
 }
 
 pub fn find_tool_catalog_entry(name: &str) -> Option<ToolCatalogEntry> {
-    tool_catalog().resolve(name).map(descriptor_to_entry)
+    let catalog = tool_catalog();
+    let descriptor = catalog.resolve(name)?;
+    let index = catalog.descriptor_indices.get(descriptor.name)?;
+    let entry = catalog.all_entries().get(*index)?;
+
+    Some(*entry)
 }
 
 fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
@@ -5201,6 +5302,80 @@ mod tests {
         let bash_exec = find_tool_catalog_entry("bash.exec").expect("bash.exec catalog entry");
         assert_eq!(bash_exec.scheduling_class, ToolSchedulingClass::SerialOnly);
         assert_eq!(bash_exec.concurrency_class, ToolConcurrencyClass::Mutating);
+    }
+
+    #[test]
+    fn tool_catalog_resolve_preserves_canonical_provider_and_alias_lookup() {
+        let catalog = tool_catalog();
+
+        let canonical = catalog.resolve("tool.search").expect("canonical lookup");
+        let provider_name = catalog.resolve("tool_search").expect("provider lookup");
+        let alias = catalog.resolve("shell").expect("alias lookup");
+
+        assert_eq!(canonical.name, "tool.search");
+        assert_eq!(provider_name.name, "tool.search");
+        assert_eq!(alias.name, "shell.exec");
+    }
+
+    #[test]
+    fn cached_catalog_entry_partitions_match_descriptor_filters() {
+        let catalog = tool_catalog();
+
+        let expected_all_entries = descriptor_identity_list(catalog.descriptors().iter());
+        let expected_provider_core_entries = descriptor_identity_list(
+            catalog
+                .descriptors()
+                .iter()
+                .filter(|descriptor| descriptor.is_provider_core()),
+        );
+        let expected_discoverable_entries = descriptor_identity_list(
+            catalog
+                .descriptors()
+                .iter()
+                .filter(|descriptor| descriptor.is_discoverable()),
+        );
+
+        let actual_all_entries = entry_identity_list(all_tool_catalog().iter());
+        let actual_provider_core_entries = entry_identity_list(provider_core_tool_catalog().iter());
+        let actual_discoverable_entries = entry_identity_list(discoverable_tool_catalog().iter());
+
+        assert_eq!(actual_all_entries, expected_all_entries);
+        assert_eq!(actual_provider_core_entries, expected_provider_core_entries);
+        assert_eq!(actual_discoverable_entries, expected_discoverable_entries);
+    }
+
+    fn descriptor_identity_list<'a>(
+        descriptors: impl Iterator<Item = &'a ToolDescriptor>,
+    ) -> Vec<(&'static str, &'static str, ToolExposureClass)> {
+        let mut identities = Vec::new();
+
+        for descriptor in descriptors {
+            let identity = (
+                descriptor.name,
+                descriptor.provider_name,
+                descriptor.exposure,
+            );
+            identities.push(identity);
+        }
+
+        identities
+    }
+
+    fn entry_identity_list<'a>(
+        entries: impl Iterator<Item = &'a ToolCatalogEntry>,
+    ) -> Vec<(&'static str, &'static str, ToolExposureClass)> {
+        let mut identities = Vec::new();
+
+        for entry in entries {
+            let identity = (
+                entry.canonical_name,
+                entry.provider_function_name,
+                entry.exposure,
+            );
+            identities.push(identity);
+        }
+
+        identities
     }
 
     #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1793,9 +1793,7 @@ fn sign_tool_lease(encoded_claims: &str) -> String {
 }
 
 fn tool_catalog_digest() -> String {
-    let payload = serde_json::to_vec(&catalog::all_tool_catalog()).unwrap_or_default();
-    let digest = Sha256::digest(payload);
-    hex::encode(digest)
+    catalog::stable_tool_catalog_digest().to_owned()
 }
 
 fn tool_lease_secret() -> &'static str {
@@ -4291,6 +4289,42 @@ mod tests {
         assert_eq!(outcome.payload["content"], "tool invoke fixture");
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn discovered_tool_lease_uses_current_catalog_digest() {
+        let root = unique_tool_temp_dir("loongclaw-tool-lease-digest");
+        let config = test_tool_runtime_config(root.clone());
+        let search = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({"query": "read file"}),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let lease = search.payload["results"]
+            .as_array()
+            .expect("results")
+            .iter()
+            .find(|entry| entry["tool_id"] == "file.read")
+            .and_then(|entry| entry["lease"].as_str())
+            .expect("file.read lease");
+        let lease_parts = lease.split_once('.').expect("lease separator");
+        let encoded_claims = lease_parts.0;
+        let claims_bytes = URL_SAFE_NO_PAD
+            .decode(encoded_claims)
+            .expect("decode claims");
+        let claims: ToolLeaseClaims = serde_json::from_slice(&claims_bytes).expect("parse claims");
+        let expected_digest = tool_catalog_digest();
+        let repeated_digest = tool_catalog_digest();
+
+        assert_eq!(claims.catalog_digest, expected_digest);
+        assert_eq!(repeated_digest, expected_digest);
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[cfg(feature = "tool-file")]

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T08:35:27Z
+- Generated at: 2026-04-10T09:04:05Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6415 | 7300 | 885 | 97 | 160 | 63 | 87.9% | WATCH | 6936 | -7.5% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10299 | 11200 | 901 | 86 | 120 | 34 | 92.0% | WATCH | 10831 | -4.9% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14778 | 15000 | 222 | 61 | 70 | 9 | 98.5% | TIGHT | 14472 | 2.1% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14812 | 15000 | 188 | 61 | 70 | 9 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6498 | 6500 | 2 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.5%), daemon_lib (100.0%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.7%), daemon_lib (100.0%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (87.9%), turn_coordinator (92.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6415 functions=97 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10299 functions=86 -->
-<!-- arch-hotspot key=tools_mod lines=14778 functions=61 -->
+<!-- arch-hotspot key=tools_mod lines=14812 functions=61 -->
 <!-- arch-hotspot key=daemon_lib lines=6498 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - The static tool catalog still paid repeated lookup, entry-rebuild, and lease-digest costs on hot runtime paths.
  - After `dev` moved forward, the tracked architecture drift report also needed to be refreshed so governance measured the new tools-module pressure against the rebased branch instead of stale baselines.
- Why it matters:
  - tool.search and tool.invoke exercise this path repeatedly, so repeated linear scans and full-catalog reserialization add avoidable CPU/allocation churn inside one of the repo's highest-pressure modules.
- What changed:
  - Kept `ToolDescriptor` as the single source of truth.
  - Added one-time derived name indexes and prebuilt provider-core / discoverable / all entry caches inside `ToolCatalog`.
  - Reused the stable catalog snapshot for tool lease digest derivation.
  - Refreshed `docs/releases/architecture-drift-2026-04.md` after rebasing so governance reflects the current tools-module pressure.
  - Added regression coverage for canonical/provider/alias lookup, cached partition equivalence, and lease digest stability.
- What did not change (scope boundary):
  - No tool schema changes.
  - No behavior changes to tool.search or tool.invoke.
  - No channels or sqlite cleanup in this PR.

## Linked Issues

- Closes #1170
- Related #238

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
bash scripts/generate_architecture_drift_report.sh docs/releases/architecture-drift-2026-04.md
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md
cargo audit
CARGO_TARGET_DIR=/tmp/loongclaw-pr1171-check cargo test -p loongclaw-app tool_catalog_resolve_preserves_canonical_provider_and_alias_lookup --lib -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-pr1171-check cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-pr1171-check cargo test --workspace --locked -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1171-check cargo test --workspace --all-features --locked -- --test-threads=1
```

## User-visible / Operator-visible Changes

- None. This is an internal performance/maintainability improvement to tool catalog and lease derivation paths.

## Failure Recovery

- Fast rollback or disable path:
  - Revert commit `f1570f1f8`.
- Observable failure symptoms reviewers should watch for:
  - tool.search stops returning expected entries
  - tool.invoke starts rejecting fresh leases with catalog mismatch
  - alias/provider-name lookup drifts from prior behavior

## Reviewer Focus

- `crates/app/src/tools/catalog.rs`: verify the new caches remain purely derived from the sorted descriptor list.
- `crates/app/src/tools/mod.rs`: verify lease digest still tracks the same stable catalog snapshot used by lookup.
- `docs/releases/architecture-drift-2026-04.md`: verify the refreshed hotspot numbers match the rebased tools-module pressure.
- Regression tests around alias/provider lookup and tool.search/tool.invoke lease behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool catalog lookups now use indexed caches for faster, more reliable name and alias resolution.
  * A stable catalog digest is produced during catalog construction and exposed for consistent verification.

* **Tests**
  * Added tests validating name/alias/provider resolution and that lease/catalog digests are accurate and stable.

* **Documentation**
  * Updated architecture drift report metrics and hotspot entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->