### PR TITLE
docs: define plugin marketplace and sdk boundary contracts

### DIFF
--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -12,6 +12,7 @@ Catalog of design documents and architectural decisions.
 | [Governance Simplification Classification](governance-simplification-classification.md) | Classifies governance surfaces as structural, transitional, cleanup-safe, or replacement-first | Active |
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
 | [Plugin Package Manifest Contract](plugin-package-manifest-contract.md) | Manifest-first plugin metadata, setup surface, and slot ownership contract | Active |
+| [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md) | Native SDK layering, marketplace boundaries, migration lanes, and ecosystem maturity model | Active |
 | [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md) | Foreign dialect normalization, compatibility-mode gating, and polyglot plugin strategy | Active |
 | [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |
 | [Reference Runtime Comparison](reference-runtime-comparison.md) | Productization gap analysis and convergence order for tasks, skills, and memory | Active |

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -13,6 +13,7 @@ Catalog of design documents and architectural decisions.
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
 | [Plugin Package Manifest Contract](plugin-package-manifest-contract.md) | Manifest-first plugin metadata, setup surface, and slot ownership contract | Active |
 | [Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md) | Catalog listing, install/auth policy, interface metadata, and marketplace/package precedence rules | Active |
+| [Plugin SDK Boundary Contract](plugin-sdk-boundary-contract.md) | Contract/runtime/compatibility SDK layering and host-extension boundary rules | Active |
 | [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md) | Native SDK layering, marketplace boundaries, migration lanes, and ecosystem maturity model | Active |
 | [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md) | Foreign dialect normalization, compatibility-mode gating, and polyglot plugin strategy | Active |
 | [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -12,6 +12,7 @@ Catalog of design documents and architectural decisions.
 | [Governance Simplification Classification](governance-simplification-classification.md) | Classifies governance surfaces as structural, transitional, cleanup-safe, or replacement-first | Active |
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
 | [Plugin Package Manifest Contract](plugin-package-manifest-contract.md) | Manifest-first plugin metadata, setup surface, and slot ownership contract | Active |
+| [Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md) | Catalog listing, install/auth policy, interface metadata, and marketplace/package precedence rules | Active |
 | [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md) | Native SDK layering, marketplace boundaries, migration lanes, and ecosystem maturity model | Active |
 | [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md) | Foreign dialect normalization, compatibility-mode gating, and polyglot plugin strategy | Active |
 | [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |

--- a/docs/design-docs/openclaw-plugin-compatibility-contract.md
+++ b/docs/design-docs/openclaw-plugin-compatibility-contract.md
@@ -484,7 +484,8 @@ It should not require a new execution architecture.
 
 Examples of future growth:
 
-- marketplace importers for third-party plugin registries
+- marketplace importers for third-party plugin registries, aligned with the
+  [Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md)
 - richer shim families for OpenClaw modern and legacy packages
 - signed compatibility bundles
 - dialect-specific migration CLIs that emit native `loongclaw.plugin.json`

--- a/docs/design-docs/openclaw-plugin-compatibility-contract.md
+++ b/docs/design-docs/openclaw-plugin-compatibility-contract.md
@@ -465,6 +465,10 @@ That gives LoongClaw a controlled migration path:
 - explicit by activation
 - conservative by runtime default
 
+The complementary [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md)
+document defines how marketplace packaging, SDK layering, and migration tooling
+should grow on top of this compatibility seam without widening the kernel.
+
 ## Future Extensions
 
 This model generalizes cleanly to other ecosystems.

--- a/docs/design-docs/plugin-marketplace-contract.md
+++ b/docs/design-docs/plugin-marketplace-contract.md
@@ -392,7 +392,9 @@ LoongClaw is governance-heavy.
 Some listings may be valid and curated while still requiring explicit operator
 consent before installation.
 That nuance should live in the marketplace contract instead of being treated as
-an implementation detail.
+an implementation detail. Marketplace install policy, review status, or
+default-bundle placement never grants eligibility for the native host-extension
+ABI lane; that lane requires separate host approval for native packages.
 
 ## Authentication Policy Vocabulary
 

--- a/docs/design-docs/plugin-marketplace-contract.md
+++ b/docs/design-docs/plugin-marketplace-contract.md
@@ -1,0 +1,658 @@
+# Plugin Marketplace And Interface Contract
+
+## Purpose
+
+LoongClaw already has the lower layers of a governed plugin system:
+
+- package identity and setup through the plugin package manifest contract
+- foreign-dialect normalization through the OpenClaw compatibility contract
+- activation and governance truth through preflight, bridge policy, and
+  attestation
+
+What it still lacks is a first-class contract for the layer above those
+runtime-bound truths:
+
+- catalog listing
+- install policy
+- authentication timing
+- interface metadata
+- distribution provenance
+- imported registry and marketplace views
+
+This document defines that missing marketplace layer.
+
+It complements, rather than replaces:
+
+- [Plugin Package Manifest Contract](plugin-package-manifest-contract.md)
+- [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md)
+- [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md)
+
+Those documents define package truth, compatibility truth, and SDK layering.
+This document defines how packages are listed, presented, installed, and
+curated without turning marketplace metadata into a second activation authority.
+
+## Why This Contract Exists
+
+The current architecture already talks about marketplace workflows in multiple
+places:
+
+- `plugin_preflight` has a `marketplace_submission` profile
+- package and compatibility docs refer to future registry, importer, and
+  marketplace tooling
+- the SDK strategy now explicitly calls for a separate marketplace and
+  interface contract
+
+Without a dedicated contract, those higher-level concerns are at risk of
+splitting into parallel metadata models:
+
+- one shape for package authors
+- one shape for CI and preflight tools
+- one shape for curated catalogs
+- one shape for future install UX
+
+That drift would create the exact kind of slop debt the plugin package contract
+was written to avoid.
+
+The marketplace layer therefore needs its own typed contract, but it must stay
+strictly above package and activation truth.
+
+## Core Principle
+
+Marketplace metadata describes packages.
+It does not authorize packages.
+
+The marketplace layer may answer questions such as:
+
+- how should this package be displayed?
+- where can it be obtained from?
+- should it be installable by default or by explicit operator action?
+- when is additional authentication expected?
+- what curated category or trust tier should the listing advertise?
+
+The marketplace layer must not answer questions such as:
+
+- may this host activate the package right now?
+- which compatibility mode is actually approved at runtime?
+- which bridge profile is currently in force?
+- whether a listing can bypass manifest, preflight, or attestation checks?
+
+Those remain package, compatibility, and host-governance questions.
+
+## Design Goal
+
+LoongClaw should support a marketplace layer that is:
+
+- descriptive instead of authority-bearing
+- native-first but foreign-package-aware
+- portable across local files, curated catalogs, and future remote registries
+- compositional for skills, MCP servers, apps, and interface assets
+- aligned with `plugin_preflight` and future marketplace submission workflows
+
+It should not:
+
+- duplicate package-manifest truth
+- silently widen activation privileges
+- hide compatibility or setup blockers behind optimistic catalog entries
+- force package authors and catalog operators into unrelated metadata models
+
+## Contract Scope
+
+This contract covers four things:
+
+1. the marketplace catalog root shape
+2. the plugin listing entry shape
+3. the interface metadata shape for display and discovery
+4. the install and authentication policy vocabulary
+
+It does not define:
+
+- package runtime execution
+- host bridge implementation
+- package manifest parsing
+- signature verification mechanics in detail
+- registry transport or network protocol
+
+Those concerns are separate layers.
+
+## Recommended Artifact Shape
+
+The marketplace contract should be serializable as a standalone file.
+
+Recommended filename:
+
+- `loongclaw.marketplace.json`
+
+Recommended behavior:
+
+- hosts may store or fetch catalogs through other mechanisms
+- `loongclaw.marketplace.json` is the canonical serialized contract shape
+- alternative transport layers should preserve the same typed fields instead of
+  inventing a different wire schema
+
+That keeps local curated catalogs, exported snapshots, and future remote
+registries aligned on one contract.
+
+## Contract Layers
+
+### 1. Marketplace Catalog Root
+
+A catalog root should describe the marketplace itself.
+
+Minimum responsibilities:
+
+- identify the catalog
+- describe catalog provenance
+- define optional display metadata for the marketplace
+- carry the ordered listing set
+
+Recommended root fields:
+
+- `api_version`
+- `marketplace_id`
+- `display_name`
+- `description`
+- `provenance`
+- `plugins`
+
+### 2. Plugin Listing Entry
+
+A listing entry should describe one package as it appears in a marketplace.
+
+Minimum responsibilities:
+
+- identify which package is being listed
+- identify where the package can be obtained
+- define install policy
+- define authentication timing expectations
+- provide display-layer metadata
+- carry descriptive trust and compatibility hints
+
+Recommended listing fields:
+
+- `plugin_id`
+- `source`
+- `install_policy`
+- `auth_policy`
+- `interface`
+- `trust`
+- `compatibility`
+- `bundle`
+
+### 3. Interface Metadata Layer
+
+Interface metadata is for display, discovery, and user guidance.
+
+It should cover:
+
+- display name
+- summaries and long description
+- category and capability tags
+- website, privacy, and terms links
+- logo, icon, and screenshots
+- starter prompts or example tasks
+
+This metadata may be curated or overridden by the marketplace, but only at the
+interface layer. Package manifests remain the source of baseline package-authored
+display metadata. Marketplace interface data is a listing-scoped overlay and
+must not feed back into package normalization, preflight, activation, or
+attestation truth.
+
+### 4. Policy Overlay Layer
+
+Marketplace policy is intentionally narrower than runtime policy.
+
+It may define:
+
+- installability
+- authentication timing
+- curation or review tier
+- product or host gating for listing visibility
+
+It must not define:
+
+- activation approval
+- capability grants
+- bridge profile overrides
+- package-trust bypasses
+
+## Root Contract Shape
+
+A marketplace root should be typed and strict enough for tooling.
+
+Illustrative shape:
+
+```json
+{
+  "api_version": "v1alpha1",
+  "marketplace_id": "loongclaw-curated",
+  "display_name": "LoongClaw Curated",
+  "description": "Reviewed plugin listings for governed local hosts.",
+  "provenance": {
+    "publisher": "loongclaw-ai",
+    "source": "curated-catalog",
+    "url": "https://example.invalid/marketplace/loongclaw-curated"
+  },
+  "plugins": []
+}
+```
+
+### Root field intent
+
+- `api_version`
+  - schema contract for the catalog itself
+- `marketplace_id`
+  - stable machine-facing identifier for the catalog
+- `display_name`
+  - user-facing marketplace title
+- `description`
+  - optional summary of the catalog's purpose and curation posture
+- `provenance`
+  - who publishes or curates the catalog and where it came from
+- `plugins`
+  - ordered listing entries
+
+## Plugin Listing Contract Shape
+
+Illustrative shape:
+
+```json
+{
+  "plugin_id": "gmail-sync",
+  "source": {
+    "kind": "git_ref",
+    "url": "https://github.com/example/gmail-sync",
+    "ref": "v0.4.2"
+  },
+  "install_policy": "operator_install",
+  "auth_policy": "on_first_use",
+  "interface": {
+    "display_name": "Gmail Sync",
+    "short_description": "Search and act on Gmail data through governed tools.",
+    "category": "Productivity",
+    "capabilities": ["Read", "Search"],
+    "starter_prompts": [
+      "Summarize my unread mail.",
+      "List threads from the last 24 hours."
+    ]
+  },
+  "trust": {
+    "review_tier": "reviewed",
+    "publisher": "example"
+  },
+  "compatibility": {
+    "declared_dialect": "loongclaw_package_manifest",
+    "preferred_preflight_profile": "marketplace_submission"
+  },
+  "bundle": {
+    "skills": true,
+    "mcp_servers": true,
+    "apps": false
+  }
+}
+```
+
+This is intentionally an illustrative contract, not a full implementation dump.
+The important thing is the boundary between package truth and listing truth.
+
+## Source Descriptor Contract
+
+The source descriptor identifies where the package comes from.
+
+It should be narrow and typed.
+
+Recommended initial source kinds:
+
+- `local_path`
+- `git_ref`
+- `archive`
+- `registry_package`
+
+### Why keep source kinds narrow
+
+The marketplace contract should identify package origin without embedding a full
+package manager inside the catalog schema.
+
+That means:
+
+- enough data to locate the package
+- enough data to attach provenance and integrity metadata later
+- no attempt to encode all transport-specific installation logic into the root
+  schema
+
+### Illustrative source shapes
+
+Local path:
+
+```json
+{
+  "kind": "local_path",
+  "path": "./plugins/gmail-sync"
+}
+```
+
+Git ref:
+
+```json
+{
+  "kind": "git_ref",
+  "url": "https://github.com/example/gmail-sync",
+  "ref": "v0.4.2"
+}
+```
+
+Archive:
+
+```json
+{
+  "kind": "archive",
+  "url": "https://example.invalid/releases/gmail-sync-v0.4.2.tar.gz",
+  "sha256": "..."
+}
+```
+
+Registry package:
+
+```json
+{
+  "kind": "registry_package",
+  "registry": "loongclaw-registry",
+  "package": "gmail-sync",
+  "version": "0.4.2"
+}
+```
+
+## Install Policy Vocabulary
+
+Install policy should answer one question only:
+
+- how does this listing expect installation to happen?
+
+Recommended initial values:
+
+- `not_installable`
+- `operator_install`
+- `available`
+- `installed_by_default`
+
+### Semantics
+
+- `not_installable`
+  - listed for awareness or migration context only
+  - the catalog does not permit normal installation from this entry
+- `operator_install`
+  - installation is possible, but only through explicit operator action
+- `available`
+  - installable through the normal product/operator path
+- `installed_by_default`
+  - intended to land as part of a default bundle or curated baseline
+
+### Why both `operator_install` and `available`
+
+LoongClaw is governance-heavy.
+Some listings may be valid and curated while still requiring explicit operator
+consent before installation.
+That nuance should live in the marketplace contract instead of being treated as
+an implementation detail.
+
+## Authentication Policy Vocabulary
+
+Authentication policy should answer:
+
+- when does the listing expect user or operator authentication to matter?
+
+Recommended initial values:
+
+- `none`
+- `on_install`
+- `on_first_use`
+
+### Semantics
+
+- `none`
+  - no extra authentication is expected for normal package use
+- `on_install`
+  - installation should guide the operator through setup or auth immediately
+- `on_first_use`
+  - installation may remain lightweight, but real use should trigger setup or
+    auth guidance before execution
+
+This is intentionally smaller than a full auth state machine.
+Detailed setup remains package-manifest and onboarding territory.
+
+## Interface Metadata Contract
+
+Interface metadata should be strict enough for product and marketplace tooling.
+
+Recommended fields:
+
+- `display_name`
+- `short_description`
+- `long_description`
+- `developer_name`
+- `category`
+- `capabilities`
+- `website_url`
+- `privacy_policy_url`
+- `terms_of_service_url`
+- `brand_color`
+- `icon`
+- `logo`
+- `screenshots`
+- `starter_prompts`
+
+### Why allow marketplace-level interface metadata
+
+A package manifest may remain intentionally runtime-focused.
+A curated catalog may still need:
+
+- better summaries
+- translated display copy
+- category normalization
+- operator-facing install notes
+
+That is acceptable as long as:
+
+- the marketplace layer only changes display and listing semantics
+- runtime identity and activation truth still come from the package contract
+
+## Bundle Composition Contract
+
+A listing should be able to advertise which product surfaces the package
+contributes to.
+
+Recommended initial fields:
+
+- `skills`
+- `mcp_servers`
+- `apps`
+
+These may be booleans or summary counts in an implementation-specific shape,
+provided the semantics remain descriptive.
+
+### Why this matters
+
+Codex's strongest packaging lesson is that plugins are often bundles of product
+surfaces, not only executable extensions.
+LoongClaw should preserve that lesson without collapsing bundle metadata into
+activation authority.
+
+## Trust And Review Contract
+
+The marketplace layer may expose trust and review posture, but it must remain
+advisory to runtime activation.
+
+Recommended fields:
+
+- `review_tier`
+- `publisher`
+- `review_notes`
+- `attestation_required`
+
+### Suggested `review_tier` vocabulary
+
+- `unreviewed`
+- `reviewed`
+- `official`
+
+This is compatible with the broader trust-tier and provenance direction, but it
+is not itself the runtime trust gate. Manifest `trust_tier` and package
+provenance remain package-sourced inputs. Marketplace `review_tier` is curated
+listing metadata. Marketplace `attestation_required` is advisory listing
+metadata only, not a runtime attestation gate. Actual attestation validity and
+enforcement remain preflight, activation, and runtime-governance concerns.
+
+## Compatibility Projection Contract
+
+A marketplace listing may include descriptive compatibility metadata so
+operators and UIs can understand the likely posture before install.
+
+Recommended fields:
+
+- `declared_dialect`
+- `declared_compatibility_mode`
+- `preferred_preflight_profile`
+- `expected_bundle_kind`
+
+### Important rule
+
+These fields are projections, not runtime overrides.
+
+If they disagree with package or preflight truth:
+
+- the package and governance layers win
+- the marketplace entry is treated as stale or invalid metadata
+- the host should surface that mismatch instead of silently trusting the listing
+
+## Precedence Rules
+
+The system should keep precedence explicit.
+
+### Package contract wins for
+
+- `plugin_id`
+- setup requirements
+- declared capabilities
+- slot claims
+- host compatibility declarations
+- dialect normalization truth
+- activation and attestation truth
+
+### Marketplace contract may define or override only
+
+- display and discovery metadata
+- install policy
+- authentication timing
+- curation and review metadata
+- listing-specific visibility hints
+- narrowly typed host-version or product gating for listing visibility
+
+### Host governance still wins for
+
+- whether a package is allowed to install in the current environment
+- whether a package passes `plugin_preflight`
+- whether a package may activate under the current bridge matrix
+- whether a loaded provider's attestation is still valid
+
+This is the most important marketplace rule.
+It prevents catalog metadata from becoming shadow authority.
+
+## Relationship To `plugin_preflight`
+
+The marketplace contract should explicitly align with the existing
+`marketplace_submission` preflight lane.
+
+That means:
+
+- marketplace publication workflows should evaluate package truth through
+  `plugin_preflight`
+- marketplace tooling should consume the same diagnostics and action plans that
+  operator tooling already sees
+- marketplace catalogs should not ship their own private policy parser as the
+  primary source of truth
+
+### Practical implication
+
+A curated catalog entry may be listed before install, but publication and
+promotion decisions should still be explainable through the same:
+
+- diagnostics
+- remediation classes
+- recommended actions
+- policy provenance
+
+that the host already emits.
+
+## Relationship To Imported Registries And Foreign Ecosystems
+
+The marketplace contract should support imported ecosystems without claiming
+that imported packages are native.
+
+That means a listing may describe:
+
+- a native LoongClaw package
+- an OpenClaw-compatible package
+- a future imported foreign package
+
+while still preserving:
+
+- package provenance
+- dialect identity
+- compatibility posture
+
+The catalog is therefore a listing surface, not a flattening surface.
+It should never erase the distinction between native and foreign packages.
+
+## Suggested Validation Standard
+
+Any implementation that claims conformance with this contract should verify:
+
+- strict schema parsing for catalog roots and entries
+- stable precedence between package truth and marketplace truth
+- rejection or warning when marketplace projections contradict package truth
+- preservation of foreign-dialect identity in imported listings
+- alignment with `plugin_preflight` and `marketplace_submission` workflows
+- zero paths where marketplace metadata bypasses activation governance
+
+For doc-only changes, the minimum repository checks should include:
+
+- `cargo fmt --all -- --check`
+- `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`
+
+## Relationship To Existing RFCs And Issues
+
+This contract should be treated as a sibling layer to:
+
+- `#522` manifest-first plugin package contract
+- `#426` plugin SDK crate RFC
+- the OpenClaw compatibility contract
+
+The package contract defines runtime-facing package truth.
+The SDK RFC defines author-facing tooling layers.
+This marketplace contract defines how listed packages are distributed,
+curated, and presented without redefining runtime truth.
+
+## Non-Goals
+
+This contract does not:
+
+- implement a marketplace backend
+- define package signature verification in detail
+- define ranking or recommendation algorithms
+- replace host governance with catalog metadata
+- guarantee that every listed package is activation-ready on every host
+- define UI rendering details for every product surface
+
+Those are follow-on implementation concerns.
+
+## Future Direction
+
+The long-term target is a marketplace layer that remains:
+
+- aligned with package and compatibility truth
+- explicit about install and auth posture
+- compatible with native and foreign package ecosystems
+- reusable across local catalogs, imported registries, and remote products
+- safe because it stays descriptive rather than authoritative
+
+That gives LoongClaw the missing ecosystem layer between package manifests and
+future marketplace products, without weakening the kernel-first architecture.

--- a/docs/design-docs/plugin-package-manifest-contract.md
+++ b/docs/design-docs/plugin-package-manifest-contract.md
@@ -217,7 +217,9 @@ This contract does not:
 - switch LoongClaw to untrusted in-process native plugins by default
 - replace kernel registry or policy ownership with plugin-owned runtime policy
 - force every plugin onto the same runtime bridge
-- solve marketplace distribution, signing, or supply-chain trust by itself
+- solve marketplace distribution, signing, or supply-chain trust by itself; the
+  complementary [Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md)
+  defines the listing and catalog layer above this package contract
 - replace the existing source-marker intake path in one breaking step
 
 Those concerns are follow-on work. This contract exists so those later steps
@@ -236,7 +238,7 @@ Recommended filename:
 The manifest is the source of truth for:
 
 - canonical `plugin_id`
-- version and display metadata
+- version and baseline package-authored display metadata
 - provided runtime surfaces
 - bridge/runtime metadata
 - declared `trust_tier` classification metadata for operator-visible policy and review

--- a/docs/design-docs/plugin-package-manifest-contract.md
+++ b/docs/design-docs/plugin-package-manifest-contract.md
@@ -511,7 +511,10 @@ This contract should be treated as an upstream architecture layer for:
 - `#426` Plugin SDK Crate
 
 Those RFCs define execution and authoring surfaces. This document defines the
-package metadata and ownership contract they should target.
+package metadata and ownership contract they should target. The complementary
+[Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md)
+document defines how SDK layering, marketplace packaging, and migration tooling
+should build on this contract instead of inventing a parallel metadata model.
 
 It also supports the broader goals in `#292` without forcing the current
 registry-first design to regress into a plugin-owned runtime model.

--- a/docs/design-docs/plugin-package-manifest-contract.md
+++ b/docs/design-docs/plugin-package-manifest-contract.md
@@ -413,7 +413,11 @@ current bootstrap policy keeps `allow_native_ffi_auto_apply` disabled by
 default, because direct FFI bindings weaken the runtime isolation boundary that
 WASM, process bridge, MCP, ACP, and policy-allowed HTTP JSON preserve. Native
 FFI can remain an explicit operator-controlled opt-in for trusted cases, but it
-should not be the default target for third-party plugin packages.
+should not be the default target for third-party plugin packages. Any future
+`NativeFfi`-style in-process surface belongs to the separate native
+host-extension ABI lane and therefore requires native-package status plus
+separate host approval; compatibility-origin packages and marketplace review
+alone are not sufficient.
 
 It should explicitly reject the assumption that third-party plugins should run
 in-process with the daemon by default.
@@ -516,7 +520,10 @@ Those RFCs define execution and authoring surfaces. This document defines the
 package metadata and ownership contract they should target. The complementary
 [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md)
 document defines how SDK layering, marketplace packaging, and migration tooling
-should build on this contract instead of inventing a parallel metadata model.
+should build on this contract instead of inventing a parallel metadata model,
+and the [Plugin SDK Boundary Contract](plugin-sdk-boundary-contract.md)
+document defines how future SDK layers stay separate from host-governance and
+marketplace authority.
 
 It also supports the broader goals in `#292` without forcing the current
 registry-first design to regress into a plugin-owned runtime model.

--- a/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
+++ b/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
@@ -1,0 +1,554 @@
+# Plugin SDK And Ecosystem Strategy
+
+## Purpose
+
+LoongClaw already has two strong plugin foundations:
+
+- a strict native package contract through `PluginManifest`
+- a foreign-dialect compatibility seam through `PluginDescriptor`, `PluginIR`,
+  `PluginActivationPlan`, and bridge-support policy
+
+Those foundations are necessary, but not sufficient, for a mature plugin
+ecosystem.
+
+A durable ecosystem also needs a clear answer to four product questions:
+
+1. What contract should native LoongClaw plugin authors target?
+2. How should OpenClaw-compatible packages enter the system without polluting
+   the kernel?
+3. What metadata shape should marketplace, installation, onboarding, and UI
+   surfaces consume?
+4. How do SDKs, migration tooling, and operator governance stay aligned instead
+   of drifting into parallel policy engines?
+
+This document defines the missing strategy layer.
+
+It complements, rather than replaces:
+
+- [Plugin Package Manifest Contract](plugin-package-manifest-contract.md)
+- [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md)
+
+Those documents define the package and compatibility boundaries.
+This document defines the ecosystem, SDK, migration, and marketplace shape that
+should grow on top of those boundaries.
+
+## Design Goal
+
+LoongClaw should become:
+
+- native-first for authoring and long-term host evolution
+- compatibility-capable for OpenClaw and future foreign ecosystems
+- explicit about marketplace and installation policy
+- governable through one preflight, activation, and attestation truth
+
+It should not become:
+
+- an in-process OpenClaw runtime clone
+- a marketplace-only shell with no host-level governance
+- a pile of ecosystem-specific SDKs that bypass kernel contracts
+
+## Executive Summary
+
+The mature ecosystem shape has four layers:
+
+1. **Native package contract**
+   - one stable host-facing plugin contract
+   - one typed manifest-first package shape
+2. **Marketplace and interface contract**
+   - one user-facing catalog shape for install, auth, category, and display
+   - decoupled from kernel activation semantics
+3. **Runtime bridge contract**
+   - one bridge-oriented execution boundary for `process_stdio`, `http_json`,
+     `mcp_server`, future WASM, and related lanes
+4. **SDK and migration contract**
+   - one native SDK family for LoongClaw packages
+   - one compatibility SDK family for OpenClaw ingestion and migration
+
+The core architectural move is simple:
+
+- native LoongClaw remains the primary authoring target
+- OpenClaw enters as a foreign dialect
+- compatibility is translated into canonical LoongClaw truth before activation
+- marketplace and SDK surfaces consume that same truth instead of inventing
+  new metadata models
+
+## What OpenClaw Teaches
+
+OpenClaw's strongest lesson is not "copy the runtime".
+Its strongest lesson is that plugin ecosystems become useful only when package
+metadata, setup metadata, and author-facing helpers are real product surfaces.
+
+OpenClaw is worth learning from in three areas:
+
+### 1. Manifest-first plugin identity
+
+`openclaw.plugin.json` lets OpenClaw validate plugin configuration and discover
+plugin-owned surfaces without executing plugin code.
+
+LoongClaw should keep absorbing that lesson:
+
+- package metadata must stay manifest-first
+- setup and doctor should not require runtime execution
+- plugin identity should not be inferred from runtime side effects
+
+### 2. Rich authoring helpers
+
+OpenClaw's `openclaw/plugin-sdk/*` surface is large because it optimizes for
+plugin-author speed.
+
+That is useful, but it also means:
+
+- SDK surface area grows quickly
+- host internals become part of the authoring contract
+- host refactors become expensive
+
+LoongClaw should learn the positive lesson without taking on the same coupling:
+
+- authoring helpers should be rich
+- kernel contracts should remain narrow
+- helper libraries should be layered above the contract, not fused into it
+
+### 3. Optional tool exposure policy
+
+OpenClaw's optional plugin tools and allowlist policy are worth reusing at the
+architectural level.
+
+The important principle is:
+
+- a package may declare a tool
+- that does not mean the model may automatically call it
+
+LoongClaw should keep this principle, but enforce it through kernel-visible
+exposure policy instead of runtime-only plugin conventions.
+
+## What Codex Teaches
+
+Codex is more useful as a marketplace and packaging reference than as a runtime
+plugin reference.
+
+Its local plugin model emphasizes:
+
+- `.codex-plugin/plugin.json` as the package manifest
+- `.agents/plugins/marketplace.json` as catalog and ordering truth
+- plugin bundles composed from `skills`, `mcpServers`, and `apps`
+- interface metadata for display, discovery, and installation UX
+
+The strongest lessons are structural:
+
+### 1. Marketplace policy should be separate from runtime contract
+
+A catalog entry should answer:
+
+- where the package comes from
+- whether it is installable
+- when authentication is required
+- how it is categorized and presented
+
+That is a different concern from:
+
+- what the kernel may activate
+- which bridges or shims are allowed
+- what compatibility mode is required
+
+### 2. Plugin bundles should compose existing product surfaces
+
+Plugins are not only runtime code.
+They may also contribute:
+
+- skills
+- MCP servers
+- app connectors
+- setup assets
+- UI metadata
+
+LoongClaw should therefore treat marketplace packaging as a composition surface,
+not only as a bridge-execution surface.
+
+### 3. Interface metadata deserves a stable home
+
+Display names, categories, screenshots, starter prompts, and install guidance
+belong in a stable interface contract.
+They should not be squeezed into kernel-only runtime metadata.
+
+## Architectural Principle
+
+LoongClaw should be **native-first, bridge-compatible, and marketplace-aware**.
+
+That principle implies three rules:
+
+1. **Native-first authoring**
+   - new LoongClaw packages should target the native package contract and native
+     SDKs first
+2. **Bridge-compatible foreign intake**
+   - OpenClaw and future ecosystems should enter through descriptor
+     normalization plus bridge-support policy
+3. **Marketplace-aware packaging**
+   - operator and user-facing install/catalog surfaces should live in a typed
+     marketplace contract instead of leaking through kernel metadata
+
+## Layered Ecosystem Model
+
+### Layer 1: Native Package Contract
+
+The native package contract is the first-class host contract.
+
+Its responsibilities are:
+
+- stable identity
+- versioning
+- setup metadata
+- slot ownership
+- host compatibility declarations
+- capability and bridge metadata
+- attestation inputs
+
+This layer should stay small and typed.
+It is the target for native SDK generation and native package validation.
+
+### Layer 2: Foreign Dialect Normalization
+
+Foreign packages should never skip normalization.
+
+This layer is responsible for:
+
+- dialect detection
+- dialect provenance
+- canonical descriptor projection
+- compatibility-mode selection
+- foreign diagnostics
+- migration hints
+
+The kernel should continue to reason about one normalized shape after this
+step.
+
+### Layer 3: Runtime Bridge Contract
+
+Bridge execution remains separate from dialect identity.
+
+This layer is responsible for:
+
+- `process_stdio`
+- `http_json`
+- `mcp_server`
+- future WASM or ACP-related bridge lanes
+- runtime profile validation
+- execution attestation re-checks
+
+The system should keep bridge semantics explicit and avoid ecosystem-specific
+execution planes.
+
+### Layer 4: Marketplace And Interface Contract
+
+Marketplace metadata should sit above the kernel, not inside it.
+
+This layer is responsible for:
+
+- catalog source and provenance
+- install policy
+- auth policy
+- category and discovery ranking inputs
+- interface display metadata
+- bundle composition metadata for skills, MCP servers, and apps
+
+This layer may consume kernel truth, but it must not redefine it.
+Marketplace metadata must stay descriptive and policy-scoped. It must never
+become a second activation authority or a backdoor path around preflight,
+bridge-policy, or attestation checks.
+
+### Layer 5: Native Host Extension ABI
+
+Not every plugin should get deep host authority.
+
+A narrower native host-extension ABI should exist only for cases where a
+package truly needs:
+
+- a native connector adapter
+- a native memory adapter
+- a native runtime adapter
+- tightly-scoped typed hook points
+
+This lane should remain smaller and more controlled than OpenClaw's broad
+in-process registration surface. It should be trusted, narrow, and non-default,
+with explicit operator intent before any package gains deeper host authority.
+
+## SDK Family Strategy
+
+LoongClaw should not ship one giant plugin SDK.
+It should ship a family of SDK layers.
+
+The layer names below are illustrative, not a locked future crate or package
+layout. The architectural commitment is to keep contract, runtime-helper, and
+compatibility-helper concerns separate. The exact packaging can still evolve as
+long as it preserves that separation and continues to target the same manifest
+and activation contracts.
+
+### 1. `loongclaw-sdk-contract`
+
+Purpose:
+
+- expose the stable package, bridge, setup, diagnostics, and governance types
+- let external tooling reuse one schema surface
+
+Primary consumers:
+
+- CI and release tooling
+- marketplace validators
+- migration tools
+- policy and preflight automation
+- native or foreign package generators
+
+This layer should remain narrow and versioned. SDK generators, CI, and
+marketplace tooling should inherit the same strict manifest contract instead of
+introducing a parallel metadata model.
+
+### 2. `loongclaw-sdk-runtime`
+
+Purpose:
+
+- help plugin authors implement bridge-style packages cleanly
+- provide structured helpers above the stable contract
+
+Primary helpers should include:
+
+- stdio bridge helpers
+- HTTP JSON bridge helpers
+- MCP bridge helpers
+- state and temp-path helpers
+- structured logging and health helpers
+- setup and capability declaration helpers
+
+This layer may be richer than the contract layer.
+The key rule is that it must build on the contract instead of redefining it.
+
+### 3. `loongclaw-sdk-openclaw-compat`
+
+Purpose:
+
+- help OpenClaw packages migrate or integrate without contaminating the native
+  SDK shape
+
+Primary helpers should include:
+
+- OpenClaw manifest parsing
+- metadata projection helpers
+- compatibility shim helpers
+- migration scaffolding
+- compatibility diagnostics and linting
+
+This layer should be explicit about being transitional.
+It is a compatibility lane, not the preferred authoring target.
+
+## Marketplace Contract Strategy
+
+LoongClaw should define one explicit marketplace contract that is separate from
+`loongclaw.plugin.json`.
+
+A marketplace entry should answer:
+
+- `marketplace_id`
+- package source and provenance
+- install policy
+- auth policy
+- category
+- interface metadata overrides or additions
+- trust/review tier
+- compatibility posture
+- host-version or product gating where needed
+
+The marketplace contract should be able to describe both:
+
+- native LoongClaw packages
+- imported foreign packages that still enter through compatibility lanes
+
+That makes it possible to list an OpenClaw-compatible package without claiming
+that it is native.
+
+## Capability And Tool Exposure Strategy
+
+Tool declaration and model exposure should be distinct.
+
+The desired flow is:
+
+1. package declares tool surfaces
+2. translation and activation normalize those surfaces
+3. preflight evaluates risk and support posture
+4. host policy decides whether the tool is exposed to the model
+
+This keeps the system aligned with the kernel-first design:
+
+- plugin metadata may request surfaces
+- only the host policy may expose them
+
+Optional or higher-risk tools should be opt-in by default.
+
+## Compatibility Levels
+
+OpenClaw compatibility should be described in explicit levels rather than one
+vague promise of "full compatibility".
+
+### Level 0: Discovery Compatibility
+
+LoongClaw can:
+
+- detect the package
+- classify dialect and provenance
+- inventory it
+- preflight it
+
+### Level 1: Packaging Compatibility
+
+LoongClaw can additionally:
+
+- project package metadata
+- preserve setup guidance
+- preserve install and UI hints
+- expose the package through marketplace and operator surfaces
+
+### Level 2: Bridge Runtime Compatibility
+
+LoongClaw can additionally execute the package through supported bridge lanes,
+starting with:
+
+- `process_stdio`
+- `http_json`
+- `mcp_server`
+
+### Level 3: Semantic Shim Compatibility
+
+LoongClaw can additionally emulate or adapt selected host-level OpenClaw plugin
+semantics, such as a constrained registration subset.
+
+This level should be incremental and explicit.
+It is the most expensive compatibility layer and should not be treated as the
+baseline requirement for ecosystem usefulness.
+
+## Migration Strategy
+
+The migration story should be a first-class product surface.
+
+A mature ecosystem should support three flows:
+
+### 1. Native-first authoring
+
+New packages start from the native LoongClaw contract and native SDK.
+
+### 2. Compatibility intake
+
+Existing OpenClaw packages can be:
+
+- discovered
+- inventoried
+- preflighted
+- gated by runtime bridge profiles
+- installed into a catalog without pretending they are native
+
+### 3. Guided migration
+
+A future migration CLI should be able to:
+
+- read an OpenClaw package
+- emit a native `loongclaw.plugin.json` scaffold
+- preserve compatibility metadata and setup hints
+- emit a migration report with explicit TODO items
+
+That gives LoongClaw a healthy ecosystem funnel:
+
+- compatible by discovery
+- useful by bridge execution
+- durable by migration to native
+
+## Operator Surface Strategy
+
+Operator surfaces should stay thin wrappers over canonical truth.
+
+The operator should not need to re-derive ecosystem state from raw manifests.
+The existing direction is correct:
+
+- `plugin_inventory` surfaces package and activation truth
+- `plugin_preflight` surfaces governance truth
+- `plugins bridge-profiles` surfaces compatibility presets
+- attestation keeps runtime execution aligned with approved activation
+
+Future ecosystem tooling should continue to build on those same surfaces.
+
+## Recommended Implementation Order
+
+### Phase 1: Strategy Closure
+
+- keep the native package contract authoritative
+- keep OpenClaw normalization explicit and fail-closed
+- define the marketplace and interface contract separately from kernel metadata
+- define the SDK family boundaries explicitly
+
+### Phase 2: Runtime Compatibility MVP
+
+Start with the bridge lanes that preserve the cleanest safety boundary:
+
+- modern OpenClaw manifests
+- `process_stdio`
+- `http_json`
+- `mcp_server`
+
+Do not make broad in-process semantic emulation the first milestone.
+
+### Phase 3: Marketplace And Migration Tooling
+
+- define marketplace schema and validation
+- define package listing and install policy semantics
+- add migration scaffolding for OpenClaw packages
+- align docs, preflight outputs, and future SDK generators on one metadata
+  model
+
+### Phase 4: Narrow Native Host Extension ABI
+
+After the native package and bridge lanes are stable:
+
+- define the minimum native host-extension ABI
+- expose only typed, policy-bounded extension points
+- avoid copying OpenClaw's broad runtime registration model
+
+## Anti-Patterns
+
+The following patterns should be avoided:
+
+- treating OpenClaw host semantics as the native LoongClaw authoring target
+- putting marketplace or display metadata into kernel-only runtime fields
+- building a parallel SDK metadata model that disagrees with package manifests
+- auto-enabling foreign compatibility just because discovery succeeded
+- exposing declared plugin tools to the model without separate host approval
+- equating bridge execution support with full semantic host compatibility
+- letting compatibility shims widen kernel policy implicitly
+
+## Validation Standard
+
+Any change that claims to advance this strategy should verify:
+
+- native package contracts remain the first-class authoring target
+- foreign dialects still normalize into canonical activation truth
+- marketplace or SDK tooling consumes that canonical truth instead of inventing
+  a parallel model
+- bridge-support policy remains the single runtime compatibility gate
+- optional or high-risk tool surfaces require explicit exposure policy
+- migration tooling preserves provenance and compatibility context
+
+For doc-only changes, the minimum repository checks should include:
+
+- `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`
+
+## Decision
+
+LoongClaw should mature its plugin ecosystem through:
+
+- one native package contract
+- one explicit foreign-dialect normalization seam
+- one bridge-first runtime execution boundary
+- one separate marketplace and interface contract
+- one layered SDK family with native and compatibility lanes
+- one migration funnel from ecosystem compatibility into native packages
+
+That is the smallest ecosystem architecture that stays:
+
+- native-first
+- OpenClaw-compatible
+- marketplace-ready
+- kernel-safe

--- a/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
+++ b/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
@@ -49,7 +49,7 @@ It should not become:
 
 ## Executive Summary
 
-The mature ecosystem shape has four layers:
+The mature ecosystem shape has five layers:
 
 1. **Native package contract**
    - one stable host-facing plugin contract
@@ -270,11 +270,15 @@ package truly needs:
 This lane should remain smaller and more controlled than OpenClaw's broad
 in-process registration surface. It should be trusted, narrow, and non-default,
 with explicit operator intent before any package gains deeper host authority.
+This lane is for separately host-approved native packages, not for direct
+compatibility-origin intake or marketplace-review status alone.
 
 ## SDK Family Strategy
 
 LoongClaw should not ship one giant plugin SDK.
-It should ship a family of SDK layers.
+It should ship a family of SDK layers. The complementary
+[Plugin SDK Boundary Contract](plugin-sdk-boundary-contract.md) document defines
+how those layers stay separate from package, marketplace, and governance truth.
 
 The layer names below are illustrative, not a locked future crate or package
 layout. The architectural commitment is to keep contract, runtime-helper, and
@@ -286,7 +290,7 @@ and activation contracts.
 
 Purpose:
 
-- expose the stable package, bridge, setup, diagnostics, and governance types
+- expose the stable package, bridge, setup, diagnostics, and governance-result schema types
 - let external tooling reuse one schema surface
 
 Primary consumers:

--- a/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
+++ b/docs/design-docs/plugin-sdk-and-ecosystem-strategy.md
@@ -341,11 +341,19 @@ It is a compatibility lane, not the preferred authoring target.
 ## Marketplace Contract Strategy
 
 LoongClaw should define one explicit marketplace contract that is separate from
-`loongclaw.plugin.json`.
+`loongclaw.plugin.json`. The complementary
+[Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md)
+document defines that catalog layer in detail.
+
+A marketplace catalog should answer:
+
+- `marketplace_id`
+- catalog provenance
+- marketplace display metadata
 
 A marketplace entry should answer:
 
-- `marketplace_id`
+- `plugin_id`
 - package source and provenance
 - install policy
 - auth policy

--- a/docs/design-docs/plugin-sdk-boundary-contract.md
+++ b/docs/design-docs/plugin-sdk-boundary-contract.md
@@ -1,0 +1,464 @@
+# Plugin SDK Boundary Contract
+
+## Purpose
+
+LoongClaw now has four public plugin architecture layers:
+
+- package truth through the plugin package manifest contract
+- foreign-dialect normalization through the OpenClaw compatibility contract
+- ecosystem and migration direction through the plugin SDK and ecosystem strategy
+- listing and install semantics through the plugin marketplace contract
+
+What still remains underspecified is the next layer between those contracts and
+actual author-facing implementation crates:
+
+- which SDK layers exist
+- what each SDK layer may expose
+- which layer owns guest-side helpers versus host-side extension APIs
+- how SDK work should sequence relative to the existing `#426` WASM-oriented SDK
+  RFC
+
+This document defines that missing boundary.
+
+It complements, rather than replaces:
+
+- [Plugin Package Manifest Contract](plugin-package-manifest-contract.md)
+- [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md)
+- [Plugin Marketplace And Interface Contract](plugin-marketplace-contract.md)
+- [Plugin SDK And Ecosystem Strategy](plugin-sdk-and-ecosystem-strategy.md)
+
+Those documents define package, compatibility, marketplace, and ecosystem
+truth. This document defines how author-facing SDK surfaces should be layered on
+those truths without creating a second architecture.
+
+## Why This Contract Exists
+
+Issue `#426` already proposes a concrete WASM guest-side SDK crate.
+That RFC is valuable, but it is still only one slice of the broader SDK story.
+By itself it does not answer:
+
+- whether there should be one SDK crate or a family of SDK layers
+- which types belong in a stable contract crate versus bridge-specific helper
+  crates
+- how future stdio, HTTP JSON, MCP, and compatibility helpers should relate to
+  a WASM guest SDK
+- how native host extension APIs should stay narrower and more trusted than
+  general plugin authoring helpers
+
+Without a boundary contract, the most likely failure mode is not "no SDK".
+The likely failure mode is a sprawling SDK surface that:
+
+- re-exports host internals
+- duplicates package or preflight metadata models
+- blurs guest-side, host-side, and compatibility responsibilities
+- makes every future bridge lane invent its own helper vocabulary
+
+This contract exists to prevent that drift before multiple SDK slices land.
+
+## Core Principle
+
+LoongClaw SDKs should help authors target existing contracts.
+They should not become new sources of truth.
+
+That means:
+
+- manifests, compatibility, preflight, and marketplace contracts stay
+  authoritative
+- SDKs provide typed helpers and ergonomics above those contracts
+- SDK helpers must not redefine activation, compatibility, or policy truth
+- SDK layers must stay small enough that host refactors do not become SDK-wide
+  breaking events
+
+## Design Goal
+
+LoongClaw should support an SDK family that is:
+
+- layered instead of monolithic
+- native-first but compatible with foreign-package migration flows
+- bridge-aware without becoming bridge-fragmented
+- explicit about guest-side versus host-side responsibilities
+- aligned with package, compatibility, and marketplace contracts
+
+It should not:
+
+- collapse guest-side and host-side APIs into one giant crate
+- expose internal host modules as the default authoring surface
+- let compatibility helpers redefine package or governance truth
+- force every plugin author to depend on the heaviest bridge-specific helper set
+
+## Contract Layers
+
+### 1. SDK Contract Layer
+
+The contract layer is the narrowest and most stable author-facing layer.
+
+It should expose:
+
+- manifest-related schema types that are intentionally author-facing
+- setup-related schema types
+- bridge request/response envelope types where stable
+- preflight, diagnostics, inventory, and summary schema types intended for
+  external tooling reuse
+- narrow marketplace-facing bindings only where they are explicitly
+  listing-scoped and derived from canonical package and governance truth, not as
+  a second source of marketplace authority
+
+It must not expose:
+
+- host runtime internals
+- app-layer service implementations
+- kernel registry implementations
+- bridge execution engines
+- compatibility policy decisions as mutable helper state
+
+### 2. SDK Runtime Helper Layer
+
+The runtime-helper layer exists to make bridge-style plugins practical to build.
+
+It may expose:
+
+- guest-side WASM helpers
+- stdio helper scaffolding
+- HTTP JSON helper scaffolding
+- MCP helper scaffolding
+- structured logging, health, and state helpers
+- small bridge-lane utilities that sit above the stable contract layer
+
+It must not:
+
+- override package or activation truth
+- silently add capabilities or approval semantics
+- bypass bridge policy, preflight, or attestation
+- turn one bridge helper into the mandatory dependency for unrelated plugin
+  lanes
+
+### 3. Compatibility Helper Layer
+
+The compatibility-helper layer is for foreign ecosystems and migration paths.
+
+It may expose:
+
+- OpenClaw manifest parsing helpers
+- migration report builders
+- compatibility diagnostics helpers
+- shims or adapters that help foreign packages target canonical LoongClaw
+  contracts
+
+It must not:
+
+- redefine dialect normalization truth
+- become the preferred native authoring surface
+- silently widen foreign-package privileges beyond what package and governance
+  contracts allow
+- flatten native and foreign package identity into one fake neutral model
+
+### 4. Native Host Extension ABI Layer
+
+This is not the same thing as a general-purpose SDK helper crate.
+It is the narrowest and most sensitive author-facing extension layer.
+
+It is only for cases that truly need:
+
+- native connector adapters
+- native memory adapters
+- native runtime adapters
+- tightly scoped trusted hook points
+
+This layer must remain:
+
+- trusted
+- narrow
+- non-default
+- explicitly governed
+
+It should be treated as a separate lane from general plugin-author SDKs.
+
+## Boundary Rules
+
+### Rule 1: Package truth stays below SDKs
+
+If package and SDK helper semantics disagree:
+
+- package truth wins
+- SDK helpers must adapt
+- SDK documentation should be corrected instead of normalizing divergence into
+  helper behavior
+
+### Rule 2: Governance truth stays outside SDKs
+
+SDKs may serialize, display, or interpret governance output.
+They may not become governance engines.
+
+That means SDKs must not:
+
+- embed private policy evaluators
+- decide activation eligibility on their own
+- convert advisory marketplace metadata into runtime permissions
+- reinterpret attestation validity outside the host's canonical governance flow
+
+### Rule 3: Marketplace truth stays descriptive
+
+SDKs that interact with marketplace data should treat it as listing-layer
+metadata.
+They must not reinterpret marketplace entries as package, activation, or trust
+truth.
+
+### Rule 4: Compatibility helpers stay subordinate to normalization
+
+Compatibility helpers may help authors or migration tooling consume foreign
+contracts.
+They must still target the same normalized descriptor and compatibility model
+that the host uses.
+
+### Rule 5: Helper crates should not force a locked package layout too early
+
+The architectural commitment is to the layer separation, not to one final crate
+layout today.
+The family of SDK layers may initially land as:
+
+- one crate with internally separated modules
+- a few focused crates
+- or an incremental sequence starting with one specific bridge helper crate
+
+The important thing is that the layers remain conceptually separate and do not
+collapse into one unbounded host-coupled surface.
+
+### Rule 6: Dependency direction must preserve the boundary
+
+Conceptual layering is not only a documentation boundary; it is also a coupling
+boundary.
+
+That means:
+
+- the SDK contract layer must not depend on runtime-helper,
+  compatibility-helper, or native host-extension ABI layers
+- runtime-helper and compatibility-helper layers may depend on the SDK
+  contract layer
+- compatibility-helper layers must not back-feed foreign-ecosystem abstractions
+  into the SDK contract layer
+- the native host-extension ABI must not become a default or transitive
+  dependency of general plugin-author SDK surfaces
+
+## Recommended SDK Family Shape
+
+The ecosystem strategy document already uses illustrative names.
+This boundary contract keeps those names as conceptual slices, not locked
+package commitments.
+
+### Conceptual layer: `sdk-contract`
+
+Responsibilities:
+
+- stable shared types
+- schema-level serialization contracts
+- author-facing manifest/setup/diagnostic vocabulary
+
+Ideal consumers:
+
+- CI tooling
+- catalog tooling
+- generators and scaffolds
+- migration tooling
+- external validation and packaging utilities
+
+### Conceptual layer: `sdk-runtime`
+
+Responsibilities:
+
+- bridge-lane helper APIs
+- typed I/O helpers
+- runtime-state helpers
+- structured logging and health helpers
+
+Ideal consumers:
+
+- authors building executable plugins
+- bridge-targeted helper packages
+- reference examples
+
+### Conceptual layer: `sdk-openclaw-compat`
+
+Responsibilities:
+
+- foreign dialect parsing
+- migration and translation helpers
+- compatibility diagnostics and adaptation helpers
+
+Ideal consumers:
+
+- migration CLIs
+- importer pipelines
+- compatibility-aware package authors or maintainers
+
+### Conceptual lane: native host extension ABI
+
+Responsibilities:
+
+- explicit trusted extension points for in-process host integrations
+
+Ideal consumers:
+
+- separately host-approved native packages with deeper host requirements
+- future curated internal extension packages
+
+Compatibility-origin packages and compatibility shims must not target the native
+host-extension ABI directly unless they are first re-authored or repackaged as
+native LoongClaw packages and pass separate host governance for that lane.
+
+## Relationship To `#426`
+
+Issue `#426` should now be read as one implementation slice inside this broader
+boundary contract.
+
+Specifically, `#426` maps most naturally onto:
+
+- the **runtime-helper layer**
+- for the **WASM guest-side lane**
+
+That means the WASM guest SDK should be treated as:
+
+- a concrete bridge-targeted helper package
+- not as the total plugin SDK story
+- not as the owner of manifest or marketplace truth
+- not as the default shape for host-native extension APIs
+
+## Recommended Execution Order
+
+### Phase 1: Boundary-first planning
+
+Before more helper crates appear, the system should have explicit answers for:
+
+- which types belong to the stable contract layer
+- which helper APIs are bridge-specific
+- which lanes are compatibility-only
+- which lanes require trusted host-extension treatment
+
+This document provides that answer.
+
+### Phase 2: Narrow stable contract extraction
+
+If shared schema types are needed externally, introduce a minimal contract layer
+or contract module surface first.
+This should happen before expanding bridge helper crates.
+
+### Phase 3: Bridge-targeted helper slices
+
+Land helper APIs lane by lane.
+The most defensible order is:
+
+1. WASM guest-side helper surface (`#426` scope)
+2. stdio or HTTP JSON helper surfaces if and when their execution lanes become
+   author-facing
+3. MCP helper surfaces where the host contract is stable enough
+
+### Phase 4: Compatibility helper slices
+
+OpenClaw or future foreign-package helper surfaces should land only after the
+canonical package and runtime-helper layers are clear enough that compatibility
+code has a stable target.
+
+### Phase 5: Native host extension ABI
+
+Trusted in-process extension lanes should stay later and narrower than the
+bridge-targeted helper surfaces.
+They are not the general plugin-author default path.
+
+## Illustrative Responsibilities Matrix
+
+| Layer | Owns stable types? | Owns helper ergonomics? | Owns governance truth? | Default authoring lane? |
+|------|---------------------|--------------------------|------------------------|-------------------------|
+| SDK contract layer | Yes | Minimal | No | Yes |
+| SDK runtime helper layer | No | Yes | No | Yes |
+| Compatibility helper layer | No | Yes | No | No |
+| Native host extension ABI | Narrow, trusted subset only | Narrow | No | No |
+
+This matrix is the boundary in one glance:
+
+- contract layers carry shared truths
+- helper layers provide ergonomics
+- governance stays with the host
+- compatibility and host-native lanes stay specialized instead of becoming the
+  default path
+
+## Anti-Patterns
+
+The following patterns violate this contract:
+
+- treating the WASM guest SDK as the only plugin SDK the project will ever
+  need
+- re-exporting host-internal app or kernel modules as the default SDK surface
+- putting marketplace policy logic inside runtime helper crates
+- letting compatibility helper crates redefine normalized descriptor or
+  activation semantics
+- mixing trusted host-native extension APIs into the same default crate that is
+  meant for ordinary bridge-targeted plugin authors
+- duplicating package-manifest, marketplace, or preflight schemas inside helper
+  crates instead of consuming the canonical contracts
+
+## Validation Standard
+
+Any implementation that claims conformance with this boundary contract should
+verify:
+
+- stable separation between contract and helper layers
+- no helper crate becomes a second policy or activation engine
+- foreign compatibility helpers still target canonical normalized truth
+- host-native extension lanes stay narrower and more trusted than general
+  plugin authoring surfaces
+- future SDK work references this boundary when deciding whether a new helper
+  belongs in contract, runtime-helper, compatibility-helper, or host-native
+  lanes
+
+For doc-only changes, the minimum repository checks should include:
+
+- `cargo fmt --all -- --check`
+- `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`
+
+## Relationship To Existing Documents
+
+This boundary contract should be treated as the explicit bridge between:
+
+- package truth (`plugin-package-manifest-contract.md`)
+- compatibility truth (`openclaw-plugin-compatibility-contract.md`)
+- marketplace truth (`plugin-marketplace-contract.md`)
+- ecosystem strategy (`plugin-sdk-and-ecosystem-strategy.md`)
+- concrete helper implementation slices such as `#426`
+
+Those layers already existed conceptually.
+This document makes their author-facing boundaries explicit.
+
+## Non-Goals
+
+This contract does not:
+
+- implement the `#426` WASM guest SDK
+- define a final crates.io publishing plan
+- define all future bridge helper APIs in detail
+- specify exact proc-macro syntax
+- choose a final permanent crate layout for every SDK layer
+- replace the existing package, compatibility, or marketplace contracts
+
+Those are follow-on implementation and packaging tasks.
+
+## Future Direction
+
+The long-term target is an SDK family that remains:
+
+- contract-driven instead of helper-driven
+- bridge-aware instead of bridge-fragmented
+- native-first while still supporting foreign migration lanes
+- small enough that host refactors do not automatically become ecosystem-wide
+  breakages
+- explicit enough that future issues can say "this belongs to the contract
+  layer" or "this is a runtime-helper concern" without reopening the whole
+  architecture question
+
+That gives LoongClaw a clean next step after the marketplace contract:
+
+- package truth is defined
+- compatibility truth is defined
+- marketplace truth is defined
+- SDK boundaries are now defined
+
+The next implementation slices can therefore land against explicit boundaries
+instead of inventing new ones.


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw already had a manifest-first plugin package contract, an OpenClaw compatibility contract, an ecosystem strategy document, and a marketplace contract, but it still lacked one explicit boundary contract for the author-facing SDK family. Without that layer, future SDK work can sprawl across guest-side helpers, host-native extension APIs, and compatibility tooling without a clear separation rule.
- Why it matters:
  Without an SDK boundary contract, the project risks letting a single bridge-targeted SDK slice (such as the WASM guest SDK in `#426`) become the accidental shape of the whole plugin SDK story, while helper crates drift into parallel metadata or policy models.
- What changed:
  - added `docs/design-docs/plugin-sdk-boundary-contract.md`
  - linked the SDK boundary contract from the design-doc index
  - linked the SDK boundary contract from the plugin SDK strategy doc
  - tightened the package and marketplace docs so native host-extension ABI and marketplace/install semantics stay distinct from compatibility and helper layers
  - preserved the earlier strategy and marketplace contract work already present on this branch
- What did not change (scope boundary):
  - no implementation of the `#426` WASM guest SDK
  - no runtime bridge behavior changes
  - no new package manager, registry backend, or crates.io publication flow
  - no change to package, compatibility, preflight, or marketplace authority semantics beyond boundary clarification

## Linked Issues

- Closes #1197
- Related #1193
- Related #426
- Related #1136

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
env CARGO_TARGET_DIR=<redacted-target-dir> cargo fmt --all -- --check
env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=/private/tmp/loongclaw-plugin-sdk-boundary-target cargo clippy --workspace --all-targets --all-features -- -D warnings
env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=/private/tmp/loongclaw-plugin-sdk-boundary-target cargo test --workspace --locked
env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=/private/tmp/loongclaw-plugin-sdk-boundary-target cargo test --workspace --all-features --locked
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh

The docs check still fails on untouched baseline release-trace and debug-doc gaps under `.docs/` and `docs/releases/`:
- missing `.docs/releases/v0.1.0-alpha.2-debug.md`
- missing `.docs/releases/v0.1.0-alpha.1-debug.md`
- missing `.docs/traces/index.jsonl`
- missing `.docs/traces/latest`
- missing by-tag trace pointers and metadata for the two released versions
```

## User-visible / Operator-visible Changes

- Public plugin architecture guidance now defines an explicit SDK boundary contract that separates stable contract types, bridge-targeted runtime helpers, compatibility helpers, and the separately governed native host-extension ABI lane.

## Failure Recovery

- Fast rollback or disable path:
  Revert the documentation changes or drop the SDK boundary contract from this branch before merge.
- Observable failure symptoms reviewers should watch for:
  Boundary drift between package truth, marketplace truth, compatibility truth, and future SDK helper responsibilities.

## Reviewer Focus

- Verify that the SDK boundary contract keeps package, marketplace, and governance truth authoritative instead of letting SDK layers redefine them.
- Verify that the native host-extension ABI remains clearly separate from compatibility-origin packages and marketplace review state.
- Verify that `#426` is now framed as one implementation slice rather than the total plugin SDK architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three active design documents to the index: Plugin Marketplace & Interface Contract, Plugin SDK Boundary Contract, and Plugin SDK & Ecosystem Strategy.
  * Introduced a Plugin Marketplace & Interface Contract specifying catalog/listing schema, install/auth policies, interface metadata, and precedence rules.
  * Added an SDK Boundary Contract and an SDK & Ecosystem Strategy outlining layered SDKs, compatibility levels, and migration pathways.
  * Updated plugin package and compatibility documents with cross-references to the new specs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->