### PR TITLE
[Feature]: centralize hosted conversation runtime overrides

### DIFF
--- a/crates/app/src/acp/backend.rs
+++ b/crates/app/src/acp/backend.rs
@@ -462,6 +462,8 @@ pub struct StreamingTokenEvent {
     pub event_type: String,
     pub delta: TokenDelta,
     pub index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -5352,12 +5352,16 @@ allowed_decisions: yes / auto / full / esc";
             tool_call_count: 0,
             message_count: Some(4),
             estimated_tokens: Some(128),
+            first_token_latency_ms: Some(123),
             draft_preview: Some("Inspecting the repo layout...".to_owned()),
             tools: Vec::new(),
         };
         let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, 72);
 
-        assert_eq!(lines[0], "╭─ loong · live · round 1 · 4 msgs · ~128 tok");
+        assert_eq!(
+            lines[0],
+            "╭─ loong · live · round 1 · 4 msgs · ~128 tok · ttft 123ms"
+        );
         assert!(
             lines
                 .iter()
@@ -5370,9 +5374,15 @@ allowed_decisions: yes / auto / full / esc";
         );
         assert!(
             lines.iter().any(|line| {
-                line.contains("[WARN] call model") && line.contains("provider round 1 in progress")
+                line.contains("[WARN] call model") && line.contains("first token in 123 ms")
             }),
             "live surface should keep the model step actively highlighted: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("first token") && line.contains("123 ms")),
+            "live surface should surface first-token latency in status rows: {lines:#?}"
         );
         assert!(
             !lines
@@ -5419,6 +5429,7 @@ allowed_decisions: yes / auto / full / esc";
                 tool_call: None,
             },
             index: None,
+            elapsed_ms: Some(42),
         });
 
         let batches = captured_batches
@@ -5438,6 +5449,10 @@ allowed_decisions: yes / auto / full / esc";
                 .iter()
                 .any(|line| line.contains("Draft response")),
             "preview batch should include the streamed text: {preview_batch:#?}"
+        );
+        assert!(
+            preview_batch.iter().any(|line| line.contains("ttft 42ms")),
+            "preview batch should include the first-token latency in the title: {preview_batch:#?}"
         );
     }
 
@@ -5471,6 +5486,7 @@ allowed_decisions: yes / auto / full / esc";
                 }),
             },
             index: Some(0),
+            elapsed_ms: None,
         });
         observer.on_streaming_token(crate::acp::StreamingTokenEvent {
             event_type: "tool_call_input_delta".to_owned(),
@@ -5483,6 +5499,7 @@ allowed_decisions: yes / auto / full / esc";
                 }),
             },
             index: Some(0),
+            elapsed_ms: None,
         });
         observer.on_tool(ConversationTurnToolEvent::completed(
             "call-tool-1",
@@ -5621,6 +5638,7 @@ allowed_decisions: yes / auto / full / esc";
                 ExecutionLane::Fast,
                 1,
             )),
+            first_token_latency_ms: Some(88),
             ..CliChatLiveSurfaceState::default()
         };
 
@@ -5655,6 +5673,7 @@ allowed_decisions: yes / auto / full / esc";
         assert_eq!(tool.stdout.text, "hello");
         assert_eq!(tool.duration_ms, Some(12));
         assert_eq!(tool.exit_code, Some(0));
+        assert_eq!(snapshot.first_token_latency_ms, Some(88));
     }
 
     #[test]
@@ -5693,6 +5712,7 @@ allowed_decisions: yes / auto / full / esc";
                 tool_call: None,
             },
             index: None,
+            elapsed_ms: Some(55),
         });
         observer.on_streaming_token(crate::acp::StreamingTokenEvent {
             event_type: "tool_call_input_delta".to_owned(),
@@ -5705,6 +5725,7 @@ allowed_decisions: yes / auto / full / esc";
                 }),
             },
             index: Some(0),
+            elapsed_ms: None,
         });
         observer.on_phase(ConversationTurnPhaseEvent::requesting_followup_provider(
             2,
@@ -5726,6 +5747,10 @@ allowed_decisions: yes / auto / full / esc";
         assert!(
             !last_batch.iter().any(|line| line.contains("tool activity")),
             "follow-up provider requests should not reuse prior tool activity lines: {last_batch:#?}"
+        );
+        assert!(
+            !last_batch.iter().any(|line| line.contains("ttft 55ms")),
+            "follow-up provider requests should reset prior first-token latency: {last_batch:#?}"
         );
         assert!(
             !last_batch
@@ -5771,6 +5796,7 @@ allowed_decisions: yes / auto / full / esc";
                 }),
             },
             index: Some(0),
+            elapsed_ms: None,
         });
 
         let batch_count_after_tool_delta = captured_batches

--- a/crates/app/src/chat/live_runtime.rs
+++ b/crates/app/src/chat/live_runtime.rs
@@ -67,6 +67,7 @@ pub(super) struct CliChatLiveSurfaceSnapshot {
     pub tool_call_count: usize,
     pub message_count: Option<usize>,
     pub estimated_tokens: Option<usize>,
+    pub first_token_latency_ms: Option<u64>,
     pub draft_preview: Option<String>,
     pub tools: Vec<CliChatLiveToolSnapshot>,
 }
@@ -112,6 +113,7 @@ impl CliChatLiveToolState {
 #[derive(Debug, Clone, Default)]
 pub(super) struct CliChatLiveSurfaceState {
     pub latest_phase_event: Option<ConversationTurnPhaseEvent>,
+    pub first_token_latency_ms: Option<u64>,
     pub draft_preview: String,
     pub tool_states: BTreeMap<String, CliChatLiveToolState>,
     pub tool_call_index_map: BTreeMap<usize, String>,
@@ -227,6 +229,9 @@ impl CliChatLiveSurfaceObserver {
             let mut should_render = false;
 
             if let Some(text_delta) = text_delta {
+                if state.first_token_latency_ms.is_none() {
+                    state.first_token_latency_ms = event.elapsed_ms;
+                }
                 let preview_char_limit = cli_chat_live_preview_char_limit(self.render_width);
                 append_cli_chat_live_buffer(
                     &mut state.draft_preview,
@@ -319,6 +324,7 @@ pub(super) fn cli_chat_live_phase_starts_provider_request(phase: ConversationTur
 }
 
 pub(super) fn reset_cli_chat_live_request_state(state: &mut CliChatLiveSurfaceState) {
+    state.first_token_latency_ms = None;
     state.draft_preview.clear();
     state.tool_states.clear();
     state.tool_call_index_map.clear();
@@ -676,6 +682,7 @@ pub(super) fn build_cli_chat_live_surface_snapshot(
         tool_call_count: phase_event.tool_call_count,
         message_count: phase_event.message_count,
         estimated_tokens: phase_event.estimated_tokens,
+        first_token_latency_ms: state.first_token_latency_ms,
         draft_preview,
         tools,
     })
@@ -865,6 +872,10 @@ fn build_cli_chat_live_surface_card_title(snapshot: &CliChatLiveSurfaceSnapshot)
         segments.push(format!("~{estimated_tokens} tok"));
     }
 
+    if let Some(first_token_latency_ms) = snapshot.first_token_latency_ms {
+        segments.push(format!("ttft {first_token_latency_ms}ms"));
+    }
+
     segments.join(" · ")
 }
 
@@ -904,6 +915,12 @@ fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String
         }
         ConversationTurnPhase::RequestingProvider => {
             let provider_round = snapshot.provider_round.unwrap_or(1);
+            if let Some(first_token_latency_ms) = snapshot.first_token_latency_ms {
+                return format!(
+                    "Provider round {provider_round} started streaming after {first_token_latency_ms} ms."
+                );
+            }
+
             format!("Requesting provider round {provider_round} and waiting for the reply.")
         }
         ConversationTurnPhase::RunningTools => {
@@ -918,6 +935,12 @@ fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String
         }
         ConversationTurnPhase::RequestingFollowupProvider => {
             let provider_round = snapshot.provider_round.unwrap_or(1);
+            if let Some(first_token_latency_ms) = snapshot.first_token_latency_ms {
+                return format!(
+                    "Follow-up provider round {provider_round} started streaming after {first_token_latency_ms} ms."
+                );
+            }
+
             format!("Sending tool results back for provider round {provider_round}.")
         }
         ConversationTurnPhase::FinalizingReply => {
@@ -1004,6 +1027,10 @@ fn cli_chat_live_model_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
         ConversationTurnPhase::RequestingProvider
         | ConversationTurnPhase::RequestingFollowupProvider => {
             let provider_round = snapshot.provider_round.unwrap_or(1);
+            if let Some(first_token_latency_ms) = snapshot.first_token_latency_ms {
+                return format!("first token in {first_token_latency_ms} ms");
+            }
+
             format!("provider round {provider_round} in progress")
         }
         ConversationTurnPhase::RunningTools
@@ -1164,6 +1191,13 @@ fn build_cli_chat_live_status_items(snapshot: &CliChatLiveSurfaceSnapshot) -> Ve
         items.push(TuiKeyValueSpec::Plain {
             key: "estimated tokens".to_owned(),
             value: estimated_tokens.to_string(),
+        });
+    }
+
+    if let Some(first_token_latency_ms) = snapshot.first_token_latency_ms {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "first token".to_owned(),
+            value: format!("{first_token_latency_ms} ms"),
         });
     }
 

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -683,6 +683,7 @@ fn fallback_live_surface_snapshot() -> CliChatLiveSurfaceSnapshot {
         tool_call_count: 0,
         message_count: None,
         estimated_tokens: None,
+        first_token_latency_ms: None,
         draft_preview: None,
         tools: Vec::new(),
     }
@@ -3725,6 +3726,9 @@ impl ConversationTurnObserver for SurfaceLiveObserver {
             && let Some(current_phase) = current_phase
             && phase_supports_cli_chat_live_preview(current_phase)
         {
+            if state.live.state.first_token_latency_ms.is_none() {
+                state.live.state.first_token_latency_ms = event.elapsed_ms;
+            }
             let preview_char_limit = cli_chat_live_preview_char_limit(render_width);
             state.live.state.total_text_chars_seen = state
                 .live

--- a/crates/app/src/conversation/delegate_support.rs
+++ b/crates/app/src/conversation/delegate_support.rs
@@ -27,8 +27,8 @@ use crate::session::repository::{FinalizeSessionTerminalRequest, SessionReposito
 use super::announce::{DelegateAnnounceSettings, enqueue_delegate_result_announce};
 #[cfg(feature = "memory-sqlite")]
 use super::runtime::{
-    AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime,
-    DefaultConversationRuntime, SessionContext,
+    AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime, SessionContext,
+    load_default_conversation_runtime,
 };
 #[cfg(feature = "memory-sqlite")]
 use super::runtime_binding::ConversationRuntimeBinding;
@@ -155,7 +155,7 @@ pub(crate) fn spawn_async_delegate_detached(
             announce_settings.clone(),
         );
 
-        let runtime = DefaultConversationRuntime::from_config_or_env(config.as_ref());
+        let runtime = load_default_conversation_runtime(config.as_ref());
         match runtime {
             Ok(runtime) => {
                 emit_async_delegate_child_terminal_event(

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -83,7 +83,8 @@ pub use runtime::{
     ConversationRuntime, DefaultConversationRuntime, HostedConversationRuntime, SessionContext,
     TurnMiddlewareRuntimeSnapshot, TurnMiddlewareSelection, TurnMiddlewareSelectionSource,
     async_delegate_spawn_request_from_serialized_parts, collect_context_engine_runtime_snapshot,
-    execute_async_delegate_spawn_request, resolve_context_engine_selection,
+    execute_async_delegate_spawn_request, load_default_conversation_runtime,
+    load_hosted_default_conversation_runtime, resolve_context_engine_selection,
     resolve_turn_middleware_selection,
 };
 pub use runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -110,9 +110,9 @@ pub use subagent::{
     ConstrainedSubagentControlScope, ConstrainedSubagentCoordinationAction,
     ConstrainedSubagentCoordinationActionKind, ConstrainedSubagentExecution,
     ConstrainedSubagentHandle, ConstrainedSubagentIdentity, ConstrainedSubagentIsolation,
-    ConstrainedSubagentMode, ConstrainedSubagentProfile, ConstrainedSubagentRole,
-    ConstrainedSubagentRuntimeBinding, ConstrainedSubagentTerminalReason, DelegateBuiltinProfile,
-    coordination_actions_for_subagent_handle, subagent_surface_fields,
+    ConstrainedSubagentMode, ConstrainedSubagentOwnerKind, ConstrainedSubagentProfile,
+    ConstrainedSubagentRole, ConstrainedSubagentRuntimeBinding, ConstrainedSubagentTerminalReason,
+    DelegateBuiltinProfile, coordination_actions_for_subagent_handle, subagent_surface_fields,
 };
 pub(crate) use tool_discovery_state::latest_tool_discovery_state_from_assistant_contents;
 pub use turn_budget::SafeLaneFailureRouteReason;

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -80,8 +80,8 @@ pub use prompt_orchestrator::{PromptCompilation, PromptCompiler};
 pub use runtime::{
     AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ContextCompactionPolicySnapshot,
     ContextEngineRuntimeSnapshot, ContextEngineSelection, ContextEngineSelectionSource,
-    ConversationRuntime, DefaultConversationRuntime, SessionContext, TurnMiddlewareRuntimeSnapshot,
-    TurnMiddlewareSelection, TurnMiddlewareSelectionSource,
+    ConversationRuntime, DefaultConversationRuntime, HostedConversationRuntime, SessionContext,
+    TurnMiddlewareRuntimeSnapshot, TurnMiddlewareSelection, TurnMiddlewareSelectionSource,
     async_delegate_spawn_request_from_serialized_parts, collect_context_engine_runtime_snapshot,
     execute_async_delegate_spawn_request, resolve_context_engine_selection,
     resolve_turn_middleware_selection,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -858,6 +858,43 @@ pub struct DefaultConversationRuntime<E = DefaultContextEngine> {
     turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[derive(Clone)]
+pub struct HostedConversationRuntime<R> {
+    inner: R,
+    async_delegate_spawner_override: Option<Arc<dyn AsyncDelegateSpawner>>,
+    background_task_spawner_override: Option<Arc<dyn AsyncDelegateSpawner>>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl<R> HostedConversationRuntime<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            async_delegate_spawner_override: None,
+            background_task_spawner_override: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_async_delegate_spawner(
+        mut self,
+        async_delegate_spawner: Arc<dyn AsyncDelegateSpawner>,
+    ) -> Self {
+        self.async_delegate_spawner_override = Some(async_delegate_spawner);
+        self
+    }
+
+    #[must_use]
+    pub fn with_background_task_spawner(
+        mut self,
+        background_task_spawner: Arc<dyn AsyncDelegateSpawner>,
+    ) -> Self {
+        self.background_task_spawner_override = Some(background_task_spawner);
+        self
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextEngineSelectionSource {
     Env,
@@ -1432,6 +1469,197 @@ pub trait ConversationRuntime: Send + Sync {
     }
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R> ConversationRuntime for HostedConversationRuntime<R>
+where
+    R: ConversationRuntime,
+{
+    fn session_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<SessionContext> {
+        self.inner.session_context(config, session_id, binding)
+    }
+
+    fn tool_view(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ToolView> {
+        self.inner.tool_view(config, session_id, binding)
+    }
+
+    fn async_delegate_spawner(
+        &self,
+        config: &LoongClawConfig,
+    ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
+        let override_spawner = self.async_delegate_spawner_override.clone();
+        match override_spawner {
+            Some(override_spawner) => Some(override_spawner),
+            None => self.inner.async_delegate_spawner(config),
+        }
+    }
+
+    fn background_task_spawner(
+        &self,
+        config: &LoongClawConfig,
+    ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
+        let override_spawner = self.background_task_spawner_override.clone();
+        match override_spawner {
+            Some(override_spawner) => Some(override_spawner),
+            None => self.inner.background_task_spawner(config),
+        }
+    }
+
+    async fn bootstrap(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<ContextEngineBootstrapResult> {
+        self.inner.bootstrap(config, session_id, kernel_ctx).await
+    }
+
+    async fn ingest(
+        &self,
+        session_id: &str,
+        message: &Value,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<ContextEngineIngestResult> {
+        self.inner.ingest(session_id, message, kernel_ctx).await
+    }
+
+    async fn build_messages(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        tool_view: &ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<Vec<Value>> {
+        self.inner
+            .build_messages(
+                config,
+                session_id,
+                include_system_prompt,
+                tool_view,
+                binding,
+            )
+            .await
+    }
+
+    async fn request_completion(
+        &self,
+        config: &LoongClawConfig,
+        messages: &[Value],
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<String> {
+        self.inner
+            .request_completion(config, messages, binding)
+            .await
+    }
+
+    async fn request_turn(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn(config, session_id, turn_id, messages, tool_view, binding)
+            .await
+    }
+
+    async fn request_turn_streaming(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+        on_token: crate::provider::StreamingTokenCallback,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn_streaming(
+                config, session_id, turn_id, messages, tool_view, binding, on_token,
+            )
+            .await
+    }
+
+    async fn persist_turn(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<()> {
+        self.inner
+            .persist_turn(session_id, role, content, binding)
+            .await
+    }
+
+    async fn after_turn(
+        &self,
+        session_id: &str,
+        user_input: &str,
+        assistant_reply: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.inner
+            .after_turn(
+                session_id,
+                user_input,
+                assistant_reply,
+                messages,
+                kernel_ctx,
+            )
+            .await
+    }
+
+    async fn compact_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.inner
+            .compact_context(config, session_id, messages, kernel_ctx)
+            .await
+    }
+
+    async fn prepare_subagent_spawn(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.inner
+            .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
+            .await
+    }
+
+    async fn on_subagent_ended(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.inner
+            .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)
+            .await
+    }
+}
+
 #[async_trait]
 impl<E> ConversationRuntime for DefaultConversationRuntime<E>
 where
@@ -1835,6 +2063,109 @@ fn normalize_turn_middleware_ids(ids: Vec<String>) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::test_support::TurnTestHarness;
+    #[cfg(feature = "memory-sqlite")]
+    use std::sync::Arc;
+
+    #[cfg(feature = "memory-sqlite")]
+    #[derive(Clone)]
+    struct NoopTestSpawner;
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl AsyncDelegateSpawner for NoopTestSpawner {
+        async fn spawn(&self, _request: AsyncDelegateSpawnRequest) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    struct SpawnerAwareRuntime {
+        async_delegate_spawner: Option<Arc<dyn AsyncDelegateSpawner>>,
+        background_task_spawner: Option<Arc<dyn AsyncDelegateSpawner>>,
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl ConversationRuntime for SpawnerAwareRuntime {
+        fn tool_view(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ToolView> {
+            let tool_view = crate::tools::runtime_tool_view();
+            Ok(tool_view)
+        }
+
+        fn async_delegate_spawner(
+            &self,
+            _config: &LoongClawConfig,
+        ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
+            self.async_delegate_spawner.clone()
+        }
+
+        fn background_task_spawner(
+            &self,
+            _config: &LoongClawConfig,
+        ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
+            self.background_task_spawner.clone()
+        }
+
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _include_system_prompt: bool,
+            _tool_view: &ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            Ok(Vec::new())
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Ok(String::new())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ProviderTurn> {
+            Ok(ProviderTurn::default())
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+            _on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<ProviderTurn> {
+            Ok(ProviderTurn::default())
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn provider_runtime_binding_maps_direct_conversation_binding_to_advisory_only() {
@@ -1852,6 +2183,35 @@ mod tests {
             provider_runtime_binding(ConversationRuntimeBinding::kernel(&harness.kernel_ctx)),
             provider::ProviderRuntimeBinding::Kernel(kernel_ctx)
                 if std::ptr::eq(kernel_ctx, &harness.kernel_ctx)
+        ));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hosted_runtime_overrides_background_task_spawner_without_changing_async_delegate_spawner() {
+        let config = LoongClawConfig::default();
+        let inner_async_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let inner_background_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let override_background_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let inner_runtime = SpawnerAwareRuntime {
+            async_delegate_spawner: Some(inner_async_spawner.clone()),
+            background_task_spawner: Some(inner_background_spawner),
+        };
+
+        let hosted_runtime = HostedConversationRuntime::new(inner_runtime)
+            .with_background_task_spawner(override_background_spawner.clone());
+
+        let resolved_async_spawner = hosted_runtime
+            .async_delegate_spawner(&config)
+            .expect("async delegate spawner");
+        let resolved_background_spawner = hosted_runtime
+            .background_task_spawner(&config)
+            .expect("background task spawner");
+
+        assert!(Arc::ptr_eq(&resolved_async_spawner, &inner_async_spawner));
+        assert!(Arc::ptr_eq(
+            &resolved_background_spawner,
+            &override_background_spawner
         ));
     }
 }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -791,7 +791,7 @@ pub async fn execute_async_delegate_spawn_request(
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
-    let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+    let runtime = load_default_conversation_runtime(config)?;
     let runtime_ref = &runtime;
     let child_session_id_for_spawn = child_session_id.clone();
     let parent_session_id_for_spawn = parent_session_id.clone();
@@ -857,6 +857,9 @@ pub struct DefaultConversationRuntime<E = DefaultContextEngine> {
     context_engine: E,
     turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
 }
+
+pub type BoxedDefaultConversationRuntime =
+    DefaultConversationRuntime<Box<dyn ConversationContextEngine>>;
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Clone)]
@@ -1300,6 +1303,21 @@ impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
             turn_middlewares,
         })
     }
+}
+
+pub fn load_default_conversation_runtime(
+    config: &LoongClawConfig,
+) -> CliResult<BoxedDefaultConversationRuntime> {
+    BoxedDefaultConversationRuntime::from_config_or_env(config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn load_hosted_default_conversation_runtime(
+    config: &LoongClawConfig,
+) -> CliResult<HostedConversationRuntime<BoxedDefaultConversationRuntime>> {
+    let inner_runtime = load_default_conversation_runtime(config)?;
+    let runtime = HostedConversationRuntime::new(inner_runtime);
+    Ok(runtime)
 }
 
 #[async_trait]
@@ -2213,5 +2231,19 @@ mod tests {
             &resolved_background_spawner,
             &override_background_spawner
         ));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn load_hosted_default_conversation_runtime_keeps_default_async_spawner_only() {
+        let config = LoongClawConfig::default();
+        let runtime = load_hosted_default_conversation_runtime(&config)
+            .expect("load hosted default conversation runtime");
+
+        let async_delegate_spawner = runtime.async_delegate_spawner(&config);
+        let background_task_spawner = runtime.background_task_spawner(&config);
+
+        assert!(async_delegate_spawner.is_some());
+        assert!(background_task_spawner.is_none());
     }
 }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -1306,14 +1306,14 @@ impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
 }
 
 pub fn load_default_conversation_runtime(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
 ) -> CliResult<BoxedDefaultConversationRuntime> {
     BoxedDefaultConversationRuntime::from_config_or_env(config)
 }
 
 #[cfg(feature = "memory-sqlite")]
 pub fn load_hosted_default_conversation_runtime(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
 ) -> CliResult<HostedConversationRuntime<BoxedDefaultConversationRuntime>> {
     let inner_runtime = load_default_conversation_runtime(config)?;
     let runtime = HostedConversationRuntime::new(inner_runtime);
@@ -1495,7 +1495,7 @@ where
 {
     fn session_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
@@ -1504,7 +1504,7 @@ where
 
     fn tool_view(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
@@ -1513,7 +1513,7 @@ where
 
     fn async_delegate_spawner(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
     ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
         let override_spawner = self.async_delegate_spawner_override.clone();
         match override_spawner {
@@ -1524,7 +1524,7 @@ where
 
     fn background_task_spawner(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
     ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
         let override_spawner = self.background_task_spawner_override.clone();
         match override_spawner {
@@ -1535,7 +1535,7 @@ where
 
     async fn bootstrap(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
@@ -1551,9 +1551,21 @@ where
         self.inner.ingest(session_id, message, kernel_ctx).await
     }
 
+    async fn build_context(
+        &self,
+        config: &LoongConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        self.inner
+            .build_context(config, session_id, include_system_prompt, binding)
+            .await
+    }
+
     async fn build_messages(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         include_system_prompt: bool,
         tool_view: &ToolView,
@@ -1572,7 +1584,7 @@ where
 
     async fn request_completion(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         messages: &[Value],
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
@@ -1583,7 +1595,7 @@ where
 
     async fn request_turn(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1597,7 +1609,7 @@ where
 
     async fn request_turn_streaming(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         turn_id: &str,
         messages: &[Value],
@@ -1645,7 +1657,7 @@ where
 
     async fn compact_context(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         messages: &[Value],
         kernel_ctx: &KernelContext,
@@ -2107,7 +2119,7 @@ mod tests {
     impl ConversationRuntime for SpawnerAwareRuntime {
         fn tool_view(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
             _session_id: &str,
             _binding: ConversationRuntimeBinding<'_>,
         ) -> CliResult<ToolView> {
@@ -2117,21 +2129,21 @@ mod tests {
 
         fn async_delegate_spawner(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
         ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
             self.async_delegate_spawner.clone()
         }
 
         fn background_task_spawner(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
         ) -> Option<Arc<dyn AsyncDelegateSpawner>> {
             self.background_task_spawner.clone()
         }
 
         async fn build_messages(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
             _session_id: &str,
             _include_system_prompt: bool,
             _tool_view: &ToolView,
@@ -2142,7 +2154,7 @@ mod tests {
 
         async fn request_completion(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
             _messages: &[Value],
             _binding: ConversationRuntimeBinding<'_>,
         ) -> CliResult<String> {
@@ -2151,7 +2163,7 @@ mod tests {
 
         async fn request_turn(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
             _session_id: &str,
             _turn_id: &str,
             _messages: &[Value],
@@ -2163,7 +2175,7 @@ mod tests {
 
         async fn request_turn_streaming(
             &self,
-            _config: &LoongClawConfig,
+            _config: &LoongConfig,
             _session_id: &str,
             _turn_id: &str,
             _messages: &[Value],
@@ -2207,7 +2219,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn hosted_runtime_overrides_background_task_spawner_without_changing_async_delegate_spawner() {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let inner_async_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
         let inner_background_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
         let override_background_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
@@ -2235,8 +2247,164 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn hosted_runtime_overrides_async_delegate_spawner_without_changing_background_task_spawner() {
+        let config = LoongConfig::default();
+        let inner_async_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let inner_background_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let override_async_spawner: Arc<dyn AsyncDelegateSpawner> = Arc::new(NoopTestSpawner);
+        let inner_runtime = SpawnerAwareRuntime {
+            async_delegate_spawner: Some(inner_async_spawner),
+            background_task_spawner: Some(inner_background_spawner.clone()),
+        };
+
+        let hosted_runtime = HostedConversationRuntime::new(inner_runtime)
+            .with_async_delegate_spawner(override_async_spawner.clone());
+
+        let resolved_async_spawner = hosted_runtime
+            .async_delegate_spawner(&config)
+            .expect("async delegate spawner");
+        let resolved_background_spawner = hosted_runtime
+            .background_task_spawner(&config)
+            .expect("background task spawner");
+
+        assert!(Arc::ptr_eq(
+            &resolved_async_spawner,
+            &override_async_spawner
+        ));
+        assert!(Arc::ptr_eq(
+            &resolved_background_spawner,
+            &inner_background_spawner
+        ));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn hosted_runtime_build_context_delegates_to_inner_runtime() {
+        #[derive(Clone)]
+        struct BuildContextAwareRuntime;
+
+        #[async_trait]
+        impl ConversationRuntime for BuildContextAwareRuntime {
+            fn tool_view(
+                &self,
+                _config: &LoongConfig,
+                _session_id: &str,
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<ToolView> {
+                Ok(crate::tools::runtime_tool_view())
+            }
+
+            async fn build_context(
+                &self,
+                _config: &LoongConfig,
+                _session_id: &str,
+                _include_system_prompt: bool,
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<AssembledConversationContext> {
+                let messages = vec![serde_json::json!({
+                    "role": "system",
+                    "content": "delegated"
+                })];
+                let prompt_fragment = PromptFragment::new(
+                    "fragment",
+                    PromptLane::RuntimeSelf,
+                    "runtime-self",
+                    "delegated fragment",
+                    ContextArtifactKind::RuntimeContract,
+                );
+                let assembled = AssembledConversationContext {
+                    messages,
+                    artifacts: Vec::new(),
+                    estimated_tokens: Some(7),
+                    prompt_fragments: vec![prompt_fragment],
+                    system_prompt_addition: Some("addition".to_owned()),
+                };
+
+                Ok(assembled)
+            }
+
+            async fn build_messages(
+                &self,
+                _config: &LoongConfig,
+                _session_id: &str,
+                _include_system_prompt: bool,
+                _tool_view: &ToolView,
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<Vec<Value>> {
+                Err("build_messages should not be used when build_context is delegated".to_owned())
+            }
+
+            async fn request_completion(
+                &self,
+                _config: &LoongConfig,
+                _messages: &[Value],
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<String> {
+                Ok(String::new())
+            }
+
+            async fn request_turn(
+                &self,
+                _config: &LoongConfig,
+                _session_id: &str,
+                _turn_id: &str,
+                _messages: &[Value],
+                _tool_view: &ToolView,
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<ProviderTurn> {
+                Err("unused".to_owned())
+            }
+
+            async fn request_turn_streaming(
+                &self,
+                _config: &LoongConfig,
+                _session_id: &str,
+                _turn_id: &str,
+                _messages: &[Value],
+                _tool_view: &ToolView,
+                _binding: ConversationRuntimeBinding<'_>,
+                _on_token: crate::provider::StreamingTokenCallback,
+            ) -> CliResult<ProviderTurn> {
+                Err("unused".to_owned())
+            }
+
+            async fn persist_turn(
+                &self,
+                _session_id: &str,
+                _role: &str,
+                _content: &str,
+                _binding: ConversationRuntimeBinding<'_>,
+            ) -> CliResult<()> {
+                Ok(())
+            }
+        }
+
+        let config = LoongConfig::default();
+        let hosted_runtime = HostedConversationRuntime::new(BuildContextAwareRuntime);
+
+        let assembled = hosted_runtime
+            .build_context(
+                &config,
+                "session-1",
+                true,
+                ConversationRuntimeBinding::Direct,
+            )
+            .await
+            .expect("delegated build_context");
+
+        assert_eq!(assembled.messages.len(), 1);
+        assert_eq!(assembled.estimated_tokens, Some(7));
+        assert_eq!(assembled.prompt_fragments.len(), 1);
+        assert_eq!(
+            assembled.system_prompt_addition.as_deref(),
+            Some("addition")
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn load_hosted_default_conversation_runtime_keeps_default_async_spawner_only() {
-        let config = LoongClawConfig::default();
+        let config = LoongConfig::default();
         let runtime = load_hosted_default_conversation_runtime(&config)
             .expect("load hosted default conversation runtime");
 

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -21,6 +21,22 @@ pub enum ConstrainedSubagentIsolation {
     Worktree,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentOwnerKind {
+    AsyncDelegateSpawner,
+    BackgroundTaskHost,
+}
+
+impl ConstrainedSubagentOwnerKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AsyncDelegateSpawner => "async_delegate_spawner",
+            Self::BackgroundTaskHost => "background_task_host",
+        }
+    }
+}
+
 impl ConstrainedSubagentIsolation {
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -467,6 +483,8 @@ pub struct ConstrainedSubagentExecution {
     pub mode: ConstrainedSubagentMode,
     #[serde(default)]
     pub isolation: ConstrainedSubagentIsolation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_kind: Option<ConstrainedSubagentOwnerKind>,
     pub depth: usize,
     pub max_depth: usize,
     pub active_children: usize,
@@ -598,6 +616,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: ConstrainedSubagentIsolation::Shared,
+            owner_kind: Some(ConstrainedSubagentOwnerKind::BackgroundTaskHost),
             depth: 1,
             max_depth: 2,
             active_children: 0,
@@ -629,6 +648,12 @@ mod tests {
             ConstrainedSubagentExecution::profile_from_event_payload(&payload),
             Some(DelegateBuiltinProfile::Research)
         );
+        assert_eq!(
+            ConstrainedSubagentExecution::from_event_payload(&payload)
+                .and_then(|execution| execution.owner_kind)
+                .map(ConstrainedSubagentOwnerKind::as_str),
+            Some("background_task_host")
+        );
     }
 
     #[test]
@@ -636,6 +661,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Inline,
             isolation: ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 2,
             active_children: 0,
@@ -692,6 +718,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 3,
             active_children: 0,
@@ -728,6 +755,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Inline,
             isolation: ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 2,
             max_depth: 3,
             active_children: 1,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3018,6 +3018,7 @@ fn session_context_keeps_execution_and_contract_in_sync_when_child_contract_is_o
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 3,
         active_children: 0,
@@ -3085,6 +3086,7 @@ fn session_context_with_subagent_execution_preserves_prior_runtime_narrowing() {
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 3,
         active_children: 0,
@@ -3137,6 +3139,7 @@ fn session_context_with_subagent_execution_promotes_execution_runtime_narrowing_
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 3,
         active_children: 0,
@@ -13785,6 +13788,7 @@ async fn continue_session_with_runtime_reopens_completed_delegate_child_and_refr
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -13907,6 +13911,7 @@ async fn continue_session_with_runtime_preserves_prior_terminal_outcome_when_res
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -14002,6 +14007,7 @@ async fn continue_session_with_runtime_backfills_profile_from_older_delegate_anc
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -14139,6 +14145,7 @@ async fn continue_session_with_runtime_rejects_failed_delegate_child() {
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -14211,6 +14218,7 @@ async fn continue_session_with_runtime_rejects_archived_delegate_child() {
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -14292,6 +14300,7 @@ async fn continue_session_with_runtime_rejects_invalid_timeout_override() {
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -14367,6 +14376,7 @@ async fn continue_session_with_runtime_caps_timeout_override_and_persists_contra
     let execution = crate::conversation::ConstrainedSubagentExecution {
         mode: crate::conversation::ConstrainedSubagentMode::Inline,
         isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+        owner_kind: None,
         depth: 1,
         max_depth: 2,
         active_children: 0,
@@ -24090,6 +24100,13 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
     assert!(
         Arc::ptr_eq(&child_kernel_ctx.kernel, &expected_kernel_ctx.kernel),
         "spawned child should inherit the same kernel instance"
+    );
+    assert_eq!(
+        spawn_request
+            .execution
+            .owner_kind
+            .map(crate::conversation::ConstrainedSubagentOwnerKind::as_str),
+        Some("async_delegate_spawner")
     );
 
     release_notify.notify_waiters();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -19,7 +19,7 @@ use super::super::config::{
     AuditMode, AutonomyProfile, LoongClawConfig, MemoryProfile, MemorySystemKind, ProviderConfig,
 };
 use super::persistence::format_provider_error_reply;
-use super::runtime::DefaultConversationRuntime;
+use super::runtime::{DefaultConversationRuntime, load_default_conversation_runtime};
 use super::*;
 use crate::CliResult;
 use crate::KernelContext;
@@ -2334,8 +2334,8 @@ async fn default_runtime_prefers_configured_context_engine_when_env_not_set() {
     let mut config = test_config();
     config.conversation.context_engine = Some("stub-config".to_owned());
 
-    let runtime = DefaultConversationRuntime::from_config_or_env(&config)
-        .expect("resolve context engine from config");
+    let runtime =
+        load_default_conversation_runtime(&config).expect("resolve context engine from config");
     let binding = ConversationRuntimeBinding::direct();
     let tool_view = runtime
         .tool_view(&config, "session-config", binding)
@@ -4569,7 +4569,7 @@ async fn default_runtime_prefers_env_context_engine_over_config() {
     let mut config = test_config();
     config.conversation.context_engine = Some("stub-config-env-priority".to_owned());
 
-    let runtime = DefaultConversationRuntime::from_config_or_env(&config)
+    let runtime = load_default_conversation_runtime(&config)
         .expect("resolve context engine from env override");
     let binding = ConversationRuntimeBinding::direct();
     let tool_view = runtime

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -53,7 +53,7 @@ use super::analytics::{
 use super::announce::DelegateAnnounceSettings;
 #[cfg(feature = "memory-sqlite")]
 use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
-use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
+use super::context_engine::AssembledConversationContext;
 #[cfg(feature = "memory-sqlite")]
 use super::delegate_support::{
     enqueue_delegate_result_announce_with_memory_config,
@@ -80,7 +80,8 @@ use super::plan_verifier::{
     PlanVerificationReport, verify_output,
 };
 use super::runtime::{
-    AsyncDelegateSpawnRequest, ConversationRuntime, DefaultConversationRuntime, SessionContext,
+    AsyncDelegateSpawnRequest, BoxedDefaultConversationRuntime, ConversationRuntime,
+    SessionContext, load_default_conversation_runtime,
 };
 use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::safe_lane_failure::{
@@ -1117,7 +1118,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.compact_session_with_runtime(config, session_id, &runtime, binding)
             .await
     }
@@ -1228,7 +1229,7 @@ impl ConversationTurnCoordinator {
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         let address = ConversationSessionAddress::from_session_id(session_id);
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             &address,
@@ -1269,7 +1270,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.repair_turn_checkpoint_tail_with_runtime(config, session_id, &runtime, binding)
             .await
     }
@@ -1298,7 +1299,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
             config,
             session_id,
@@ -1328,7 +1329,7 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
             config, session_id, limit, &runtime, binding,
         )
@@ -1359,7 +1360,7 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
             session_id,
@@ -1396,7 +1397,7 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config, session_id, limit, &runtime, binding,
         )
@@ -1495,7 +1496,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             address,
@@ -1518,7 +1519,7 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             address,
@@ -1609,11 +1610,11 @@ impl ConversationTurnCoordinator {
     fn build_default_runtime_or_observe_failure(
         config: &LoongClawConfig,
         observer: Option<&ConversationTurnObserverHandle>,
-    ) -> CliResult<DefaultConversationRuntime<Box<dyn ConversationContextEngine>>> {
+    ) -> CliResult<BoxedDefaultConversationRuntime> {
         // Keep runtime-construction failures visible to the turn observer so
         // operator surfaces receive the same failed phase signal as execution
         // errors later in the turn pipeline.
-        let runtime_result = DefaultConversationRuntime::from_config_or_env(config);
+        let runtime_result = load_default_conversation_runtime(config);
         let runtime = match runtime_result {
             Ok(runtime) => runtime,
             Err(error) => {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -94,7 +94,8 @@ use super::session_history::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::subagent::{
-    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
+    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentOwnerKind,
+    ConstrainedSubagentTerminalReason,
 };
 use super::tool_discovery_state::{TOOL_DISCOVERY_REFRESHED_EVENT_NAME, ToolDiscoveryState};
 use super::trust_projection::{
@@ -4295,6 +4296,7 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                     let execution_policy = DelegateChildExecutionPolicy {
                         isolation: delegate_policy.isolation,
                         profile: delegate_policy.profile,
+                        owner_kind: None,
                         timeout_seconds: delegate_policy.timeout_seconds,
                         allow_shell_in_child: delegate_policy.allow_shell_in_child,
                         child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -4374,6 +4376,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         runtime,
         session_context,
         delegate_request,
+        ConstrainedSubagentOwnerKind::AsyncDelegateSpawner,
         binding,
     )
     .await?;
@@ -4414,6 +4417,7 @@ async fn enqueue_background_task_with_runtime<R: ConversationRuntime + ?Sized>(
         runtime,
         session_context,
         delegate_request,
+        ConstrainedSubagentOwnerKind::BackgroundTaskHost,
         binding,
     )
     .await?;
@@ -4472,6 +4476,7 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_context: &SessionContext,
     delegate_request: crate::tools::delegate::DelegateRequest,
+    owner_kind: ConstrainedSubagentOwnerKind,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<PreparedAsyncDelegateEnqueue, String> {
     let delegate_policy =
@@ -4498,6 +4503,7 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
                 let execution_policy = DelegateChildExecutionPolicy {
                     isolation: delegate_policy.isolation,
                     profile: delegate_policy.profile,
+                    owner_kind: Some(owner_kind),
                     timeout_seconds: delegate_policy.timeout_seconds,
                     allow_shell_in_child: delegate_policy.allow_shell_in_child,
                     child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -7584,6 +7590,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,
@@ -7716,6 +7723,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2893,7 +2893,8 @@ async fn request_provider_turn_with_observer<R: ConversationRuntime + ?Sized>(
     if let Some(observer) = observer
         && provider_turn_observer_supports_streaming(config, Some(observer))
     {
-        let on_token = build_observer_streaming_token_callback(observer);
+        let request_started_at = std::time::Instant::now();
+        let on_token = build_observer_streaming_token_callback(observer, request_started_at);
         return runtime
             .request_turn_streaming(
                 config, session_id, turn_id, messages, tool_view, binding, on_token,
@@ -6875,6 +6876,7 @@ mod tests {
         assert_eq!(token_events.len(), 1);
         assert_eq!(token_events[0].event_type, "text_delta");
         assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
+        assert!(token_events[0].elapsed_ms.is_some());
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1130,7 +1130,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
         let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
 
         self.compact_session_with_runtime(config, session_id, &runtime, production_binding)
             .await
@@ -1282,7 +1282,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
         let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
 
         self.repair_turn_checkpoint_tail_with_runtime(
             config,
@@ -1378,7 +1378,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
 
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
@@ -1412,7 +1412,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
 
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -43,7 +43,7 @@ use super::autonomy_policy::{
     AUTONOMY_POLICY_SOURCE, AutonomyTurnBudgetState, PolicyDecision, PolicyDecisionInput,
     evaluate_policy, render_reason,
 };
-use super::runtime::{DefaultConversationRuntime, SessionContext};
+use super::runtime::{SessionContext, load_default_conversation_runtime};
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary;
 use super::turn_observer::{ConversationTurnObserverHandle, ConversationTurnRuntimeEvent};
@@ -1716,7 +1716,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 .app_config
                 .as_ref()
                 .ok_or_else(|| "session_continue_not_configured".to_owned())?;
-            let runtime = DefaultConversationRuntime::from_config_or_env(app_config.as_ref())?;
+            let runtime = load_default_conversation_runtime(app_config.as_ref())?;
             return crate::tools::continue_session_with_runtime(
                 request.payload,
                 &session_context.session_id,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -11,7 +11,7 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 use super::super::config::LoongClawConfig;
 use super::ProviderErrorMode;
 use super::persistence::persist_reply_turns_with_mode;
-use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
+use super::runtime::{ConversationRuntime, load_default_conversation_runtime};
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
@@ -100,7 +100,7 @@ impl ConversationTurnLoop {
         error_mode: ProviderErrorMode,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = load_default_conversation_runtime(config)?;
         self.handle_turn_with_runtime(
             config, session_id, user_input, error_mode, &runtime, binding,
         )

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::acp::{StreamingTokenEvent, TokenDelta, ToolCallDelta};
 use crate::tools::runtime_events::ToolRuntimeEvent;
@@ -296,10 +297,12 @@ pub type ConversationTurnObserverHandle = Arc<dyn ConversationTurnObserver>;
 
 pub(crate) fn build_observer_streaming_token_callback(
     observer: &ConversationTurnObserverHandle,
+    request_started_at: Instant,
 ) -> crate::provider::StreamingTokenCallback {
     let observer = Arc::clone(observer);
     let callback = move |data: crate::provider::StreamingCallbackData| {
-        let event = map_streaming_callback_data_to_token_event(data);
+        let elapsed_ms = saturating_elapsed_ms(request_started_at);
+        let event = map_streaming_callback_data_to_token_event_with_elapsed(data, Some(elapsed_ms));
         observer.on_streaming_token(event);
     };
     Some(Arc::new(callback))
@@ -307,6 +310,13 @@ pub(crate) fn build_observer_streaming_token_callback(
 
 pub(crate) fn map_streaming_callback_data_to_token_event(
     data: crate::provider::StreamingCallbackData,
+) -> StreamingTokenEvent {
+    map_streaming_callback_data_to_token_event_with_elapsed(data, None)
+}
+
+pub(crate) fn map_streaming_callback_data_to_token_event_with_elapsed(
+    data: crate::provider::StreamingCallbackData,
+    elapsed_ms: Option<u64>,
 ) -> StreamingTokenEvent {
     match data {
         crate::provider::StreamingCallbackData::Text { text } => StreamingTokenEvent {
@@ -316,6 +326,7 @@ pub(crate) fn map_streaming_callback_data_to_token_event(
                 tool_call: None,
             },
             index: None,
+            elapsed_ms,
         },
         crate::provider::StreamingCallbackData::ToolCallStart { index, name, id } => {
             let tool_call = ToolCallDelta {
@@ -331,6 +342,7 @@ pub(crate) fn map_streaming_callback_data_to_token_event(
                 event_type: "tool_call_start".to_owned(),
                 delta,
                 index: Some(index),
+                elapsed_ms,
             }
         }
         crate::provider::StreamingCallbackData::ToolCallInput {
@@ -350,9 +362,16 @@ pub(crate) fn map_streaming_callback_data_to_token_event(
                 event_type: "tool_call_input_delta".to_owned(),
                 delta,
                 index: Some(index),
+                elapsed_ms,
             }
         }
     }
+}
+
+fn saturating_elapsed_ms(started_at: Instant) -> u64 {
+    let elapsed = started_at.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    u64::try_from(elapsed_ms).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -370,6 +389,7 @@ mod tests {
         assert_eq!(event.delta.text.as_deref(), Some("hello"));
         assert!(event.delta.tool_call.is_none());
         assert!(event.index.is_none());
+        assert_eq!(event.elapsed_ms, None);
     }
 
     #[test]
@@ -389,6 +409,7 @@ mod tests {
         assert_eq!(tool_call.args.as_deref(), Some("{\"query\":\"rust\"}"));
         assert!(tool_call.name.is_none());
         assert!(tool_call.id.is_none());
+        assert_eq!(event.elapsed_ms, None);
     }
 
     #[test]
@@ -409,5 +430,18 @@ mod tests {
         assert_eq!(tool_call.name.as_deref(), Some("search"));
         assert_eq!(tool_call.id.as_deref(), Some("call_123"));
         assert!(tool_call.args.is_none());
+        assert_eq!(event.elapsed_ms, None);
+    }
+
+    #[test]
+    fn map_streaming_callback_data_to_token_event_with_elapsed_keeps_latency_metadata() {
+        let data = crate::provider::StreamingCallbackData::Text {
+            text: "hello".to_owned(),
+        };
+        let event = map_streaming_callback_data_to_token_event_with_elapsed(data, Some(42));
+
+        assert_eq!(event.event_type, "text_delta");
+        assert_eq!(event.delta.text.as_deref(), Some("hello"));
+        assert_eq!(event.elapsed_ms, Some(42));
     }
 }

--- a/crates/app/src/conversation/workspace_isolation.rs
+++ b/crates/app/src/conversation/workspace_isolation.rs
@@ -461,6 +461,7 @@ mod tests {
         let clean_execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Inline,
             isolation: ConstrainedSubagentIsolation::Worktree,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,
@@ -491,6 +492,7 @@ mod tests {
         let dirty_execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Inline,
             isolation: ConstrainedSubagentIsolation::Worktree,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -5,8 +5,9 @@ use serde_json::{Value, json};
 use crate::config::LoongClawConfig;
 use crate::conversation::{
     ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentIdentity,
-    ConstrainedSubagentIsolation, ConstrainedSubagentMode, ConstrainedSubagentProfile,
-    ConstrainedSubagentTerminalReason, ConversationRuntimeBinding, DelegateBuiltinProfile,
+    ConstrainedSubagentIsolation, ConstrainedSubagentMode, ConstrainedSubagentOwnerKind,
+    ConstrainedSubagentProfile, ConstrainedSubagentTerminalReason, ConversationRuntimeBinding,
+    DelegateBuiltinProfile,
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity::RuntimeSelfContinuity;
@@ -36,6 +37,7 @@ pub(crate) struct DelegateChildLifecycleSeed {
 pub(crate) struct DelegateChildExecutionPolicy {
     pub isolation: ConstrainedSubagentIsolation,
     pub profile: Option<DelegateBuiltinProfile>,
+    pub owner_kind: Option<ConstrainedSubagentOwnerKind>,
     pub timeout_seconds: u64,
     pub allow_shell_in_child: bool,
     pub child_tool_allowlist: Vec<String>,
@@ -168,6 +170,7 @@ fn build_delegate_child_execution(
     ConstrainedSubagentExecution {
         mode,
         isolation: execution_policy.isolation,
+        owner_kind: execution_policy.owner_kind,
         depth: next_child_depth,
         max_depth: config.tools.delegate.max_depth,
         active_children,
@@ -712,6 +715,7 @@ mod tests {
         let execution_policy = DelegateChildExecutionPolicy {
             isolation: ConstrainedSubagentIsolation::Shared,
             profile: None,
+            owner_kind: None,
             timeout_seconds: 42,
             allow_shell_in_child: false,
             child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
@@ -746,6 +750,7 @@ mod tests {
         let execution_policy = DelegateChildExecutionPolicy {
             isolation: ConstrainedSubagentIsolation::Shared,
             profile: None,
+            owner_kind: None,
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
@@ -881,6 +886,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: ConstrainedSubagentIsolation::default(),
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,

--- a/crates/app/src/provider/http_client_runtime.rs
+++ b/crates/app/src/provider/http_client_runtime.rs
@@ -63,32 +63,21 @@ fn with_provider_http_client_runtime_metrics<R>(
     run(&mut guard)
 }
 
-fn load_cached_provider_http_client(
+fn load_or_build_provider_http_client(
     cache_key: ProviderHttpClientCacheKey,
-) -> Option<reqwest::Client> {
-    with_provider_http_client_cache(|cache| {
-        let cached_client = cache.entries.get(&cache_key)?;
-        let cloned_client = cached_client.clone();
-
-        Some(cloned_client)
-    })
-}
-
-fn store_provider_http_client(
-    cache_key: ProviderHttpClientCacheKey,
-    built_client: reqwest::Client,
-) -> reqwest::Client {
+) -> CliResult<reqwest::Client> {
     with_provider_http_client_cache(|cache| {
         if let Some(cached_client) = cache.entries.get(&cache_key) {
-            let cloned_client = cached_client.clone();
-
-            return cloned_client;
+            record_provider_http_client_cache_hit();
+            return Ok(cached_client.clone());
         }
 
+        record_provider_http_client_cache_miss();
+        let built_client = build_provider_http_client(cache_key)?;
         let cached_client = built_client.clone();
         cache.entries.insert(cache_key, cached_client);
 
-        built_client
+        Ok(built_client)
     })
 }
 
@@ -110,16 +99,7 @@ pub(super) fn build_http_client(
 ) -> CliResult<reqwest::Client> {
     let cache_key = ProviderHttpClientCacheKey::from_request_policy(request_policy);
 
-    if let Some(cached_client) = load_cached_provider_http_client(cache_key) {
-        record_provider_http_client_cache_hit();
-        return Ok(cached_client);
-    }
-
-    record_provider_http_client_cache_miss();
-    let built_client = build_provider_http_client(cache_key)?;
-    let cached_client = store_provider_http_client(cache_key, built_client);
-
-    Ok(cached_client)
+    load_or_build_provider_http_client(cache_key)
 }
 
 static PROVIDER_HTTP_CLIENT_CACHE: OnceLock<Mutex<ProviderHttpClientCache>> = OnceLock::new();

--- a/crates/app/src/provider/http_client_runtime.rs
+++ b/crates/app/src/provider/http_client_runtime.rs
@@ -1,14 +1,208 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::CliResult;
 
 use super::policy;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ProviderHttpClientCacheKey {
+    timeout_ms: u64,
+}
+
+impl ProviderHttpClientCacheKey {
+    fn from_request_policy(request_policy: &policy::ProviderRequestPolicy) -> Self {
+        Self {
+            timeout_ms: request_policy.timeout_ms,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ProviderHttpClientCache {
+    entries: HashMap<ProviderHttpClientCacheKey, reqwest::Client>,
+}
+
+fn with_provider_http_client_cache<R>(run: impl FnOnce(&mut ProviderHttpClientCache) -> R) -> R {
+    let cache =
+        PROVIDER_HTTP_CLIENT_CACHE.get_or_init(|| Mutex::new(ProviderHttpClientCache::default()));
+    let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    run(&mut guard)
+}
+
+fn load_cached_provider_http_client(
+    cache_key: ProviderHttpClientCacheKey,
+) -> Option<reqwest::Client> {
+    with_provider_http_client_cache(|cache| {
+        let cached_client = cache.entries.get(&cache_key)?;
+        let cloned_client = cached_client.clone();
+
+        Some(cloned_client)
+    })
+}
+
+fn store_provider_http_client(
+    cache_key: ProviderHttpClientCacheKey,
+    built_client: reqwest::Client,
+) -> reqwest::Client {
+    with_provider_http_client_cache(|cache| {
+        if let Some(cached_client) = cache.entries.get(&cache_key) {
+            let cloned_client = cached_client.clone();
+
+            return cloned_client;
+        }
+
+        let cached_client = built_client.clone();
+        cache.entries.insert(cache_key, cached_client);
+
+        built_client
+    })
+}
+
+fn build_provider_http_client(cache_key: ProviderHttpClientCacheKey) -> CliResult<reqwest::Client> {
+    let timeout = Duration::from_millis(cache_key.timeout_ms);
+    let client_builder = reqwest::Client::builder();
+    let timeout_builder = client_builder.timeout(timeout);
+    let built_client = timeout_builder
+        .build()
+        .map_err(|error| format!("build provider http client failed: {error}"))?;
+
+    #[cfg(test)]
+    {
+        record_provider_http_client_build(cache_key);
+    }
+
+    Ok(built_client)
+}
+
 pub(super) fn build_http_client(
     request_policy: &policy::ProviderRequestPolicy,
 ) -> CliResult<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_millis(request_policy.timeout_ms))
-        .build()
-        .map_err(|error| format!("build provider http client failed: {error}"))
+    let cache_key = ProviderHttpClientCacheKey::from_request_policy(request_policy);
+
+    if let Some(cached_client) = load_cached_provider_http_client(cache_key) {
+        return Ok(cached_client);
+    }
+
+    let built_client = build_provider_http_client(cache_key)?;
+    let cached_client = store_provider_http_client(cache_key, built_client);
+
+    Ok(cached_client)
+}
+
+static PROVIDER_HTTP_CLIENT_CACHE: OnceLock<Mutex<ProviderHttpClientCache>> = OnceLock::new();
+
+#[cfg(test)]
+static PROVIDER_HTTP_CLIENT_BUILD_COUNTS: OnceLock<Mutex<HashMap<u64, usize>>> = OnceLock::new();
+
+#[cfg(test)]
+fn clear_provider_http_client_cache() {
+    with_provider_http_client_cache(|cache| {
+        cache.entries.clear();
+    });
+    with_provider_http_client_build_counts(|build_counts| {
+        build_counts.clear();
+    });
+}
+
+#[cfg(test)]
+fn provider_http_client_cache_contains_timeout(timeout_ms: u64) -> bool {
+    let cache_key = ProviderHttpClientCacheKey { timeout_ms };
+
+    with_provider_http_client_cache(|cache| cache.entries.contains_key(&cache_key))
+}
+
+#[cfg(test)]
+fn with_provider_http_client_build_counts<R>(run: impl FnOnce(&mut HashMap<u64, usize>) -> R) -> R {
+    let build_counts = PROVIDER_HTTP_CLIENT_BUILD_COUNTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = match build_counts.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    run(&mut guard)
+}
+
+#[cfg(test)]
+fn record_provider_http_client_build(cache_key: ProviderHttpClientCacheKey) {
+    with_provider_http_client_build_counts(|build_counts| {
+        let build_count = build_counts.entry(cache_key.timeout_ms).or_default();
+        *build_count += 1;
+    });
+}
+
+#[cfg(test)]
+fn provider_http_client_build_count_for_timeout(timeout_ms: u64) -> usize {
+    with_provider_http_client_build_counts(|build_counts| {
+        build_counts.get(&timeout_ms).copied().unwrap_or_default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_http_client_cache_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn test_request_policy(timeout_ms: u64) -> policy::ProviderRequestPolicy {
+        policy::ProviderRequestPolicy {
+            timeout_ms,
+            max_attempts: 1,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 50,
+        }
+    }
+
+    #[test]
+    fn provider_http_client_cache_reuses_clients_for_same_timeout_policy() {
+        let _guard = provider_http_client_cache_test_lock()
+            .lock()
+            .expect("provider http client cache test lock");
+        clear_provider_http_client_cache();
+        let timeout_ms = 123_457;
+        let request_policy = test_request_policy(timeout_ms);
+
+        let _first_client = build_http_client(&request_policy).expect("first cached client");
+        let _second_client = build_http_client(&request_policy).expect("second cached client");
+
+        let contains_timeout = provider_http_client_cache_contains_timeout(timeout_ms);
+        let build_count = provider_http_client_build_count_for_timeout(timeout_ms);
+
+        assert!(contains_timeout);
+        assert_eq!(build_count, 1);
+    }
+
+    #[test]
+    fn provider_http_client_cache_separates_distinct_timeout_policies() {
+        let _guard = provider_http_client_cache_test_lock()
+            .lock()
+            .expect("provider http client cache test lock");
+        clear_provider_http_client_cache();
+        let fast_timeout_ms = 123_458;
+        let slow_timeout_ms = 123_459;
+        let fast_policy = test_request_policy(fast_timeout_ms);
+        let slow_policy = test_request_policy(slow_timeout_ms);
+
+        let _fast_client = build_http_client(&fast_policy).expect("fast cached client");
+        let _slow_client = build_http_client(&slow_policy).expect("slow cached client");
+
+        let contains_fast_timeout = provider_http_client_cache_contains_timeout(fast_timeout_ms);
+        let contains_slow_timeout = provider_http_client_cache_contains_timeout(slow_timeout_ms);
+        let fast_build_count = provider_http_client_build_count_for_timeout(fast_timeout_ms);
+        let slow_build_count = provider_http_client_build_count_for_timeout(slow_timeout_ms);
+
+        assert!(contains_fast_timeout);
+        assert!(contains_slow_timeout);
+        assert_eq!(fast_build_count, 1);
+        assert_eq!(slow_build_count, 1);
+    }
 }

--- a/crates/app/src/provider/http_client_runtime.rs
+++ b/crates/app/src/provider/http_client_runtime.rs
@@ -6,6 +6,14 @@ use crate::CliResult;
 
 use super::policy;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProviderHttpClientRuntimeMetricsSnapshot {
+    pub cache_entry_count: usize,
+    pub cache_hit_count: u64,
+    pub cache_miss_count: u64,
+    pub built_client_count: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ProviderHttpClientCacheKey {
     timeout_ms: u64,
@@ -24,10 +32,30 @@ struct ProviderHttpClientCache {
     entries: HashMap<ProviderHttpClientCacheKey, reqwest::Client>,
 }
 
+#[derive(Debug, Default)]
+struct ProviderHttpClientRuntimeMetrics {
+    cache_hit_count: u64,
+    cache_miss_count: u64,
+    built_client_count: u64,
+}
+
 fn with_provider_http_client_cache<R>(run: impl FnOnce(&mut ProviderHttpClientCache) -> R) -> R {
     let cache =
         PROVIDER_HTTP_CLIENT_CACHE.get_or_init(|| Mutex::new(ProviderHttpClientCache::default()));
     let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    run(&mut guard)
+}
+
+fn with_provider_http_client_runtime_metrics<R>(
+    run: impl FnOnce(&mut ProviderHttpClientRuntimeMetrics) -> R,
+) -> R {
+    let metrics = PROVIDER_HTTP_CLIENT_RUNTIME_METRICS
+        .get_or_init(|| Mutex::new(ProviderHttpClientRuntimeMetrics::default()));
+    let mut guard = match metrics.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
@@ -72,10 +100,7 @@ fn build_provider_http_client(cache_key: ProviderHttpClientCacheKey) -> CliResul
         .build()
         .map_err(|error| format!("build provider http client failed: {error}"))?;
 
-    #[cfg(test)]
-    {
-        record_provider_http_client_build(cache_key);
-    }
+    record_provider_http_client_build();
 
     Ok(built_client)
 }
@@ -86,9 +111,11 @@ pub(super) fn build_http_client(
     let cache_key = ProviderHttpClientCacheKey::from_request_policy(request_policy);
 
     if let Some(cached_client) = load_cached_provider_http_client(cache_key) {
+        record_provider_http_client_cache_hit();
         return Ok(cached_client);
     }
 
+    record_provider_http_client_cache_miss();
     let built_client = build_provider_http_client(cache_key)?;
     let cached_client = store_provider_http_client(cache_key, built_client);
 
@@ -96,17 +123,44 @@ pub(super) fn build_http_client(
 }
 
 static PROVIDER_HTTP_CLIENT_CACHE: OnceLock<Mutex<ProviderHttpClientCache>> = OnceLock::new();
+static PROVIDER_HTTP_CLIENT_RUNTIME_METRICS: OnceLock<Mutex<ProviderHttpClientRuntimeMetrics>> =
+    OnceLock::new();
 
-#[cfg(test)]
-static PROVIDER_HTTP_CLIENT_BUILD_COUNTS: OnceLock<Mutex<HashMap<u64, usize>>> = OnceLock::new();
+pub fn provider_http_client_runtime_metrics_snapshot() -> ProviderHttpClientRuntimeMetricsSnapshot {
+    let cache_entry_count = with_provider_http_client_cache(|cache| cache.entries.len());
+    with_provider_http_client_runtime_metrics(|metrics| ProviderHttpClientRuntimeMetricsSnapshot {
+        cache_entry_count,
+        cache_hit_count: metrics.cache_hit_count,
+        cache_miss_count: metrics.cache_miss_count,
+        built_client_count: metrics.built_client_count,
+    })
+}
+
+fn record_provider_http_client_cache_hit() {
+    with_provider_http_client_runtime_metrics(|metrics| {
+        metrics.cache_hit_count = metrics.cache_hit_count.saturating_add(1);
+    });
+}
+
+fn record_provider_http_client_cache_miss() {
+    with_provider_http_client_runtime_metrics(|metrics| {
+        metrics.cache_miss_count = metrics.cache_miss_count.saturating_add(1);
+    });
+}
+
+fn record_provider_http_client_build() {
+    with_provider_http_client_runtime_metrics(|metrics| {
+        metrics.built_client_count = metrics.built_client_count.saturating_add(1);
+    });
+}
 
 #[cfg(test)]
 fn clear_provider_http_client_cache() {
     with_provider_http_client_cache(|cache| {
         cache.entries.clear();
     });
-    with_provider_http_client_build_counts(|build_counts| {
-        build_counts.clear();
+    with_provider_http_client_runtime_metrics(|metrics| {
+        *metrics = ProviderHttpClientRuntimeMetrics::default();
     });
 }
 
@@ -115,32 +169,6 @@ fn provider_http_client_cache_contains_timeout(timeout_ms: u64) -> bool {
     let cache_key = ProviderHttpClientCacheKey { timeout_ms };
 
     with_provider_http_client_cache(|cache| cache.entries.contains_key(&cache_key))
-}
-
-#[cfg(test)]
-fn with_provider_http_client_build_counts<R>(run: impl FnOnce(&mut HashMap<u64, usize>) -> R) -> R {
-    let build_counts = PROVIDER_HTTP_CLIENT_BUILD_COUNTS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = match build_counts.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-
-    run(&mut guard)
-}
-
-#[cfg(test)]
-fn record_provider_http_client_build(cache_key: ProviderHttpClientCacheKey) {
-    with_provider_http_client_build_counts(|build_counts| {
-        let build_count = build_counts.entry(cache_key.timeout_ms).or_default();
-        *build_count += 1;
-    });
-}
-
-#[cfg(test)]
-fn provider_http_client_build_count_for_timeout(timeout_ms: u64) -> usize {
-    with_provider_http_client_build_counts(|build_counts| {
-        build_counts.get(&timeout_ms).copied().unwrap_or_default()
-    })
 }
 
 #[cfg(test)]
@@ -175,10 +203,13 @@ mod tests {
         let _second_client = build_http_client(&request_policy).expect("second cached client");
 
         let contains_timeout = provider_http_client_cache_contains_timeout(timeout_ms);
-        let build_count = provider_http_client_build_count_for_timeout(timeout_ms);
+        let metrics = provider_http_client_runtime_metrics_snapshot();
 
         assert!(contains_timeout);
-        assert_eq!(build_count, 1);
+        assert_eq!(metrics.cache_entry_count, 1);
+        assert_eq!(metrics.cache_hit_count, 1);
+        assert_eq!(metrics.cache_miss_count, 1);
+        assert_eq!(metrics.built_client_count, 1);
     }
 
     #[test]
@@ -197,12 +228,13 @@ mod tests {
 
         let contains_fast_timeout = provider_http_client_cache_contains_timeout(fast_timeout_ms);
         let contains_slow_timeout = provider_http_client_cache_contains_timeout(slow_timeout_ms);
-        let fast_build_count = provider_http_client_build_count_for_timeout(fast_timeout_ms);
-        let slow_build_count = provider_http_client_build_count_for_timeout(slow_timeout_ms);
+        let metrics = provider_http_client_runtime_metrics_snapshot();
 
         assert!(contains_fast_timeout);
         assert!(contains_slow_timeout);
-        assert_eq!(fast_build_count, 1);
-        assert_eq!(slow_build_count, 1);
+        assert_eq!(metrics.cache_entry_count, 2);
+        assert_eq!(metrics.cache_hit_count, 0);
+        assert_eq!(metrics.cache_miss_count, 2);
+        assert_eq!(metrics.built_client_count, 2);
     }
 }

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -51,6 +51,7 @@ mod transport_trait;
 
 pub use copilot_auth::device_code_login as copilot_device_code_login;
 pub use failover::parse_provider_failover_snapshot_payload;
+pub use http_client_runtime::ProviderHttpClientRuntimeMetricsSnapshot;
 pub use rate_limit::RateLimitObservation;
 pub use request_executor::{StreamingCallbackData, StreamingTokenCallback};
 pub use runtime_binding::ProviderRuntimeBinding;
@@ -89,6 +90,10 @@ pub fn provider_tool_schema_readiness(config: &LoongConfig) -> ProviderToolSchem
         structured_tool_schema_enabled,
         effective_tool_schema_mode: effective_tool_schema_mode.to_owned(),
     }
+}
+
+pub fn provider_http_client_runtime_metrics_snapshot() -> ProviderHttpClientRuntimeMetricsSnapshot {
+    http_client_runtime::provider_http_client_runtime_metrics_snapshot()
 }
 
 pub fn is_auth_style_failure_message(message: &str) -> bool {

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1388,6 +1388,7 @@ mod tests {
                 tool_call: None,
             },
             index: None,
+            elapsed_ms: None,
         };
 
         let json = serde_json::to_string(&text_event).expect("should serialize");
@@ -1412,6 +1413,7 @@ mod tests {
                 }),
             },
             index: Some(0),
+            elapsed_ms: None,
         };
 
         let json = serde_json::to_string(&tool_event).expect("should serialize");

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -3365,6 +3365,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: crate::conversation::ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 2,
             active_children: 0,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -156,6 +156,7 @@ pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 mod runtime_snapshot_render;
+mod runtime_snapshot_types;
 pub mod runtime_trajectory_cli;
 pub mod session_cli;
 pub mod sessions_cli;
@@ -201,6 +202,10 @@ pub(crate) use runtime_snapshot_render::{
     runtime_snapshot_external_skills_json, runtime_snapshot_memory_system_json,
     runtime_snapshot_provider_json, runtime_snapshot_runtime_plugins_json,
     runtime_snapshot_tool_runtime_json,
+};
+pub use runtime_snapshot_types::{
+    RuntimeSnapshotProviderProfileState, RuntimeSnapshotProviderState,
+    RuntimeSnapshotProviderTransportState,
 };
 pub use session_cli::{
     SESSION_SEARCH_ARTIFACT_JSON_SCHEMA_VERSION, SessionSearchArtifactDocument,
@@ -2710,39 +2715,6 @@ pub struct RuntimeSnapshotCliState {
     pub restore_spec: RuntimeSnapshotRestoreSpec,
 }
 
-#[derive(Debug, Clone)]
-pub struct RuntimeSnapshotProviderState {
-    pub active_profile_id: String,
-    pub active_label: String,
-    pub last_provider_id: Option<String>,
-    pub saved_profile_ids: Vec<String>,
-    pub profiles: Vec<RuntimeSnapshotProviderProfileState>,
-}
-
-#[derive(Debug, Clone)]
-pub struct RuntimeSnapshotProviderProfileState {
-    pub profile_id: String,
-    pub is_active: bool,
-    pub default_for_kind: bool,
-    pub descriptor: mvp::config::ProviderDescriptorDocument,
-    pub kind: mvp::config::ProviderKind,
-    pub model: String,
-    pub wire_api: mvp::config::ProviderWireApi,
-    pub base_url: String,
-    pub endpoint: String,
-    pub models_endpoint: String,
-    pub protocol_family: &'static str,
-    pub credential_resolved: bool,
-    pub auth_env: Option<String>,
-    pub reasoning_effort: Option<String>,
-    pub temperature: f64,
-    pub max_tokens: Option<u32>,
-    pub request_timeout_ms: u64,
-    pub retry_max_attempts: usize,
-    pub header_names: Vec<String>,
-    pub preferred_models: Vec<String>,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeSnapshotInventoryStatus {
     Ok,
@@ -3023,11 +2995,20 @@ fn collect_runtime_snapshot_provider_state(
             .collect::<Vec<_>>()
     };
 
+    let transport_metrics = mvp::provider::provider_http_client_runtime_metrics_snapshot();
+    let transport_runtime = RuntimeSnapshotProviderTransportState {
+        http_client_cache_entries: transport_metrics.cache_entry_count,
+        http_client_cache_hits: transport_metrics.cache_hit_count,
+        http_client_cache_misses: transport_metrics.cache_miss_count,
+        built_http_clients: transport_metrics.built_client_count,
+    };
+
     RuntimeSnapshotProviderState {
         active_profile_id,
         active_label: provider_presentation::active_provider_detail_label(config),
         last_provider_id: config.last_provider_id().map(str::to_owned),
         saved_profile_ids,
+        transport_runtime,
         profiles,
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -160,6 +160,7 @@ mod runtime_snapshot_types;
 pub mod runtime_trajectory_cli;
 pub mod session_cli;
 mod session_prompt_frame_cli;
+mod session_runtime_truth_cli;
 pub mod sessions_cli;
 pub mod skills_cli;
 pub mod source_presentation;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -159,6 +159,7 @@ mod runtime_snapshot_render;
 mod runtime_snapshot_types;
 pub mod runtime_trajectory_cli;
 pub mod session_cli;
+mod session_prompt_frame_cli;
 pub mod sessions_cli;
 pub mod skills_cli;
 pub mod source_presentation;

--- a/crates/daemon/src/runtime_snapshot_render.rs
+++ b/crates/daemon/src/runtime_snapshot_render.rs
@@ -28,6 +28,16 @@ pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> Strin
                     .map(String::as_str)
             )
         ),
+        format!(
+            "provider transport cache_entries={} cache_hits={} cache_misses={} built_clients={}",
+            snapshot
+                .provider
+                .transport_runtime
+                .http_client_cache_entries,
+            snapshot.provider.transport_runtime.http_client_cache_hits,
+            snapshot.provider.transport_runtime.http_client_cache_misses,
+            snapshot.provider.transport_runtime.built_http_clients
+        ),
     ];
 
     for profile in &snapshot.provider.profiles {
@@ -425,6 +435,12 @@ pub(crate) fn runtime_snapshot_provider_json(snapshot: &RuntimeSnapshotProviderS
         "active_label": snapshot.active_label,
         "last_provider_id": snapshot.last_provider_id,
         "saved_profile_ids": snapshot.saved_profile_ids,
+        "transport_runtime": {
+            "http_client_cache_entries": snapshot.transport_runtime.http_client_cache_entries,
+            "http_client_cache_hits": snapshot.transport_runtime.http_client_cache_hits,
+            "http_client_cache_misses": snapshot.transport_runtime.http_client_cache_misses,
+            "built_http_clients": snapshot.transport_runtime.built_http_clients,
+        },
         "profiles": snapshot
             .profiles
             .iter()

--- a/crates/daemon/src/runtime_snapshot_types.rs
+++ b/crates/daemon/src/runtime_snapshot_types.rs
@@ -1,0 +1,43 @@
+use crate::mvp;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotProviderState {
+    pub active_profile_id: String,
+    pub active_label: String,
+    pub last_provider_id: Option<String>,
+    pub saved_profile_ids: Vec<String>,
+    pub transport_runtime: RuntimeSnapshotProviderTransportState,
+    pub profiles: Vec<RuntimeSnapshotProviderProfileState>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeSnapshotProviderTransportState {
+    pub http_client_cache_entries: usize,
+    pub http_client_cache_hits: u64,
+    pub http_client_cache_misses: u64,
+    pub built_http_clients: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshotProviderProfileState {
+    pub profile_id: String,
+    pub is_active: bool,
+    pub default_for_kind: bool,
+    pub descriptor: mvp::config::ProviderDescriptorDocument,
+    pub kind: mvp::config::ProviderKind,
+    pub model: String,
+    pub wire_api: mvp::config::ProviderWireApi,
+    pub base_url: String,
+    pub endpoint: String,
+    pub models_endpoint: String,
+    pub protocol_family: &'static str,
+    pub credential_resolved: bool,
+    pub auth_env: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub temperature: f64,
+    pub max_tokens: Option<u32>,
+    pub request_timeout_ms: u64,
+    pub retry_max_attempts: usize,
+    pub header_names: Vec<String>,
+    pub preferred_models: Vec<String>,
+}

--- a/crates/daemon/src/session_prompt_frame_cli.rs
+++ b/crates/daemon/src/session_prompt_frame_cli.rs
@@ -1,0 +1,94 @@
+use loongclaw_app as mvp;
+use serde_json::{Value, json};
+
+pub(crate) async fn load_session_prompt_frame_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    session_id: &str,
+) -> Value {
+    let summary_limit = prompt_frame_summary_limit(memory_config);
+    let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let summary_result = mvp::conversation::load_prompt_frame_event_summary(
+        session_id,
+        summary_limit,
+        binding,
+        memory_config,
+    )
+    .await;
+
+    match summary_result {
+        Ok(summary) => {
+            let available = summary.snapshot_events > 0;
+            json!({
+                "available": available,
+                "limit": summary_limit,
+                "summary": summary,
+            })
+        }
+        Err(error) => json!({
+            "available": false,
+            "limit": summary_limit,
+            "error": error,
+        }),
+    }
+}
+
+pub(crate) fn render_prompt_frame_summary(prompt_frame: Option<&Value>) -> String {
+    let Some(prompt_frame) = prompt_frame else {
+        return "-".to_owned();
+    };
+
+    let available = prompt_frame
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !available {
+        let error = prompt_frame
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        return format!("unavailable error={error}");
+    }
+
+    let Some(summary) = prompt_frame.get("summary") else {
+        return "present".to_owned();
+    };
+
+    let phase = summary
+        .get("latest_phase")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let total_tokens = summary
+        .get("latest_total_estimated_tokens")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let stable_prefix = summary
+        .get("latest_stable_prefix_hash")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let cached_prefix = summary
+        .get("latest_cached_prefix_hash")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let stable_prefix_changes = summary
+        .get("stable_prefix_hash_change_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    let cached_prefix_changes = summary
+        .get("cached_prefix_hash_change_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+
+    format!(
+        "phase={phase} total_tokens={total_tokens} stable_prefix={stable_prefix} cached_prefix={cached_prefix} stable_prefix_changes={stable_prefix_changes} cached_prefix_changes={cached_prefix_changes}"
+    )
+}
+
+fn prompt_frame_summary_limit(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+) -> usize {
+    let scaled_limit = memory_config.sliding_window.saturating_mul(4);
+    scaled_limit.clamp(16, 128)
+}

--- a/crates/daemon/src/session_runtime_truth_cli.rs
+++ b/crates/daemon/src/session_runtime_truth_cli.rs
@@ -1,0 +1,196 @@
+use loongclaw_app as mvp;
+use serde_json::{Value, json};
+
+pub(crate) async fn load_session_safe_lane_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    session_id: &str,
+) -> Value {
+    let summary_limit = runtime_truth_summary_limit(memory_config);
+    let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let summary_result = mvp::conversation::load_safe_lane_event_summary(
+        session_id,
+        summary_limit,
+        binding,
+        memory_config,
+    )
+    .await;
+
+    match summary_result {
+        Ok(summary) => {
+            let available = summary != mvp::conversation::SafeLaneEventSummary::default();
+            json!({
+                "available": available,
+                "limit": summary_limit,
+                "summary": summary,
+            })
+        }
+        Err(error) => json!({
+            "available": false,
+            "limit": summary_limit,
+            "error": error,
+        }),
+    }
+}
+
+pub(crate) async fn load_session_turn_checkpoint_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    session_id: &str,
+) -> Value {
+    let summary_limit = runtime_truth_summary_limit(memory_config);
+    let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let summary_result = mvp::conversation::load_turn_checkpoint_event_summary(
+        session_id,
+        summary_limit,
+        binding,
+        memory_config,
+    )
+    .await;
+
+    match summary_result {
+        Ok(summary) => {
+            let available = summary != mvp::conversation::TurnCheckpointEventSummary::default();
+            json!({
+                "available": available,
+                "limit": summary_limit,
+                "summary": summary,
+            })
+        }
+        Err(error) => json!({
+            "available": false,
+            "limit": summary_limit,
+            "error": error,
+        }),
+    }
+}
+
+pub(crate) fn render_safe_lane_summary(safe_lane: Option<&Value>) -> String {
+    let Some(safe_lane) = safe_lane else {
+        return "-".to_owned();
+    };
+
+    let available = safe_lane
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !available {
+        let error = safe_lane
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        return format!("unavailable error={error}");
+    }
+
+    let Some(summary) = safe_lane.get("summary") else {
+        return "present".to_owned();
+    };
+
+    let status = summary
+        .get("final_status")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let rounds_started = summary
+        .get("round_started_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    let verify_failed = summary
+        .get("verify_failed_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    let replans = summary
+        .get("replan_triggered_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    let failure_code = summary
+        .get("final_failure_code")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let route_decision = summary
+        .get("final_route_decision")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let route_reason = summary
+        .get("final_route_reason")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let health = summary
+        .get("latest_health_signal")
+        .and_then(|value| value.get("severity"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+
+    format!(
+        "status={status} rounds_started={rounds_started} verify_failed={verify_failed} replans={replans} failure_code={failure_code} route={route_decision}/{route_reason} health={health}"
+    )
+}
+
+pub(crate) fn render_turn_checkpoint_summary(turn_checkpoint: Option<&Value>) -> String {
+    let Some(turn_checkpoint) = turn_checkpoint else {
+        return "-".to_owned();
+    };
+
+    let available = turn_checkpoint
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !available {
+        let error = turn_checkpoint
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        return format!("unavailable error={error}");
+    }
+
+    let Some(summary) = turn_checkpoint.get("summary") else {
+        return "present".to_owned();
+    };
+
+    let session_state = summary
+        .get("session_state")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let durable = summary
+        .get("checkpoint_durable")
+        .and_then(Value::as_bool)
+        .map(render_bool_flag)
+        .unwrap_or("-");
+    let reply_durable = summary
+        .get("reply_durable")
+        .and_then(Value::as_bool)
+        .map(render_bool_flag)
+        .unwrap_or("-");
+    let requires_recovery = summary
+        .get("requires_recovery")
+        .and_then(Value::as_bool)
+        .map(render_bool_flag)
+        .unwrap_or("-");
+    let stage = summary
+        .get("latest_stage")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let after_turn = summary
+        .get("latest_after_turn")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let compaction = summary
+        .get("latest_compaction")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+
+    format!(
+        "session_state={session_state} durable={durable} reply_durable={reply_durable} requires_recovery={requires_recovery} stage={stage} after_turn={after_turn} compaction={compaction}"
+    )
+}
+
+fn render_bool_flag(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn runtime_truth_summary_limit(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+) -> usize {
+    let scaled_limit = memory_config.sliding_window.saturating_mul(4);
+    scaled_limit.clamp(16, 128)
+}

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -334,7 +334,11 @@ async fn load_session_status_payload_with_prompt_frame(
 ) -> CliResult<Value> {
     let mut detail =
         load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
-    let prompt_frame = load_session_prompt_frame_payload(memory_config, session_id).await;
+    let prompt_frame = crate::session_prompt_frame_cli::load_session_prompt_frame_payload(
+        memory_config,
+        session_id,
+    )
+    .await;
 
     let detail_object = detail
         .as_object_mut()
@@ -548,44 +552,6 @@ fn load_session_status_payload(
         payload,
     )?;
     Ok(outcome.payload)
-}
-
-async fn load_session_prompt_frame_payload(
-    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
-    session_id: &str,
-) -> Value {
-    let summary_limit = prompt_frame_summary_limit(memory_config);
-    let binding = mvp::conversation::ConversationRuntimeBinding::direct();
-    let summary_result = mvp::conversation::load_prompt_frame_event_summary(
-        session_id,
-        summary_limit,
-        binding,
-        memory_config,
-    )
-    .await;
-
-    match summary_result {
-        Ok(summary) => {
-            let available = summary.snapshot_events > 0;
-            json!({
-                "available": available,
-                "limit": summary_limit,
-                "summary": summary,
-            })
-        }
-        Err(error) => json!({
-            "available": false,
-            "limit": summary_limit,
-            "error": error,
-        }),
-    }
-}
-
-fn prompt_frame_summary_limit(
-    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
-) -> usize {
-    let scaled_limit = memory_config.sliding_window.saturating_mul(4);
-    scaled_limit.clamp(16, 128)
 }
 
 fn extract_single_mutation_result(payload: &Value) -> Option<Value> {
@@ -1136,7 +1102,9 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
         .unwrap_or_else(|| "-".to_owned());
     let continuity =
         render_runtime_self_continuity_summary(workflow.get("runtime_self_continuity"));
-    let prompt_frame_summary = render_session_prompt_frame_summary(detail.get("prompt_frame"));
+    let prompt_frame_summary =
+        crate::session_prompt_frame_cli::render_prompt_frame_summary(detail.get("prompt_frame"));
+    let prompt_frame_summary = sanitize_terminal_text(prompt_frame_summary.as_str());
     let delegate_mode = detail
         .get("delegate_lifecycle")
         .and_then(|value| value.get("mode"))
@@ -1232,63 +1200,6 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("recovery_kind: {recovery_kind}"));
     lines.push(format!("recent_events: {recent_events}"));
     Ok(lines)
-}
-
-fn render_session_prompt_frame_summary(prompt_frame: Option<&Value>) -> String {
-    let Some(prompt_frame) = prompt_frame else {
-        return "-".to_owned();
-    };
-
-    let available = prompt_frame
-        .get("available")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    if !available {
-        let error = prompt_frame
-            .get("error")
-            .and_then(Value::as_str)
-            .map(sanitize_terminal_text)
-            .unwrap_or_else(|| "-".to_owned());
-        return format!("unavailable error={error}");
-    }
-
-    let Some(summary) = prompt_frame.get("summary") else {
-        return "present".to_owned();
-    };
-
-    let phase = summary
-        .get("latest_phase")
-        .and_then(Value::as_str)
-        .unwrap_or("-");
-    let total_tokens = summary
-        .get("latest_total_estimated_tokens")
-        .and_then(Value::as_u64)
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "-".to_owned());
-    let stable_prefix = summary
-        .get("latest_stable_prefix_hash")
-        .and_then(Value::as_str)
-        .unwrap_or("-");
-    let cached_prefix = summary
-        .get("latest_cached_prefix_hash")
-        .and_then(Value::as_str)
-        .unwrap_or("-");
-    let stable_prefix_changes = summary
-        .get("stable_prefix_hash_change_events")
-        .and_then(Value::as_u64)
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "0".to_owned());
-    let cached_prefix_changes = summary
-        .get("cached_prefix_hash_change_events")
-        .and_then(Value::as_u64)
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "0".to_owned());
-
-    format!(
-        "phase={phase} total_tokens={total_tokens} stable_prefix={} cached_prefix={} stable_prefix_changes={stable_prefix_changes} cached_prefix_changes={cached_prefix_changes}",
-        sanitize_terminal_text(stable_prefix),
-        sanitize_terminal_text(cached_prefix),
-    )
 }
 
 fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value>) -> String {

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -305,7 +305,7 @@ async fn execute_status_command(
     tool_config: &mvp::config::ToolConfig,
     session_id: &str,
 ) -> CliResult<Value> {
-    let detail = load_session_status_payload_with_prompt_frame(
+    let detail = load_session_status_payload_with_runtime_summaries(
         memory_config,
         tool_config,
         current_session_id,
@@ -326,7 +326,7 @@ async fn execute_status_command(
     }))
 }
 
-async fn load_session_status_payload_with_prompt_frame(
+async fn load_session_status_payload_with_runtime_summaries(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
@@ -339,11 +339,21 @@ async fn load_session_status_payload_with_prompt_frame(
         session_id,
     )
     .await;
+    let safe_lane =
+        crate::session_runtime_truth_cli::load_session_safe_lane_payload(memory_config, session_id)
+            .await;
+    let turn_checkpoint = crate::session_runtime_truth_cli::load_session_turn_checkpoint_payload(
+        memory_config,
+        session_id,
+    )
+    .await;
 
     let detail_object = detail
         .as_object_mut()
         .ok_or_else(|| "session status payload must be an object".to_owned())?;
     detail_object.insert("prompt_frame".to_owned(), prompt_frame);
+    detail_object.insert("safe_lane".to_owned(), safe_lane);
+    detail_object.insert("turn_checkpoint".to_owned(), turn_checkpoint);
 
     Ok(detail)
 }
@@ -638,7 +648,7 @@ pub fn render_sessions_cli_text(execution: &SessionsCommandExecution) -> CliResu
     Ok(rendered)
 }
 
-fn sanitize_terminal_text(value: &str) -> String {
+pub(crate) fn sanitize_terminal_text(value: &str) -> String {
     let mut sanitized = String::new();
     for character in value.chars() {
         if character.is_control() {
@@ -1105,6 +1115,13 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     let prompt_frame_summary =
         crate::session_prompt_frame_cli::render_prompt_frame_summary(detail.get("prompt_frame"));
     let prompt_frame_summary = sanitize_terminal_text(prompt_frame_summary.as_str());
+    let safe_lane_summary =
+        crate::session_runtime_truth_cli::render_safe_lane_summary(detail.get("safe_lane"));
+    let safe_lane_summary = sanitize_terminal_text(safe_lane_summary.as_str());
+    let turn_checkpoint_summary = crate::session_runtime_truth_cli::render_turn_checkpoint_summary(
+        detail.get("turn_checkpoint"),
+    );
+    let turn_checkpoint_summary = sanitize_terminal_text(turn_checkpoint_summary.as_str());
     let delegate_mode = detail
         .get("delegate_lifecycle")
         .and_then(|value| value.get("mode"))
@@ -1189,6 +1206,8 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("lineage_depth: {lineage_depth}"));
     lines.push(format!("runtime_self_continuity: {continuity}"));
     lines.push(format!("prompt_frame: {prompt_frame_summary}"));
+    lines.push(format!("safe_lane: {safe_lane_summary}"));
+    lines.push(format!("turn_checkpoint: {turn_checkpoint_summary}"));
     lines.push(format!("turn_count: {turn_count}"));
     lines.push(format!("last_turn_at: {last_turn_at}"));
     lines.push(format!("last_error: {sanitized_last_error}"));

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -138,13 +138,16 @@ pub async fn execute_sessions_command(
             include_archived,
             include_delegate_lifecycle,
         )?,
-        SessionsCommands::Status { session_id } => execute_status_command(
-            &resolved_config_path,
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &session_id,
-        )?,
+        SessionsCommands::Status { session_id } => {
+            execute_status_command(
+                &resolved_config_path,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+            )
+            .await?
+        }
         SessionsCommands::Events {
             session_id,
             after_id,
@@ -295,15 +298,20 @@ fn execute_list_command(
     }))
 }
 
-fn execute_status_command(
+async fn execute_status_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     session_id: &str,
 ) -> CliResult<Value> {
-    let detail =
-        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let detail = load_session_status_payload_with_prompt_frame(
+        memory_config,
+        tool_config,
+        current_session_id,
+        session_id,
+    )
+    .await?;
     let recipes = build_session_recipes(resolved_config_path, current_session_id, session_id);
     let next_steps = build_session_next_steps();
 
@@ -316,6 +324,24 @@ fn execute_status_command(
         "recipes": recipes,
         "next_steps": next_steps,
     }))
+}
+
+async fn load_session_status_payload_with_prompt_frame(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    session_id: &str,
+) -> CliResult<Value> {
+    let mut detail =
+        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let prompt_frame = load_session_prompt_frame_payload(memory_config, session_id).await;
+
+    let detail_object = detail
+        .as_object_mut()
+        .ok_or_else(|| "session status payload must be an object".to_owned())?;
+    detail_object.insert("prompt_frame".to_owned(), prompt_frame);
+
+    Ok(detail)
 }
 
 fn execute_events_command(
@@ -522,6 +548,44 @@ fn load_session_status_payload(
         payload,
     )?;
     Ok(outcome.payload)
+}
+
+async fn load_session_prompt_frame_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    session_id: &str,
+) -> Value {
+    let summary_limit = prompt_frame_summary_limit(memory_config);
+    let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let summary_result = mvp::conversation::load_prompt_frame_event_summary(
+        session_id,
+        summary_limit,
+        binding,
+        memory_config,
+    )
+    .await;
+
+    match summary_result {
+        Ok(summary) => {
+            let available = summary.snapshot_events > 0;
+            json!({
+                "available": available,
+                "limit": summary_limit,
+                "summary": summary,
+            })
+        }
+        Err(error) => json!({
+            "available": false,
+            "limit": summary_limit,
+            "error": error,
+        }),
+    }
+}
+
+fn prompt_frame_summary_limit(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+) -> usize {
+    let scaled_limit = memory_config.sliding_window.saturating_mul(4);
+    scaled_limit.clamp(16, 128)
 }
 
 fn extract_single_mutation_result(payload: &Value) -> Option<Value> {
@@ -1072,6 +1136,7 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
         .unwrap_or_else(|| "-".to_owned());
     let continuity =
         render_runtime_self_continuity_summary(workflow.get("runtime_self_continuity"));
+    let prompt_frame_summary = render_session_prompt_frame_summary(detail.get("prompt_frame"));
     let delegate_mode = detail
         .get("delegate_lifecycle")
         .and_then(|value| value.get("mode"))
@@ -1155,6 +1220,7 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     ));
     lines.push(format!("lineage_depth: {lineage_depth}"));
     lines.push(format!("runtime_self_continuity: {continuity}"));
+    lines.push(format!("prompt_frame: {prompt_frame_summary}"));
     lines.push(format!("turn_count: {turn_count}"));
     lines.push(format!("last_turn_at: {last_turn_at}"));
     lines.push(format!("last_error: {sanitized_last_error}"));
@@ -1166,6 +1232,63 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("recovery_kind: {recovery_kind}"));
     lines.push(format!("recent_events: {recent_events}"));
     Ok(lines)
+}
+
+fn render_session_prompt_frame_summary(prompt_frame: Option<&Value>) -> String {
+    let Some(prompt_frame) = prompt_frame else {
+        return "-".to_owned();
+    };
+
+    let available = prompt_frame
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !available {
+        let error = prompt_frame
+            .get("error")
+            .and_then(Value::as_str)
+            .map(sanitize_terminal_text)
+            .unwrap_or_else(|| "-".to_owned());
+        return format!("unavailable error={error}");
+    }
+
+    let Some(summary) = prompt_frame.get("summary") else {
+        return "present".to_owned();
+    };
+
+    let phase = summary
+        .get("latest_phase")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let total_tokens = summary
+        .get("latest_total_estimated_tokens")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let stable_prefix = summary
+        .get("latest_stable_prefix_hash")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let cached_prefix = summary
+        .get("latest_cached_prefix_hash")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let stable_prefix_changes = summary
+        .get("stable_prefix_hash_change_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    let cached_prefix_changes = summary
+        .get("cached_prefix_hash_change_events")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+
+    format!(
+        "phase={phase} total_tokens={total_tokens} stable_prefix={} cached_prefix={} stable_prefix_changes={stable_prefix_changes} cached_prefix_changes={cached_prefix_changes}",
+        sanitize_terminal_text(stable_prefix),
+        sanitize_terminal_text(cached_prefix),
+    )
 }
 
 fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value>) -> String {

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -149,36 +149,45 @@ pub async fn execute_tasks_command(
             state,
             overdue_only,
             include_archived,
-        } => execute_list_command(
-            &resolved_path.display().to_string(),
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            limit,
-            state.as_deref(),
-            overdue_only,
-            include_archived,
-        )?,
-        TasksCommands::Status { task_id } => execute_status_command(
-            &resolved_path.display().to_string(),
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &task_id,
-        )?,
+        } => {
+            execute_list_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                limit,
+                state.as_deref(),
+                overdue_only,
+                include_archived,
+            )
+            .await?
+        }
+        TasksCommands::Status { task_id } => {
+            execute_status_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task_id,
+            )
+            .await?
+        }
         TasksCommands::Events {
             task_id,
             after_id,
             limit,
-        } => execute_events_command(
-            &resolved_path.display().to_string(),
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &task_id,
-            after_id,
-            limit,
-        )?,
+        } => {
+            execute_events_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task_id,
+                after_id,
+                limit,
+            )
+            .await?
+        }
         TasksCommands::Wait {
             task_id,
             after_id,
@@ -195,22 +204,28 @@ pub async fn execute_tasks_command(
             )
             .await?
         }
-        TasksCommands::Cancel { task_id, dry_run } => execute_cancel_command(
-            &resolved_path.display().to_string(),
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &task_id,
-            dry_run,
-        )?,
-        TasksCommands::Recover { task_id, dry_run } => execute_recover_command(
-            &resolved_path.display().to_string(),
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &task_id,
-            dry_run,
-        )?,
+        TasksCommands::Cancel { task_id, dry_run } => {
+            execute_cancel_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task_id,
+                dry_run,
+            )
+            .await?
+        }
+        TasksCommands::Recover { task_id, dry_run } => {
+            execute_recover_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task_id,
+                dry_run,
+            )
+            .await?
+        }
     };
 
     Ok(TasksCommandExecution {
@@ -250,7 +265,8 @@ async fn execute_create_command(
     .await?;
     let task_id = required_string_field(&queued.payload, "child_session_id", "tasks create")?;
     let (task_detail, task_lookup_error) =
-        build_best_effort_task_detail(memory_config, tool_config, current_session_id, &task_id);
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, &task_id)
+            .await;
     let recipes = build_task_recipes(resolved_config_path, current_session_id, &task_id);
     let next_steps = build_task_next_steps();
     let payload = json!({
@@ -288,7 +304,7 @@ fn build_tasks_create_runtime(
     }
 }
 
-fn execute_list_command(
+async fn execute_list_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
@@ -314,7 +330,8 @@ fn execute_list_command(
         if tasks.len() >= raw_limit {
             break;
         }
-        let task = build_task_detail(memory_config, tool_config, current_session_id, &session_id)?;
+        let task =
+            build_task_detail(memory_config, tool_config, current_session_id, &session_id).await?;
         tasks.push(task);
     }
 
@@ -336,14 +353,14 @@ fn execute_list_command(
     Ok(payload)
 }
 
-fn execute_status_command(
+async fn execute_status_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     task_id: &str,
 ) -> CliResult<Value> {
-    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
     let payload = json!({
         "command": "status",
         "config": resolved_config_path,
@@ -353,7 +370,7 @@ fn execute_status_command(
     Ok(payload)
 }
 
-fn execute_events_command(
+async fn execute_events_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
@@ -362,7 +379,7 @@ fn execute_events_command(
     after_id: Option<i64>,
     limit: usize,
 ) -> CliResult<Value> {
-    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
     let event_limit = limit.clamp(1, 200);
     let payload = json!({
         "session_id": task_id,
@@ -407,7 +424,7 @@ async fn execute_wait_command(
     after_id: Option<i64>,
     timeout_ms: u64,
 ) -> CliResult<Value> {
-    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
     let payload = json!({
         "session_id": task_id,
         "after_id": after_id,
@@ -420,7 +437,7 @@ async fn execute_wait_command(
         tool_config,
     )
     .await?;
-    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
     let wait_payload = outcome.payload;
     let next_after_id = wait_payload
         .get("next_after_id")
@@ -445,7 +462,7 @@ async fn execute_wait_command(
     Ok(output)
 }
 
-fn execute_cancel_command(
+async fn execute_cancel_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
@@ -466,7 +483,8 @@ fn execute_cancel_command(
         payload,
     )?;
     let (task, task_lookup_error) =
-        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id);
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id)
+            .await;
     let mutation_result = extract_single_mutation_result(&outcome.payload);
     let result = mutation_result
         .as_ref()
@@ -503,7 +521,7 @@ fn execute_cancel_command(
     Ok(output)
 }
 
-fn execute_recover_command(
+async fn execute_recover_command(
     resolved_config_path: &str,
     current_session_id: &str,
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
@@ -524,7 +542,8 @@ fn execute_recover_command(
         payload,
     )?;
     let (task, task_lookup_error) =
-        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id);
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id)
+            .await;
     let mutation_result = extract_single_mutation_result(&outcome.payload);
     let result = mutation_result
         .as_ref()
@@ -745,7 +764,7 @@ fn current_unix_timestamp() -> i64 {
     duration.as_secs().min(i64::MAX as u64) as i64
 }
 
-fn build_task_detail(
+async fn build_task_detail(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
@@ -836,6 +855,9 @@ fn build_task_detail(
         &tool_policy,
         &recent_events,
     );
+    let prompt_frame =
+        crate::session_prompt_frame_cli::load_session_prompt_frame_payload(memory_config, task_id)
+            .await;
 
     let detail = json!({
         "task_id": task_id,
@@ -867,17 +889,19 @@ fn build_task_detail(
         "terminal_outcome": terminal_outcome,
         "recent_events": recent_events,
         "task_status": task_status,
+        "prompt_frame": prompt_frame,
     });
     Ok(detail)
 }
 
-fn build_best_effort_task_detail(
+async fn build_best_effort_task_detail(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
     task_id: &str,
 ) -> (Value, Value) {
-    let detail_result = build_task_detail(memory_config, tool_config, current_session_id, task_id);
+    let detail_result =
+        build_task_detail(memory_config, tool_config, current_session_id, task_id).await;
     match detail_result {
         Ok(task_detail) => (task_detail, Value::Null),
         Err(error) => {
@@ -1834,6 +1858,8 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         .and_then(|value| value.get("effective_runtime_narrowing"))
         .cloned()
         .unwrap_or(Value::Null);
+    let prompt_frame_summary =
+        crate::session_prompt_frame_cli::render_prompt_frame_summary(task.get("prompt_frame"));
     let rendered_runtime_narrowing = if effective_runtime_narrowing.is_null() {
         "-".to_owned()
     } else {
@@ -1880,6 +1906,7 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
     lines.push(format!(
         "effective_runtime_narrowing: {rendered_runtime_narrowing}"
     ));
+    lines.push(format!("prompt_frame: {prompt_frame_summary}"));
     Ok(lines)
 }
 

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -773,10 +773,18 @@ async fn build_task_detail(
     let status_payload =
         load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
     ensure_background_task_status_payload(&status_payload, task_id)?;
-    let approvals_payload =
-        load_task_approvals_payload(memory_config, tool_config, current_session_id, task_id)?;
-    let tool_policy_payload =
-        load_task_tool_policy_payload(memory_config, tool_config, current_session_id, task_id)?;
+    let (approvals_payload, approval_lookup_error) = load_best_effort_task_approvals_payload(
+        memory_config,
+        tool_config,
+        current_session_id,
+        task_id,
+    );
+    let (tool_policy_payload, tool_policy_lookup_error) = load_best_effort_task_tool_policy_payload(
+        memory_config,
+        tool_config,
+        current_session_id,
+        task_id,
+    );
 
     let session = status_payload
         .get("session")
@@ -867,40 +875,39 @@ async fn build_task_detail(
     )
     .await;
 
-    let detail = json!({
-        "task_id": task_id,
-        "session_id": task_id,
-        "scope_session_id": current_session_id,
-        "label": label,
-        "session_state": session_state,
-        "phase": phase,
-        "mode": mode,
-        "owner_kind": owner_kind,
-        "timeout_seconds": timeout_seconds,
-        "workflow": workflow,
-        "created_at": created_at,
-        "updated_at": updated_at,
-        "archived": archived,
-        "last_error": last_error,
-        "approval": {
-            "matched_count": approval_matched_count,
-            "returned_count": approval_returned_count,
-            "attention_summary": approval_attention_summary,
-            "requests": approval_requests,
-        },
-        "tool_policy": tool_policy,
-        "session": session,
-        "delegate": delegate,
-        "terminal_outcome_state": terminal_outcome_state,
-        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
-        "recovery": recovery,
-        "terminal_outcome": terminal_outcome,
-        "recent_events": recent_events,
-        "task_status": task_status,
-        "prompt_frame": prompt_frame,
-        "safe_lane": safe_lane,
-        "turn_checkpoint": turn_checkpoint,
-    });
+    let detail = compose_task_detail_payload(
+        current_session_id,
+        task_id,
+        session,
+        delegate,
+        label,
+        session_state,
+        phase,
+        mode,
+        owner_kind,
+        timeout_seconds,
+        workflow,
+        created_at,
+        updated_at,
+        archived,
+        last_error,
+        approval_requests,
+        approval_attention_summary,
+        approval_matched_count,
+        approval_returned_count,
+        approval_lookup_error,
+        tool_policy,
+        tool_policy_lookup_error,
+        task_status,
+        terminal_outcome_state,
+        terminal_outcome_missing_reason,
+        recovery,
+        terminal_outcome,
+        recent_events,
+        prompt_frame,
+        safe_lane,
+        turn_checkpoint,
+    );
     Ok(detail)
 }
 
@@ -931,9 +938,13 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
         "label": Value::Null,
         "session_state": Value::Null,
         "phase": Value::Null,
+        "mode": Value::Null,
         "owner_kind": Value::Null,
         "timeout_seconds": Value::Null,
         "workflow": Value::Null,
+        "created_at": Value::Null,
+        "updated_at": Value::Null,
+        "archived": Value::Null,
         "last_error": Value::Null,
         "approval": {
             "matched_count": 0,
@@ -941,8 +952,20 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
             "attention_summary": Value::Null,
             "requests": [],
         },
+        "approval_lookup_error": Value::Null,
         "tool_policy": Value::Null,
+        "tool_policy_lookup_error": Value::Null,
         "task_status": task_status,
+        "session": Value::Null,
+        "delegate": Value::Null,
+        "terminal_outcome_state": Value::Null,
+        "terminal_outcome_missing_reason": Value::Null,
+        "recovery": Value::Null,
+        "terminal_outcome": Value::Null,
+        "recent_events": [],
+        "prompt_frame": Value::Null,
+        "safe_lane": Value::Null,
+        "turn_checkpoint": Value::Null,
     })
 }
 
@@ -1319,6 +1342,18 @@ fn load_task_approvals_payload(
     Ok(outcome.payload)
 }
 
+fn load_best_effort_task_approvals_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> (Value, Value) {
+    let result =
+        load_task_approvals_payload(memory_config, tool_config, current_session_id, task_id);
+    let fallback_payload = fallback_task_approvals_payload();
+    best_effort_task_lookup_payload(result, fallback_payload)
+}
+
 fn load_task_tool_policy_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
@@ -1336,6 +1371,109 @@ fn load_task_tool_policy_payload(
         payload,
     )?;
     Ok(outcome.payload)
+}
+
+fn load_best_effort_task_tool_policy_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> (Value, Value) {
+    let result =
+        load_task_tool_policy_payload(memory_config, tool_config, current_session_id, task_id);
+    let fallback_payload = Value::Null;
+    best_effort_task_lookup_payload(result, fallback_payload)
+}
+
+fn best_effort_task_lookup_payload(
+    result: CliResult<Value>,
+    fallback_payload: Value,
+) -> (Value, Value) {
+    match result {
+        Ok(payload) => (payload, Value::Null),
+        Err(error) => (fallback_payload, Value::String(error)),
+    }
+}
+
+fn fallback_task_approvals_payload() -> Value {
+    json!({
+        "matched_count": 0,
+        "returned_count": 0,
+        "attention_summary": Value::Null,
+        "requests": [],
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compose_task_detail_payload(
+    current_session_id: &str,
+    task_id: &str,
+    session: Value,
+    delegate: Value,
+    label: Value,
+    session_state: Value,
+    phase: Value,
+    mode: Value,
+    owner_kind: Value,
+    timeout_seconds: Value,
+    workflow: Value,
+    created_at: Value,
+    updated_at: Value,
+    archived: Value,
+    last_error: Value,
+    approval_requests: Value,
+    approval_attention_summary: Value,
+    approval_matched_count: Value,
+    approval_returned_count: Value,
+    approval_lookup_error: Value,
+    tool_policy: Value,
+    tool_policy_lookup_error: Value,
+    task_status: Value,
+    terminal_outcome_state: Value,
+    terminal_outcome_missing_reason: Value,
+    recovery: Value,
+    terminal_outcome: Value,
+    recent_events: Value,
+    prompt_frame: Value,
+    safe_lane: Value,
+    turn_checkpoint: Value,
+) -> Value {
+    json!({
+        "task_id": task_id,
+        "session_id": task_id,
+        "scope_session_id": current_session_id,
+        "label": label,
+        "session_state": session_state,
+        "phase": phase,
+        "mode": mode,
+        "owner_kind": owner_kind,
+        "timeout_seconds": timeout_seconds,
+        "workflow": workflow,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "archived": archived,
+        "last_error": last_error,
+        "approval": {
+            "matched_count": approval_matched_count,
+            "returned_count": approval_returned_count,
+            "attention_summary": approval_attention_summary,
+            "requests": approval_requests,
+        },
+        "approval_lookup_error": approval_lookup_error,
+        "tool_policy": tool_policy,
+        "tool_policy_lookup_error": tool_policy_lookup_error,
+        "task_status": task_status,
+        "session": session,
+        "delegate": delegate,
+        "terminal_outcome_state": terminal_outcome_state,
+        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
+        "recovery": recovery,
+        "terminal_outcome": terminal_outcome,
+        "recent_events": recent_events,
+        "prompt_frame": prompt_frame,
+        "safe_lane": safe_lane,
+        "turn_checkpoint": turn_checkpoint,
+    })
 }
 
 fn build_task_recipes(
@@ -1907,6 +2045,14 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         crate::sessions_cli::sanitize_terminal_text(safe_lane_summary.as_str());
     let sanitized_turn_checkpoint_summary =
         crate::sessions_cli::sanitize_terminal_text(turn_checkpoint_summary.as_str());
+    let approval_lookup_error = task
+        .get("approval_lookup_error")
+        .and_then(Value::as_str)
+        .map(crate::sessions_cli::sanitize_terminal_text);
+    let tool_policy_lookup_error = task
+        .get("tool_policy_lookup_error")
+        .and_then(Value::as_str)
+        .map(crate::sessions_cli::sanitize_terminal_text);
 
     let mut lines = Vec::new();
     lines.push(format!("task_id: {sanitized_task_id}"));
@@ -1954,6 +2100,14 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
     lines.push(format!(
         "turn_checkpoint: {sanitized_turn_checkpoint_summary}"
     ));
+    if let Some(approval_lookup_error) = approval_lookup_error {
+        lines.push(format!("approval_lookup_error: {approval_lookup_error}"));
+    }
+    if let Some(tool_policy_lookup_error) = tool_policy_lookup_error {
+        lines.push(format!(
+            "tool_policy_lookup_error: {tool_policy_lookup_error}"
+        ));
+    }
     Ok(lines)
 }
 
@@ -2155,5 +2309,123 @@ mod tests {
         assert!(rendered.contains("status=approval_pending"));
         assert!(rendered.contains("blocked=true"));
         assert!(rendered.contains("signals=approval_pending"));
+    }
+
+    #[test]
+    fn best_effort_task_approvals_payload_falls_back_when_session_tools_are_disabled() {
+        let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::default();
+        let mut tool_config = mvp::config::ToolConfig::default();
+        tool_config.sessions.enabled = false;
+
+        let (payload, lookup_error) = load_best_effort_task_approvals_payload(
+            &memory_config,
+            &tool_config,
+            "ops-root",
+            "delegate:task-1",
+        );
+
+        assert_eq!(payload["matched_count"], 0);
+        assert_eq!(payload["returned_count"], 0);
+        assert_eq!(payload["requests"], json!([]));
+        assert!(
+            lookup_error
+                .as_str()
+                .expect("lookup error")
+                .contains("session tools are disabled"),
+            "expected degraded approval lookup error, got: {lookup_error:?}"
+        );
+    }
+
+    #[test]
+    fn best_effort_task_tool_policy_payload_falls_back_when_session_tools_are_disabled() {
+        let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::default();
+        let mut tool_config = mvp::config::ToolConfig::default();
+        tool_config.sessions.enabled = false;
+
+        let (payload, lookup_error) = load_best_effort_task_tool_policy_payload(
+            &memory_config,
+            &tool_config,
+            "ops-root",
+            "delegate:task-1",
+        );
+
+        assert!(
+            payload.is_null(),
+            "expected null fallback payload, got: {payload:?}"
+        );
+        assert!(
+            lookup_error
+                .as_str()
+                .expect("lookup error")
+                .contains("session tools are disabled"),
+            "expected degraded tool-policy lookup error, got: {lookup_error:?}"
+        );
+    }
+
+    #[test]
+    fn compose_task_detail_payload_keeps_core_status_truth_when_secondary_lookups_degrade() {
+        let session = json!({
+            "session_id": "delegate:task-1",
+            "kind": "delegate_child",
+            "state": "running",
+            "created_at": 10,
+            "updated_at": 20,
+            "archived": false,
+            "label": "Release Check",
+            "last_error": Value::Null,
+        });
+        let delegate = json!({
+            "mode": "async",
+            "phase": "running",
+            "execution": {
+                "owner_kind": "background_task_host"
+            },
+            "timeout_seconds": 60
+        });
+        let detail = compose_task_detail_payload(
+            "ops-root",
+            "delegate:task-1",
+            session.clone(),
+            delegate.clone(),
+            json!("Release Check"),
+            json!("running"),
+            json!("running"),
+            json!("async"),
+            json!("background_task_host"),
+            json!(60),
+            Value::Null,
+            json!(10),
+            json!(20),
+            json!(false),
+            Value::Null,
+            json!([]),
+            Value::Null,
+            json!(0),
+            json!(0),
+            json!("approval lookup failed"),
+            Value::Null,
+            json!("tool policy lookup failed"),
+            unknown_task_status_payload(),
+            json!("missing"),
+            json!("not_terminal"),
+            Value::Null,
+            Value::Null,
+            json!([]),
+            Value::Null,
+            Value::Null,
+            Value::Null,
+        );
+
+        assert_eq!(detail["session"], session);
+        assert_eq!(detail["delegate"], delegate);
+        assert_eq!(detail["task_id"], "delegate:task-1");
+        assert_eq!(detail["approval_lookup_error"], "approval lookup failed");
+        assert_eq!(
+            detail["tool_policy_lookup_error"],
+            "tool policy lookup failed"
+        );
+        assert_eq!(detail["tool_policy"], Value::Null);
+        assert_eq!(detail["approval"]["matched_count"], 0);
+        assert_eq!(detail["terminal_outcome_state"], "missing");
     }
 }

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -858,6 +858,14 @@ async fn build_task_detail(
     let prompt_frame =
         crate::session_prompt_frame_cli::load_session_prompt_frame_payload(memory_config, task_id)
             .await;
+    let safe_lane =
+        crate::session_runtime_truth_cli::load_session_safe_lane_payload(memory_config, task_id)
+            .await;
+    let turn_checkpoint = crate::session_runtime_truth_cli::load_session_turn_checkpoint_payload(
+        memory_config,
+        task_id,
+    )
+    .await;
 
     let detail = json!({
         "task_id": task_id,
@@ -890,6 +898,8 @@ async fn build_task_detail(
         "recent_events": recent_events,
         "task_status": task_status,
         "prompt_frame": prompt_frame,
+        "safe_lane": safe_lane,
+        "turn_checkpoint": turn_checkpoint,
     });
     Ok(detail)
 }
@@ -1404,14 +1414,15 @@ fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
         .get("next_steps")
         .and_then(Value::as_array)
         .ok_or_else(|| "tasks create payload missing next_steps".to_owned())?;
+    let scope = payload
+        .get("current_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
 
     let mut lines = Vec::new();
+    let sanitized_scope = crate::sessions_cli::sanitize_terminal_text(scope);
     lines.push(format!(
-        "background task queued in session `{}`",
-        payload
-            .get("current_session_id")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
+        "background task queued in session `{sanitized_scope}`"
     ));
     lines.extend(render_task_detail_lines(task)?);
     append_task_lookup_error_line(payload, &mut lines);
@@ -1419,7 +1430,8 @@ fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
     if !recipes.is_empty() {
         for recipe in recipes {
             let text = recipe.as_str().unwrap_or("");
-            lines.push(format!("- {text}"));
+            let sanitized_text = crate::sessions_cli::sanitize_terminal_text(text);
+            lines.push(format!("- {sanitized_text}"));
         }
     }
 
@@ -1427,7 +1439,8 @@ fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
     if !next_steps.is_empty() {
         for step in next_steps {
             let text = step.as_str().unwrap_or("");
-            next_lines.push(format!("- {text}"));
+            let sanitized_text = crate::sessions_cli::sanitize_terminal_text(text);
+            next_lines.push(format!("- {sanitized_text}"));
         }
     }
 
@@ -1466,8 +1479,9 @@ fn render_tasks_list_text(payload: &Value) -> CliResult<String> {
         .unwrap_or("unknown");
 
     let mut lines = Vec::new();
+    let sanitized_scope = crate::sessions_cli::sanitize_terminal_text(scope);
     lines.push(format!(
-        "visible background tasks from session `{scope}`: {returned_count}/{matched_count}"
+        "visible background tasks from session `{sanitized_scope}`: {returned_count}/{matched_count}"
     ));
     if tasks.is_empty() {
         lines.push("No async background tasks are currently visible.".to_owned());
@@ -1532,8 +1546,9 @@ fn render_tasks_events_text(payload: &Value) -> CliResult<String> {
         .unwrap_or(0);
 
     let mut lines = Vec::new();
+    let sanitized_task_id = crate::sessions_cli::sanitize_terminal_text(task_id);
     lines.push(format!(
-        "events for `{task_id}` (next_after_id={next_after_id})"
+        "events for `{sanitized_task_id}` (next_after_id={next_after_id})"
     ));
     if events.is_empty() {
         lines.push("No newer events.".to_owned());
@@ -1553,7 +1568,8 @@ fn render_tasks_events_text(payload: &Value) -> CliResult<String> {
             .and_then(Value::as_str)
             .unwrap_or("unknown");
         let ts = event.get("ts").and_then(Value::as_i64).unwrap_or_default();
-        lines.push(format!("- #{event_id} {event_kind} ts={ts}"));
+        let sanitized_event_kind = crate::sessions_cli::sanitize_terminal_text(event_kind);
+        lines.push(format!("- #{event_id} {sanitized_event_kind} ts={ts}"));
     }
 
     Ok(render_tasks_surface(
@@ -1595,7 +1611,8 @@ fn render_tasks_wait_text(payload: &Value) -> CliResult<String> {
                 .get("event_kind")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            lines.push(format!("- #{event_id} {event_kind}"));
+            let sanitized_event_kind = crate::sessions_cli::sanitize_terminal_text(event_kind);
+            lines.push(format!("- #{event_id} {sanitized_event_kind}"));
         }
     }
 
@@ -1627,10 +1644,12 @@ fn render_tasks_mutation_text(payload: &Value) -> CliResult<String> {
     let mut lines = Vec::new();
     lines.push(format!("{command} dry_run={dry_run}"));
     if let Some(result) = result {
-        lines.push(format!("result: {result}"));
+        let sanitized_result = crate::sessions_cli::sanitize_terminal_text(result);
+        lines.push(format!("result: {sanitized_result}"));
     }
     if let Some(message) = message {
-        lines.push(format!("message: {message}"));
+        let sanitized_message = crate::sessions_cli::sanitize_terminal_text(message);
+        lines.push(format!("message: {sanitized_message}"));
     }
     if !action.is_null() {
         let rendered_action = serde_json::to_string_pretty(&action)
@@ -1726,8 +1745,11 @@ fn render_task_brief_line(task: &Value) -> CliResult<String> {
         .and_then(Value::as_array)
         .map(|values| render_string_array(values))
         .unwrap_or_else(|| "-".to_owned());
+    let sanitized_task_id = crate::sessions_cli::sanitize_terminal_text(task_id.as_str());
+    let sanitized_label = crate::sessions_cli::sanitize_terminal_text(label);
+    let sanitized_owner_kind = crate::sessions_cli::sanitize_terminal_text(owner_kind);
     let line = format!(
-        "{task_id} status={status_display} blocked={blocked} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={label} owner_kind={owner_kind} approval_attention={approval_attention} signals={signals}"
+        "{sanitized_task_id} status={status_display} blocked={blocked} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={sanitized_label} owner_kind={sanitized_owner_kind} approval_attention={approval_attention} signals={signals}"
     );
     Ok(line)
 }
@@ -1860,17 +1882,36 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         .unwrap_or(Value::Null);
     let prompt_frame_summary =
         crate::session_prompt_frame_cli::render_prompt_frame_summary(task.get("prompt_frame"));
+    let safe_lane_summary =
+        crate::session_runtime_truth_cli::render_safe_lane_summary(task.get("safe_lane"));
+    let turn_checkpoint_summary = crate::session_runtime_truth_cli::render_turn_checkpoint_summary(
+        task.get("turn_checkpoint"),
+    );
     let rendered_runtime_narrowing = if effective_runtime_narrowing.is_null() {
         "-".to_owned()
     } else {
         serde_json::to_string(&effective_runtime_narrowing)
             .map_err(|error| format!("render runtime narrowing failed: {error}"))?
     };
+    let sanitized_task_id = crate::sessions_cli::sanitize_terminal_text(task_id.as_str());
+    let sanitized_scope_session_id = crate::sessions_cli::sanitize_terminal_text(scope_session_id);
+    let sanitized_label = crate::sessions_cli::sanitize_terminal_text(label);
+    let sanitized_last_error = crate::sessions_cli::sanitize_terminal_text(last_error);
+    let sanitized_effective_tool_ids =
+        crate::sessions_cli::sanitize_terminal_text(effective_tool_ids.as_str());
+    let sanitized_runtime_narrowing =
+        crate::sessions_cli::sanitize_terminal_text(rendered_runtime_narrowing.as_str());
+    let sanitized_prompt_frame_summary =
+        crate::sessions_cli::sanitize_terminal_text(prompt_frame_summary.as_str());
+    let sanitized_safe_lane_summary =
+        crate::sessions_cli::sanitize_terminal_text(safe_lane_summary.as_str());
+    let sanitized_turn_checkpoint_summary =
+        crate::sessions_cli::sanitize_terminal_text(turn_checkpoint_summary.as_str());
 
     let mut lines = Vec::new();
-    lines.push(format!("task_id: {task_id}"));
-    lines.push(format!("scope_session_id: {scope_session_id}"));
-    lines.push(format!("label: {label}"));
+    lines.push(format!("task_id: {sanitized_task_id}"));
+    lines.push(format!("scope_session_id: {sanitized_scope_session_id}"));
+    lines.push(format!("label: {sanitized_label}"));
     lines.push(format!("task_status: {task_status_display}"));
     lines.push(format!("task_blocked: {blocked}"));
     lines.push(format!("task_needs_attention: {needs_attention}"));
@@ -1899,14 +1940,20 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("phase: {phase}"));
     lines.push(format!("owner_kind: {owner_kind}"));
     lines.push(format!("timeout_seconds: {timeout_seconds}"));
-    lines.push(format!("last_error: {last_error}"));
+    lines.push(format!("last_error: {sanitized_last_error}"));
     lines.push(format!("approval_requests: {approval_total}"));
     lines.push(format!("approval_attention: {approval_attention}"));
-    lines.push(format!("effective_tool_ids: {effective_tool_ids}"));
     lines.push(format!(
-        "effective_runtime_narrowing: {rendered_runtime_narrowing}"
+        "effective_tool_ids: {sanitized_effective_tool_ids}"
     ));
-    lines.push(format!("prompt_frame: {prompt_frame_summary}"));
+    lines.push(format!(
+        "effective_runtime_narrowing: {sanitized_runtime_narrowing}"
+    ));
+    lines.push(format!("prompt_frame: {sanitized_prompt_frame_summary}"));
+    lines.push(format!("safe_lane: {sanitized_safe_lane_summary}"));
+    lines.push(format!(
+        "turn_checkpoint: {sanitized_turn_checkpoint_summary}"
+    ));
     Ok(lines)
 }
 
@@ -1914,7 +1961,9 @@ fn append_task_lookup_error_line(payload: &Value, lines: &mut Vec<String>) {
     let Some(task_lookup_error) = payload.get("task_lookup_error").and_then(Value::as_str) else {
         return;
     };
-    lines.push(format!("task_lookup_error: {task_lookup_error}"));
+    let sanitized_task_lookup_error =
+        crate::sessions_cli::sanitize_terminal_text(task_lookup_error);
+    lines.push(format!("task_lookup_error: {sanitized_task_lookup_error}"));
 }
 
 fn render_string_array(values: &[Value]) -> String {

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -275,17 +275,15 @@ fn build_tasks_create_runtime(
     // conversation runtime.
     #[cfg(feature = "memory-sqlite")]
     {
-        let inner_runtime =
-            mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
         let background_task_spawner = Arc::new(DetachedTasksSpawner);
-        let runtime = mvp::conversation::HostedConversationRuntime::new(inner_runtime)
+        let runtime = mvp::conversation::load_hosted_default_conversation_runtime(config)?
             .with_background_task_spawner(background_task_spawner);
         Ok(runtime)
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let runtime = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+        let runtime = mvp::conversation::load_default_conversation_runtime(config)?;
         Ok(runtime)
     }
 }

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -79,129 +79,6 @@ pub struct TasksCommandExecution {
 }
 
 #[cfg(feature = "memory-sqlite")]
-struct DetachedTasksRuntime {
-    inner: mvp::conversation::DefaultConversationRuntime<
-        Box<dyn mvp::conversation::ConversationContextEngine>,
-    >,
-    background_task_spawner: Arc<dyn mvp::conversation::AsyncDelegateSpawner>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-impl DetachedTasksRuntime {
-    fn from_config(config: &mvp::config::LoongClawConfig) -> CliResult<Self> {
-        let inner = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
-        let background_task_spawner = Arc::new(DetachedTasksSpawner);
-
-        Ok(Self {
-            inner,
-            background_task_spawner,
-        })
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[async_trait]
-impl mvp::conversation::ConversationRuntime for DetachedTasksRuntime {
-    fn session_context(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        session_id: &str,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<mvp::conversation::SessionContext> {
-        self.inner.session_context(config, session_id, binding)
-    }
-
-    fn tool_view(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        session_id: &str,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<mvp::tools::ToolView> {
-        self.inner.tool_view(config, session_id, binding)
-    }
-
-    fn background_task_spawner(
-        &self,
-        _config: &mvp::config::LoongClawConfig,
-    ) -> Option<Arc<dyn mvp::conversation::AsyncDelegateSpawner>> {
-        Some(self.background_task_spawner.clone())
-    }
-
-    async fn build_messages(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        session_id: &str,
-        include_system_prompt: bool,
-        tool_view: &mvp::tools::ToolView,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Vec<Value>> {
-        self.inner
-            .build_messages(
-                config,
-                session_id,
-                include_system_prompt,
-                tool_view,
-                binding,
-            )
-            .await
-    }
-
-    async fn request_completion(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        messages: &[Value],
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        self.inner
-            .request_completion(config, messages, binding)
-            .await
-    }
-
-    async fn request_turn(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        session_id: &str,
-        turn_id: &str,
-        messages: &[Value],
-        tool_view: &mvp::tools::ToolView,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<mvp::conversation::ProviderTurn> {
-        self.inner
-            .request_turn(config, session_id, turn_id, messages, tool_view, binding)
-            .await
-    }
-
-    async fn request_turn_streaming(
-        &self,
-        config: &mvp::config::LoongClawConfig,
-        session_id: &str,
-        turn_id: &str,
-        messages: &[Value],
-        tool_view: &mvp::tools::ToolView,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-        on_token: mvp::provider::StreamingTokenCallback,
-    ) -> CliResult<mvp::conversation::ProviderTurn> {
-        self.inner
-            .request_turn_streaming(
-                config, session_id, turn_id, messages, tool_view, binding, on_token,
-            )
-            .await
-    }
-
-    async fn persist_turn(
-        &self,
-        session_id: &str,
-        role: &str,
-        content: &str,
-        binding: mvp::conversation::ConversationRuntimeBinding<'_>,
-    ) -> CliResult<()> {
-        self.inner
-            .persist_turn(session_id, role, content, binding)
-            .await
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
 #[derive(Clone)]
 struct DetachedTasksSpawner;
 
@@ -398,7 +275,11 @@ fn build_tasks_create_runtime(
     // conversation runtime.
     #[cfg(feature = "memory-sqlite")]
     {
-        let runtime = DetachedTasksRuntime::from_config(config)?;
+        let inner_runtime =
+            mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+        let background_task_spawner = Arc::new(DetachedTasksSpawner);
+        let runtime = mvp::conversation::HostedConversationRuntime::new(inner_runtime)
+            .with_background_task_spawner(background_task_spawner);
         Ok(runtime)
     }
 

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -773,6 +773,11 @@ fn build_task_detail(
     let session_state = session.get("state").cloned().unwrap_or(Value::Null);
     let phase = delegate.get("phase").cloned().unwrap_or(Value::Null);
     let mode = delegate.get("mode").cloned().unwrap_or(Value::Null);
+    let owner_kind = delegate
+        .get("execution")
+        .and_then(|value| value.get("owner_kind"))
+        .cloned()
+        .unwrap_or(Value::Null);
     let timeout_seconds = delegate
         .get("timeout_seconds")
         .cloned()
@@ -842,6 +847,7 @@ fn build_task_detail(
         "session_state": session_state,
         "phase": phase,
         "mode": mode,
+        "owner_kind": owner_kind,
         "timeout_seconds": timeout_seconds,
         "workflow": workflow,
         "created_at": created_at,
@@ -893,6 +899,7 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
         "label": Value::Null,
         "session_state": Value::Null,
         "phase": Value::Null,
+        "owner_kind": Value::Null,
         "timeout_seconds": Value::Null,
         "workflow": Value::Null,
         "last_error": Value::Null,
@@ -1688,13 +1695,17 @@ fn render_task_brief_line(task: &Value) -> CliResult<String> {
         .and_then(|value| value.get("needs_attention_count"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
+    let owner_kind = task
+        .get("owner_kind")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
     let signals = task_status
         .get("signals")
         .and_then(Value::as_array)
         .map(|values| render_string_array(values))
         .unwrap_or_else(|| "-".to_owned());
     let line = format!(
-        "{task_id} status={status_display} blocked={blocked} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={label} approval_attention={approval_attention} signals={signals}"
+        "{task_id} status={status_display} blocked={blocked} state={state} workflow_phase={workflow_phase} delegate_phase={phase} label={label} owner_kind={owner_kind} approval_attention={approval_attention} signals={signals}"
     );
     Ok(line)
 }
@@ -1737,6 +1748,10 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         .unwrap_or("unknown");
     let phase = task
         .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let owner_kind = task
+        .get("owner_kind")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
     let workflow_id = task
@@ -1858,6 +1873,7 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         "workflow_workspace_root: {workflow_workspace_root}"
     ));
     lines.push(format!("phase: {phase}"));
+    lines.push(format!("owner_kind: {owner_kind}"));
     lines.push(format!("timeout_seconds: {timeout_seconds}"));
     lines.push(format!("last_error: {last_error}"));
     lines.push(format!("approval_requests: {approval_total}"));

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -57,37 +57,35 @@ fn unique_runtime_dir(label: &str) -> PathBuf {
     runtime_dir
 }
 
-fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
-    let runtime_root = unique_runtime_dir("headless-config");
-    let config_path = runtime_root.join("loongclaw.toml");
-    let sqlite_path = runtime_root.join("memory.sqlite3");
+fn headless_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
     let mut config = mvp::config::LoongClawConfig::default();
+    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
 
     LoadedSupervisorConfig {
-        resolved_path: config_path,
+        resolved_path: runtime_dir.join("loongclaw.toml"),
         config,
     }
 }
 
-fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
-    let runtime_root = unique_runtime_dir("telegram-config");
-    let config_path = runtime_root.join("loongclaw.toml");
-    let sqlite_path = runtime_root.join("memory.sqlite3");
+fn telegram_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
+    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
     LoadedSupervisorConfig {
-        resolved_path: config_path,
+        resolved_path: runtime_dir.join("loongclaw.toml"),
         config,
     }
 }
 
-fn plugin_backed_loaded_config_fixture() -> LoadedSupervisorConfig {
-    let config = super::mixed_account_weixin_plugin_bridge_config();
+fn plugin_backed_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
+    let mut config = super::mixed_account_weixin_plugin_bridge_config();
+    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
+    config.memory.sqlite_path = sqlite_path.display().to_string();
 
     LoadedSupervisorConfig {
-        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        resolved_path: runtime_dir.join("loongclaw.toml"),
         config,
     }
 }
@@ -151,7 +149,10 @@ async fn wait_for_gateway_control_surface(
 async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request() {
     let runtime_dir = unique_runtime_dir("headless-stop");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -211,7 +212,10 @@ async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request
 async fn gateway_owner_state_rejects_second_active_owner_slot() {
     let runtime_dir = unique_runtime_dir("exclusive-slot");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -241,7 +245,10 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
     .await;
 
     let second_hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -276,7 +283,10 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
 async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request() {
     let runtime_dir = unique_runtime_dir("duplicate-start-pending-stop");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -309,7 +319,10 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
     assert_eq!(stop_result, GatewayStopRequestOutcome::Requested);
 
     let second_hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -349,7 +362,10 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
         telegram_runner,
     )]);
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(telegram_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(telegram_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|options| {
             boxed_cli_result(async move {
@@ -406,7 +422,10 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     let _lock = lock_daemon_test_environment();
     let runtime_dir = unique_runtime_dir("localhost-control");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -681,7 +700,10 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
 async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy() {
     let runtime_dir = unique_runtime_dir("turn-policy-disabled");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -749,7 +771,10 @@ async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy()
 async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stops_runtime() {
     let runtime_dir = unique_runtime_dir("local-client");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -853,7 +878,10 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
 {
     let runtime_dir = unique_runtime_dir("plugin-backed-parity");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new(|_| Ok(plugin_backed_loaded_config_fixture())),
+        load_config: Arc::new({
+            let runtime_dir = runtime_dir.clone();
+            move |_| Ok(plugin_backed_loaded_config_fixture(runtime_dir.as_path()))
+        }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -308,6 +308,10 @@ fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inven
     )
     .expect("active provider profile should be present");
     assert_eq!(active_profile["credential_resolved"], true);
+    assert!(payload["provider"]["transport_runtime"]["http_client_cache_entries"].is_number());
+    assert!(payload["provider"]["transport_runtime"]["http_client_cache_hits"].is_number());
+    assert!(payload["provider"]["transport_runtime"]["http_client_cache_misses"].is_number());
+    assert!(payload["provider"]["transport_runtime"]["built_http_clients"].is_number());
     assert!(array_contains_string(
         &payload["tools"]["visible_tool_names"],
         "external_skills.list"
@@ -590,6 +594,7 @@ fn runtime_snapshot_text_highlights_experiment_relevant_sections() {
     );
     assert!(rendered.contains("runtime snapshot"));
     assert!(rendered.contains("provider active_profile=deepseek-lab"));
+    assert!(rendered.contains("provider transport cache_entries="));
     assert!(rendered.contains("context_engine selected="));
     assert!(rendered.contains("memory selected="));
     assert!(rendered.contains("acp enabled=true"));

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -529,8 +529,12 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
         "status render should surface turn-checkpoint durability: {rendered}"
     );
     assert!(
-        rendered.contains("stage=finalized after_turn=completed compaction=completed"),
+        rendered.contains("stage=finalized after_turn=completed"),
         "status render should surface turn-checkpoint stage detail: {rendered}"
+    );
+    assert!(
+        rendered.contains("compaction=completed"),
+        "status render should surface turn-checkpoint compaction detail: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -269,6 +269,50 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
         },
     )
     .expect("append assistant turn");
+    let prompt_frame_event = json!({
+        "type": "conversation_event",
+        "event": "provider_prompt_frame_snapshot",
+        "payload": {
+            "provider_round": 1,
+            "phase": "initial",
+            "prompt_frame": {
+                "schema_version": 1,
+                "total_estimated_tokens": 42,
+                "stable_runtime_segment_count": 1,
+                "stable_runtime_estimated_tokens": 12,
+                "session_latched_segment_count": 1,
+                "session_latched_estimated_tokens": 8,
+                "advisory_profile_segment_count": 1,
+                "advisory_profile_estimated_tokens": 6,
+                "session_local_recall_segment_count": 1,
+                "session_local_recall_estimated_tokens": 5,
+                "recent_window_segment_count": 1,
+                "recent_window_estimated_tokens": 7,
+                "turn_ephemeral_segment_count": 0,
+                "turn_ephemeral_estimated_tokens": 0,
+                "stable_runtime_hash": "stable-a",
+                "session_latched_hash": "latched-a",
+                "stable_prefix_hash_sha256": "prefix-a",
+                "cached_prefix_sha256": "cached-a",
+                "advisory_profile_hash": "profile-a",
+                "session_local_recall_hash": "recall-a",
+                "recent_window_hash": "window-a",
+                "turn_ephemeral_hash": null
+            }
+        }
+    });
+    let prompt_frame_event =
+        serde_json::to_string(&prompt_frame_event).expect("serialize prompt frame event");
+    mvp::memory::append_turn_direct(
+        "delegate:session-1",
+        "assistant",
+        &prompt_frame_event,
+        &mvp::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(root.path().join("memory.sqlite3")),
+            ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
+        },
+    )
+    .expect("append prompt frame event");
 
     let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
         loongclaw_daemon::sessions_cli::SessionsCommandOptions {
@@ -305,7 +349,15 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
         execution.payload["detail"]["workflow"]["binding"]["worktree"]["worktree_id"],
         "delegate:session-1"
     );
-    assert_eq!(execution.payload["detail"]["session"]["turn_count"], 2);
+    assert_eq!(execution.payload["detail"]["session"]["turn_count"], 3);
+    assert_eq!(
+        execution.payload["detail"]["prompt_frame"]["summary"]["latest_phase"],
+        "initial"
+    );
+    assert_eq!(
+        execution.payload["detail"]["prompt_frame"]["summary"]["latest_total_estimated_tokens"],
+        42
+    );
     let recipes = execution.payload["recipes"]
         .as_array()
         .expect("recipes array");
@@ -367,6 +419,14 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
     assert!(
         rendered.contains("runtime_self_continuity: present"),
         "status render should surface continuity summary: {rendered}"
+    );
+    assert!(
+        rendered.contains("prompt_frame: phase=initial total_tokens=42"),
+        "status render should surface prompt-frame summary: {rendered}"
+    );
+    assert!(
+        rendered.contains("stable_prefix=prefix-a"),
+        "status render should surface prompt-frame stable prefix hash: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -32,6 +32,16 @@ fn append_session_turn(
         .expect("append session turn");
 }
 
+fn append_session_conversation_event(
+    root: &super::tasks_cli::TempDirGuard,
+    session_id: &str,
+    payload: Value,
+) {
+    let serialized_payload =
+        serde_json::to_string(&payload).expect("serialize session conversation event");
+    append_session_turn(root, session_id, "assistant", &serialized_payload);
+}
+
 #[test]
 fn sessions_list_cli_parses_global_flags_after_subcommand() {
     let cli = try_parse_cli([
@@ -301,18 +311,80 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
             }
         }
     });
-    let prompt_frame_event =
-        serde_json::to_string(&prompt_frame_event).expect("serialize prompt frame event");
-    mvp::memory::append_turn_direct(
+    append_session_conversation_event(&root, "delegate:session-1", prompt_frame_event);
+    append_session_conversation_event(
+        &root,
         "delegate:session-1",
-        "assistant",
-        &prompt_frame_event,
-        &mvp::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(root.path().join("memory.sqlite3")),
-            ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
-        },
-    )
-    .expect("append prompt frame event");
+        json!({
+            "type": "conversation_event",
+            "event": "plan_round_started",
+            "payload": {
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 0,
+                    "verify_failures": 0,
+                    "replans_triggered": 0,
+                    "total_attempts_used": 1
+                },
+                "health_signal": {
+                    "severity": "warn",
+                    "flags": ["warmup"]
+                }
+            }
+        }),
+    );
+    append_session_conversation_event(
+        &root,
+        "delegate:session-1",
+        json!({
+            "type": "conversation_event",
+            "event": "final_status",
+            "payload": {
+                "status": "succeeded",
+                "route_decision": "return",
+                "route_reason": "completed",
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 1,
+                    "rounds_failed": 0,
+                    "verify_failures": 0,
+                    "replans_triggered": 0,
+                    "total_attempts_used": 1
+                },
+                "health_signal": {
+                    "severity": "warn",
+                    "flags": ["warmup"]
+                }
+            }
+        }),
+    );
+    append_session_conversation_event(
+        &root,
+        "delegate:session-1",
+        json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalized",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "safe",
+                        "result_kind": "final_text"
+                    },
+                    "finalization": {
+                        "persistence_mode": "success"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "completed"
+                },
+                "failure": null
+            }
+        }),
+    );
 
     let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
         loongclaw_daemon::sessions_cli::SessionsCommandOptions {
@@ -349,7 +421,7 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
         execution.payload["detail"]["workflow"]["binding"]["worktree"]["worktree_id"],
         "delegate:session-1"
     );
-    assert_eq!(execution.payload["detail"]["session"]["turn_count"], 3);
+    assert_eq!(execution.payload["detail"]["session"]["turn_count"], 6);
     assert_eq!(
         execution.payload["detail"]["prompt_frame"]["summary"]["latest_phase"],
         "initial"
@@ -357,6 +429,22 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
     assert_eq!(
         execution.payload["detail"]["prompt_frame"]["summary"]["latest_total_estimated_tokens"],
         42
+    );
+    assert_eq!(
+        execution.payload["detail"]["safe_lane"]["summary"]["final_status"],
+        "succeeded"
+    );
+    assert_eq!(
+        execution.payload["detail"]["safe_lane"]["summary"]["round_started_events"],
+        1
+    );
+    assert_eq!(
+        execution.payload["detail"]["turn_checkpoint"]["summary"]["session_state"],
+        "finalized"
+    );
+    assert_eq!(
+        execution.payload["detail"]["turn_checkpoint"]["summary"]["checkpoint_durable"],
+        true
     );
     let recipes = execution.payload["recipes"]
         .as_array()
@@ -427,6 +515,22 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
     assert!(
         rendered.contains("stable_prefix=prefix-a"),
         "status render should surface prompt-frame stable prefix hash: {rendered}"
+    );
+    assert!(
+        rendered.contains("safe_lane: status=succeeded rounds_started=1"),
+        "status render should surface safe-lane summary: {rendered}"
+    );
+    assert!(
+        rendered.contains("health=warn"),
+        "status render should surface safe-lane health: {rendered}"
+    );
+    assert!(
+        rendered.contains("turn_checkpoint: session_state=finalized durable=yes"),
+        "status render should surface turn-checkpoint durability: {rendered}"
+    );
+    assert!(
+        rendered.contains("stage=finalized after_turn=completed compaction=completed"),
+        "status render should surface turn-checkpoint stage detail: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -313,6 +313,12 @@ fn append_tasks_session_turn(config_path: &Path, session_id: &str, role: &str, c
         .expect("append tasks session turn");
 }
 
+fn append_tasks_conversation_event(config_path: &Path, session_id: &str, payload: Value) {
+    let serialized_payload =
+        serde_json::to_string(&payload).expect("serialize tasks conversation event");
+    append_tasks_session_turn(config_path, session_id, "assistant", &serialized_payload);
+}
+
 fn open_tasks_test_connection(config_path: &Path) -> Connection {
     let loaded =
         mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
@@ -588,13 +594,127 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
             }
         }
     });
-    let prompt_frame_event =
-        serde_json::to_string(&prompt_frame_event).expect("serialize prompt frame event");
-    append_tasks_session_turn(
+    append_tasks_conversation_event(&config_path, "delegate:task-1", prompt_frame_event);
+    append_tasks_conversation_event(
         &config_path,
         "delegate:task-1",
-        "assistant",
-        &prompt_frame_event,
+        json!({
+            "type": "conversation_event",
+            "event": "plan_round_started",
+            "payload": {
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 0,
+                    "verify_failures": 0,
+                    "replans_triggered": 0,
+                    "total_attempts_used": 1
+                },
+                "health_signal": {
+                    "severity": "warn",
+                    "flags": ["warmup"]
+                }
+            }
+        }),
+    );
+    append_tasks_conversation_event(
+        &config_path,
+        "delegate:task-1",
+        json!({
+            "type": "conversation_event",
+            "event": "verify_failed",
+            "payload": {
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 0,
+                    "verify_failures": 1,
+                    "replans_triggered": 0,
+                    "total_attempts_used": 1
+                },
+                "health_signal": {
+                    "severity": "critical",
+                    "flags": ["verify"]
+                }
+            }
+        }),
+    );
+    append_tasks_conversation_event(
+        &config_path,
+        "delegate:task-1",
+        json!({
+            "type": "conversation_event",
+            "event": "replan_triggered",
+            "payload": {
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 0,
+                    "verify_failures": 1,
+                    "replans_triggered": 1,
+                    "total_attempts_used": 1
+                },
+                "health_signal": {
+                    "severity": "critical",
+                    "flags": ["verify"]
+                }
+            }
+        }),
+    );
+    append_tasks_conversation_event(
+        &config_path,
+        "delegate:task-1",
+        json!({
+            "type": "conversation_event",
+            "event": "final_status",
+            "payload": {
+                "status": "failed",
+                "failure_code": "safe_lane_backpressure_limit",
+                "route_decision": "terminal",
+                "route_reason": "session_governor_failed_threshold",
+                "metrics": {
+                    "rounds_started": 1,
+                    "rounds_succeeded": 0,
+                    "rounds_failed": 1,
+                    "verify_failures": 1,
+                    "replans_triggered": 1,
+                    "total_attempts_used": 2
+                },
+                "health_signal": {
+                    "severity": "critical",
+                    "flags": ["verify"]
+                }
+            }
+        }),
+    );
+    append_tasks_conversation_event(
+        &config_path,
+        "delegate:task-1",
+        json!({
+            "type": "conversation_event",
+            "event": "turn_checkpoint",
+            "payload": {
+                "schema_version": 1,
+                "stage": "finalization_failed",
+                "checkpoint": {
+                    "lane": {
+                        "lane": "safe",
+                        "result_kind": "tool_call"
+                    },
+                    "finalization": {
+                        "persistence_mode": "inline_provider_error"
+                    }
+                },
+                "finalization_progress": {
+                    "after_turn": "completed",
+                    "compaction": "failed"
+                },
+                "failure": {
+                    "step": "compaction",
+                    "error": "compact failure"
+                }
+            }
+        }),
     );
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -650,6 +770,26 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
         execution.payload["task"]["prompt_frame"]["summary"]["latest_total_estimated_tokens"],
         64
     );
+    assert_eq!(
+        execution.payload["task"]["safe_lane"]["summary"]["final_status"],
+        "failed"
+    );
+    assert_eq!(
+        execution.payload["task"]["safe_lane"]["summary"]["verify_failed_events"],
+        1
+    );
+    assert_eq!(
+        execution.payload["task"]["safe_lane"]["summary"]["replan_triggered_events"],
+        1
+    );
+    assert_eq!(
+        execution.payload["task"]["turn_checkpoint"]["summary"]["session_state"],
+        "finalization_failed"
+    );
+    assert_eq!(
+        execution.payload["task"]["turn_checkpoint"]["summary"]["requires_recovery"],
+        true
+    );
 
     let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
         .expect("render tasks status");
@@ -688,6 +828,26 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
     assert!(
         rendered.contains("stable_prefix=prefix-task"),
         "status render should surface prompt-frame stable prefix: {rendered}"
+    );
+    assert!(
+        rendered.contains("safe_lane: status=failed rounds_started=1 verify_failed=1 replans=1"),
+        "status render should surface safe-lane summary: {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "failure_code=safe_lane_backpressure_limit route=terminal/session_governor_failed_threshold health=critical"
+        ),
+        "status render should surface safe-lane failure context: {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "turn_checkpoint: session_state=finalization_failed durable=yes reply_durable=yes requires_recovery=yes"
+        ),
+        "status render should surface turn-checkpoint recovery context: {rendered}"
+    );
+    assert!(
+        rendered.contains("stage=finalization_failed after_turn=completed compaction=failed"),
+        "status render should surface turn-checkpoint stage detail: {rendered}"
     );
 }
 
@@ -1097,6 +1257,119 @@ async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
     assert!(
         rendered.contains("task_next_action: resolve_request"),
         "wait render should surface next action: {rendered}"
+    );
+}
+
+#[test]
+fn render_tasks_status_text_escapes_control_characters() {
+    let execution = loongclaw_daemon::tasks_cli::TasksCommandExecution {
+        resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+        current_session_id: "ops-root".to_owned(),
+        payload: json!({
+            "command": "status",
+            "task": {
+                "task_id": "delegate:\u{1b}[31mchild",
+                "scope_session_id": "ops-root\nnext",
+                "label": "line1\nline2",
+                "session_state": "running",
+                "phase": "queued",
+                "owner_kind": "background_task_host",
+                "timeout_seconds": 60,
+                "last_error": "boom\u{1b}[0m",
+                "approval": {
+                    "matched_count": 1,
+                    "attention_summary": {
+                        "needs_attention_count": 1
+                    }
+                },
+                "tool_policy": {
+                    "effective_tool_ids": ["file.read\nnext"],
+                    "effective_runtime_narrowing": {
+                        "allow": "line1\nline2"
+                    }
+                },
+                "prompt_frame": {
+                    "available": false,
+                    "error": "prompt\nmissing"
+                },
+                "safe_lane": {
+                    "available": false,
+                    "error": "lane\nmissing"
+                },
+                "turn_checkpoint": {
+                    "available": false,
+                    "error": "checkpoint\nmissing"
+                }
+            }
+        }),
+    };
+
+    let rendered =
+        loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution).expect("render tasks");
+
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "rendered status should not contain raw escape characters: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("scope_session_id: ops-root\\nnext"),
+        "expected escaped scope session id: {rendered}"
+    );
+    assert!(
+        rendered.contains("label: line1\\nline2"),
+        "expected escaped label: {rendered}"
+    );
+    assert!(
+        rendered.contains("last_error: boom\\u{1b}[0m"),
+        "expected escaped last_error: {rendered}"
+    );
+    assert!(
+        rendered.contains("prompt_frame: unavailable error=prompt\\nmissing"),
+        "expected escaped prompt-frame error: {rendered}"
+    );
+    assert!(
+        rendered.contains("safe_lane: unavailable error=lane\\nmissing"),
+        "expected escaped safe-lane error: {rendered}"
+    );
+    assert!(
+        rendered.contains("turn_checkpoint: unavailable error=checkpoint\\nmissing"),
+        "expected escaped turn-checkpoint error: {rendered}"
+    );
+}
+
+#[test]
+fn render_tasks_events_text_escapes_control_characters() {
+    let execution = loongclaw_daemon::tasks_cli::TasksCommandExecution {
+        resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+        current_session_id: "ops-root".to_owned(),
+        payload: json!({
+            "command": "events",
+            "task_id": "delegate:\u{1b}[31mchild",
+            "next_after_id": 7,
+            "events": [
+                {
+                    "id": 1,
+                    "event_kind": "delegate_queued\nnext",
+                    "ts": 123
+                }
+            ]
+        }),
+    };
+
+    let rendered =
+        loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution).expect("render events");
+
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "rendered events should not contain raw escape characters: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("events for `delegate:\\u{1b}[31mchild`"),
+        "expected escaped task id: {rendered}"
+    );
+    assert!(
+        rendered.contains("- #1 delegate_queued\\nnext ts=123"),
+        "expected escaped event kind: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -675,6 +675,10 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
     assert_eq!(execution.payload["task"]["label"], "Release Check");
     assert_eq!(execution.payload["task"]["timeout_seconds"], 45);
     assert_eq!(
+        execution.payload["task"]["owner_kind"],
+        "background_task_host"
+    );
+    assert_eq!(
         execution.payload["task"]["session"]["kind"],
         "delegate_child"
     );
@@ -729,6 +733,13 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
     assert_eq!(
         child_session.kind,
         mvp::session::repository::SessionKind::DelegateChild
+    );
+
+    let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
+        .expect("render tasks create");
+    assert!(
+        rendered.contains("owner_kind: background_task_host"),
+        "tasks create render should surface owner kind: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -556,6 +556,46 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
     let _env = TasksCliEnvironmentGuard::set(&[]);
     let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
+    let prompt_frame_event = json!({
+        "type": "conversation_event",
+        "event": "provider_prompt_frame_snapshot",
+        "payload": {
+            "provider_round": 1,
+            "phase": "initial",
+            "prompt_frame": {
+                "schema_version": 1,
+                "total_estimated_tokens": 64,
+                "stable_runtime_segment_count": 1,
+                "stable_runtime_estimated_tokens": 12,
+                "session_latched_segment_count": 1,
+                "session_latched_estimated_tokens": 8,
+                "advisory_profile_segment_count": 1,
+                "advisory_profile_estimated_tokens": 6,
+                "session_local_recall_segment_count": 1,
+                "session_local_recall_estimated_tokens": 5,
+                "recent_window_segment_count": 1,
+                "recent_window_estimated_tokens": 7,
+                "turn_ephemeral_segment_count": 0,
+                "turn_ephemeral_estimated_tokens": 0,
+                "stable_runtime_hash": "stable-a",
+                "session_latched_hash": "latched-a",
+                "stable_prefix_hash_sha256": "prefix-task",
+                "cached_prefix_sha256": "cached-task",
+                "advisory_profile_hash": "profile-a",
+                "session_local_recall_hash": "recall-a",
+                "recent_window_hash": "window-a",
+                "turn_ephemeral_hash": null
+            }
+        }
+    });
+    let prompt_frame_event =
+        serde_json::to_string(&prompt_frame_event).expect("serialize prompt frame event");
+    append_tasks_session_turn(
+        &config_path,
+        "delegate:task-1",
+        "assistant",
+        &prompt_frame_event,
+    );
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
         loongclaw_daemon::tasks_cli::TasksCommandOptions {
@@ -602,6 +642,14 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
         execution.payload["task"]["tool_policy"]["effective_tool_ids"][0],
         "file.read"
     );
+    assert_eq!(
+        execution.payload["task"]["prompt_frame"]["summary"]["latest_phase"],
+        "initial"
+    );
+    assert_eq!(
+        execution.payload["task"]["prompt_frame"]["summary"]["latest_total_estimated_tokens"],
+        64
+    );
 
     let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
         .expect("render tasks status");
@@ -632,6 +680,14 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
     assert!(
         rendered.contains("effective_tool_ids: file.read"),
         "status render should surface effective tool ids: {rendered}"
+    );
+    assert!(
+        rendered.contains("prompt_frame: phase=initial total_tokens=64"),
+        "status render should surface prompt-frame summary: {rendered}"
+    );
+    assert!(
+        rendered.contains("stable_prefix=prefix-task"),
+        "status render should surface prompt-frame stable prefix: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -834,20 +834,28 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
         "status render should surface safe-lane summary: {rendered}"
     );
     assert!(
-        rendered.contains(
-            "failure_code=safe_lane_backpressure_limit route=terminal/session_governor_failed_threshold health=critical"
-        ),
-        "status render should surface safe-lane failure context: {rendered}"
+        rendered.contains("failure_code=safe_lane_backpressure_limit"),
+        "status render should surface safe-lane failure code: {rendered}"
     );
     assert!(
-        rendered.contains(
-            "turn_checkpoint: session_state=finalization_failed durable=yes reply_durable=yes requires_recovery=yes"
-        ),
+        rendered.contains("route=terminal/session_governor_failed_threshold health=critical"),
+        "status render should surface safe-lane failure route and health: {rendered}"
+    );
+    assert!(
+        rendered.contains("turn_checkpoint: session_state=finalization_failed durable=yes"),
         "status render should surface turn-checkpoint recovery context: {rendered}"
     );
     assert!(
-        rendered.contains("stage=finalization_failed after_turn=completed compaction=failed"),
-        "status render should surface turn-checkpoint stage detail: {rendered}"
+        rendered.contains("reply_durable=yes requires_recovery=yes"),
+        "status render should surface turn-checkpoint recovery flags: {rendered}"
+    );
+    assert!(
+        rendered.contains("stage=finalization_failed"),
+        "status render should surface turn-checkpoint stage: {rendered}"
+    );
+    assert!(
+        rendered.contains("after_turn=completed compaction=failed"),
+        "status render should surface turn-checkpoint progress detail: {rendered}"
     );
 }
 

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -991,6 +991,12 @@ async fn execute_tasks_command_create_returns_queued_outcome_when_task_hydration
     assert_eq!(execution.payload["command"], "create");
     assert_eq!(execution.payload["task"]["task_id"], queued_task_id);
     assert_eq!(execution.payload["task"]["scope_session_id"], "ops-root");
+    assert!(execution.payload["task"]["session"].is_null());
+    assert!(execution.payload["task"]["delegate"].is_null());
+    assert_eq!(execution.payload["task"]["recent_events"], json!([]));
+    assert!(execution.payload["task"]["prompt_frame"].is_null());
+    assert!(execution.payload["task"]["safe_lane"].is_null());
+    assert!(execution.payload["task"]["turn_checkpoint"].is_null());
     assert!(
         execution.payload["task_lookup_error"]
             .as_str()
@@ -1282,12 +1288,14 @@ fn render_tasks_status_text_escapes_control_characters() {
                         "needs_attention_count": 1
                     }
                 },
+                "approval_lookup_error": "approval\nmissing",
                 "tool_policy": {
                     "effective_tool_ids": ["file.read\nnext"],
                     "effective_runtime_narrowing": {
                         "allow": "line1\nline2"
                     }
                 },
+                "tool_policy_lookup_error": "policy\nmissing",
                 "prompt_frame": {
                     "available": false,
                     "error": "prompt\nmissing"
@@ -1334,6 +1342,14 @@ fn render_tasks_status_text_escapes_control_characters() {
     assert!(
         rendered.contains("turn_checkpoint: unavailable error=checkpoint\\nmissing"),
         "expected escaped turn-checkpoint error: {rendered}"
+    );
+    assert!(
+        rendered.contains("approval_lookup_error: approval\\nmissing"),
+        "expected escaped approval lookup error: {rendered}"
+    );
+    assert!(
+        rendered.contains("tool_policy_lookup_error: policy\\nmissing"),
+        "expected escaped tool-policy lookup error: {rendered}"
     );
 }
 

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-17T06:12:36Z
+- Generated at: 2026-04-17T06:18:46Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -33,23 +33,23 @@ release review. It is not part of the primary public release trail.
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3515 | 3600 | 85 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 1.7% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3576 | 3700 | 124 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.8% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 411 | 1000 | 589 | 12 | 20 | 8 | 60.0% | HEALTHY | 375 | 9.6% | PASS | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 416 | 1000 | 584 | 13 | 20 | 7 | 65.0% | HEALTHY | 375 | 10.9% | BREACH | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH | 3383 | -8.5% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10123 | 10500 | 377 | 78 | 90 | 12 | 96.4% | TIGHT | 9922 | 2.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8919 | 9800 | 881 | 17 | 90 | 73 | 91.0% | WATCH | 9796 | -9.0% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6725 | 7300 | 575 | 95 | 160 | 65 | 92.1% | WATCH | 6936 | -3.0% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6751 | 7300 | 549 | 95 | 160 | 65 | 92.5% | WATCH | 6936 | -2.7% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2113 | 6400 | 4287 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.8% | BREACH | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9977 | 11200 | 1223 | 61 | 120 | 59 | 89.1% | WATCH | 10831 | -7.9% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9988 | 11200 | 1212 | 61 | 120 | 59 | 89.2% | WATCH | 10831 | -7.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14430 | 15000 | 570 | 45 | 70 | 25 | 96.2% | TIGHT | 14472 | -0.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5972 | 6500 | 528 | 178 | 210 | 32 | 91.9% | WATCH | 6324 | -5.6% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5955 | 6500 | 545 | 178 | 210 | 32 | 91.6% | WATCH | 6324 | -5.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9238 | 9800 | 562 | 206 | 250 | 44 | 94.3% | WATCH | 9519 | -3.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), channel_registry (96.4%), tools_mod (96.2%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_config (91.0%), chat_runtime (92.1%), turn_coordinator (89.1%), daemon_lib (91.9%), onboard_cli (94.3%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_config (91.0%), chat_runtime (92.5%), turn_coordinator (89.2%), daemon_lib (91.6%), onboard_cli (94.3%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -87,17 +87,17 @@ release review. It is not part of the primary public release trail.
 
 <!-- arch-hotspot key=spec_runtime lines=3515 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3576 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=411 functions=12 -->
+<!-- arch-hotspot key=provider_mod lines=416 functions=13 -->
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3096 functions=0 -->
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
 <!-- arch-hotspot key=channel_registry lines=10123 functions=78 -->
 <!-- arch-hotspot key=channel_config lines=8919 functions=17 -->
-<!-- arch-hotspot key=chat_runtime lines=6725 functions=95 -->
+<!-- arch-hotspot key=chat_runtime lines=6751 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2113 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=9977 functions=61 -->
+<!-- arch-hotspot key=turn_coordinator lines=9988 functions=61 -->
 <!-- arch-hotspot key=tools_mod lines=14430 functions=45 -->
-<!-- arch-hotspot key=daemon_lib lines=5972 functions=178 -->
+<!-- arch-hotspot key=daemon_lib lines=5955 functions=178 -->
 <!-- arch-hotspot key=onboard_cli lines=9238 functions=206 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: `loong tasks` owned a bespoke `DetachedTasksRuntime` that reimplemented the full `ConversationRuntime` trait only to swap the background-task spawner.
- Why it matters: this duplicated runtime bootstrap behavior, increased drift risk, and made it easier for runtime-owned surfaces to fork their own private wrappers instead of sharing one truth-preserving seam.
- What changed: introduced a reusable `HostedConversationRuntime<R>` wrapper in the conversation runtime layer, delegated the full runtime trait through it, exposed explicit async/background spawner overrides, and switched tasks CLI to the shared wrapper.
- What did not change (scope boundary): no task semantics change, no runtime caching, no persistent `AgentRuntimeHost` yet.

## Linked Issues

- Closes #1192
- Related #1189

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy -p loongclaw-app -p loongclaw --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app hosted_runtime --lib -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw --test integration execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes -- --nocapture
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
./scripts/check_architecture_boundaries.sh
./scripts/check_dep_graph.sh
```

## User-visible / Operator-visible Changes

- No user-facing command behavior change is intended; this is a runtime-foundation refactor that keeps task create behavior stable while reducing wrapper drift.

## Failure Recovery

- Fast rollback or disable path: revert this PR.
- Observable failure symptoms reviewers should watch for: `loong tasks create` no longer queuing detached background work, or background-task spawner overrides silently not taking effect.

## Reviewer Focus

- `crates/app/src/conversation/runtime.rs`: hosted wrapper delegation and override precedence.
- `crates/daemon/src/tasks_cli.rs`: replacement of the bespoke runtime wrapper with the shared host wrapper.
- `crates/app/src/conversation/runtime.rs` tests: regression coverage for override semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now include an owner_kind field surfaced in JSON and CLI output.
  * Live chat now shows first-token latency (ttft) in status and previews.

* **Refactor**
  * Conversation runtime loading and spawner configuration made pluggable so task/background spawners can be overridden without altering core behavior.
  * Introduced a hosted runtime wrapper to host optional spawner overrides.

* **Tests**
  * Expanded tests for spawner overrides, owner_kind propagation, and latency rendering.

* **Performance**
  * HTTP client construction now reuses cached clients to reduce allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->