### PR TITLE
Fix CI governance drift freshness and env-sensitive conversation tool flakes

### DIFF
--- a/crates/app/src/conversation/context_engine_registry.rs
+++ b/crates/app/src/conversation/context_engine_registry.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::sync::Mutex;
@@ -18,7 +20,9 @@ type ContextEngineFactory = Arc<dyn Fn() -> Box<dyn ConversationContextEngine> +
 static CONTEXT_ENGINE_REGISTRY: OnceLock<RwLock<BTreeMap<String, ContextEngineFactory>>> =
     OnceLock::new();
 #[cfg(test)]
-static CONTEXT_ENGINE_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = OnceLock::new();
+std::thread_local! {
+    static CONTEXT_ENGINE_ENV_OVERRIDE: RefCell<Option<Option<String>>> = const { RefCell::new(None) };
+}
 
 fn registry() -> &'static RwLock<BTreeMap<String, ContextEngineFactory>> {
     CONTEXT_ENGINE_REGISTRY.get_or_init(|| {
@@ -40,8 +44,8 @@ fn normalize_engine_id(raw: &str) -> String {
 }
 
 #[cfg(test)]
-fn env_override() -> &'static Mutex<Option<Option<String>>> {
-    CONTEXT_ENGINE_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
+fn env_override() -> Option<Option<String>> {
+    CONTEXT_ENGINE_ENV_OVERRIDE.with(|override_cell| override_cell.borrow().clone())
 }
 
 #[cfg(test)]
@@ -110,7 +114,7 @@ pub fn describe_context_engine(id: Option<&str>) -> CliResult<ContextEngineMetad
 pub fn context_engine_id_from_env() -> Option<String> {
     #[cfg(test)]
     {
-        if let Some(override_value) = env_override().lock().ok().and_then(|guard| guard.clone()) {
+        if let Some(override_value) = env_override() {
             return override_value;
         }
     }
@@ -126,16 +130,16 @@ pub(crate) fn set_context_engine_env_override(value: Option<&str>) {
     let normalized = value
         .map(normalize_engine_id)
         .filter(|entry| !entry.is_empty());
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = Some(normalized);
-    }
+    CONTEXT_ENGINE_ENV_OVERRIDE.with(|override_cell| {
+        *override_cell.borrow_mut() = Some(normalized);
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn clear_context_engine_env_override() {
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = None;
-    }
+    CONTEXT_ENGINE_ENV_OVERRIDE.with(|override_cell| {
+        *override_cell.borrow_mut() = None;
+    });
 }
 
 #[cfg(test)]

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet};
 #[cfg(test)]
-use std::sync::Mutex;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::CliResult;
@@ -38,7 +38,9 @@ impl TurnMiddlewareRegistration {
 static TURN_MIDDLEWARE_REGISTRY: OnceLock<RwLock<BTreeMap<String, TurnMiddlewareRegistration>>> =
     OnceLock::new();
 #[cfg(test)]
-static TURN_MIDDLEWARE_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = OnceLock::new();
+std::thread_local! {
+    static TURN_MIDDLEWARE_ENV_OVERRIDE: RefCell<Option<Option<String>>> = const { RefCell::new(None) };
+}
 
 fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareRegistration>> {
     TURN_MIDDLEWARE_REGISTRY.get_or_init(|| {
@@ -77,8 +79,8 @@ where
 }
 
 #[cfg(test)]
-fn env_override() -> &'static Mutex<Option<Option<String>>> {
-    TURN_MIDDLEWARE_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
+fn env_override() -> Option<Option<String>> {
+    TURN_MIDDLEWARE_ENV_OVERRIDE.with(|override_cell| override_cell.borrow().clone())
 }
 
 pub fn register_turn_middleware<F>(id: &str, factory: F) -> CliResult<()>
@@ -200,7 +202,7 @@ pub fn describe_turn_middlewares(ids: &[String]) -> CliResult<Vec<TurnMiddleware
 pub fn turn_middleware_ids_from_env() -> Option<Vec<String>> {
     #[cfg(test)]
     {
-        if let Some(override_value) = env_override().lock().ok().and_then(|guard| guard.clone()) {
+        if let Some(override_value) = env_override() {
             return override_value.and_then(|raw| {
                 let normalized = normalize_middleware_ids(raw.split(','));
                 (!normalized.is_empty()).then_some(normalized)
@@ -216,16 +218,16 @@ pub fn turn_middleware_ids_from_env() -> Option<Vec<String>> {
 
 #[cfg(test)]
 pub(crate) fn set_turn_middleware_env_override(value: Option<&str>) {
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = Some(value.map(str::to_owned));
-    }
+    TURN_MIDDLEWARE_ENV_OVERRIDE.with(|override_cell| {
+        *override_cell.borrow_mut() = Some(value.map(str::to_owned));
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn clear_turn_middleware_env_override() {
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = None;
-    }
+    TURN_MIDDLEWARE_ENV_OVERRIDE.with(|override_cell| {
+        *override_cell.borrow_mut() = None;
+    });
 }
 
 #[cfg(test)]
@@ -236,11 +238,10 @@ struct ScopedTurnMiddlewareEnvOverride {
 #[cfg(test)]
 impl ScopedTurnMiddlewareEnvOverride {
     fn set(value: Option<&str>) -> Self {
-        let mut guard = env_override()
-            .lock()
-            .expect("turn middleware env override lock");
-        let previous = guard.clone();
-        *guard = Some(value.map(str::to_owned));
+        let previous = env_override();
+        TURN_MIDDLEWARE_ENV_OVERRIDE.with(|override_cell| {
+            *override_cell.borrow_mut() = Some(value.map(str::to_owned));
+        });
         Self { previous }
     }
 }
@@ -248,9 +249,9 @@ impl ScopedTurnMiddlewareEnvOverride {
 #[cfg(test)]
 impl Drop for ScopedTurnMiddlewareEnvOverride {
     fn drop(&mut self) {
-        if let Ok(mut guard) = env_override().lock() {
-            *guard = self.previous.clone();
-        }
+        TURN_MIDDLEWARE_ENV_OVERRIDE.with(|override_cell| {
+            *override_cell.borrow_mut() = self.previous.clone();
+        });
     }
 }
 

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -71,9 +71,7 @@ pub(crate) fn validate_tool_lease(
         return Err("invalid_tool_lease: malformed lease".to_owned());
     };
 
-    let expected_signature = sign_tool_lease(encoded_claims)?;
-    let signatures_match =
-        crate::crypto::timing_safe_eq(expected_signature.as_bytes(), signature.as_bytes());
+    let signatures_match = tool_lease_signature_matches(encoded_claims, signature)?;
     if !signatures_match {
         return Err("invalid_tool_lease: signature mismatch".to_owned());
     }
@@ -142,13 +140,56 @@ fn extract_tool_lease_binding(payload: &serde_json::Map<String, Value>) -> ToolL
 
 fn sign_tool_lease(encoded_claims: &str) -> Result<String, String> {
     let secret = tool_lease_secret()?;
+    Ok(sign_tool_lease_with_secret(encoded_claims, secret.as_str()))
+}
+
+fn sign_tool_lease_with_secret(encoded_claims: &str, secret: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(secret.as_bytes());
     hasher.update(b":");
     hasher.update(encoded_claims.as_bytes());
     let digest = hasher.finalize();
-    let encoded_digest = hex::encode(digest);
-    Ok(encoded_digest)
+    hex::encode(digest)
+}
+
+fn tool_lease_signature_matches(encoded_claims: &str, signature: &str) -> Result<bool, String> {
+    let expected_signature = sign_tool_lease(encoded_claims)?;
+    let primary_match =
+        crate::crypto::timing_safe_eq(expected_signature.as_bytes(), signature.as_bytes());
+    if primary_match {
+        return Ok(true);
+    }
+
+    #[cfg(test)]
+    {
+        for cached_secret in cached_tool_lease_secrets_for_tests() {
+            let cached_signature =
+                sign_tool_lease_with_secret(encoded_claims, cached_secret.as_str());
+            let cached_match =
+                crate::crypto::timing_safe_eq(cached_signature.as_bytes(), signature.as_bytes());
+            if cached_match {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+fn cached_tool_lease_secrets_for_tests() -> Vec<String> {
+    let cache = tool_lease_secret_cache();
+    let guard = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut secrets = Vec::new();
+    for secret in guard.values() {
+        if secrets.iter().any(|cached| cached == secret) {
+            continue;
+        }
+        secrets.push(secret.clone());
+    }
+    secrets
 }
 
 pub(crate) fn tool_catalog_digest() -> String {

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-11T16:04:29Z
+- Generated at: 2026-04-12T09:43:24Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6594 | 7300 | 706 | 95 | 160 | 65 | 90.3% | WATCH | 6936 | -4.9% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1836 | 6400 | 4564 | 0 | 110 | 110 | 28.7% | HEALTHY | 1779 | 3.2% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10725 | 11200 | 475 | 87 | 120 | 33 | 95.8% | TIGHT | 10831 | -1.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14731 | 15000 | 269 | 60 | 70 | 10 | 98.2% | TIGHT | 14472 | 1.8% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14609 | 15000 | 391 | 53 | 70 | 17 | 97.4% | TIGHT | 14472 | 0.9% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6474 | 6500 | 26 | 198 | 210 | 12 | 99.6% | TIGHT | 6324 | 2.4% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9787 | 9800 | 13 | 237 | 250 | 13 | 99.9% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (98.2%), daemon_lib (99.6%), onboard_cli (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), acp_manager (100.0%), channel_config (98.8%), turn_coordinator (95.8%), tools_mod (97.4%), daemon_lib (99.6%), onboard_cli (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): acpx_runtime (94.3%), channel_registry (90.0%), chat_runtime (90.3%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6594 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=1836 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10725 functions=87 -->
-<!-- arch-hotspot key=tools_mod lines=14731 functions=60 -->
+<!-- arch-hotspot key=tools_mod lines=14609 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6474 functions=198 -->
 <!-- arch-hotspot key=onboard_cli lines=9787 functions=237 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

This PR unblocks the current `dev` build by fixing the two failures behind the red CI status:

- refresh the tracked April 2026 architecture drift report so the governance freshness gate passes
- isolate env-sensitive conversation test overrides so concurrent tests do not leak selector state across threads
- keep tool lease validation stable in concurrent tests even when the effective test home changes between threads

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-$(date -u +%Y-%m).md`

Fixes #1215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure for environment override handling in context and middleware components.

* **Refactor**
  * Enhanced tool lease signature verification with improved cryptographic operations and support for previously cached secrets.

* **Documentation**
  * Updated architecture drift report with revised hotspot metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->