### PR TITLE
Improve gateway and Feishu runtime observability

### DIFF
--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -188,6 +188,19 @@ pub(super) async fn run_feishu_channel(
         path
     );
 
+    tracing::info!(
+        target: "loongclaw.channel.feishu",
+        transport = "webhook",
+        config_path = %resolved_path.display(),
+        configured_account_id = %resolved.configured_account_id,
+        account_id = %resolved.account.id,
+        selected_by_default,
+        default_source = default_account_source.as_str(),
+        bind = %bind,
+        path = %path,
+        "feishu runtime started"
+    );
+
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             stop.wait().await;

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -135,6 +135,14 @@ impl FeishuWebhookState {
     ) {
         dispatch_deferred_feishu_card_updates(self.config.clone(), updates);
     }
+
+    pub(super) fn configured_account_id(&self) -> &str {
+        self.configured_account_id.as_str()
+    }
+
+    pub(super) fn account_id(&self) -> &str {
+        self.account_id.as_str()
+    }
 }
 
 struct RecentIdCache {
@@ -412,6 +420,15 @@ pub(super) async fn feishu_webhook_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
+    tracing::debug!(
+        target: "loongclaw.channel.feishu",
+        transport = "webhook",
+        configured_account_id = %state.configured_account_id,
+        content_length = body.len(),
+        has_signature = headers.contains_key("X-Lark-Signature"),
+        "received feishu webhook request"
+    );
+
     let body_text = match std::str::from_utf8(&body) {
         Ok(value) => value,
         Err(error) => {
@@ -483,19 +500,46 @@ pub(super) async fn handle_feishu_parsed_action(
     parsed: FeishuWebhookAction,
 ) -> Result<FeishuParsedActionResponse, (StatusCode, String)> {
     match parsed {
-        FeishuWebhookAction::UrlVerification { challenge } => Ok(
-            FeishuParsedActionResponse::immediate(json!({ "challenge": challenge })),
-        ),
+        FeishuWebhookAction::UrlVerification { challenge } => {
+            tracing::debug!(
+                target: "loongclaw.channel.feishu",
+                transport = "webhook",
+                configured_account_id = %state.configured_account_id,
+                "accepted feishu url verification request"
+            );
+            Ok(FeishuParsedActionResponse::immediate(
+                json!({ "challenge": challenge }),
+            ))
+        }
         FeishuWebhookAction::Ignore => Ok(FeishuParsedActionResponse::immediate(
             json!({"code": 0, "msg": "ignored"}),
         )),
         FeishuWebhookAction::CardCallback(event) => {
+            tracing::info!(
+                target: "loongclaw.channel.feishu",
+                transport = "webhook",
+                action = "card_callback",
+                configured_account_id = %state.configured_account_id,
+                event_id = %event.event_id,
+                conversation_id = %event.session.conversation_id,
+                has_open_message_id = event.context.open_message_id.is_some(),
+                has_open_chat_id = event.context.open_chat_id.is_some(),
+                has_principal = event.principal.is_some(),
+                "accepted feishu card callback event"
+            );
             {
                 let mut dedupe = state.seen_events.lock().await;
-                if !matches!(
-                    dedupe.begin_processing(&event.event_id),
-                    RecentIdReservation::Accepted
-                ) {
+                let reservation = dedupe.begin_processing(&event.event_id);
+                if !matches!(reservation, RecentIdReservation::Accepted) {
+                    tracing::debug!(
+                        target: "loongclaw.channel.feishu",
+                        transport = "webhook",
+                        action = "card_callback",
+                        configured_account_id = %state.configured_account_id,
+                        event_id = %event.event_id,
+                        reservation = ?reservation,
+                        "deduplicated feishu card callback event"
+                    );
                     return Ok(FeishuParsedActionResponse::immediate(
                         FeishuCallbackResponse::Noop.as_json(),
                     ));
@@ -513,12 +557,32 @@ pub(super) async fn handle_feishu_parsed_action(
             Ok(response)
         }
         FeishuWebhookAction::Inbound(event) => {
+            tracing::info!(
+                target: "loongclaw.channel.feishu",
+                transport = "webhook",
+                action = "inbound",
+                configured_account_id = %state.configured_account_id,
+                event_id = %event.event_id,
+                message_id = %event.message_id,
+                conversation_id = %event.session.conversation_id,
+                has_thread = event.session.thread_id.is_some(),
+                has_principal = event.principal.is_some(),
+                resource_count = event.resources.len(),
+                "accepted feishu inbound event"
+            );
             {
                 let mut dedupe = state.seen_events.lock().await;
-                if !matches!(
-                    dedupe.begin_processing(&event.event_id),
-                    RecentIdReservation::Accepted
-                ) {
+                let reservation = dedupe.begin_processing(&event.event_id);
+                if !matches!(reservation, RecentIdReservation::Accepted) {
+                    tracing::debug!(
+                        target: "loongclaw.channel.feishu",
+                        transport = "webhook",
+                        action = "inbound",
+                        configured_account_id = %state.configured_account_id,
+                        event_id = %event.event_id,
+                        reservation = ?reservation,
+                        "deduplicated feishu inbound event"
+                    );
                     return Ok(FeishuParsedActionResponse::immediate(
                         json!({"code": 0, "msg": "duplicate_event"}),
                     ));
@@ -582,6 +646,10 @@ async fn handle_feishu_inbound_event(
     state: &FeishuWebhookState,
     event: super::payload::FeishuInboundEvent,
 ) -> Result<FeishuParsedActionResponse, (StatusCode, String)> {
+    let inbound_event_id = event.event_id.clone();
+    let inbound_message_id = event.message_id.clone();
+    let inbound_conversation_id = event.session.conversation_id.clone();
+
     state.runtime.mark_run_start().await.map_err(|error| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -650,6 +718,19 @@ async fn handle_feishu_inbound_event(
         ))
     }
     .await;
+
+    if result.is_ok() {
+        tracing::info!(
+            target: "loongclaw.channel.feishu",
+            transport = "webhook",
+            action = "inbound",
+            configured_account_id = %state.configured_account_id,
+            event_id = %inbound_event_id,
+            message_id = %inbound_message_id,
+            conversation_id = %inbound_conversation_id,
+            "feishu inbound event processed successfully"
+        );
+    }
 
     if let Err(error) = state.runtime.mark_run_end().await {
         log_feishu_inbound_warning("runtime end failed", &error);

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -208,6 +208,17 @@ pub(super) async fn run_feishu_websocket_channel(
         );
     }
 
+    tracing::info!(
+        target: "loongclaw.channel.feishu",
+        transport = "websocket",
+        config_path = %resolved_path.display(),
+        configured_account_id = %resolved.configured_account_id,
+        account_id = %resolved.account.id,
+        selected_by_default,
+        default_source = default_account_source.as_str(),
+        "feishu runtime started"
+    );
+
     loop {
         let endpoint = match tokio::select! {
             _ = stop.wait() => return Ok(()),
@@ -256,6 +267,15 @@ async fn run_feishu_websocket_session(
     ws_config: &FeishuWsEndpointClientConfig,
     stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
+    tracing::info!(
+        target: "loongclaw.channel.feishu",
+        transport = "websocket",
+        configured_account_id = %state.configured_account_id(),
+        account_id = %state.account_id(),
+        url = %url,
+        "connecting feishu websocket session"
+    );
+
     let parsed_url = reqwest::Url::parse(url)
         .map_err(|error| format!("parse Feishu websocket URL failed: {error}"))?;
     let service_id = parsed_url
@@ -350,6 +370,15 @@ async fn run_feishu_websocket_session(
                         let payload = serde_json::from_slice::<Value>(&payload_bytes).map_err(|error| {
                             format!("decode Feishu websocket event payload failed: {error}")
                         })?;
+                        tracing::info!(
+                            target: "loongclaw.channel.feishu",
+                            transport = "websocket",
+                            configured_account_id = %state.configured_account_id(),
+                            message_id = %message_id,
+                            seq,
+                            total,
+                            "received feishu websocket event payload"
+                        );
                         let response: FeishuWsOutboundResponse = match state.parse_websocket_payload(&payload) {
                             Ok(parsed) => match handle_feishu_parsed_action(state, parsed).await {
                                 Ok(response) => build_ws_success_response(response, started_at.elapsed()),

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -45,6 +45,23 @@ fn ensure_feishu_websocket_rustls_provider() {
     });
 }
 
+fn redact_feishu_websocket_log_url(raw_url: &str) -> String {
+    let trimmed_url = raw_url.trim();
+    let parsed_url = reqwest::Url::parse(trimmed_url);
+
+    let Ok(mut parsed_url) = parsed_url else {
+        let without_query = trimmed_url.split('?').next().unwrap_or(trimmed_url);
+        let without_fragment = without_query.split('#').next().unwrap_or(without_query);
+        return without_fragment.to_owned();
+    };
+
+    let _ = parsed_url.set_username("");
+    let _ = parsed_url.set_password(None);
+    parsed_url.set_query(None);
+    parsed_url.set_fragment(None);
+    parsed_url.to_string()
+}
+
 #[derive(Clone, PartialEq, prost::Message)]
 struct FeishuWsHeader {
     #[prost(string, tag = "1")]
@@ -267,12 +284,14 @@ async fn run_feishu_websocket_session(
     ws_config: &FeishuWsEndpointClientConfig,
     stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
+    let redacted_url = redact_feishu_websocket_log_url(url);
+
     tracing::info!(
         target: "loongclaw.channel.feishu",
         transport = "websocket",
         configured_account_id = %state.configured_account_id(),
         account_id = %state.account_id(),
-        url = %url,
+        url = %redacted_url,
         "connecting feishu websocket session"
     );
 
@@ -497,6 +516,23 @@ mod tests {
         path: String,
         authorization: Option<String>,
         body: String,
+    }
+
+    #[test]
+    fn redact_feishu_websocket_log_url_strips_query_fragment_and_userinfo() {
+        let raw_url =
+            "wss://user:secret@example.com/ws/connect?ticket=secret-token&service_id=7#fragment";
+        let redacted_url = redact_feishu_websocket_log_url(raw_url);
+
+        assert_eq!(redacted_url, "wss://example.com/ws/connect");
+    }
+
+    #[test]
+    fn redact_feishu_websocket_log_url_falls_back_for_invalid_urls() {
+        let raw_url = "not a url?ticket=secret-token#fragment";
+        let redacted_url = redact_feishu_websocket_log_url(raw_url);
+
+        assert_eq!(redacted_url, "not a url");
     }
 
     #[derive(Clone, Default)]

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -45,6 +45,15 @@ enum GatewayRuntimeEntryPoint {
     MultiChannelServeCompatibility,
 }
 
+impl GatewayRuntimeEntryPoint {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::GatewayRun => "gateway_run",
+            Self::MultiChannelServeCompatibility => "multi_channel_compat",
+        }
+    }
+}
+
 pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
     match command {
         GatewayCommand::Run {
@@ -106,6 +115,22 @@ async fn run_gateway_runtime_with_hooks_for_test(
     let spec =
         build_gateway_supervisor_spec(&loaded_config, session, &channel_accounts, entry_point)?;
     let owner_mode = gateway_owner_mode(entry_point, session);
+    let configured_surface_count = spec.surfaces.len();
+    let resolved_config_path = loaded_config.resolved_path.display().to_string();
+    let runtime_dir_display = runtime_dir.display().to_string();
+    let attached_cli_session = session.unwrap_or("-");
+
+    tracing::info!(
+        target: "loongclaw.gateway",
+        entry_point = entry_point.as_str(),
+        owner_mode = owner_mode.as_str(),
+        config_path = %resolved_config_path,
+        runtime_dir = %runtime_dir_display,
+        attached_cli_session = %attached_cli_session,
+        configured_surface_count,
+        "starting gateway runtime"
+    );
+
     let tracker = Arc::new(GatewayOwnerTracker::acquire(
         runtime_dir,
         owner_mode,
@@ -135,6 +160,22 @@ async fn run_gateway_runtime_with_hooks_for_test(
         tracker.finalize_with_error(final_error.as_str())?;
         return Err(final_error);
     }
+
+    let control_binding = control_surface.binding();
+    let bind_address = control_binding.bind_address.as_str();
+    let port = control_binding.port;
+    let token_path = control_binding.token_path.display().to_string();
+
+    tracing::info!(
+        target: "loongclaw.gateway",
+        entry_point = entry_point.as_str(),
+        owner_mode = owner_mode.as_str(),
+        configured_surface_count,
+        bind_address = %bind_address,
+        port,
+        token_path = %token_path,
+        "gateway control surface is ready"
+    );
 
     let mut runtime_hooks = hooks.clone();
     let original_wait_for_shutdown = hooks.wait_for_shutdown.clone();


### PR DESCRIPTION
## Summary

- Problem: `loong gateway run` and Feishu channel runtime startup could look idle even when the runtime had started or inbound events were arriving, which left operators without enough evidence to tell whether the bot was listening, deduplicating, or dispatching work.
- Why it matters: issue #1083 reports a real blocked debugging loop where chat and outbound send both worked, but inbound Feishu traffic produced no actionable logs.
- What changed: added privacy-safe structured tracing for gateway runtime startup/control-surface readiness and for Feishu webhook/websocket startup, ingress, deduplication, and successful inbound processing milestones.
- What did not change (scope boundary): this does not add a new telemetry framework, does not change runtime behavior, and does not log message bodies, tokens, or approval payloads.

## Linked Issues

- Closes #1083
- Related #1172

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app runtime_backend_supports_local_abort_for_running_prompt --lib -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app ensure_session_falls_back_to_sessions_new_when_ensure_has_no_identifiers --lib -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app runtime_backend_executes_session_turn_and_controls --lib -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app doctor_accepts_path_discovered_fake_version_command --lib -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app browser_companion_session_start_reports_balanced_execution_tier --lib -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw gateway_owner_state --test integration -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked -j 1
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked -j 1 -- --test-threads=1
```

Notes:
- An earlier all-features run with default test scheduling surfaced timing-sensitive noise in unrelated shell/browser companion tests; rerunning with serialized test threads passed cleanly and no changed-area regressions remained.
- The changed logging paths are metadata-only. No message body, token, or secret payload logging was introduced.

## User-visible / Operator-visible Changes

- Operators now get explicit structured logs when the gateway runtime starts and when the control surface becomes ready.
- Feishu webhook and websocket runtimes now log startup metadata, accepted inbound/card callback events, deduplication outcomes, and successful inbound processing.

## Failure Recovery

- Fast rollback or disable path: revert commit `e25d497ee` to restore prior logging behavior.
- Observable failure symptoms reviewers should watch for: overly noisy logs on busy Feishu channels, or any accidental exposure of request contents beyond the added metadata fields.

## Reviewer Focus

- `crates/daemon/src/gateway/service.rs`: startup vs control-surface-ready log boundaries and field selection.
- `crates/app/src/channel/feishu/webhook.rs`: metadata-only logging and dedupe/process-success points.
- `crates/app/src/channel/feishu/websocket.rs`: websocket session ingress logging without altering dispatch semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced structured logging and observability across Feishu channel handlers (webhook and websocket modes) and gateway runtime components. Added startup event logs, request/event processing logs, and control surface readiness indicators to improve monitoring and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->