### PR TITLE
Fail closed governed app tool turns without kernel binding

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12485,6 +12485,97 @@ async fn turn_engine_routes_direct_binding_to_app_dispatcher() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_direct_binding_denies_sessions_send_before_dispatch() {
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct GovernedAppBarrierDispatcher {
+        executed: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for GovernedAppBarrierDispatcher {
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            let tool_name = request.tool_name;
+            self.executed
+                .lock()
+                .expect("dispatcher executed lock")
+                .push(tool_name.clone());
+
+            let payload = json!({
+                "tool_name": tool_name,
+            });
+
+            let outcome = ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload,
+            };
+
+            Ok(outcome)
+        }
+    }
+
+    let dispatcher = GovernedAppBarrierDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![provider_tool_intent(
+            "sessions_send",
+            json!({
+                "session_id": "target-session",
+                "text": "hello",
+            }),
+            "root-session",
+            "turn-app-governed-direct",
+            "call-app-governed-direct",
+        )],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code.as_str(), "no_kernel_context");
+            assert_eq!(failure.reason.as_str(), "no_kernel_context");
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied(no_kernel_context), got: {other:?}")
+        }
+    }
+
+    let executed = dispatcher
+        .executed
+        .lock()
+        .expect("dispatcher executed lock");
+
+    assert!(executed.is_empty(), "governed app tool should not dispatch");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_requires_governed_approval_before_later_app_intent_execution() {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2902,46 +2902,37 @@ impl<'a, 'b, D: AppToolDispatcher + ?Sized> ToolIntentPreparationHarness<'a, 'b,
             }
         };
 
-        let preflight = match effective_execution_kind {
-            ToolExecutionKind::Core => {
-                if self.binding.kernel_context().is_none() {
-                    let turn_result =
-                        TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
-                    let denial_decision = ToolDecisionTelemetry::deny(
-                        effective_tool_name.as_str(),
-                        "no_kernel_context",
-                        "no_kernel_context",
-                    );
-
-                    return Err(PreparedToolIntentFailure {
-                        intent: effective_intent,
-                        turn_result,
-                        decision: denial_decision,
-                    });
-                }
-
-                self.app_dispatcher
-                    .preflight_tool_execution_with_binding(
-                        self.session_context,
-                        &effective_intent,
-                        effective_request,
-                        &descriptor,
-                        self.binding,
-                    )
-                    .await
-            }
-            ToolExecutionKind::App => {
-                self.app_dispatcher
-                    .preflight_tool_execution_with_binding(
-                        self.session_context,
-                        &effective_intent,
-                        effective_request,
-                        &descriptor,
-                        self.binding,
-                    )
-                    .await
-            }
+        let requires_kernel_binding = match effective_execution_kind {
+            ToolExecutionKind::Core => true,
+            ToolExecutionKind::App => descriptor.requires_kernel_binding(),
         };
+        let has_kernel_context = self.binding.kernel_context().is_some();
+
+        if requires_kernel_binding && !has_kernel_context {
+            let turn_result = TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
+            let denial_decision = ToolDecisionTelemetry::deny(
+                effective_tool_name.as_str(),
+                "no_kernel_context",
+                "no_kernel_context",
+            );
+
+            return Err(PreparedToolIntentFailure {
+                intent: effective_intent,
+                turn_result,
+                decision: denial_decision,
+            });
+        }
+
+        let preflight = self
+            .app_dispatcher
+            .preflight_tool_execution_with_binding(
+                self.session_context,
+                &effective_intent,
+                effective_request,
+                &descriptor,
+                self.binding,
+            )
+            .await;
 
         let (effective_request, trusted_preflight_context) = match preflight {
             Ok(ToolExecutionPreflight::Ready {

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -308,11 +308,15 @@ impl ToolDescriptor {
     }
 
     pub fn requires_kernel_binding(&self) -> bool {
+        let execution_kind = self.execution_kind;
+        if execution_kind != ToolExecutionKind::App {
+            return false;
+        }
+
         let governance_profile = self.governance_profile();
         let approval_mode = governance_profile.approval_mode;
-        let execution_kind = self.execution_kind;
 
-        execution_kind == ToolExecutionKind::App && approval_mode == ToolApprovalMode::PolicyDriven
+        approval_mode == ToolApprovalMode::PolicyDriven
     }
 }
 


### PR DESCRIPTION
## Summary

- Problem:
  The turn engine only failed closed for kernel-free `Core` tools. Governed `App` tools still depended on dispatcher-specific guards, so direct bindings could reach policy-bearing app-tool paths unless every dispatcher remembered to deny them itself.
- Why it matters:
  This weakens the kernel-first contract at the lower conversation-runtime boundary and makes future runtime hosts or alternate dispatchers easier to get wrong.
- What changed:
  Added a TurnEngine preflight guard for App tools whose catalog semantics already require kernel binding, and added regression coverage proving direct bindings still allow read-only app tools while failing closed for governed app-dispatched turns.
- What did not change (scope boundary):
  This PR does not remove `ConversationRuntimeBinding::direct()` from low-level compatibility surfaces, does not replace the broader production-ingress hardening in PR #1160, and does not reclassify `approval_request_resolve` as globally kernel-bound.

## Linked Issues

- Closes #838
- Related #839
- Related #1160

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The turn-engine preflight contract now denies some App-tool turns earlier than before. The diff intentionally keeps read-only direct-mode app paths valid and preserves existing approval-resolution direct-mode behavior that does not replay governed work.
- Rollout / guardrails:
  Regression tests cover both sides of the boundary: `sessions_send` now fails closed under direct binding, while direct approval-resolution cases that only update approval state remain valid.
- Rollback path:
  Revert commit `5b9dc77bf` if downstream callers unexpectedly depend on direct-mode governed App-tool execution.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app turn_engine_direct_binding_denies_sessions_send_before_dispatch --lib
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_approve_once_preserves_consent_without_replay_when_direct --lib
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_keeps_delegate_async_pending_without_kernel_binding --lib
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked -j 1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked -j 1
```

## User-visible / Operator-visible Changes

- Direct bindings now fail closed earlier for governed App-tool turns such as `sessions_send`.
- Read-only direct-mode app paths and direct approval-resolution flows that do not replay governed work keep their previous behavior.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `5b9dc77bf`.
- Observable failure symptoms reviewers should watch for:
  Unexpected new `no_kernel_context` denials on App-tool turns that were supposed to remain read-only compatible.

## Reviewer Focus

- `crates/app/src/conversation/turn_engine.rs`: new App-tool kernel-binding preflight gate.
- `crates/app/src/tools/catalog.rs`: why the fix continues to derive kernel-binding semantics from catalog metadata rather than per-dispatcher branching.
- `crates/app/src/conversation/tests.rs`: regression coverage for both governed-deny and direct-approval-preserve cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced kernel-context validation so tool attempts requiring kernel context are consistently denied with "no_kernel_context" and recorded as policy denials.

* **Tests**
  * Added a test that verifies such denials return the expected failure and that no governed app preflight or execution occurs.

* **Refactor**
  * Centralized and simplified binding/preflight gating and optimized how tool binding requirements are evaluated to avoid unnecessary checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->