### PR TITLE
Extract ProviderTransport trait for testability

### DIFF
--- a/crates/app/src/provider/mock_transport.rs
+++ b/crates/app/src/provider/mock_transport.rs
@@ -1,0 +1,110 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use futures_util::stream;
+use serde_json::Value;
+
+use super::transport_trait::{
+    ProviderTransport, TransportError, TransportRequest, TransportResponse, TransportStream,
+};
+
+enum MockStreamResponse {
+    Events(Vec<Result<Value, TransportError>>),
+    Response(TransportResponse),
+}
+
+#[derive(Default)]
+struct MockTransportState {
+    execute_responses: VecDeque<Result<TransportResponse, TransportError>>,
+    stream_responses: VecDeque<Result<MockStreamResponse, TransportError>>,
+    requests: Vec<TransportRequest>,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct MockTransport {
+    state: Arc<Mutex<MockTransportState>>,
+}
+
+impl MockTransport {
+    pub(super) fn with_execute_responses<I>(responses: I) -> Self
+    where
+        I: IntoIterator<Item = Result<TransportResponse, TransportError>>,
+    {
+        let mut state = MockTransportState::default();
+        state.execute_responses.extend(responses);
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub(super) fn with_stream_events<I>(responses: I) -> Self
+    where
+        I: IntoIterator<Item = Result<Vec<Result<Value, TransportError>>, TransportError>>,
+    {
+        let mut state = MockTransportState::default();
+        state.stream_responses.extend(
+            responses
+                .into_iter()
+                .map(|response| response.map(MockStreamResponse::Events)),
+        );
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub(super) fn with_stream_response(response: TransportResponse) -> Self {
+        let mut state = MockTransportState::default();
+        state
+            .stream_responses
+            .push_back(Ok(MockStreamResponse::Response(response)));
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub(super) fn requests(&self) -> Vec<TransportRequest> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .requests
+            .clone()
+    }
+}
+
+#[async_trait]
+impl ProviderTransport for MockTransport {
+    async fn execute(
+        &self,
+        request: TransportRequest,
+    ) -> Result<TransportResponse, TransportError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        state.requests.push(request);
+        state
+            .execute_responses
+            .pop_front()
+            .unwrap_or_else(|| Err(TransportError::other("mock execute response missing")))
+    }
+
+    async fn stream(&self, request: TransportRequest) -> Result<TransportStream, TransportError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        state.requests.push(request);
+        match state
+            .stream_responses
+            .pop_front()
+            .unwrap_or_else(|| Err(TransportError::other("mock stream response missing")))
+        {
+            Ok(MockStreamResponse::Events(events)) => Ok(TransportStream::Events {
+                events: Box::pin(stream::iter(events)),
+            }),
+            Ok(MockStreamResponse::Response(response)) => Ok(TransportStream::Response(response)),
+            Err(error) => Err(error),
+        }
+    }
+}

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -23,6 +23,8 @@ mod copilot_auth;
 mod failover;
 mod failover_telemetry_runtime;
 mod http_client_runtime;
+#[cfg(test)]
+mod mock_transport;
 mod model_candidate_cooldown_runtime;
 mod model_candidate_resolver_runtime;
 mod policy;
@@ -41,8 +43,10 @@ mod request_planner;
 mod request_session_runtime;
 mod runtime_binding;
 mod shape;
+mod sse;
 mod transport;
 mod transport_profile_runtime;
+mod transport_trait;
 
 pub use copilot_auth::device_code_login as copilot_device_code_login;
 pub(crate) use failover::parse_provider_failover_snapshot_payload;

--- a/crates/app/src/provider/policy.rs
+++ b/crates/app/src/provider/policy.rs
@@ -4,6 +4,8 @@ use std::time::{Duration, SystemTime};
 use time::OffsetDateTime;
 use time::format_description::well_known::{Rfc2822, Rfc3339};
 
+use super::transport_trait::TransportError;
+
 const MIN_BACKOFF_MS: u64 = 50;
 
 pub(super) struct ProviderRequestPolicy {
@@ -36,7 +38,7 @@ pub(super) fn should_retry_status(status_code: u16) -> bool {
     matches!(status_code, 408 | 409 | 425 | 429 | 500 | 502 | 503 | 504)
 }
 
-pub(super) fn should_retry_error(error: &reqwest::Error) -> bool {
+pub(super) fn should_retry_error(error: &TransportError) -> bool {
     error.is_timeout() || error.is_connect() || error.is_request()
 }
 

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -22,6 +22,7 @@ use super::request_payload_runtime::{
 };
 use super::shape;
 use super::transport_profile_runtime::resolve_provider_request_transport_profile;
+use super::transport_trait::ProviderTransport;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn request_completion_with_model(
@@ -91,6 +92,33 @@ async fn request_completion_with_provider(
     request_policy: &policy::ProviderRequestPolicy,
     client: &reqwest::Client,
 ) -> Result<String, ModelRequestError> {
+    let transport = super::transport::ReqwestTransport::new(client.clone(), auth_context.clone());
+    request_completion_with_provider_transport(
+        base_config,
+        request_provider,
+        messages,
+        model,
+        auto_model_mode,
+        auth_profile,
+        auth_context,
+        request_policy,
+        &transport,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn request_completion_with_provider_transport(
+    base_config: &LoongClawConfig,
+    request_provider: &ProviderConfig,
+    messages: &[Value],
+    model: &str,
+    auto_model_mode: bool,
+    auth_profile: &ProviderAuthProfile,
+    auth_context: &super::transport::RequestAuthContext,
+    request_policy: &policy::ProviderRequestPolicy,
+    transport: &dyn ProviderTransport,
+) -> Result<String, ModelRequestError> {
     let mut current_provider = request_provider.clone();
     loop {
         let transport_profile = resolve_request_transport_profile(&current_provider, model)
@@ -157,7 +185,7 @@ async fn request_completion_with_provider(
             endpoint: transport_profile.endpoint.as_str(),
             headers: &request_headers,
             request_policy,
-            client,
+            transport,
             auth_context,
         };
 
@@ -211,6 +239,39 @@ async fn request_turn_with_provider(
     auth_context: &super::transport::RequestAuthContext,
     request_policy: &policy::ProviderRequestPolicy,
     client: &reqwest::Client,
+) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
+    let transport = super::transport::ReqwestTransport::new(client.clone(), auth_context.clone());
+    request_turn_with_provider_transport(
+        base_config,
+        request_provider,
+        session_id,
+        turn_id,
+        messages,
+        model,
+        auto_model_mode,
+        tool_definitions,
+        auth_profile,
+        auth_context,
+        request_policy,
+        &transport,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn request_turn_with_provider_transport(
+    base_config: &LoongClawConfig,
+    request_provider: &ProviderConfig,
+    session_id: &str,
+    turn_id: &str,
+    messages: &[Value],
+    model: &str,
+    auto_model_mode: bool,
+    tool_definitions: &[Value],
+    auth_profile: &ProviderAuthProfile,
+    auth_context: &super::transport::RequestAuthContext,
+    request_policy: &policy::ProviderRequestPolicy,
+    transport: &dyn ProviderTransport,
 ) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
     let mut current_provider = request_provider.clone();
     loop {
@@ -280,7 +341,7 @@ async fn request_turn_with_provider(
             endpoint: transport_profile.endpoint.as_str(),
             headers: &request_headers,
             request_policy,
-            client,
+            transport,
             auth_context,
         };
 
@@ -355,6 +416,41 @@ pub(super) async fn request_turn_streaming(
     client: &reqwest::Client,
     on_token: super::request_executor::StreamingTokenCallback,
 ) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
+    let transport = super::transport::ReqwestTransport::new(client.clone(), auth_context.clone());
+    request_turn_streaming_with_transport(
+        base_config,
+        request_provider,
+        session_id,
+        turn_id,
+        messages,
+        model,
+        auto_model_mode,
+        tool_definitions,
+        auth_profile,
+        auth_context,
+        request_policy,
+        &transport,
+        on_token,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn request_turn_streaming_with_transport(
+    base_config: &LoongClawConfig,
+    request_provider: &ProviderConfig,
+    session_id: &str,
+    turn_id: &str,
+    messages: &[Value],
+    model: &str,
+    auto_model_mode: bool,
+    tool_definitions: &[Value],
+    auth_profile: &ProviderAuthProfile,
+    auth_context: &super::transport::RequestAuthContext,
+    request_policy: &policy::ProviderRequestPolicy,
+    transport: &dyn ProviderTransport,
+    on_token: super::request_executor::StreamingTokenCallback,
+) -> Result<crate::conversation::turn_engine::ProviderTurn, ModelRequestError> {
     let mut current_provider = request_provider.clone();
     loop {
         let transport_profile = resolve_request_transport_profile(&current_provider, model)
@@ -423,7 +519,7 @@ pub(super) async fn request_turn_streaming(
             endpoint: transport_profile.endpoint.as_str(),
             headers: &request_headers,
             request_policy,
-            client,
+            transport,
             auth_context,
         };
 
@@ -643,4 +739,55 @@ fn should_fallback_responses_to_chat_completions(
         || rejects_responses_input
         || requires_messages
         || textual_messages_hint
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::auth_profile_runtime::resolve_provider_auth_profiles;
+    use crate::provider::mock_transport::MockTransport;
+    use crate::provider::transport::RequestAuthContext;
+    use crate::provider::transport_trait::TransportResponse;
+    use serde_json::json;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_completion_with_provider_uses_injected_transport() {
+        let config = LoongClawConfig::default();
+        let provider = config.provider.clone();
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let auth_context = RequestAuthContext::default();
+        let auth_profiles = resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_execute_responses([Ok(TransportResponse {
+            status: reqwest::StatusCode::OK,
+            headers: reqwest::header::HeaderMap::new(),
+            body: json!({
+                "choices": [{
+                    "message": {
+                        "content": "dispatch mocked completion"
+                    }
+                }]
+            }),
+        })]);
+
+        let result = request_completion_with_provider_transport(
+            &config,
+            &provider,
+            &[json!({
+                "role": "user",
+                "content": "ping"
+            })],
+            "gpt-5.4",
+            false,
+            auth_profile,
+            &auth_context,
+            &request_policy,
+            &transport,
+        )
+        .await
+        .expect("dispatch should use injected transport");
+
+        assert_eq!(result, "dispatch mocked completion");
+        assert_eq!(transport.requests().len(), 1);
+    }
 }

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -762,8 +762,10 @@ mod tests {
             oauth_access_token_env: None,
             ..ProviderConfig::default()
         };
-        let mut config = LoongClawConfig::default();
-        config.provider = provider.clone();
+        let config = LoongClawConfig {
+            provider: provider.clone(),
+            ..LoongClawConfig::default()
+        };
         let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
         let auth_context = RequestAuthContext::default();
         let auth_profiles = resolve_provider_auth_profiles(&provider);

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -744,16 +744,26 @@ fn should_fallback_responses_to_chat_completions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ProviderConfig;
     use crate::provider::auth_profile_runtime::resolve_provider_auth_profiles;
     use crate::provider::mock_transport::MockTransport;
     use crate::provider::transport::RequestAuthContext;
     use crate::provider::transport_trait::TransportResponse;
+    use loongclaw_contracts::SecretRef;
     use serde_json::json;
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_completion_with_provider_uses_injected_transport() {
-        let config = LoongClawConfig::default();
-        let provider = config.provider.clone();
+        let provider = ProviderConfig {
+            kind: crate::config::ProviderKind::Openai,
+            api_key: Some(SecretRef::Inline("dispatch-test-secret".to_owned())),
+            api_key_env: None,
+            oauth_access_token: None,
+            oauth_access_token_env: None,
+            ..ProviderConfig::default()
+        };
+        let mut config = LoongClawConfig::default();
+        config.provider = provider.clone();
         let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
         let auth_context = RequestAuthContext::default();
         let auth_profiles = resolve_provider_auth_profiles(&provider);
@@ -788,6 +798,12 @@ mod tests {
         .expect("dispatch should use injected transport");
 
         assert_eq!(result, "dispatch mocked completion");
-        assert_eq!(transport.requests().len(), 1);
+        let requests = transport.requests();
+        assert_eq!(requests.len(), 1);
+        let authorization_header = requests[0]
+            .headers
+            .get(reqwest::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok());
+        assert_eq!(authorization_header, Some("Bearer dispatch-test-secret"));
     }
 }

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1,12 +1,9 @@
 use std::collections::VecDeque;
-use std::marker::PhantomData;
 use std::pin::Pin;
-use std::str::from_utf8;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures_util::Stream;
 use serde_json::Value;
 use tokio::time::sleep;
@@ -29,7 +26,8 @@ use super::{
         ModelRequestStatusPlan, classify_model_status_failure_reason_with_capability,
         plan_model_request_status_with_capability, plan_transport_error_retry,
     },
-    transport::{self, RequestExecutionError},
+    transport,
+    transport_trait::{ProviderTransport, TransportEventStream, TransportStream},
 };
 
 pub(super) struct ModelRequestRuntime<'a> {
@@ -43,7 +41,7 @@ pub(super) struct ModelRequestRuntime<'a> {
     pub(super) endpoint: &'a str,
     pub(super) headers: &'a reqwest::header::HeaderMap,
     pub(super) request_policy: &'a policy::ProviderRequestPolicy,
-    pub(super) client: &'a reqwest::Client,
+    pub(super) transport: &'a dyn ProviderTransport,
     pub(super) auth_context: &'a transport::RequestAuthContext,
 }
 
@@ -58,7 +56,7 @@ pub(super) struct StreamingModelRequestRuntime<'a> {
     pub(super) endpoint: &'a str,
     pub(super) headers: &'a reqwest::header::HeaderMap,
     pub(super) request_policy: &'a policy::ProviderRequestPolicy,
-    pub(super) client: &'a reqwest::Client,
+    pub(super) transport: &'a dyn ProviderTransport,
     pub(super) auth_context: &'a transport::RequestAuthContext,
 }
 
@@ -215,85 +213,37 @@ where
                 None,
             )
         })?;
-        transport::apply_auth_profile_headers(
-            &mut headers,
+        let request = transport::build_transport_request(
+            reqwest::Method::POST,
+            request_endpoint.clone(),
+            headers,
+            body_bytes,
             Some(runtime.auth_profile),
             runtime.request_auth_scheme,
         )
-        .map_err(
-            |error| {
-                build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        model = runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                )
-            },
-        )?;
-        let req = runtime
-            .client
-            .post(request_endpoint.as_str())
-            .headers(headers)
-            .body(body_bytes.clone())
-            .build()
-            .map_err(|error| {
-                build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        model = runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                )
-            })?;
+        .map_err(|error| {
+            build_model_request_error(
+                format!(
+                    "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
+                    model = runtime.model,
+                    max_attempts = runtime.request_policy.max_attempts
+                ),
+                false,
+                ProviderFailoverReason::TransportFailure,
+                ProviderFailoverStage::TransportFailure,
+                runtime.model,
+                attempt,
+                runtime.request_policy.max_attempts,
+                None,
+                None,
+            )
+        })?;
 
-        match transport::execute_request(
-            runtime.client,
-            req,
-            Some(body_bytes.as_slice()),
-            runtime.auth_context,
-            Some(transport::BedrockService::Runtime),
-        )
-        .await
-        {
+        match runtime.transport.execute(request).await {
             Ok(response) => {
-                let status = response.status();
-                let response_headers = response.headers().clone();
-                let response_body = transport::decode_response_body(response)
-                    .await
-                    .map_err(|error| {
-                        build_model_request_error(
-                            format!(
-                                "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                                model = runtime.model,
-                                max_attempts = runtime.request_policy.max_attempts
-                            ),
-                            false,
-                            ProviderFailoverReason::ResponseDecodeFailure,
-                            ProviderFailoverStage::ResponseDecode,
-                            runtime.model,
-                            attempt,
-                            runtime.request_policy.max_attempts,
-                            None,
-                            None,
-                        )
-                    })?;
+                let status = response.status;
+                let response_headers = response.headers;
+                let response_body = response.body;
 
                 if status.is_success() {
                     let parsed = parse_success(&response_body).ok_or_else(|| {
@@ -391,7 +341,7 @@ where
                     }
                 }
             }
-            Err(transport::RequestExecutionError::Transport(error)) => {
+            Err(error) => {
                 if let Some((retry_delay_ms, next_backoff_ms)) =
                     plan_transport_error_retry(attempt, runtime.request_policy, &error, backoff_ms)
                 {
@@ -400,42 +350,45 @@ where
                     continue;
                 }
                 let error_message = error.to_string();
-                let mut message = format!(
-                    "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
-                    runtime.model,
-                    max_attempts = runtime.request_policy.max_attempts
-                );
-                if let Some(route_hint) = transport::render_transport_route_hint(
-                    request_endpoint.as_str(),
-                    error_message.as_str(),
-                    error.is_timeout(),
-                    error.is_connect(),
-                ) {
+                let mut message = match error.reason() {
+                    ProviderFailoverReason::ResponseDecodeFailure => format!(
+                        "provider response decode failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                        runtime.model,
+                        max_attempts = runtime.request_policy.max_attempts
+                    ),
+                    ProviderFailoverReason::ResponseShapeInvalid => format!(
+                        "provider response shape invalid for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                        runtime.model,
+                        max_attempts = runtime.request_policy.max_attempts
+                    ),
+                    ProviderFailoverReason::ModelMismatch
+                    | ProviderFailoverReason::RateLimited
+                    | ProviderFailoverReason::ProviderOverloaded
+                    | ProviderFailoverReason::AuthRejected
+                    | ProviderFailoverReason::PayloadIncompatible
+                    | ProviderFailoverReason::TransportFailure
+                    | ProviderFailoverReason::RequestRejected => format!(
+                        "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                        runtime.model,
+                        max_attempts = runtime.request_policy.max_attempts
+                    ),
+                };
+                if error.reason() == ProviderFailoverReason::TransportFailure
+                    && let Some(route_hint) = transport::render_transport_route_hint(
+                        request_endpoint.as_str(),
+                        error_message.as_str(),
+                        error.is_timeout(),
+                        error.is_connect(),
+                    )
+                {
                     message.push(' ');
                     message.push_str(route_hint.as_str());
                 }
                 return Err(build_model_request_error(
                     message,
                     false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                ));
-            }
-            Err(transport::RequestExecutionError::Setup(error)) => {
-                return Err(build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{}` on attempt {attempt}/{max_attempts}: {error}",
-                        runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
+                    error.reason(),
+                    error.stage(),
                     runtime.model,
                     attempt,
                     runtime.request_policy.max_attempts,
@@ -525,92 +478,41 @@ where
                 None,
             )
         })?;
-        transport::apply_auth_profile_headers(
-            &mut headers,
+        let request = transport::build_transport_request(
+            reqwest::Method::POST,
+            request_endpoint.clone(),
+            headers,
+            body_bytes,
             Some(runtime.auth_profile),
             runtime.request_auth_scheme,
         )
-        .map_err(
-            |error| {
-                build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        model = runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                )
-            },
-        )?;
-        let req = runtime
-            .client
-            .post(request_endpoint.as_str())
-            .headers(headers)
-            .body(body_bytes.clone())
-            .build()
-            .map_err(|error| {
-                build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                        model = runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                )
-            })?;
+        .map_err(|error| {
+            build_model_request_error(
+                format!(
+                    "provider request setup failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
+                    model = runtime.model,
+                    max_attempts = runtime.request_policy.max_attempts
+                ),
+                false,
+                ProviderFailoverReason::TransportFailure,
+                ProviderFailoverStage::TransportFailure,
+                runtime.model,
+                attempt,
+                runtime.request_policy.max_attempts,
+                None,
+                None,
+            )
+        })?;
 
-        match transport::execute_request(
-            runtime.client,
-            req,
-            Some(body_bytes.as_slice()),
-            runtime.auth_context,
-            Some(transport::BedrockService::Runtime),
-        )
-        .await
-        {
-            Ok(response) => {
-                let status = response.status();
-                let response_headers = response.headers().clone();
-
-                if status.is_success() {
-                    let byte_stream = transport::decode_streaming_response(response);
-                    let stream = SseByteStreamParser::new(Box::pin(byte_stream), parse_stream_item);
-                    return Ok(stream);
-                }
-
-                let response_body = transport::decode_response_body(response)
-                    .await
-                    .map_err(|error| {
-                        build_model_request_error(
-                            format!(
-                                "provider response decode failed for model `{model}` on attempt {attempt}/{max_attempts}: {error}",
-                                model = runtime.model,
-                                max_attempts = runtime.request_policy.max_attempts
-                            ),
-                            false,
-                            ProviderFailoverReason::ResponseDecodeFailure,
-                            ProviderFailoverStage::ResponseDecode,
-                            runtime.model,
-                            attempt,
-                            runtime.request_policy.max_attempts,
-                            None,
-                            None,
-                        )
-                    })?;
+        match runtime.transport.stream(request).await {
+            Ok(TransportStream::Events { events }) => {
+                let stream = ParsedTransportStream::new(events, parse_stream_item);
+                return Ok(stream);
+            }
+            Ok(TransportStream::Response(response)) => {
+                let status = response.status;
+                let response_headers = response.headers;
+                let response_body = response.body;
 
                 let api_error = parse_provider_api_error(&response_body);
                 if let Some(next_mode) = adapt_payload_mode_for_error(
@@ -684,7 +586,7 @@ where
                     }
                 }
             }
-            Err(transport::RequestExecutionError::Transport(error)) => {
+            Err(error) => {
                 if let Some((retry_delay_ms, next_backoff_ms)) =
                     plan_transport_error_retry(attempt, runtime.request_policy, &error, backoff_ms)
                 {
@@ -693,42 +595,46 @@ where
                     continue;
                 }
                 let error_message = error.to_string();
-                let mut message = format!(
-                    "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
-                    runtime.model,
-                    max_attempts = runtime.request_policy.max_attempts
-                );
-                if let Some(route_hint) = transport::render_transport_route_hint(
-                    request_endpoint.as_str(),
-                    error_message.as_str(),
-                    error.is_timeout(),
-                    error.is_connect(),
-                ) {
-                    message.push(' ');
-                    message.push_str(route_hint.as_str());
-                }
-                return Err(build_model_request_error(
-                    message,
-                    false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
-                    runtime.model,
-                    attempt,
-                    runtime.request_policy.max_attempts,
-                    None,
-                    None,
-                ));
-            }
-            Err(transport::RequestExecutionError::Setup(error)) => {
-                return Err(build_model_request_error(
-                    format!(
-                        "provider request setup failed for model `{}` on attempt {attempt}/{max_attempts}: {error}",
+                let message = match error.reason() {
+                    ProviderFailoverReason::ResponseDecodeFailure => format!(
+                        "provider response decode failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
                         runtime.model,
                         max_attempts = runtime.request_policy.max_attempts
                     ),
+                    ProviderFailoverReason::ResponseShapeInvalid => format!(
+                        "provider response shape invalid for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                        runtime.model,
+                        max_attempts = runtime.request_policy.max_attempts
+                    ),
+                    ProviderFailoverReason::ModelMismatch
+                    | ProviderFailoverReason::RateLimited
+                    | ProviderFailoverReason::ProviderOverloaded
+                    | ProviderFailoverReason::AuthRejected
+                    | ProviderFailoverReason::PayloadIncompatible
+                    | ProviderFailoverReason::TransportFailure
+                    | ProviderFailoverReason::RequestRejected => {
+                        let mut message = format!(
+                            "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                            runtime.model,
+                            max_attempts = runtime.request_policy.max_attempts
+                        );
+                        if let Some(route_hint) = transport::render_transport_route_hint(
+                            request_endpoint.as_str(),
+                            error_message.as_str(),
+                            error.is_timeout(),
+                            error.is_connect(),
+                        ) {
+                            message.push(' ');
+                            message.push_str(route_hint.as_str());
+                        }
+                        message
+                    }
+                };
+                return Err(build_model_request_error(
+                    message,
                     false,
-                    ProviderFailoverReason::TransportFailure,
-                    ProviderFailoverStage::TransportFailure,
+                    error.reason(),
+                    error.stage(),
                     runtime.model,
                     attempt,
                     runtime.request_policy.max_attempts,
@@ -740,35 +646,26 @@ where
     }
 }
 
-struct SseByteStreamParser<T, ParseStreamItem> {
-    byte_stream: Pin<Box<dyn Stream<Item = Result<Bytes, RequestExecutionError>> + Send>>,
+struct ParsedTransportStream<T, ParseStreamItem> {
+    event_stream: TransportEventStream,
     parse_stream_item: ParseStreamItem,
-    line_buffer: Vec<u8>,
-    event_type: Option<String>,
     pending: VecDeque<Result<T, ModelRequestError>>,
-    _phantom: PhantomData<T>,
 }
 
-impl<T, ParseStreamItem> SseByteStreamParser<T, ParseStreamItem>
+impl<T, ParseStreamItem> ParsedTransportStream<T, ParseStreamItem>
 where
     ParseStreamItem: FnMut(Value) -> Option<T>,
 {
-    fn new(
-        byte_stream: Pin<Box<dyn Stream<Item = Result<Bytes, RequestExecutionError>> + Send>>,
-        parse_stream_item: ParseStreamItem,
-    ) -> Self {
+    fn new(event_stream: TransportEventStream, parse_stream_item: ParseStreamItem) -> Self {
         Self {
-            byte_stream,
+            event_stream,
             parse_stream_item,
-            line_buffer: Vec::new(),
-            event_type: None,
             pending: VecDeque::new(),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, ParseStreamItem> Stream for SseByteStreamParser<T, ParseStreamItem>
+impl<T, ParseStreamItem> Stream for ParsedTransportStream<T, ParseStreamItem>
 where
     T: Unpin,
     ParseStreamItem: FnMut(Value) -> Option<T> + Unpin,
@@ -781,101 +678,24 @@ where
             if let Some(item) = this.pending.pop_front() {
                 return Poll::Ready(Some(item));
             }
-            match this.byte_stream.as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok(bytes))) => {
-                    for byte in bytes {
-                        if byte == b'\n' {
-                            let line = std::mem::take(&mut this.line_buffer);
-                            let line_str = match from_utf8(&line) {
-                                Ok(s) => s,
-                                Err(e) => {
-                                    this.pending.push_back(Err(build_model_request_error(
-                                        format!("invalid UTF-8 in SSE stream: {e}"),
-                                        false,
-                                        ProviderFailoverReason::ResponseShapeInvalid,
-                                        ProviderFailoverStage::ResponseDecode,
-                                        "",
-                                        1,
-                                        1,
-                                        None,
-                                        None,
-                                    )));
-                                    continue;
-                                }
-                            };
-                            let parsed_line = transport::parse_sse_line(line_str);
-                            match parsed_line {
-                                transport::SseLine::EventType { name } => {
-                                    this.event_type = Some(name);
-                                }
-                                transport::SseLine::Data { content } => {
-                                    let current_event_type = this.event_type.take();
-                                    if !content.is_empty() {
-                                        match transport::SseStreamEvent::from_sse_lines(
-                                            current_event_type,
-                                            &[content],
-                                        ) {
-                                            Ok(Some(event)) => match event {
-                                                transport::SseStreamEvent::Message {
-                                                    data, ..
-                                                } => {
-                                                    let parse_fn = &mut this.parse_stream_item;
-                                                    if let Some(item) = parse_fn(data) {
-                                                        this.pending.push_back(Ok(item));
-                                                    }
-                                                }
-                                                transport::SseStreamEvent::Error { message } => {
-                                                    this.pending.push_back(Err(build_model_request_error(
-                                                        message,
-                                                        false,
-                                                        ProviderFailoverReason::ResponseShapeInvalid,
-                                                        ProviderFailoverStage::ResponseDecode,
-                                                        "",
-                                                        1,
-                                                        1,
-                                                        None,
-                                                        None,
-                                                    )));
-                                                }
-                                                transport::SseStreamEvent::Done => {
-                                                    return Poll::Ready(None);
-                                                }
-                                            },
-                                            Ok(None) => {}
-                                            Err(error) => {
-                                                this.pending
-                                                    .push_back(Err(build_model_request_error(
-                                                    format!(
-                                                        "streaming event parse failed: {error}"
-                                                    ),
-                                                    false,
-                                                    ProviderFailoverReason::ResponseShapeInvalid,
-                                                    ProviderFailoverStage::ResponseDecode,
-                                                    "",
-                                                    1,
-                                                    1,
-                                                    None,
-                                                    None,
-                                                )));
-                                            }
-                                        }
-                                    }
-                                }
-                                transport::SseLine::Empty => {}
-                                transport::SseLine::Comment => {}
-                                transport::SseLine::Retry { .. } => {}
-                            }
-                        } else if byte != b'\r' {
-                            this.line_buffer.push(byte);
-                        }
+            match this.event_stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(data))) => {
+                    let parse_fn = &mut this.parse_stream_item;
+                    if let Some(item) = parse_fn(data) {
+                        this.pending.push_back(Ok(item));
                     }
                 }
-                Poll::Ready(Some(Err(e))) => {
+                Poll::Ready(Some(Err(error))) => {
+                    let message = if error.reason() == ProviderFailoverReason::TransportFailure {
+                        format!("streaming response error: {error}")
+                    } else {
+                        error.to_string()
+                    };
                     return Poll::Ready(Some(Err(build_model_request_error(
-                        format!("streaming response error: {:?}", e),
+                        message,
                         false,
-                        ProviderFailoverReason::TransportFailure,
-                        ProviderFailoverStage::TransportFailure,
+                        error.reason(),
+                        error.stage(),
                         "",
                         1,
                         1,
@@ -1333,7 +1153,7 @@ mod tests {
 
     #[test]
     fn sse_stream_event_assembles_anthropic_delta_correctly() {
-        use crate::provider::transport::SseStreamEvent;
+        use crate::provider::sse::SseStreamEvent;
         let event_type = Some("content_block_delta".to_owned());
         let data_lines = vec!["{\"type\":\"text_delta\",\"text\":\"Hello\"}".to_owned()];
         let event = SseStreamEvent::from_sse_lines(event_type, &data_lines);
@@ -1508,5 +1328,274 @@ mod tests {
 
         let final_text = accumulator.text.clone();
         assert_eq!(final_text, "Hello World");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_model_request_uses_mock_transport_without_http() {
+        use crate::provider::mock_transport::MockTransport;
+        use crate::provider::transport_trait::TransportResponse;
+
+        let provider = ProviderConfig::default();
+        let runtime_contract = provider_runtime_contract(&provider);
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let headers = reqwest::header::HeaderMap::new();
+        let auth_context = transport::RequestAuthContext::default();
+        let auth_profiles =
+            crate::provider::auth_profile_runtime::resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_execute_responses([Ok(TransportResponse {
+            status: reqwest::StatusCode::OK,
+            headers: reqwest::header::HeaderMap::new(),
+            body: json!({
+                "choices": [{
+                    "message": {
+                        "content": "mocked completion"
+                    }
+                }]
+            }),
+        })]);
+        let runtime = ModelRequestRuntime {
+            provider: &provider,
+            model: "gpt-5.4",
+            runtime_contract,
+            capability: runtime_contract.capability,
+            auto_model_mode: false,
+            auth_profile,
+            request_auth_scheme: crate::config::ProviderAuthScheme::Bearer,
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            headers: &headers,
+            request_policy: &request_policy,
+            transport: &transport,
+            auth_context: &auth_context,
+        };
+
+        let result = execute_model_request(
+            runtime,
+            |_| {
+                json!({
+                    "messages": [{
+                        "role": "user",
+                        "content": "ping"
+                    }]
+                })
+            },
+            crate::provider::shape::extract_message_content,
+            "choices[0].message.content",
+            |_| false,
+        )
+        .await
+        .expect("mock completion should succeed");
+
+        assert_eq!(result, "mocked completion");
+        let recorded_requests = transport.requests();
+        assert_eq!(recorded_requests.len(), 1);
+        assert_eq!(
+            recorded_requests[0].url,
+            "https://api.openai.com/v1/chat/completions"
+        );
+        assert_eq!(recorded_requests[0].method, reqwest::Method::POST);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_streaming_model_request_uses_mock_transport_events() {
+        use crate::provider::mock_transport::MockTransport;
+        use futures_util::StreamExt;
+
+        let provider = ProviderConfig::default();
+        let runtime_contract = provider_runtime_contract(&provider);
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let headers = reqwest::header::HeaderMap::new();
+        let auth_context = transport::RequestAuthContext::default();
+        let auth_profiles =
+            crate::provider::auth_profile_runtime::resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_stream_events([Ok(vec![
+            Ok(json!({
+                "type": "content_block_delta",
+                "delta": {
+                    "type": "text_delta",
+                    "text": "streamed hello"
+                }
+            })),
+            Ok(json!({
+                "type": "message_delta",
+                "delta": {
+                    "type": "message_stop"
+                }
+            })),
+        ])]);
+        let runtime = StreamingModelRequestRuntime {
+            provider: &provider,
+            model: "gpt-5.4",
+            runtime_contract,
+            capability: runtime_contract.capability,
+            auto_model_mode: false,
+            auth_profile,
+            request_auth_scheme: crate::config::ProviderAuthScheme::Bearer,
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            headers: &headers,
+            request_policy: &request_policy,
+            transport: &transport,
+            auth_context: &auth_context,
+        };
+
+        let mut stream = execute_streaming_model_request(
+            runtime,
+            |_| json!({}),
+            |data: Value| {
+                data.get("delta")
+                    .and_then(|delta| delta.get("text"))
+                    .and_then(|text| text.as_str())
+                    .map(str::to_owned)
+            },
+        )
+        .await
+        .expect("mock stream should succeed");
+
+        let first = stream.next().await.expect("first streamed item");
+        assert_eq!(first.expect("text event"), "streamed hello");
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_model_request_preserves_response_decode_failure_reason() {
+        use crate::provider::mock_transport::MockTransport;
+
+        let provider = ProviderConfig::default();
+        let runtime_contract = provider_runtime_contract(&provider);
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let headers = reqwest::header::HeaderMap::new();
+        let auth_context = transport::RequestAuthContext::default();
+        let auth_profiles =
+            crate::provider::auth_profile_runtime::resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_execute_responses([Err(
+            crate::provider::transport_trait::TransportError::response_decode(
+                "read response body failed",
+            ),
+        )]);
+        let runtime = ModelRequestRuntime {
+            provider: &provider,
+            model: "gpt-5.4",
+            runtime_contract,
+            capability: runtime_contract.capability,
+            auto_model_mode: false,
+            auth_profile,
+            request_auth_scheme: crate::config::ProviderAuthScheme::Bearer,
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            headers: &headers,
+            request_policy: &request_policy,
+            transport: &transport,
+            auth_context: &auth_context,
+        };
+
+        let error = execute_model_request(
+            runtime,
+            |_| json!({}),
+            |_| Some("ok".to_owned()),
+            "choices[0].message.content",
+            |_| false,
+        )
+        .await
+        .expect_err("decode failures should surface as model request errors");
+
+        assert_eq!(error.reason, ProviderFailoverReason::ResponseDecodeFailure);
+        assert_eq!(error.snapshot.stage, ProviderFailoverStage::ResponseDecode);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn streaming_transport_errors_preserve_response_shape_invalid_reason() {
+        use crate::provider::mock_transport::MockTransport;
+        use futures_util::StreamExt;
+
+        let provider = ProviderConfig::default();
+        let runtime_contract = provider_runtime_contract(&provider);
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let headers = reqwest::header::HeaderMap::new();
+        let auth_context = transport::RequestAuthContext::default();
+        let auth_profiles =
+            crate::provider::auth_profile_runtime::resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_stream_events([Ok(vec![Err(
+            crate::provider::transport_trait::TransportError::response_shape_invalid(
+                "invalid UTF-8 in SSE stream",
+            ),
+        )])]);
+        let runtime = StreamingModelRequestRuntime {
+            provider: &provider,
+            model: "gpt-5.4",
+            runtime_contract,
+            capability: runtime_contract.capability,
+            auto_model_mode: false,
+            auth_profile,
+            request_auth_scheme: crate::config::ProviderAuthScheme::Bearer,
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            headers: &headers,
+            request_policy: &request_policy,
+            transport: &transport,
+            auth_context: &auth_context,
+        };
+
+        let mut stream =
+            execute_streaming_model_request(runtime, |_| json!({}), |_| Some("ok".to_owned()))
+                .await
+                .expect("stream should be created");
+
+        let error = stream
+            .next()
+            .await
+            .expect("stream item")
+            .expect_err("malformed SSE should fail");
+
+        assert_eq!(error.reason, ProviderFailoverReason::ResponseShapeInvalid);
+        assert_eq!(error.snapshot.stage, ProviderFailoverStage::ResponseDecode);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_streaming_model_request_handles_response_branch_without_http() {
+        use crate::provider::mock_transport::MockTransport;
+
+        let provider = ProviderConfig::default();
+        let runtime_contract = provider_runtime_contract(&provider);
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let headers = reqwest::header::HeaderMap::new();
+        let auth_context = transport::RequestAuthContext::default();
+        let auth_profiles =
+            crate::provider::auth_profile_runtime::resolve_provider_auth_profiles(&provider);
+        let auth_profile = auth_profiles.first().expect("auth profile");
+        let transport = MockTransport::with_stream_response(
+            crate::provider::transport_trait::TransportResponse {
+                status: reqwest::StatusCode::BAD_REQUEST,
+                headers: reqwest::header::HeaderMap::new(),
+                body: json!({
+                    "error": {
+                        "message": "bad request"
+                    }
+                }),
+            },
+        );
+        let runtime = StreamingModelRequestRuntime {
+            provider: &provider,
+            model: "gpt-5.4",
+            runtime_contract,
+            capability: runtime_contract.capability,
+            auto_model_mode: false,
+            auth_profile,
+            request_auth_scheme: crate::config::ProviderAuthScheme::Bearer,
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            headers: &headers,
+            request_policy: &request_policy,
+            transport: &transport,
+            auth_context: &auth_context,
+        };
+
+        let error =
+            execute_streaming_model_request(runtime, |_| json!({}), |_| Some("ok".to_owned()))
+                .await
+                .err()
+                .expect("non-event transport response should fail");
+
+        assert_eq!(error.snapshot.stage, ProviderFailoverStage::StatusFailure);
+        assert_eq!(error.snapshot.status_code, Some(400));
     }
 }

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1334,8 +1334,16 @@ mod tests {
     async fn execute_model_request_uses_mock_transport_without_http() {
         use crate::provider::mock_transport::MockTransport;
         use crate::provider::transport_trait::TransportResponse;
+        use loongclaw_contracts::SecretRef;
 
-        let provider = ProviderConfig::default();
+        let provider = ProviderConfig {
+            kind: crate::config::ProviderKind::Openai,
+            api_key: Some(SecretRef::Inline("mock-transport-secret".to_owned())),
+            api_key_env: None,
+            oauth_access_token: None,
+            oauth_access_token_env: None,
+            ..ProviderConfig::default()
+        };
         let runtime_contract = provider_runtime_contract(&provider);
         let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
         let headers = reqwest::header::HeaderMap::new();
@@ -1394,6 +1402,13 @@ mod tests {
             "https://api.openai.com/v1/chat/completions"
         );
         assert_eq!(recorded_requests[0].method, reqwest::Method::POST);
+        assert_eq!(
+            recorded_requests[0]
+                .headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer mock-transport-secret")
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1563,7 +1563,10 @@ mod tests {
             .expect_err("malformed SSE should fail");
 
         assert_eq!(error.reason, ProviderFailoverReason::ResponseShapeInvalid);
-        assert_eq!(error.snapshot.stage, ProviderFailoverStage::ResponseDecode);
+        assert_eq!(
+            error.snapshot.stage,
+            ProviderFailoverStage::ResponseShapeInvalid
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/app/src/provider/request_planner.rs
+++ b/crates/app/src/provider/request_planner.rs
@@ -6,6 +6,7 @@ use super::{
     },
     failover::ProviderFailoverReason,
     policy,
+    transport_trait::TransportError,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,7 +40,7 @@ pub(super) fn plan_status_retry(
 pub(super) fn plan_transport_error_retry(
     attempt: usize,
     request_policy: &policy::ProviderRequestPolicy,
-    error: &reqwest::Error,
+    error: &TransportError,
     backoff_ms: u64,
 ) -> Option<(u64, u64)> {
     if attempt >= request_policy.max_attempts || !policy::should_retry_error(error) {

--- a/crates/app/src/provider/request_planner.rs
+++ b/crates/app/src/provider/request_planner.rs
@@ -193,6 +193,7 @@ mod tests {
     use super::*;
     use crate::config::ProviderConfig;
     use crate::provider::contracts::ProviderToolSchemaMode;
+    use crate::provider::transport_trait::TransportErrorKind;
 
     #[test]
     fn classify_model_status_failure_reason_prioritizes_status_over_error_text() {
@@ -474,5 +475,50 @@ mod tests {
                 case.name, case.status_code, case.api_error
             );
         }
+    }
+
+    #[test]
+    fn plan_transport_error_retry_only_retries_transient_transport_kinds() {
+        let provider = ProviderConfig::default();
+        let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+        let backoff_ms = request_policy.initial_backoff_ms;
+
+        let retryable_kinds = [
+            TransportErrorKind::Timeout,
+            TransportErrorKind::Connect,
+            TransportErrorKind::Request,
+        ];
+
+        for kind in retryable_kinds {
+            let error = TransportError::new(kind, "transient");
+            assert_eq!(
+                plan_transport_error_retry(1, &request_policy, &error, backoff_ms),
+                Some((
+                    backoff_ms.min(request_policy.max_backoff_ms),
+                    policy::next_backoff_ms(
+                        backoff_ms.min(request_policy.max_backoff_ms),
+                        request_policy.max_backoff_ms,
+                    ),
+                )),
+                "expected retry for transport kind {kind:?}"
+            );
+        }
+
+        let other_error = TransportError::new(TransportErrorKind::Other, "non-retryable");
+        assert_eq!(
+            plan_transport_error_retry(1, &request_policy, &other_error, backoff_ms),
+            None
+        );
+
+        let timeout_error = TransportError::new(TransportErrorKind::Timeout, "timeout");
+        assert_eq!(
+            plan_transport_error_retry(
+                request_policy.max_attempts,
+                &request_policy,
+                &timeout_error,
+                backoff_ms,
+            ),
+            None
+        );
     }
 }

--- a/crates/app/src/provider/sse.rs
+++ b/crates/app/src/provider/sse.rs
@@ -17,6 +17,7 @@ pub(super) enum SseLine {
     Retry { timeout_ms: u64 },
     Comment,
     Empty,
+    Ignored,
 }
 
 pub(super) fn parse_sse_line(line: &str) -> SseLine {
@@ -41,7 +42,7 @@ pub(super) fn parse_sse_line(line: &str) -> SseLine {
             content: rest.strip_prefix(' ').unwrap_or(rest).to_owned(),
         };
     }
-    SseLine::Empty
+    SseLine::Ignored
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -116,7 +117,7 @@ impl SseDecoder {
             SseLine::Data { content } => {
                 self.data_lines.push(content);
             }
-            SseLine::Retry { .. } | SseLine::Comment => {}
+            SseLine::Retry { .. } | SseLine::Comment | SseLine::Ignored => {}
             SseLine::Empty => {
                 self.flush_event(messages)?;
             }
@@ -279,6 +280,18 @@ mod tests {
 
     #[allow(clippy::wildcard_enum_match_arm)]
     #[test]
+    fn sse_line_parser_ignores_unknown_fields_without_flushing() {
+        let parsed = parse_sse_line("id: evt_123");
+        match parsed {
+            SseLine::Ignored => {}
+            other => {
+                panic!("expected SseLine::Ignored, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
     fn sse_line_parser_data_field_without_json_value() {
         let line = "data:";
         let parsed = parse_sse_line(line);
@@ -362,5 +375,20 @@ mod tests {
         assert_eq!(second.len(), 1);
         assert_eq!(second[0]["type"], "text_delta");
         assert_eq!(second[0]["text"], "hello");
+    }
+
+    #[test]
+    fn sse_decoder_ignores_unknown_fields_between_data_lines() {
+        let mut decoder = SseDecoder::default();
+
+        let messages = decoder
+            .push_chunk(
+                b"event: content_block_delta\ndata: {\"type\":\"text_delta\",\nid: evt_123\ndata: \"text\":\"Hello\"}\n\n",
+            )
+            .expect("decoder should ignore unknown fields");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["type"], "text_delta");
+        assert_eq!(messages[0]["text"], "Hello");
     }
 }

--- a/crates/app/src/provider/sse.rs
+++ b/crates/app/src/provider/sse.rs
@@ -150,6 +150,7 @@ pub(super) struct SseEventStream {
     byte_stream: Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>,
     decoder: SseDecoder,
     pending: VecDeque<Result<Value, TransportError>>,
+    finished: bool,
 }
 
 impl SseEventStream {
@@ -160,6 +161,7 @@ impl SseEventStream {
             byte_stream,
             decoder: SseDecoder::default(),
             pending: VecDeque::new(),
+            finished: false,
         }
     }
 }
@@ -173,29 +175,37 @@ impl Stream for SseEventStream {
             if let Some(item) = this.pending.pop_front() {
                 return Poll::Ready(Some(item));
             }
+            if this.finished {
+                return Poll::Ready(None);
+            }
             match this.byte_stream.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => match this.decoder.push_chunk(bytes.as_ref()) {
                     Ok(messages) => {
                         this.pending.extend(messages.into_iter().map(Ok));
                     }
                     Err(error) => {
+                        this.finished = true;
                         this.pending.push_back(Err(error));
                     }
                 },
                 Poll::Ready(Some(Err(error))) => {
+                    this.finished = true;
                     return Poll::Ready(Some(Err(error)));
                 }
-                Poll::Ready(None) => match this.decoder.finish() {
-                    Ok(messages) => {
-                        if messages.is_empty() {
-                            return Poll::Ready(None);
+                Poll::Ready(None) => {
+                    this.finished = true;
+                    match this.decoder.finish() {
+                        Ok(messages) => {
+                            if messages.is_empty() {
+                                return Poll::Ready(None);
+                            }
+                            this.pending.extend(messages.into_iter().map(Ok));
                         }
-                        this.pending.extend(messages.into_iter().map(Ok));
+                        Err(error) => {
+                            return Poll::Ready(Some(Err(error)));
+                        }
                     }
-                    Err(error) => {
-                        return Poll::Ready(Some(Err(error)));
-                    }
-                },
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -390,5 +400,27 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0]["type"], "text_delta");
         assert_eq!(messages[0]["text"], "Hello");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sse_event_stream_stops_after_terminal_decode_error() {
+        use futures_util::StreamExt;
+
+        let invalid_bytes = Bytes::from_static(&[0x80]);
+        let valid_bytes = Bytes::from_static(br#"data: {"type":"text_delta","text":"late"}\n\n"#);
+        let byte_stream = futures_util::stream::iter(vec![Ok(invalid_bytes), Ok(valid_bytes)]);
+        let mut stream = SseEventStream::new(Box::pin(byte_stream));
+
+        let first = stream.next().await.expect("first event should exist");
+        assert!(
+            first.is_err(),
+            "first event should be the terminal decode error"
+        );
+
+        let second = stream.next().await;
+        assert!(
+            second.is_none(),
+            "stream should stop polling after the terminal decode error"
+        );
     }
 }

--- a/crates/app/src/provider/sse.rs
+++ b/crates/app/src/provider/sse.rs
@@ -1,0 +1,366 @@
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::str::from_utf8;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::Stream;
+use serde_json::Value;
+
+use super::transport_trait::TransportError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub(super) enum SseLine {
+    EventType { name: String },
+    Data { content: String },
+    Retry { timeout_ms: u64 },
+    Comment,
+    Empty,
+}
+
+pub(super) fn parse_sse_line(line: &str) -> SseLine {
+    if line.is_empty() {
+        return SseLine::Empty;
+    }
+    if line.starts_with(':') {
+        return SseLine::Comment;
+    }
+    if let Some(rest) = line.strip_prefix("event:") {
+        return SseLine::EventType {
+            name: rest.trim().to_owned(),
+        };
+    }
+    if let Some(rest) = line.strip_prefix("retry:") {
+        return SseLine::Retry {
+            timeout_ms: rest.trim().parse().unwrap_or(3000),
+        };
+    }
+    if let Some(rest) = line.strip_prefix("data:") {
+        return SseLine::Data {
+            content: rest.trim().to_owned(),
+        };
+    }
+    SseLine::Empty
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum SseStreamEvent {
+    Message {
+        data: Value,
+        event_type: Option<String>,
+    },
+}
+
+impl SseStreamEvent {
+    pub(super) fn from_sse_lines(
+        event_type: Option<String>,
+        data_lines: &[String],
+    ) -> Result<Option<Self>, serde_json::Error> {
+        if data_lines.is_empty() {
+            return Ok(None);
+        }
+        let combined = data_lines.join("\n");
+        if combined.is_empty() {
+            return Ok(None);
+        }
+        let parsed: Value = serde_json::from_str(&combined)?;
+        Ok(Some(SseStreamEvent::Message {
+            data: parsed,
+            event_type,
+        }))
+    }
+}
+
+#[derive(Default)]
+pub(super) struct SseDecoder {
+    line_buffer: Vec<u8>,
+    event_type: Option<String>,
+    data_lines: Vec<String>,
+}
+
+impl SseDecoder {
+    pub(super) fn push_chunk(&mut self, chunk: &[u8]) -> Result<Vec<Value>, TransportError> {
+        let mut messages = Vec::new();
+        for byte in chunk {
+            if *byte == b'\n' {
+                let line = std::mem::take(&mut self.line_buffer);
+                self.push_line(line.as_slice(), &mut messages)?;
+                continue;
+            }
+            if *byte != b'\r' {
+                self.line_buffer.push(*byte);
+            }
+        }
+        Ok(messages)
+    }
+
+    pub(super) fn finish(&mut self) -> Result<Vec<Value>, TransportError> {
+        let mut messages = Vec::new();
+        if !self.line_buffer.is_empty() {
+            let line = std::mem::take(&mut self.line_buffer);
+            self.push_line(line.as_slice(), &mut messages)?;
+        }
+        self.flush_event(&mut messages)?;
+        Ok(messages)
+    }
+
+    fn push_line(&mut self, line: &[u8], messages: &mut Vec<Value>) -> Result<(), TransportError> {
+        let line = from_utf8(line).map_err(|error| {
+            TransportError::response_shape_invalid(format!("invalid UTF-8 in SSE stream: {error}"))
+        })?;
+        match parse_sse_line(line) {
+            SseLine::EventType { name } => {
+                self.event_type = Some(name);
+            }
+            SseLine::Data { content } => {
+                self.data_lines.push(content);
+            }
+            SseLine::Retry { .. } | SseLine::Comment => {}
+            SseLine::Empty => {
+                self.flush_event(messages)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn flush_event(&mut self, messages: &mut Vec<Value>) -> Result<(), TransportError> {
+        let event_type = self.event_type.take();
+        let data_lines = std::mem::take(&mut self.data_lines);
+        let Some(event) =
+            SseStreamEvent::from_sse_lines(event_type, &data_lines).map_err(|error| {
+                TransportError::response_shape_invalid(format!(
+                    "streaming event parse failed: {error}"
+                ))
+            })?
+        else {
+            return Ok(());
+        };
+        match event {
+            SseStreamEvent::Message { data, .. } => {
+                messages.push(data);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) struct SseEventStream {
+    byte_stream: Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>,
+    decoder: SseDecoder,
+    pending: VecDeque<Result<Value, TransportError>>,
+}
+
+impl SseEventStream {
+    pub(super) fn new(
+        byte_stream: Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>,
+    ) -> Self {
+        Self {
+            byte_stream,
+            decoder: SseDecoder::default(),
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+impl Stream for SseEventStream {
+    type Item = Result<Value, TransportError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(item) = this.pending.pop_front() {
+                return Poll::Ready(Some(item));
+            }
+            match this.byte_stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => match this.decoder.push_chunk(bytes.as_ref()) {
+                    Ok(messages) => {
+                        this.pending.extend(messages.into_iter().map(Ok));
+                    }
+                    Err(error) => {
+                        this.pending.push_back(Err(error));
+                    }
+                },
+                Poll::Ready(Some(Err(error))) => {
+                    return Poll::Ready(Some(Err(error)));
+                }
+                Poll::Ready(None) => match this.decoder.finish() {
+                    Ok(messages) => {
+                        if messages.is_empty() {
+                            return Poll::Ready(None);
+                        }
+                        this.pending.extend(messages.into_iter().map(Ok));
+                    }
+                    Err(error) => {
+                        return Poll::Ready(Some(Err(error)));
+                    }
+                },
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_extracts_data_field() {
+        let line = "data: {\"type\":\"content_block_delta\",\"text\":\"Hello\"}";
+        let parsed = parse_sse_line(line);
+        match parsed {
+            SseLine::Data { content } => {
+                assert_eq!(
+                    content,
+                    "{\"type\":\"content_block_delta\",\"text\":\"Hello\"}"
+                );
+            }
+            other => {
+                panic!("expected SseLine::Data, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_extracts_event_type() {
+        let line = "event: content_block_delta";
+        let parsed = parse_sse_line(line);
+        match parsed {
+            SseLine::EventType { name } => {
+                assert_eq!(name.as_str(), "content_block_delta");
+            }
+            other => {
+                panic!("expected SseLine::EventType, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_extracts_retry_field() {
+        let line = "retry: 1000";
+        let parsed = parse_sse_line(line);
+        match parsed {
+            SseLine::Retry { timeout_ms } => {
+                assert_eq!(timeout_ms, 1000);
+            }
+            other => {
+                panic!("expected SseLine::Retry, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_handles_empty_line() {
+        let parsed = parse_sse_line("");
+        match parsed {
+            SseLine::Empty => {}
+            other => {
+                panic!("expected SseLine::Empty, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_handles_comment_line() {
+        let parsed = parse_sse_line(": this is a comment");
+        match parsed {
+            SseLine::Comment => {}
+            other => {
+                panic!("expected SseLine::Comment, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_line_parser_data_field_without_json_value() {
+        let line = "data:";
+        let parsed = parse_sse_line(line);
+        match parsed {
+            SseLine::Data { content } => {
+                assert_eq!(content, "");
+            }
+            other => {
+                panic!("expected SseLine::Data, got {:?}", other)
+            }
+        }
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[test]
+    fn sse_lines_accumulate_into_complete_event() {
+        let event_type_line = parse_sse_line("event: content_block_delta");
+        let data_line = parse_sse_line("data: {\"type\":\"text_delta\",\"text\":\"Hello\"}");
+
+        let (event_type, data) = match (&event_type_line, &data_line) {
+            (SseLine::EventType { name: event_type }, SseLine::Data { content }) => {
+                (event_type.clone(), content.clone())
+            }
+            _ => panic!("expected EventType and Data"),
+        };
+
+        assert_eq!(event_type.as_str(), "content_block_delta");
+        assert_eq!(data, "{\"type\":\"text_delta\",\"text\":\"Hello\"}");
+    }
+
+    #[test]
+    fn sse_stream_event_from_lines_parses_json() {
+        let event_type = Some("content_block_delta".to_owned());
+        let data_lines = vec!["{\"type\":\"text_delta\",\"text\":\"Hello\"}".to_owned()];
+        let event = SseStreamEvent::from_sse_lines(event_type, &data_lines);
+
+        match event {
+            Ok(Some(SseStreamEvent::Message { data, event_type })) => {
+                assert_eq!(event_type.as_deref(), Some("content_block_delta"));
+                assert_eq!(
+                    data.get("type").and_then(|value| value.as_str()),
+                    Some("text_delta")
+                );
+                assert_eq!(
+                    data.get("text").and_then(|value| value.as_str()),
+                    Some("Hello")
+                );
+            }
+            Err(_) | Ok(None) => panic!("expected SseStreamEvent::Message, got {:?}", event),
+        }
+    }
+
+    #[test]
+    fn sse_stream_event_from_lines_returns_none_for_empty_data() {
+        let event_type = Some("content_block_delta".to_owned());
+        let data_lines: Vec<String> = vec![];
+        let event = SseStreamEvent::from_sse_lines(event_type, &data_lines);
+        assert!(event.unwrap().is_none());
+    }
+
+    #[test]
+    fn sse_stream_event_from_lines_returns_err_for_invalid_json() {
+        let event_type = Some("content_block_delta".to_owned());
+        let data_lines = vec!["not valid json".to_owned()];
+        let event = SseStreamEvent::from_sse_lines(event_type, &data_lines);
+        assert!(event.is_err());
+    }
+
+    #[test]
+    fn sse_decoder_buffers_partial_chunks_until_event_is_complete() {
+        let mut decoder = SseDecoder::default();
+
+        let first = decoder
+            .push_chunk(b"event: content_block_delta\ndata: {\"type\":\"text_delta\"")
+            .expect("first chunk");
+        assert!(first.is_empty());
+
+        let second = decoder
+            .push_chunk(b",\"text\":\"hello\"}\n\n")
+            .expect("second chunk");
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0]["type"], "text_delta");
+        assert_eq!(second[0]["text"], "hello");
+    }
+}

--- a/crates/app/src/provider/sse.rs
+++ b/crates/app/src/provider/sse.rs
@@ -38,7 +38,7 @@ pub(super) fn parse_sse_line(line: &str) -> SseLine {
     }
     if let Some(rest) = line.strip_prefix("data:") {
         return SseLine::Data {
-            content: rest.trim().to_owned(),
+            content: rest.strip_prefix(' ').unwrap_or(rest).to_owned(),
         };
     }
     SseLine::Empty

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -2596,6 +2596,49 @@ async fn request_turn_streaming_rejects_unsupported_transport_modes() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn sibling_provider_tests_can_inject_mock_transport_into_dispatch_layer() {
+    let config = LoongClawConfig::default();
+    let provider = config.provider.clone();
+    let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
+    let auth_context = transport::RequestAuthContext::default();
+    let auth_profiles = resolve_provider_auth_profiles(&provider);
+    let auth_profile = auth_profiles.first().expect("auth profile");
+    let transport = mock_transport::MockTransport::with_execute_responses([Ok(
+        transport_trait::TransportResponse {
+            status: reqwest::StatusCode::OK,
+            headers: reqwest::header::HeaderMap::new(),
+            body: json!({
+                "choices": [{
+                    "message": {
+                        "content": "sibling dispatch mock"
+                    }
+                }]
+            }),
+        },
+    )]);
+
+    let result = request_dispatch_runtime::request_completion_with_provider_transport(
+        &config,
+        &provider,
+        &[json!({
+            "role": "user",
+            "content": "ping"
+        })],
+        "gpt-5.4",
+        false,
+        auth_profile,
+        &auth_context,
+        &request_policy,
+        &transport,
+    )
+    .await
+    .expect("dispatch helper should accept mock transport from sibling tests");
+
+    assert_eq!(result, "sibling dispatch mock");
+    assert_eq!(transport.requests().len(), 1);
+}
+
 #[test]
 fn plain_kimi_completion_body_skips_kimi_extra_body() {
     let mut config = test_config(ProviderConfig {

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -2598,8 +2598,15 @@ async fn request_turn_streaming_rejects_unsupported_transport_modes() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn sibling_provider_tests_can_inject_mock_transport_into_dispatch_layer() {
-    let config = LoongClawConfig::default();
-    let provider = config.provider.clone();
+    let provider = ProviderConfig {
+        kind: ProviderKind::Openai,
+        api_key: Some(SecretRef::Inline("dispatch-test-secret".to_owned())),
+        api_key_env: None,
+        oauth_access_token: None,
+        oauth_access_token_env: None,
+        ..ProviderConfig::default()
+    };
+    let config = test_config(provider.clone());
     let request_policy = policy::ProviderRequestPolicy::from_config(&provider);
     let auth_context = transport::RequestAuthContext::default();
     let auth_profiles = resolve_provider_auth_profiles(&provider);

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -27,8 +27,8 @@ use crate::config::{ProviderAuthScheme, ProviderConfig, ProviderKind, active_cli
 use super::auth_profile_runtime::ProviderAuthProfile;
 use super::sse::SseEventStream;
 use super::transport_trait::{
-    PreparedTransportAuth, ProviderTransport, TransportError, TransportRequest, TransportResponse,
-    TransportStream, resolve_transport_auth,
+    ProviderTransport, TransportError, TransportRequest, TransportResponse, TransportStream,
+    resolve_transport_auth,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -94,21 +94,13 @@ impl ReqwestTransport {
         }
     }
 
-    fn prepare_headers(&self, headers: &mut HeaderMap, auth: Option<&PreparedTransportAuth>) {
-        if let Some(auth) = auth {
-            auth.apply(headers);
-        }
-    }
-
     fn build_request(
         &self,
         request: &TransportRequest,
     ) -> Result<reqwest::Request, TransportError> {
-        let mut headers = request.headers.clone();
-        self.prepare_headers(&mut headers, request.auth.as_ref());
         self.client
             .request(request.method.clone(), request.url.as_str())
-            .headers(headers)
+            .headers(request.headers.clone())
             .body(request.body.clone())
             .build()
             .map_err(|error| {
@@ -349,13 +341,15 @@ pub(super) fn build_transport_request(
     profile: Option<&ProviderAuthProfile>,
     auth_scheme: ProviderAuthScheme,
 ) -> CliResult<TransportRequest> {
-    let auth = resolve_transport_auth(profile, auth_scheme)?;
+    let mut headers = headers;
+    if let Some(auth) = resolve_transport_auth(profile, auth_scheme)? {
+        auth.apply(&mut headers);
+    }
     Ok(TransportRequest {
         method,
         url,
         headers,
         body,
-        auth,
     })
 }
 

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "provider-bedrock")]
 use std::time::SystemTime;
 
+use async_trait::async_trait;
 #[cfg(feature = "provider-bedrock")]
 use aws_config::{
     Region,
@@ -14,7 +15,6 @@ use aws_sigv4::{
     sign::v4,
 };
 use bytes::Bytes;
-use futures_util::Stream;
 use futures_util::StreamExt;
 use reqwest::header::{
     AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, USER_AGENT,
@@ -25,6 +25,11 @@ use crate::CliResult;
 use crate::config::{ProviderAuthScheme, ProviderConfig, ProviderKind, active_cli_command_name};
 
 use super::auth_profile_runtime::ProviderAuthProfile;
+use super::sse::SseEventStream;
+use super::transport_trait::{
+    PreparedTransportAuth, ProviderTransport, TransportError, TransportRequest, TransportResponse,
+    TransportStream, resolve_transport_auth,
+};
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct RequestAuthContext {
@@ -71,74 +76,106 @@ impl BedrockService {
 
 #[derive(Debug)]
 pub(super) enum RequestExecutionError {
-    Transport(reqwest::Error),
+    Transport(TransportError),
     Setup(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub(super) enum SseLine {
-    EventType { name: String },
-    Data { content: String },
-    Retry { timeout_ms: u64 },
-    Comment,
-    Empty,
+#[derive(Clone)]
+pub(super) struct ReqwestTransport {
+    client: reqwest::Client,
+    auth_context: RequestAuthContext,
 }
 
-pub(super) fn parse_sse_line(line: &str) -> SseLine {
-    if line.is_empty() {
-        return SseLine::Empty;
-    }
-    if line.starts_with(':') {
-        return SseLine::Comment;
-    }
-    if let Some(rest) = line.strip_prefix("event:") {
-        let trimmed = rest.trim();
-        return SseLine::EventType {
-            name: trimmed.to_owned(),
-        };
-    }
-    if let Some(rest) = line.strip_prefix("retry:") {
-        let trimmed = rest.trim();
-        let timeout_ms = trimmed.parse().unwrap_or(3000);
-        return SseLine::Retry { timeout_ms };
-    }
-    if let Some(rest) = line.strip_prefix("data:") {
-        let content = rest.trim().to_owned();
-        return SseLine::Data { content };
-    }
-    SseLine::Empty
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(super) enum SseStreamEvent {
-    Message {
-        data: Value,
-        event_type: Option<String>,
-    },
-    #[allow(dead_code)]
-    Error { message: String },
-    #[allow(dead_code)]
-    Done,
-}
-
-impl SseStreamEvent {
-    pub(super) fn from_sse_lines(
-        event_type: Option<String>,
-        data_lines: &[String],
-    ) -> Result<Option<Self>, serde_json::Error> {
-        if data_lines.is_empty() {
-            return Ok(None);
+impl ReqwestTransport {
+    pub(super) fn new(client: reqwest::Client, auth_context: RequestAuthContext) -> Self {
+        Self {
+            client,
+            auth_context,
         }
-        let combined = data_lines.join("\n");
-        if combined.is_empty() {
-            return Ok(None);
+    }
+
+    fn prepare_headers(&self, headers: &mut HeaderMap, auth: Option<&PreparedTransportAuth>) {
+        if let Some(auth) = auth {
+            auth.apply(headers);
         }
-        let parsed: Value = serde_json::from_str(&combined)?;
-        Ok(Some(SseStreamEvent::Message {
-            data: parsed,
-            event_type,
-        }))
+    }
+
+    fn build_request(
+        &self,
+        request: &TransportRequest,
+    ) -> Result<reqwest::Request, TransportError> {
+        let mut headers = request.headers.clone();
+        self.prepare_headers(&mut headers, request.auth.as_ref());
+        self.client
+            .request(request.method.clone(), request.url.as_str())
+            .headers(headers)
+            .body(request.body.clone())
+            .build()
+            .map_err(|error| {
+                TransportError::other(format!("provider request setup failed: {error}"))
+            })
+    }
+}
+
+#[async_trait]
+impl ProviderTransport for ReqwestTransport {
+    async fn execute(
+        &self,
+        request: TransportRequest,
+    ) -> Result<TransportResponse, TransportError> {
+        let body_bytes = request.body.clone();
+        let req = self.build_request(&request)?;
+        let response = execute_request(
+            &self.client,
+            req,
+            Some(body_bytes.as_slice()),
+            &self.auth_context,
+            Some(BedrockService::Runtime),
+        )
+        .await
+        .map_err(map_request_execution_error)?;
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = decode_response_body(response)
+            .await
+            .map_err(TransportError::response_decode)?;
+        Ok(TransportResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    async fn stream(&self, request: TransportRequest) -> Result<TransportStream, TransportError> {
+        let body_bytes = request.body.clone();
+        let req = self.build_request(&request)?;
+        let response = execute_request(
+            &self.client,
+            req,
+            Some(body_bytes.as_slice()),
+            &self.auth_context,
+            Some(BedrockService::Runtime),
+        )
+        .await
+        .map_err(map_request_execution_error)?;
+        let status = response.status();
+        let headers = response.headers().clone();
+        if !status.is_success() {
+            let body = decode_response_body(response)
+                .await
+                .map_err(TransportError::response_decode)?;
+            return Ok(TransportStream::Response(TransportResponse {
+                status,
+                headers,
+                body,
+            }));
+        }
+        let byte_stream = decode_streaming_response(response);
+        let _ = status;
+        let _ = headers;
+        Ok(TransportStream::Events {
+            events: Box::pin(SseEventStream::new(Box::pin(byte_stream))),
+        })
     }
 }
 
@@ -304,6 +341,24 @@ pub(super) fn build_request_headers_without_provider_auth_for_transport(
     build_request_headers_with_defaults(provider, default_user_agent, default_headers, false)
 }
 
+pub(super) fn build_transport_request(
+    method: reqwest::Method,
+    url: String,
+    headers: HeaderMap,
+    body: Vec<u8>,
+    profile: Option<&ProviderAuthProfile>,
+    auth_scheme: ProviderAuthScheme,
+) -> CliResult<TransportRequest> {
+    let auth = resolve_transport_auth(profile, auth_scheme)?;
+    Ok(TransportRequest {
+        method,
+        url,
+        headers,
+        body,
+        auth,
+    })
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn build_request_headers(provider: &ProviderConfig) -> CliResult<HeaderMap> {
     build_request_headers_internal(provider, true)
@@ -364,57 +419,10 @@ pub(super) fn apply_auth_profile_headers(
     profile: Option<&ProviderAuthProfile>,
     auth_scheme: ProviderAuthScheme,
 ) -> CliResult<()> {
-    let Some(profile) = profile else {
+    let Some(auth) = resolve_transport_auth(profile, auth_scheme)? else {
         return Ok(());
     };
-    apply_profile_secret_headers(headers, profile, auth_scheme)?;
-    Ok(())
-}
-
-fn apply_profile_secret_headers(
-    headers: &mut HeaderMap,
-    profile: &ProviderAuthProfile,
-    auth_scheme: ProviderAuthScheme,
-) -> CliResult<()> {
-    match auth_scheme {
-        ProviderAuthScheme::Bearer => {
-            if headers.contains_key(AUTHORIZATION) {
-                return Ok(());
-            }
-            let Some(secret) = profile
-                .authorization_secret
-                .as_deref()
-                .or(profile.api_key_secret.as_deref())
-            else {
-                return Ok(());
-            };
-            let header_value = HeaderValue::from_str(format!("Bearer {secret}").as_str())
-                .map_err(|error| format!("invalid provider authorization header: {error}"))?;
-            headers.insert(AUTHORIZATION, header_value);
-        }
-        ProviderAuthScheme::XApiKey => {
-            if headers.contains_key("x-api-key") {
-                return Ok(());
-            }
-            let Some(secret) = profile.api_key_secret.as_deref() else {
-                return Ok(());
-            };
-            let header_value = HeaderValue::from_str(secret)
-                .map_err(|error| format!("invalid provider x-api-key header: {error}"))?;
-            headers.insert(HeaderName::from_static("x-api-key"), header_value);
-        }
-        ProviderAuthScheme::XGoogApiKey => {
-            if headers.contains_key("x-goog-api-key") {
-                return Ok(());
-            }
-            let Some(secret) = profile.api_key_secret.as_deref() else {
-                return Ok(());
-            };
-            let header_value = HeaderValue::from_str(secret)
-                .map_err(|error| format!("invalid provider x-goog-api-key header: {error}"))?;
-            headers.insert(HeaderName::from_static("x-goog-api-key"), header_value);
-        }
-    }
+    auth.apply(headers);
     Ok(())
 }
 
@@ -490,6 +498,7 @@ pub(super) async fn execute_request(
     client
         .execute(request)
         .await
+        .map_err(TransportError::from)
         .map_err(RequestExecutionError::Transport)
 }
 
@@ -522,12 +531,17 @@ pub(super) async fn decode_response_body(response: reqwest::Response) -> CliResu
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn decode_streaming_response(
     response: reqwest::Response,
-) -> impl Stream<Item = Result<Bytes, RequestExecutionError>> + Unpin {
+) -> impl futures_util::Stream<Item = Result<Bytes, TransportError>> + Unpin {
     response
         .bytes_stream()
-        .map(|result: Result<Bytes, reqwest::Error>| {
-            result.map_err(RequestExecutionError::Transport)
-        })
+        .map(|result: Result<Bytes, reqwest::Error>| result.map_err(TransportError::from))
+}
+
+fn map_request_execution_error(error: RequestExecutionError) -> TransportError {
+    match error {
+        RequestExecutionError::Transport(error) => error,
+        RequestExecutionError::Setup(error) => TransportError::other(error),
+    }
 }
 
 async fn resolve_bedrock_region(provider: &ProviderConfig) -> CliResult<String> {
@@ -696,6 +710,7 @@ fn percent_encode_path_segment(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::sse::{SseLine, SseStreamEvent, parse_sse_line};
     use crate::test_support::ScopedEnv;
     use std::collections::BTreeMap;
 
@@ -914,9 +929,7 @@ mod tests {
                 );
                 assert_eq!(data.get("text").and_then(|v| v.as_str()), Some("Hello"));
             }
-            Ok(Some(SseStreamEvent::Error { .. } | SseStreamEvent::Done)) | Err(_) | Ok(None) => {
-                panic!("expected SseStreamEvent::Message, got {:?}", event)
-            }
+            Err(_) | Ok(None) => panic!("expected SseStreamEvent::Message, got {:?}", event),
         }
     }
 
@@ -934,5 +947,22 @@ mod tests {
         let data_lines = vec!["not valid json".to_owned()];
         let event = SseStreamEvent::from_sse_lines(event_type, &data_lines);
         assert!(event.is_err());
+    }
+
+    #[test]
+    fn sse_decoder_buffers_partial_chunks_until_event_is_complete() {
+        let mut decoder = crate::provider::sse::SseDecoder::default();
+
+        let first = decoder
+            .push_chunk(b"event: content_block_delta\ndata: {\"type\":\"text_delta\"")
+            .expect("first chunk");
+        assert!(first.is_empty());
+
+        let second = decoder
+            .push_chunk(b",\"text\":\"hello\"}\n\n")
+            .expect("second chunk");
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0]["type"], "text_delta");
+        assert_eq!(second[0]["text"], "hello");
     }
 }

--- a/crates/app/src/provider/transport_trait.rs
+++ b/crates/app/src/provider/transport_trait.rs
@@ -113,7 +113,7 @@ impl TransportError {
         Self {
             kind: TransportErrorKind::Other,
             reason: ProviderFailoverReason::ResponseShapeInvalid,
-            stage: ProviderFailoverStage::ResponseDecode,
+            stage: ProviderFailoverStage::ResponseShapeInvalid,
             message: message.into(),
         }
     }

--- a/crates/app/src/provider/transport_trait.rs
+++ b/crates/app/src/provider/transport_trait.rs
@@ -36,7 +36,6 @@ pub(super) struct TransportRequest {
     pub(super) url: String,
     pub(super) headers: HeaderMap,
     pub(super) body: Vec<u8>,
-    pub(super) auth: Option<PreparedTransportAuth>,
 }
 
 #[derive(Debug)]

--- a/crates/app/src/provider/transport_trait.rs
+++ b/crates/app/src/provider/transport_trait.rs
@@ -1,0 +1,201 @@
+use std::fmt;
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures_util::Stream;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde_json::Value;
+
+use crate::CliResult;
+use crate::config::ProviderAuthScheme;
+
+use super::auth_profile_runtime::ProviderAuthProfile;
+use super::failover::{ProviderFailoverReason, ProviderFailoverStage};
+
+pub(super) type TransportEventStream =
+    Pin<Box<dyn Stream<Item = Result<Value, TransportError>> + Send>>;
+
+#[derive(Debug, Clone)]
+pub(super) struct PreparedTransportAuth {
+    header_name: HeaderName,
+    header_value: HeaderValue,
+}
+
+impl PreparedTransportAuth {
+    pub(super) fn apply(&self, headers: &mut HeaderMap) {
+        if headers.contains_key(&self.header_name) {
+            return;
+        }
+        headers.insert(self.header_name.clone(), self.header_value.clone());
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct TransportRequest {
+    pub(super) method: reqwest::Method,
+    pub(super) url: String,
+    pub(super) headers: HeaderMap,
+    pub(super) body: Vec<u8>,
+    pub(super) auth: Option<PreparedTransportAuth>,
+}
+
+#[derive(Debug)]
+pub(super) struct TransportResponse {
+    pub(super) status: reqwest::StatusCode,
+    pub(super) headers: HeaderMap,
+    pub(super) body: Value,
+}
+
+pub(super) enum TransportStream {
+    Events { events: TransportEventStream },
+    Response(TransportResponse),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TransportErrorKind {
+    Timeout,
+    Connect,
+    Request,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TransportError {
+    kind: TransportErrorKind,
+    reason: ProviderFailoverReason,
+    stage: ProviderFailoverStage,
+    message: String,
+}
+
+impl TransportError {
+    pub(super) fn new(kind: TransportErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            reason: ProviderFailoverReason::TransportFailure,
+            stage: ProviderFailoverStage::TransportFailure,
+            message: message.into(),
+        }
+    }
+
+    pub(super) fn other(message: impl Into<String>) -> Self {
+        Self::new(TransportErrorKind::Other, message)
+    }
+
+    pub(super) fn is_timeout(&self) -> bool {
+        self.kind == TransportErrorKind::Timeout
+    }
+
+    pub(super) fn is_connect(&self) -> bool {
+        self.kind == TransportErrorKind::Connect
+    }
+
+    pub(super) fn is_request(&self) -> bool {
+        self.kind == TransportErrorKind::Request
+    }
+
+    pub(super) fn reason(&self) -> ProviderFailoverReason {
+        self.reason
+    }
+
+    pub(super) fn stage(&self) -> ProviderFailoverStage {
+        self.stage
+    }
+
+    pub(super) fn response_decode(message: impl Into<String>) -> Self {
+        Self {
+            kind: TransportErrorKind::Other,
+            reason: ProviderFailoverReason::ResponseDecodeFailure,
+            stage: ProviderFailoverStage::ResponseDecode,
+            message: message.into(),
+        }
+    }
+
+    pub(super) fn response_shape_invalid(message: impl Into<String>) -> Self {
+        Self {
+            kind: TransportErrorKind::Other,
+            reason: ProviderFailoverReason::ResponseShapeInvalid,
+            stage: ProviderFailoverStage::ResponseDecode,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.message.as_str())
+    }
+}
+
+impl std::error::Error for TransportError {}
+
+impl From<reqwest::Error> for TransportError {
+    fn from(error: reqwest::Error) -> Self {
+        let kind = if error.is_timeout() {
+            TransportErrorKind::Timeout
+        } else if error.is_connect() {
+            TransportErrorKind::Connect
+        } else if error.is_request() {
+            TransportErrorKind::Request
+        } else {
+            TransportErrorKind::Other
+        };
+        Self::new(kind, error.to_string())
+    }
+}
+
+pub(super) fn resolve_transport_auth(
+    profile: Option<&ProviderAuthProfile>,
+    auth_scheme: ProviderAuthScheme,
+) -> CliResult<Option<PreparedTransportAuth>> {
+    let Some(profile) = profile else {
+        return Ok(None);
+    };
+
+    match auth_scheme {
+        ProviderAuthScheme::Bearer => {
+            let Some(secret) = profile
+                .authorization_secret
+                .as_deref()
+                .or(profile.api_key_secret.as_deref())
+            else {
+                return Ok(None);
+            };
+            let header_value = HeaderValue::from_str(format!("Bearer {secret}").as_str())
+                .map_err(|error| format!("invalid provider authorization header: {error}"))?;
+            Ok(Some(PreparedTransportAuth {
+                header_name: HeaderName::from_static("authorization"),
+                header_value,
+            }))
+        }
+        ProviderAuthScheme::XApiKey => {
+            let Some(secret) = profile.api_key_secret.as_deref() else {
+                return Ok(None);
+            };
+            let header_value = HeaderValue::from_str(secret)
+                .map_err(|error| format!("invalid provider x-api-key header: {error}"))?;
+            Ok(Some(PreparedTransportAuth {
+                header_name: HeaderName::from_static("x-api-key"),
+                header_value,
+            }))
+        }
+        ProviderAuthScheme::XGoogApiKey => {
+            let Some(secret) = profile.api_key_secret.as_deref() else {
+                return Ok(None);
+            };
+            let header_value = HeaderValue::from_str(secret)
+                .map_err(|error| format!("invalid provider x-goog-api-key header: {error}"))?;
+            Ok(Some(PreparedTransportAuth {
+                header_name: HeaderName::from_static("x-goog-api-key"),
+                header_value,
+            }))
+        }
+    }
+}
+
+#[async_trait]
+pub(super) trait ProviderTransport: Send + Sync {
+    async fn execute(&self, request: TransportRequest)
+    -> Result<TransportResponse, TransportError>;
+
+    async fn stream(&self, request: TransportRequest) -> Result<TransportStream, TransportError>;
+}

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-10T16:14:16Z
+- Generated at: 2026-04-11T13:36:35Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -14,7 +14,7 @@
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3573 | 3700 | 127 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.7% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 405 | 1000 | 595 | 11 | 20 | 9 | 55.0% | HEALTHY | 375 | 8.0% | PASS | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 409 | 1000 | 591 | 11 | 20 | 9 | 55.0% | HEALTHY | 375 | 9.1% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3476 | 3600 | 124 | 12 | 12 | 0 | 100.0% | TIGHT | 3383 | 2.7% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
@@ -60,7 +60,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3573 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=405 functions=11 -->
+<!-- arch-hotspot key=provider_mod lines=409 functions=11 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3476 functions=12 -->
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->


### PR DESCRIPTION
## Summary

- Problem:
  provider request execution mixed reqwest transport, auth header injection, bedrock signing, and sse decoding in the same path, which made provider behavior hard to unit test without live http or process-level mocks.
- Why it matters:
  the provider stack needs a stable transport seam so dispatch and executor behavior can be tested in isolation, especially around streaming, auth routing, and response/error classification.
- What changed:
  extracted `ProviderTransport` plus transport request/response types into `crates/app/src/provider/transport_trait.rs`; added `ReqwestTransport`, `MockTransport`, and extracted sse decoding into `crates/app/src/provider/sse.rs`; refactored request execution and provider dispatch to use transport-injected helpers; preserved response decode / response shape failure semantics across the transport boundary; added dispatch-level and streaming-response regression coverage without live http.
- What did not change (scope boundary):
  no config schema changes, no public contracts/protocol move, no user-facing cli behavior changes, and model-catalog fetch remains on its existing path outside this refactor.

## Linked Issues

- Closes #972
- Related #1002

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this changes the provider request execution seam, including auth application, streaming decode, and transport/error mapping.
- Rollout / guardrails:
  regression coverage now includes dispatch-level mock injection, streaming `TransportStream::Response`, response decode failure classification, and malformed sse classification, in addition to existing provider tests.
- Rollback path:
  revert commit `7abb9ceb` (`refactor(provider): extract transport trait`).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

cargo test --workspace --all-features
- passed on the feat branch during verification

additional targeted checks:
cargo test -p loongclaw-app execute_model_request_preserves_response_decode_failure_reason
- passed

cargo test -p loongclaw-app streaming_transport_errors_preserve_response_shape_invalid_reason
- passed

cargo test -p loongclaw-app request_completion_with_provider_uses_injected_transport
- passed

cargo test -p loongclaw-app sibling_provider_tests_can_inject_mock_transport_into_dispatch_layer
- passed

cargo test -p loongclaw-app execute_streaming_model_request_handles_response_branch_without_http
- passed

notes:
- i did not run the exact --locked variants, so those boxes remain unchecked.
- the canonical dep-graph helper hung locally when invoking cargo metadata, so that check is not claimed here.
- the new tests added in this change do not mutate process-global env; existing provider env-mutation tests in this crate use ScopedEnv to restore state.
```

## User-visible / Operator-visible Changes

- None, or describe the exact change:
  none. this is an internal provider refactor for testability and error-path correctness.

## Failure Recovery

- Fast rollback or disable path:
  revert `7abb9ceb` to restore the pre-refactor provider request path.
- Observable failure symptoms reviewers should watch for:
  provider requests failing before status parsing, malformed streaming events being misclassified, or dispatch-level tests unexpectedly requiring real http again.

## Reviewer Focus

- `crates/app/src/provider/transport_trait.rs`
  trait shape and transport error semantics.
- `crates/app/src/provider/transport.rs`
  `ReqwestTransport`, bedrock signing containment, and `build_transport_request`.
- `crates/app/src/provider/request_executor.rs`
  decode/shape failure mapping and streaming response handling.
- `crates/app/src/provider/request_dispatch_runtime.rs`
  transport-injected dispatch helpers and whether they fully solve the testability seam.
- `crates/app/src/provider/mock_transport.rs`
  event-stream and response-branch coverage.
- `crates/app/src/provider/sse.rs`
  extracted decoder behavior and malformed-frame handling.
- `crates/app/src/provider/tests.rs`
  sibling-level proof that dispatch is mock-injectable outside the dispatch module itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal transport layer architecture to improve error handling and testability, enabling more consistent classification of network failures (timeout, connection, request errors) and better error messaging during provider interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->