### PR TITLE
Unify production turn entry surfaces under AgentRuntime

### DIFF
--- a/crates/app/src/acp/backend.rs
+++ b/crates/app/src/acp/backend.rs
@@ -262,6 +262,7 @@ pub struct AcpConversationTurnOptions<'a> {
     pub event_sink: Option<&'a dyn AcpTurnEventSink>,
     pub additional_bootstrap_mcp_servers: Option<&'a [String]>,
     pub working_directory: Option<&'a Path>,
+    pub metadata: Option<&'a BTreeMap<String, String>>,
     pub provenance: AcpTurnProvenance<'a>,
 }
 
@@ -272,6 +273,7 @@ impl Default for AcpConversationTurnOptions<'_> {
             event_sink: None,
             additional_bootstrap_mcp_servers: None,
             working_directory: None,
+            metadata: None,
             provenance: AcpTurnProvenance::default(),
         }
     }
@@ -313,6 +315,11 @@ impl<'a> AcpConversationTurnOptions<'a> {
 
     pub fn with_working_directory(mut self, working_directory: Option<&'a Path>) -> Self {
         self.working_directory = working_directory.filter(|path| !path.as_os_str().is_empty());
+        self
+    }
+
+    pub fn with_metadata(mut self, metadata: Option<&'a BTreeMap<String, String>>) -> Self {
+        self.metadata = metadata.filter(|metadata| !metadata.is_empty());
         self
     }
 

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -52,6 +52,7 @@ pub use runtime::{
 };
 pub(crate) use runtime::{
     AcpConversationTurnExecutionOutcome, execute_acp_conversation_turn_for_address,
+    execute_acp_conversation_turn_for_address_with_manager,
 };
 #[cfg(feature = "memory-sqlite")]
 pub use store::AcpSqliteSessionStore;

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -526,6 +526,11 @@ pub fn prepare_acp_conversation_turn_for_address(
         .extend_request_metadata(&mut request_metadata);
     if let Some(extra_metadata) = options.metadata {
         for (key, value) in extra_metadata {
+            let is_reserved_key =
+                key.starts_with("loongclaw.acp.") || key.starts_with("loongclaw.channel.");
+            if is_reserved_key {
+                continue;
+            }
             insert_trimmed_metadata(&mut bootstrap_metadata, key.as_str(), Some(value.as_str()));
             insert_trimmed_metadata(&mut request_metadata, key.as_str(), Some(value.as_str()));
         }

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -375,6 +375,26 @@ pub(crate) async fn execute_acp_conversation_turn_for_address(
 ) -> CliResult<ExecutedAcpConversationTurn> {
     let prepared = prepare_acp_conversation_turn_for_address(config, address, user_input, options)?;
     let manager = shared_acp_session_manager(config)?;
+    execute_prepared_acp_conversation_turn(config, prepared, options, manager).await
+}
+
+pub(crate) async fn execute_acp_conversation_turn_for_address_with_manager(
+    config: &LoongClawConfig,
+    address: &ConversationSessionAddress,
+    user_input: &str,
+    options: &AcpConversationTurnOptions<'_>,
+    manager: Arc<AcpSessionManager>,
+) -> CliResult<ExecutedAcpConversationTurn> {
+    let prepared = prepare_acp_conversation_turn_for_address(config, address, user_input, options)?;
+    execute_prepared_acp_conversation_turn(config, prepared, options, manager).await
+}
+
+async fn execute_prepared_acp_conversation_turn(
+    config: &LoongClawConfig,
+    prepared: PreparedAcpConversationTurn,
+    options: &AcpConversationTurnOptions<'_>,
+    manager: Arc<AcpSessionManager>,
+) -> CliResult<ExecutedAcpConversationTurn> {
     let backend_selection = resolve_acp_backend_selection(config);
     let persistence_event_sink = config
         .acp
@@ -504,6 +524,12 @@ pub fn prepare_acp_conversation_turn_for_address(
     options
         .provenance
         .extend_request_metadata(&mut request_metadata);
+    if let Some(extra_metadata) = options.metadata {
+        for (key, value) in extra_metadata {
+            insert_trimmed_metadata(&mut bootstrap_metadata, key.as_str(), Some(value.as_str()));
+            insert_trimmed_metadata(&mut request_metadata, key.as_str(), Some(value.as_str()));
+        }
+    }
     let additional_bootstrap_mcp_servers = options.additional_bootstrap_mcp_servers.unwrap_or(&[]);
     let bootstrap_mcp_servers = config
         .acp

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -1,0 +1,661 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::CliResult;
+use crate::acp::{AcpTurnEventSink, AcpTurnProvenance, JsonlAcpTurnEventSink};
+use crate::chat::{
+    CliChatOptions, initialize_cli_turn_runtime, initialize_cli_turn_runtime_with_loaded_config,
+};
+use crate::config::load as load_config;
+use crate::conversation::{
+    ConversationIngressContext, ConversationRuntimeBinding, ConversationSessionAddress,
+    PromptFrameEventSummary, load_prompt_frame_event_summary,
+};
+use crate::tools;
+use loongclaw_contracts::ToolCoreRequest;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTurnMode {
+    Interactive,
+    #[default]
+    Oneshot,
+    Delegate,
+    Acp,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentTurnRequest {
+    pub message: String,
+    pub turn_mode: AgentTurnMode,
+    pub channel_id: Option<String>,
+    pub account_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub metadata: BTreeMap<String, String>,
+    pub acp: bool,
+    pub acp_event_stream: bool,
+    pub acp_bootstrap_mcp_servers: Vec<String>,
+    pub acp_cwd: Option<String>,
+    pub live_surface_enabled: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PromptAssemblyPlan {
+    pub total_estimated_tokens: Option<usize>,
+    pub stable_runtime_estimated_tokens: Option<usize>,
+    pub session_latched_estimated_tokens: Option<usize>,
+    pub session_local_recall_estimated_tokens: Option<usize>,
+    pub turn_ephemeral_estimated_tokens: Option<usize>,
+    pub stable_prefix_hash_sha256: Option<String>,
+    pub cached_prefix_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PromptCachePlan {
+    pub stable_prefix_hash_sha256: Option<String>,
+    pub cached_prefix_sha256: Option<String>,
+    pub stable_prefix_reused: bool,
+    pub cached_prefix_reused: bool,
+    pub session_latched_context_drifted: bool,
+    pub session_local_recall_drifted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentTurnResult {
+    pub session_id: String,
+    pub output_text: String,
+    pub turn_mode: AgentTurnMode,
+    pub governed_session_mode: loongclaw_contracts::GovernedSessionMode,
+    pub state: Option<String>,
+    pub stop_reason: Option<String>,
+    pub usage: Option<Value>,
+    pub event_count: usize,
+    pub prompt_assembly: PromptAssemblyPlan,
+    pub prompt_cache: PromptCachePlan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRuntimeEvent {
+    pub id: i64,
+    pub session_id: String,
+    pub event_kind: String,
+    pub actor_session_id: Option<String>,
+    pub payload_json: Value,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AgentRuntime;
+
+impl AgentRuntime {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub async fn run_turn(
+        &self,
+        config_path: Option<&str>,
+        session_hint: Option<&str>,
+        request: &AgentTurnRequest,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime(
+            config_path,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+        )?;
+        let acp_event_printer = request
+            .acp_event_stream
+            .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
+        self.run_turn_with_runtime(
+            &runtime,
+            request,
+            acp_event_printer
+                .as_ref()
+                .map(|printer| printer as &dyn AcpTurnEventSink),
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_runtime(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+    ) -> CliResult<AgentTurnResult> {
+        let acp_manager = crate::acp::shared_acp_session_manager(&runtime.config)?;
+        self.run_turn_with_runtime_and_context_and_manager(
+            runtime,
+            request,
+            event_sink,
+            None,
+            None,
+            AcpTurnProvenance::default(),
+            crate::conversation::ProviderErrorMode::InlineMessage,
+            acp_manager,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_runtime_and_observer(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_observer_and_context(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            None,
+            AcpTurnProvenance::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_runtime_and_observer_and_context(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            crate::conversation::ProviderErrorMode::InlineMessage,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_runtime_and_observer_and_context_and_error_mode(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+        provider_error_mode: crate::conversation::ProviderErrorMode,
+    ) -> CliResult<AgentTurnResult> {
+        let acp_manager = crate::acp::shared_acp_session_manager(&runtime.config)?;
+        self.run_turn_with_runtime_and_context_and_manager(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            provider_error_mode,
+            acp_manager,
+        )
+        .await
+    }
+
+    async fn run_turn_with_runtime_and_context_and_manager(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+        provider_error_mode: crate::conversation::ProviderErrorMode,
+        acp_manager: Arc<crate::acp::AcpSessionManager>,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+        let message = request.message.as_str();
+
+        let turn_address = resolved_session_address(runtime, request);
+        let explicit_acp_request = runtime.explicit_acp_request
+            || request.acp
+            || matches!(request.turn_mode, AgentTurnMode::Acp);
+
+        if explicit_acp_request {
+            let acp_options = acp_turn_options_from_runtime(runtime, event_sink, request)
+                .with_provenance(provenance);
+            let execution = crate::acp::execute_acp_conversation_turn_for_address_with_manager(
+                &runtime.config,
+                &turn_address,
+                message,
+                &acp_options,
+                acp_manager,
+            )
+            .await?;
+            let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+            let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+            return match execution.outcome {
+                crate::acp::AcpConversationTurnExecutionOutcome::Succeeded(success) => {
+                    Ok(AgentTurnResult {
+                        session_id: runtime.session_id.clone(),
+                        output_text: success.result.output_text,
+                        turn_mode: request.turn_mode,
+                        governed_session_mode: ConversationRuntimeBinding::kernel(
+                            &runtime.kernel_ctx,
+                        )
+                        .session_mode(),
+                        state: Some(acp_session_state_label(success.result.state).to_owned()),
+                        stop_reason: success
+                            .result
+                            .stop_reason
+                            .map(acp_turn_stop_reason_label)
+                            .map(ToOwned::to_owned),
+                        usage: success.result.usage,
+                        event_count: success.runtime_events.len(),
+                        prompt_assembly,
+                        prompt_cache,
+                    })
+                }
+                crate::acp::AcpConversationTurnExecutionOutcome::Failed(failure) => {
+                    Err(failure.error)
+                }
+            };
+        }
+
+        let has_provenance = provenance.trace_id.is_some()
+            || provenance.source_message_id.is_some()
+            || provenance.ack_cursor.is_some();
+        let output_text = if ingress.is_none() && !has_provenance {
+            crate::chat::run_cli_turn_with_address(
+                runtime,
+                &turn_address,
+                message,
+                event_sink,
+                request.live_surface_enabled,
+                Some(&request.metadata),
+                observer,
+            )
+            .await?
+        } else {
+            crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode(
+                runtime,
+                &turn_address,
+                message,
+                event_sink,
+                request.live_surface_enabled,
+                Some(&request.metadata),
+                ingress,
+                provenance,
+                provider_error_mode,
+                observer,
+            )
+            .await?
+        };
+        let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+        let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+
+        Ok(AgentTurnResult {
+            session_id: runtime.session_id.clone(),
+            output_text,
+            turn_mode: request.turn_mode,
+            governed_session_mode: ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)
+                .session_mode(),
+            state: None,
+            stop_reason: None,
+            usage: None,
+            event_count: 0,
+            prompt_assembly,
+            prompt_cache,
+        })
+    }
+
+    pub async fn resume_turn(
+        &self,
+        config_path: Option<&str>,
+        session_hint: Option<&str>,
+        request: &AgentTurnRequest,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn(config_path, session_hint, request).await
+    }
+
+    pub async fn run_turn_with_loaded_config(
+        &self,
+        resolved_path: PathBuf,
+        config: crate::config::LoongClawConfig,
+        session_hint: Option<&str>,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            true,
+        )?;
+
+        self.run_turn_with_runtime(&runtime, request, event_sink)
+            .await
+    }
+
+    pub async fn run_turn_with_loaded_config_and_acp_manager(
+        &self,
+        resolved_path: PathBuf,
+        config: crate::config::LoongClawConfig,
+        session_hint: Option<&str>,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        acp_manager: Arc<crate::acp::AcpSessionManager>,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            true,
+        )?;
+
+        self.run_turn_with_runtime_and_context_and_manager(
+            &runtime,
+            request,
+            event_sink,
+            None,
+            None,
+            AcpTurnProvenance::default(),
+            crate::conversation::ProviderErrorMode::InlineMessage,
+            acp_manager,
+        )
+        .await
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub async fn session_events(
+        &self,
+        config_path: Option<&str>,
+        current_session_hint: Option<&str>,
+        target_session_id: &str,
+        limit: usize,
+        after_id: Option<i64>,
+    ) -> CliResult<Vec<AgentRuntimeEvent>> {
+        let runtime = initialize_cli_turn_runtime(
+            config_path,
+            current_session_hint.or(Some(target_session_id)),
+            &CliChatOptions::default(),
+            "agent-runtime-session-events",
+        )?;
+        let outcome = tools::execute_app_tool_with_visibility_checked_config(
+            ToolCoreRequest {
+                tool_name: "session_events".to_owned(),
+                payload: json!({
+                    "session_id": target_session_id,
+                    "limit": limit,
+                    "after_id": after_id,
+                }),
+            },
+            &runtime.session_id,
+            &runtime.memory_config,
+            &runtime.config.tools,
+        )?;
+        parse_agent_runtime_events(&outcome.payload)
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    pub async fn session_events(
+        &self,
+        _config_path: Option<&str>,
+        _current_session_hint: Option<&str>,
+        _target_session_id: &str,
+        _limit: usize,
+        _after_id: Option<i64>,
+    ) -> CliResult<Vec<AgentRuntimeEvent>> {
+        Err("agent runtime session events unavailable: memory-sqlite feature disabled".to_owned())
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    pub async fn cancel_turn(
+        &self,
+        config_path: Option<&str>,
+        current_session_hint: Option<&str>,
+        target_session_id: &str,
+    ) -> CliResult<Value> {
+        let runtime = initialize_cli_turn_runtime(
+            config_path,
+            current_session_hint.or(Some(target_session_id)),
+            &CliChatOptions::default(),
+            "agent-runtime-cancel-turn",
+        )?;
+        let outcome = tools::execute_app_tool_with_visibility_checked_config(
+            ToolCoreRequest {
+                tool_name: "session_cancel".to_owned(),
+                payload: json!({
+                    "session_id": target_session_id,
+                }),
+            },
+            &runtime.session_id,
+            &runtime.memory_config,
+            &runtime.config.tools,
+        )?;
+        Ok(outcome.payload)
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    pub async fn cancel_turn(
+        &self,
+        _config_path: Option<&str>,
+        _current_session_hint: Option<&str>,
+        _target_session_id: &str,
+    ) -> CliResult<Value> {
+        Err("agent runtime cancel unavailable: memory-sqlite feature disabled".to_owned())
+    }
+}
+
+fn cli_chat_options_for_turn_request(request: &AgentTurnRequest) -> CliChatOptions {
+    CliChatOptions {
+        acp_requested: request.acp || matches!(request.turn_mode, AgentTurnMode::Acp),
+        acp_event_stream: request.acp_event_stream,
+        acp_bootstrap_mcp_servers: request.acp_bootstrap_mcp_servers.clone(),
+        acp_working_directory: request.acp_cwd.as_deref().map(std::path::PathBuf::from),
+    }
+}
+
+fn resolved_session_address(
+    runtime: &crate::chat::CliTurnRuntime,
+    request: &AgentTurnRequest,
+) -> ConversationSessionAddress {
+    let mut address = ConversationSessionAddress::from_session_id(runtime.session_id.clone());
+    if let (Some(channel_id), Some(conversation_id)) = (
+        request.channel_id.as_deref(),
+        request.conversation_id.as_deref(),
+    ) {
+        address = address.with_channel_scope(channel_id, conversation_id);
+    }
+    if let Some(account_id) = request.account_id.as_deref() {
+        address = address.with_account_id(account_id);
+    }
+    if let Some(thread_id) = request.thread_id.as_deref() {
+        address = address.with_thread_id(thread_id);
+    }
+    address
+}
+
+fn acp_turn_options_from_runtime<'a>(
+    runtime: &'a crate::chat::CliTurnRuntime,
+    event_sink: Option<&'a dyn AcpTurnEventSink>,
+    request: &'a AgentTurnRequest,
+) -> crate::acp::AcpConversationTurnOptions<'a> {
+    let base = if runtime.explicit_acp_request || request.acp {
+        crate::acp::AcpConversationTurnOptions::explicit()
+    } else {
+        crate::acp::AcpConversationTurnOptions::automatic()
+    };
+    base.with_event_sink(event_sink)
+        .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
+        .with_working_directory(runtime.effective_working_directory.as_deref())
+        .with_metadata(Some(&request.metadata))
+}
+
+fn acp_session_state_label(state: crate::acp::AcpSessionState) -> &'static str {
+    match state {
+        crate::acp::AcpSessionState::Initializing => "initializing",
+        crate::acp::AcpSessionState::Ready => "ready",
+        crate::acp::AcpSessionState::Busy => "busy",
+        crate::acp::AcpSessionState::Cancelling => "cancelling",
+        crate::acp::AcpSessionState::Error => "error",
+        crate::acp::AcpSessionState::Closed => "closed",
+    }
+}
+
+fn acp_turn_stop_reason_label(stop_reason: crate::acp::AcpTurnStopReason) -> &'static str {
+    match stop_reason {
+        crate::acp::AcpTurnStopReason::Completed => "completed",
+        crate::acp::AcpTurnStopReason::Cancelled => "cancelled",
+    }
+}
+
+fn kernel_scope_for_turn_mode(turn_mode: AgentTurnMode) -> &'static str {
+    match turn_mode {
+        AgentTurnMode::Interactive => "agent-runtime-interactive",
+        AgentTurnMode::Oneshot => "agent-runtime-oneshot",
+        AgentTurnMode::Delegate => "agent-runtime-delegate",
+        AgentTurnMode::Acp => "agent-runtime-acp",
+    }
+}
+
+async fn load_runtime_prompt_frame_summary(
+    runtime: &crate::chat::CliTurnRuntime,
+) -> PromptFrameEventSummary {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        return load_prompt_frame_event_summary(
+            &runtime.session_id,
+            32,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            &runtime.memory_config,
+        )
+        .await
+        .unwrap_or_default();
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = runtime;
+        PromptFrameEventSummary::default()
+    }
+}
+
+fn build_prompt_plans(summary: &PromptFrameEventSummary) -> (PromptAssemblyPlan, PromptCachePlan) {
+    let prompt_assembly = PromptAssemblyPlan {
+        total_estimated_tokens: summary.latest_total_estimated_tokens,
+        stable_runtime_estimated_tokens: summary.latest_stable_runtime_estimated_tokens,
+        session_latched_estimated_tokens: summary.latest_session_latched_estimated_tokens,
+        session_local_recall_estimated_tokens: summary.latest_session_local_recall_estimated_tokens,
+        turn_ephemeral_estimated_tokens: summary.latest_turn_ephemeral_estimated_tokens,
+        stable_prefix_hash_sha256: summary.latest_stable_prefix_hash.clone(),
+        cached_prefix_sha256: summary.latest_cached_prefix_hash.clone(),
+    };
+    let prompt_cache = PromptCachePlan {
+        stable_prefix_hash_sha256: summary.latest_stable_prefix_hash.clone(),
+        cached_prefix_sha256: summary.latest_cached_prefix_hash.clone(),
+        stable_prefix_reused: summary.snapshot_events > 0
+            && summary.stable_prefix_hash_change_events == 0,
+        cached_prefix_reused: summary.snapshot_events > 0
+            && summary.cached_prefix_hash_change_events == 0,
+        session_latched_context_drifted: summary.session_latched_hash_change_events > 0,
+        session_local_recall_drifted: summary.session_local_recall_hash_change_events > 0,
+    };
+
+    (prompt_assembly, prompt_cache)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_agent_runtime_events(payload: &Value) -> CliResult<Vec<AgentRuntimeEvent>> {
+    let Some(events) = payload.get("events").and_then(Value::as_array) else {
+        return Err("agent runtime session events payload missing `events` array".to_owned());
+    };
+
+    events
+        .iter()
+        .cloned()
+        .map(|event| {
+            serde_json::from_value::<AgentRuntimeEvent>(event)
+                .map_err(|error| format!("parse agent runtime event failed: {error}"))
+        })
+        .collect()
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn load_agent_runtime(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+) -> CliResult<(std::path::PathBuf, crate::config::LoongClawConfig, String)> {
+    let (resolved_path, config) = load_config(config_path)?;
+    let runtime = initialize_cli_turn_runtime(
+        Some(resolved_path.to_string_lossy().as_ref()),
+        session_hint,
+        &CliChatOptions::default(),
+        "agent-runtime-load",
+    )?;
+    Ok((resolved_path, config, runtime.session_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_prompt_plans_flags_prefix_reuse_and_drift() {
+        let summary = PromptFrameEventSummary {
+            snapshot_events: 2,
+            stable_prefix_hash_change_events: 0,
+            cached_prefix_hash_change_events: 1,
+            session_latched_hash_change_events: 1,
+            session_local_recall_hash_change_events: 0,
+            latest_total_estimated_tokens: Some(128),
+            latest_stable_runtime_estimated_tokens: Some(40),
+            latest_session_latched_estimated_tokens: Some(32),
+            latest_session_local_recall_estimated_tokens: Some(16),
+            latest_turn_ephemeral_estimated_tokens: Some(8),
+            latest_stable_prefix_hash: Some("stable-a".to_owned()),
+            latest_cached_prefix_hash: Some("cached-b".to_owned()),
+            ..PromptFrameEventSummary::default()
+        };
+
+        let (prompt_assembly, prompt_cache) = build_prompt_plans(&summary);
+
+        assert_eq!(prompt_assembly.total_estimated_tokens, Some(128));
+        assert_eq!(
+            prompt_cache.stable_prefix_hash_sha256.as_deref(),
+            Some("stable-a")
+        );
+        assert!(prompt_cache.stable_prefix_reused);
+        assert!(!prompt_cache.cached_prefix_reused);
+        assert!(prompt_cache.session_latched_context_drifted);
+        assert!(!prompt_cache.session_local_recall_drifted);
+    }
+}

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -135,7 +135,6 @@ impl AgentRuntime {
         request: &AgentTurnRequest,
         event_sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AgentTurnResult> {
-        let acp_manager = crate::acp::shared_acp_session_manager(&runtime.config)?;
         self.run_turn_with_runtime_and_context_and_manager(
             runtime,
             request,
@@ -144,7 +143,7 @@ impl AgentRuntime {
             None,
             AcpTurnProvenance::default(),
             crate::conversation::ProviderErrorMode::InlineMessage,
-            acp_manager,
+            None,
         )
         .await
     }
@@ -198,7 +197,6 @@ impl AgentRuntime {
         provenance: AcpTurnProvenance<'_>,
         provider_error_mode: crate::conversation::ProviderErrorMode,
     ) -> CliResult<AgentTurnResult> {
-        let acp_manager = crate::acp::shared_acp_session_manager(&runtime.config)?;
         self.run_turn_with_runtime_and_context_and_manager(
             runtime,
             request,
@@ -207,7 +205,7 @@ impl AgentRuntime {
             ingress,
             provenance,
             provider_error_mode,
-            acp_manager,
+            None,
         )
         .await
     }
@@ -221,7 +219,7 @@ impl AgentRuntime {
         ingress: Option<&ConversationIngressContext>,
         provenance: AcpTurnProvenance<'_>,
         provider_error_mode: crate::conversation::ProviderErrorMode,
-        acp_manager: Arc<crate::acp::AcpSessionManager>,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<AgentTurnResult> {
         if request.message.trim().is_empty() {
             return Err("agent runtime message must not be empty".to_owned());
@@ -234,6 +232,10 @@ impl AgentRuntime {
             || matches!(request.turn_mode, AgentTurnMode::Acp);
 
         if explicit_acp_request {
+            let acp_manager = match acp_manager {
+                Some(manager) => manager,
+                None => crate::acp::shared_acp_session_manager(&runtime.config)?,
+            };
             let acp_options = acp_turn_options_from_runtime(runtime, event_sink, request)
                 .with_provenance(provenance);
             let execution = crate::acp::execute_acp_conversation_turn_for_address_with_manager(
@@ -277,32 +279,25 @@ impl AgentRuntime {
         let has_provenance = provenance.trace_id.is_some()
             || provenance.source_message_id.is_some()
             || provenance.ack_cursor.is_some();
-        let output_text = if ingress.is_none() && !has_provenance {
-            crate::chat::run_cli_turn_with_address(
-                runtime,
-                &turn_address,
-                message,
-                event_sink,
-                request.live_surface_enabled,
-                Some(&request.metadata),
-                observer,
-            )
-            .await?
+        let effective_ingress = if has_provenance { ingress } else { None };
+        let effective_provenance = if has_provenance {
+            provenance
         } else {
-            crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode(
-                runtime,
-                &turn_address,
-                message,
-                event_sink,
-                request.live_surface_enabled,
-                Some(&request.metadata),
-                ingress,
-                provenance,
-                provider_error_mode,
-                observer,
-            )
-            .await?
+            AcpTurnProvenance::default()
         };
+        let output_text = crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode(
+            runtime,
+            &turn_address,
+            message,
+            event_sink,
+            request.live_surface_enabled,
+            Some(&request.metadata),
+            effective_ingress,
+            effective_provenance,
+            provider_error_mode,
+            observer,
+        )
+        .await?;
         let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
         let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
@@ -389,7 +384,7 @@ impl AgentRuntime {
             None,
             AcpTurnProvenance::default(),
             crate::conversation::ProviderErrorMode::InlineMessage,
-            acp_manager,
+            Some(acp_manager),
         )
         .await
     }

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -30,6 +30,8 @@ use crate::CliResult;
     feature = "channel-imessage",
 ))]
 use crate::KernelContext;
+#[cfg(test)]
+use crate::acp::AcpConversationTurnOptions;
 #[cfg(any(
     feature = "channel-telegram",
     feature = "channel-discord",
@@ -52,7 +54,7 @@ use crate::KernelContext;
     feature = "channel-whatsapp",
     feature = "channel-imessage",
 ))]
-use crate::acp::{AcpConversationTurnOptions, AcpTurnProvenance};
+use crate::acp::AcpTurnProvenance;
 use crate::config::LoongClawConfig;
 #[cfg(any(
     feature = "channel-telegram",
@@ -150,8 +152,7 @@ use crate::config::ResolvedWhatsappChannelConfig;
 use crate::conversation::{
     ConversationIngressChannel, ConversationIngressContext, ConversationIngressDelivery,
     ConversationIngressDeliveryResource, ConversationIngressFeishuCallbackContext,
-    ConversationIngressPrivateContext, ConversationRuntime, ConversationRuntimeBinding,
-    DefaultConversationRuntime,
+    ConversationIngressPrivateContext,
 };
 #[cfg(any(
     feature = "channel-telegram",
@@ -160,6 +161,16 @@ use crate::conversation::{
     feature = "channel-wecom",
     feature = "channel-whatsapp",
 ))]
+#[cfg(test)]
+use crate::conversation::{ConversationRuntime, ConversationRuntimeBinding};
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp",
+))]
+#[cfg(test)]
 use crate::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
 pub(super) use super::commands::{
@@ -3029,6 +3040,7 @@ pub(crate) async fn send_text_to_known_session(
     feature = "channel-wecom",
     feature = "channel-whatsapp"
 ))]
+#[cfg(test)]
 pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
@@ -3077,19 +3089,58 @@ pub(crate) async fn process_inbound_with_provider(
 ) -> CliResult<String> {
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
-        Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
-            Ok(runtime) => {
-                process_inbound_with_runtime_and_feedback(
-                    &turn_config,
+        Ok(turn_config) => {
+            let address = message.session.conversation_address();
+            let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
+            let request = crate::agent_runtime::AgentTurnRequest {
+                message: message.text.clone(),
+                turn_mode: crate::agent_runtime::AgentTurnMode::Oneshot,
+                channel_id: address.channel_id.clone(),
+                account_id: address.account_id.clone(),
+                conversation_id: address.conversation_id.clone(),
+                thread_id: address.thread_id.clone(),
+                acp_bootstrap_mcp_servers: acp_turn_hints.bootstrap_mcp_servers.clone(),
+                acp_cwd: acp_turn_hints
+                    .working_directory
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                ..Default::default()
+            };
+            let runtime =
+                crate::chat::initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+                    resolved_path
+                        .map(std::path::Path::to_path_buf)
+                        .unwrap_or_default(),
+                    turn_config,
+                    Some(address.session_id.as_str()),
+                    &crate::chat::CliChatOptions {
+                        acp_requested: false,
+                        acp_event_stream: false,
+                        acp_bootstrap_mcp_servers: request.acp_bootstrap_mcp_servers.clone(),
+                        acp_working_directory: request
+                            .acp_cwd
+                            .as_deref()
+                            .map(std::path::PathBuf::from),
+                    },
+                    kernel_ctx.clone(),
+                    crate::chat::CliSessionRequirement::AllowImplicitDefault,
+                )?;
+            let ingress = channel_message_ingress_context(message);
+            let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
+            let observer = feedback_capture.observer_handle();
+            let result = crate::agent_runtime::AgentRuntime::new()
+                .run_turn_with_runtime_and_observer_and_context_and_error_mode(
                     &runtime,
-                    message,
-                    ConversationRuntimeBinding::kernel(kernel_ctx),
-                    feedback_policy,
+                    &request,
+                    None,
+                    observer,
+                    ingress.as_ref(),
+                    channel_message_acp_turn_provenance(message),
+                    crate::conversation::ProviderErrorMode::Propagate,
                 )
-                .await
-            }
-            Err(error) => Err(error),
-        },
+                .await?;
+            Ok(feedback_capture.render_reply(result.output_text))
+        }
         Err(error) => Err(error),
     };
     let duration_ms = started_at.elapsed().as_millis();

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -954,11 +954,13 @@ mod tests {
     use serde_json::json;
     use sha2::{Digest, Sha256};
     use std::collections::{BTreeMap, BTreeSet};
+    use std::future::Future;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::Mutex;
 
     const MOCK_PROVIDER_MARKDOWN_REPLY: &str = "## structured inbound ack\n\n- rendered";
+    const FEISHU_WEBHOOK_TEST_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct MockRequest {
@@ -981,6 +983,28 @@ mod tests {
                 .expect("clock")
                 .as_nanos()
         ))
+    }
+
+    fn run_feishu_webhook_test_on_large_stack<F, Fut>(thread_name: &str, operation: F)
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let join_handle = std::thread::Builder::new()
+            .name(thread_name.to_owned())
+            .stack_size(FEISHU_WEBHOOK_TEST_STACK_SIZE_BYTES)
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build feishu webhook test runtime");
+                runtime.block_on(operation());
+            })
+            .expect("spawn feishu webhook large-stack test thread");
+        match join_handle.join() {
+            Ok(()) => {}
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
     }
 
     fn webhook_tool_runtime_config(config: &LoongClawConfig) -> ToolRuntimeConfig {
@@ -1752,8 +1776,14 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies() {
+    #[test]
+    fn feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-file-event", || async move {
+            feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -1890,8 +1920,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_skips_ack_reaction_when_disabled() {
+    #[test]
+    fn feishu_webhook_skips_ack_reaction_when_disabled() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-no-ack", || async move {
+            feishu_webhook_skips_ack_reaction_when_disabled_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_skips_ack_reaction_when_disabled_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -1973,8 +2009,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction() {
+    #[test]
+    fn feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-ack-retry", || async move {
+            feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -2073,8 +2115,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_reaction_failure_stays_best_effort_after_reply() {
+    #[test]
+    fn feishu_webhook_reaction_failure_stays_best_effort_after_reply() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-ack-best-effort", || async move {
+            feishu_webhook_reaction_failure_stays_best_effort_after_reply_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_reaction_failure_stays_best_effort_after_reply_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -2163,8 +2211,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_inbound_reply_stays_successful_when_runtime_end_write_fails() {
+    #[test]
+    fn feishu_webhook_inbound_reply_stays_successful_when_runtime_end_write_fails() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-runtime-end", || async move {
+            feishu_webhook_inbound_reply_stays_successful_when_runtime_end_write_fails_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_inbound_reply_stays_successful_when_runtime_end_write_fails_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_delayed_success_server(
@@ -2273,8 +2327,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_reaches_provider_and_returns_safe_noop_body() {
+    #[test]
+    fn feishu_webhook_card_callback_reaches_provider_and_returns_safe_noop_body() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-callback-noop", || async move {
+            feishu_webhook_card_callback_reaches_provider_and_returns_safe_noop_body_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_card_callback_reaches_provider_and_returns_safe_noop_body_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -2377,8 +2437,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_structured_toast_response_is_returned() {
+    #[test]
+    fn feishu_webhook_card_callback_structured_toast_response_is_returned() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-callback-toast", || async move {
+            feishu_webhook_card_callback_structured_toast_response_is_returned_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_card_callback_structured_toast_response_is_returned_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2467,8 +2533,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_structured_card_response_is_returned() {
+    #[test]
+    fn feishu_webhook_card_callback_structured_card_response_is_returned() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-callback-card", || async move {
+            feishu_webhook_card_callback_structured_card_response_is_returned_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_card_callback_structured_card_response_is_returned_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2559,8 +2631,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_structured_card_markdown_response_is_returned() {
+    #[test]
+    fn feishu_webhook_card_callback_structured_card_markdown_response_is_returned() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-callback-card-md", || async move {
+            feishu_webhook_card_callback_structured_card_markdown_response_is_returned_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_card_callback_structured_card_markdown_response_is_returned_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2659,8 +2737,18 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_structured_card_response_with_toast_is_returned() {
+    #[test]
+    fn feishu_webhook_card_callback_structured_card_response_with_toast_is_returned() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-callback-card-toast",
+            || async move {
+                feishu_webhook_card_callback_structured_card_response_with_toast_is_returned_impl()
+                    .await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_card_callback_structured_card_response_with_toast_is_returned_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2757,9 +2845,18 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_structured_card_markdown_response_with_toast_is_returned()
-    {
+    #[test]
+    fn feishu_webhook_card_callback_structured_card_markdown_response_with_toast_is_returned() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-callback-card-md-toast",
+            || async move {
+                feishu_webhook_card_callback_structured_card_markdown_response_with_toast_is_returned_impl().await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_card_callback_structured_card_markdown_response_with_toast_is_returned_impl()
+     {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2880,9 +2977,18 @@ mod tests {
         assert!(response.is_none());
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_invalid_structured_response_falls_back_to_safe_noop_body()
-    {
+    #[test]
+    fn feishu_webhook_card_callback_invalid_structured_response_falls_back_to_safe_noop_body() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-callback-invalid-toast",
+            || async move {
+                feishu_webhook_card_callback_invalid_structured_response_falls_back_to_safe_noop_body_impl().await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_card_callback_invalid_structured_response_falls_back_to_safe_noop_body_impl()
+     {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) = spawn_mock_provider_callback_toast_server(
@@ -2958,8 +3064,18 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_invalid_structured_card_response_falls_back_to_safe_noop_body()
+    #[test]
+    fn feishu_webhook_card_callback_invalid_structured_card_response_falls_back_to_safe_noop_body()
+    {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-callback-invalid-card",
+            || async move {
+                feishu_webhook_card_callback_invalid_structured_card_response_falls_back_to_safe_noop_body_impl().await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_card_callback_invalid_structured_card_response_falls_back_to_safe_noop_body_impl()
      {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
@@ -3036,8 +3152,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_duplicate_is_deduped_safely() {
+    #[test]
+    fn feishu_webhook_card_callback_duplicate_is_deduped_safely() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-callback-dedupe", || async move {
+            feishu_webhook_card_callback_duplicate_is_deduped_safely_impl().await;
+        });
+    }
+
+    async fn feishu_webhook_card_callback_duplicate_is_deduped_safely_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -3123,224 +3245,247 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_delayed_update_waits_for_response_body_consumption() {
-        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
-        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
-        let (provider_base_url, provider_server) =
-            spawn_mock_provider_card_update_server(provider_requests.clone()).await;
-        let (feishu_base_url, feishu_server) =
-            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_unused").await;
+    #[test]
+    fn feishu_webhook_card_callback_delayed_update_waits_for_response_body_consumption() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-delayed-update-response-order",
+            || async move {
+                let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+                let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+                let (provider_base_url, provider_server) =
+                    spawn_mock_provider_card_update_server(provider_requests.clone()).await;
+                let (feishu_base_url, feishu_server) =
+                    spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_unused").await;
 
-        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
-        let resolved = config
-            .feishu
-            .resolve_account(None)
-            .expect("resolve feishu account");
-        let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_webhook_kernel_context(
-            "feishu-webhook-card-callback-delayed-update-response-order",
-            DEFAULT_TOKEN_TTL_S,
-            &config,
-        )
-        .expect("bootstrap kernel context");
-        let runtime = Arc::new(
-            ChannelOperationRuntimeTracker::start(
-                ChannelPlatform::Feishu,
-                "serve",
-                resolved.account.id.as_str(),
-                resolved.account.label.as_str(),
-            )
-            .await
-            .expect("start runtime tracker"),
-        );
-        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
-
-        let payload = json!({
-            "header": {
-                "event_id": "evt_card_webhook_response_order_1",
-                "event_type": "card.action.trigger",
-                "token": "verify-token"
-            },
-            "event": {
-                "token": "callback-token-response-order",
-                "operator": {
-                    "operator_id": {
-                        "open_id": "ou_sender_1"
-                    }
-                },
-                "action": {
-                    "tag": "button",
-                    "name": "approve_request"
-                },
-                "context": {
-                    "open_message_id": "om_card_source_response_order",
-                    "open_chat_id": "oc_demo"
-                }
-            }
-        });
-        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
-        let headers = signed_headers(&raw_body, "encrypt-key");
-
-        let response = feishu_webhook_handler(State(state), headers, Bytes::from(raw_body.clone()))
-            .await
-            .into_response();
-
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        assert_eq!(
-            feishu_requests
-                .lock()
-                .await
-                .iter()
-                .filter(|request| request.path == "/open-apis/interactive/v1/card/update")
-                .count(),
-            0,
-            "delayed update must wait until the callback HTTP response body is consumed"
-        );
-
-        let response_body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("read callback response body");
-        assert_eq!(
-            serde_json::from_slice::<Value>(&response_body).expect("response body json"),
-            json!({})
-        );
-
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let feishu_requests = feishu_requests.lock().await.clone();
-        let provider_requests = provider_requests.lock().await.clone();
-        let delayed_update = feishu_requests
-            .iter()
-            .find(|request| request.path == "/open-apis/interactive/v1/card/update")
-            .unwrap_or_else(|| {
-                panic!(
-                    "delayed update request after body consumption; feishu_requests={feishu_requests:?}; provider_requests={provider_requests:?}"
+                let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+                let resolved = config
+                    .feishu
+                    .resolve_account(None)
+                    .expect("resolve feishu account");
+                let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+                let kernel_ctx = bootstrap_webhook_kernel_context(
+                    "feishu-webhook-card-callback-delayed-update-response-order",
+                    DEFAULT_TOKEN_TTL_S,
+                    &config,
                 )
-            });
-        assert_eq!(
-            delayed_update.authorization.as_deref(),
-            Some("Bearer t-token-webhook")
-        );
-        assert!(
-            delayed_update
-                .body
-                .contains("\"token\":\"callback-token-response-order\"")
-        );
-        assert!(
-            delayed_update
-                .body
-                .contains("\"content\":\"callback updated\"")
-        );
-        assert!(
-            !provider_requests.is_empty(),
-            "callback processing should still reach the provider before deferred dispatch"
-        );
+                .expect("bootstrap kernel context");
+                let runtime = Arc::new(
+                    ChannelOperationRuntimeTracker::start(
+                        ChannelPlatform::Feishu,
+                        "serve",
+                        resolved.account.id.as_str(),
+                        resolved.account.label.as_str(),
+                    )
+                    .await
+                    .expect("start runtime tracker"),
+                );
+                let state =
+                    FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
 
-        provider_server.abort();
-        feishu_server.abort();
+                let payload = json!({
+                    "header": {
+                        "event_id": "evt_card_webhook_response_order_1",
+                        "event_type": "card.action.trigger",
+                        "token": "verify-token"
+                    },
+                    "event": {
+                        "token": "callback-token-response-order",
+                        "operator": {
+                            "operator_id": {
+                                "open_id": "ou_sender_1"
+                            }
+                        },
+                        "action": {
+                            "tag": "button",
+                            "name": "approve_request"
+                        },
+                        "context": {
+                            "open_message_id": "om_card_source_response_order",
+                            "open_chat_id": "oc_demo"
+                        }
+                    }
+                });
+                let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+                let headers = signed_headers(&raw_body, "encrypt-key");
+
+                let response =
+                    feishu_webhook_handler(State(state), headers, Bytes::from(raw_body.clone()))
+                        .await
+                        .into_response();
+
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                assert_eq!(
+                    feishu_requests
+                        .lock()
+                        .await
+                        .iter()
+                        .filter(|request| request.path == "/open-apis/interactive/v1/card/update")
+                        .count(),
+                    0,
+                    "delayed update must wait until the callback HTTP response body is consumed"
+                );
+
+                let response_body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("read callback response body");
+                assert_eq!(
+                    serde_json::from_slice::<Value>(&response_body).expect("response body json"),
+                    json!({})
+                );
+
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let feishu_requests = feishu_requests.lock().await.clone();
+                let provider_requests = provider_requests.lock().await.clone();
+                let delayed_update = feishu_requests
+                    .iter()
+                    .find(|request| request.path == "/open-apis/interactive/v1/card/update")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "delayed update request after body consumption; feishu_requests={feishu_requests:?}; provider_requests={provider_requests:?}"
+                        )
+                    });
+                assert_eq!(
+                    delayed_update.authorization.as_deref(),
+                    Some("Bearer t-token-webhook")
+                );
+                assert!(
+                    delayed_update
+                        .body
+                        .contains("\"token\":\"callback-token-response-order\"")
+                );
+                assert!(
+                    delayed_update
+                        .body
+                        .contains("\"content\":\"callback updated\"")
+                );
+                assert!(
+                    !provider_requests.is_empty(),
+                    "callback processing should still reach the provider before deferred dispatch"
+                );
+
+                provider_server.abort();
+                feishu_server.abort();
+            },
+        );
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_delayed_update_dispatches_when_response_body_is_dropped()
-    {
-        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
-        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
-        let (provider_base_url, provider_server) =
-            spawn_mock_provider_card_update_server(provider_requests.clone()).await;
-        let (feishu_base_url, feishu_server) =
-            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_unused").await;
+    #[test]
+    fn feishu_webhook_card_callback_delayed_update_dispatches_when_response_body_is_dropped() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-delayed-update-response-drop",
+            || async move {
+                let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+                let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+                let (provider_base_url, provider_server) =
+                    spawn_mock_provider_card_update_server(provider_requests.clone()).await;
+                let (feishu_base_url, feishu_server) =
+                    spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_unused").await;
 
-        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
-        let resolved = config
-            .feishu
-            .resolve_account(None)
-            .expect("resolve feishu account");
-        let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
-        let kernel_ctx = bootstrap_webhook_kernel_context(
-            "feishu-webhook-card-callback-delayed-update-response-drop",
-            DEFAULT_TOKEN_TTL_S,
-            &config,
-        )
-        .expect("bootstrap kernel context");
-        let runtime = Arc::new(
-            ChannelOperationRuntimeTracker::start(
-                ChannelPlatform::Feishu,
-                "serve",
-                resolved.account.id.as_str(),
-                resolved.account.label.as_str(),
-            )
-            .await
-            .expect("start runtime tracker"),
-        );
-        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
-
-        let payload = json!({
-            "header": {
-                "event_id": "evt_card_webhook_response_drop_1",
-                "event_type": "card.action.trigger",
-                "token": "verify-token"
-            },
-            "event": {
-                "token": "callback-token-response-drop",
-                "operator": {
-                    "operator_id": {
-                        "open_id": "ou_sender_1"
-                    }
-                },
-                "action": {
-                    "tag": "button",
-                    "name": "approve_request"
-                },
-                "context": {
-                    "open_message_id": "om_card_source_response_drop",
-                    "open_chat_id": "oc_demo"
-                }
-            }
-        });
-        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
-        let headers = signed_headers(&raw_body, "encrypt-key");
-
-        let response = feishu_webhook_handler(State(state), headers, Bytes::from(raw_body.clone()))
-            .await
-            .into_response();
-        drop(response);
-
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let feishu_requests = feishu_requests.lock().await.clone();
-        let provider_requests = provider_requests.lock().await.clone();
-        let delayed_update = feishu_requests
-            .iter()
-            .find(|request| request.path == "/open-apis/interactive/v1/card/update")
-            .unwrap_or_else(|| {
-                panic!(
-                    "delayed update request after response drop; feishu_requests={feishu_requests:?}; provider_requests={provider_requests:?}"
+                let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+                let resolved = config
+                    .feishu
+                    .resolve_account(None)
+                    .expect("resolve feishu account");
+                let adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+                let kernel_ctx = bootstrap_webhook_kernel_context(
+                    "feishu-webhook-card-callback-delayed-update-response-drop",
+                    DEFAULT_TOKEN_TTL_S,
+                    &config,
                 )
-            });
-        assert_eq!(
-            delayed_update.authorization.as_deref(),
-            Some("Bearer t-token-webhook")
-        );
-        assert!(
-            delayed_update
-                .body
-                .contains("\"token\":\"callback-token-response-drop\"")
-        );
-        assert!(
-            delayed_update
-                .body
-                .contains("\"content\":\"callback updated\"")
-        );
-        assert!(
-            !provider_requests.is_empty(),
-            "callback processing should still reach the provider before deferred dispatch"
-        );
+                .expect("bootstrap kernel context");
+                let runtime = Arc::new(
+                    ChannelOperationRuntimeTracker::start(
+                        ChannelPlatform::Feishu,
+                        "serve",
+                        resolved.account.id.as_str(),
+                        resolved.account.label.as_str(),
+                    )
+                    .await
+                    .expect("start runtime tracker"),
+                );
+                let state =
+                    FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
 
-        provider_server.abort();
-        feishu_server.abort();
+                let payload = json!({
+                    "header": {
+                        "event_id": "evt_card_webhook_response_drop_1",
+                        "event_type": "card.action.trigger",
+                        "token": "verify-token"
+                    },
+                    "event": {
+                        "token": "callback-token-response-drop",
+                        "operator": {
+                            "operator_id": {
+                                "open_id": "ou_sender_1"
+                            }
+                        },
+                        "action": {
+                            "tag": "button",
+                            "name": "approve_request"
+                        },
+                        "context": {
+                            "open_message_id": "om_card_source_response_drop",
+                            "open_chat_id": "oc_demo"
+                        }
+                    }
+                });
+                let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+                let headers = signed_headers(&raw_body, "encrypt-key");
+
+                let response =
+                    feishu_webhook_handler(State(state), headers, Bytes::from(raw_body.clone()))
+                        .await
+                        .into_response();
+                drop(response);
+
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let feishu_requests = feishu_requests.lock().await.clone();
+                let provider_requests = provider_requests.lock().await.clone();
+                let delayed_update = feishu_requests
+                    .iter()
+                    .find(|request| request.path == "/open-apis/interactive/v1/card/update")
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "delayed update request after response drop; feishu_requests={feishu_requests:?}; provider_requests={provider_requests:?}"
+                        )
+                    });
+                assert_eq!(
+                    delayed_update.authorization.as_deref(),
+                    Some("Bearer t-token-webhook")
+                );
+                assert!(
+                    delayed_update
+                        .body
+                        .contains("\"token\":\"callback-token-response-drop\"")
+                );
+                assert!(
+                    delayed_update
+                        .body
+                        .contains("\"content\":\"callback updated\"")
+                );
+                assert!(
+                    !provider_requests.is_empty(),
+                    "callback processing should still reach the provider before deferred dispatch"
+                );
+
+                provider_server.abort();
+                feishu_server.abort();
+            },
+        );
     }
 
-    #[tokio::test]
-    async fn feishu_webhook_card_callback_provider_failure_still_returns_safe_noop_body() {
+    #[test]
+    fn feishu_webhook_card_callback_provider_failure_still_returns_safe_noop_body() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-callback-provider-failure",
+            || async move {
+                feishu_webhook_card_callback_provider_failure_still_returns_safe_noop_body_impl()
+                    .await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_card_callback_provider_failure_still_returns_safe_noop_body_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -3417,8 +3562,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn execute_deferred_feishu_card_update_uses_delayed_update_api() {
+    #[test]
+    fn execute_deferred_feishu_card_update_uses_delayed_update_api() {
+        run_feishu_webhook_test_on_large_stack("feishu-webhook-deferred-update", || async move {
+            execute_deferred_feishu_card_update_uses_delayed_update_api_impl().await;
+        });
+    }
+
+    async fn execute_deferred_feishu_card_update_uses_delayed_update_api_impl() {
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let state = MockServerState {
             requests: feishu_requests.clone(),

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -441,6 +441,7 @@ fn map_parse_error_status(error: &str) -> StatusCode {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -460,6 +461,7 @@ mod tests {
     use crate::channel::ChannelPlatform;
 
     const MOCK_PROVIDER_MARKDOWN_REPLY: &str = "## structured inbound ack\n\n- rendered";
+    const FEISHU_WEBSOCKET_TEST_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
     use crate::config::{FeishuChannelServeMode, LoongClawConfig, ProviderConfig};
     use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_test_kernel_context};
 
@@ -483,6 +485,28 @@ mod tests {
                 .expect("clock")
                 .as_nanos()
         ))
+    }
+
+    fn run_feishu_websocket_test_on_large_stack<F, Fut>(thread_name: &str, operation: F)
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let join_handle = std::thread::Builder::new()
+            .name(thread_name.to_owned())
+            .stack_size(FEISHU_WEBSOCKET_TEST_STACK_SIZE_BYTES)
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build feishu websocket test runtime");
+                runtime.block_on(operation());
+            })
+            .expect("spawn feishu websocket large-stack test thread");
+        match join_handle.join() {
+            Ok(()) => {}
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
     }
 
     async fn spawn_mock_http_server(router: Router) -> (String, tokio::task::JoinHandle<()>) {
@@ -768,8 +792,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn feishu_websocket_fragments_refresh_ttl_when_new_chunks_arrive() {
+    #[test]
+    fn feishu_websocket_fragments_refresh_ttl_when_new_chunks_arrive() {
+        run_feishu_websocket_test_on_large_stack("feishu-websocket-fragments", || async move {
+            feishu_websocket_fragments_refresh_ttl_when_new_chunks_arrive_impl().await;
+        });
+    }
+
+    async fn feishu_websocket_fragments_refresh_ttl_when_new_chunks_arrive_impl() {
         let mut fragments = FeishuWsFragments::default();
         assert_eq!(
             fragments.combine("evt_ws_fragments", 3, 0, b"hel".to_vec()),
@@ -796,8 +826,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn feishu_websocket_wss_urls_do_not_fail_due_to_missing_tls_support() {
+    #[test]
+    fn feishu_websocket_wss_urls_do_not_fail_due_to_missing_tls_support() {
+        run_feishu_websocket_test_on_large_stack("feishu-websocket-wss-url", || async move {
+            feishu_websocket_wss_urls_do_not_fail_due_to_missing_tls_support_impl().await;
+        });
+    }
+
+    async fn feishu_websocket_wss_urls_do_not_fail_due_to_missing_tls_support_impl() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind disposable tcp listener");
@@ -814,8 +850,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn feishu_websocket_wss_session_surfaces_tls_errors_without_panicking() {
+    #[test]
+    fn feishu_websocket_wss_session_surfaces_tls_errors_without_panicking() {
+        run_feishu_websocket_test_on_large_stack("feishu-websocket-wss-session", || async move {
+            feishu_websocket_wss_session_surfaces_tls_errors_without_panicking_impl().await;
+        });
+    }
+
+    async fn feishu_websocket_wss_session_surfaces_tls_errors_without_panicking_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -892,8 +934,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_websocket_session_stop_interrupts_stalled_initial_connect() {
+    #[test]
+    fn feishu_websocket_session_stop_interrupts_stalled_initial_connect() {
+        run_feishu_websocket_test_on_large_stack("feishu-websocket-stop", || async move {
+            feishu_websocket_session_stop_interrupts_stalled_initial_connect_impl().await;
+        });
+    }
+
+    async fn feishu_websocket_session_stop_interrupts_stalled_initial_connect_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -979,8 +1027,14 @@ mod tests {
         feishu_server.abort();
     }
 
-    #[tokio::test]
-    async fn feishu_websocket_session_reaches_provider_and_replies() {
+    #[test]
+    fn feishu_websocket_session_reaches_provider_and_replies() {
+        run_feishu_websocket_test_on_large_stack("feishu-websocket-session", || async move {
+            feishu_websocket_session_reaches_provider_and_replies_impl().await;
+        });
+    }
+
+    async fn feishu_websocket_session_reaches_provider_and_replies_impl() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -10,7 +11,9 @@ use std::sync::{
 use tokio::sync::Notify;
 
 use crate::CliResult;
-use crate::acp::{AcpConversationTurnOptions, AcpTurnEventSink, JsonlAcpTurnEventSink};
+use crate::acp::{
+    AcpConversationTurnOptions, AcpTurnEventSink, AcpTurnProvenance, JsonlAcpTurnEventSink,
+};
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 mod cli_input;
@@ -71,10 +74,11 @@ use super::conversation::ContextCompactionReport;
 #[cfg(test)]
 use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
 use super::conversation::{
-    ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
-    ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
-    ConversationTurnPhaseEvent, ConversationTurnRuntimeEvent, ConversationTurnToolEvent,
-    ConversationTurnToolState, ExecutionLane, ProviderErrorMode, parse_approval_prompt_view,
+    ConversationIngressContext, ConversationRuntimeBinding, ConversationSessionAddress,
+    ConversationTurnCoordinator, ConversationTurnObserver, ConversationTurnObserverHandle,
+    ConversationTurnPhase, ConversationTurnPhaseEvent, ConversationTurnRuntimeEvent,
+    ConversationTurnToolEvent, ConversationTurnToolState, ExecutionLane, ProviderErrorMode,
+    parse_approval_prompt_view,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -243,23 +247,23 @@ fn format_onboard_command_hint(config_path: Option<&str>, resolved_config_path: 
     command
 }
 
-struct CliTurnRuntime {
-    resolved_path: PathBuf,
-    config: LoongClawConfig,
-    session_id: String,
-    session_address: ConversationSessionAddress,
-    turn_coordinator: ConversationTurnCoordinator,
-    kernel_ctx: crate::KernelContext,
-    explicit_acp_request: bool,
-    effective_bootstrap_mcp_servers: Vec<String>,
-    effective_working_directory: Option<PathBuf>,
-    memory_label: String,
+pub(crate) struct CliTurnRuntime {
+    pub(crate) resolved_path: PathBuf,
+    pub(crate) config: LoongClawConfig,
+    pub(crate) session_id: String,
+    pub(crate) session_address: ConversationSessionAddress,
+    pub(crate) turn_coordinator: ConversationTurnCoordinator,
+    pub(crate) kernel_ctx: crate::KernelContext,
+    pub(crate) explicit_acp_request: bool,
+    pub(crate) effective_bootstrap_mcp_servers: Vec<String>,
+    pub(crate) effective_working_directory: Option<PathBuf>,
+    pub(crate) memory_label: String,
     #[cfg(feature = "memory-sqlite")]
-    memory_config: MemoryRuntimeConfig,
+    pub(crate) memory_config: MemoryRuntimeConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CliSessionRequirement {
+pub(crate) enum CliSessionRequirement {
     AllowImplicitDefault,
     RequireExplicit,
 }
@@ -442,7 +446,7 @@ fn run_concurrent_cli_host_repl(options: &ConcurrentCliHostOptions) -> CliResult
     })
 }
 
-fn initialize_cli_turn_runtime(
+pub(crate) fn initialize_cli_turn_runtime(
     config_path: Option<&str>,
     session_hint: Option<&str>,
     options: &CliChatOptions,
@@ -460,7 +464,7 @@ fn initialize_cli_turn_runtime(
     )
 }
 
-fn initialize_cli_turn_runtime_with_loaded_config(
+pub(crate) fn initialize_cli_turn_runtime_with_loaded_config(
     resolved_path: PathBuf,
     config: LoongClawConfig,
     session_hint: Option<&str>,
@@ -485,6 +489,28 @@ fn initialize_cli_turn_runtime_with_loaded_config(
     }
     let kernel_ctx =
         bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
+    initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+        resolved_path,
+        config,
+        session_hint,
+        options,
+        kernel_ctx,
+        session_requirement,
+    )
+}
+
+pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+    kernel_ctx: crate::KernelContext,
+    session_requirement: CliSessionRequirement,
+) -> CliResult<CliTurnRuntime> {
+    if !config.cli.enabled {
+        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
+    }
+
     let explicit_acp_request = options.requests_explicit_acp();
     let effective_bootstrap_mcp_servers = config
         .acp
@@ -849,9 +875,32 @@ async fn process_cli_chat_input(
         ChatCommandMatchResult::NotMatched => {}
     }
 
-    Ok(CliChatLoopControl::AssistantText(
-        run_cli_turn(runtime, input, event_sink, true).await?,
-    ))
+    let agent_runtime = crate::agent_runtime::AgentRuntime::new();
+    let turn_result = agent_runtime
+        .run_turn_with_runtime(
+            runtime,
+            &crate::agent_runtime::AgentTurnRequest {
+                message: input.to_owned(),
+                turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
+                channel_id: runtime.session_address.channel_id.clone(),
+                account_id: runtime.session_address.account_id.clone(),
+                conversation_id: runtime.session_address.conversation_id.clone(),
+                thread_id: runtime.session_address.thread_id.clone(),
+                metadata: BTreeMap::new(),
+                acp: runtime.explicit_acp_request,
+                acp_event_stream: event_sink.is_some(),
+                acp_bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
+                acp_cwd: runtime
+                    .effective_working_directory
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                live_surface_enabled: true,
+            },
+            event_sink,
+        )
+        .await?;
+
+    Ok(CliChatLoopControl::AssistantText(turn_result.output_text))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1398,11 +1447,86 @@ fn normalize_markdown_display_line(line: &str) -> String {
     trimmed_end.to_owned()
 }
 
-async fn run_cli_turn(
+pub(crate) async fn run_cli_turn(
     runtime: &CliTurnRuntime,
     input: &str,
     event_sink: Option<&dyn AcpTurnEventSink>,
     live_surface_enabled: bool,
+) -> CliResult<String> {
+    run_cli_turn_with_address(
+        runtime,
+        &runtime.session_address,
+        input,
+        event_sink,
+        live_surface_enabled,
+        None,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn run_cli_turn_with_address(
+    runtime: &CliTurnRuntime,
+    address: &ConversationSessionAddress,
+    input: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+    live_surface_enabled: bool,
+    metadata: Option<&BTreeMap<String, String>>,
+    observer_override: Option<ConversationTurnObserverHandle>,
+) -> CliResult<String> {
+    run_cli_turn_with_address_and_ingress_and_error_mode(
+        runtime,
+        address,
+        input,
+        event_sink,
+        live_surface_enabled,
+        metadata,
+        None,
+        AcpTurnProvenance::default(),
+        ProviderErrorMode::InlineMessage,
+        observer_override,
+    )
+    .await
+}
+
+pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode(
+    runtime: &CliTurnRuntime,
+    address: &ConversationSessionAddress,
+    input: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+    live_surface_enabled: bool,
+    metadata: Option<&BTreeMap<String, String>>,
+    ingress: Option<&ConversationIngressContext>,
+    provenance: AcpTurnProvenance<'_>,
+    provider_error_mode: ProviderErrorMode,
+    observer_override: Option<ConversationTurnObserverHandle>,
+) -> CliResult<String> {
+    run_cli_turn_with_address_and_ingress(
+        runtime,
+        address,
+        input,
+        event_sink,
+        live_surface_enabled,
+        metadata,
+        ingress,
+        provenance,
+        provider_error_mode,
+        observer_override,
+    )
+    .await
+}
+
+pub(crate) async fn run_cli_turn_with_address_and_ingress(
+    runtime: &CliTurnRuntime,
+    address: &ConversationSessionAddress,
+    input: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+    live_surface_enabled: bool,
+    metadata: Option<&BTreeMap<String, String>>,
+    ingress: Option<&ConversationIngressContext>,
+    provenance: AcpTurnProvenance<'_>,
+    provider_error_mode: ProviderErrorMode,
+    observer_override: Option<ConversationTurnObserverHandle>,
 ) -> CliResult<String> {
     let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
     let acp_options = if runtime.explicit_acp_request {
@@ -1412,31 +1536,54 @@ async fn run_cli_turn(
     }
     .with_event_sink(event_sink)
     .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
-    .with_working_directory(runtime.effective_working_directory.as_deref());
-    let live_surface_observer = if live_surface_enabled {
+    .with_working_directory(runtime.effective_working_directory.as_deref())
+    .with_metadata(metadata)
+    .with_provenance(provenance);
+    let live_surface_observer = if let Some(observer) = observer_override {
+        Some(observer)
+    } else if live_surface_enabled {
         let render_width = detect_cli_chat_render_width();
         Some(build_cli_chat_live_surface_observer(render_width))
     } else {
         None
     };
-    runtime
-        .turn_coordinator
-        .handle_production_turn_with_address_and_acp_options_and_observer(
-            &turn_config,
-            &runtime.session_address,
-            input,
-            ProviderErrorMode::InlineMessage,
-            &acp_options,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            live_surface_observer,
-        )
-        .await
+    if let Some(ingress) = ingress {
+        runtime
+            .turn_coordinator
+            .handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+                &turn_config,
+                address,
+                input,
+                provider_error_mode,
+                &acp_options,
+                crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                Some(ingress),
+                live_surface_observer,
+            )
+            .await
+    } else {
+        runtime
+            .turn_coordinator
+            .handle_production_turn_with_address_and_acp_options_and_observer(
+                &turn_config,
+                address,
+                input,
+                provider_error_mode,
+                &acp_options,
+                crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                live_surface_observer,
+            )
+            .await
+    }
 }
 
 fn reload_cli_turn_config(
     config: &LoongClawConfig,
     resolved_path: &Path,
 ) -> CliResult<LoongClawConfig> {
+    if resolved_path.as_os_str().is_empty() {
+        return Ok(config.clone());
+    }
     config.reload_provider_runtime_state_from_path(resolved_path)
 }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -280,6 +280,7 @@ pub async fn run_cli_chat(
     session_hint: Option<&str>,
     options: &CliChatOptions,
 ) -> CliResult<()> {
+    ensure_cli_channel_enabled_for_entrypoint(config_path)?;
     if session_surface::interactive_terminal_surface_supported() {
         return session_surface::run_cli_chat_surface(config_path, session_hint, options).await;
     }
@@ -396,6 +397,7 @@ pub async fn run_cli_ask(
     if input.is_empty() {
         return Err("ask message must not be empty".to_owned());
     }
+    ensure_cli_channel_enabled_for_entrypoint(config_path)?;
 
     let runtime = initialize_cli_turn_runtime(config_path, session_hint, options, "cli-ask")?;
     let acp_event_printer = options
@@ -415,6 +417,7 @@ pub async fn run_cli_ask(
 }
 
 pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<()> {
+    reject_disabled_cli_channel(&options.config)?;
     if session_surface::interactive_terminal_surface_supported() {
         return session_surface::run_concurrent_cli_host_surface(options);
     }
@@ -446,6 +449,32 @@ fn run_concurrent_cli_host_repl(options: &ConcurrentCliHostOptions) -> CliResult
     })
 }
 
+pub(crate) fn reject_disabled_cli_channel(config: &LoongClawConfig) -> CliResult<()> {
+    if config.cli.enabled {
+        return Ok(());
+    }
+
+    Err("CLI channel is disabled by config.cli.enabled=false".to_owned())
+}
+
+fn ensure_cli_channel_enabled_for_entrypoint(config_path: Option<&str>) -> CliResult<()> {
+    let resolved_config_path = config_path
+        .map(config::expand_path)
+        .unwrap_or_else(config::default_config_path);
+    let config_exists = resolved_config_path.try_exists().map_err(|error| {
+        format!(
+            "failed to access config path {}: {error}",
+            resolved_config_path.display()
+        )
+    })?;
+    if !config_exists {
+        return Ok(());
+    }
+
+    let (_resolved_path, config) = config::load(config_path)?;
+    reject_disabled_cli_channel(&config)
+}
+
 pub(crate) fn initialize_cli_turn_runtime(
     config_path: Option<&str>,
     session_hint: Option<&str>,
@@ -474,13 +503,11 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config(
     initialize_runtime_environment: bool,
 ) -> CliResult<CliTurnRuntime> {
     let mut config = config;
-    if !config.cli.enabled {
-        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
-    }
-
     let runtime_workspace_root = std::env::current_dir()
         .ok()
         .unwrap_or_else(|| config.tools.resolved_file_root());
+    let runtime_workspace_root =
+        dunce::canonicalize(&runtime_workspace_root).unwrap_or(runtime_workspace_root);
     let runtime_workspace_root = runtime_workspace_root.display().to_string();
     config.tools.runtime_workspace_root = Some(runtime_workspace_root);
 
@@ -507,10 +534,6 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
     kernel_ctx: crate::KernelContext,
     session_requirement: CliSessionRequirement,
 ) -> CliResult<CliTurnRuntime> {
-    if !config.cli.enabled {
-        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
-    }
-
     let explicit_acp_request = options.requests_explicit_acp();
     let effective_bootstrap_mcp_servers = config
         .acp

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -1067,30 +1067,32 @@ impl ChatSessionSurface {
         self.render()?;
 
         let observer = build_surface_live_observer(self.state.clone(), self.term.clone());
-        let assistant_text = self
-            .runtime
-            .turn_coordinator
-            .handle_turn_with_address_and_acp_options_and_observer(
-                &reload_cli_turn_config(
-                    &self.runtime.config,
-                    self.runtime.resolved_path.as_path(),
-                )?,
-                &self.runtime.session_address,
-                trimmed,
-                ProviderErrorMode::InlineMessage,
-                &if self.runtime.explicit_acp_request {
-                    AcpConversationTurnOptions::explicit()
-                } else {
-                    AcpConversationTurnOptions::automatic()
-                }
-                .with_additional_bootstrap_mcp_servers(
-                    &self.runtime.effective_bootstrap_mcp_servers,
-                )
-                .with_working_directory(self.runtime.effective_working_directory.as_deref()),
-                crate::conversation::ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
+        let assistant_text = crate::agent_runtime::AgentRuntime::new()
+            .run_turn_with_runtime_and_observer(
+                &self.runtime,
+                &crate::agent_runtime::AgentTurnRequest {
+                    message: trimmed.to_owned(),
+                    turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
+                    channel_id: self.runtime.session_address.channel_id.clone(),
+                    account_id: self.runtime.session_address.account_id.clone(),
+                    conversation_id: self.runtime.session_address.conversation_id.clone(),
+                    thread_id: self.runtime.session_address.thread_id.clone(),
+                    metadata: std::collections::BTreeMap::new(),
+                    acp: self.runtime.explicit_acp_request,
+                    acp_event_stream: false,
+                    acp_bootstrap_mcp_servers: self.runtime.effective_bootstrap_mcp_servers.clone(),
+                    acp_cwd: self
+                        .runtime
+                        .effective_working_directory
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                    live_surface_enabled: true,
+                },
+                None,
                 Some(observer),
             )
-            .await?;
+            .await?
+            .output_text;
 
         {
             let mut state = self.lock_state();

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -58,6 +58,7 @@ pub(super) async fn run_cli_chat_surface(
 }
 
 pub(super) fn run_concurrent_cli_host_surface(options: &ConcurrentCliHostOptions) -> CliResult<()> {
+    reject_disabled_cli_channel(&options.config)?;
     let chat_options = CliChatOptions::default();
     let runtime = initialize_cli_turn_runtime_with_loaded_config(
         options.resolved_path.clone(),

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -1786,7 +1786,8 @@ impl ControlPlaneAcpView {
         if self.current_session_id == DEFAULT_CONTROL_PLANE_SESSION_ID {
             return Ok(None);
         }
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+        let memory_config =
+            MemoryRuntimeConfig::from_memory_config_without_env_overrides(&self.config.memory);
         SessionRepository::new(&memory_config).map(Some)
     }
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod acp;
 mod advisory_prompt;
+pub mod agent_runtime;
 pub mod channel;
 pub mod chat;
 pub mod config;

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -146,6 +146,10 @@ impl MemoryRuntimeConfig {
         runtime
     }
 
+    pub fn from_memory_config_without_env_overrides(config: &MemoryConfig) -> Self {
+        Self::from_memory_config_base(config)
+    }
+
     pub const fn strict_mode_requested(&self) -> bool {
         !self.fail_open
     }

--- a/crates/app/src/provider/request_dispatch_runtime.rs
+++ b/crates/app/src/provider/request_dispatch_runtime.rs
@@ -159,6 +159,10 @@ pub(super) async fn request_completion_with_provider_transport(
                 transport_profile.default_user_agent,
                 transport_profile.default_headers,
             )
+            .and_then(|mut headers| {
+                super::transport::append_prompt_cache_headers(&mut headers, None, None, messages)?;
+                Ok(headers)
+            })
             .map_err(|error| {
                 build_model_request_error(
                     error,
@@ -315,6 +319,15 @@ pub(super) async fn request_turn_with_provider_transport(
                 transport_profile.default_user_agent,
                 transport_profile.default_headers,
             )
+            .and_then(|mut headers| {
+                super::transport::append_prompt_cache_headers(
+                    &mut headers,
+                    Some(session_id),
+                    Some(turn_id),
+                    messages,
+                )?;
+                Ok(headers)
+            })
             .map_err(|error| {
                 build_model_request_error(
                     error,
@@ -493,6 +506,15 @@ pub(super) async fn request_turn_streaming_with_transport(
                 transport_profile.default_user_agent,
                 transport_profile.default_headers,
             )
+            .and_then(|mut headers| {
+                super::transport::append_prompt_cache_headers(
+                    &mut headers,
+                    Some(session_id),
+                    Some(turn_id),
+                    messages,
+                )?;
+                Ok(headers)
+            })
             .map_err(|error| {
                 build_model_request_error(
                     error,

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -20,6 +20,7 @@ use reqwest::header::{
     AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, USER_AGENT,
 };
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use crate::CliResult;
 use crate::config::{ProviderAuthScheme, ProviderConfig, ProviderKind, active_cli_command_name};
@@ -408,6 +409,96 @@ fn build_request_headers_with_defaults(
     Ok(headers)
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct PromptCacheHeaderPlan {
+    pub(super) stable_prefix_sha256: Option<String>,
+    pub(super) cached_prefix_sha256: Option<String>,
+    pub(super) cache_eligible: bool,
+}
+
+pub(super) fn derive_prompt_cache_header_plan(messages: &[Value]) -> PromptCacheHeaderPlan {
+    let stable_prefix_messages = messages
+        .iter()
+        .take_while(|message| message.get("role").and_then(Value::as_str) == Some("system"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let stable_prefix_sha256 = hash_prompt_cache_messages(stable_prefix_messages.as_slice());
+
+    let cached_prefix_messages = match messages.last() {
+        Some(last) if last.get("role").and_then(Value::as_str) == Some("user") => messages
+            .get(..messages.len().saturating_sub(1))
+            .unwrap_or(&[]),
+        Some(_) => messages,
+        None => &[],
+    };
+    let cached_prefix_sha256 = hash_prompt_cache_messages(cached_prefix_messages);
+    let cache_eligible = cached_prefix_sha256.is_some();
+
+    PromptCacheHeaderPlan {
+        stable_prefix_sha256,
+        cached_prefix_sha256,
+        cache_eligible,
+    }
+}
+
+pub(super) fn append_prompt_cache_headers(
+    headers: &mut HeaderMap,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    messages: &[Value],
+) -> CliResult<()> {
+    let plan = derive_prompt_cache_header_plan(messages);
+
+    if let Some(session_id) = session_id {
+        insert_runtime_header(headers, "x-loongclaw-session-id", session_id)?;
+    }
+    if let Some(turn_id) = turn_id {
+        insert_runtime_header(headers, "x-loongclaw-turn-id", turn_id)?;
+    }
+    if let Some(stable_prefix_sha256) = plan.stable_prefix_sha256.as_deref() {
+        insert_runtime_header(
+            headers,
+            "x-loongclaw-stable-prefix-sha256",
+            stable_prefix_sha256,
+        )?;
+    }
+    if let Some(cached_prefix_sha256) = plan.cached_prefix_sha256.as_deref() {
+        insert_runtime_header(
+            headers,
+            "x-loongclaw-cached-prefix-sha256",
+            cached_prefix_sha256,
+        )?;
+    }
+    insert_runtime_header(
+        headers,
+        "x-loongclaw-cache-eligible",
+        if plan.cache_eligible { "true" } else { "false" },
+    )?;
+
+    Ok(())
+}
+
+fn insert_runtime_header(headers: &mut HeaderMap, name: &str, value: &str) -> CliResult<()> {
+    let header_name = HeaderName::from_bytes(name.as_bytes())
+        .map_err(|error| format!("invalid runtime request header name `{name}`: {error}"))?;
+    let header_value = HeaderValue::from_str(value)
+        .map_err(|error| format!("invalid runtime request header `{name}`: {error}"))?;
+    headers.insert(header_name, header_value);
+    Ok(())
+}
+
+fn hash_prompt_cache_messages(messages: &[Value]) -> Option<String> {
+    if messages.is_empty() {
+        return None;
+    }
+
+    let Ok(serialized) = serde_json::to_vec(messages) else {
+        return None;
+    };
+    let digest = Sha256::digest(serialized);
+    Some(hex::encode(digest))
+}
+
 pub(super) fn apply_auth_profile_headers(
     headers: &mut HeaderMap,
     profile: Option<&ProviderAuthProfile>,
@@ -733,6 +824,61 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("custom-key")
         );
+    }
+
+    #[test]
+    fn derive_prompt_cache_header_plan_uses_leading_system_and_cached_prefix() {
+        let messages = vec![
+            json!({"role": "system", "content": "sys-a"}),
+            json!({"role": "system", "content": "sys-b"}),
+            json!({"role": "assistant", "content": "prior-answer"}),
+            json!({"role": "user", "content": "hello"}),
+        ];
+
+        let plan = derive_prompt_cache_header_plan(messages.as_slice());
+
+        assert!(plan.stable_prefix_sha256.is_some());
+        assert!(plan.cached_prefix_sha256.is_some());
+        assert!(plan.cache_eligible);
+        assert_ne!(plan.stable_prefix_sha256, plan.cached_prefix_sha256);
+    }
+
+    #[test]
+    fn append_prompt_cache_headers_inserts_runtime_request_metadata() {
+        let mut headers = HeaderMap::new();
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+        ];
+
+        append_prompt_cache_headers(
+            &mut headers,
+            Some("session-1"),
+            Some("turn-1"),
+            messages.as_slice(),
+        )
+        .expect("append prompt cache headers");
+
+        assert_eq!(
+            headers
+                .get("x-loongclaw-session-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("session-1")
+        );
+        assert_eq!(
+            headers
+                .get("x-loongclaw-turn-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("turn-1")
+        );
+        assert_eq!(
+            headers
+                .get("x-loongclaw-cache-eligible")
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
+        );
+        assert!(headers.contains_key("x-loongclaw-stable-prefix-sha256"));
+        assert!(headers.contains_key("x-loongclaw-cached-prefix-sha256"));
     }
 
     #[test]

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -450,10 +450,16 @@ pub(super) fn append_prompt_cache_headers(
     let plan = derive_prompt_cache_header_plan(messages);
 
     if let Some(session_id) = session_id {
-        insert_runtime_header(headers, "x-loongclaw-session-id", session_id)?;
+        let hashed_session_id = hash_runtime_identifier(session_id);
+        insert_runtime_header(
+            headers,
+            "x-loongclaw-session-id",
+            hashed_session_id.as_str(),
+        )?;
     }
     if let Some(turn_id) = turn_id {
-        insert_runtime_header(headers, "x-loongclaw-turn-id", turn_id)?;
+        let hashed_turn_id = hash_runtime_identifier(turn_id);
+        insert_runtime_header(headers, "x-loongclaw-turn-id", hashed_turn_id.as_str())?;
     }
     if let Some(stable_prefix_sha256) = plan.stable_prefix_sha256.as_deref() {
         insert_runtime_header(
@@ -497,6 +503,11 @@ fn hash_prompt_cache_messages(messages: &[Value]) -> Option<String> {
     };
     let digest = Sha256::digest(serialized);
     Some(hex::encode(digest))
+}
+
+fn hash_runtime_identifier(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(digest)
 }
 
 pub(super) fn apply_auth_profile_headers(
@@ -863,13 +874,13 @@ mod tests {
             headers
                 .get("x-loongclaw-session-id")
                 .and_then(|value| value.to_str().ok()),
-            Some("session-1")
+            Some(hash_runtime_identifier("session-1").as_str())
         );
         assert_eq!(
             headers
                 .get("x-loongclaw-turn-id")
                 .and_then(|value| value.to_str().ok()),
-            Some("turn-1")
+            Some(hash_runtime_identifier("turn-1").as_str())
         );
         assert_eq!(
             headers

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -56,6 +56,7 @@ pub fn initialize_runtime_environment(
     let workspace_root = std::env::current_dir()
         .ok()
         .unwrap_or_else(|| config.tools.resolved_file_root());
+    let workspace_root = dunce::canonicalize(&workspace_root).unwrap_or(workspace_root);
     set_env_var(
         "LOONGCLAW_WORKSPACE_ROOT",
         workspace_root.display().to_string(),

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -1294,8 +1294,6 @@ fn canonicalize_or_fallback(path: PathBuf) -> Result<PathBuf, String> {
 }
 
 fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, String> {
-    ensure_path_within_root(root, normalized)?;
-
     if normalized.exists() {
         let canonical = dunce::canonicalize(normalized).map_err(|error| {
             format!(
@@ -1307,6 +1305,8 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
         ensure_path_within_root(root, &canonical)?;
         return Ok(canonical);
     }
+
+    ensure_path_within_root(root, normalized)?;
 
     let (ancestor, suffix) = split_existing_ancestor(normalized)?;
     let canonical_ancestor = dunce::canonicalize(&ancestor).map_err(|error| {

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -5,7 +5,9 @@ impl Commands {
         match self {
             Self::Welcome => "welcome",
             Self::Demo => "demo",
-            Self::RunTask { .. } => "run_task",
+            Self::Turn { command } => match command {
+                crate::TurnCommands::Run { .. } => "turn_run",
+            },
             Self::InvokeConnector { .. } => "invoke_connector",
             Self::AuditDemo => "audit_demo",
             Self::InitSpec { .. } => "init_spec",

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -5,6 +5,7 @@ impl Commands {
         match self {
             Self::Welcome => "welcome",
             Self::Demo => "demo",
+            Self::RunTask { .. } => "run_task",
             Self::Turn { command } => match command {
                 crate::TurnCommands::Run { .. } => "turn_run",
             },

--- a/crates/daemon/src/command_kind_tests.rs
+++ b/crates/daemon/src/command_kind_tests.rs
@@ -5,12 +5,19 @@ fn command_kind_for_logging_uses_stable_variant_names() {
     assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
     assert_eq!(Commands::AuditDemo.command_kind_for_logging(), "audit_demo");
     assert_eq!(
-        Commands::RunTask {
-            objective: "test".to_owned(),
-            payload: "{}".to_owned(),
+        Commands::Turn {
+            command: crate::TurnCommands::Run {
+                config: None,
+                session: None,
+                message: "test".to_owned(),
+                acp: false,
+                acp_event_stream: false,
+                acp_bootstrap_mcp_server: Vec::new(),
+                acp_cwd: None,
+            },
         }
         .command_kind_for_logging(),
-        "run_task"
+        "turn_run"
     );
     assert_eq!(
         Commands::ListMcpServers {

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -209,6 +209,7 @@ struct ControlPlaneTurnStreamState {
 }
 
 struct ControlPlaneTurnRuntime {
+    resolved_path: std::path::PathBuf,
     config: mvp::config::LoongClawConfig,
     acp_manager: Arc<mvp::acp::AcpSessionManager>,
     registry: Arc<mvp::control_plane::ControlPlaneTurnRegistry>,
@@ -924,16 +925,21 @@ fn control_plane_subscribe_stream(
 }
 
 impl ControlPlaneTurnRuntime {
-    fn new(config: mvp::config::LoongClawConfig) -> Result<Self, String> {
+    fn new(
+        resolved_path: std::path::PathBuf,
+        config: mvp::config::LoongClawConfig,
+    ) -> Result<Self, String> {
         let acp_manager = mvp::acp::shared_acp_session_manager(&config)?;
-        Ok(Self::with_manager(config, acp_manager))
+        Ok(Self::with_manager(resolved_path, config, acp_manager))
     }
 
     fn with_manager(
+        resolved_path: std::path::PathBuf,
         config: mvp::config::LoongClawConfig,
         acp_manager: Arc<mvp::acp::AcpSessionManager>,
     ) -> Self {
         Self {
+            resolved_path,
             config,
             acp_manager,
             registry: Arc::new(mvp::control_plane::ControlPlaneTurnRegistry::new()),
@@ -949,26 +955,6 @@ impl mvp::acp::AcpTurnEventSink for ControlPlaneTurnEventForwarder {
         let payload = map_turn_event_payload(&recorded_event);
         let _ = self.manager.record_acp_turn_event(payload, true);
         Ok(())
-    }
-}
-
-fn extend_turn_metadata(
-    target: &mut std::collections::BTreeMap<String, String>,
-    extra: &std::collections::BTreeMap<String, String>,
-) {
-    for (key, value) in extra {
-        let normalized_key = key.trim();
-        let normalized_value = value.trim();
-        if normalized_key.is_empty() {
-            continue;
-        }
-        if normalized_value.is_empty() {
-            continue;
-        }
-
-        let normalized_key = normalized_key.to_owned();
-        let normalized_value = normalized_value.to_owned();
-        target.entry(normalized_key).or_insert(normalized_value);
     }
 }
 
@@ -1136,14 +1122,6 @@ fn control_plane_turn_stream(
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, String> {
     let initial_state = initial_turn_stream_state(registry, turn_id.as_str(), after_seq)?;
     Ok(stream::unfold(initial_state, next_turn_sse_item))
-}
-
-fn stop_reason_label(stop_reason: Option<mvp::acp::AcpTurnStopReason>) -> Option<&'static str> {
-    match stop_reason {
-        Some(mvp::acp::AcpTurnStopReason::Completed) => Some("completed"),
-        Some(mvp::acp::AcpTurnStopReason::Cancelled) => Some("cancelled"),
-        None => None,
-    }
 }
 
 fn connection_principal_from_connect(
@@ -2132,51 +2110,35 @@ async fn turn_submit(
         Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
     };
 
-    let turn_address = match crate::build_acp_dispatch_address(
+    if let Err(error) = crate::build_acp_dispatch_address(
         session_id.as_str(),
         request.channel_id.as_deref(),
         request.conversation_id.as_deref(),
         request.account_id.as_deref(),
         request.thread_id.as_deref(),
     ) {
-        Ok(turn_address) => turn_address,
-        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
-    };
-
-    let working_directory = request
-        .working_directory
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(std::path::PathBuf::from);
-    let turn_options = mvp::acp::AcpConversationTurnOptions::explicit();
-    let turn_options = turn_options.with_working_directory(working_directory.as_deref());
-    let prepared_turn = mvp::acp::prepare_acp_conversation_turn_for_address(
-        &turn_runtime.config,
-        &turn_address,
-        input.as_str(),
-        &turn_options,
-    );
-    let prepared_turn = match prepared_turn {
-        Ok(prepared_turn) => prepared_turn,
-        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
-    };
+        return error_response(StatusCode::BAD_REQUEST, error);
+    }
 
     let turn_snapshot = turn_runtime.registry.issue_turn(session_id.as_str());
     let turn_id = turn_snapshot.turn_id.clone();
-    let mut bootstrap = prepared_turn.bootstrap;
-    let mut acp_request = prepared_turn.request;
-    extend_turn_metadata(&mut bootstrap.metadata, &request.metadata);
-    extend_turn_metadata(&mut acp_request.metadata, &request.metadata);
-    acp_request
-        .metadata
-        .insert("control_plane.turn_id".to_owned(), turn_id.clone());
-
+    let resolved_path = turn_runtime.resolved_path.clone();
     let config = turn_runtime.config.clone();
     let acp_manager = turn_runtime.acp_manager.clone();
     let turn_registry = turn_runtime.registry.clone();
     let manager = state.manager.clone();
     let spawned_turn_id = turn_id;
+    let channel_id = request.channel_id.clone();
+    let account_id = request.account_id.clone();
+    let conversation_id = request.conversation_id.clone();
+    let thread_id = request.thread_id.clone();
+    let metadata = request.metadata.clone();
+    let working_directory = request
+        .working_directory
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
 
     tokio::spawn(async move {
         let event_forwarder = ControlPlaneTurnEventForwarder {
@@ -2184,17 +2146,37 @@ async fn turn_submit(
             registry: turn_registry.clone(),
             turn_id: spawned_turn_id.clone(),
         };
-        let execution_result = acp_manager
-            .run_turn_with_sink(&config, &bootstrap, &acp_request, Some(&event_forwarder))
+        let turn_request = mvp::agent_runtime::AgentTurnRequest {
+            message: input,
+            turn_mode: mvp::agent_runtime::AgentTurnMode::Acp,
+            channel_id,
+            account_id,
+            conversation_id,
+            thread_id,
+            metadata,
+            acp: true,
+            acp_event_stream: true,
+            acp_bootstrap_mcp_servers: Vec::new(),
+            acp_cwd: working_directory,
+            live_surface_enabled: false,
+        };
+        let execution_result = mvp::agent_runtime::AgentRuntime::new()
+            .run_turn_with_loaded_config_and_acp_manager(
+                resolved_path,
+                config,
+                Some(session_id.as_str()),
+                &turn_request,
+                Some(&event_forwarder),
+                acp_manager,
+            )
             .await;
 
         match execution_result {
             Ok(result) => {
-                let stop_reason = stop_reason_label(result.stop_reason);
                 let completion = turn_registry.complete_success(
                     spawned_turn_id.as_str(),
                     result.output_text.as_str(),
-                    stop_reason,
+                    result.stop_reason.as_deref(),
                     result.usage.clone(),
                 );
                 if let Ok(record) = completion {
@@ -2450,7 +2432,10 @@ pub async fn run_control_plane_serve_cli(
     let manager = Arc::new(mvp::control_plane::ControlPlaneManager::new());
     manager.set_runtime_ready(true);
     let turn_runtime = match loaded_config.as_ref() {
-        Some((_, config)) => Some(Arc::new(ControlPlaneTurnRuntime::new(config.clone())?)),
+        Some((resolved_path, config)) => Some(Arc::new(ControlPlaneTurnRuntime::new(
+            resolved_path.clone(),
+            config.clone(),
+        )?)),
         None => None,
     };
     #[cfg(feature = "memory-sqlite")]
@@ -2759,8 +2744,25 @@ mod tests {
         })
         .expect("register control-plane turn backend");
         let config = turn_runtime_test_config(backend_id);
+        let temp_root = std::env::temp_dir().join(format!(
+            "loongclaw-control-plane-turn-runtime-{}-{}",
+            backend_id,
+            current_time_ms()
+        ));
+        std::fs::create_dir_all(&temp_root).expect("create control-plane turn runtime temp root");
+        let resolved_path = temp_root.join("config.toml");
+        mvp::config::write(
+            Some(resolved_path.to_str().expect("utf8 config path")),
+            &config,
+            true,
+        )
+        .expect("write control-plane turn runtime config");
         let acp_manager = Arc::new(mvp::acp::AcpSessionManager::default());
-        Arc::new(ControlPlaneTurnRuntime::with_manager(config, acp_manager))
+        Arc::new(ControlPlaneTurnRuntime::with_manager(
+            resolved_path,
+            config,
+            acp_manager,
+        ))
     }
 
     fn remote_control_plane_config(shared_token: &str) -> mvp::config::LoongClawConfig {
@@ -2914,13 +2916,19 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     fn isolated_memory_config(test_name: &str) -> mvp::memory::runtime_config::MemoryRuntimeConfig {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT_ISOLATED_MEMORY_CONFIG_ID: AtomicU64 = AtomicU64::new(1);
+        let nonce = NEXT_ISOLATED_MEMORY_CONFIG_ID.fetch_add(1, Ordering::Relaxed);
         let base = std::env::temp_dir().join(format!(
-            "loongclaw-control-plane-server-{test_name}-{}",
-            std::process::id()
+            "loongclaw-control-plane-server-{test_name}-{}-{nonce}",
+            std::process::id(),
         ));
         let _ = std::fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(base.join("memory.sqlite3-wal"));
+        let _ = std::fs::remove_file(base.join("memory.sqlite3-shm"));
         mvp::memory::runtime_config::MemoryRuntimeConfig {
             sqlite_path: Some(db_path),
             ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()

--- a/crates/daemon/src/gateway/api_turn.rs
+++ b/crates/daemon/src/gateway/api_turn.rs
@@ -11,11 +11,9 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::mvp::acp::{AcpConversationTurnOptions, AcpTurnResult, AcpTurnStopReason};
-
 use super::control::{GatewayControlAppState, authorize_request_from_state};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct GatewayTurnRequest {
     pub session_id: String,
     pub input: String,
@@ -43,39 +41,21 @@ pub(crate) struct GatewayTurnResponse {
 }
 
 impl GatewayTurnResponse {
-    fn from_acp_result(result: &AcpTurnResult) -> Self {
-        let state = crate::acp_session_state_label(result.state).to_owned();
+    fn from_agent_turn_result(result: &crate::mvp::agent_runtime::AgentTurnResult) -> Self {
         Self {
             output_text: result.output_text.clone(),
-            state,
-            stop_reason: result.stop_reason.as_ref().map(|r| match r {
-                AcpTurnStopReason::Completed => "completed".to_string(),
-                AcpTurnStopReason::Cancelled => "cancelled".to_string(),
-            }),
+            state: result
+                .state
+                .clone()
+                .unwrap_or_else(|| "completed".to_owned()),
+            stop_reason: result.stop_reason.clone(),
             usage: result.usage.clone(),
-            event_count: result.events.len(),
+            event_count: result.event_count,
         }
     }
 }
 
 type TurnJsonResponse = (StatusCode, Json<Value>);
-
-fn extend_turn_metadata(target: &mut BTreeMap<String, String>, extra: &BTreeMap<String, String>) {
-    for (key, value) in extra {
-        let normalized_key = key.trim();
-        let normalized_value = value.trim();
-        if normalized_key.is_empty() {
-            continue;
-        }
-        if normalized_value.is_empty() {
-            continue;
-        }
-
-        let normalized_key = normalized_key.to_owned();
-        let normalized_value = normalized_value.to_owned();
-        target.entry(normalized_key).or_insert(normalized_value);
-    }
-}
 
 pub(crate) async fn handle_turn(
     headers: HeaderMap,
@@ -103,22 +83,18 @@ pub(crate) async fn handle_turn(
         );
     }
 
-    let turn_address = match crate::build_acp_dispatch_address(
+    if let Err(error) = crate::build_acp_dispatch_address(
         turn_request.session_id.as_str(),
         turn_request.channel_id.as_deref(),
         turn_request.conversation_id.as_deref(),
         turn_request.account_id.as_deref(),
         turn_request.thread_id.as_deref(),
     ) {
-        Ok(turn_address) => turn_address,
-        Err(error) => {
-            let error_message = format!("invalid turn target: {error}");
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": error_message})),
-            );
-        }
-    };
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid turn target: {error}")})),
+        );
+    }
 
     let (Some(acp_manager), Some(config)) = (&app_state.acp_manager, &app_state.config) else {
         return (
@@ -133,51 +109,42 @@ pub(crate) async fn handle_turn(
         );
     }
 
-    let working_directory = turn_request.working_directory.as_deref().map(PathBuf::from);
-    let turn_options = AcpConversationTurnOptions::explicit();
-    let turn_options = turn_options.with_working_directory(working_directory.as_deref());
-    let prepared_turn = crate::mvp::acp::prepare_acp_conversation_turn_for_address(
-        config,
-        &turn_address,
-        turn_request.input.as_str(),
-        &turn_options,
-    );
-    let prepared_turn = match prepared_turn {
-        Ok(prepared_turn) => prepared_turn,
-        Err(error) => {
-            let error_message = format!("unable to prepare turn target: {error}");
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": error_message})),
-            );
-        }
-    };
-    let mut bootstrap = prepared_turn.bootstrap;
-    let mut acp_request = prepared_turn.request;
-    extend_turn_metadata(&mut bootstrap.metadata, &turn_request.metadata);
-    extend_turn_metadata(&mut acp_request.metadata, &turn_request.metadata);
-
     let event_sink = app_state.event_bus.as_ref().map(|bus| bus.sink());
-    let sink_ref = event_sink
-        .as_ref()
-        .map(|s| s as &dyn crate::mvp::acp::AcpTurnEventSink);
-
-    let result = acp_manager
-        .run_turn_with_sink(config, &bootstrap, &acp_request, sink_ref)
+    let result = crate::mvp::agent_runtime::AgentRuntime::new()
+        .run_turn_with_loaded_config_and_acp_manager(
+            PathBuf::from(app_state.config_path.clone()),
+            config.clone(),
+            Some(turn_request.session_id.as_str()),
+            &crate::mvp::agent_runtime::AgentTurnRequest {
+                message: turn_request.input.clone(),
+                turn_mode: crate::mvp::agent_runtime::AgentTurnMode::Acp,
+                channel_id: turn_request.channel_id.clone(),
+                account_id: turn_request.account_id.clone(),
+                conversation_id: turn_request.conversation_id.clone(),
+                thread_id: turn_request.thread_id.clone(),
+                metadata: turn_request.metadata.clone(),
+                acp: true,
+                acp_event_stream: event_sink.is_some(),
+                acp_bootstrap_mcp_servers: Vec::new(),
+                acp_cwd: turn_request.working_directory.clone(),
+                live_surface_enabled: false,
+            },
+            event_sink
+                .as_ref()
+                .map(|sink| sink as &dyn crate::mvp::acp::AcpTurnEventSink),
+            acp_manager.clone(),
+        )
         .await;
 
     match result {
         Ok(turn_result) => {
-            let response = GatewayTurnResponse::from_acp_result(&turn_result);
+            let response = GatewayTurnResponse::from_agent_turn_result(&turn_result);
             match serde_json::to_value(response) {
                 Ok(value) => (StatusCode::OK, Json(value)),
-                Err(error) => {
-                    let error_message = format!("response serialization failed: {error}");
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": error_message})),
-                    )
-                }
+                Err(error) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": format!("response serialization failed: {error}")})),
+                ),
             }
         }
         Err(error) => (
@@ -187,11 +154,56 @@ pub(crate) async fn handle_turn(
     }
 }
 
-/// Test-only router with no ACP backend (returns 503 for valid turn requests).
 #[doc(hidden)]
 pub fn build_turn_test_router_no_backend(bearer_token: String) -> Router {
     let app_state = Arc::new(GatewayControlAppState::test_minimal(bearer_token));
     Router::new()
         .route("/v1/turn", post(handle_turn))
         .with_state(app_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn gateway_turn_returns_service_unavailable_without_acp_backend() {
+        let token = "gateway-test-token";
+        let router = build_turn_test_router_no_backend(token.to_owned());
+        let request = GatewayTurnRequest {
+            session_id: "session-1".to_owned(),
+            input: "hello".to_owned(),
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            working_directory: None,
+            metadata: BTreeMap::new(),
+        };
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/turn")
+                    .method("POST")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&request).expect("encode gateway turn request"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("gateway turn response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("gateway turn response body");
+        let payload: Value = serde_json::from_slice(&body).expect("gateway turn error payload");
+        assert_eq!(payload["error"], "ACP session manager not available");
+    }
 }

--- a/crates/daemon/src/gateway/api_turn.rs
+++ b/crates/daemon/src/gateway/api_turn.rs
@@ -76,7 +76,7 @@ pub(crate) async fn handle_turn(
         }
     };
 
-    if turn_request.input.is_empty() {
+    if turn_request.input.trim().is_empty() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "input must not be empty"})),
@@ -109,6 +109,13 @@ pub(crate) async fn handle_turn(
         );
     }
 
+    let working_directory = turn_request
+        .working_directory
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
     let event_sink = app_state.event_bus.as_ref().map(|bus| bus.sink());
     let result = crate::mvp::agent_runtime::AgentRuntime::new()
         .run_turn_with_loaded_config_and_acp_manager(
@@ -126,7 +133,7 @@ pub(crate) async fn handle_turn(
                 acp: true,
                 acp_event_stream: event_sink.is_some(),
                 acp_bootstrap_mcp_servers: Vec::new(),
-                acp_cwd: turn_request.working_directory.clone(),
+                acp_cwd: working_directory,
                 live_surface_enabled: false,
             },
             event_sink

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -144,6 +144,7 @@ pub mod tasks_cli;
 mod tlon_cli;
 mod tool_calling_readiness;
 pub mod trajectory_cli;
+mod turn_cli;
 pub mod work_unit_cli;
 use channel_bridge_render::{
     push_channel_surface_managed_plugin_bridge_discovery,
@@ -171,9 +172,10 @@ pub use session_cli::{
     run_session_search_cli, run_session_search_inspect_cli,
 };
 use task_execution::execute_daemon_task_with_supervisor;
-pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
+pub use task_execution::{DaemonTaskExecution, run_demo};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
+pub use turn_cli::{TurnCommands, build_cli_chat_options, run_ask_cli, run_chat_cli};
 #[rustfmt::skip]
 use tool_calling_readiness::{RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state};
 pub use trajectory_cli::{
@@ -257,7 +259,10 @@ pub fn native_spec_tool_executor(
     if mvp::tools::canonical_tool_name(request.tool_name.as_str()) != "config.import" {
         return None;
     }
-    Some(mvp::tools::execute_tool_core(request))
+    Some(mvp::tools::execute_tool_core_with_config(
+        request,
+        &mvp::tools::runtime_config::ToolRuntimeConfig::default(),
+    ))
 }
 
 pub type ChannelCliCommandFuture<'a> = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'a>>;
@@ -368,12 +373,10 @@ pub enum Commands {
     Welcome,
     /// Run the original end-to-end bootstrap demo
     Demo,
-    /// Execute one task through the kernel+harness path
-    RunTask {
-        #[arg(long)]
-        objective: String,
-        #[arg(long, default_value = "{}")]
-        payload: String,
+    /// Run agent turns through the unified runtime entry surface
+    Turn {
+        #[command(subcommand)]
+        command: TurnCommands,
     },
     /// Invoke one connector operation through kernel policy gate
     InvokeConnector {
@@ -1738,14 +1741,21 @@ mod first_run_entry_tests {
 
     #[test]
     fn redacted_command_name_omits_sensitive_command_payloads() {
-        let command = Commands::RunTask {
-            objective: "secret objective".to_owned(),
-            payload: "{\"api_key\":\"secret\"}".to_owned(),
+        let command = Commands::Turn {
+            command: TurnCommands::Run {
+                config: Some("/tmp/private.toml".to_owned()),
+                session: Some("session-secret".to_owned()),
+                message: "secret objective".to_owned(),
+                acp: false,
+                acp_event_stream: false,
+                acp_bootstrap_mcp_server: Vec::new(),
+                acp_cwd: None,
+            },
         };
 
         let redacted_name = redacted_command_name(&command);
 
-        assert_eq!(redacted_name, "run_task");
+        assert_eq!(redacted_name, "turn_run");
     }
 
     #[test]
@@ -4651,48 +4661,6 @@ pub fn resolve_acp_status_session_key(
             "acp-status requires --session <session_key>, --conversation-id <conversation_id>, or --route-session-id <route_session_id>"
                 .to_owned(),
         ),
-    }
-}
-
-pub async fn run_chat_cli(
-    config_path: Option<&str>,
-    session: Option<&str>,
-    acp: bool,
-    acp_event_stream: bool,
-    acp_bootstrap_mcp_server: &[String],
-    acp_cwd: Option<&str>,
-) -> CliResult<()> {
-    let options = build_cli_chat_options(acp, acp_event_stream, acp_bootstrap_mcp_server, acp_cwd);
-    mvp::chat::run_cli_chat(config_path, session, &options).await
-}
-
-pub async fn run_ask_cli(
-    config_path: Option<&str>,
-    session: Option<&str>,
-    message: &str,
-    acp: bool,
-    acp_event_stream: bool,
-    acp_bootstrap_mcp_server: &[String],
-    acp_cwd: Option<&str>,
-) -> CliResult<()> {
-    let options = build_cli_chat_options(acp, acp_event_stream, acp_bootstrap_mcp_server, acp_cwd);
-    mvp::chat::run_cli_ask(config_path, session, message, &options).await
-}
-
-pub fn build_cli_chat_options(
-    acp: bool,
-    acp_event_stream: bool,
-    acp_bootstrap_mcp_server: &[String],
-    acp_cwd: Option<&str>,
-) -> mvp::chat::CliChatOptions {
-    mvp::chat::CliChatOptions {
-        acp_requested: acp,
-        acp_event_stream,
-        acp_bootstrap_mcp_servers: acp_bootstrap_mcp_server.to_vec(),
-        acp_working_directory: acp_cwd
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(std::path::PathBuf::from),
     }
 }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -172,7 +172,7 @@ pub use session_cli::{
     run_session_search_cli, run_session_search_inspect_cli,
 };
 use task_execution::execute_daemon_task_with_supervisor;
-pub use task_execution::{DaemonTaskExecution, run_demo};
+pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
 pub use turn_cli::{TurnCommands, build_cli_chat_options, run_ask_cli, run_chat_cli};
@@ -373,6 +373,14 @@ pub enum Commands {
     Welcome,
     /// Run the original end-to-end bootstrap demo
     Demo,
+    #[command(hide = true)]
+    /// Deprecated compatibility alias for the generic task runner
+    RunTask {
+        #[arg(long)]
+        objective: String,
+        #[arg(long, default_value = "{}")]
+        payload: String,
+    },
     /// Run agent turns through the unified runtime entry surface
     Turn {
         #[command(subcommand)]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)] // CLI daemon binary
 use loongclaw_daemon::*;
 
@@ -105,7 +106,28 @@ async fn main() {
     let result = match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
-        Commands::RunTask { objective, payload } => run_task_cli(&objective, &payload).await,
+        Commands::Turn { command } => match command {
+            loongclaw_daemon::TurnCommands::Run {
+                config,
+                session,
+                message,
+                acp,
+                acp_event_stream,
+                acp_bootstrap_mcp_server,
+                acp_cwd,
+            } => {
+                run_ask_cli(
+                    config.as_deref(),
+                    session.as_deref(),
+                    &message,
+                    acp,
+                    acp_event_stream,
+                    &acp_bootstrap_mcp_server,
+                    acp_cwd.as_deref(),
+                )
+                .await
+            }
+        },
         Commands::InvokeConnector { operation, payload } => {
             invoke_connector_cli(&operation, &payload).await
         }
@@ -1133,7 +1155,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::{error_code, redacted_command_name};
-    use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount};
+    use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount, TurnCommands};
 
     #[test]
     fn command_kind_uses_stable_snake_case_labels() {
@@ -1174,14 +1196,21 @@ mod tests {
 
     #[test]
     fn redacted_command_name_omits_struct_field_values() {
-        let command = Commands::RunTask {
-            objective: "ship feature".to_owned(),
-            payload: "{\"secret\":\"value\"}".to_owned(),
+        let command = Commands::Turn {
+            command: TurnCommands::Run {
+                config: None,
+                session: None,
+                message: "ship feature".to_owned(),
+                acp: false,
+                acp_event_stream: false,
+                acp_bootstrap_mcp_server: Vec::new(),
+                acp_cwd: None,
+            },
         };
 
         let redacted = redacted_command_name(&command);
 
-        assert_eq!(redacted, "run_task");
+        assert_eq!(redacted, "turn_run");
     }
 
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -106,6 +106,7 @@ async fn main() {
     let result = match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
+        Commands::RunTask { objective, payload } => run_task_cli(&objective, &payload).await,
         Commands::Turn { command } => match command {
             loongclaw_daemon::TurnCommands::Run {
                 config,

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -141,12 +141,19 @@ mod tests {
     #[test]
     fn debug_variant_name_keeps_only_variant_identity() {
         let welcome = debug_variant_name(&Commands::Welcome);
-        let run_task = debug_variant_name(&Commands::RunTask {
-            objective: "ship".to_owned(),
-            payload: "{\"mode\":\"safe\"}".to_owned(),
+        let turn_run = debug_variant_name(&Commands::Turn {
+            command: crate::TurnCommands::Run {
+                config: None,
+                session: None,
+                message: "ship".to_owned(),
+                acp: false,
+                acp_event_stream: false,
+                acp_bootstrap_mcp_server: Vec::new(),
+                acp_cwd: None,
+            },
         });
 
         assert_eq!(welcome, "Welcome");
-        assert_eq!(run_task, "RunTask");
+        assert_eq!(turn_run, "Turn");
     }
 }

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -174,6 +174,34 @@ pub async fn run_demo() -> CliResult<()> {
     Ok(())
 }
 
+pub async fn run_task_cli(objective: &str, payload_raw: &str) -> CliResult<()> {
+    let payload = crate::cli_json::parse_json_payload(payload_raw, "run-task payload")?;
+
+    let kernel = kernel_bootstrap::KernelBuilder::default().build();
+    let token = kernel
+        .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
+        .map_err(|error| format!("token issue failed: {error}"))?;
+
+    let dispatch = execute_daemon_task_with_supervisor(
+        &kernel,
+        DEFAULT_PACK_ID,
+        &token,
+        TaskIntent {
+            task_id: "task-cli-01".to_owned(),
+            objective: objective.to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+            payload,
+        },
+    )
+    .await?;
+
+    let pretty = serde_json::to_string_pretty(&dispatch)
+        .map_err(|error| format!("serialize task outcome failed: {error}"))?;
+    println!("{pretty}");
+    require_successful_daemon_task_execution(&dispatch)?;
+    Ok(())
+}
+
 pub(crate) async fn run_turn_cli(
     config_path: Option<&str>,
     session_hint: Option<&str>,
@@ -185,6 +213,10 @@ pub(crate) async fn run_turn_cli(
 ) -> CliResult<()> {
     if message.trim().is_empty() {
         return Err("turn message must not be empty".to_owned());
+    }
+    let (_resolved_path, config) = loongclaw_app::config::load(config_path)?;
+    if !config.cli.enabled {
+        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
     let kernel = build_daemon_runtime_kernel();

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeSet;
 
+use async_trait::async_trait;
 use kernel::{
-    Capability, CapabilityToken, ConnectorCommand, ExecutionRoute, HarnessOutcome, LoongClawKernel,
-    PolicyEngine, TaskIntent, TaskState, TaskSupervisor,
+    Capability, CapabilityToken, ConnectorCommand, ExecutionRoute, HarnessAdapter, HarnessError,
+    HarnessKind, HarnessOutcome, HarnessRequest, LoongClawKernel, PolicyEngine, StaticPolicyEngine,
+    TaskIntent, TaskState, TaskSupervisor,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::{CliResult, DEFAULT_AGENT_ID, DEFAULT_PACK_ID, PUBLIC_GITHUB_REPO, kernel_bootstrap};
@@ -44,6 +46,77 @@ pub(crate) async fn execute_daemon_task_with_supervisor<P: PolicyEngine>(
             })
         }
     }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+struct DaemonTurnTaskPayload {
+    config_path: Option<String>,
+    session_hint: Option<String>,
+    message: Option<String>,
+    turn_mode: loongclaw_app::agent_runtime::AgentTurnMode,
+    metadata: std::collections::BTreeMap<String, String>,
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_servers: Vec<String>,
+    acp_cwd: Option<String>,
+}
+
+struct EmbeddedAgentHarness;
+
+#[async_trait]
+impl HarnessAdapter for EmbeddedAgentHarness {
+    fn name(&self) -> &str {
+        "pi-local"
+    }
+
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::EmbeddedPi
+    }
+
+    async fn execute(&self, request: HarnessRequest) -> Result<HarnessOutcome, HarnessError> {
+        let payload = serde_json::from_value::<DaemonTurnTaskPayload>(request.payload)
+            .map_err(|error| HarnessError::Execution(format!("invalid_turn_payload: {error}")))?;
+        let message = payload.message.unwrap_or(request.objective);
+        let runtime = loongclaw_app::agent_runtime::AgentRuntime::new();
+        let turn_result = runtime
+            .run_turn(
+                payload.config_path.as_deref(),
+                payload.session_hint.as_deref(),
+                &loongclaw_app::agent_runtime::AgentTurnRequest {
+                    message,
+                    turn_mode: payload.turn_mode,
+                    channel_id: None,
+                    account_id: None,
+                    conversation_id: None,
+                    thread_id: None,
+                    metadata: payload.metadata,
+                    acp: payload.acp,
+                    acp_event_stream: payload.acp_event_stream,
+                    acp_bootstrap_mcp_servers: payload.acp_bootstrap_mcp_servers,
+                    acp_cwd: payload.acp_cwd,
+                    live_surface_enabled: matches!(
+                        payload.turn_mode,
+                        loongclaw_app::agent_runtime::AgentTurnMode::Interactive
+                    ),
+                },
+            )
+            .await
+            .map_err(HarnessError::Execution)?;
+
+        Ok(HarnessOutcome {
+            status: "ok".to_owned(),
+            output: serde_json::to_value(turn_result).map_err(|error| {
+                HarnessError::Execution(format!("serialize_turn_result_failed: {error}"))
+            })?,
+        })
+    }
+}
+
+fn build_daemon_runtime_kernel() -> LoongClawKernel<StaticPolicyEngine> {
+    let mut kernel = kernel_bootstrap::BootstrapBuilder::default().into_builder();
+    kernel.register_harness_adapter(EmbeddedAgentHarness);
+    kernel
 }
 
 fn require_successful_daemon_task_execution(
@@ -101,31 +174,62 @@ pub async fn run_demo() -> CliResult<()> {
     Ok(())
 }
 
-pub async fn run_task_cli(objective: &str, payload_raw: &str) -> CliResult<()> {
-    let payload = crate::cli_json::parse_json_payload(payload_raw, "run-task payload")?;
+pub(crate) async fn run_turn_cli(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    message: &str,
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> CliResult<()> {
+    if message.trim().is_empty() {
+        return Err("turn message must not be empty".to_owned());
+    }
 
-    let kernel = kernel_bootstrap::KernelBuilder::default().build();
+    let kernel = build_daemon_runtime_kernel();
     let token = kernel
         .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
         .map_err(|error| format!("token issue failed: {error}"))?;
+    let payload = serde_json::to_value(DaemonTurnTaskPayload {
+        config_path: config_path.map(ToOwned::to_owned),
+        session_hint: session_hint.map(ToOwned::to_owned),
+        message: Some(message.to_owned()),
+        turn_mode: if acp {
+            loongclaw_app::agent_runtime::AgentTurnMode::Acp
+        } else {
+            loongclaw_app::agent_runtime::AgentTurnMode::Oneshot
+        },
+        metadata: std::collections::BTreeMap::new(),
+        acp,
+        acp_event_stream,
+        acp_bootstrap_mcp_servers: acp_bootstrap_mcp_server.to_vec(),
+        acp_cwd: acp_cwd.map(ToOwned::to_owned),
+    })
+    .map_err(|error| format!("serialize turn payload failed: {error}"))?;
 
     let dispatch = execute_daemon_task_with_supervisor(
         &kernel,
         DEFAULT_PACK_ID,
         &token,
         TaskIntent {
-            task_id: "task-cli-01".to_owned(),
-            objective: objective.to_owned(),
-            required_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::MemoryRead]),
+            task_id: "turn-run-01".to_owned(),
+            objective: message.to_owned(),
+            required_capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::MemoryRead,
+                Capability::MemoryWrite,
+            ]),
             payload,
         },
     )
     .await?;
-
-    let pretty = serde_json::to_string_pretty(&dispatch)
-        .map_err(|error| format!("serialize task outcome failed: {error}"))?;
-    println!("{pretty}");
-    require_successful_daemon_task_execution(&dispatch)?;
+    let (_, outcome) = require_successful_daemon_task_execution(&dispatch)?;
+    let result = serde_json::from_value::<loongclaw_app::agent_runtime::AgentTurnResult>(
+        outcome.output.clone(),
+    )
+    .map_err(|error| format!("parse turn result failed: {error}"))?;
+    println!("{}", result.output_text);
     Ok(())
 }
 
@@ -240,5 +344,47 @@ mod tests {
         assert!(matches!(execution.supervisor_state, TaskState::Faulted(_)));
         assert!(payload["route"].is_null());
         assert!(payload["outcome"].is_null());
+    }
+
+    #[tokio::test]
+    async fn daemon_runtime_kernel_overrides_pi_local_stub_harness() {
+        let kernel = build_daemon_runtime_kernel();
+        let token = kernel
+            .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
+            .expect("issue token");
+        let payload = serde_json::to_value(DaemonTurnTaskPayload {
+            message: Some("hello".to_owned()),
+            ..DaemonTurnTaskPayload::default()
+        })
+        .expect("serialize turn payload");
+
+        let execution = execute_daemon_task_with_supervisor(
+            &kernel,
+            DEFAULT_PACK_ID,
+            &token,
+            TaskIntent {
+                task_id: "task-runtime-harness-01".to_owned(),
+                objective: "hello".to_owned(),
+                required_capabilities: BTreeSet::from([
+                    Capability::InvokeTool,
+                    Capability::MemoryRead,
+                    Capability::MemoryWrite,
+                ]),
+                payload,
+            },
+        )
+        .await
+        .expect("execute daemon task");
+
+        let error = execution
+            .error
+            .as_deref()
+            .expect("missing config should fail through the real runtime harness");
+
+        assert!(execution.outcome.is_none());
+        assert!(
+            error.contains("failed to read config"),
+            "expected unified runtime harness failure, got: {error}"
+        );
     }
 }

--- a/crates/daemon/src/turn_cli.rs
+++ b/crates/daemon/src/turn_cli.rs
@@ -1,0 +1,80 @@
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::CliResult;
+use crate::mvp;
+
+#[derive(Subcommand, Debug)]
+pub enum TurnCommands {
+    #[command(
+        about = "Run one non-interactive assistant turn through the unified runtime",
+        long_about = "Run one non-interactive assistant turn through the unified runtime.\n\nThis is the canonical one-shot turn entrypoint. It routes through the real agent runtime rather than the legacy demo harness path."
+    )]
+    Run {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        session: Option<String>,
+        #[arg(long)]
+        message: String,
+        #[arg(long, default_value_t = false)]
+        acp: bool,
+        #[arg(long, default_value_t = false)]
+        acp_event_stream: bool,
+        #[arg(long = "acp-bootstrap-mcp-server")]
+        acp_bootstrap_mcp_server: Vec<String>,
+        #[arg(long = "acp-cwd")]
+        acp_cwd: Option<String>,
+    },
+}
+
+pub async fn run_chat_cli(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> CliResult<()> {
+    let options = build_cli_chat_options(acp, acp_event_stream, acp_bootstrap_mcp_server, acp_cwd);
+    mvp::chat::run_cli_chat(config_path, session, &options).await
+}
+
+pub async fn run_ask_cli(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    message: &str,
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> CliResult<()> {
+    crate::task_execution::run_turn_cli(
+        config_path,
+        session,
+        message,
+        acp,
+        acp_event_stream,
+        acp_bootstrap_mcp_server,
+        acp_cwd,
+    )
+    .await
+}
+
+pub fn build_cli_chat_options(
+    acp: bool,
+    acp_event_stream: bool,
+    acp_bootstrap_mcp_server: &[String],
+    acp_cwd: Option<&str>,
+) -> mvp::chat::CliChatOptions {
+    mvp::chat::CliChatOptions {
+        acp_requested: acp,
+        acp_event_stream,
+        acp_bootstrap_mcp_servers: acp_bootstrap_mcp_server.to_vec(),
+        acp_working_directory: acp_cwd
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from),
+    }
+}

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -58,17 +58,27 @@ fn unique_runtime_dir(label: &str) -> PathBuf {
 }
 
 fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let runtime_root = unique_runtime_dir("headless-config");
+    let config_path = runtime_root.join("loongclaw.toml");
+    let sqlite_path = runtime_root.join("memory.sqlite3");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.sqlite_path = sqlite_path.display().to_string();
+
     LoadedSupervisorConfig {
-        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
-        config: mvp::config::LoongClawConfig::default(),
+        resolved_path: config_path,
+        config,
     }
 }
 
 fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let runtime_root = unique_runtime_dir("telegram-config");
+    let config_path = runtime_root.join("loongclaw.toml");
+    let sqlite_path = runtime_root.join("memory.sqlite3");
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
+    config.memory.sqlite_path = sqlite_path.display().to_string();
     LoadedSupervisorConfig {
-        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        resolved_path: config_path,
         config,
     }
 }
@@ -391,7 +401,9 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
 }
 
 #[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
 async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_runtime() {
+    let _lock = lock_daemon_test_environment();
     let runtime_dir = unique_runtime_dir("localhost-control");
     let hooks = SupervisorRuntimeHooks {
         load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),

--- a/crates/daemon/tests/integration/latest_selector_process_support.rs
+++ b/crates/daemon/tests/integration/latest_selector_process_support.rs
@@ -56,8 +56,9 @@ impl LatestSelectorCliFixture {
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config =
-            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config_without_env_overrides(
+            &config.memory,
+        );
         let resolved_sqlite_path = config.memory.resolved_sqlite_path();
         mvp::memory::ensure_memory_db_ready(Some(resolved_sqlite_path), &memory_config)
             .expect("initialize latest selector sqlite memory");

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1515,6 +1515,19 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
 
 #[test]
 fn render_memory_system_snapshot_text_reports_fail_open_policy() {
+    let mut env = loongclaw_daemon::test_support::ScopedEnv::new();
+    for key in [
+        "LOONGCLAW_MEMORY_BACKEND",
+        "LOONGCLAW_MEMORY_PROFILE",
+        "LOONGCLAW_MEMORY_FAIL_OPEN",
+        "LOONGCLAW_MEMORY_INGEST_MODE",
+        "LOONGCLAW_SQLITE_PATH",
+        "LOONGCLAW_SLIDING_WINDOW",
+        "LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS",
+        "LOONGCLAW_MEMORY_PROFILE_NOTE",
+    ] {
+        env.remove(key);
+    }
     let config = mvp::config::LoongClawConfig {
         memory: mvp::config::MemoryConfig {
             profile: mvp::config::MemoryProfile::WindowPlusSummary,

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1518,6 +1518,7 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
     let mut env = loongclaw_daemon::test_support::ScopedEnv::new();
     for key in [
         "LOONGCLAW_MEMORY_BACKEND",
+        "LOONGCLAW_MEMORY_SYSTEM",
         "LOONGCLAW_MEMORY_PROFILE",
         "LOONGCLAW_MEMORY_FAIL_OPEN",
         "LOONGCLAW_MEMORY_INGEST_MODE",

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-11T15:16:35Z
+- Generated at: 2026-04-11T16:04:29Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,17 +20,17 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6571 | 7300 | 729 | 94 | 160 | 66 | 90.0% | WATCH | 6936 | -5.3% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6594 | 7300 | 706 | 95 | 160 | 65 | 90.3% | WATCH | 6936 | -4.9% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1836 | 6400 | 4564 | 0 | 110 | 110 | 28.7% | HEALTHY | 1779 | 3.2% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10725 | 11200 | 475 | 87 | 120 | 33 | 95.8% | TIGHT | 10831 | -1.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14731 | 15000 | 269 | 60 | 70 | 10 | 98.2% | TIGHT | 14472 | 1.8% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6466 | 6500 | 34 | 198 | 210 | 12 | 99.5% | TIGHT | 6324 | 2.2% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6474 | 6500 | 26 | 198 | 210 | 12 | 99.6% | TIGHT | 6324 | 2.4% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (98.2%), daemon_lib (99.5%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (90.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (98.2%), daemon_lib (99.6%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (90.3%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,11 +66,11 @@
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
-<!-- arch-hotspot key=chat_runtime lines=6571 functions=94 -->
+<!-- arch-hotspot key=chat_runtime lines=6594 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=1836 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10725 functions=87 -->
 <!-- arch-hotspot key=tools_mod lines=14731 functions=60 -->
-<!-- arch-hotspot key=daemon_lib lines=6466 functions=198 -->
+<!-- arch-hotspot key=daemon_lib lines=6474 functions=198 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-11T13:36:35Z
+- Generated at: 2026-04-11T15:16:35Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,17 +20,17 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2641 | 2800 | 159 | 49 | 65 | 16 | 94.3% | WATCH | 2698 | -2.1% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9449 | 10500 | 1051 | 72 | 90 | 18 | 90.0% | WATCH | 9922 | -4.8% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9684 | 9800 | 116 | 87 | 90 | 3 | 98.8% | TIGHT | 9796 | -1.1% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6424 | 7300 | 876 | 97 | 160 | 63 | 88.0% | WATCH | 6936 | -7.4% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6571 | 7300 | 729 | 94 | 160 | 66 | 90.0% | WATCH | 6936 | -5.3% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1836 | 6400 | 4564 | 0 | 110 | 110 | 28.7% | HEALTHY | 1779 | 3.2% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10725 | 11200 | 475 | 87 | 120 | 33 | 95.8% | TIGHT | 10831 | -1.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14731 | 15000 | 269 | 60 | 70 | 10 | 98.2% | TIGHT | 14472 | 1.8% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6498 | 6500 | 2 | 201 | 210 | 9 | 100.0% | TIGHT | 6324 | 2.8% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6466 | 6500 | 34 | 198 | 210 | 12 | 99.5% | TIGHT | 6324 | 2.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (98.2%), daemon_lib (100.0%), onboard_cli (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (88.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (98.2%), daemon_lib (99.5%), onboard_cli (99.9%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (90.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,11 +66,11 @@
 <!-- arch-hotspot key=acpx_runtime lines=2641 functions=49 -->
 <!-- arch-hotspot key=channel_registry lines=9449 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9684 functions=87 -->
-<!-- arch-hotspot key=chat_runtime lines=6424 functions=97 -->
+<!-- arch-hotspot key=chat_runtime lines=6571 functions=94 -->
 <!-- arch-hotspot key=channel_mod lines=1836 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10725 functions=87 -->
 <!-- arch-hotspot key=tools_mod lines=14731 functions=60 -->
-<!-- arch-hotspot key=daemon_lib lines=6498 functions=201 -->
+<!-- arch-hotspot key=daemon_lib lines=6466 functions=198 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

This PR unifies the main production turn entry surfaces under `AgentRuntime`.

It routes the following through the same runtime spine:

- `ask`
- `turn run`
- interactive chat turns
- kernel task execution via the visible runtime-backed harness path
- control-plane turn submit
- gateway `/v1/turn`
- channel provider ingress

It also promotes prompt-frame cache metadata into actual provider request headers, preserves host-specific propagation behavior for channel ingress, and stabilizes Feishu inbound runtime tests that became stack-sensitive after the runtime convergence work.

## What changed

- add `AgentRuntime` request/result contracts in `crates/app/src/agent_runtime.rs`
- add canonical `turn run` CLI support and route `ask` through the same runtime helper
- replace the visible `pi-local` stub harness path with a runtime-backed adapter
- move control-plane and gateway turn execution onto the shared runtime surface
- route channel provider ingress through `AgentRuntime` while preserving ingress/provenance and `Propagate` error semantics
- emit prompt cache planning metadata through provider request headers
- stabilize Feishu webhook and websocket inbound tests with explicit large-stack test wrappers

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features -q`
- `./scripts/check_architecture_boundaries.sh`

Closes #1205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent runtime API and public "turn" CLI for running/resuming conversation turns with structured results and events.

* **Improvements**
  * Optional per-turn metadata supported and propagated into session/bootstrap requests.
  * Prompt-cache headers with SHA‑256 prefix hashing and cache-eligibility flag for providers.
  * Memory/runtime config loading option that avoids environment-variable overrides.
  * Workspace path canonicalization and safer path resolution behavior for file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->