### PR TITLE
Harden debug channel serving against stack overflows

### DIFF
--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -3371,59 +3371,19 @@ pub async fn process_inbound_with_provider(
 ) -> CliResult<String> {
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
-        Ok(turn_config) => {
-            let address = message.session.conversation_address();
-            let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
-            let request = crate::agent_runtime::AgentTurnRequest {
-                message: message.text.clone(),
-                turn_mode: crate::agent_runtime::AgentTurnMode::Oneshot,
-                channel_id: address.channel_id.clone(),
-                account_id: address.account_id.clone(),
-                conversation_id: address.conversation_id.clone(),
-                participant_id: address.participant_id.clone(),
-                thread_id: address.thread_id.clone(),
-                acp_bootstrap_mcp_servers: acp_turn_hints.bootstrap_mcp_servers.clone(),
-                acp_cwd: acp_turn_hints
-                    .working_directory
-                    .as_ref()
-                    .map(|path| path.display().to_string()),
-                ..Default::default()
-            };
-            let runtime =
-                crate::chat::initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
-                    resolved_path
-                        .map(std::path::Path::to_path_buf)
-                        .unwrap_or_default(),
-                    turn_config,
-                    Some(address.session_id.as_str()),
-                    &crate::chat::CliChatOptions {
-                        acp_requested: false,
-                        acp_event_stream: false,
-                        acp_bootstrap_mcp_servers: request.acp_bootstrap_mcp_servers.clone(),
-                        acp_working_directory: request
-                            .acp_cwd
-                            .as_deref()
-                            .map(std::path::PathBuf::from),
-                    },
-                    kernel_ctx.clone(),
-                    crate::chat::CliSessionRequirement::AllowImplicitDefault,
-                )?;
-            let ingress = channel_message_ingress_context(message);
-            let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
-            let observer = feedback_capture.observer_handle();
-            let result = crate::agent_runtime::AgentRuntime::new()
-                .run_turn_with_runtime_and_observer_and_context_and_error_mode(
+        Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
+            Ok(runtime) => {
+                Box::pin(process_inbound_with_runtime_and_feedback(
+                    &turn_config,
                     &runtime,
-                    &request,
-                    None,
-                    observer,
-                    ingress.as_ref(),
-                    channel_message_acp_turn_provenance(message),
-                    crate::conversation::ProviderErrorMode::Propagate,
-                )
-                .await?;
-            Ok(feedback_capture.render_reply(result.output_text))
-        }
+                    message,
+                    ConversationRuntimeBinding::kernel(kernel_ctx),
+                    feedback_policy,
+                ))
+                .await
+            }
+            Err(error) => Err(error),
+        },
         Err(error) => Err(error),
     };
     let duration_ms = started_at.elapsed().as_millis();

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -273,15 +273,9 @@ use super::wecom;
 use super::whatsapp;
 
 use super::runtime::state::ChannelOperationRuntime;
+#[cfg(any(feature = "channel-telegram", feature = "channel-matrix"))]
+use super::types::ChannelProcessFuture;
 use super::types::FeishuChannelSendRequest;
-#[cfg(any(
-    feature = "channel-plugin-bridge",
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-))]
 use super::types::{
     ChannelAdapter, ChannelDeliveryFeishuCallback, ChannelDeliveryResource, ChannelInboundMessage,
     ChannelOutboundTargetKind, ChannelPlatform, ChannelSendReceipt, ChannelSession,
@@ -324,6 +318,26 @@ use super::types::{KnownChannelSessionSendTarget, parse_known_channel_session_se
 enum EndpointBackedSendTargetSource {
     CliTarget,
     ConfiguredEndpoint,
+}
+
+#[cfg(any(feature = "channel-telegram", feature = "channel-matrix"))]
+fn process_inbound_with_provider_future(
+    config: LoongClawConfig,
+    resolved_path: PathBuf,
+    message: ChannelInboundMessage,
+    kernel_ctx: Arc<crate::KernelContext>,
+    turn_feedback_policy: ChannelTurnFeedbackPolicy,
+) -> ChannelProcessFuture {
+    Box::pin(async move {
+        Box::pin(process_inbound_with_provider(
+            &config,
+            Some(resolved_path.as_path()),
+            &message,
+            kernel_ctx.as_ref(),
+            turn_feedback_policy,
+        ))
+        .await
+    })
 }
 
 #[cfg(any(
@@ -1011,118 +1025,116 @@ fn build_nostr_command_context(
 
 #[cfg(feature = "channel-telegram")]
 #[allow(clippy::print_stdout)] // CLI startup banner
-async fn run_telegram_channel_with_context(
+fn run_telegram_channel_with_context(
     context: ChannelCommandContext<ResolvedTelegramChannelConfig>,
     once: bool,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    validate_telegram_security_config(&context.resolved)?;
-    if initialize_runtime_environment {
-        crate::runtime_env::initialize_runtime_environment(
-            &context.config,
-            Some(context.resolved_path.as_path()),
-        );
-    }
-    let kernel_ctx = bootstrap_kernel_context_with_config(
-        "channel-telegram",
-        DEFAULT_TOKEN_TTL_S,
-        &context.config,
-    )?;
-    let token = context
-        .resolved
-        .bot_token()
-        .ok_or_else(|| "telegram bot token missing (set telegram.bot_token or env)".to_owned())?;
-    let route = context.route.clone();
-    let resolved_path = context.resolved_path.clone();
-    let resolved = context.resolved.clone();
-    let batch_config = context.config.clone();
-    let batch_kernel_ctx = Arc::new(crate::KernelContext {
-        kernel: kernel_ctx.kernel.clone(),
-        token: kernel_ctx.token.clone(),
-    });
-    let runtime_account_id = resolved.account.id.clone();
-    let runtime_account_label = resolved.account.label.clone();
-
-    with_channel_serve_runtime_with_stop(
-        ChannelServeRuntimeSpec {
-            platform: ChannelPlatform::Telegram,
-            operation_id: CHANNEL_OPERATION_SERVE_ID,
-            account_id: runtime_account_id.as_str(),
-            account_label: runtime_account_label.as_str(),
-        },
-        stop,
-        move |runtime, stop| async move {
-            let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
-            context.emit_route_notice("telegram");
-
-            println!(
-                "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
-                adapter.name(),
-                resolved_path.display(),
-                resolved.configured_account_id,
-                resolved.account.label,
-                route.selected_by_default(),
-                route.default_account_source.as_str(),
-                resolved.polling_timeout_s
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    Box::pin(async move {
+        validate_telegram_security_config(&context.resolved)?;
+        if initialize_runtime_environment {
+            crate::runtime_env::initialize_runtime_environment(
+                &context.config,
+                Some(context.resolved_path.as_path()),
             );
+        }
+        let kernel_ctx = bootstrap_kernel_context_with_config(
+            "channel-telegram",
+            DEFAULT_TOKEN_TTL_S,
+            &context.config,
+        )?;
+        let token = context.resolved.bot_token().ok_or_else(|| {
+            "telegram bot token missing (set telegram.bot_token or env)".to_owned()
+        })?;
+        let route = context.route.clone();
+        let resolved_path = context.resolved_path.clone();
+        let resolved = context.resolved.clone();
+        let batch_config = context.config.clone();
+        let batch_kernel_ctx = Arc::new(crate::KernelContext {
+            kernel: kernel_ctx.kernel.clone(),
+            token: kernel_ctx.token.clone(),
+        });
+        let runtime_account_id = resolved.account.id.clone();
+        let runtime_account_label = resolved.account.label.clone();
 
-            loop {
-                let batch = tokio::select! {
-                    _ = stop.wait() => break,
-                    batch = adapter.receive_batch() => batch?,
-                };
-                let config = batch_config.clone();
-                let kernel_ctx = batch_kernel_ctx.clone();
-                let had_messages = process_channel_batch(
-                    &mut adapter,
-                    batch,
-                    Some(runtime.as_ref()),
-                    |message, turn_feedback_policy| {
-                        let config = config.clone();
-                        let kernel_ctx = kernel_ctx.clone();
-                        let resolved_path = resolved_path.clone();
-                        Box::pin(async move {
-                            process_inbound_with_provider(
-                                &config,
-                                Some(resolved_path.as_path()),
-                                &message,
-                                kernel_ctx.as_ref(),
+        Box::pin(with_channel_serve_runtime_with_stop(
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Telegram,
+                operation_id: CHANNEL_OPERATION_SERVE_ID,
+                account_id: runtime_account_id.as_str(),
+                account_label: runtime_account_label.as_str(),
+            },
+            stop,
+            move |runtime, stop| async move {
+                let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
+                context.emit_route_notice("telegram");
+
+                println!(
+                    "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
+                    adapter.name(),
+                    resolved_path.display(),
+                    resolved.configured_account_id,
+                    resolved.account.label,
+                    route.selected_by_default(),
+                    route.default_account_source.as_str(),
+                    resolved.polling_timeout_s
+                );
+
+                loop {
+                    let batch = tokio::select! {
+                        _ = stop.wait() => break,
+                        batch = adapter.receive_batch() => batch?,
+                    };
+                    let config = batch_config.clone();
+                    let kernel_ctx = batch_kernel_ctx.clone();
+                    let had_messages = process_channel_batch(
+                        &mut adapter,
+                        batch,
+                        Some(runtime.as_ref()),
+                        |message, turn_feedback_policy| {
+                            process_inbound_with_provider_future(
+                                config.clone(),
+                                resolved_path.clone(),
+                                message,
+                                kernel_ctx.clone(),
                                 turn_feedback_policy,
                             )
-                            .await
-                        })
-                    },
-                )
-                .await?;
-                if !had_messages && once {
-                    break;
+                        },
+                    )
+                    .await?;
+                    if !had_messages && once {
+                        break;
+                    }
+                    if once {
+                        break;
+                    }
+                    tokio::select! {
+                        _ = stop.wait() => break,
+                        _ = sleep(Duration::from_millis(250)) => {}
+                    }
                 }
-                if once {
-                    break;
-                }
-                tokio::select! {
-                    _ = stop.wait() => break,
-                    _ = sleep(Duration::from_millis(250)) => {}
-                }
-            }
-            Ok(())
-        },
-    )
-    .await
+                Ok(())
+            },
+        ))
+        .await
+    })
 }
 
 #[cfg(feature = "channel-telegram")]
-pub async fn run_telegram_channel_with_stop(
+pub fn run_telegram_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongClawConfig,
     once: bool,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    let context = build_telegram_command_context(resolved_path, config, account_id)?;
-    run_telegram_channel_with_context(context, once, stop, initialize_runtime_environment).await
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    let account_id = account_id.map(str::to_owned);
+    Box::pin(async move {
+        let context = build_telegram_command_context(resolved_path, config, account_id.as_deref())?;
+        run_telegram_channel_with_context(context, once, stop, initialize_runtime_environment).await
+    })
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -1591,13 +1603,13 @@ pub async fn run_whatsapp_channel(
     #[cfg(feature = "channel-whatsapp")]
     {
         let context = load_whatsapp_command_context(config_path, account_id)?;
-        whatsapp::run_whatsapp_channel_with_context(
+        Box::pin(whatsapp::run_whatsapp_channel_with_context(
             context,
             bind_override,
             path_override,
             ChannelServeStopHandle::new(),
             true,
-        )
+        ))
         .await
     }
 }
@@ -1610,13 +1622,13 @@ pub async fn run_whatsapp_channel_with_stop(
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
 ) -> CliResult<()> {
-    whatsapp::run_whatsapp_channel_with_stop(
+    Box::pin(whatsapp::run_whatsapp_channel_with_stop(
         resolved_path,
         config,
         account_id,
         stop,
         initialize_runtime_environment,
-    )
+    ))
     .await
 }
 
@@ -2224,7 +2236,13 @@ pub async fn run_telegram_channel(
     #[cfg(feature = "channel-telegram")]
     {
         let context = load_telegram_command_context(config_path, account_id)?;
-        run_telegram_channel_with_context(context, once, ChannelServeStopHandle::new(), true).await
+        Box::pin(run_telegram_channel_with_context(
+            context,
+            once,
+            ChannelServeStopHandle::new(),
+            true,
+        ))
+        .await
     }
 }
 
@@ -2360,28 +2378,28 @@ pub async fn run_feishu_channel(
     #[cfg(feature = "channel-feishu")]
     {
         let context = load_feishu_command_context(config_path, account_id)?;
-        run_feishu_channel_with_context(
+        Box::pin(run_feishu_channel_with_context(
             context,
             bind_override,
             path_override,
             ChannelServeStopHandle::new(),
             true,
-        )
+        ))
         .await
     }
 }
 
 #[cfg(feature = "channel-feishu")]
-async fn run_feishu_channel_with_context(
+fn run_feishu_channel_with_context(
     context: ChannelCommandContext<ResolvedFeishuChannelConfig>,
     bind_override: Option<&str>,
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
     let bind_override = bind_override.map(str::to_owned);
     let path_override = path_override.map(str::to_owned);
-    run_channel_serve_command_with_stop(
+    Box::pin(run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: FEISHU_COMMAND_FAMILY_DESCRIPTOR,
@@ -2395,7 +2413,7 @@ async fn run_feishu_channel_with_context(
                 let resolved_path = context.resolved_path.clone();
                 let resolved = context.resolved.clone();
                 let config = context.config.clone();
-                feishu::run_feishu_channel(
+                Box::pin(feishu::run_feishu_channel(
                     &config,
                     &resolved,
                     &resolved_path,
@@ -2406,16 +2424,15 @@ async fn run_feishu_channel_with_context(
                     kernel_ctx,
                     runtime,
                     stop,
-                )
+                ))
                 .await
             })
         },
-    )
-    .await
+    ))
 }
 
 #[cfg(feature = "channel-feishu")]
-pub async fn run_feishu_channel_with_stop(
+pub fn run_feishu_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongClawConfig,
     account_id: Option<&str>,
@@ -2423,16 +2440,21 @@ pub async fn run_feishu_channel_with_stop(
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    let context = build_feishu_command_context(resolved_path, config, account_id)?;
-    run_feishu_channel_with_context(
-        context,
-        bind_override,
-        path_override,
-        stop,
-        initialize_runtime_environment,
-    )
-    .await
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    let account_id = account_id.map(str::to_owned);
+    let bind_override = bind_override.map(str::to_owned);
+    let path_override = path_override.map(str::to_owned);
+    Box::pin(async move {
+        let context = build_feishu_command_context(resolved_path, config, account_id.as_deref())?;
+        run_feishu_channel_with_context(
+            context,
+            bind_override.as_deref(),
+            path_override.as_deref(),
+            stop,
+            initialize_runtime_environment,
+        )
+        .await
+    })
 }
 
 #[doc(hidden)]
@@ -2565,19 +2587,25 @@ pub async fn run_matrix_channel(
     #[cfg(feature = "channel-matrix")]
     {
         let context = load_matrix_command_context(config_path, account_id)?;
-        run_matrix_channel_with_context(context, once, ChannelServeStopHandle::new(), true).await
+        Box::pin(run_matrix_channel_with_context(
+            context,
+            once,
+            ChannelServeStopHandle::new(),
+            true,
+        ))
+        .await
     }
 }
 
 #[cfg(feature = "channel-matrix")]
 #[allow(clippy::print_stdout)]
-async fn run_matrix_channel_with_context(
+fn run_matrix_channel_with_context(
     context: ChannelCommandContext<ResolvedMatrixChannelConfig>,
     once: bool,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    run_channel_serve_command_with_stop(
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    Box::pin(run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: MATRIX_COMMAND_FAMILY_DESCRIPTOR,
@@ -2624,16 +2652,13 @@ async fn run_matrix_channel_with_context(
                             let config = config.clone();
                             let kernel_ctx = batch_kernel_ctx.clone();
                             let resolved_path = resolved_path.clone();
-                            Box::pin(async move {
-                                process_inbound_with_provider(
-                                    &config,
-                                    Some(resolved_path.as_path()),
-                                    &message,
-                                    kernel_ctx.as_ref(),
-                                    turn_feedback_policy,
-                                )
-                                .await
-                            })
+                            process_inbound_with_provider_future(
+                                config,
+                                resolved_path,
+                                message,
+                                kernel_ctx,
+                                turn_feedback_policy,
+                            )
                         },
                     )
                     .await?;
@@ -2647,21 +2672,23 @@ async fn run_matrix_channel_with_context(
                 Ok(())
             })
         },
-    )
-    .await
+    ))
 }
 
 #[cfg(feature = "channel-matrix")]
-pub async fn run_matrix_channel_with_stop(
+pub fn run_matrix_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongClawConfig,
     once: bool,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    let context = build_matrix_command_context(resolved_path, config, account_id)?;
-    run_matrix_channel_with_context(context, once, stop, initialize_runtime_environment).await
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    let account_id = account_id.map(str::to_owned);
+    Box::pin(async move {
+        let context = build_matrix_command_context(resolved_path, config, account_id.as_deref())?;
+        run_matrix_channel_with_context(context, once, stop, initialize_runtime_environment).await
+    })
 }
 
 #[allow(clippy::print_stdout)]
@@ -2737,17 +2764,22 @@ pub async fn run_wecom_channel(
     #[cfg(feature = "channel-wecom")]
     {
         let context = load_wecom_command_context(config_path, account_id)?;
-        run_wecom_channel_with_context(context, ChannelServeStopHandle::new(), true).await
+        Box::pin(run_wecom_channel_with_context(
+            context,
+            ChannelServeStopHandle::new(),
+            true,
+        ))
+        .await
     }
 }
 
 #[cfg(feature = "channel-wecom")]
-async fn run_wecom_channel_with_context(
+fn run_wecom_channel_with_context(
     context: ChannelCommandContext<ResolvedWecomChannelConfig>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    run_channel_serve_command_with_stop(
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    Box::pin(run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: WECOM_COMMAND_FAMILY_DESCRIPTOR,
@@ -2761,7 +2793,7 @@ async fn run_wecom_channel_with_context(
                 let resolved_path = context.resolved_path.clone();
                 let resolved = context.resolved.clone();
                 let config = context.config.clone();
-                wecom::run_wecom_channel(
+                Box::pin(wecom::run_wecom_channel(
                     &config,
                     &resolved,
                     &resolved_path,
@@ -2770,47 +2802,57 @@ async fn run_wecom_channel_with_context(
                     kernel_ctx,
                     runtime,
                     stop,
-                )
+                ))
                 .await
             })
         },
-    )
-    .await
+    ))
 }
 
 #[cfg(feature = "channel-wecom")]
-pub async fn run_wecom_channel_with_stop(
+pub fn run_wecom_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongClawConfig,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
-    let context = build_wecom_command_context(resolved_path, config, account_id)?;
-    run_wecom_channel_with_context(context, stop, initialize_runtime_environment).await
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+    let account_id = account_id.map(str::to_owned);
+    Box::pin(async move {
+        let context = build_wecom_command_context(resolved_path, config, account_id.as_deref())?;
+        run_wecom_channel_with_context(context, stop, initialize_runtime_environment).await
+    })
 }
 
-pub async fn run_background_channel_with_stop(
+/// Keep this as a plain dispatcher that returns boxed per-channel futures.
+///
+/// A monolithic `async fn` match across every compiled background channel can
+/// produce one very large debug-only state machine. Returning boxed branch
+/// futures keeps the dispatch frame shallow and prevents multi-channel serve
+/// startup from consuming excessive Tokio worker stack.
+pub fn run_background_channel_with_stop(
     channel_id: &str,
     resolved_path: PathBuf,
     config: LoongClawConfig,
-    account_id: Option<&str>,
+    account_id: Option<String>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> CliResult<()> {
+) -> crate::channel::core::types::ChannelCommandFuture<'static> {
     match channel_id {
         "telegram" => {
             #[cfg(feature = "channel-telegram")]
             {
-                return run_telegram_channel_with_stop(
-                    resolved_path,
-                    config,
-                    false,
-                    account_id,
-                    stop,
-                    initialize_runtime_environment,
-                )
-                .await;
+                Box::pin(async move {
+                    run_telegram_channel_with_stop(
+                        resolved_path,
+                        config,
+                        false,
+                        account_id.as_deref(),
+                        stop,
+                        initialize_runtime_environment,
+                    )
+                    .await
+                })
             }
             #[cfg(not(feature = "channel-telegram"))]
             {
@@ -2821,24 +2863,29 @@ pub async fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                return Err(
-                    "telegram channel is disabled (enable feature `channel-telegram`)".to_owned(),
-                );
+                Box::pin(async {
+                    Err(
+                        "telegram channel is disabled (enable feature `channel-telegram`)"
+                            .to_owned(),
+                    )
+                })
             }
         }
         "feishu" => {
             #[cfg(feature = "channel-feishu")]
             {
-                return run_feishu_channel_with_stop(
-                    resolved_path,
-                    config,
-                    account_id,
-                    None,
-                    None,
-                    stop,
-                    initialize_runtime_environment,
-                )
-                .await;
+                Box::pin(async move {
+                    run_feishu_channel_with_stop(
+                        resolved_path,
+                        config,
+                        account_id.as_deref(),
+                        None,
+                        None,
+                        stop,
+                        initialize_runtime_environment,
+                    )
+                    .await
+                })
             }
             #[cfg(not(feature = "channel-feishu"))]
             {
@@ -2849,23 +2896,25 @@ pub async fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                return Err(
-                    "feishu channel is disabled (enable feature `channel-feishu`)".to_owned(),
-                );
+                Box::pin(async {
+                    Err("feishu channel is disabled (enable feature `channel-feishu`)".to_owned())
+                })
             }
         }
         "matrix" => {
             #[cfg(feature = "channel-matrix")]
             {
-                return run_matrix_channel_with_stop(
-                    resolved_path,
-                    config,
-                    false,
-                    account_id,
-                    stop,
-                    initialize_runtime_environment,
-                )
-                .await;
+                Box::pin(async move {
+                    run_matrix_channel_with_stop(
+                        resolved_path,
+                        config,
+                        false,
+                        account_id.as_deref(),
+                        stop,
+                        initialize_runtime_environment,
+                    )
+                    .await
+                })
             }
             #[cfg(not(feature = "channel-matrix"))]
             {
@@ -2876,22 +2925,24 @@ pub async fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                return Err(
-                    "matrix channel is disabled (enable feature `channel-matrix`)".to_owned(),
-                );
+                Box::pin(async {
+                    Err("matrix channel is disabled (enable feature `channel-matrix`)".to_owned())
+                })
             }
         }
         "wecom" => {
             #[cfg(feature = "channel-wecom")]
             {
-                return run_wecom_channel_with_stop(
-                    resolved_path,
-                    config,
-                    account_id,
-                    stop,
-                    initialize_runtime_environment,
-                )
-                .await;
+                Box::pin(async move {
+                    run_wecom_channel_with_stop(
+                        resolved_path,
+                        config,
+                        account_id.as_deref(),
+                        stop,
+                        initialize_runtime_environment,
+                    )
+                    .await
+                })
             }
             #[cfg(not(feature = "channel-wecom"))]
             {
@@ -2902,20 +2953,24 @@ pub async fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                return Err("wecom channel is disabled (enable feature `channel-wecom`)".to_owned());
+                Box::pin(async {
+                    Err("wecom channel is disabled (enable feature `channel-wecom`)".to_owned())
+                })
             }
         }
         "whatsapp" => {
             #[cfg(feature = "channel-whatsapp")]
             {
-                return run_whatsapp_channel_with_stop(
-                    resolved_path,
-                    config,
-                    account_id,
-                    stop,
-                    initialize_runtime_environment,
-                )
-                .await;
+                Box::pin(async move {
+                    run_whatsapp_channel_with_stop(
+                        resolved_path,
+                        config,
+                        account_id.as_deref(),
+                        stop,
+                        initialize_runtime_environment,
+                    )
+                    .await
+                })
             }
             #[cfg(not(feature = "channel-whatsapp"))]
             {
@@ -2926,12 +2981,22 @@ pub async fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                return Err(
-                    "whatsapp channel is disabled (enable feature `channel-whatsapp`)".to_owned(),
-                );
+                Box::pin(async {
+                    Err(
+                        "whatsapp channel is disabled (enable feature `channel-whatsapp`)"
+                            .to_owned(),
+                    )
+                })
             }
         }
-        _ => Err(format!("unsupported background channel `{channel_id}`")),
+        _ => {
+            let unsupported_channel_id = channel_id.to_owned();
+            Box::pin(async move {
+                Err(format!(
+                    "unsupported background channel `{unsupported_channel_id}`"
+                ))
+            })
+        }
     }
 }
 
@@ -3308,13 +3373,13 @@ pub async fn process_inbound_with_provider(
     let result = match reload_channel_turn_config(config, resolved_path) {
         Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
             Ok(runtime) => {
-                process_inbound_with_runtime_and_feedback(
+                Box::pin(process_inbound_with_runtime_and_feedback(
                     &turn_config,
                     &runtime,
                     message,
                     ConversationRuntimeBinding::kernel(kernel_ctx),
                     feedback_policy,
-                )
+                ))
                 .await
             }
             Err(error) => Err(error),
@@ -3815,5 +3880,28 @@ mod tests {
             !result,
             "non-matched chat_id should be rejected without wildcard"
         );
+    }
+}
+
+#[cfg(test)]
+mod background_dispatch_tests {
+    use super::run_background_channel_with_stop;
+    use crate::{channel::ChannelServeStopHandle, config::LoongClawConfig};
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn run_background_channel_with_stop_rejects_unknown_channel() {
+        let error = run_background_channel_with_stop(
+            "unknown",
+            PathBuf::from("/tmp/loongclaw-channel-unknown.toml"),
+            LoongClawConfig::default(),
+            Some("account-1".to_owned()),
+            ChannelServeStopHandle::new(),
+            false,
+        )
+        .await
+        .expect_err("unknown channel should fail");
+
+        assert_eq!(error, "unsupported background channel `unknown`");
     }
 }

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -3371,19 +3371,59 @@ pub async fn process_inbound_with_provider(
 ) -> CliResult<String> {
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
-        Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
-            Ok(runtime) => {
-                Box::pin(process_inbound_with_runtime_and_feedback(
-                    &turn_config,
+        Ok(turn_config) => {
+            let address = message.session.conversation_address();
+            let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
+            let request = crate::agent_runtime::AgentTurnRequest {
+                message: message.text.clone(),
+                turn_mode: crate::agent_runtime::AgentTurnMode::Oneshot,
+                channel_id: address.channel_id.clone(),
+                account_id: address.account_id.clone(),
+                conversation_id: address.conversation_id.clone(),
+                participant_id: address.participant_id.clone(),
+                thread_id: address.thread_id.clone(),
+                acp_bootstrap_mcp_servers: acp_turn_hints.bootstrap_mcp_servers.clone(),
+                acp_cwd: acp_turn_hints
+                    .working_directory
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                ..Default::default()
+            };
+            let runtime =
+                crate::chat::initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+                    resolved_path
+                        .map(std::path::Path::to_path_buf)
+                        .unwrap_or_default(),
+                    turn_config,
+                    Some(address.session_id.as_str()),
+                    &crate::chat::CliChatOptions {
+                        acp_requested: false,
+                        acp_event_stream: false,
+                        acp_bootstrap_mcp_servers: request.acp_bootstrap_mcp_servers.clone(),
+                        acp_working_directory: request
+                            .acp_cwd
+                            .as_deref()
+                            .map(std::path::PathBuf::from),
+                    },
+                    kernel_ctx.clone(),
+                    crate::chat::CliSessionRequirement::AllowImplicitDefault,
+                )?;
+            let ingress = channel_message_ingress_context(message);
+            let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
+            let observer = feedback_capture.observer_handle();
+            let result = crate::agent_runtime::AgentRuntime::new()
+                .run_turn_with_runtime_and_observer_and_context_and_error_mode(
                     &runtime,
-                    message,
-                    ConversationRuntimeBinding::kernel(kernel_ctx),
-                    feedback_policy,
-                ))
-                .await
-            }
-            Err(error) => Err(error),
-        },
+                    &request,
+                    None,
+                    observer,
+                    ingress.as_ref(),
+                    channel_message_acp_turn_provenance(message),
+                    crate::conversation::ProviderErrorMode::Propagate,
+                )
+                .await?;
+            Ok(feedback_capture.render_reply(result.output_text))
+        }
         Err(error) => Err(error),
     };
     let duration_ms = started_at.elapsed().as_millis();

--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -132,7 +132,7 @@ pub(super) async fn run_feishu_channel(
     stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
     if resolved.mode == crate::config::FeishuChannelServeMode::Websocket {
-        return websocket::run_feishu_websocket_channel(
+        return Box::pin(websocket::run_feishu_websocket_channel(
             config,
             resolved,
             resolved_path,
@@ -141,7 +141,7 @@ pub(super) async fn run_feishu_channel(
             kernel_ctx,
             runtime,
             stop,
-        )
+        ))
         .await;
     }
 

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -262,8 +262,13 @@ pub(super) async fn run_feishu_websocket_channel(
                 .max(1),
         );
 
-        if let Err(error) =
-            run_feishu_websocket_session(&state, &endpoint.url, &ws_config, stop.clone()).await
+        if let Err(error) = Box::pin(run_feishu_websocket_session(
+            &state,
+            &endpoint.url,
+            &ws_config,
+            stop.clone(),
+        ))
+        .await
         {
             #[allow(clippy::print_stderr)]
             {
@@ -399,7 +404,7 @@ async fn run_feishu_websocket_session(
                             "received feishu websocket event payload"
                         );
                         let response: FeishuWsOutboundResponse = match state.parse_websocket_payload(&payload) {
-                            Ok(parsed) => match handle_feishu_parsed_action(state, parsed).await {
+                            Ok(parsed) => match Box::pin(handle_feishu_parsed_action(state, parsed)).await {
                                 Ok(response) => build_ws_success_response(response, started_at.elapsed()),
                                 Err((status, message)) => build_ws_error_response(status, started_at.elapsed(), message),
                             },

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,6 +2,10 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)] // CLI daemon binary
 use loongclaw_daemon::*;
 
+const DEBUG_TOKIO_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
+const MAX_TOKIO_WORKER_STACK_BYTES: usize = 16 * 1024 * 1024;
+const TOKIO_WORKER_STACK_ENV: &str = "LOONG_TOKIO_WORKER_STACK_BYTES";
+
 /// Discard any unread input from the terminal's tty input queue.
 ///
 /// When a user pastes multi-line text at an interactive prompt, `read_line()`
@@ -56,6 +60,86 @@ fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
+fn command_prefers_large_tokio_worker_stack(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::TelegramServe { .. }
+            | Commands::FeishuServe { .. }
+            | Commands::MatrixServe { .. }
+            | Commands::WecomServe { .. }
+            | Commands::WhatsappServe { .. }
+            | Commands::MultiChannelServe { .. }
+            | Commands::Feishu {
+                command: feishu_cli::FeishuCommand::Serve(_),
+            }
+    )
+}
+
+fn default_tokio_worker_thread_stack_size(command: &Commands) -> Option<usize> {
+    #[cfg(debug_assertions)]
+    {
+        command_prefers_large_tokio_worker_stack(command).then_some(DEBUG_TOKIO_WORKER_STACK_BYTES)
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = command;
+        None
+    }
+}
+
+fn resolve_tokio_worker_thread_stack_size(
+    raw: Option<&str>,
+    command: &Commands,
+) -> CliResult<Option<usize>> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) => {
+            let parsed_stack_size = value.parse::<usize>().map_err(|error| {
+                format!(
+                    "invalid {TOKIO_WORKER_STACK_ENV} value `{value}`: expected integer bytes in 1..={MAX_TOKIO_WORKER_STACK_BYTES} ({error})"
+                )
+            })?;
+
+            let stack_size_is_in_range =
+                (1..=MAX_TOKIO_WORKER_STACK_BYTES).contains(&parsed_stack_size);
+
+            if !stack_size_is_in_range {
+                return Err(format!(
+                    "invalid {TOKIO_WORKER_STACK_ENV} value `{value}`: expected integer bytes in 1..={MAX_TOKIO_WORKER_STACK_BYTES}"
+                ));
+            }
+
+            Ok(Some(parsed_stack_size))
+        }
+        None => Ok(default_tokio_worker_thread_stack_size(command)),
+    }
+}
+
+fn tokio_worker_thread_stack_size(command: &Commands) -> CliResult<Option<usize>> {
+    let raw = std::env::var(TOKIO_WORKER_STACK_ENV).ok();
+    resolve_tokio_worker_thread_stack_size(raw.as_deref(), command)
+}
+
+fn build_daemon_runtime(command: &Commands) -> CliResult<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+
+    if let Some(stack_size) = tokio_worker_thread_stack_size(command)? {
+        tracing::debug!(
+            target: "loongclaw.daemon",
+            thread_stack_size = stack_size,
+            override_env = TOKIO_WORKER_STACK_ENV,
+            command = %redacted_command_name(command),
+            "using configured Tokio worker thread stack size"
+        );
+        builder.thread_stack_size(stack_size);
+    }
+
+    builder
+        .build()
+        .map_err(|error| format!("failed to build Tokio runtime: {error}"))
+}
+
 fn check_legacy_home_migration() {
     if std::env::var_os("LOONG_HOME")
         .as_deref()
@@ -81,8 +165,7 @@ fn check_legacy_home_migration() {
     }
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _stdin_guard = StdinGuard;
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
@@ -103,7 +186,27 @@ async fn main() {
         command = %redacted_command,
         "resolved CLI command"
     );
-    let result = match command {
+    let result =
+        build_daemon_runtime(&command).and_then(|runtime| runtime.block_on(run_command(command)));
+    if let Err(error) = result {
+        let error_code = error_code(error.as_str());
+        tracing::error!(
+            target: "loongclaw.daemon",
+            command_kind = %command_kind,
+            error_code = %error_code,
+            "CLI command failed"
+        );
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!("error: {error}");
+        }
+        flush_stdin();
+        std::process::exit(2);
+    }
+}
+
+async fn run_command(command: Commands) -> CliResult<()> {
+    match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
         Commands::RunTask { objective, payload } => run_task_cli(&objective, &payload).await,
@@ -1270,27 +1373,15 @@ async fn main() {
                 shell,
             })
         }
-    };
-    if let Err(error) = result {
-        let error_code = error_code(error.as_str());
-        tracing::error!(
-            target: "loongclaw.daemon",
-            command_kind = %command_kind,
-            error_code = %error_code,
-            "CLI command failed"
-        );
-        #[allow(clippy::print_stderr)]
-        {
-            eprintln!("error: {error}");
-        }
-        flush_stdin();
-        std::process::exit(2);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{error_code, redacted_command_name};
+    use super::{
+        DEBUG_TOKIO_WORKER_STACK_BYTES, MAX_TOKIO_WORKER_STACK_BYTES, TOKIO_WORKER_STACK_ENV,
+        error_code, redacted_command_name, resolve_tokio_worker_thread_stack_size,
+    };
     use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount, TurnCommands};
 
     #[test]
@@ -1354,5 +1445,68 @@ mod tests {
         let redacted = redacted_command_name(&Commands::Welcome);
 
         assert_eq!(redacted, "welcome");
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_uses_debug_default_for_multi_channel_serve() {
+        let stack_size = resolve_tokio_worker_thread_stack_size(
+            None,
+            &Commands::MultiChannelServe {
+                config: None,
+                session: "session-1".to_owned(),
+                channel_account: Vec::new(),
+            },
+        )
+        .expect("unset stack size should resolve");
+
+        assert_eq!(stack_size, Some(DEBUG_TOKIO_WORKER_STACK_BYTES));
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_keeps_default_for_non_serve_commands() {
+        let stack_size = resolve_tokio_worker_thread_stack_size(None, &Commands::Welcome)
+            .expect("non-serve command should resolve");
+
+        assert_eq!(stack_size, None);
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_accepts_explicit_override() {
+        let stack_size =
+            resolve_tokio_worker_thread_stack_size(Some("16777216"), &Commands::Welcome)
+                .expect("explicit stack size should parse");
+
+        assert_eq!(stack_size, Some(16 * 1024 * 1024));
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_rejects_invalid_override() {
+        let error = resolve_tokio_worker_thread_stack_size(Some("oops"), &Commands::Welcome)
+            .expect_err("invalid stack size should fail");
+
+        assert!(error.contains(TOKIO_WORKER_STACK_ENV));
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_rejects_zero_override() {
+        let error = resolve_tokio_worker_thread_stack_size(Some("0"), &Commands::Welcome)
+            .expect_err("zero stack size should fail");
+
+        assert!(error.contains(TOKIO_WORKER_STACK_ENV));
+        assert!(error.contains("1..="));
+    }
+
+    #[test]
+    fn resolve_tokio_worker_thread_stack_size_rejects_huge_override() {
+        let too_large_stack_size = MAX_TOKIO_WORKER_STACK_BYTES + 1;
+        let raw_stack_size = too_large_stack_size.to_string();
+        let error = resolve_tokio_worker_thread_stack_size(
+            Some(raw_stack_size.as_str()),
+            &Commands::Welcome,
+        )
+        .expect_err("too-large stack size should fail");
+
+        assert!(error.contains(TOKIO_WORKER_STACK_ENV));
+        assert!(error.contains(MAX_TOKIO_WORKER_STACK_BYTES.to_string().as_str()));
     }
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -648,17 +648,14 @@ impl SupervisorRuntimeHooks {
             let channel_id = runtime_descriptor.channel_id;
             let runner: BackgroundChannelRunner = Arc::new(
                 move |request: BackgroundChannelRunnerRequest| -> BoxedSupervisorFuture {
-                    Box::pin(async move {
-                        mvp::channel::run_background_channel_with_stop(
-                            channel_id,
-                            request.resolved_path,
-                            request.config,
-                            request.account_id.as_deref(),
-                            request.stop,
-                            request.initialize_runtime_environment,
-                        )
-                        .await
-                    })
+                    mvp::channel::run_background_channel_with_stop(
+                        channel_id,
+                        request.resolved_path,
+                        request.config,
+                        request.account_id,
+                        request.stop,
+                        request.initialize_runtime_environment,
+                    )
                 },
             );
             runners.insert(channel_id, runner);


### PR DESCRIPTION
## Summary

- Problem: runtime-backed channel serve flows could overflow the Tokio worker stack in debug builds, especially through `multi-channel-serve` and Feishu-backed serve entrypoints on Windows.
- Why it matters: operators could hit a tooling/runtime failure before they could validate real channel behavior, which pushed debugging toward slower release-only iteration.
- What changed:
  - Reworked the background channel dispatch path to return boxed branch futures instead of one monolithic async dispatcher.
  - Forwarded those boxed futures directly from the supervisor.
  - Boxed the heaviest Feishu websocket/serve awaits on the current branch.
  - Switched daemon runtime bootstrap to a command-sensitive Tokio runtime builder with a configurable worker-stack safeguard for high-risk serve commands.
  - Added narrow regression coverage for dispatch/runtime stack configuration behavior.
- What did not change (scope boundary): no user-facing channel semantics, routing rules, approval policy behavior, or broad send-surface redesign.

## Linked Issues

- Closes #1181
- Related #1181

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: touches the runtime-backed channel serve path and daemon startup runtime configuration, so regressions could affect debug serve startup or shutdown behavior.
- Rollout / guardrails: kept the change bounded to runtime-backed serve seams, preserved existing channel semantics, added focused regressions, and verified workspace clippy/tests plus architecture checks.
- Rollback path: revert commit `d00f67df0` to restore the previous dispatcher/runtime bootstrap behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
CARGO_TARGET_DIR=<redacted-target-dir> cargo fmt --all -- --check
./scripts/check_architecture_boundaries.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --locked -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test --workspace --all-features --locked -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw --test integration multi_channel_serve_
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw --bin loong resolve_tokio_worker_thread_stack_size -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy -p loongclaw-app --lib --message-format short -- -W clippy::large_futures -W clippy::large_stack_frames

Result: all listed commands passed. The targeted large-future scan no longer reports the previous giant multi-channel / Feishu serve hotspots; remaining warnings are limited to unrelated send-path futures in `channel/dispatch.rs`.
```

## User-visible / Operator-visible Changes

- Debug runs of runtime-backed serve commands are more resilient against Tokio worker stack overflows.
- Operators can override the worker stack size for those high-risk serve commands with `LOONG_TOKIO_WORKER_STACK_BYTES`.

## Failure Recovery

- Fast rollback or disable path: revert `d00f67df0`, or temporarily set a larger `LOONG_TOKIO_WORKER_STACK_BYTES` value if a platform-specific debug issue still appears.
- Observable failure symptoms reviewers should watch for: runtime-backed serve commands failing to start, supervisor shutdown regressions, or command-specific runtime bootstrap errors.

## Reviewer Focus

- `crates/app/src/channel/dispatch.rs`: boxed future boundaries for runtime-backed serve helpers and background dispatch.
- `crates/daemon/src/main.rs`: command-sensitive Tokio runtime stack sizing and env override behavior.
- `crates/daemon/src/supervisor.rs`: direct forwarding of boxed background runner futures.
- `crates/app/src/channel/feishu/mod.rs` and `crates/app/src/channel/feishu/websocket.rs`: boxed Feishu websocket/serve hotspots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved async execution handling for background channel operations.
  * Added environment variable configuration for Tokio worker thread stack sizing to support performance optimization for specific workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->