### PR TITLE
[Bug]: keep discoverable tool leases stable across runtime handoffs

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -6,15 +6,12 @@ use std::{
     ffi::OsString,
     future::Future,
     path::{Path, PathBuf},
-    sync::{OnceLock, mpsc},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::mpsc,
+    time::Duration,
 };
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
-use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 #[cfg(test)]
 use tool_search::searchable_entry_from_provider_definition;
 use tool_search::{
@@ -24,7 +21,6 @@ use tool_search::{
 
 use crate::KernelContext;
 use crate::config::ToolConfig;
-use crate::crypto::timing_safe_eq;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 pub(crate) mod approval;
@@ -68,6 +64,7 @@ mod session_search;
 mod shell;
 pub mod shell_policy_ext;
 mod shell_request_prep;
+mod tool_lease_authority;
 mod tool_search;
 // Browser reuses the shared SSRF and HTML helpers from web_fetch even when the
 // public web.fetch tool is compiled out.
@@ -1317,17 +1314,6 @@ pub fn tool_parameter_schema_types() -> BTreeMap<String, BTreeMap<String, &'stat
     tools_by_name
 }
 
-const TOOL_LEASE_TTL_SECONDS: u64 = 300;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ToolLeaseClaims {
-    tool_id: String,
-    catalog_digest: String,
-    expires_at_unix: u64,
-    token_id: Option<String>,
-    session_id: Option<String>,
-    turn_id: Option<String>,
-}
 fn execute_tool_search_tool_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
@@ -1378,7 +1364,8 @@ fn execute_tool_search_tool_with_config(
     let mut diagnostics_reason = None;
     let results: Vec<Value> = if let Some(entry) = exact_match_entry {
         let why = Vec::new();
-        vec![tool_search_result_entry_json(&entry, why, payload)]
+        let entry_json = tool_search_result_entry_json(&entry, why, payload)?;
+        vec![entry_json]
     } else if let Some(query) = query.as_deref() {
         let ranking = rank_searchable_entries(searchable_entries, query, limit);
         diagnostics_reason = ranking.diagnostics_reason;
@@ -1391,7 +1378,7 @@ fn execute_tool_search_tool_with_config(
 
                 tool_search_result_entry_json(&entry, why, payload)
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?
     } else {
         let ranking = rank_searchable_entries(searchable_entries, "", limit);
         diagnostics_reason = ranking.diagnostics_reason;
@@ -1404,7 +1391,7 @@ fn execute_tool_search_tool_with_config(
 
                 tool_search_result_entry_json(&entry, why, payload)
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?
     };
     let diagnostics = tool_search_diagnostics_json(
         requested_exact_tool_id.as_deref(),
@@ -1436,8 +1423,9 @@ fn tool_search_result_entry_json(
     entry: &SearchableToolEntry,
     why: Vec<String>,
     payload: &serde_json::Map<String, Value>,
-) -> Value {
-    json!({
+) -> Result<Value, String> {
+    let lease = tool_lease_authority::issue_tool_lease(entry.canonical_name.as_str(), payload)?;
+    let entry_json = json!({
         "tool_id": entry.canonical_name,
         "summary": entry.summary,
         "search_hint": entry.search_hint,
@@ -1447,8 +1435,9 @@ fn tool_search_result_entry_json(
         "schema_preview": entry.schema_preview,
         "tags": entry.tags,
         "why": why,
-        "lease": issue_tool_lease(entry.canonical_name.as_str(), payload),
-    })
+        "lease": lease,
+    });
+    Ok(entry_json)
 }
 
 fn tool_search_diagnostics_json(
@@ -1625,7 +1614,7 @@ pub(crate) fn resolve_tool_invoke_request(
             resolved_tool_name
         ));
     }
-    validate_tool_lease(resolved_tool_name, lease, payload)?;
+    tool_lease_authority::validate_tool_lease(resolved_tool_name, lease, payload)?;
 
     Ok((
         resolved,
@@ -1658,22 +1647,6 @@ fn execute_tool_invoke_tool_with_config(
     }
 }
 
-fn issue_tool_lease(tool_id: &str, payload: &serde_json::Map<String, Value>) -> String {
-    let binding = extract_tool_lease_binding(payload);
-    let claims = ToolLeaseClaims {
-        tool_id: tool_id.to_owned(),
-        catalog_digest: tool_catalog_digest(),
-        expires_at_unix: now_unix_seconds().saturating_add(TOOL_LEASE_TTL_SECONDS),
-        token_id: binding.token_id,
-        session_id: binding.session_id,
-        turn_id: binding.turn_id,
-    };
-    let claims_bytes = serde_json::to_vec(&claims).unwrap_or_default();
-    let encoded_claims = URL_SAFE_NO_PAD.encode(claims_bytes);
-    let signature = sign_tool_lease(encoded_claims.as_str());
-    format!("{encoded_claims}.{signature}")
-}
-
 #[allow(dead_code)]
 pub(crate) fn bridge_provider_tool_call_with_scope(
     tool_name: &str,
@@ -1690,7 +1663,14 @@ pub(crate) fn bridge_provider_tool_call_with_scope(
     }
     let mut lease_payload = serde_json::Map::new();
     inject_tool_lease_binding(&mut lease_payload, None, session_id, turn_id);
-    let lease = issue_tool_lease(entry.canonical_name, &lease_payload);
+    let lease_result = tool_lease_authority::issue_tool_lease(entry.canonical_name, &lease_payload);
+    let lease = match lease_result {
+        Ok(lease) => lease,
+        Err(error) => {
+            let invalid_lease = format!("tool-lease-error:{error}");
+            invalid_lease
+        }
+    };
     let mut outer_payload = serde_json::Map::new();
     outer_payload.insert("tool_id".to_owned(), json!(entry.canonical_name));
     outer_payload.insert("lease".to_owned(), json!(lease));
@@ -1718,110 +1698,6 @@ pub(crate) fn synthesize_test_provider_tool_call_with_scope(
     turn_id: Option<&str>,
 ) -> (String, Value) {
     bridge_provider_tool_call_with_scope(tool_name, args_json, session_id, turn_id)
-}
-
-fn validate_tool_lease(
-    expected_tool_id: &str,
-    lease: &str,
-    payload: &serde_json::Map<String, Value>,
-) -> Result<(), String> {
-    let Some((encoded_claims, signature)) = lease.split_once('.') else {
-        return Err("invalid_tool_lease: malformed lease".to_owned());
-    };
-    let expected_signature = sign_tool_lease(encoded_claims);
-    if !timing_safe_eq(expected_signature.as_bytes(), signature.as_bytes()) {
-        return Err("invalid_tool_lease: signature mismatch".to_owned());
-    }
-    let claims_bytes = URL_SAFE_NO_PAD
-        .decode(encoded_claims)
-        .map_err(|error| format!("invalid_tool_lease: claims decode failed: {error}"))?;
-    let claims: ToolLeaseClaims = serde_json::from_slice(&claims_bytes)
-        .map_err(|error| format!("invalid_tool_lease: claims parse failed: {error}"))?;
-    if claims.tool_id != expected_tool_id {
-        return Err("invalid_tool_lease: tool mismatch".to_owned());
-    }
-    if claims.catalog_digest != tool_catalog_digest() {
-        return Err("invalid_tool_lease: catalog mismatch".to_owned());
-    }
-    if claims.expires_at_unix <= now_unix_seconds() {
-        return Err("invalid_tool_lease: expired lease".to_owned());
-    }
-    let binding = extract_tool_lease_binding(payload);
-    if claims.token_id.is_some() && claims.token_id != binding.token_id {
-        return Err("invalid_tool_lease: token mismatch".to_owned());
-    }
-    if claims.session_id.is_some() && claims.session_id != binding.session_id {
-        return Err("invalid_tool_lease: session mismatch".to_owned());
-    }
-    if claims.turn_id.is_some() && claims.turn_id != binding.turn_id {
-        return Err("invalid_tool_lease: turn mismatch".to_owned());
-    }
-    Ok(())
-}
-
-#[derive(Debug, Clone, Default)]
-struct ToolLeaseBinding {
-    token_id: Option<String>,
-    session_id: Option<String>,
-    turn_id: Option<String>,
-}
-
-fn extract_tool_lease_binding(payload: &serde_json::Map<String, Value>) -> ToolLeaseBinding {
-    ToolLeaseBinding {
-        token_id: payload
-            .get(TOOL_LEASE_TOKEN_ID_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        session_id: payload
-            .get(TOOL_LEASE_SESSION_ID_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        turn_id: payload
-            .get(TOOL_LEASE_TURN_ID_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-    }
-}
-
-fn sign_tool_lease(encoded_claims: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(tool_lease_secret().as_bytes());
-    hasher.update(b":");
-    hasher.update(encoded_claims.as_bytes());
-    let digest = hasher.finalize();
-    hex::encode(digest)
-}
-
-fn tool_catalog_digest() -> String {
-    catalog::stable_tool_catalog_digest().to_owned()
-}
-
-fn tool_lease_secret() -> &'static str {
-    static SECRET: OnceLock<String> = OnceLock::new();
-    SECRET.get_or_init(|| {
-        // Use RandomState for OS-level entropy rather than deterministic PID+timestamp.
-        // RandomState is seeded from the OS CSPRNG on most platforms.
-        use std::collections::hash_map::RandomState;
-        use std::hash::{BuildHasher, Hasher};
-        let random_state = RandomState::new();
-        let mut hasher = random_state.build_hasher();
-        hasher.write_u64(std::process::id() as u64);
-        hasher.write_u64(now_unix_seconds());
-        let entropy = hasher.finish();
-        let seed = format!(
-            "tool-lease:{entropy:x}:{:x}",
-            random_state.build_hasher().finish()
-        );
-        let digest = Sha256::digest(seed.as_bytes());
-        hex::encode(digest)
-    })
-}
-
-fn now_unix_seconds() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
 }
 
 fn tool_function_name(tool: &Value) -> &str {
@@ -1916,6 +1792,8 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
 mod tests {
     use super::*;
     use crate::test_support::{ScopedEnv, unique_temp_dir};
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use std::path::{Path, PathBuf};
     use std::sync::{MutexGuard, OnceLock};
 
@@ -4317,11 +4195,11 @@ mod tests {
         let claims_bytes = URL_SAFE_NO_PAD
             .decode(encoded_claims)
             .expect("decode claims");
-        let claims: ToolLeaseClaims = serde_json::from_slice(&claims_bytes).expect("parse claims");
-        let expected_digest = tool_catalog_digest();
-        let repeated_digest = tool_catalog_digest();
+        let claims: Value = serde_json::from_slice(&claims_bytes).expect("parse claims");
+        let expected_digest = tool_lease_authority::tool_catalog_digest();
+        let repeated_digest = tool_lease_authority::tool_catalog_digest();
 
-        assert_eq!(claims.catalog_digest, expected_digest);
+        assert_eq!(claims["catalog_digest"], json!(expected_digest));
         assert_eq!(repeated_digest, expected_digest);
 
         std::fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
+++ b/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
@@ -390,7 +390,9 @@ fn tool_invoke_shell_exec_normalizes_embedded_whitespace_into_args_when_args_mis
     let command = "echo hello from invoke";
     #[cfg(windows)]
     let command = "cmd /C echo hello from invoke";
-    let lease = issue_tool_lease("shell.exec", &serde_json::Map::new());
+    let lease =
+        crate::tools::tool_lease_authority::issue_tool_lease("shell.exec", &serde_json::Map::new())
+            .expect("tool lease");
     let outcome = execute_tool_core_with_config(
         ToolCoreRequest {
             tool_name: "tool.invoke".to_owned(),

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -1,0 +1,420 @@
+use std::collections::HashMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::Digest;
+use sha2::Sha256;
+
+const TOOL_LEASE_TTL_SECONDS: u64 = 300;
+const TOOL_LEASE_SECRET_BYTES: usize = 32;
+const TOOL_LEASE_SECRET_FILE_NAME: &str = "tool-lease-secret.hex";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ToolLeaseClaims {
+    tool_id: String,
+    catalog_digest: String,
+    expires_at_unix: u64,
+    token_id: Option<String>,
+    session_id: Option<String>,
+    turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ToolLeaseBinding {
+    token_id: Option<String>,
+    session_id: Option<String>,
+    turn_id: Option<String>,
+}
+
+pub(crate) fn issue_tool_lease(
+    tool_id: &str,
+    payload: &serde_json::Map<String, Value>,
+) -> Result<String, String> {
+    let binding = extract_tool_lease_binding(payload);
+    let catalog_digest = tool_catalog_digest();
+    let expires_at_unix = now_unix_seconds().saturating_add(TOOL_LEASE_TTL_SECONDS);
+    let claims = ToolLeaseClaims {
+        tool_id: tool_id.to_owned(),
+        catalog_digest,
+        expires_at_unix,
+        token_id: binding.token_id,
+        session_id: binding.session_id,
+        turn_id: binding.turn_id,
+    };
+    let claims_bytes = serde_json::to_vec(&claims)
+        .map_err(|error| format!("tool_lease_claims_serialize_failed: {error}"))?;
+    let encoded_claims = URL_SAFE_NO_PAD.encode(claims_bytes);
+    let signature = sign_tool_lease(encoded_claims.as_str())?;
+    let lease = format!("{encoded_claims}.{signature}");
+    Ok(lease)
+}
+
+pub(crate) fn validate_tool_lease(
+    expected_tool_id: &str,
+    lease: &str,
+    payload: &serde_json::Map<String, Value>,
+) -> Result<(), String> {
+    let split = lease.split_once('.');
+    let Some((encoded_claims, signature)) = split else {
+        return Err("invalid_tool_lease: malformed lease".to_owned());
+    };
+
+    let expected_signature = sign_tool_lease(encoded_claims)?;
+    let signatures_match =
+        crate::crypto::timing_safe_eq(expected_signature.as_bytes(), signature.as_bytes());
+    if !signatures_match {
+        return Err("invalid_tool_lease: signature mismatch".to_owned());
+    }
+
+    let claims_bytes = URL_SAFE_NO_PAD
+        .decode(encoded_claims)
+        .map_err(|error| format!("invalid_tool_lease: claims decode failed: {error}"))?;
+    let claims: ToolLeaseClaims = serde_json::from_slice(&claims_bytes)
+        .map_err(|error| format!("invalid_tool_lease: claims parse failed: {error}"))?;
+
+    let tool_matches = claims.tool_id == expected_tool_id;
+    if !tool_matches {
+        return Err("invalid_tool_lease: tool mismatch".to_owned());
+    }
+
+    let catalog_digest = tool_catalog_digest();
+    let catalog_matches = claims.catalog_digest == catalog_digest;
+    if !catalog_matches {
+        return Err("invalid_tool_lease: catalog mismatch".to_owned());
+    }
+
+    let now_unix = now_unix_seconds();
+    let lease_is_expired = claims.expires_at_unix <= now_unix;
+    if lease_is_expired {
+        return Err("invalid_tool_lease: expired lease".to_owned());
+    }
+
+    let binding = extract_tool_lease_binding(payload);
+    let token_matches = claims.token_id.is_none() || claims.token_id == binding.token_id;
+    if !token_matches {
+        return Err("invalid_tool_lease: token mismatch".to_owned());
+    }
+
+    let session_matches = claims.session_id.is_none() || claims.session_id == binding.session_id;
+    if !session_matches {
+        return Err("invalid_tool_lease: session mismatch".to_owned());
+    }
+
+    let turn_matches = claims.turn_id.is_none() || claims.turn_id == binding.turn_id;
+    if !turn_matches {
+        return Err("invalid_tool_lease: turn mismatch".to_owned());
+    }
+
+    Ok(())
+}
+
+fn extract_tool_lease_binding(payload: &serde_json::Map<String, Value>) -> ToolLeaseBinding {
+    let token_id = payload
+        .get(super::TOOL_LEASE_TOKEN_ID_FIELD)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let session_id = payload
+        .get(super::TOOL_LEASE_SESSION_ID_FIELD)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let turn_id = payload
+        .get(super::TOOL_LEASE_TURN_ID_FIELD)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    ToolLeaseBinding {
+        token_id,
+        session_id,
+        turn_id,
+    }
+}
+
+fn sign_tool_lease(encoded_claims: &str) -> Result<String, String> {
+    let secret = tool_lease_secret()?;
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    hasher.update(b":");
+    hasher.update(encoded_claims.as_bytes());
+    let digest = hasher.finalize();
+    let encoded_digest = hex::encode(digest);
+    Ok(encoded_digest)
+}
+
+pub(crate) fn tool_catalog_digest() -> String {
+    let digest = super::catalog::stable_tool_catalog_digest();
+    digest.to_owned()
+}
+
+fn tool_lease_secret() -> Result<String, String> {
+    let secret_path = default_tool_lease_secret_path();
+    let cached_secret = cached_tool_lease_secret(secret_path.as_path());
+    if let Some(cached_secret) = cached_secret {
+        return Ok(cached_secret);
+    }
+
+    let loaded_secret = load_or_create_tool_lease_secret(secret_path.as_path())?;
+    cache_tool_lease_secret(secret_path, loaded_secret.clone());
+    Ok(loaded_secret)
+}
+
+fn default_tool_lease_secret_path() -> PathBuf {
+    let loongclaw_home = crate::config::default_loongclaw_home();
+    loongclaw_home.join(TOOL_LEASE_SECRET_FILE_NAME)
+}
+
+fn load_or_create_tool_lease_secret(secret_path: &Path) -> Result<String, String> {
+    let existing_secret = read_tool_lease_secret_file(secret_path)?;
+    if let Some(existing_secret) = existing_secret {
+        return Ok(existing_secret);
+    }
+
+    ensure_tool_lease_secret_parent_dir(secret_path)?;
+
+    let generated_secret = generate_tool_lease_secret();
+    let create_result = write_tool_lease_secret_if_missing(secret_path, generated_secret.as_str());
+
+    match create_result {
+        Ok(()) => Ok(generated_secret),
+        Err(CreateToolLeaseSecretError::AlreadyExists) => {
+            let existing_secret = read_tool_lease_secret_file(secret_path)?;
+            let Some(existing_secret) = existing_secret else {
+                let message = format!(
+                    "tool_lease_authority_unavailable: secret file appeared without readable contents at {}",
+                    secret_path.display()
+                );
+                return Err(message);
+            };
+            Ok(existing_secret)
+        }
+        Err(CreateToolLeaseSecretError::Io(error)) => {
+            let message = format!(
+                "tool_lease_authority_unavailable: failed to persist secret at {}: {error}",
+                secret_path.display()
+            );
+            Err(message)
+        }
+    }
+}
+
+fn ensure_tool_lease_secret_parent_dir(secret_path: &Path) -> Result<(), String> {
+    let parent = secret_path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "tool_lease_authority_unavailable: failed to create secret directory {}: {error}",
+            parent.display()
+        )
+    })
+}
+
+fn read_tool_lease_secret_file(secret_path: &Path) -> Result<Option<String>, String> {
+    let raw_secret = match fs::read_to_string(secret_path) {
+        Ok(raw_secret) => raw_secret,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            let message = format!(
+                "tool_lease_authority_unavailable: failed to read secret file {}: {error}",
+                secret_path.display()
+            );
+            return Err(message);
+        }
+    };
+
+    let trimmed_secret = raw_secret.trim();
+    if trimmed_secret.is_empty() {
+        let message = format!(
+            "tool_lease_authority_unavailable: secret file {} is empty",
+            secret_path.display()
+        );
+        return Err(message);
+    }
+
+    let decoded_secret = hex::decode(trimmed_secret).map_err(|error| {
+        format!(
+            "tool_lease_authority_unavailable: secret file {} is not valid hex: {error}",
+            secret_path.display()
+        )
+    })?;
+
+    let secret_length = decoded_secret.len();
+    let has_expected_length = secret_length == TOOL_LEASE_SECRET_BYTES;
+    if !has_expected_length {
+        let message = format!(
+            "tool_lease_authority_unavailable: secret file {} has {} bytes; expected {}",
+            secret_path.display(),
+            secret_length,
+            TOOL_LEASE_SECRET_BYTES
+        );
+        return Err(message);
+    }
+
+    let normalized_secret = trimmed_secret.to_owned();
+    Ok(Some(normalized_secret))
+}
+
+fn generate_tool_lease_secret() -> String {
+    let secret_bytes = rand::random::<[u8; TOOL_LEASE_SECRET_BYTES]>();
+    hex::encode(secret_bytes)
+}
+
+enum CreateToolLeaseSecretError {
+    AlreadyExists,
+    Io(std::io::Error),
+}
+
+fn write_tool_lease_secret_if_missing(
+    secret_path: &Path,
+    secret: &str,
+) -> Result<(), CreateToolLeaseSecretError> {
+    let mut options = OpenOptions::new();
+    options.write(true);
+    options.create_new(true);
+
+    let file = options.open(secret_path);
+    let mut file = match file {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(CreateToolLeaseSecretError::AlreadyExists);
+        }
+        Err(error) => return Err(CreateToolLeaseSecretError::Io(error)),
+    };
+
+    let write_result = writeln!(file, "{secret}");
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(secret_path);
+        return Err(CreateToolLeaseSecretError::Io(error));
+    }
+
+    let sync_result = file.sync_all();
+    if let Err(error) = sync_result {
+        let _ = fs::remove_file(secret_path);
+        return Err(CreateToolLeaseSecretError::Io(error));
+    }
+
+    Ok(())
+}
+
+fn cached_tool_lease_secret(secret_path: &Path) -> Option<String> {
+    let cache = tool_lease_secret_cache();
+    let guard = cache.lock();
+    let guard = match guard {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.get(secret_path).cloned()
+}
+
+fn cache_tool_lease_secret(secret_path: PathBuf, secret: String) {
+    let cache = tool_lease_secret_cache();
+    let guard = cache.lock();
+    let mut guard = match guard {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.insert(secret_path, secret);
+}
+
+fn tool_lease_secret_cache() -> &'static Mutex<HashMap<PathBuf, String>> {
+    static TOOL_LEASE_SECRET_CACHE: OnceLock<Mutex<HashMap<PathBuf, String>>> = OnceLock::new();
+    TOOL_LEASE_SECRET_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_unix_seconds() -> u64 {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    duration.as_secs()
+}
+
+#[cfg(test)]
+pub(super) fn clear_tool_lease_secret_cache_for_tests() {
+    let cache = tool_lease_secret_cache();
+    let guard = cache.lock();
+    let mut guard = match guard {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::clear_tool_lease_secret_cache_for_tests;
+    use super::default_tool_lease_secret_path;
+    use super::issue_tool_lease;
+    use super::read_tool_lease_secret_file;
+    use super::validate_tool_lease;
+    use crate::test_support::ScopedEnv;
+
+    fn scoped_tool_lease_home() -> (TempDir, ScopedEnv) {
+        let temp_home = TempDir::new().expect("temp home");
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_HOME", temp_home.path());
+        clear_tool_lease_secret_cache_for_tests();
+        (temp_home, env)
+    }
+
+    #[test]
+    fn issue_tool_lease_persists_secret_under_loong_home() {
+        let (_temp_home, _env) = scoped_tool_lease_home();
+        let payload = serde_json::Map::new();
+
+        let lease = issue_tool_lease("file.read", &payload).expect("lease");
+        let secret_path = default_tool_lease_secret_path();
+        let persisted_secret =
+            read_tool_lease_secret_file(secret_path.as_path()).expect("persisted secret");
+
+        assert!(!lease.is_empty());
+        assert!(secret_path.exists());
+        assert!(persisted_secret.is_some());
+    }
+
+    #[test]
+    fn issued_tool_lease_survives_authority_cache_reset() {
+        let (_temp_home, _env) = scoped_tool_lease_home();
+        let payload = serde_json::Map::new();
+
+        let lease = issue_tool_lease("file.read", &payload).expect("lease");
+
+        clear_tool_lease_secret_cache_for_tests();
+
+        let validation_result = validate_tool_lease("file.read", &lease, &payload);
+
+        validation_result.expect("lease should survive authority reload");
+    }
+
+    #[test]
+    fn issued_tool_lease_is_home_scoped() {
+        let home_a = TempDir::new().expect("temp home");
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_HOME", home_a.path());
+        clear_tool_lease_secret_cache_for_tests();
+        let payload = serde_json::Map::new();
+        let lease = issue_tool_lease("file.read", &payload).expect("lease");
+
+        let temp_home_b = TempDir::new().expect("temp home");
+        env.set("LOONG_HOME", temp_home_b.path());
+        clear_tool_lease_secret_cache_for_tests();
+
+        let validation_result = validate_tool_lease("file.read", &lease, &payload);
+        let error = validation_result.expect_err("different home should reject lease");
+
+        assert!(error.contains("signature mismatch"), "error={error}");
+    }
+}


### PR DESCRIPTION
## Summary

- Problem: discoverable tool leases were signed with a process-local secret, so `tool.search -> tool.invoke` could fail after restarts or detached/background runtime handoffs.
- Why it matters: this made the discovery-first tool surface unreliable exactly in the always-on/runtime-authority scenarios we are trying to harden.
- What changed: extracted lease issuance/validation into a focused durable authority module backed by a host-local secret under `LOONG_HOME`, wired `tool.search` to fail closed when authority bootstrap fails, and added regression coverage for authority reload persistence and home scoping.
- What did not change (scope boundary): no scheduler redesign, no new database-backed authority, no change to lease TTL/binding semantics beyond making the signing key durable.

## Linked Issues

- Closes #1189
- Related #1177

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: lease issuance is now backed by a durable per-home secret file, so any bug here would affect discoverable tool follow-up flows.
- Rollout / guardrails: leases remain short-lived and still validate tool id, catalog digest, expiry, and optional session/turn/token bindings; authority bootstrap fails closed instead of silently minting a fallback lease.
- Rollback path: revert this commit to restore the old process-local signing behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app tool_lease --lib -- --nocapture --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app tool_invoke --lib -- --test-threads=1
```

Notes:
- The new lease-authority tests use `ScopedEnv`, which serializes process-global env mutation and restores `LOONG_HOME` on drop.
- Cross-process durability is covered by clearing the in-process authority cache and re-validating the same lease against the persisted home secret.

## User-visible / Operator-visible Changes

- Discoverable tool leases now remain valid across same-home runtime handoffs instead of spuriously failing with `invalid_tool_lease: signature mismatch` after a restart/detached transition.

## Failure Recovery

- Fast rollback or disable path: revert this PR.
- Observable failure symptoms reviewers should watch for: `tool.search` failing with `tool_lease_authority_unavailable:*` if the durable secret path cannot be created/read, or unexpected `invalid_tool_lease:*` regressions in `tool.invoke` flows.

## Reviewer Focus

- `crates/app/src/tools/tool_lease_authority.rs`: durable-secret load/create logic, fail-closed behavior, and session/home scoping.
- `crates/app/src/tools/mod.rs`: `tool.search` result generation and `tool.invoke` validation routing.
- `crates/app/src/tools/tests/mod_tests_search_and_shell.rs`: unchanged `tool.invoke` shell flow through the new authority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal tool lease management into a dedicated module for improved code organization and maintainability.
  
* **Bug Fixes**
  * Enhanced error handling and propagation for tool lease validation and invocation, providing more consistent error messages when lease operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->