### PR TITLE
Surface explicit task status and attention on background tasks

### DIFF
--- a/crates/daemon/src/onboard_web_search.rs
+++ b/crates/daemon/src/onboard_web_search.rs
@@ -607,6 +607,8 @@ mod tests {
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.web_search.default_provider =
             mvp::config::WEB_SEARCH_PROVIDER_TAVILY.to_owned();
+        let mut env = ScopedEnv::new();
+        clear_web_search_credential_envs(&mut env);
 
         let recommendation = resolve_web_search_provider_recommendation(&options, &config)
             .await

--- a/crates/daemon/src/onboard_web_search.rs
+++ b/crates/daemon/src/onboard_web_search.rs
@@ -554,6 +554,9 @@ mod tests {
             for env_name in descriptor.api_key_env_names {
                 env.remove(*env_name);
             }
+            if let Some(default_env_name) = descriptor.default_api_key_env {
+                env.remove(default_env_name);
+            }
         }
     }
 

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -944,6 +944,14 @@ fn build_task_detail(
         .get("recent_events")
         .cloned()
         .unwrap_or_else(|| json!([]));
+    let task_status = build_task_status_payload(
+        &session,
+        &delegate,
+        &approval_requests,
+        &approval_attention_summary,
+        &tool_policy,
+        &recent_events,
+    );
 
     let detail = json!({
         "task_id": task_id,
@@ -973,6 +981,7 @@ fn build_task_detail(
         "recovery": recovery,
         "terminal_outcome": terminal_outcome,
         "recent_events": recent_events,
+        "task_status": task_status,
     });
     Ok(detail)
 }
@@ -995,6 +1004,7 @@ fn build_best_effort_task_detail(
 }
 
 fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
+    let task_status = unknown_task_status_payload();
     json!({
         "task_id": task_id,
         "session_id": task_id,
@@ -1012,6 +1022,7 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
             "requests": [],
         },
         "tool_policy": Value::Null,
+        "task_status": task_status,
     })
 }
 
@@ -1075,6 +1086,278 @@ fn parse_task_state_filter(raw_state: &str) -> CliResult<mvp::session::repositor
 struct TaskStatusSummary {
     is_background_task: bool,
     is_overdue: bool,
+}
+
+fn build_task_status_payload(
+    session: &Value,
+    delegate: &Value,
+    approval_requests: &Value,
+    approval_attention_summary: &Value,
+    tool_policy: &Value,
+    recent_events: &Value,
+) -> Value {
+    let session_state = session
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let phase = delegate
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let staleness_state = delegate
+        .get("staleness")
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str);
+    let cancellation_state = delegate
+        .get("cancellation")
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str);
+    let approval_attention_count = approval_attention_summary
+        .get("needs_attention_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let has_approval_attention = approval_attention_count > 0;
+    let approval_primary_action = primary_approval_action(approval_requests).map(ToOwned::to_owned);
+    let recovered = recent_events_contains_kind(recent_events, "delegate_recovery_applied");
+    let tool_narrowing_active = task_tool_narrowing_active(tool_policy);
+    let kind = derive_task_status_kind(
+        session_state,
+        phase,
+        staleness_state,
+        cancellation_state,
+        has_approval_attention,
+    );
+    let display = render_task_status_display(kind, recovered);
+    let blocked = task_status_is_blocked(kind);
+    let terminal = task_status_is_terminal(kind);
+    let status = kind;
+    let needs_attention = task_status_needs_attention(kind, approval_primary_action.as_deref());
+    let next_action = task_status_next_action(kind, approval_primary_action.as_deref());
+    let signals = build_task_status_signals(
+        kind,
+        recovered,
+        tool_narrowing_active,
+        has_approval_attention,
+        staleness_state,
+        cancellation_state,
+    );
+
+    json!({
+        "status": status,
+        "kind": kind,
+        "display": display,
+        "blocked": blocked,
+        "terminal": terminal,
+        "needs_attention": needs_attention,
+        "next_action": next_action,
+        "approval_primary_action": approval_primary_action,
+        "recovered": recovered,
+        "tool_narrowing_active": tool_narrowing_active,
+        "signals": signals,
+    })
+}
+
+fn unknown_task_status_payload() -> Value {
+    json!({
+        "status": "unknown",
+        "kind": "unknown",
+        "display": "unknown",
+        "blocked": false,
+        "terminal": false,
+        "needs_attention": false,
+        "next_action": "status",
+        "approval_primary_action": Value::Null,
+        "recovered": false,
+        "tool_narrowing_active": false,
+        "signals": [],
+    })
+}
+
+fn derive_task_status_kind(
+    session_state: &str,
+    phase: &str,
+    staleness_state: Option<&str>,
+    cancellation_state: Option<&str>,
+    has_approval_attention: bool,
+) -> &'static str {
+    if session_state == "completed" {
+        return "completed";
+    }
+
+    if session_state == "failed" {
+        return "failed";
+    }
+
+    if session_state == "timed_out" {
+        return "timed_out";
+    }
+
+    let is_overdue = staleness_state == Some("overdue");
+    if is_overdue {
+        return "overdue";
+    }
+
+    let cancel_requested = cancellation_state == Some("requested");
+    if cancel_requested {
+        return "cancel_requested";
+    }
+
+    if has_approval_attention {
+        return "approval_pending";
+    }
+
+    if session_state == "running" {
+        return "running";
+    }
+
+    let queued_state = session_state == "ready";
+    let queued_phase = phase == "queued";
+    if queued_state || queued_phase {
+        return "queued";
+    }
+
+    "unknown"
+}
+
+fn render_task_status_display(kind: &str, recovered: bool) -> String {
+    let base = kind.to_owned();
+    if !recovered {
+        return base;
+    }
+
+    let display = format!("{base} (recovered)");
+    display
+}
+
+fn task_status_is_blocked(kind: &str) -> bool {
+    matches!(kind, "approval_pending" | "overdue")
+}
+
+fn task_status_is_terminal(kind: &str) -> bool {
+    matches!(kind, "completed" | "failed" | "timed_out")
+}
+
+fn task_status_needs_attention(kind: &str, approval_primary_action: Option<&str>) -> bool {
+    let status_requires_attention = matches!(
+        kind,
+        "approval_pending" | "overdue" | "failed" | "timed_out"
+    );
+    if status_requires_attention {
+        return true;
+    }
+
+    approval_primary_action.is_some()
+}
+
+fn task_status_next_action(kind: &str, approval_primary_action: Option<&str>) -> String {
+    if let Some(approval_primary_action) = approval_primary_action {
+        let next_action = approval_primary_action.to_owned();
+        return next_action;
+    }
+
+    match kind {
+        "approval_pending" => "status".to_owned(),
+        "overdue" => "recover".to_owned(),
+        "queued" => "wait".to_owned(),
+        "running" => "wait".to_owned(),
+        "cancel_requested" => "wait".to_owned(),
+        "completed" => "events".to_owned(),
+        "failed" => "events".to_owned(),
+        "timed_out" => "events".to_owned(),
+        _ => "status".to_owned(),
+    }
+}
+
+fn build_task_status_signals(
+    kind: &str,
+    recovered: bool,
+    tool_narrowing_active: bool,
+    has_approval_attention: bool,
+    staleness_state: Option<&str>,
+    cancellation_state: Option<&str>,
+) -> Vec<String> {
+    let mut signals = Vec::new();
+
+    if has_approval_attention {
+        signals.push("approval_pending".to_owned());
+    }
+
+    if staleness_state == Some("overdue") {
+        signals.push("overdue".to_owned());
+    }
+
+    if cancellation_state == Some("requested") {
+        signals.push("cancel_requested".to_owned());
+    }
+
+    if recovered {
+        signals.push("recovered".to_owned());
+    }
+
+    if tool_narrowing_active {
+        signals.push("tool_narrowing_active".to_owned());
+    }
+
+    let terminal = task_status_is_terminal(kind);
+    if terminal {
+        signals.push("terminal".to_owned());
+    }
+
+    signals
+}
+
+fn recent_events_contains_kind(recent_events: &Value, expected_kind: &str) -> bool {
+    let Some(events) = recent_events.as_array() else {
+        return false;
+    };
+
+    for event in events {
+        let event_kind = event
+            .get("event_kind")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let matches_kind = event_kind == expected_kind;
+        if matches_kind {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn primary_approval_action(approval_requests: &Value) -> Option<&str> {
+    let requests = approval_requests.as_array()?;
+
+    for request in requests {
+        let action = request
+            .get("attention")
+            .and_then(|value| value.get("primary_action"))
+            .and_then(Value::as_str);
+        if action.is_some() {
+            return action;
+        }
+    }
+
+    None
+}
+
+fn task_tool_narrowing_active(tool_policy: &Value) -> bool {
+    let effective_tool_ids = tool_policy
+        .get("effective_tool_ids")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let base_tool_ids = tool_policy
+        .get("base_tool_ids")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let runtime_narrowing = tool_policy.get("effective_runtime_narrowing");
+    let runtime_narrowing = runtime_narrowing.cloned().unwrap_or(Value::Null);
+    let tool_ids_changed = effective_tool_ids != base_tool_ids;
+    let runtime_narrowing_active = !runtime_narrowing.is_null();
+
+    tool_ids_changed || runtime_narrowing_active
 }
 
 fn load_task_status_payload(
@@ -1403,6 +1686,18 @@ fn render_task_brief_line(task: &Value) -> CliResult<String> {
         .get("phase")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let task_status = task
+        .get("task_status")
+        .cloned()
+        .unwrap_or_else(unknown_task_status_payload);
+    let status_display = task_status
+        .get("display")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let blocked = task_status
+        .get("blocked")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let workflow_phase = task
         .get("workflow")
         .and_then(|value| value.get("phase"))
@@ -1415,8 +1710,13 @@ fn render_task_brief_line(task: &Value) -> CliResult<String> {
         .and_then(|value| value.get("needs_attention_count"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
+    let signals = task_status
+        .get("signals")
+        .and_then(Value::as_array)
+        .map(|values| render_string_array(values))
+        .unwrap_or_else(|| "-".to_owned());
     let line = format!(
-        "{task_id} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={label} approval_attention={approval_attention}"
+        "{task_id} status={status_display} blocked={blocked} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={label} approval_attention={approval_attention} signals={signals}"
     );
     Ok(line)
 }
@@ -1427,6 +1727,31 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         .get("scope_session_id")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let task_status = task
+        .get("task_status")
+        .cloned()
+        .unwrap_or_else(unknown_task_status_payload);
+    let task_status_display = task_status
+        .get("display")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let blocked = task_status
+        .get("blocked")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let needs_attention = task_status
+        .get("needs_attention")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let next_action = task_status
+        .get("next_action")
+        .and_then(Value::as_str)
+        .unwrap_or("status");
+    let task_signals = task_status
+        .get("signals")
+        .and_then(Value::as_array)
+        .map(|values| render_string_array(values))
+        .unwrap_or_else(|| "-".to_owned());
     let label = task.get("label").and_then(Value::as_str).unwrap_or("-");
     let state = task
         .get("session_state")
@@ -1529,6 +1854,11 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("task_id: {task_id}"));
     lines.push(format!("scope_session_id: {scope_session_id}"));
     lines.push(format!("label: {label}"));
+    lines.push(format!("task_status: {task_status_display}"));
+    lines.push(format!("task_blocked: {blocked}"));
+    lines.push(format!("task_needs_attention: {needs_attention}"));
+    lines.push(format!("task_next_action: {next_action}"));
+    lines.push(format!("task_signals: {task_signals}"));
     lines.push(format!("state: {state}"));
     lines.push(format!("workflow_id: {workflow_id}"));
     lines.push(format!("workflow_phase: {workflow_phase}"));
@@ -1579,4 +1909,183 @@ fn render_string_array(values: &[Value]) -> String {
         return "-".to_owned();
     }
     items.join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_task_payload(
+        session_state: &str,
+        phase: &str,
+        approval_primary_action: Option<&str>,
+        tool_narrowing_active: bool,
+        recovered: bool,
+        staleness_state: Option<&str>,
+    ) -> Value {
+        let approval_requests = approval_primary_action
+            .map(|primary_action| {
+                vec![json!({
+                    "attention": {
+                        "primary_action": primary_action,
+                    },
+                })]
+            })
+            .unwrap_or_default();
+        let approval_summary = json!({
+            "needs_attention_count": u64::from(approval_primary_action.is_some()),
+        });
+        let tool_policy = if tool_narrowing_active {
+            json!({
+                "base_tool_ids": ["file.read", "web.fetch"],
+                "effective_tool_ids": ["file.read"],
+                "effective_runtime_narrowing": {
+                    "web_fetch": {
+                        "allowed_domains": ["docs.example.com"],
+                    },
+                },
+            })
+        } else {
+            json!({
+                "base_tool_ids": ["file.read"],
+                "effective_tool_ids": ["file.read"],
+                "effective_runtime_narrowing": Value::Null,
+            })
+        };
+        let recent_events = if recovered {
+            json!([
+                {
+                    "event_kind": "delegate_recovery_applied",
+                }
+            ])
+        } else {
+            json!([])
+        };
+        let delegate = json!({
+            "phase": phase,
+            "staleness": staleness_state.map(|value| {
+                json!({
+                    "state": value,
+                })
+            }),
+            "cancellation": Value::Null,
+        });
+        let session = json!({
+            "state": session_state,
+        });
+        let task_status = build_task_status_payload(
+            &session,
+            &delegate,
+            &json!(approval_requests),
+            &approval_summary,
+            &tool_policy,
+            &recent_events,
+        );
+
+        json!({
+            "task_id": "delegate:task-1",
+            "scope_session_id": "ops-root",
+            "label": "Release Check",
+            "session_state": session_state,
+            "phase": phase,
+            "timeout_seconds": 60,
+            "last_error": Value::Null,
+            "approval": {
+                "matched_count": approval_requests.len(),
+                "attention_summary": approval_summary,
+            },
+            "tool_policy": tool_policy,
+            "task_status": task_status,
+        })
+    }
+
+    #[test]
+    fn build_task_status_payload_uses_approval_action_and_tool_narrowing_signal() {
+        let task = build_task_payload(
+            "ready",
+            "queued",
+            Some("resolve_request"),
+            true,
+            false,
+            None,
+        );
+        let task_status = &task["task_status"];
+
+        assert_eq!(task_status["kind"], "approval_pending");
+        assert_eq!(task_status["blocked"], true);
+        assert_eq!(task_status["status"], "approval_pending");
+        assert_eq!(task_status["needs_attention"], true);
+        assert_eq!(task_status["next_action"], "resolve_request");
+        assert_eq!(task_status["tool_narrowing_active"], true);
+        assert!(
+            task_status["signals"]
+                .as_array()
+                .expect("signals array")
+                .iter()
+                .any(|value| value == "tool_narrowing_active"),
+            "signals should include narrowing"
+        );
+    }
+
+    #[test]
+    fn build_task_status_payload_marks_failed_task_as_recovered_when_event_present() {
+        let task = build_task_payload("failed", "failed", None, false, true, None);
+        let task_status = &task["task_status"];
+
+        assert_eq!(task_status["status"], "failed");
+        assert_eq!(task_status["kind"], "failed");
+        assert_eq!(task_status["display"], "failed (recovered)");
+        assert_eq!(task_status["needs_attention"], true);
+        assert_eq!(task_status["recovered"], true);
+        assert_eq!(task_status["next_action"], "events");
+    }
+
+    #[test]
+    fn build_task_status_payload_marks_overdue_task_recoverable() {
+        let task = build_task_payload("running", "running", None, false, false, Some("overdue"));
+        let task_status = &task["task_status"];
+
+        assert_eq!(task_status["kind"], "overdue");
+        assert_eq!(task_status["blocked"], true);
+        assert_eq!(task_status["status"], "overdue");
+        assert_eq!(task_status["needs_attention"], true);
+        assert_eq!(task_status["next_action"], "recover");
+    }
+
+    #[test]
+    fn render_task_detail_lines_surface_task_status_summary() {
+        let task = build_task_payload(
+            "ready",
+            "queued",
+            Some("resolve_request"),
+            true,
+            false,
+            None,
+        );
+        let rendered = render_task_detail_lines(&task).expect("render task detail");
+        let joined = rendered.join("\n");
+
+        assert!(joined.contains("task_status: approval_pending"));
+        assert!(joined.contains("task_blocked: true"));
+        assert!(joined.contains("task_needs_attention: true"));
+        assert!(joined.contains("task_next_action: resolve_request"));
+        assert!(joined.contains("task_signals: approval_pending, tool_narrowing_active"));
+    }
+
+    #[test]
+    fn render_task_brief_line_prefers_derived_task_status_summary() {
+        let task = build_task_payload(
+            "ready",
+            "queued",
+            Some("resolve_request"),
+            false,
+            false,
+            None,
+        );
+        let rendered = render_task_brief_line(&task).expect("render task brief");
+
+        assert!(rendered.contains("status=approval_pending"));
+        assert!(rendered.contains("blocked=true"));
+        assert!(rendered.contains("signals=approval_pending"));
+    }
 }

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -662,6 +662,12 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
     let recipes = execution.payload["recipes"]
         .as_array()
         .expect("recipes array");
+    let task_status = execution.payload["task"]["task_status"]["status"]
+        .as_str()
+        .expect("task status");
+    let task_next_action = execution.payload["task"]["task_status"]["next_action"]
+        .as_str()
+        .expect("task next action");
 
     assert_eq!(execution.payload["command"], "create");
     assert_eq!(execution.payload["current_session_id"], "ops-root");
@@ -672,9 +678,12 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
         execution.payload["task"]["session"]["kind"],
         "delegate_child"
     );
-    assert_eq!(execution.payload["task"]["task_status"]["status"], "queued");
     assert!(task_id.starts_with("delegate:"));
     assert_eq!(recipes.len(), 3);
+    assert!(
+        matches!(task_status, "queued" | "failed"),
+        "create should surface truthful immediate task status, got: {task_status}"
+    );
     assert!(
         recipes[0]
             .as_str()
@@ -691,12 +700,14 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
     );
     let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
         .expect("render tasks create");
+    let expected_status_line = format!("task_status: {task_status}");
+    let expected_next_action_line = format!("task_next_action: {task_next_action}");
     assert!(
-        rendered.contains("task_status: queued"),
+        rendered.contains(&expected_status_line),
         "create render should surface derived task status: {rendered}"
     );
     assert!(
-        rendered.contains("task_next_action: wait"),
+        rendered.contains(&expected_next_action_line),
         "create render should surface next action: {rendered}"
     );
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -534,6 +534,20 @@ async fn execute_tasks_command_list_returns_visible_background_tasks() {
         execution.payload["tasks"][0]["workflow"]["binding"]["mode"],
         "advisory_only"
     );
+    assert_eq!(
+        execution.payload["tasks"][0]["task_status"]["kind"],
+        "approval_pending"
+    );
+    let rendered =
+        loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution).expect("render tasks list");
+    assert!(
+        rendered.contains("status=approval_pending"),
+        "list render should surface derived task status: {rendered}"
+    );
+    assert!(
+        rendered.contains("workflow_phase=execute"),
+        "list render should surface workflow phase: {rendered}"
+    );
 }
 
 #[tokio::test]
@@ -577,6 +591,14 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
         "delegate:task-1"
     );
     assert_eq!(
+        execution.payload["task"]["task_status"]["kind"],
+        "approval_pending"
+    );
+    assert_eq!(
+        execution.payload["task"]["task_status"]["next_action"],
+        "resolve_request"
+    );
+    assert_eq!(
         execution.payload["task"]["tool_policy"]["effective_tool_ids"][0],
         "file.read"
     );
@@ -586,6 +608,14 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
     assert!(
         rendered.contains("approval_requests: 1"),
         "status render should surface approval count: {rendered}"
+    );
+    assert!(
+        rendered.contains("task_status: approval_pending"),
+        "status render should surface derived task status: {rendered}"
+    );
+    assert!(
+        rendered.contains("task_next_action: resolve_request"),
+        "status render should surface next action: {rendered}"
     );
     assert!(
         rendered.contains("workflow_phase: execute"),
@@ -642,6 +672,7 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
         execution.payload["task"]["session"]["kind"],
         "delegate_child"
     );
+    assert_eq!(execution.payload["task"]["task_status"]["status"], "queued");
     assert!(task_id.starts_with("delegate:"));
     assert_eq!(recipes.len(), 3);
     assert!(
@@ -657,6 +688,16 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
             .expect("next steps array")
             .len(),
         3
+    );
+    let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
+        .expect("render tasks create");
+    assert!(
+        rendered.contains("task_status: queued"),
+        "create render should surface derived task status: {rendered}"
+    );
+    assert!(
+        rendered.contains("task_next_action: wait"),
+        "create render should surface next action: {rendered}"
     );
 
     let repo = load_session_repository(&config_path);
@@ -965,6 +1006,20 @@ async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
     assert_eq!(wait_execution.payload["wait_status"], "timeout");
     assert_eq!(wait_execution.payload["events"], json!([]));
     assert_eq!(wait_execution.payload["task"]["task_id"], "delegate:task-1");
+    assert_eq!(
+        wait_execution.payload["task"]["task_status"]["status"],
+        "approval_pending"
+    );
+    let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&wait_execution)
+        .expect("render tasks wait");
+    assert!(
+        rendered.contains("task_status: approval_pending"),
+        "wait render should surface derived task status: {rendered}"
+    );
+    assert!(
+        rendered.contains("task_next_action: resolve_request"),
+        "wait render should surface next action: {rendered}"
+    );
 }
 
 #[tokio::test]

--- a/crates/protocol/src/control_plane.rs
+++ b/crates/protocol/src/control_plane.rs
@@ -405,7 +405,7 @@ pub struct ControlPlaneSessionWorkflowBinding {
     pub worktree: Option<ControlPlaneSessionWorkflowBindingWorktree>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ControlPlaneSessionWorkflow {
     pub workflow_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -426,23 +426,6 @@ pub struct ControlPlaneSessionWorkflow {
     pub runtime_self_continuity: Option<ControlPlaneSessionWorkflowContinuity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binding: Option<ControlPlaneSessionWorkflowBinding>,
-}
-
-impl Default for ControlPlaneSessionWorkflow {
-    fn default() -> Self {
-        Self {
-            workflow_id: String::new(),
-            task: None,
-            phase: None,
-            operation_kind: None,
-            operation_scope: None,
-            task_session_id: None,
-            lineage_root_session_id: None,
-            lineage_depth: None,
-            runtime_self_continuity: None,
-            binding: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/product-specs/background-tasks.md
+++ b/docs/product-specs/background-tasks.md
@@ -1,0 +1,53 @@
+# Background Tasks
+
+## User Story
+
+As a LoongClaw operator, I want a task-shaped background work surface so that I
+can launch, inspect, wait on, and control delegated async work without having
+to reason directly in raw session-runtime terms.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes a task-shaped operator surface for background delegated
+      work rather than requiring the operator to compose raw `delegate_async`
+      and `session_*` calls manually.
+- [ ] The first slice supports:
+      create, list, inspect status, wait or follow, cancel, and recover for
+      visible background tasks.
+- [ ] Task output surfaces approval-pending, blocked, failed, and recovered
+      states explicitly.
+- [ ] Task output surfaces any session-scoped tool narrowing that materially
+      affects what the delegated child may do.
+- [ ] `tasks create`, `tasks list`, `tasks status`, and `tasks wait` expose a
+      derived `task_status.status`, `task_status.needs_attention`, and
+      `task_status.next_action` summary instead of leaving operators to infer
+      meaning only from raw session state and delegate phase.
+- [ ] The task surface remains truthful to the current runtime:
+      background tasks are implemented as child sessions rather than a parallel
+      scheduler-specific state model.
+- [ ] Product docs clearly distinguish this first-slice background task surface
+      from future cron, heartbeat, or always-on daemon scheduling work.
+
+## Current Baseline
+
+The current runtime already ships the substrate for this surface:
+
+- `delegate_async`
+- `session_status`
+- `session_wait`
+- `session_events`
+- `session_cancel`
+- `session_recover`
+- approval request tooling
+- session-scoped tool policy controls
+
+The missing part is the operator-facing product contract that turns those
+session primitives into a coherent task workflow.
+
+## Out of Scope
+
+- cron
+- heartbeat jobs
+- daemon ownership and service installation
+- distributed scheduling
+- Web UI task dashboards


### PR DESCRIPTION
## Summary

- Problem:
  - `loong tasks` already exposed truthful child-session, approval, and tool-policy facts, but operators still had to reconstruct effective task state from raw `state`, `phase`, approval counts, and tool policy details.
- Why it matters:
  - Background task inspection was still substrate-shaped instead of operator-shaped, which made it easy to miss approval blockers, overdue recoverability, or task-specific next steps.
- What changed:
  - derive a stable `task_status` summary from existing task/session facts
  - surface `task_status.status`, `task_status.needs_attention`, `task_status.next_action`, and `task_status.signals` in the machine-readable payload
  - render the derived summary directly in `tasks create`, `tasks list`, `tasks status`, and `tasks wait`
  - lock the new behavior with daemon unit/integration coverage
  - harden one onboarding web-search test by clearing credential env vars so local all-features verification stays hermetic when operator API keys are present
- What did not change (scope boundary):
  - no new task scheduler or parallel state machine
  - no background execution semantic changes
  - no web UI task dashboard work
  - no changes to persisted session/task records

## Linked Issues

- Closes #1177
- Related #217

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked -q
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked -q
cargo test -p loongclaw tasks_cli::tests:: --lib -- --test-threads=1
cargo test -p loongclaw --test integration execute_tasks_command_list_returns_visible_background_tasks -- --test-threads=1
cargo test -p loongclaw --test integration execute_tasks_command_status_surfaces_approval_and_tool_policy -- --test-threads=1
cargo test -p loongclaw --test integration execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes -- --test-threads=1
cargo test -p loongclaw --test integration execute_tasks_command_events_and_wait_surface_incremental_payloads -- --test-threads=1
cargo test -p loongclaw resolve_web_search_provider_recommendation_keeps_explicitly_configured_default_provider --lib -- --test-threads=1
cargo test -p loongclaw-app delegate_announce_queue_batches_children_completed_within_debounce_window --lib -- --test-threads=1
cargo test -p loongclaw-app reopening_current_schema_db_skips_metadata_repairs --lib -- --test-threads=1
./scripts/check-docs.sh
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh

Result: all commands passed on the rebased branch. `check-docs.sh` reported the existing non-blocking release-artifact warnings but still passed governance checks.

Env restoration note: the onboarding web-search regression test now uses `ScopedEnv` + `clear_web_search_credential_envs(...)` so any process-global credential env state is cleared for the test body and restored on scope exit.
```

## User-visible / Operator-visible Changes

- `loong tasks create|list|status|wait` now surface an explicit derived task summary instead of leaving operators to infer the task state from raw session fields.
- Task payloads now include machine-readable `task_status.status`, `task_status.needs_attention`, `task_status.next_action`, and `task_status.signals`.
- Text rendering now calls out approval-pending, overdue/recoverable, cancellation, recovery, and tool-narrowing cues directly.

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR; the change is limited to daemon rendering/summary derivation plus one test hardening path
- Observable failure symptoms reviewers should watch for:
  - task text rendering shows a derived status that disagrees with raw `state` / `phase`
  - task payload misses `task_status` on create/list/status/wait surfaces
  - onboarding web-search test behavior changes when credential env vars are present

## Reviewer Focus

- `crates/daemon/src/tasks_cli.rs`
  - verify the derived status precedence (`completed/failed/timed_out` vs overdue vs approval-pending vs queued/running)
  - verify `needs_attention`, `next_action`, and `signals` stay truthful to existing session/approval/tool-policy facts
- `crates/daemon/tests/integration/tasks_cli.rs`
  - confirm the create/list/status/wait surfaces are all locked by integration coverage
- `crates/daemon/src/onboard_web_search.rs`
  - confirm the env cleanup keeps the configured-provider test hermetic without changing product behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now surface a comprehensive derived task_status (kind, status, display, attention flags, next action, signals, recovery hints) in create/list/status/wait and CLI brief/detail output.

* **Tests**
  * Added/extended unit and integration tests validating derived task_status fields and CLI rendering.
  * Improved test utilities to fully clear web-search credential env vars to avoid accidental credential detection.

* **Documentation**
  * Updated task specs to require derived status display in task commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->