### PR TITLE
[Feature]: Productize typed live tool runtime state in interactive chat

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,6 +1,6 @@
-use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::sync::Mutex as StdMutex;
 use std::sync::{
     Arc,
@@ -17,10 +17,12 @@ mod cli_input;
 #[cfg(all(test, feature = "memory-sqlite"))]
 #[allow(clippy::expect_used)]
 mod latest_session_selector_tests;
+mod live_runtime;
 mod operator_surfaces;
 mod session_surface;
 
 use self::cli_input::ConcurrentCliInputReader;
+use self::live_runtime::*;
 #[cfg(test)]
 use self::operator_surfaces::CliChatStartupSummary;
 #[cfg(test)]
@@ -71,8 +73,8 @@ use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
 use super::conversation::{
     ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
-    ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,
-    ExecutionLane, ProviderErrorMode, parse_approval_prompt_view,
+    ConversationTurnPhaseEvent, ConversationTurnRuntimeEvent, ConversationTurnToolEvent,
+    ConversationTurnToolState, ExecutionLane, ProviderErrorMode, parse_approval_prompt_view,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -101,15 +103,12 @@ use super::tui_surface::{
     TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec, render_tui_message_body_spec,
     render_tui_screen_spec,
 };
+#[cfg(test)]
+use crate::tools::runtime_events::{ToolCommandMetrics, ToolFileChangePreview, ToolOutputDelta};
+use crate::tools::runtime_events::{ToolFileChangeKind, ToolRuntimeEvent, ToolRuntimeStream};
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
 const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
-const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 80;
-const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 240;
-const CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS: usize = 320;
-const CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS: usize = 4096;
-const CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS: usize = 160;
-const CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS: usize = 1024;
 const CLI_CHAT_HELP_COMMAND: &str = "/help";
 const CLI_CHAT_COMPACT_COMMAND: &str = "/compact";
 const CLI_CHAT_STATUS_COMMAND: &str = "/status";
@@ -269,61 +268,6 @@ enum CliChatLoopControl {
     Continue,
     Exit,
     AssistantText(String),
-}
-
-type CliChatLiveSurfaceSink = Arc<dyn Fn(Vec<String>) + Send + Sync>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CliChatLiveSurfaceSnapshot {
-    phase: ConversationTurnPhase,
-    provider_round: Option<usize>,
-    lane: Option<ExecutionLane>,
-    tool_call_count: usize,
-    message_count: Option<usize>,
-    estimated_tokens: Option<usize>,
-    draft_preview: Option<String>,
-    tool_activity_lines: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CliChatLiveToolState {
-    tool_call_id: String,
-    display_order: usize,
-    name: Option<String>,
-    args: String,
-    status: ConversationTurnToolState,
-    detail: Option<String>,
-}
-
-impl CliChatLiveToolState {
-    fn new(tool_call_id: String, display_order: usize) -> Self {
-        Self {
-            tool_call_id,
-            display_order,
-            name: None,
-            args: String::new(),
-            status: ConversationTurnToolState::Running,
-            detail: None,
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct CliChatLiveSurfaceState {
-    latest_phase_event: Option<ConversationTurnPhaseEvent>,
-    draft_preview: String,
-    tool_states: BTreeMap<String, CliChatLiveToolState>,
-    tool_call_index_map: BTreeMap<usize, String>,
-    next_tool_display_order: usize,
-    total_text_chars_seen: usize,
-    last_preview_emit_chars_seen: usize,
-    last_emitted_snapshot: Option<CliChatLiveSurfaceSnapshot>,
-}
-
-struct CliChatLiveSurfaceObserver {
-    render_width: usize,
-    render_sink: CliChatLiveSurfaceSink,
-    state: StdMutex<CliChatLiveSurfaceState>,
 }
 
 #[allow(clippy::print_stdout)] // CLI REPL output
@@ -1118,871 +1062,6 @@ fn render_cli_chat_card_lines(title: &str, body_lines: &[String], width: usize) 
 
     lines.push("╰─".to_owned());
     lines
-}
-
-fn build_cli_chat_live_surface_observer(render_width: usize) -> ConversationTurnObserverHandle {
-    let render_sink: CliChatLiveSurfaceSink = Arc::new(|lines| {
-        print_rendered_cli_chat_lines(&lines);
-    });
-    let observer = CliChatLiveSurfaceObserver::new(render_width, render_sink);
-    Arc::new(observer)
-}
-
-impl CliChatLiveSurfaceObserver {
-    fn new(render_width: usize, render_sink: CliChatLiveSurfaceSink) -> Self {
-        Self {
-            render_width,
-            render_sink,
-            state: StdMutex::new(CliChatLiveSurfaceState::default()),
-        }
-    }
-
-    fn lock_state(&self) -> std::sync::MutexGuard<'_, CliChatLiveSurfaceState> {
-        match self.state.lock() {
-            Ok(state) => state,
-            Err(poisoned_state) => poisoned_state.into_inner(),
-        }
-    }
-
-    fn record_phase_event(&self, event: ConversationTurnPhaseEvent) {
-        let lines_to_render = {
-            let mut state = self.lock_state();
-            if cli_chat_live_phase_starts_provider_request(event.phase) {
-                reset_cli_chat_live_request_state(&mut state);
-            }
-            state.latest_phase_event = Some(event.clone());
-            reconcile_cli_chat_live_tool_states_for_phase(&mut state.tool_states, event.phase);
-            if !should_render_cli_chat_live_phase(event.phase) {
-                None
-            } else {
-                self.prepare_live_surface_lines(&mut state)
-            }
-        };
-
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
-        }
-    }
-
-    fn record_tool_event(&self, event: ConversationTurnToolEvent) {
-        let lines_to_render = {
-            let mut state = self.lock_state();
-            apply_cli_chat_live_tool_event(&mut state, &event, self.render_width);
-            let current_phase = match state.latest_phase_event.as_ref() {
-                Some(phase_event) => phase_event.phase,
-                None => return,
-            };
-            if should_render_cli_chat_live_phase(current_phase) {
-                self.prepare_live_surface_lines(&mut state)
-            } else {
-                None
-            }
-        };
-
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
-        }
-    }
-
-    fn record_streaming_token_event(&self, event: crate::acp::StreamingTokenEvent) {
-        let lines_to_render = {
-            let mut state = self.lock_state();
-            let current_phase = match state.latest_phase_event.as_ref() {
-                Some(phase_event) => phase_event.phase,
-                None => return,
-            };
-
-            let text_delta = event.delta.text;
-            let tool_call_delta = event.delta.tool_call;
-            let tool_call_index = event.index;
-            let mut should_render = false;
-
-            if let Some(text_delta) = text_delta {
-                let preview_char_limit = cli_chat_live_preview_char_limit(self.render_width);
-                append_cli_chat_live_buffer(
-                    &mut state.draft_preview,
-                    text_delta.as_str(),
-                    preview_char_limit,
-                );
-                let delta_chars = text_delta.chars().count();
-                state.total_text_chars_seen =
-                    state.total_text_chars_seen.saturating_add(delta_chars);
-
-                if should_emit_cli_chat_live_preview(&state, self.render_width)
-                    && phase_supports_cli_chat_live_preview(current_phase)
-                {
-                    should_render = true;
-                }
-            }
-
-            let tool_call_update = match (tool_call_delta, tool_call_index) {
-                (Some(tool_call_delta), Some(index)) => Some((tool_call_delta, index)),
-                (Some(_), None) | (None, Some(_)) | (None, None) => None,
-            };
-
-            if let Some((tool_call_delta, index)) = tool_call_update {
-                update_cli_chat_live_tool_state(
-                    &mut state,
-                    index,
-                    &tool_call_delta,
-                    self.render_width,
-                );
-
-                let render_tool_activity_now = event.event_type == "tool_call_start"
-                    && current_phase == ConversationTurnPhase::RunningTools;
-                if render_tool_activity_now {
-                    should_render = true;
-                }
-            }
-
-            if should_render {
-                self.prepare_live_surface_lines(&mut state)
-            } else {
-                None
-            }
-        };
-
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
-        }
-    }
-
-    fn prepare_live_surface_lines(
-        &self,
-        state: &mut CliChatLiveSurfaceState,
-    ) -> Option<Vec<String>> {
-        let snapshot = build_cli_chat_live_surface_snapshot(state)?;
-        if state.last_emitted_snapshot.as_ref() == Some(&snapshot) {
-            return None;
-        }
-
-        let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, self.render_width);
-        state.last_preview_emit_chars_seen = state.total_text_chars_seen;
-        state.last_emitted_snapshot = Some(snapshot);
-        Some(lines)
-    }
-}
-
-impl ConversationTurnObserver for CliChatLiveSurfaceObserver {
-    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
-        self.record_phase_event(event);
-    }
-
-    fn on_tool(&self, event: ConversationTurnToolEvent) {
-        self.record_tool_event(event);
-    }
-
-    fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
-        self.record_streaming_token_event(event);
-    }
-}
-
-fn cli_chat_live_phase_starts_provider_request(phase: ConversationTurnPhase) -> bool {
-    matches!(
-        phase,
-        ConversationTurnPhase::RequestingProvider
-            | ConversationTurnPhase::RequestingFollowupProvider
-    )
-}
-
-fn reset_cli_chat_live_request_state(state: &mut CliChatLiveSurfaceState) {
-    state.draft_preview.clear();
-    state.tool_states.clear();
-    state.tool_call_index_map.clear();
-    state.next_tool_display_order = 0;
-    state.total_text_chars_seen = 0;
-    state.last_preview_emit_chars_seen = 0;
-}
-
-fn should_render_cli_chat_live_phase(phase: ConversationTurnPhase) -> bool {
-    match phase {
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Failed => true,
-        ConversationTurnPhase::ContextReady | ConversationTurnPhase::Completed => false,
-    }
-}
-
-fn phase_supports_cli_chat_live_preview(phase: ConversationTurnPhase) -> bool {
-    match phase {
-        ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RequestingFollowupProvider => true,
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed
-        | ConversationTurnPhase::Failed => false,
-    }
-}
-
-fn should_emit_cli_chat_live_preview(state: &CliChatLiveSurfaceState, render_width: usize) -> bool {
-    if state.total_text_chars_seen == 0 {
-        return false;
-    }
-
-    if state.last_preview_emit_chars_seen == 0 {
-        return true;
-    }
-
-    let emit_stride = cli_chat_live_preview_emit_stride(render_width);
-    let unseen_chars = state
-        .total_text_chars_seen
-        .saturating_sub(state.last_preview_emit_chars_seen);
-    unseen_chars >= emit_stride
-}
-
-fn cli_chat_live_preview_emit_stride(render_width: usize) -> usize {
-    let doubled_width = render_width.saturating_mul(2);
-    doubled_width.clamp(
-        CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS,
-        CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS,
-    )
-}
-
-fn cli_chat_live_preview_char_limit(render_width: usize) -> usize {
-    let expanded_width = render_width.saturating_mul(16);
-    expanded_width.clamp(
-        CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS,
-        CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS,
-    )
-}
-
-fn cli_chat_live_tool_args_char_limit(render_width: usize) -> usize {
-    let expanded_width = render_width.saturating_mul(8);
-    expanded_width.clamp(
-        CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS,
-        CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS,
-    )
-}
-
-fn append_cli_chat_live_buffer(buffer: &mut String, chunk: &str, char_limit: usize) {
-    buffer.push_str(chunk);
-    trim_cli_chat_live_buffer(buffer, char_limit);
-}
-
-fn trim_cli_chat_live_buffer(buffer: &mut String, char_limit: usize) {
-    let current_char_count = buffer.chars().count();
-    if current_char_count <= char_limit {
-        return;
-    }
-
-    let retained_char_count = char_limit.saturating_sub(1);
-    let skipped_char_count = current_char_count.saturating_sub(retained_char_count);
-    let trimmed_tail = buffer.chars().skip(skipped_char_count).collect::<String>();
-
-    buffer.clear();
-    buffer.push('…');
-    buffer.push_str(trimmed_tail.as_str());
-}
-
-fn truncate_cli_chat_live_text(value: &str, char_limit: usize) -> String {
-    let mut truncated = value.to_owned();
-    trim_cli_chat_live_buffer(&mut truncated, char_limit);
-    truncated
-}
-
-fn cli_chat_live_pending_tool_call_id(index: usize) -> String {
-    format!("pending-stream-tool-{index}")
-}
-
-fn ensure_cli_chat_live_tool_state<'a>(
-    state: &'a mut CliChatLiveSurfaceState,
-    tool_call_id: &str,
-) -> &'a mut CliChatLiveToolState {
-    let tool_call_key = tool_call_id.to_owned();
-    let entry = state.tool_states.entry(tool_call_key.clone());
-
-    match entry {
-        std::collections::btree_map::Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
-        std::collections::btree_map::Entry::Vacant(vacant_entry) => {
-            let display_order = state.next_tool_display_order;
-            let tool_state = CliChatLiveToolState::new(tool_call_key, display_order);
-            state.next_tool_display_order = state.next_tool_display_order.saturating_add(1);
-            vacant_entry.insert(tool_state)
-        }
-    }
-}
-
-fn merge_cli_chat_live_pending_tool_state(
-    state: &mut CliChatLiveSurfaceState,
-    pending_tool_call_id: &str,
-    tool_call_id: &str,
-) {
-    if pending_tool_call_id == tool_call_id {
-        return;
-    }
-
-    let pending_state = match state.tool_states.remove(pending_tool_call_id) {
-        Some(pending_state) => pending_state,
-        None => return,
-    };
-    let target_state = ensure_cli_chat_live_tool_state(state, tool_call_id);
-
-    if target_state.name.is_none() {
-        target_state.name = pending_state.name;
-    }
-    if target_state.args.is_empty() {
-        target_state.args = pending_state.args;
-    }
-    if target_state.detail.is_none() {
-        target_state.detail = pending_state.detail;
-    }
-    if target_state.status == ConversationTurnToolState::Running {
-        target_state.status = pending_state.status;
-    }
-}
-
-fn update_cli_chat_live_tool_state(
-    state: &mut CliChatLiveSurfaceState,
-    index: usize,
-    delta: &crate::acp::ToolCallDelta,
-    render_width: usize,
-) {
-    let pending_tool_call_id = cli_chat_live_pending_tool_call_id(index);
-    let tool_call_id = delta.id.clone().unwrap_or_else(|| {
-        state
-            .tool_call_index_map
-            .get(&index)
-            .cloned()
-            .unwrap_or_else(|| pending_tool_call_id.clone())
-    });
-    let args_char_limit = cli_chat_live_tool_args_char_limit(render_width);
-
-    state
-        .tool_call_index_map
-        .insert(index, tool_call_id.clone());
-    merge_cli_chat_live_pending_tool_state(
-        state,
-        pending_tool_call_id.as_str(),
-        tool_call_id.as_str(),
-    );
-
-    let tool_state = ensure_cli_chat_live_tool_state(state, tool_call_id.as_str());
-    tool_state.status = ConversationTurnToolState::Running;
-    tool_state.detail = None;
-
-    if let Some(name) = delta.name.as_ref() {
-        tool_state.name = Some(name.clone());
-    }
-
-    if let Some(args) = delta.args.as_ref() {
-        append_cli_chat_live_buffer(&mut tool_state.args, args.as_str(), args_char_limit);
-    }
-}
-
-fn apply_cli_chat_live_tool_event(
-    state: &mut CliChatLiveSurfaceState,
-    event: &ConversationTurnToolEvent,
-    render_width: usize,
-) {
-    let tool_state = ensure_cli_chat_live_tool_state(state, event.tool_call_id.as_str());
-    let detail_char_limit = cli_chat_live_tool_args_char_limit(render_width);
-
-    tool_state.name = Some(event.tool_name.clone());
-    tool_state.status = event.state;
-    tool_state.detail = event
-        .detail
-        .as_deref()
-        .map(|detail| truncate_cli_chat_live_text(detail, detail_char_limit));
-}
-
-fn reconcile_cli_chat_live_tool_states_for_phase(
-    tool_states: &mut BTreeMap<String, CliChatLiveToolState>,
-    phase: ConversationTurnPhase,
-) {
-    let fallback_status = match phase {
-        ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed => Some(ConversationTurnToolState::Completed),
-        ConversationTurnPhase::Failed => Some(ConversationTurnToolState::Interrupted),
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools => None,
-    };
-    let Some(fallback_status) = fallback_status else {
-        return;
-    };
-
-    for tool_state in tool_states.values_mut() {
-        if tool_state.status != ConversationTurnToolState::Running {
-            continue;
-        }
-
-        tool_state.status = fallback_status;
-        if fallback_status == ConversationTurnToolState::Interrupted && tool_state.detail.is_none()
-        {
-            tool_state.detail =
-                Some("turn failed before a terminal tool result was recorded".to_owned());
-        }
-    }
-}
-
-fn build_cli_chat_live_surface_snapshot(
-    state: &CliChatLiveSurfaceState,
-) -> Option<CliChatLiveSurfaceSnapshot> {
-    let phase_event = state.latest_phase_event.as_ref()?;
-    let draft_preview = if state.draft_preview.trim().is_empty() {
-        None
-    } else {
-        Some(state.draft_preview.clone())
-    };
-    let tool_activity_lines = format_cli_chat_live_tool_activity_lines(&state.tool_states);
-
-    Some(CliChatLiveSurfaceSnapshot {
-        phase: phase_event.phase,
-        provider_round: phase_event.provider_round,
-        lane: phase_event.lane,
-        tool_call_count: phase_event.tool_call_count,
-        message_count: phase_event.message_count,
-        estimated_tokens: phase_event.estimated_tokens,
-        draft_preview,
-        tool_activity_lines,
-    })
-}
-
-fn format_cli_chat_live_tool_activity_lines(
-    tool_states: &BTreeMap<String, CliChatLiveToolState>,
-) -> Vec<String> {
-    let mut lines = Vec::new();
-    let mut ordered_states = tool_states.values().collect::<Vec<_>>();
-    ordered_states.sort_by_key(|tool_state| tool_state.display_order);
-
-    for tool_state in ordered_states {
-        let status = tool_state.status.as_str().replace('_', " ");
-        let name = tool_state.name.as_deref().unwrap_or("pending");
-        let tool_call_id = tool_state.tool_call_id.as_str();
-        let tool_line = if let Some(detail) = tool_state.detail.as_deref() {
-            format!("[{status}] {name} (id={tool_call_id}) - {detail}")
-        } else {
-            format!("[{status}] {name} (id={tool_call_id})")
-        };
-        lines.push(tool_line);
-
-        if !tool_state.args.is_empty() {
-            let args_line = format!("args: {}", tool_state.args);
-            lines.push(args_line);
-        }
-    }
-
-    lines
-}
-
-fn render_cli_chat_live_surface_lines_with_width(
-    snapshot: &CliChatLiveSurfaceSnapshot,
-    width: usize,
-) -> Vec<String> {
-    let message_spec = build_cli_chat_live_surface_message_spec(snapshot);
-    let body_lines = render_tui_message_body_spec(&message_spec, cli_chat_card_inner_width(width));
-    let title = build_cli_chat_live_surface_card_title(snapshot);
-    render_cli_chat_card_lines(title.as_str(), &body_lines, width)
-}
-
-fn build_cli_chat_live_surface_message_spec(
-    snapshot: &CliChatLiveSurfaceSnapshot,
-) -> TuiMessageSpec {
-    let phase_tone = cli_chat_live_surface_tone(snapshot.phase);
-    let phase_title = cli_chat_live_surface_title(snapshot.phase);
-    let phase_detail = cli_chat_live_surface_detail(snapshot);
-    let phase_section = TuiSectionSpec::Callout {
-        tone: phase_tone,
-        title: Some(phase_title.to_owned()),
-        lines: vec![phase_detail],
-    };
-    let pipeline_items = build_cli_chat_live_pipeline_items(snapshot);
-    let pipeline_section = TuiSectionSpec::Checklist {
-        title: Some("turn pipeline".to_owned()),
-        items: pipeline_items,
-    };
-    let status_items = build_cli_chat_live_status_items(snapshot);
-    let mut sections = vec![phase_section, pipeline_section];
-
-    if !status_items.is_empty() {
-        let status_section = TuiSectionSpec::KeyValues {
-            title: Some("status".to_owned()),
-            items: status_items,
-        };
-        sections.push(status_section);
-    }
-
-    if let Some(preview_section) = build_cli_chat_live_preview_section(snapshot) {
-        sections.push(preview_section);
-    }
-
-    if let Some(tool_section) = build_cli_chat_live_tool_section(snapshot) {
-        sections.push(tool_section);
-    }
-
-    TuiMessageSpec {
-        role: config::CLI_COMMAND_NAME.to_owned(),
-        caption: Some("live".to_owned()),
-        sections,
-        footer_lines: vec![
-            "Streaming turn state · /status runtime · /compact checkpoint".to_owned(),
-        ],
-    }
-}
-
-fn build_cli_chat_live_surface_card_title(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
-    let mut segments = vec![build_cli_chat_message_card_title(
-        config::CLI_COMMAND_NAME,
-        Some("live"),
-    )];
-
-    if let Some(provider_round) = snapshot.provider_round {
-        segments.push(format!("round {provider_round}"));
-    }
-
-    if let Some(message_count) = snapshot.message_count {
-        segments.push(format!("{message_count} msgs"));
-    }
-
-    if let Some(estimated_tokens) = snapshot.estimated_tokens {
-        segments.push(format!("~{estimated_tokens} tok"));
-    }
-
-    segments.join(" · ")
-}
-
-fn cli_chat_live_surface_tone(phase: ConversationTurnPhase) -> TuiCalloutTone {
-    match phase {
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply => TuiCalloutTone::Info,
-        ConversationTurnPhase::Completed => TuiCalloutTone::Success,
-        ConversationTurnPhase::Failed => TuiCalloutTone::Warning,
-    }
-}
-
-fn cli_chat_live_surface_title(phase: ConversationTurnPhase) -> &'static str {
-    match phase {
-        ConversationTurnPhase::Preparing => "assembling context",
-        ConversationTurnPhase::ContextReady => "context ready",
-        ConversationTurnPhase::RequestingProvider => "querying model",
-        ConversationTurnPhase::RunningTools => "running tools",
-        ConversationTurnPhase::RequestingFollowupProvider => "requesting follow-up",
-        ConversationTurnPhase::FinalizingReply => "finalizing reply",
-        ConversationTurnPhase::Completed => "reply ready",
-        ConversationTurnPhase::Failed => "turn failed",
-    }
-}
-
-fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
-    match snapshot.phase {
-        ConversationTurnPhase::Preparing => {
-            "Building the session context and preparing the next provider turn.".to_owned()
-        }
-        ConversationTurnPhase::ContextReady => {
-            "Context is ready for the next provider round.".to_owned()
-        }
-        ConversationTurnPhase::RequestingProvider => {
-            let provider_round = snapshot.provider_round.unwrap_or(1);
-            format!("Requesting provider round {provider_round} and waiting for the reply.")
-        }
-        ConversationTurnPhase::RunningTools => {
-            let lane_label = snapshot
-                .lane
-                .map(format_cli_chat_live_lane)
-                .unwrap_or_else(|| "-".to_owned());
-            format!(
-                "Executing {} tool call(s) in the {lane_label} lane.",
-                snapshot.tool_call_count
-            )
-        }
-        ConversationTurnPhase::RequestingFollowupProvider => {
-            let provider_round = snapshot.provider_round.unwrap_or(1);
-            format!("Sending tool results back for provider round {provider_round}.")
-        }
-        ConversationTurnPhase::FinalizingReply => {
-            "Persisting the assistant reply and finishing after-turn work.".to_owned()
-        }
-        ConversationTurnPhase::Completed => "The assistant reply is ready.".to_owned(),
-        ConversationTurnPhase::Failed => {
-            "The turn failed before a stable reply could be finalized.".to_owned()
-        }
-    }
-}
-
-fn build_cli_chat_live_pipeline_items(
-    snapshot: &CliChatLiveSurfaceSnapshot,
-) -> Vec<TuiChecklistItemSpec> {
-    let prepare_item = TuiChecklistItemSpec {
-        status: cli_chat_live_prepare_status(snapshot.phase),
-        label: "prepare context".to_owned(),
-        detail: cli_chat_live_prepare_detail(snapshot.phase),
-    };
-    let model_item = TuiChecklistItemSpec {
-        status: cli_chat_live_model_status(snapshot.phase),
-        label: "call model".to_owned(),
-        detail: cli_chat_live_model_detail(snapshot),
-    };
-    let tools_item = TuiChecklistItemSpec {
-        status: cli_chat_live_tools_status(snapshot),
-        label: "run tools".to_owned(),
-        detail: cli_chat_live_tools_detail(snapshot),
-    };
-    let finalize_item = TuiChecklistItemSpec {
-        status: cli_chat_live_finalize_status(snapshot.phase),
-        label: "finalize reply".to_owned(),
-        detail: cli_chat_live_finalize_detail(snapshot.phase),
-    };
-
-    vec![prepare_item, model_item, tools_item, finalize_item]
-}
-
-fn cli_chat_live_prepare_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
-    match phase {
-        ConversationTurnPhase::Preparing => TuiChecklistStatus::Warn,
-        ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed
-        | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
-    }
-}
-
-fn cli_chat_live_prepare_detail(phase: ConversationTurnPhase) -> String {
-    match phase {
-        ConversationTurnPhase::Preparing => "assembling the next turn context".to_owned(),
-        ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed
-        | ConversationTurnPhase::Failed => "context assembled".to_owned(),
-    }
-}
-
-fn cli_chat_live_model_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
-    match phase {
-        ConversationTurnPhase::Preparing | ConversationTurnPhase::ContextReady => {
-            TuiChecklistStatus::Warn
-        }
-        ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
-        ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
-        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
-    }
-}
-
-fn cli_chat_live_model_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
-    match snapshot.phase {
-        ConversationTurnPhase::Preparing => "waiting for a provider round".to_owned(),
-        ConversationTurnPhase::ContextReady => "provider request is about to start".to_owned(),
-        ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RequestingFollowupProvider => {
-            let provider_round = snapshot.provider_round.unwrap_or(1);
-            format!("provider round {provider_round} in progress")
-        }
-        ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed => "provider reply resolved".to_owned(),
-        ConversationTurnPhase::Failed => "provider step did not finish cleanly".to_owned(),
-    }
-}
-
-fn cli_chat_live_tools_status(snapshot: &CliChatLiveSurfaceSnapshot) -> TuiChecklistStatus {
-    let tools_needed = snapshot.tool_call_count > 0;
-    if !tools_needed {
-        return match snapshot.phase {
-            ConversationTurnPhase::FinalizingReply
-            | ConversationTurnPhase::Completed
-            | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
-            ConversationTurnPhase::Preparing
-            | ConversationTurnPhase::ContextReady
-            | ConversationTurnPhase::RequestingProvider
-            | ConversationTurnPhase::RunningTools
-            | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
-        };
-    }
-
-    match snapshot.phase {
-        ConversationTurnPhase::RunningTools => TuiChecklistStatus::Warn,
-        ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
-        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider => TuiChecklistStatus::Warn,
-    }
-}
-
-fn cli_chat_live_tools_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
-    let tools_needed = snapshot.tool_call_count > 0;
-    if !tools_needed {
-        return match snapshot.phase {
-            ConversationTurnPhase::FinalizingReply | ConversationTurnPhase::Completed => {
-                "no tool calls were needed for this turn".to_owned()
-            }
-            ConversationTurnPhase::Failed => "no tool step was completed".to_owned(),
-            ConversationTurnPhase::Preparing
-            | ConversationTurnPhase::ContextReady
-            | ConversationTurnPhase::RequestingProvider
-            | ConversationTurnPhase::RunningTools
-            | ConversationTurnPhase::RequestingFollowupProvider => {
-                "waiting to see whether tools are needed".to_owned()
-            }
-        };
-    }
-
-    let lane_label = snapshot
-        .lane
-        .map(format_cli_chat_live_lane)
-        .unwrap_or_else(|| "-".to_owned());
-    match snapshot.phase {
-        ConversationTurnPhase::RunningTools => {
-            format!(
-                "{} tool call(s) currently running in the {lane_label} lane",
-                snapshot.tool_call_count
-            )
-        }
-        ConversationTurnPhase::RequestingFollowupProvider
-        | ConversationTurnPhase::FinalizingReply
-        | ConversationTurnPhase::Completed => {
-            format!(
-                "{} tool call(s) finished in the {lane_label} lane",
-                snapshot.tool_call_count
-            )
-        }
-        ConversationTurnPhase::Failed => {
-            format!(
-                "{} tool call(s) did not converge cleanly",
-                snapshot.tool_call_count
-            )
-        }
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider => {
-            format!(
-                "{} tool call(s) are queued if the provider asks for them",
-                snapshot.tool_call_count
-            )
-        }
-    }
-}
-
-fn cli_chat_live_finalize_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
-    match phase {
-        ConversationTurnPhase::FinalizingReply => TuiChecklistStatus::Warn,
-        ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
-        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
-    }
-}
-
-fn cli_chat_live_finalize_detail(phase: ConversationTurnPhase) -> String {
-    match phase {
-        ConversationTurnPhase::FinalizingReply => {
-            "persisting reply state and final runtime side effects".to_owned()
-        }
-        ConversationTurnPhase::Completed => "reply finalized".to_owned(),
-        ConversationTurnPhase::Failed => "reply finalization did not complete".to_owned(),
-        ConversationTurnPhase::Preparing
-        | ConversationTurnPhase::ContextReady
-        | ConversationTurnPhase::RequestingProvider
-        | ConversationTurnPhase::RunningTools
-        | ConversationTurnPhase::RequestingFollowupProvider => {
-            "waiting for a final reply".to_owned()
-        }
-    }
-}
-
-fn build_cli_chat_live_status_items(snapshot: &CliChatLiveSurfaceSnapshot) -> Vec<TuiKeyValueSpec> {
-    let mut items = Vec::new();
-
-    items.push(TuiKeyValueSpec::Plain {
-        key: "phase".to_owned(),
-        value: snapshot.phase.as_str().to_owned(),
-    });
-
-    if let Some(provider_round) = snapshot.provider_round {
-        items.push(TuiKeyValueSpec::Plain {
-            key: "round".to_owned(),
-            value: provider_round.to_string(),
-        });
-    }
-
-    if let Some(lane) = snapshot.lane {
-        items.push(TuiKeyValueSpec::Plain {
-            key: "lane".to_owned(),
-            value: format_cli_chat_live_lane(lane),
-        });
-    }
-
-    if snapshot.tool_call_count > 0 {
-        items.push(TuiKeyValueSpec::Plain {
-            key: "tool calls".to_owned(),
-            value: snapshot.tool_call_count.to_string(),
-        });
-    }
-
-    if let Some(message_count) = snapshot.message_count {
-        items.push(TuiKeyValueSpec::Plain {
-            key: "context messages".to_owned(),
-            value: message_count.to_string(),
-        });
-    }
-
-    if let Some(estimated_tokens) = snapshot.estimated_tokens {
-        items.push(TuiKeyValueSpec::Plain {
-            key: "estimated tokens".to_owned(),
-            value: estimated_tokens.to_string(),
-        });
-    }
-
-    items
-}
-
-fn format_cli_chat_live_lane(lane: ExecutionLane) -> String {
-    match lane {
-        ExecutionLane::Fast => "fast".to_owned(),
-        ExecutionLane::Safe => "safe".to_owned(),
-    }
-}
-
-fn build_cli_chat_live_preview_section(
-    snapshot: &CliChatLiveSurfaceSnapshot,
-) -> Option<TuiSectionSpec> {
-    let preview = snapshot.draft_preview.as_ref()?;
-    let preview_lines = preview
-        .lines()
-        .map(|line| line.to_owned())
-        .collect::<Vec<_>>();
-
-    Some(TuiSectionSpec::Narrative {
-        title: Some("draft preview".to_owned()),
-        lines: preview_lines,
-    })
-}
-
-fn build_cli_chat_live_tool_section(
-    snapshot: &CliChatLiveSurfaceSnapshot,
-) -> Option<TuiSectionSpec> {
-    if snapshot.tool_activity_lines.is_empty() {
-        return None;
-    }
-
-    Some(TuiSectionSpec::Narrative {
-        title: Some("tool activity".to_owned()),
-        lines: snapshot.tool_activity_lines.clone(),
-    })
 }
 
 fn parse_cli_chat_markdown_sections(text: &str) -> Vec<TuiSectionSpec> {
@@ -5993,7 +5072,7 @@ allowed_decisions: yes / auto / full / esc";
             message_count: Some(4),
             estimated_tokens: Some(128),
             draft_preview: Some("Inspecting the repo layout...".to_owned()),
-            tool_activity_lines: Vec::new(),
+            tools: Vec::new(),
         };
         let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, 72);
 
@@ -6166,6 +5245,135 @@ allowed_decisions: yes / auto / full / esc";
                 .any(|line| line.contains("args: {\"path\":\"README.md\"}")),
             "tool batch should preserve streamed tool args: {completed_batch:#?}"
         );
+    }
+
+    #[test]
+    fn cli_chat_live_surface_observer_renders_runtime_output_and_file_change_updates() {
+        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let render_sink: CliChatLiveSurfaceSink = {
+            let captured_batches = Arc::clone(&captured_batches);
+            Arc::new(move |lines| {
+                let mut batches = captured_batches
+                    .lock()
+                    .expect("captured batches lock should not be poisoned");
+                batches.push(lines);
+            })
+        };
+        let observer = CliChatLiveSurfaceObserver::new(72, render_sink);
+
+        observer.on_phase(ConversationTurnPhaseEvent::running_tools(
+            1,
+            ExecutionLane::Fast,
+            1,
+        ));
+        observer.on_tool(
+            ConversationTurnToolEvent::running("call-tool-2", "shell.exec")
+                .with_request_summary(Some("{\"command\":\"printf\"}".to_owned())),
+        );
+        observer.on_runtime(ConversationTurnRuntimeEvent::new(
+            "call-tool-2",
+            ToolRuntimeEvent::OutputDelta(ToolOutputDelta {
+                stream: ToolRuntimeStream::Stdout,
+                chunk: "first line\nsecond line".to_owned(),
+                total_bytes: 22,
+                total_lines: 2,
+                truncated: false,
+            }),
+        ));
+        observer.on_runtime(ConversationTurnRuntimeEvent::new(
+            "call-tool-2",
+            ToolRuntimeEvent::FileChangePreview(ToolFileChangePreview {
+                path: "src/lib.rs".to_owned(),
+                kind: ToolFileChangeKind::Edit,
+                added_lines: 2,
+                removed_lines: 1,
+                preview: Some("@@ -1,1 +1,2 @@\n-old\n+new\n+line".to_owned()),
+            }),
+        ));
+        observer.on_runtime(ConversationTurnRuntimeEvent::new(
+            "call-tool-2",
+            ToolRuntimeEvent::CommandMetrics(ToolCommandMetrics {
+                exit_code: Some(0),
+                duration_ms: 42,
+            }),
+        ));
+        observer.on_tool(ConversationTurnToolEvent::completed(
+            "call-tool-2",
+            "shell.exec",
+            Some("ok".to_owned()),
+        ));
+
+        let batches = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned");
+        let final_batch = batches.last().expect("final runtime batch");
+
+        assert!(
+            final_batch
+                .iter()
+                .any(|line| line.contains("stdout: 2 lines · 22 bytes")),
+            "runtime output should surface stdout counters: {final_batch:#?}"
+        );
+        assert!(
+            final_batch.iter().any(|line| line.contains("first line")),
+            "runtime output should retain stdout preview lines: {final_batch:#?}"
+        );
+        assert!(
+            final_batch
+                .iter()
+                .any(|line| line.contains("file: edit src/lib.rs (+2 / -1)")),
+            "runtime output should surface file change summaries: {final_batch:#?}"
+        );
+        assert!(
+            final_batch
+                .iter()
+                .any(|line| line.contains("metrics: 42ms · exit=0")),
+            "runtime output should surface command metrics: {final_batch:#?}"
+        );
+    }
+
+    #[test]
+    fn build_cli_chat_live_surface_snapshot_preserves_structured_tool_state() {
+        let mut state = CliChatLiveSurfaceState {
+            latest_phase_event: Some(ConversationTurnPhaseEvent::running_tools(
+                1,
+                ExecutionLane::Fast,
+                1,
+            )),
+            ..CliChatLiveSurfaceState::default()
+        };
+
+        let tool_state = ensure_cli_chat_live_tool_state(&mut state, "call-structured");
+        tool_state.name = Some("shell.exec".to_owned());
+        tool_state.request_summary = Some("{\"command\":\"printf\"}".to_owned());
+        tool_state.args = "{\"command\":\"printf\"}".to_owned();
+        tool_state.stdout = CliChatLiveOutputView {
+            text: "hello".to_owned(),
+            total_bytes: 5,
+            total_lines: 1,
+            truncated: false,
+        };
+        tool_state.duration_ms = Some(12);
+        tool_state.exit_code = Some(0);
+
+        let snapshot =
+            build_cli_chat_live_surface_snapshot(&state).expect("snapshot should be available");
+        let tool = snapshot
+            .tools
+            .first()
+            .expect("snapshot should include one tool");
+
+        assert_eq!(snapshot.tools.len(), 1);
+        assert_eq!(tool.tool_call_id, "call-structured");
+        assert_eq!(tool.name.as_deref(), Some("shell.exec"));
+        assert_eq!(
+            tool.request_summary.as_deref(),
+            Some("{\"command\":\"printf\"}")
+        );
+        assert_eq!(tool.args, "{\"command\":\"printf\"}");
+        assert_eq!(tool.stdout.text, "hello");
+        assert_eq!(tool.duration_ms, Some(12));
+        assert_eq!(tool.exit_code, Some(0));
     }
 
     #[test]

--- a/crates/app/src/chat/live_runtime.rs
+++ b/crates/app/src/chat/live_runtime.rs
@@ -1,0 +1,1208 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use super::*;
+
+const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 80;
+const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 240;
+const CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS: usize = 320;
+const CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS: usize = 4096;
+const CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS: usize = 160;
+const CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS: usize = 1024;
+const CLI_CHAT_LIVE_OUTPUT_MIN_BUFFER_CHARS: usize = 192;
+const CLI_CHAT_LIVE_OUTPUT_MAX_BUFFER_CHARS: usize = 1536;
+const CLI_CHAT_LIVE_OUTPUT_RENDER_MAX_LINES: usize = 4;
+const CLI_CHAT_LIVE_DIFF_PREVIEW_MAX_LINES: usize = 6;
+pub(super) type CliChatLiveSurfaceSink = Arc<dyn Fn(Vec<String>) + Send + Sync>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveOutputView {
+    pub text: String,
+    pub total_bytes: usize,
+    pub total_lines: usize,
+    pub truncated: bool,
+}
+
+impl CliChatLiveOutputView {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            total_bytes: 0,
+            total_lines: 0,
+            truncated: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveFileChangeView {
+    pub path: String,
+    pub operation: ToolFileChangeKind,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub preview: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveToolSnapshot {
+    pub tool_call_id: String,
+    pub name: Option<String>,
+    pub request_summary: Option<String>,
+    pub args: String,
+    pub status: ConversationTurnToolState,
+    pub detail: Option<String>,
+    pub stdout: CliChatLiveOutputView,
+    pub stderr: CliChatLiveOutputView,
+    pub file_change: Option<CliChatLiveFileChangeView>,
+    pub duration_ms: Option<u64>,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveSurfaceSnapshot {
+    pub phase: ConversationTurnPhase,
+    pub provider_round: Option<usize>,
+    pub lane: Option<ExecutionLane>,
+    pub tool_call_count: usize,
+    pub message_count: Option<usize>,
+    pub estimated_tokens: Option<usize>,
+    pub draft_preview: Option<String>,
+    pub tools: Vec<CliChatLiveToolSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveToolState {
+    pub tool_call_id: String,
+    pub display_order: usize,
+    pub name: Option<String>,
+    pub request_summary: Option<String>,
+    pub args: String,
+    pub status: ConversationTurnToolState,
+    pub detail: Option<String>,
+    pub stdout: CliChatLiveOutputView,
+    pub stderr: CliChatLiveOutputView,
+    pub file_change: Option<CliChatLiveFileChangeView>,
+    pub duration_ms: Option<u64>,
+    pub exit_code: Option<i32>,
+}
+
+impl CliChatLiveToolState {
+    fn new(tool_call_id: String, display_order: usize) -> Self {
+        let stdout = CliChatLiveOutputView::new();
+        let stderr = CliChatLiveOutputView::new();
+
+        Self {
+            tool_call_id,
+            display_order,
+            name: None,
+            request_summary: None,
+            args: String::new(),
+            status: ConversationTurnToolState::Running,
+            detail: None,
+            stdout,
+            stderr,
+            file_change: None,
+            duration_ms: None,
+            exit_code: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct CliChatLiveSurfaceState {
+    pub latest_phase_event: Option<ConversationTurnPhaseEvent>,
+    pub draft_preview: String,
+    pub tool_states: BTreeMap<String, CliChatLiveToolState>,
+    pub tool_call_index_map: BTreeMap<usize, String>,
+    pub next_tool_display_order: usize,
+    pub total_text_chars_seen: usize,
+    pub last_preview_emit_chars_seen: usize,
+    pub last_emitted_snapshot: Option<CliChatLiveSurfaceSnapshot>,
+}
+
+pub(super) struct CliChatLiveSurfaceObserver {
+    render_width: usize,
+    render_sink: CliChatLiveSurfaceSink,
+    state: StdMutex<CliChatLiveSurfaceState>,
+}
+
+pub(super) fn build_cli_chat_live_surface_observer(
+    render_width: usize,
+) -> ConversationTurnObserverHandle {
+    let render_sink: CliChatLiveSurfaceSink = Arc::new(|lines| {
+        print_rendered_cli_chat_lines(&lines);
+    });
+    let observer = CliChatLiveSurfaceObserver::new(render_width, render_sink);
+    Arc::new(observer)
+}
+
+impl CliChatLiveSurfaceObserver {
+    pub(super) fn new(render_width: usize, render_sink: CliChatLiveSurfaceSink) -> Self {
+        Self {
+            render_width,
+            render_sink,
+            state: StdMutex::new(CliChatLiveSurfaceState::default()),
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, CliChatLiveSurfaceState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        }
+    }
+
+    fn record_phase_event(&self, event: ConversationTurnPhaseEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            if cli_chat_live_phase_starts_provider_request(event.phase) {
+                reset_cli_chat_live_request_state(&mut state);
+            }
+            state.latest_phase_event = Some(event.clone());
+            reconcile_cli_chat_live_tool_states_for_phase(&mut state.tool_states, event.phase);
+            if !should_render_cli_chat_live_phase(event.phase) {
+                None
+            } else {
+                self.prepare_live_surface_lines(&mut state)
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn record_tool_event(&self, event: ConversationTurnToolEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            apply_cli_chat_live_tool_event(&mut state, &event, self.render_width);
+            let current_phase = match state.latest_phase_event.as_ref() {
+                Some(phase_event) => phase_event.phase,
+                None => return,
+            };
+            if should_render_cli_chat_live_phase(current_phase) {
+                self.prepare_live_surface_lines(&mut state)
+            } else {
+                None
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn record_runtime_event(&self, event: ConversationTurnRuntimeEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            apply_cli_chat_live_runtime_event(&mut state, &event, self.render_width);
+            let current_phase = match state.latest_phase_event.as_ref() {
+                Some(phase_event) => phase_event.phase,
+                None => return,
+            };
+            if should_render_cli_chat_live_phase(current_phase) {
+                self.prepare_live_surface_lines(&mut state)
+            } else {
+                None
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn record_streaming_token_event(&self, event: crate::acp::StreamingTokenEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            let current_phase = match state.latest_phase_event.as_ref() {
+                Some(phase_event) => phase_event.phase,
+                None => return,
+            };
+
+            let text_delta = event.delta.text;
+            let tool_call_delta = event.delta.tool_call;
+            let tool_call_index = event.index;
+            let mut should_render = false;
+
+            if let Some(text_delta) = text_delta {
+                let preview_char_limit = cli_chat_live_preview_char_limit(self.render_width);
+                append_cli_chat_live_buffer(
+                    &mut state.draft_preview,
+                    text_delta.as_str(),
+                    preview_char_limit,
+                );
+                let delta_chars = text_delta.chars().count();
+                state.total_text_chars_seen =
+                    state.total_text_chars_seen.saturating_add(delta_chars);
+
+                if should_emit_cli_chat_live_preview(&state, self.render_width)
+                    && phase_supports_cli_chat_live_preview(current_phase)
+                {
+                    should_render = true;
+                }
+            }
+
+            let tool_call_update = match (tool_call_delta, tool_call_index) {
+                (Some(tool_call_delta), Some(index)) => Some((tool_call_delta, index)),
+                (Some(_), None) | (None, Some(_)) | (None, None) => None,
+            };
+
+            if let Some((tool_call_delta, index)) = tool_call_update {
+                update_cli_chat_live_tool_state(
+                    &mut state,
+                    index,
+                    &tool_call_delta,
+                    self.render_width,
+                );
+
+                let render_tool_activity_now = event.event_type == "tool_call_start"
+                    && current_phase == ConversationTurnPhase::RunningTools;
+                if render_tool_activity_now {
+                    should_render = true;
+                }
+            }
+
+            if should_render {
+                self.prepare_live_surface_lines(&mut state)
+            } else {
+                None
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn prepare_live_surface_lines(
+        &self,
+        state: &mut CliChatLiveSurfaceState,
+    ) -> Option<Vec<String>> {
+        let snapshot = build_cli_chat_live_surface_snapshot(state)?;
+        if state.last_emitted_snapshot.as_ref() == Some(&snapshot) {
+            return None;
+        }
+
+        let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, self.render_width);
+        state.last_preview_emit_chars_seen = state.total_text_chars_seen;
+        state.last_emitted_snapshot = Some(snapshot);
+        Some(lines)
+    }
+}
+
+impl ConversationTurnObserver for CliChatLiveSurfaceObserver {
+    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+        self.record_phase_event(event);
+    }
+
+    fn on_tool(&self, event: ConversationTurnToolEvent) {
+        self.record_tool_event(event);
+    }
+
+    fn on_runtime(&self, event: ConversationTurnRuntimeEvent) {
+        self.record_runtime_event(event);
+    }
+
+    fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
+        self.record_streaming_token_event(event);
+    }
+}
+
+pub(super) fn cli_chat_live_phase_starts_provider_request(phase: ConversationTurnPhase) -> bool {
+    matches!(
+        phase,
+        ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RequestingFollowupProvider
+    )
+}
+
+pub(super) fn reset_cli_chat_live_request_state(state: &mut CliChatLiveSurfaceState) {
+    state.draft_preview.clear();
+    state.tool_states.clear();
+    state.tool_call_index_map.clear();
+    state.next_tool_display_order = 0;
+    state.total_text_chars_seen = 0;
+    state.last_preview_emit_chars_seen = 0;
+}
+
+fn should_render_cli_chat_live_phase(phase: ConversationTurnPhase) -> bool {
+    match phase {
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Failed => true,
+        ConversationTurnPhase::ContextReady | ConversationTurnPhase::Completed => false,
+    }
+}
+
+pub(super) fn phase_supports_cli_chat_live_preview(phase: ConversationTurnPhase) -> bool {
+    match phase {
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => true,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => false,
+    }
+}
+
+fn should_emit_cli_chat_live_preview(state: &CliChatLiveSurfaceState, render_width: usize) -> bool {
+    if state.total_text_chars_seen == 0 {
+        return false;
+    }
+
+    if state.last_preview_emit_chars_seen == 0 {
+        return true;
+    }
+
+    let emit_stride = cli_chat_live_preview_emit_stride(render_width);
+    let unseen_chars = state
+        .total_text_chars_seen
+        .saturating_sub(state.last_preview_emit_chars_seen);
+    unseen_chars >= emit_stride
+}
+
+fn cli_chat_live_preview_emit_stride(render_width: usize) -> usize {
+    let doubled_width = render_width.saturating_mul(2);
+    doubled_width.clamp(
+        CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS,
+        CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS,
+    )
+}
+
+pub(super) fn cli_chat_live_preview_char_limit(render_width: usize) -> usize {
+    let expanded_width = render_width.saturating_mul(16);
+    expanded_width.clamp(
+        CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS,
+        CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS,
+    )
+}
+
+fn cli_chat_live_tool_args_char_limit(render_width: usize) -> usize {
+    let expanded_width = render_width.saturating_mul(8);
+    expanded_width.clamp(
+        CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS,
+        CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS,
+    )
+}
+
+pub(super) fn append_cli_chat_live_buffer(buffer: &mut String, chunk: &str, char_limit: usize) {
+    buffer.push_str(chunk);
+    trim_cli_chat_live_buffer(buffer, char_limit);
+}
+
+fn trim_cli_chat_live_buffer(buffer: &mut String, char_limit: usize) {
+    let current_char_count = buffer.chars().count();
+    if current_char_count <= char_limit {
+        return;
+    }
+
+    let retained_char_count = char_limit.saturating_sub(1);
+    let skipped_char_count = current_char_count.saturating_sub(retained_char_count);
+    let trimmed_tail = buffer.chars().skip(skipped_char_count).collect::<String>();
+
+    buffer.clear();
+    buffer.push('…');
+    buffer.push_str(trimmed_tail.as_str());
+}
+
+pub(super) fn truncate_cli_chat_live_text(value: &str, char_limit: usize) -> String {
+    let mut truncated = value.to_owned();
+    trim_cli_chat_live_buffer(&mut truncated, char_limit);
+    truncated
+}
+
+fn cli_chat_live_output_char_limit(render_width: usize) -> usize {
+    let scaled_limit = render_width.saturating_mul(12);
+    let scaled_limit = scaled_limit.max(CLI_CHAT_LIVE_OUTPUT_MIN_BUFFER_CHARS);
+    scaled_limit.min(CLI_CHAT_LIVE_OUTPUT_MAX_BUFFER_CHARS)
+}
+
+fn cli_chat_live_line_count(value: &str) -> usize {
+    if value.is_empty() {
+        return 0;
+    }
+
+    let line_break_count = value.chars().filter(|ch| *ch == '\n').count();
+    line_break_count.saturating_add(1)
+}
+
+fn push_cli_chat_live_output_lines(
+    lines: &mut Vec<String>,
+    label: &str,
+    output: &CliChatLiveOutputView,
+    max_lines: usize,
+) {
+    if output.text.trim().is_empty() {
+        return;
+    }
+
+    lines.push(format!(
+        "{label}: {} lines · {} bytes",
+        output.total_lines, output.total_bytes
+    ));
+
+    let output_lines = output
+        .text
+        .lines()
+        .rev()
+        .take(max_lines)
+        .collect::<Vec<_>>();
+    let output_lines = output_lines.into_iter().rev().collect::<Vec<_>>();
+
+    for output_line in output_lines {
+        let rendered_line =
+            truncate_cli_chat_live_text(output_line, CLI_CHAT_LIVE_OUTPUT_MAX_BUFFER_CHARS);
+        lines.push(format!("  {rendered_line}"));
+    }
+
+    if output.truncated {
+        lines.push("  … live output truncated".to_owned());
+    }
+}
+
+pub(super) fn cli_chat_live_pending_tool_call_id(index: usize) -> String {
+    format!("pending-stream-tool-{index}")
+}
+
+pub(super) fn ensure_cli_chat_live_tool_state<'a>(
+    state: &'a mut CliChatLiveSurfaceState,
+    tool_call_id: &str,
+) -> &'a mut CliChatLiveToolState {
+    let tool_call_key = tool_call_id.to_owned();
+    let entry = state.tool_states.entry(tool_call_key.clone());
+
+    match entry {
+        std::collections::btree_map::Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+        std::collections::btree_map::Entry::Vacant(vacant_entry) => {
+            let display_order = state.next_tool_display_order;
+            let tool_state = CliChatLiveToolState::new(tool_call_key, display_order);
+            state.next_tool_display_order = state.next_tool_display_order.saturating_add(1);
+            vacant_entry.insert(tool_state)
+        }
+    }
+}
+
+pub(super) fn merge_cli_chat_live_pending_tool_state(
+    state: &mut CliChatLiveSurfaceState,
+    pending_tool_call_id: &str,
+    tool_call_id: &str,
+) {
+    if pending_tool_call_id == tool_call_id {
+        return;
+    }
+
+    let pending_state = match state.tool_states.remove(pending_tool_call_id) {
+        Some(pending_state) => pending_state,
+        None => return,
+    };
+    let target_state = ensure_cli_chat_live_tool_state(state, tool_call_id);
+
+    if target_state.name.is_none() {
+        target_state.name = pending_state.name;
+    }
+    if target_state.args.is_empty() {
+        target_state.args = pending_state.args;
+    }
+    if target_state.detail.is_none() {
+        target_state.detail = pending_state.detail;
+    }
+    if target_state.status == ConversationTurnToolState::Running {
+        target_state.status = pending_state.status;
+    }
+}
+
+pub(super) fn update_cli_chat_live_tool_state(
+    state: &mut CliChatLiveSurfaceState,
+    index: usize,
+    delta: &crate::acp::ToolCallDelta,
+    render_width: usize,
+) {
+    let pending_tool_call_id = cli_chat_live_pending_tool_call_id(index);
+    let tool_call_id = delta.id.clone().unwrap_or_else(|| {
+        state
+            .tool_call_index_map
+            .get(&index)
+            .cloned()
+            .unwrap_or_else(|| pending_tool_call_id.clone())
+    });
+    let args_char_limit = cli_chat_live_tool_args_char_limit(render_width);
+
+    state
+        .tool_call_index_map
+        .insert(index, tool_call_id.clone());
+    merge_cli_chat_live_pending_tool_state(
+        state,
+        pending_tool_call_id.as_str(),
+        tool_call_id.as_str(),
+    );
+
+    let tool_state = ensure_cli_chat_live_tool_state(state, tool_call_id.as_str());
+    tool_state.status = ConversationTurnToolState::Running;
+    tool_state.detail = None;
+
+    if let Some(name) = delta.name.as_ref() {
+        tool_state.name = Some(name.clone());
+    }
+
+    if let Some(args) = delta.args.as_ref() {
+        append_cli_chat_live_buffer(&mut tool_state.args, args.as_str(), args_char_limit);
+    }
+}
+
+pub(super) fn apply_cli_chat_live_tool_event(
+    state: &mut CliChatLiveSurfaceState,
+    event: &ConversationTurnToolEvent,
+    render_width: usize,
+) {
+    let tool_state = ensure_cli_chat_live_tool_state(state, event.tool_call_id.as_str());
+    let detail_char_limit = cli_chat_live_tool_args_char_limit(render_width);
+
+    tool_state.name = Some(event.tool_name.clone());
+    if let Some(request_summary) = event.request_summary.as_deref() {
+        let truncated_summary =
+            truncate_cli_chat_live_text(request_summary, CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS);
+        tool_state.request_summary = Some(truncated_summary);
+    }
+    tool_state.status = event.state;
+    tool_state.detail = event
+        .detail
+        .as_deref()
+        .map(|detail| truncate_cli_chat_live_text(detail, detail_char_limit));
+}
+
+pub(super) fn apply_cli_chat_live_runtime_event(
+    state: &mut CliChatLiveSurfaceState,
+    event: &ConversationTurnRuntimeEvent,
+    render_width: usize,
+) {
+    let tool_state = ensure_cli_chat_live_tool_state(state, event.tool_call_id.as_str());
+
+    match &event.event {
+        ToolRuntimeEvent::OutputDelta(delta) => {
+            let output_char_limit = cli_chat_live_output_char_limit(render_width);
+            let target_output = match delta.stream {
+                ToolRuntimeStream::Stdout => &mut tool_state.stdout,
+                ToolRuntimeStream::Stderr => &mut tool_state.stderr,
+            };
+            let chunk = delta.chunk.as_str();
+            let fallback_line_count = cli_chat_live_line_count(chunk);
+            let total_lines = if delta.total_lines == 0 {
+                fallback_line_count
+            } else {
+                delta.total_lines
+            };
+
+            target_output.total_bytes = delta.total_bytes;
+            target_output.total_lines = total_lines;
+            target_output.truncated = delta.truncated;
+            append_cli_chat_live_buffer(&mut target_output.text, chunk, output_char_limit);
+        }
+        ToolRuntimeEvent::FileChangePreview(file_change) => {
+            let preview = file_change.preview.as_deref();
+            let preview = preview.map(|preview| {
+                let preview_limit = cli_chat_live_output_char_limit(render_width);
+                truncate_cli_chat_live_text(preview, preview_limit)
+            });
+            let file_change_view = CliChatLiveFileChangeView {
+                path: file_change.path.clone(),
+                operation: file_change.kind,
+                added_lines: file_change.added_lines,
+                removed_lines: file_change.removed_lines,
+                preview,
+            };
+            tool_state.file_change = Some(file_change_view);
+        }
+        ToolRuntimeEvent::CommandMetrics(metrics) => {
+            tool_state.duration_ms = Some(metrics.duration_ms);
+            tool_state.exit_code = metrics.exit_code;
+        }
+    }
+}
+
+pub(super) fn reconcile_cli_chat_live_tool_states_for_phase(
+    tool_states: &mut BTreeMap<String, CliChatLiveToolState>,
+    phase: ConversationTurnPhase,
+) {
+    let fallback_status = match phase {
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => Some(ConversationTurnToolState::Completed),
+        ConversationTurnPhase::Failed => Some(ConversationTurnToolState::Interrupted),
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools => None,
+    };
+    let Some(fallback_status) = fallback_status else {
+        return;
+    };
+
+    for tool_state in tool_states.values_mut() {
+        if tool_state.status != ConversationTurnToolState::Running {
+            continue;
+        }
+
+        tool_state.status = fallback_status;
+        if fallback_status == ConversationTurnToolState::Interrupted && tool_state.detail.is_none()
+        {
+            tool_state.detail =
+                Some("turn failed before a terminal tool result was recorded".to_owned());
+        }
+    }
+}
+
+pub(super) fn build_cli_chat_live_surface_snapshot(
+    state: &CliChatLiveSurfaceState,
+) -> Option<CliChatLiveSurfaceSnapshot> {
+    let phase_event = state.latest_phase_event.as_ref()?;
+    let draft_preview = if state.draft_preview.trim().is_empty() {
+        None
+    } else {
+        Some(state.draft_preview.clone())
+    };
+    let tools = build_cli_chat_live_tool_snapshots(&state.tool_states);
+
+    Some(CliChatLiveSurfaceSnapshot {
+        phase: phase_event.phase,
+        provider_round: phase_event.provider_round,
+        lane: phase_event.lane,
+        tool_call_count: phase_event.tool_call_count,
+        message_count: phase_event.message_count,
+        estimated_tokens: phase_event.estimated_tokens,
+        draft_preview,
+        tools,
+    })
+}
+
+fn build_cli_chat_live_tool_snapshots(
+    tool_states: &BTreeMap<String, CliChatLiveToolState>,
+) -> Vec<CliChatLiveToolSnapshot> {
+    let mut ordered_states = tool_states.values().collect::<Vec<_>>();
+    ordered_states.sort_by_key(|tool_state| tool_state.display_order);
+
+    let mut snapshots = Vec::with_capacity(ordered_states.len());
+    for tool_state in ordered_states {
+        let snapshot = CliChatLiveToolSnapshot {
+            tool_call_id: tool_state.tool_call_id.clone(),
+            name: tool_state.name.clone(),
+            request_summary: tool_state.request_summary.clone(),
+            args: tool_state.args.clone(),
+            status: tool_state.status,
+            detail: tool_state.detail.clone(),
+            stdout: tool_state.stdout.clone(),
+            stderr: tool_state.stderr.clone(),
+            file_change: tool_state.file_change.clone(),
+            duration_ms: tool_state.duration_ms,
+            exit_code: tool_state.exit_code,
+        };
+        snapshots.push(snapshot);
+    }
+
+    snapshots
+}
+
+pub(super) fn format_cli_chat_live_tool_activity_lines(
+    tool_snapshots: &[CliChatLiveToolSnapshot],
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    for tool_snapshot in tool_snapshots {
+        let status = tool_snapshot.status.as_str().replace('_', " ");
+        let name = tool_snapshot.name.as_deref().unwrap_or("pending");
+        let tool_call_id = tool_snapshot.tool_call_id.as_str();
+        let tool_line = if let Some(detail) = tool_snapshot.detail.as_deref() {
+            format!("[{status}] {name} (id={tool_call_id}) - {detail}")
+        } else {
+            format!("[{status}] {name} (id={tool_call_id})")
+        };
+        lines.push(tool_line);
+
+        if let Some(request_summary) = tool_snapshot.request_summary.as_deref() {
+            let request_summary = truncate_cli_chat_live_text(
+                request_summary,
+                CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS,
+            );
+            let request_line = format!("request: {request_summary}");
+            lines.push(request_line);
+        }
+
+        if !tool_snapshot.args.is_empty() {
+            let args_line = format!("args: {}", tool_snapshot.args);
+            lines.push(args_line);
+        }
+
+        push_cli_chat_live_output_lines(
+            &mut lines,
+            "stdout",
+            &tool_snapshot.stdout,
+            CLI_CHAT_LIVE_OUTPUT_RENDER_MAX_LINES,
+        );
+        push_cli_chat_live_output_lines(
+            &mut lines,
+            "stderr",
+            &tool_snapshot.stderr,
+            CLI_CHAT_LIVE_OUTPUT_RENDER_MAX_LINES,
+        );
+
+        if let Some(file_change) = tool_snapshot.file_change.as_ref() {
+            let operation = match file_change.operation {
+                ToolFileChangeKind::Create => "create",
+                ToolFileChangeKind::Overwrite => "overwrite",
+                ToolFileChangeKind::Edit => "edit",
+            };
+            let path = truncate_cli_chat_live_text(
+                file_change.path.as_str(),
+                CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS,
+            );
+            let summary_line = format!(
+                "file: {operation} {path} (+{} / -{})",
+                file_change.added_lines, file_change.removed_lines,
+            );
+            lines.push(summary_line);
+
+            if let Some(preview) = file_change.preview.as_deref() {
+                let preview_lines = preview.lines().take(CLI_CHAT_LIVE_DIFF_PREVIEW_MAX_LINES);
+                for preview_line in preview_lines {
+                    let preview_line = truncate_cli_chat_live_text(
+                        preview_line,
+                        CLI_CHAT_LIVE_OUTPUT_MAX_BUFFER_CHARS,
+                    );
+                    lines.push(format!("  {preview_line}"));
+                }
+            }
+        }
+
+        if let Some(duration_ms) = tool_snapshot.duration_ms {
+            let exit_code = match tool_snapshot.exit_code {
+                Some(exit_code) => exit_code.to_string(),
+                None => "-".to_owned(),
+            };
+            let metrics_line = format!("metrics: {duration_ms}ms · exit={exit_code}");
+            lines.push(metrics_line);
+        }
+    }
+
+    lines
+}
+
+pub(super) fn render_cli_chat_live_surface_lines_with_width(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_live_surface_message_spec(snapshot);
+    let body_lines = render_tui_message_body_spec(&message_spec, cli_chat_card_inner_width(width));
+    let title = build_cli_chat_live_surface_card_title(snapshot);
+    render_cli_chat_card_lines(title.as_str(), &body_lines, width)
+}
+
+fn build_cli_chat_live_surface_message_spec(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> TuiMessageSpec {
+    let phase_tone = cli_chat_live_surface_tone(snapshot.phase);
+    let phase_title = cli_chat_live_surface_title(snapshot.phase);
+    let phase_detail = cli_chat_live_surface_detail(snapshot);
+    let phase_section = TuiSectionSpec::Callout {
+        tone: phase_tone,
+        title: Some(phase_title.to_owned()),
+        lines: vec![phase_detail],
+    };
+    let pipeline_items = build_cli_chat_live_pipeline_items(snapshot);
+    let pipeline_section = TuiSectionSpec::Checklist {
+        title: Some("turn pipeline".to_owned()),
+        items: pipeline_items,
+    };
+    let status_items = build_cli_chat_live_status_items(snapshot);
+    let mut sections = vec![phase_section, pipeline_section];
+
+    if !status_items.is_empty() {
+        let status_section = TuiSectionSpec::KeyValues {
+            title: Some("status".to_owned()),
+            items: status_items,
+        };
+        sections.push(status_section);
+    }
+
+    if let Some(preview_section) = build_cli_chat_live_preview_section(snapshot) {
+        sections.push(preview_section);
+    }
+
+    if let Some(tool_section) = build_cli_chat_live_tool_section(snapshot) {
+        sections.push(tool_section);
+    }
+
+    TuiMessageSpec {
+        role: config::CLI_COMMAND_NAME.to_owned(),
+        caption: Some("live".to_owned()),
+        sections,
+        footer_lines: vec![
+            "Streaming turn state · /status runtime · /compact checkpoint".to_owned(),
+        ],
+    }
+}
+
+fn build_cli_chat_live_surface_card_title(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    let mut segments = vec![build_cli_chat_message_card_title(
+        config::CLI_COMMAND_NAME,
+        Some("live"),
+    )];
+
+    if let Some(provider_round) = snapshot.provider_round {
+        segments.push(format!("round {provider_round}"));
+    }
+
+    if let Some(message_count) = snapshot.message_count {
+        segments.push(format!("{message_count} msgs"));
+    }
+
+    if let Some(estimated_tokens) = snapshot.estimated_tokens {
+        segments.push(format!("~{estimated_tokens} tok"));
+    }
+
+    segments.join(" · ")
+}
+
+fn cli_chat_live_surface_tone(phase: ConversationTurnPhase) -> TuiCalloutTone {
+    match phase {
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply => TuiCalloutTone::Info,
+        ConversationTurnPhase::Completed => TuiCalloutTone::Success,
+        ConversationTurnPhase::Failed => TuiCalloutTone::Warning,
+    }
+}
+
+fn cli_chat_live_surface_title(phase: ConversationTurnPhase) -> &'static str {
+    match phase {
+        ConversationTurnPhase::Preparing => "assembling context",
+        ConversationTurnPhase::ContextReady => "context ready",
+        ConversationTurnPhase::RequestingProvider => "querying model",
+        ConversationTurnPhase::RunningTools => "running tools",
+        ConversationTurnPhase::RequestingFollowupProvider => "requesting follow-up",
+        ConversationTurnPhase::FinalizingReply => "finalizing reply",
+        ConversationTurnPhase::Completed => "reply ready",
+        ConversationTurnPhase::Failed => "turn failed",
+    }
+}
+
+fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    match snapshot.phase {
+        ConversationTurnPhase::Preparing => {
+            "Building the session context and preparing the next provider turn.".to_owned()
+        }
+        ConversationTurnPhase::ContextReady => {
+            "Context is ready for the next provider round.".to_owned()
+        }
+        ConversationTurnPhase::RequestingProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("Requesting provider round {provider_round} and waiting for the reply.")
+        }
+        ConversationTurnPhase::RunningTools => {
+            let lane_label = snapshot
+                .lane
+                .map(format_cli_chat_live_lane)
+                .unwrap_or_else(|| "-".to_owned());
+            format!(
+                "Executing {} tool call(s) in the {lane_label} lane.",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::RequestingFollowupProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("Sending tool results back for provider round {provider_round}.")
+        }
+        ConversationTurnPhase::FinalizingReply => {
+            "Persisting the assistant reply and finishing after-turn work.".to_owned()
+        }
+        ConversationTurnPhase::Completed => "The assistant reply is ready.".to_owned(),
+        ConversationTurnPhase::Failed => {
+            "The turn failed before a stable reply could be finalized.".to_owned()
+        }
+    }
+}
+
+fn build_cli_chat_live_pipeline_items(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Vec<TuiChecklistItemSpec> {
+    let prepare_item = TuiChecklistItemSpec {
+        status: cli_chat_live_prepare_status(snapshot.phase),
+        label: "prepare context".to_owned(),
+        detail: cli_chat_live_prepare_detail(snapshot.phase),
+    };
+    let model_item = TuiChecklistItemSpec {
+        status: cli_chat_live_model_status(snapshot.phase),
+        label: "call model".to_owned(),
+        detail: cli_chat_live_model_detail(snapshot),
+    };
+    let tools_item = TuiChecklistItemSpec {
+        status: cli_chat_live_tools_status(snapshot),
+        label: "run tools".to_owned(),
+        detail: cli_chat_live_tools_detail(snapshot),
+    };
+    let finalize_item = TuiChecklistItemSpec {
+        status: cli_chat_live_finalize_status(snapshot.phase),
+        label: "finalize reply".to_owned(),
+        detail: cli_chat_live_finalize_detail(snapshot.phase),
+    };
+
+    vec![prepare_item, model_item, tools_item, finalize_item]
+}
+
+fn cli_chat_live_prepare_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::Preparing => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
+    }
+}
+
+fn cli_chat_live_prepare_detail(phase: ConversationTurnPhase) -> String {
+    match phase {
+        ConversationTurnPhase::Preparing => "assembling the next turn context".to_owned(),
+        ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => "context assembled".to_owned(),
+    }
+}
+
+fn cli_chat_live_model_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::Preparing | ConversationTurnPhase::ContextReady => {
+            TuiChecklistStatus::Warn
+        }
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+    }
+}
+
+fn cli_chat_live_model_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    match snapshot.phase {
+        ConversationTurnPhase::Preparing => "waiting for a provider round".to_owned(),
+        ConversationTurnPhase::ContextReady => "provider request is about to start".to_owned(),
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("provider round {provider_round} in progress")
+        }
+        ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => "provider reply resolved".to_owned(),
+        ConversationTurnPhase::Failed => "provider step did not finish cleanly".to_owned(),
+    }
+}
+
+fn cli_chat_live_tools_status(snapshot: &CliChatLiveSurfaceSnapshot) -> TuiChecklistStatus {
+    let tools_needed = snapshot.tool_call_count > 0;
+    if !tools_needed {
+        return match snapshot.phase {
+            ConversationTurnPhase::FinalizingReply
+            | ConversationTurnPhase::Completed
+            | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
+            ConversationTurnPhase::Preparing
+            | ConversationTurnPhase::ContextReady
+            | ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RunningTools
+            | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+        };
+    }
+
+    match snapshot.phase {
+        ConversationTurnPhase::RunningTools => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider => TuiChecklistStatus::Warn,
+    }
+}
+
+fn cli_chat_live_tools_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    let tools_needed = snapshot.tool_call_count > 0;
+    if !tools_needed {
+        return match snapshot.phase {
+            ConversationTurnPhase::FinalizingReply | ConversationTurnPhase::Completed => {
+                "no tool calls were needed for this turn".to_owned()
+            }
+            ConversationTurnPhase::Failed => "no tool step was completed".to_owned(),
+            ConversationTurnPhase::Preparing
+            | ConversationTurnPhase::ContextReady
+            | ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RunningTools
+            | ConversationTurnPhase::RequestingFollowupProvider => {
+                "waiting to see whether tools are needed".to_owned()
+            }
+        };
+    }
+
+    let lane_label = snapshot
+        .lane
+        .map(format_cli_chat_live_lane)
+        .unwrap_or_else(|| "-".to_owned());
+    match snapshot.phase {
+        ConversationTurnPhase::RunningTools => {
+            format!(
+                "{} tool call(s) currently running in the {lane_label} lane",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => {
+            format!(
+                "{} tool call(s) finished in the {lane_label} lane",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::Failed => {
+            format!(
+                "{} tool call(s) did not converge cleanly",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider => {
+            format!(
+                "{} tool call(s) are queued if the provider asks for them",
+                snapshot.tool_call_count
+            )
+        }
+    }
+}
+
+fn cli_chat_live_finalize_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::FinalizingReply => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+    }
+}
+
+fn cli_chat_live_finalize_detail(phase: ConversationTurnPhase) -> String {
+    match phase {
+        ConversationTurnPhase::FinalizingReply => {
+            "persisting reply state and final runtime side effects".to_owned()
+        }
+        ConversationTurnPhase::Completed => "reply finalized".to_owned(),
+        ConversationTurnPhase::Failed => "reply finalization did not complete".to_owned(),
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider => {
+            "waiting for a final reply".to_owned()
+        }
+    }
+}
+
+fn build_cli_chat_live_status_items(snapshot: &CliChatLiveSurfaceSnapshot) -> Vec<TuiKeyValueSpec> {
+    let mut items = Vec::new();
+
+    items.push(TuiKeyValueSpec::Plain {
+        key: "phase".to_owned(),
+        value: snapshot.phase.as_str().to_owned(),
+    });
+
+    if let Some(provider_round) = snapshot.provider_round {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "round".to_owned(),
+            value: provider_round.to_string(),
+        });
+    }
+
+    if let Some(lane) = snapshot.lane {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "lane".to_owned(),
+            value: format_cli_chat_live_lane(lane),
+        });
+    }
+
+    if snapshot.tool_call_count > 0 {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "tool calls".to_owned(),
+            value: snapshot.tool_call_count.to_string(),
+        });
+    }
+
+    if let Some(message_count) = snapshot.message_count {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "context messages".to_owned(),
+            value: message_count.to_string(),
+        });
+    }
+
+    if let Some(estimated_tokens) = snapshot.estimated_tokens {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "estimated tokens".to_owned(),
+            value: estimated_tokens.to_string(),
+        });
+    }
+
+    items
+}
+
+fn format_cli_chat_live_lane(lane: ExecutionLane) -> String {
+    match lane {
+        ExecutionLane::Fast => "fast".to_owned(),
+        ExecutionLane::Safe => "safe".to_owned(),
+    }
+}
+
+fn build_cli_chat_live_preview_section(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Option<TuiSectionSpec> {
+    let preview = snapshot.draft_preview.as_ref()?;
+    let preview_lines = preview
+        .lines()
+        .map(|line| line.to_owned())
+        .collect::<Vec<_>>();
+
+    Some(TuiSectionSpec::Narrative {
+        title: Some("draft preview".to_owned()),
+        lines: preview_lines,
+    })
+}
+
+fn build_cli_chat_live_tool_section(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Option<TuiSectionSpec> {
+    if snapshot.tools.is_empty() {
+        return None;
+    }
+
+    let lines = format_cli_chat_live_tool_activity_lines(snapshot.tools.as_slice());
+
+    Some(TuiSectionSpec::Narrative {
+        title: Some("tool activity".to_owned()),
+        lines,
+    })
+}

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -307,9 +307,27 @@ fn filtered_command_palette_items(
 #[derive(Clone, Default)]
 struct LiveSurfaceModel {
     snapshot: Option<CliChatLiveSurfaceSnapshot>,
-    tool_lines: Vec<String>,
+    state: CliChatLiveSurfaceState,
     last_assistant_preview: Option<String>,
     last_phase_label: String,
+}
+
+fn sync_live_surface_snapshot(live: &mut LiveSurfaceModel) {
+    let snapshot = build_cli_chat_live_surface_snapshot(&live.state);
+    live.snapshot = snapshot;
+}
+
+fn fallback_live_surface_snapshot() -> CliChatLiveSurfaceSnapshot {
+    CliChatLiveSurfaceSnapshot {
+        phase: ConversationTurnPhase::Preparing,
+        provider_round: None,
+        lane: None,
+        tool_call_count: 0,
+        message_count: None,
+        estimated_tokens: None,
+        draft_preview: None,
+        tools: Vec::new(),
+    }
 }
 
 struct SurfaceGuard {
@@ -1088,7 +1106,7 @@ impl ChatSessionSurface {
             state.pending_turn = false;
             state.live.last_assistant_preview = Some(assistant_text);
             state.live.snapshot = None;
-            state.live.tool_lines.clear();
+            state.live.state = CliChatLiveSurfaceState::default();
             state.selected_entry = Some(state.transcript.len().saturating_sub(1));
             state.sticky_bottom = true;
         }
@@ -1426,16 +1444,7 @@ impl ChatSessionSurface {
                     .live
                     .snapshot
                     .clone()
-                    .unwrap_or(CliChatLiveSurfaceSnapshot {
-                        phase: ConversationTurnPhase::Preparing,
-                        provider_round: None,
-                        lane: None,
-                        tool_call_count: 0,
-                        message_count: None,
-                        estimated_tokens: None,
-                        draft_preview: None,
-                        tool_activity_lines: state.live.tool_lines.clone(),
-                    }),
+                    .unwrap_or_else(fallback_live_surface_snapshot),
                 width,
             );
             lines.extend(
@@ -1595,10 +1604,18 @@ impl ChatSessionSurface {
                         .map(|snapshot| snapshot.tool_call_count)
                         .unwrap_or(0)
                 ));
-                if state.live.tool_lines.is_empty() {
+                let tool_lines = state
+                    .live
+                    .snapshot
+                    .as_ref()
+                    .map(|snapshot| {
+                        format_cli_chat_live_tool_activity_lines(snapshot.tools.as_slice())
+                    })
+                    .unwrap_or_default();
+                if tool_lines.is_empty() {
                     lines.push("no tool activity recorded".to_owned());
                 } else {
-                    lines.extend(state.live.tool_lines.iter().take(10).cloned());
+                    lines.extend(tool_lines.into_iter().take(10));
                 }
             }
             SidebarTab::Help => {
@@ -1998,26 +2015,35 @@ struct SurfaceLiveObserver {
     term: Term,
 }
 
+fn live_surface_content_width(term: &Term, state: &SurfaceState) -> usize {
+    let (_, width_u16) = term.size();
+    let total_width = usize::from(width_u16);
+    let sidebar_visible = state.sidebar_visible && total_width >= MIN_SIDEBAR_TOTAL_WIDTH;
+    let sidebar_width = if sidebar_visible { SIDEBAR_WIDTH } else { 0 };
+
+    total_width
+        .saturating_sub(sidebar_width)
+        .saturating_sub(if sidebar_visible { 3 } else { 2 })
+        .max(24)
+}
+
 impl ConversationTurnObserver for SurfaceLiveObserver {
     fn on_phase(&self, event: ConversationTurnPhaseEvent) {
         let mut state = match self.state.lock() {
             Ok(state) => state,
             Err(poisoned_state) => poisoned_state.into_inner(),
         };
-        state.live.snapshot = Some(CliChatLiveSurfaceSnapshot {
-            phase: event.phase,
-            provider_round: event.provider_round,
-            lane: event.lane,
-            tool_call_count: event.tool_call_count,
-            message_count: event.message_count,
-            estimated_tokens: event.estimated_tokens,
-            draft_preview: state
-                .live
-                .snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.draft_preview.clone()),
-            tool_activity_lines: state.live.tool_lines.clone(),
-        });
+
+        if cli_chat_live_phase_starts_provider_request(event.phase) {
+            reset_cli_chat_live_request_state(&mut state.live.state);
+        }
+
+        state.live.state.latest_phase_event = Some(event.clone());
+        reconcile_cli_chat_live_tool_states_for_phase(
+            &mut state.live.state.tool_states,
+            event.phase,
+        );
+        sync_live_surface_snapshot(&mut state.live);
         state.live.last_phase_label = event.phase.as_str().to_owned();
         drop(state);
         let _ = render_live_update(self.term.clone(), self.state.clone());
@@ -2028,17 +2054,23 @@ impl ConversationTurnObserver for SurfaceLiveObserver {
             Ok(state) => state,
             Err(poisoned_state) => poisoned_state.into_inner(),
         };
-        let detail = event.detail.unwrap_or_else(|| "-".to_owned());
-        state.live.tool_lines.push(format!(
-            "[{}] {} - {}",
-            event.state.as_str(),
-            event.tool_name,
-            detail
-        ));
-        let tool_lines = state.live.tool_lines.clone();
-        if let Some(snapshot) = state.live.snapshot.as_mut() {
-            snapshot.tool_activity_lines = tool_lines;
-        }
+        let render_width = live_surface_content_width(&self.term, &state);
+
+        apply_cli_chat_live_tool_event(&mut state.live.state, &event, render_width);
+        sync_live_surface_snapshot(&mut state.live);
+        drop(state);
+        let _ = render_live_update(self.term.clone(), self.state.clone());
+    }
+
+    fn on_runtime(&self, event: ConversationTurnRuntimeEvent) {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        };
+        let render_width = live_surface_content_width(&self.term, &state);
+
+        apply_cli_chat_live_runtime_event(&mut state.live.state, &event, render_width);
+        sync_live_surface_snapshot(&mut state.live);
         drop(state);
         let _ = render_live_update(self.term.clone(), self.state.clone());
     }
@@ -2048,29 +2080,46 @@ impl ConversationTurnObserver for SurfaceLiveObserver {
             Ok(state) => state,
             Err(poisoned_state) => poisoned_state.into_inner(),
         };
-        if let Some(text) = event.delta.text {
-            let preview = state
+        let render_width = live_surface_content_width(&self.term, &state);
+        let current_phase = state
+            .live
+            .state
+            .latest_phase_event
+            .as_ref()
+            .map(|phase_event| phase_event.phase);
+
+        if let Some(text_delta) = event.delta.text
+            && let Some(current_phase) = current_phase
+            && phase_supports_cli_chat_live_preview(current_phase)
+        {
+            let preview_char_limit = cli_chat_live_preview_char_limit(render_width);
+            state.live.state.total_text_chars_seen = state
                 .live
-                .snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.draft_preview.clone())
-                .unwrap_or_default();
-            let updated = format!("{preview}{text}");
-            if let Some(snapshot) = state.live.snapshot.as_mut() {
-                snapshot.draft_preview = Some(updated);
-            } else {
-                state.live.snapshot = Some(CliChatLiveSurfaceSnapshot {
-                    phase: ConversationTurnPhase::RequestingProvider,
-                    provider_round: None,
-                    lane: None,
-                    tool_call_count: 0,
-                    message_count: None,
-                    estimated_tokens: None,
-                    draft_preview: Some(updated),
-                    tool_activity_lines: state.live.tool_lines.clone(),
-                });
-            }
+                .state
+                .total_text_chars_seen
+                .saturating_add(text_delta.chars().count());
+            append_cli_chat_live_buffer(
+                &mut state.live.state.draft_preview,
+                text_delta.as_str(),
+                preview_char_limit,
+            );
         }
+
+        let tool_call_update = match (event.delta.tool_call, event.index) {
+            (Some(tool_call_delta), Some(index)) => Some((tool_call_delta, index)),
+            (Some(_), None) | (None, Some(_)) | (None, None) => None,
+        };
+
+        if let Some((tool_call_delta, index)) = tool_call_update {
+            update_cli_chat_live_tool_state(
+                &mut state.live.state,
+                index,
+                &tool_call_delta,
+                render_width,
+            );
+        }
+
+        sync_live_surface_snapshot(&mut state.live);
         drop(state);
         let _ = render_live_update(self.term.clone(), self.state.clone());
     }
@@ -2107,53 +2156,45 @@ fn render_live_update(term: Term, state: Arc<Mutex<SurfaceState>>) -> CliResult<
         .max(24);
     let reserved_height = header_lines.len() + HEADER_GAP + COMPOSER_HEIGHT + STATUS_BAR_HEIGHT + 1;
     let transcript_height = total_height.saturating_sub(reserved_height).max(5);
-    let transcript_lines =
-        {
-            let mut lines = Vec::new();
-            for (entry_index, entry) in snapshot_state.transcript.iter().enumerate() {
-                if !lines.is_empty() {
-                    lines.push(String::new());
-                }
-                for (line_index, line) in entry.lines.iter().enumerate() {
-                    let clipped = clipped_display_line(line, content_width.saturating_sub(2));
-                    if line_index == 0 && snapshot_state.selected_entry == Some(entry_index) {
-                        lines.push(format!("▶ {clipped}"));
-                    } else {
-                        lines.push(clipped);
-                    }
+    let transcript_lines = {
+        let mut lines = Vec::new();
+        for (entry_index, entry) in snapshot_state.transcript.iter().enumerate() {
+            if !lines.is_empty() {
+                lines.push(String::new());
+            }
+            for (line_index, line) in entry.lines.iter().enumerate() {
+                let clipped = clipped_display_line(line, content_width.saturating_sub(2));
+                if line_index == 0 && snapshot_state.selected_entry == Some(entry_index) {
+                    lines.push(format!("▶ {clipped}"));
+                } else {
+                    lines.push(clipped);
                 }
             }
-            if snapshot_state.pending_turn {
-                if !lines.is_empty() {
-                    lines.push(String::new());
-                }
-                lines.extend(
-                    render_cli_chat_live_surface_lines_with_width(
-                        &snapshot_state.live.snapshot.clone().unwrap_or(
-                            CliChatLiveSurfaceSnapshot {
-                                phase: ConversationTurnPhase::Preparing,
-                                provider_round: None,
-                                lane: None,
-                                tool_call_count: 0,
-                                message_count: None,
-                                estimated_tokens: None,
-                                draft_preview: None,
-                                tool_activity_lines: snapshot_state.live.tool_lines.clone(),
-                            },
-                        ),
-                        content_width,
-                    )
-                    .into_iter()
-                    .map(|line| clipped_display_line(&line, content_width)),
-                );
+        }
+        if snapshot_state.pending_turn {
+            if !lines.is_empty() {
+                lines.push(String::new());
             }
-            if lines.len() > transcript_height {
-                let start = lines.len().saturating_sub(transcript_height);
-                lines.into_iter().skip(start).collect()
-            } else {
-                lines
-            }
-        };
+            lines.extend(
+                render_cli_chat_live_surface_lines_with_width(
+                    &snapshot_state
+                        .live
+                        .snapshot
+                        .clone()
+                        .unwrap_or_else(fallback_live_surface_snapshot),
+                    content_width,
+                )
+                .into_iter()
+                .map(|line| clipped_display_line(&line, content_width)),
+            );
+        }
+        if lines.len() > transcript_height {
+            let start = lines.len().saturating_sub(transcript_height);
+            lines.into_iter().skip(start).collect()
+        } else {
+            lines
+        }
+    };
 
     let startup_summary = snapshot_state
         .startup_summary

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -142,6 +142,7 @@ pub use turn_middleware_registry::{
     list_turn_middleware_ids, list_turn_middleware_metadata, register_turn_middleware,
     resolve_turn_middleware, resolve_turn_middlewares, turn_middleware_ids_from_env,
 };
+pub(crate) use turn_observer::ConversationTurnRuntimeEvent;
 pub use turn_observer::{
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
     ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12721,6 +12721,7 @@ async fn governed_runtime_binding_routes_mutating_app_intent_to_approval_on_advi
             &dispatcher,
             crate::conversation::ConversationRuntimeBinding::direct(),
             None,
+            None,
         )
         .await;
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2478,7 +2478,9 @@ fn observe_provider_turn_tool_batch_started(
 
     for intent in &turn.tool_intents {
         let tool_name = effective_result_tool_name(intent);
-        let event = ConversationTurnToolEvent::running(intent.tool_call_id.clone(), tool_name);
+        let request_summary = summarize_single_tool_followup_request(intent);
+        let event = ConversationTurnToolEvent::running(intent.tool_call_id.clone(), tool_name)
+            .with_request_summary(request_summary);
         observer.on_tool(event);
     }
 }
@@ -2804,6 +2806,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         &turn,
         binding,
         ingress,
+        observer,
         followup_chain_active,
     )
     .await;
@@ -4654,6 +4657,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     turn: &ProviderTurn,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
+    observer: Option<&ConversationTurnObserverHandle>,
     followup_chain_active: bool,
 ) -> ProviderTurnLaneExecution {
     let had_tool_intents = !turn.tool_intents.is_empty();
@@ -4752,6 +4756,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
                     &app_dispatcher,
                     binding,
                     ingress,
+                    observer,
                 )
                 .await;
             (result, None, trace)

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -27,6 +27,9 @@ use crate::operator::session_graph::OperatorSessionGraph;
 use crate::session::repository::{
     NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
 };
+use crate::tools::runtime_events::{
+    ToolRuntimeEvent, ToolRuntimeEventSink, with_tool_runtime_event_sink,
+};
 use crate::tools::{
     ResolvedToolExecution, ToolApprovalMode, ToolDescriptor, ToolExecutionKind,
     ToolSchedulingClass, ToolView, delegate_child_tool_view_for_contract,
@@ -43,6 +46,7 @@ use super::autonomy_policy::{
 use super::runtime::{DefaultConversationRuntime, SessionContext};
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary;
+use super::turn_observer::{ConversationTurnObserverHandle, ConversationTurnRuntimeEvent};
 
 use super::ingress::{ConversationIngressContext, inject_internal_tool_ingress};
 use super::tool_input_contract::detect_repairable_tool_request_issue;
@@ -2501,6 +2505,30 @@ async fn execute_tool_intent_via_kernel(
         })
 }
 
+struct ObserverToolRuntimeEventSink {
+    observer: ConversationTurnObserverHandle,
+    tool_call_id: String,
+}
+
+impl ToolRuntimeEventSink for ObserverToolRuntimeEventSink {
+    fn emit(&self, event: ToolRuntimeEvent) {
+        let runtime_event = ConversationTurnRuntimeEvent::new(self.tool_call_id.clone(), event);
+
+        self.observer.on_runtime(runtime_event);
+    }
+}
+
+fn build_observer_tool_runtime_event_sink(
+    observer: &ConversationTurnObserverHandle,
+    tool_call_id: &str,
+) -> Arc<dyn ToolRuntimeEventSink> {
+    let observer_sink = ObserverToolRuntimeEventSink {
+        observer: Arc::clone(observer),
+        tool_call_id: tool_call_id.to_owned(),
+    };
+    Arc::new(observer_sink)
+}
+
 /// Single orchestration boundary for tool-call evaluation and execution.
 ///
 /// `evaluate_turn` performs synchronous validation (no execution).
@@ -3114,6 +3142,7 @@ impl<'a> ToolBatchHarness<'a> {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
         trace: &mut ToolBatchExecutionTrace,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
         let result = async {
@@ -3138,6 +3167,7 @@ impl<'a> ToolBatchHarness<'a> {
                             &mut trace.intent_outcomes,
                             &mut trace.outcome_records,
                             trace_segment,
+                            observer,
                         )
                         .await?
                     }
@@ -3150,6 +3180,7 @@ impl<'a> ToolBatchHarness<'a> {
                             &mut trace.intent_outcomes,
                             &mut trace.outcome_records,
                             trace_segment,
+                            observer,
                         )
                         .await?
                     }
@@ -3177,6 +3208,7 @@ impl<'a> ToolBatchHarness<'a> {
         intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
         outcome_records: &mut Vec<ToolOutcomeTraceRecord>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
         let result = async {
@@ -3190,6 +3222,7 @@ impl<'a> ToolBatchHarness<'a> {
                         session_context,
                         app_dispatcher,
                         binding,
+                        observer,
                     )
                     .await
                 {
@@ -3264,6 +3297,7 @@ impl<'a> ToolBatchHarness<'a> {
         intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
         outcome_records: &mut Vec<ToolOutcomeTraceRecord>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
         let payload_summary_limit_chars = self.engine.tool_result_payload_summary_limit_chars;
@@ -3289,6 +3323,7 @@ impl<'a> ToolBatchHarness<'a> {
                             session_context,
                             app_dispatcher,
                             binding,
+                            observer,
                         )
                         .await
                     {
@@ -3752,6 +3787,7 @@ impl TurnEngine {
             app_dispatcher,
             binding,
             ingress,
+            None,
         )
         .await
         .0
@@ -3764,6 +3800,7 @@ impl TurnEngine {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> (TurnResult, Option<ToolBatchExecutionTrace>) {
         match self.validate_turn_in_context(turn, session_context) {
             Ok(TurnValidation::FinalText(text)) => return (TurnResult::FinalText(text), None),
@@ -3821,6 +3858,7 @@ impl TurnEngine {
                 app_dispatcher,
                 binding,
                 &mut trace,
+                observer,
             )
             .await
         {
@@ -3857,6 +3895,7 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> Result<ToolCoreOutcome, TurnResult> {
         match prepared_intent.execution_kind {
             ToolExecutionKind::Core => {
@@ -3866,13 +3905,24 @@ impl TurnEngine {
                         "no_kernel_context",
                     ));
                 };
-                execute_tool_intent_via_kernel(
+                let execution = execute_tool_intent_via_kernel(
                     prepared_intent.request.clone(),
                     kernel_ctx,
                     prepared_intent.trusted_internal_context,
-                )
-                .await
-                .map_err(turn_result_from_tool_execution_failure)
+                );
+                let outcome = match observer {
+                    Some(observer) => {
+                        let sink = build_observer_tool_runtime_event_sink(
+                            observer,
+                            prepared_intent.intent.tool_call_id.as_str(),
+                        );
+
+                        with_tool_runtime_event_sink(sink, execution).await
+                    }
+                    None => execution.await,
+                };
+
+                outcome.map_err(turn_result_from_tool_execution_failure)
             }
             ToolExecutionKind::App => match app_dispatcher
                 .execute_app_tool(session_context, prepared_intent.request.clone(), binding)
@@ -5904,6 +5954,7 @@ mod tests {
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
                 None,
+                None,
             )
             .await;
 
@@ -5968,6 +6019,7 @@ mod tests {
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
                 None,
+                None,
             )
             .await;
 
@@ -6010,6 +6062,7 @@ mod tests {
                 &session_context,
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
+                None,
                 None,
             )
             .await;
@@ -6068,6 +6121,7 @@ mod tests {
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
                 None,
+                None,
             )
             .await;
 
@@ -6112,6 +6166,7 @@ mod tests {
                 &session_context,
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
+                None,
                 None,
             )
             .await;

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -408,6 +408,7 @@ async fn evaluate_round_kernel(
                     app_dispatcher,
                     binding,
                     None,
+                    None,
                 )
                 .await
         }

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::acp::{StreamingTokenEvent, TokenDelta, ToolCallDelta};
+use crate::tools::runtime_events::ToolRuntimeEvent;
 
 use super::lane_arbiter::ExecutionLane;
 
@@ -264,10 +265,29 @@ impl ConversationTurnToolEvent {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationTurnRuntimeEvent {
+    pub tool_call_id: String,
+    pub event: ToolRuntimeEvent,
+}
+
+impl ConversationTurnRuntimeEvent {
+    pub fn new(tool_call_id: impl Into<String>, event: ToolRuntimeEvent) -> Self {
+        let tool_call_id = tool_call_id.into();
+
+        Self {
+            tool_call_id,
+            event,
+        }
+    }
+}
+
 pub trait ConversationTurnObserver: Send + Sync {
     fn on_phase(&self, _event: ConversationTurnPhaseEvent) {}
 
     fn on_tool(&self, _event: ConversationTurnToolEvent) {}
+
+    fn on_runtime(&self, _event: ConversationTurnRuntimeEvent) {}
 
     fn on_streaming_token(&self, _event: StreamingTokenEvent) {}
 }

--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(feature = "tool-shell")]
+use std::time::Instant;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 #[cfg(feature = "tool-shell")]
@@ -12,6 +14,8 @@ use super::bash_governance::{FinalGovernanceDecision, evaluate_bash_command};
 #[cfg(feature = "tool-shell")]
 use super::process_exec;
 use super::runtime_config::BashExecRuntimePolicy;
+#[cfg(feature = "tool-shell")]
+use super::runtime_events::current_tool_runtime_event_sink;
 
 const BASH_UNAVAILABLE_WARNING: &str =
     "bash unavailable; hiding bash.exec from runtime tool surface";
@@ -125,13 +129,15 @@ pub(super) fn execute_bash_tool_with_config(
             .as_deref()
             .ok_or_else(|| "bash unavailable".to_owned())?;
         let args = bash_exec_args(command, runtime.login_shell);
+        let runtime_event_sink = current_tool_runtime_event_sink();
         let output = process_exec::run_tool_async(
-            process_exec::run_process_with_timeout(
+            process_exec::run_process_with_timeout_with_sink(
                 runtime_command,
                 &args,
                 cwd.as_path(),
                 timeout_ms,
                 "bash command",
+                runtime_event_sink.clone(),
             ),
             "bash tool",
         )??;
@@ -251,13 +257,39 @@ fn probe_bash_candidate_with_timeout(candidate: &Path, timeout: Duration) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::bash_rules::{PrefixRuleDecision, compile_compatibility_rules};
     use crate::tools::runtime_config::ToolRuntimeConfig;
+    use crate::tools::runtime_events::{
+        ToolRuntimeEvent, ToolRuntimeEventSink, ToolRuntimeStream, with_tool_runtime_event_sink,
+    };
     use loongclaw_contracts::ToolCoreRequest;
     use serde_json::json;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
+
+    #[derive(Default)]
+    struct RecordingRuntimeSink {
+        events: Mutex<Vec<ToolRuntimeEvent>>,
+    }
+
+    fn lock_runtime_events(
+        sink: &RecordingRuntimeSink,
+    ) -> std::sync::MutexGuard<'_, Vec<ToolRuntimeEvent>> {
+        match sink.events.lock() {
+            Ok(events) => events,
+            Err(poisoned_events) => poisoned_events.into_inner(),
+        }
+    }
+
+    impl ToolRuntimeEventSink for RecordingRuntimeSink {
+        fn emit(&self, event: ToolRuntimeEvent) {
+            let mut events = lock_runtime_events(self);
+            events.push(event);
+        }
+    }
 
     #[test]
     fn probe_bash_runtime_prefers_path_bash_before_windows_fallbacks() {
@@ -392,6 +424,70 @@ mod tests {
             .expect_err("runtime should still be required after accepting trusted context");
 
         assert!(error.contains("bash unavailable"));
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn execute_bash_tool_with_config_emits_runtime_output_delta_and_single_metrics_event() {
+        let bash_available = probe_bash_candidate(Path::new("bash"));
+        if !bash_available {
+            eprintln!("skipping bash runtime event test because bash is unavailable");
+            return;
+        }
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let root_path = root.path().to_path_buf();
+        let mut config = ToolRuntimeConfig {
+            file_root: Some(root_path.clone()),
+            shell_allow: ["printf".to_owned()].into_iter().collect(),
+            ..ToolRuntimeConfig::default()
+        };
+        config.bash_exec.available = true;
+        config.bash_exec.command = Some(PathBuf::from("bash"));
+        config.bash_exec.governance.rules = compile_compatibility_rules(
+            "test_allow",
+            PrefixRuleDecision::Allow,
+            ["printf", "hello"],
+        );
+
+        let request = ToolCoreRequest {
+            tool_name: "bash.exec".to_owned(),
+            payload: json!({
+                "command": "printf 'hello\\nworld'",
+                "cwd": root_path.display().to_string(),
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_bash_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("bash.exec should succeed under runtime sink");
+        let events = lock_runtime_events(&sink);
+        let stdout_delta_count = events
+            .iter()
+            .filter(|event| {
+                let ToolRuntimeEvent::OutputDelta(delta) = event else {
+                    return false;
+                };
+                let is_stdout = delta.stream == ToolRuntimeStream::Stdout;
+                let contains_output = delta.chunk.contains("hello");
+                is_stdout && contains_output
+            })
+            .count();
+        let metrics_count = events
+            .iter()
+            .filter(|event| matches!(event, ToolRuntimeEvent::CommandMetrics(_)))
+            .count();
+
+        assert_eq!(outcome.status, "ok");
+        assert!(stdout_delta_count >= 1, "events: {events:?}");
+        assert_eq!(metrics_count, 1, "events: {events:?}");
     }
 
     #[cfg(not(feature = "tool-shell"))]

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -5,6 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(feature = "tool-file")]
+use super::runtime_events::{
+    ToolFileChangeKind, ToolFileChangePreview, ToolRuntimeEvent, current_tool_runtime_event_sink,
+};
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 #[cfg(feature = "tool-file")]
 use regex::{Regex, RegexBuilder};
@@ -14,6 +18,13 @@ use serde_json::{Value, json};
 use std::io::Write as _;
 #[cfg(feature = "tool-file")]
 use tempfile::NamedTempFile;
+
+#[cfg(feature = "tool-file")]
+const FILE_CHANGE_PREVIEW_MAX_LINES: usize = 8;
+#[cfg(feature = "tool-file")]
+const FILE_CHANGE_PREVIEW_MAX_CHARS: usize = 1_200;
+#[cfg(feature = "tool-file")]
+const FILE_CHANGE_PREVIEW_MAX_COMPARISON_CELLS: usize = 200_000;
 
 pub(super) fn execute_file_read_tool_with_config(
     request: ToolCoreRequest,
@@ -132,11 +143,33 @@ pub(super) fn execute_file_write_tool_with_config(
             ));
         }
 
+        let existed_before_write = resolved.exists();
+        let before_content =
+            if existed_before_write {
+                Some(fs::read_to_string(&resolved).map_err(|error| {
+                    format!("failed to read file {}: {error}", resolved.display())
+                })?)
+            } else {
+                None
+            };
+
         if overwrite {
             write_file_atomically(&resolved, content)?;
         } else {
             write_new_file_without_overwrite(&resolved, content)?;
         }
+
+        let change_kind = if existed_before_write {
+            ToolFileChangeKind::Overwrite
+        } else {
+            ToolFileChangeKind::Create
+        };
+        emit_file_change_preview(
+            resolved.as_path(),
+            change_kind,
+            before_content.as_deref(),
+            content,
+        );
 
         Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
@@ -266,6 +299,12 @@ pub(super) fn execute_file_edit_tool_with_config(
 
         fs::write(&resolved, updated.as_bytes())
             .map_err(|e| format!("failed to write {}: {e}", resolved.display()))?;
+        emit_file_change_preview(
+            resolved.as_path(),
+            ToolFileChangeKind::Edit,
+            Some(content.as_str()),
+            updated.as_str(),
+        );
 
         Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
@@ -277,6 +316,508 @@ pub(super) fn execute_file_edit_tool_with_config(
                 "bytes_written": updated.len(),
             }),
         })
+    }
+}
+
+#[cfg(feature = "tool-file")]
+fn emit_file_change_preview(
+    path: &Path,
+    kind: ToolFileChangeKind,
+    before: Option<&str>,
+    after: &str,
+) {
+    let runtime_event_sink = current_tool_runtime_event_sink();
+    let Some(sink) = runtime_event_sink.as_ref() else {
+        return;
+    };
+
+    let preview = build_file_change_preview(path, kind, before, after);
+    let event = ToolRuntimeEvent::FileChangePreview(preview);
+    sink.emit(event);
+}
+
+#[cfg(feature = "tool-file")]
+fn build_file_change_preview(
+    path: &Path,
+    kind: ToolFileChangeKind,
+    before: Option<&str>,
+    after: &str,
+) -> ToolFileChangePreview {
+    let before_lines = before.map(split_file_preview_lines).unwrap_or_default();
+    let after_lines = split_file_preview_lines(after);
+    let (added_lines, removed_lines, preview) =
+        summarize_file_change_preview(before_lines.as_slice(), after_lines.as_slice());
+    let path_display = path.display().to_string();
+
+    ToolFileChangePreview {
+        path: path_display,
+        kind,
+        added_lines,
+        removed_lines,
+        preview,
+    }
+}
+
+#[cfg(feature = "tool-file")]
+fn split_file_preview_lines(text: &str) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    text.lines().map(str::to_owned).collect()
+}
+
+#[cfg(feature = "tool-file")]
+fn summarize_file_change_preview(
+    before_lines: &[String],
+    after_lines: &[String],
+) -> (usize, usize, Option<String>) {
+    let comparison_cells = before_lines.len().saturating_mul(after_lines.len());
+    let can_use_precise_diff = comparison_cells <= FILE_CHANGE_PREVIEW_MAX_COMPARISON_CELLS;
+
+    if can_use_precise_diff {
+        let operations = build_line_diff_operations(before_lines, after_lines);
+        let added_lines = count_insert_operations(operations.as_slice());
+        let removed_lines = count_delete_operations(operations.as_slice());
+        let preview = build_file_change_preview_text_from_operations(operations.as_slice());
+
+        return (added_lines, removed_lines, preview);
+    }
+
+    summarize_file_change_preview_with_boundary_fallback(before_lines, after_lines)
+}
+
+#[cfg(feature = "tool-file")]
+fn summarize_file_change_preview_with_boundary_fallback(
+    before_lines: &[String],
+    after_lines: &[String],
+) -> (usize, usize, Option<String>) {
+    let common_prefix_len = shared_prefix_line_count(before_lines, after_lines);
+    let common_suffix_len = shared_suffix_line_count(before_lines, after_lines, common_prefix_len);
+    let removed_end = before_lines.len().saturating_sub(common_suffix_len);
+    let added_end = after_lines.len().saturating_sub(common_suffix_len);
+    let removed_slice = before_lines
+        .get(common_prefix_len..removed_end)
+        .unwrap_or(&[]);
+    let added_slice = after_lines.get(common_prefix_len..added_end).unwrap_or(&[]);
+    let removed_lines = removed_slice.len();
+    let added_lines = added_slice.len();
+
+    let preview = build_file_change_preview_text_with_boundary_fallback(
+        common_prefix_len,
+        removed_slice,
+        added_slice,
+    );
+
+    (added_lines, removed_lines, preview)
+}
+
+#[cfg(feature = "tool-file")]
+fn shared_prefix_line_count(before_lines: &[String], after_lines: &[String]) -> usize {
+    let max_prefix_len = before_lines.len().min(after_lines.len());
+    let mut prefix_len = 0_usize;
+
+    while prefix_len < max_prefix_len {
+        let Some(before_line) = before_lines.get(prefix_len) else {
+            break;
+        };
+        let Some(after_line) = after_lines.get(prefix_len) else {
+            break;
+        };
+        if before_line != after_line {
+            break;
+        }
+        prefix_len = prefix_len.saturating_add(1);
+    }
+
+    prefix_len
+}
+
+#[cfg(feature = "tool-file")]
+fn shared_suffix_line_count(
+    before_lines: &[String],
+    after_lines: &[String],
+    common_prefix_len: usize,
+) -> usize {
+    let before_remaining = before_lines.len().saturating_sub(common_prefix_len);
+    let after_remaining = after_lines.len().saturating_sub(common_prefix_len);
+    let max_suffix_len = before_remaining.min(after_remaining);
+    let mut suffix_len = 0_usize;
+
+    while suffix_len < max_suffix_len {
+        let before_index = before_lines.len().saturating_sub(suffix_len + 1);
+        let after_index = after_lines.len().saturating_sub(suffix_len + 1);
+        let Some(before_line) = before_lines.get(before_index) else {
+            break;
+        };
+        let Some(after_line) = after_lines.get(after_index) else {
+            break;
+        };
+        if before_line != after_line {
+            break;
+        }
+        suffix_len = suffix_len.saturating_add(1);
+    }
+
+    suffix_len
+}
+
+#[cfg(feature = "tool-file")]
+fn build_file_change_preview_text_with_boundary_fallback(
+    common_prefix_len: usize,
+    removed_slice: &[String],
+    added_slice: &[String],
+) -> Option<String> {
+    if removed_slice.is_empty() && added_slice.is_empty() {
+        return None;
+    }
+
+    let removed_len = removed_slice.len();
+    let added_len = added_slice.len();
+    let hunk_start = common_prefix_len.saturating_add(1);
+    let mut preview_lines = Vec::new();
+    let hunk_header = format!("@@ -{hunk_start},{removed_len} +{hunk_start},{added_len} @@");
+    preview_lines.push(hunk_header);
+
+    let mut emitted_preview_lines = 0_usize;
+    let mut omitted_preview_lines = 0_usize;
+
+    for removed_line in removed_slice {
+        let can_emit_line = emitted_preview_lines < FILE_CHANGE_PREVIEW_MAX_LINES;
+        if can_emit_line {
+            let preview_line = format!("-{removed_line}");
+            preview_lines.push(preview_line);
+            emitted_preview_lines = emitted_preview_lines.saturating_add(1);
+        } else {
+            omitted_preview_lines = omitted_preview_lines.saturating_add(1);
+        }
+    }
+
+    for added_line in added_slice {
+        let can_emit_line = emitted_preview_lines < FILE_CHANGE_PREVIEW_MAX_LINES;
+        if can_emit_line {
+            let preview_line = format!("+{added_line}");
+            preview_lines.push(preview_line);
+            emitted_preview_lines = emitted_preview_lines.saturating_add(1);
+        } else {
+            omitted_preview_lines = omitted_preview_lines.saturating_add(1);
+        }
+    }
+
+    if omitted_preview_lines > 0 {
+        let omitted_line = format!("… {omitted_preview_lines} more changed line(s)");
+        preview_lines.push(omitted_line);
+    }
+
+    let preview_text = preview_lines.join("\n");
+    let preview_char_count = preview_text.chars().count();
+    if preview_char_count <= FILE_CHANGE_PREVIEW_MAX_CHARS {
+        return Some(preview_text);
+    }
+
+    let retained_char_count = FILE_CHANGE_PREVIEW_MAX_CHARS.saturating_sub(1);
+    let truncated_tail = preview_text
+        .chars()
+        .rev()
+        .take(retained_char_count)
+        .collect::<Vec<_>>();
+    let truncated_tail = truncated_tail.into_iter().rev().collect::<String>();
+    let truncated_preview = format!("…{truncated_tail}");
+    Some(truncated_preview)
+}
+
+#[cfg(feature = "tool-file")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LineDiffKind {
+    Equal,
+    Delete,
+    Insert,
+}
+
+#[cfg(feature = "tool-file")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LineDiffOperation {
+    kind: LineDiffKind,
+    line: String,
+}
+
+#[cfg(feature = "tool-file")]
+#[derive(Default)]
+struct FileChangePreviewHunkBuilder {
+    old_start: usize,
+    new_start: usize,
+    old_len: usize,
+    new_len: usize,
+    lines: Vec<String>,
+}
+
+#[cfg(feature = "tool-file")]
+fn build_line_diff_operations(
+    before_lines: &[String],
+    after_lines: &[String],
+) -> Vec<LineDiffOperation> {
+    let row_count = before_lines.len().saturating_add(1);
+    let column_count = after_lines.len().saturating_add(1);
+    let matrix_len = row_count.saturating_mul(column_count);
+    let mut matrix = vec![0_usize; matrix_len];
+
+    let mut before_index = before_lines.len();
+    while before_index > 0 {
+        before_index = before_index.saturating_sub(1);
+
+        let mut after_index = after_lines.len();
+        while after_index > 0 {
+            after_index = after_index.saturating_sub(1);
+
+            let matrix_index = before_index.saturating_mul(column_count) + after_index;
+            let diagonal_index = (before_index.saturating_add(1)).saturating_mul(column_count)
+                + after_index.saturating_add(1);
+            let down_index =
+                (before_index.saturating_add(1)).saturating_mul(column_count) + after_index;
+            let right_index =
+                before_index.saturating_mul(column_count) + after_index.saturating_add(1);
+            let Some(before_line) = before_lines.get(before_index) else {
+                continue;
+            };
+            let Some(after_line) = after_lines.get(after_index) else {
+                continue;
+            };
+
+            if before_line == after_line {
+                let diagonal_value = *matrix.get(diagonal_index).unwrap_or(&0);
+                let next_value = diagonal_value.saturating_add(1);
+                if let Some(cell) = matrix.get_mut(matrix_index) {
+                    *cell = next_value;
+                }
+                continue;
+            }
+
+            let down_value = *matrix.get(down_index).unwrap_or(&0);
+            let right_value = *matrix.get(right_index).unwrap_or(&0);
+            let next_value = down_value.max(right_value);
+            if let Some(cell) = matrix.get_mut(matrix_index) {
+                *cell = next_value;
+            }
+        }
+    }
+
+    let mut operations = Vec::new();
+    let mut before_cursor = 0_usize;
+    let mut after_cursor = 0_usize;
+    while before_cursor < before_lines.len() && after_cursor < after_lines.len() {
+        let Some(before_line) = before_lines.get(before_cursor) else {
+            break;
+        };
+        let Some(after_line) = after_lines.get(after_cursor) else {
+            break;
+        };
+
+        if before_line == after_line {
+            let operation = LineDiffOperation {
+                kind: LineDiffKind::Equal,
+                line: before_line.clone(),
+            };
+            operations.push(operation);
+            before_cursor = before_cursor.saturating_add(1);
+            after_cursor = after_cursor.saturating_add(1);
+            continue;
+        }
+
+        let down_index =
+            (before_cursor.saturating_add(1)).saturating_mul(column_count) + after_cursor;
+        let right_index =
+            before_cursor.saturating_mul(column_count) + after_cursor.saturating_add(1);
+        let down_value = *matrix.get(down_index).unwrap_or(&0);
+        let right_value = *matrix.get(right_index).unwrap_or(&0);
+
+        if down_value >= right_value {
+            let operation = LineDiffOperation {
+                kind: LineDiffKind::Delete,
+                line: before_line.clone(),
+            };
+            operations.push(operation);
+            before_cursor = before_cursor.saturating_add(1);
+            continue;
+        }
+
+        let operation = LineDiffOperation {
+            kind: LineDiffKind::Insert,
+            line: after_line.clone(),
+        };
+        operations.push(operation);
+        after_cursor = after_cursor.saturating_add(1);
+    }
+
+    while before_cursor < before_lines.len() {
+        let Some(before_line) = before_lines.get(before_cursor) else {
+            break;
+        };
+        let operation = LineDiffOperation {
+            kind: LineDiffKind::Delete,
+            line: before_line.clone(),
+        };
+        operations.push(operation);
+        before_cursor = before_cursor.saturating_add(1);
+    }
+
+    while after_cursor < after_lines.len() {
+        let Some(after_line) = after_lines.get(after_cursor) else {
+            break;
+        };
+        let operation = LineDiffOperation {
+            kind: LineDiffKind::Insert,
+            line: after_line.clone(),
+        };
+        operations.push(operation);
+        after_cursor = after_cursor.saturating_add(1);
+    }
+
+    operations
+}
+
+#[cfg(feature = "tool-file")]
+fn count_insert_operations(operations: &[LineDiffOperation]) -> usize {
+    let mut count = 0_usize;
+    for operation in operations {
+        if operation.kind == LineDiffKind::Insert {
+            count = count.saturating_add(1);
+        }
+    }
+    count
+}
+
+#[cfg(feature = "tool-file")]
+fn count_delete_operations(operations: &[LineDiffOperation]) -> usize {
+    let mut count = 0_usize;
+    for operation in operations {
+        if operation.kind == LineDiffKind::Delete {
+            count = count.saturating_add(1);
+        }
+    }
+    count
+}
+
+#[cfg(feature = "tool-file")]
+fn build_file_change_preview_text_from_operations(
+    operations: &[LineDiffOperation],
+) -> Option<String> {
+    let has_change = operations
+        .iter()
+        .any(|operation| operation.kind != LineDiffKind::Equal);
+    if !has_change {
+        return None;
+    }
+
+    let mut preview_lines = Vec::new();
+    let mut emitted_preview_lines = 0_usize;
+    let mut omitted_preview_lines = 0_usize;
+    let mut current_hunk = None::<FileChangePreviewHunkBuilder>;
+    let mut old_line_number = 1_usize;
+    let mut new_line_number = 1_usize;
+
+    for operation in operations {
+        if operation.kind == LineDiffKind::Equal {
+            finalize_file_change_preview_hunk(
+                &mut preview_lines,
+                &mut emitted_preview_lines,
+                &mut omitted_preview_lines,
+                &mut current_hunk,
+            );
+            old_line_number = old_line_number.saturating_add(1);
+            new_line_number = new_line_number.saturating_add(1);
+            continue;
+        }
+
+        if current_hunk.is_none() {
+            let hunk = FileChangePreviewHunkBuilder {
+                old_start: old_line_number,
+                new_start: new_line_number,
+                old_len: 0,
+                new_len: 0,
+                lines: Vec::new(),
+            };
+            current_hunk = Some(hunk);
+        }
+
+        let Some(hunk) = current_hunk.as_mut() else {
+            continue;
+        };
+        let (line_prefix, advance_old, advance_new) = match operation.kind {
+            LineDiffKind::Delete => {
+                hunk.old_len = hunk.old_len.saturating_add(1);
+                ("-", true, false)
+            }
+            LineDiffKind::Insert => {
+                hunk.new_len = hunk.new_len.saturating_add(1);
+                ("+", false, true)
+            }
+            LineDiffKind::Equal => continue,
+        };
+        let preview_line = format!("{line_prefix}{}", operation.line);
+        hunk.lines.push(preview_line);
+
+        if advance_old {
+            old_line_number = old_line_number.saturating_add(1);
+        }
+        if advance_new {
+            new_line_number = new_line_number.saturating_add(1);
+        }
+    }
+
+    finalize_file_change_preview_hunk(
+        &mut preview_lines,
+        &mut emitted_preview_lines,
+        &mut omitted_preview_lines,
+        &mut current_hunk,
+    );
+
+    if omitted_preview_lines > 0 {
+        let omitted_line = format!("… {omitted_preview_lines} more changed line(s)");
+        preview_lines.push(omitted_line);
+    }
+
+    let preview_text = preview_lines.join("\n");
+    let preview_char_count = preview_text.chars().count();
+    if preview_char_count <= FILE_CHANGE_PREVIEW_MAX_CHARS {
+        return Some(preview_text);
+    }
+
+    let retained_char_count = FILE_CHANGE_PREVIEW_MAX_CHARS.saturating_sub(1);
+    let truncated_tail = preview_text
+        .chars()
+        .rev()
+        .take(retained_char_count)
+        .collect::<Vec<_>>();
+    let truncated_tail = truncated_tail.into_iter().rev().collect::<String>();
+    let truncated_preview = format!("…{truncated_tail}");
+    Some(truncated_preview)
+}
+
+#[cfg(feature = "tool-file")]
+fn finalize_file_change_preview_hunk(
+    preview_lines: &mut Vec<String>,
+    emitted_preview_lines: &mut usize,
+    omitted_preview_lines: &mut usize,
+    current_hunk: &mut Option<FileChangePreviewHunkBuilder>,
+) {
+    let Some(hunk) = current_hunk.take() else {
+        return;
+    };
+
+    let header = format!(
+        "@@ -{},{} +{},{} @@",
+        hunk.old_start, hunk.old_len, hunk.new_start, hunk.new_len,
+    );
+    preview_lines.push(header);
+
+    for line in hunk.lines {
+        let can_emit_line = *emitted_preview_lines < FILE_CHANGE_PREVIEW_MAX_LINES;
+        if can_emit_line {
+            preview_lines.push(line);
+            *emitted_preview_lines = emitted_preview_lines.saturating_add(1);
+        } else {
+            *omitted_preview_lines = omitted_preview_lines.saturating_add(1);
+        }
     }
 }
 
@@ -849,6 +1390,7 @@ fn normalize_without_fs_access(path: &Path) -> PathBuf {
 
 #[cfg(all(test, feature = "tool-file"))]
 mod tests {
+    use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use loongclaw_contracts::ToolCoreRequest;
@@ -856,6 +1398,30 @@ mod tests {
 
     use super::*;
     use crate::tools::runtime_config::ToolRuntimeConfig;
+    use crate::tools::runtime_events::{
+        ToolFileChangeKind, ToolRuntimeEvent, ToolRuntimeEventSink, with_tool_runtime_event_sink,
+    };
+
+    #[derive(Default)]
+    struct RecordingRuntimeSink {
+        events: Mutex<Vec<ToolRuntimeEvent>>,
+    }
+
+    fn lock_runtime_events(
+        sink: &RecordingRuntimeSink,
+    ) -> std::sync::MutexGuard<'_, Vec<ToolRuntimeEvent>> {
+        match sink.events.lock() {
+            Ok(events) => events,
+            Err(poisoned_events) => poisoned_events.into_inner(),
+        }
+    }
+
+    impl ToolRuntimeEventSink for RecordingRuntimeSink {
+        fn emit(&self, event: ToolRuntimeEvent) {
+            let mut events = lock_runtime_events(self);
+            events.push(event);
+        }
+    }
 
     #[cfg(unix)]
     fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
@@ -952,6 +1518,103 @@ mod tests {
         let written = fs::read_to_string(root.join("safe/note.txt")).expect("read written file");
         assert_eq!(written, "hello");
         let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_write_emits_create_change_preview_event() {
+        let base = unique_temp_dir("loongclaw-file-write-preview");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = ToolCoreRequest {
+            tool_name: "file.write".to_owned(),
+            payload: json!({
+                "path": "preview.txt",
+                "content": "alpha\nbeta\n",
+                "create_dirs": true
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_file_write_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("file.write should succeed");
+        let events = lock_runtime_events(&sink);
+        let preview = events.iter().find_map(|event| {
+            if let ToolRuntimeEvent::FileChangePreview(preview) = event {
+                return Some(preview);
+            }
+
+            None
+        });
+        let preview = preview.expect("file.write should emit change preview");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(preview.kind, ToolFileChangeKind::Create);
+        assert_eq!(preview.added_lines, 2);
+        assert_eq!(preview.removed_lines, 0);
+        assert!(preview.path.ends_with("preview.txt"));
+    }
+
+    #[test]
+    fn file_write_emits_overwrite_change_preview_event() {
+        let base = unique_temp_dir("loongclaw-file-write-overwrite-preview");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let target = root.join("preview.txt");
+        fs::write(&target, "old line\nshared\n").expect("seed original file");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = ToolCoreRequest {
+            tool_name: "file.write".to_owned(),
+            payload: json!({
+                "path": "preview.txt",
+                "content": "new line\nshared\nextra\n",
+                "overwrite": true
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_file_write_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("file.write overwrite should succeed");
+        let events = lock_runtime_events(&sink);
+        let preview = events.iter().find_map(|event| {
+            if let ToolRuntimeEvent::FileChangePreview(preview) = event {
+                return Some(preview);
+            }
+
+            None
+        });
+        let preview = preview.expect("file.write overwrite should emit change preview");
+        let preview_text = preview.preview.as_deref().unwrap_or_default();
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(preview.kind, ToolFileChangeKind::Overwrite);
+        assert_eq!(preview.added_lines, 2);
+        assert_eq!(preview.removed_lines, 1);
+        assert!(preview_text.contains("-old line"));
+        assert!(preview_text.contains("+new line"));
+        assert!(preview_text.contains("+extra"));
     }
 
     #[test]
@@ -1155,6 +1818,69 @@ mod tests {
         assert_eq!(outcome.payload["replacements_made"], 3);
         assert_eq!(fs::read_to_string(&target).unwrap(), "b\nb\nb\n");
         let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_edit_emits_change_preview_event() {
+        let base = unique_temp_dir("loongclaw-file-edit-preview");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let target = root.join("file.txt");
+        fs::write(&target, "old line\nshared\n").expect("write original file");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = make_edit_request("file.txt", "old line", "new line", None);
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_file_edit_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("file.edit should succeed");
+        let events = lock_runtime_events(&sink);
+        let preview = events.iter().find_map(|event| {
+            if let ToolRuntimeEvent::FileChangePreview(preview) = event {
+                return Some(preview);
+            }
+
+            None
+        });
+        let preview = preview.expect("file.edit should emit change preview");
+        let preview_text = preview.preview.as_deref().unwrap_or_default();
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(preview.kind, ToolFileChangeKind::Edit);
+        assert_eq!(preview.added_lines, 1);
+        assert_eq!(preview.removed_lines, 1);
+        assert!(preview_text.contains("-old line"));
+        assert!(preview_text.contains("+new line"));
+    }
+
+    #[test]
+    fn summarize_file_change_preview_preserves_shared_middle_lines_when_appending_tail() {
+        let before_lines = vec!["old line".to_owned(), "shared".to_owned()];
+        let after_lines = vec![
+            "new line".to_owned(),
+            "shared".to_owned(),
+            "extra".to_owned(),
+        ];
+
+        let (added_lines, removed_lines, preview) =
+            summarize_file_change_preview(before_lines.as_slice(), after_lines.as_slice());
+        let preview = preview.expect("preview should exist");
+
+        assert_eq!(added_lines, 2);
+        assert_eq!(removed_lines, 1);
+        assert!(preview.contains("-old line"), "preview: {preview}");
+        assert!(preview.contains("+new line"), "preview: {preview}");
+        assert!(preview.contains("+extra"), "preview: {preview}");
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -61,6 +61,7 @@ mod provider_switch;
 #[cfg(test)]
 mod required_capabilities_tests;
 pub mod runtime_config;
+pub(crate) mod runtime_events;
 mod session;
 #[cfg(feature = "memory-sqlite")]
 mod session_search;

--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -7,14 +7,20 @@ use std::path::Path;
 #[cfg(feature = "tool-shell")]
 use std::process::{Output, Stdio};
 #[cfg(feature = "tool-shell")]
+use std::sync::Arc;
+#[cfg(feature = "tool-shell")]
 use std::thread;
 #[cfg(feature = "tool-shell")]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(feature = "tool-shell")]
 use tokio::io::AsyncReadExt;
 #[cfg(feature = "tool-shell")]
 use tokio::process::Command;
 
+#[cfg(feature = "tool-shell")]
+use super::runtime_events::{
+    ToolCommandMetrics, ToolOutputDelta, ToolRuntimeEvent, ToolRuntimeEventSink, ToolRuntimeStream,
+};
 #[cfg(feature = "tool-shell")]
 use crate::process_launch::retry_executable_file_busy_async;
 
@@ -66,12 +72,20 @@ where
 }
 
 #[cfg(feature = "tool-shell")]
-async fn read_capped<R>(mut reader: R, cap: usize, stream_name: &str) -> Result<Vec<u8>, String>
+async fn read_capped_with_runtime_events<R>(
+    mut reader: R,
+    cap: usize,
+    stream_name: &str,
+    stream: ToolRuntimeStream,
+    runtime_event_sink: Option<Arc<dyn ToolRuntimeEventSink>>,
+) -> Result<Vec<u8>, String>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut output = Vec::new();
     let mut buffer = [0_u8; 8_192];
+    let mut total_bytes = 0_usize;
+    let mut newline_count = 0_usize;
 
     loop {
         let read = reader
@@ -82,10 +96,33 @@ where
             break;
         }
 
+        total_bytes = total_bytes.saturating_add(read);
+        let chunk_bytes = buffer.get(..read).unwrap_or(buffer.as_slice());
+        let chunk_newlines = chunk_bytes.iter().filter(|byte| **byte == b'\n').count();
+        newline_count = newline_count.saturating_add(chunk_newlines);
+        let last_byte_was_newline = chunk_bytes.last().copied() == Some(b'\n');
+
         let remaining = cap.saturating_sub(output.len());
         if remaining > 0 {
             let to_copy = remaining.min(read);
-            output.extend(buffer.iter().take(to_copy).copied());
+            let retained_chunk = chunk_bytes.get(..to_copy).unwrap_or(chunk_bytes);
+            output.extend(retained_chunk.iter().copied());
+        }
+
+        let has_partial_final_line = total_bytes > 0 && !last_byte_was_newline;
+        let total_lines = newline_count + usize::from(has_partial_final_line);
+        let truncated = total_bytes > cap;
+
+        if let Some(sink) = runtime_event_sink.as_ref() {
+            let chunk_text = String::from_utf8_lossy(chunk_bytes).into_owned();
+            let event = ToolRuntimeEvent::OutputDelta(ToolOutputDelta {
+                stream,
+                chunk: chunk_text,
+                total_bytes,
+                total_lines,
+                truncated,
+            });
+            sink.emit(event);
         }
     }
 
@@ -93,17 +130,19 @@ where
 }
 
 #[cfg(feature = "tool-shell")]
-pub(super) async fn run_process_with_timeout<P, S>(
+pub(super) async fn run_process_with_timeout_with_sink<P, S>(
     program: P,
     args: &[S],
     cwd: &Path,
     timeout_ms: u64,
     error_prefix: &str,
+    runtime_event_sink: Option<Arc<dyn ToolRuntimeEventSink>>,
 ) -> Result<Output, String>
 where
     P: AsRef<OsStr>,
     S: AsRef<OsStr>,
 {
+    let started_at = Instant::now();
     let mut command = Command::new(program);
     let sanitized_env = loongclaw_contracts::sanitized_child_process_env();
 
@@ -134,12 +173,31 @@ where
         .take()
         .ok_or_else(|| format!("{error_prefix} stderr pipe missing"))?;
 
-    let stdout_task =
-        tokio::spawn(async move { read_capped(stdout, OUTPUT_CAP_BYTES, "stdout").await });
-    let stderr_task =
-        tokio::spawn(async move { read_capped(stderr, OUTPUT_CAP_BYTES, "stderr").await });
+    let metrics_runtime_event_sink = runtime_event_sink.clone();
+    let stdout_runtime_event_sink = runtime_event_sink.clone();
+    let stdout_task = tokio::spawn(async move {
+        read_capped_with_runtime_events(
+            stdout,
+            OUTPUT_CAP_BYTES,
+            "stdout",
+            ToolRuntimeStream::Stdout,
+            stdout_runtime_event_sink,
+        )
+        .await
+    });
+    let stderr_runtime_event_sink = runtime_event_sink;
+    let stderr_task = tokio::spawn(async move {
+        read_capped_with_runtime_events(
+            stderr,
+            OUTPUT_CAP_BYTES,
+            "stderr",
+            ToolRuntimeStream::Stderr,
+            stderr_runtime_event_sink,
+        )
+        .await
+    });
 
-    match tokio::time::timeout(duration, child.wait()).await {
+    let result = match tokio::time::timeout(duration, child.wait()).await {
         Ok(Ok(status)) => {
             let (stdout_result, stderr_result) = tokio::join!(stdout_task, stderr_task);
             let stdout = stdout_result
@@ -175,7 +233,21 @@ where
             let _ = tokio::join!(stdout_task, stderr_task);
             Err(format!("{error_prefix} timed out after {timeout_ms}ms"))
         }
+    };
+
+    if let Some(sink) = metrics_runtime_event_sink.as_ref() {
+        let duration_ms = started_at.elapsed().as_millis();
+        let duration_ms = u64::try_from(duration_ms).unwrap_or(u64::MAX);
+        let exit_code = result.as_ref().ok().and_then(|output| output.status.code());
+        let metrics = ToolCommandMetrics {
+            exit_code,
+            duration_ms,
+        };
+        let event = ToolRuntimeEvent::CommandMetrics(metrics);
+        sink.emit(event);
     }
+
+    result
 }
 
 #[cfg(all(test, feature = "tool-shell"))]

--- a/crates/app/src/tools/runtime_events.rs
+++ b/crates/app/src/tools/runtime_events.rs
@@ -1,0 +1,66 @@
+use std::future::Future;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolRuntimeStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolFileChangeKind {
+    Create,
+    Overwrite,
+    Edit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolOutputDelta {
+    pub stream: ToolRuntimeStream,
+    pub chunk: String,
+    pub total_bytes: usize,
+    pub total_lines: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolFileChangePreview {
+    pub path: String,
+    pub kind: ToolFileChangeKind,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub preview: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCommandMetrics {
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolRuntimeEvent {
+    OutputDelta(ToolOutputDelta),
+    FileChangePreview(ToolFileChangePreview),
+    CommandMetrics(ToolCommandMetrics),
+}
+
+pub trait ToolRuntimeEventSink: Send + Sync {
+    fn emit(&self, event: ToolRuntimeEvent);
+}
+
+tokio::task_local! {
+    static TOOL_RUNTIME_EVENT_SINK_TASK: Arc<dyn ToolRuntimeEventSink>;
+}
+
+pub(crate) async fn with_tool_runtime_event_sink<T>(
+    sink: Arc<dyn ToolRuntimeEventSink>,
+    future: impl Future<Output = T>,
+) -> T {
+    TOOL_RUNTIME_EVENT_SINK_TASK.scope(sink, future).await
+}
+
+pub(crate) fn current_tool_runtime_event_sink() -> Option<Arc<dyn ToolRuntimeEventSink>> {
+    let sink = TOOL_RUNTIME_EVENT_SINK_TASK.try_with(Arc::clone);
+    sink.ok()
+}

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "tool-shell")]
 use super::process_exec;
+#[cfg(feature = "tool-shell")]
+use super::runtime_events::current_tool_runtime_event_sink;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 #[cfg(feature = "tool-shell")]
 use serde_json::{Value, json};
 #[cfg(feature = "tool-shell")]
 use std::path::{Path, PathBuf};
-
 pub(super) fn execute_shell_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -73,11 +74,16 @@ pub(super) fn execute_shell_tool_with_config(
             ));
         }
 
+        let runtime_event_sink = current_tool_runtime_event_sink();
+        // process_exec owns runtime command metrics emission. Keep shell.exec
+        // focused on payload construction so the live surface observes one
+        // metrics event per command.
         let output = run_shell_async(run_shell_command_with_timeout(
             normalized_command.as_str(),
             &args,
             cwd.as_path(),
             timeout_ms,
+            runtime_event_sink.clone(),
         ))??;
 
         Ok(ToolCoreOutcome {
@@ -186,8 +192,19 @@ async fn run_shell_command_with_timeout(
     args: &[String],
     cwd: &std::path::Path,
     timeout_ms: u64,
+    runtime_event_sink: Option<
+        std::sync::Arc<dyn crate::tools::runtime_events::ToolRuntimeEventSink>,
+    >,
 ) -> Result<std::process::Output, String> {
-    process_exec::run_process_with_timeout(command, args, cwd, timeout_ms, "shell command").await
+    process_exec::run_process_with_timeout_with_sink(
+        command,
+        args,
+        cwd,
+        timeout_ms,
+        "shell command",
+        runtime_event_sink,
+    )
+    .await
 }
 
 #[cfg(all(test, feature = "tool-shell", unix))]
@@ -195,7 +212,32 @@ mod tests {
     use super::*;
     use crate::test_support::unique_temp_dir;
     use crate::tools::runtime_config::ToolRuntimeConfig;
+    use crate::tools::runtime_events::{
+        ToolRuntimeEvent, ToolRuntimeEventSink, ToolRuntimeStream, with_tool_runtime_event_sink,
+    };
     use serde_json::json;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingRuntimeSink {
+        events: Mutex<Vec<ToolRuntimeEvent>>,
+    }
+
+    fn lock_runtime_events(
+        sink: &RecordingRuntimeSink,
+    ) -> std::sync::MutexGuard<'_, Vec<ToolRuntimeEvent>> {
+        match sink.events.lock() {
+            Ok(events) => events,
+            Err(poisoned_events) => poisoned_events.into_inner(),
+        }
+    }
+
+    impl ToolRuntimeEventSink for RecordingRuntimeSink {
+        fn emit(&self, event: ToolRuntimeEvent) {
+            let mut events = lock_runtime_events(self);
+            events.push(event);
+        }
+    }
 
     fn shell_test_config(root: &Path) -> ToolRuntimeConfig {
         ToolRuntimeConfig {
@@ -274,5 +316,152 @@ mod tests {
             execute_shell_tool_with_config(request, &config).expect_err("file cwd should fail");
 
         assert!(error.contains("is not a directory"), "error: {error}");
+    }
+
+    #[test]
+    fn shell_exec_emits_runtime_output_delta_and_metrics_events() {
+        let root = unique_temp_dir("loongclaw-shell-runtime-events");
+        std::fs::create_dir_all(&root).expect("create shell root");
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            shell_allow: ["printf".to_owned()].into_iter().collect(),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({
+                "command": "printf",
+                "args": ["hello\\nworld"],
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_shell_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("shell.exec should succeed under runtime sink");
+        let events = lock_runtime_events(&sink);
+        let has_stdout_delta = events.iter().any(|event| {
+            if let ToolRuntimeEvent::OutputDelta(delta) = event {
+                let is_stdout = delta.stream == ToolRuntimeStream::Stdout;
+                let contains_output = delta.chunk.contains("hello");
+                return is_stdout && contains_output;
+            }
+
+            false
+        });
+        let has_metrics = events.iter().any(|event| {
+            if let ToolRuntimeEvent::CommandMetrics(metrics) = event {
+                return metrics.exit_code == Some(0);
+            }
+
+            false
+        });
+        let metrics_count = events
+            .iter()
+            .filter(|event| matches!(event, ToolRuntimeEvent::CommandMetrics(_)))
+            .count();
+
+        assert_eq!(outcome.status, "ok");
+        assert!(has_stdout_delta, "events: {events:?}");
+        assert!(has_metrics, "events: {events:?}");
+        assert_eq!(metrics_count, 1, "events: {events:?}");
+    }
+
+    #[test]
+    fn shell_exec_runtime_output_delta_counts_terminal_newline_without_extra_line() {
+        let root = unique_temp_dir("loongclaw-shell-runtime-line-count");
+        std::fs::create_dir_all(&root).expect("create shell root");
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            shell_allow: ["printf".to_owned()].into_iter().collect(),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({
+                "command": "printf",
+                "args": ["alpha\\nbeta\\n"],
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_shell_tool_with_config(request, &config)
+        }));
+        let outcome = outcome.expect("shell.exec should succeed");
+        let events = lock_runtime_events(&sink);
+        let total_lines = events.iter().rev().find_map(|event| {
+            if let ToolRuntimeEvent::OutputDelta(delta) = event {
+                let is_stdout = delta.stream == ToolRuntimeStream::Stdout;
+                if is_stdout {
+                    return Some(delta.total_lines);
+                }
+            }
+
+            None
+        });
+        let total_lines = total_lines.expect("stdout delta should exist");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(total_lines, 2);
+    }
+
+    #[test]
+    fn shell_exec_emits_runtime_metrics_for_timeout_failures() {
+        let root = unique_temp_dir("loongclaw-shell-runtime-timeout-metrics");
+        std::fs::create_dir_all(&root).expect("create shell root");
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            shell_allow: ["sh".to_owned()].into_iter().collect(),
+            ..ToolRuntimeConfig::default()
+        };
+        let request = ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({
+                "command": "sh",
+                "args": ["-c", "sleep 2"],
+                "timeout_ms": 1000,
+            }),
+        };
+        let sink = Arc::new(RecordingRuntimeSink::default());
+        let runtime_sink: Arc<dyn ToolRuntimeEventSink> = sink.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let error = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
+            execute_shell_tool_with_config(request, &config)
+        }));
+        let error = error.expect_err("shell.exec should time out");
+        let events = lock_runtime_events(&sink);
+        let metrics = events.iter().find_map(|event| {
+            if let ToolRuntimeEvent::CommandMetrics(metrics) = event {
+                return Some(metrics);
+            }
+
+            None
+        });
+        let metrics = metrics.expect("timeout should still emit runtime metrics");
+        let metrics_count = events
+            .iter()
+            .filter(|event| matches!(event, ToolRuntimeEvent::CommandMetrics(_)))
+            .count();
+
+        assert!(error.contains("timed out after 1000ms"), "error: {error}");
+        assert_eq!(metrics.exit_code, None);
+        assert!(metrics.duration_ms > 0, "metrics: {metrics:?}");
+        assert_eq!(metrics_count, 1, "events: {events:?}");
     }
 }

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T05:14:20Z
+- Generated at: 2026-04-10T08:35:27Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,17 +20,17 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 7207 | 7300 | 93 | 136 | 160 | 24 | 98.7% | TIGHT | 6936 | 3.9% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6415 | 7300 | 885 | 97 | 160 | 63 | 87.9% | WATCH | 6936 | -7.5% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1790 | 6400 | 4610 | 0 | 110 | 110 | 28.0% | HEALTHY | 1779 | 0.6% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10294 | 11200 | 906 | 86 | 120 | 34 | 91.9% | WATCH | 10831 | -5.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14777 | 15000 | 223 | 61 | 70 | 9 | 98.5% | TIGHT | 14472 | 2.1% | PASS | 54 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10299 | 11200 | 901 | 86 | 120 | 34 | 92.0% | WATCH | 10831 | -4.9% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14778 | 15000 | 222 | 61 | 70 | 9 | 98.5% | TIGHT | 14472 | 2.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6498 | 6500 | 2 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), chat_runtime (98.7%), tools_mod (98.5%), daemon_lib (100.0%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), turn_coordinator (91.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), tools_mod (98.5%), daemon_lib (100.0%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (87.9%), turn_coordinator (92.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,10 +66,10 @@
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
-<!-- arch-hotspot key=chat_runtime lines=7207 functions=136 -->
+<!-- arch-hotspot key=chat_runtime lines=6415 functions=97 -->
 <!-- arch-hotspot key=channel_mod lines=1790 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10294 functions=86 -->
-<!-- arch-hotspot key=tools_mod lines=14777 functions=61 -->
+<!-- arch-hotspot key=turn_coordinator lines=10299 functions=86 -->
+<!-- arch-hotspot key=tools_mod lines=14778 functions=61 -->
 <!-- arch-hotspot key=daemon_lib lines=6498 functions=201 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  The interactive chat live surface had partial typed runtime plumbing, but it still collapsed tool state into preformatted strings too early, shell metrics could be emitted twice, overwrite previews could miscount changed lines when a tail append displaced suffix matching, and the rebased `chat.rs` had grown past the enforced architecture budget.
- Why it matters:
  Operators need trustworthy real-time tool visibility, future chat/TUI surfaces need a reusable structured runtime model instead of reconstructing state from flattened strings, and the main chat entrypoint needs to stay within governance size limits so the harness remains evolvable.
- What changed:
  Preserved structured per-tool live snapshots in the chat live surface, threaded observer runtime events through the conversation turn path, made the fullscreen session surface reuse the same typed snapshot helpers, extracted the live-runtime implementation into `chat/live_runtime.rs` to bring `chat.rs` back under budget, centralized shell metrics emission in `process_exec`, added bash runtime event coverage, and upgraded file-change preview generation to use a bounded line diff that handles shared middle lines correctly.
- What did not change (scope boundary):
  No new third-party diff dependency, no separate fullscreen-only runtime model, and no expansion of unrelated tool UI beyond the existing live runtime surfaces.

## Linked Issues

- Closes #1174
- Related #689
- Related #1147

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(covered locally for the touched `loongclaw-app` package; repo-wide clippy remains out of scope for this PR lane)*
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
bash scripts/generate_architecture_drift_report.sh docs/releases/architecture-drift-2026-04.md
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md
cargo audit
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo check -p loongclaw-app --all-features --tests --message-format short
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test -p loongclaw-app --lib cli_chat_live_surface -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test -p loongclaw-app --lib session_surface -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test -p loongclaw-app --lib 'tools::shell::tests' -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test -p loongclaw-app --lib 'tools::file::tests' -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test -p loongclaw-app --lib 'tools::bash::tests' -- --test-threads=1
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo check --workspace --all-features --locked --message-format short
CARGO_TARGET_DIR=/tmp/loongclaw-pr1176-check cargo test --workspace --all-features
```

## User-visible / Operator-visible Changes

- The live chat surface now retains structured per-tool runtime state internally instead of only preformatted tool-activity lines.
- The fullscreen interactive chat surface now consumes the same structured runtime snapshots as the REPL observer.
- `shell.exec` / `bash.exec` output deltas and command metrics are surfaced through a single runtime-event path.
- File overwrite previews no longer over-count changed lines when unchanged middle lines are followed by appended tail content.
- The chat live-runtime implementation now sits behind a dedicated module boundary, keeping the top-level chat surface easier to evolve.

## Failure Recovery

- Fast rollback or disable path:
  Revert this change set to restore the prior live-surface flattening and preview behavior.
- Observable failure symptoms reviewers should watch for:
  Missing tool runtime sections in the chat live surface, duplicated shell metrics lines, stale fullscreen tool panes, overwrite previews that still report inflated +/- counts, or future regressions that push `chat.rs` back over the architecture budget.

## Reviewer Focus

- `crates/app/src/chat/live_runtime.rs` and `crates/app/src/chat/session_surface.rs` for structured snapshot retention and cross-surface runtime-event rendering
- `crates/app/src/tools/process_exec.rs`, `crates/app/src/tools/shell.rs`, and `crates/app/src/tools/bash.rs` for single-source metrics emission and output-delta plumbing
- `crates/app/src/tools/file.rs` for the bounded line-diff preview algorithm and overwrite root-cause fix
- `docs/releases/architecture-drift-2026-04.md` for the updated architecture-budget evidence after the module split


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live CLI surface: streaming tool output, draft preview, file-change previews, and command metrics (duration & exit codes).

* **Improvements**
  * Structured runtime events for precise, truncated-aware stdout/stderr and file-diff previews.
  * Improved sizing, buffering, and rendering of live previews and sidebar tool activity.
  * Live observer logic reorganized for clearer runtime-scoped updates.

* **Tests**
  * Added tests validating runtime output deltas, file-change previews, and metrics.

* **Docs**
  * Updated architecture report metrics and timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->