### PR TITLE
Stabilize the local gateway front door around port 26306

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,9 +634,10 @@ When `gateway run` is active, it also binds a loopback-only control endpoint on
 `port_source`, and `token_path` into `loongclaw gateway status --json`. Use `--port` or
 `LOONGCLAW_GATEWAY_PORT` when you need a different localhost port; use
 `--port 0` only when you explicitly want an OS-assigned ephemeral port for
-isolated test or lab runs. Local clients such as the future Web UI can
-discover the running owner through that persisted state without introducing a
-second service lifecycle.
+isolated test or lab runs. Local clients such as the future Web UI now try the
+stable `127.0.0.1:26306` front door first and only fall back to the persisted
+owner state when operators intentionally override that port, without
+introducing a second service lifecycle.
 
 The daemon now also carries a reusable localhost gateway client/discovery layer
 that centralizes loopback validation, bearer-token loading, and route helpers

--- a/README.md
+++ b/README.md
@@ -623,8 +623,9 @@ The current gateway slice now includes:
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
 - a localhost-only authenticated control surface that publishes status,
-  channel inventory, runtime snapshot, ACP session/operator views, operator
-  summary, and cooperative stop endpoints from the same `gateway run` owner
+  channel inventory, runtime snapshot, pairing inbox/resolve routes, ACP
+  session/operator views, operator summary, and cooperative stop endpoints from
+  the same `gateway run` owner
 
 `gateway run` starts headless by default. Pass `--session` when you want the
 concurrent CLI host attached to the same runtime owner.

--- a/README.md
+++ b/README.md
@@ -476,6 +476,17 @@ default_provider = "duckduckgo"
 # or "${JINA_AUTH_TOKEN}"
 ```
 
+Gateway control-surface example:
+
+```toml
+[gateway]
+port = 26306
+```
+
+`loongclaw gateway run` uses `127.0.0.1:26306` by default. Override it with
+`--port`, `LOONGCLAW_GATEWAY_PORT`, or set `port = 0` only when you explicitly
+want an ephemeral localhost port for test or lab runs.
+
 Volcengine / ARK example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -630,8 +630,8 @@ The current gateway slice now includes:
 concurrent CLI host attached to the same runtime owner.
 
 When `gateway run` is active, it also binds a loopback-only control endpoint on
-`127.0.0.1:26306` by default and writes the actual `bind_address`, `port`, and
-`token_path` into `loongclaw gateway status --json`. Use `--port` or
+`127.0.0.1:26306` by default and writes the actual `bind_address`, `port`,
+`port_source`, and `token_path` into `loongclaw gateway status --json`. Use `--port` or
 `LOONGCLAW_GATEWAY_PORT` when you need a different localhost port; use
 `--port 0` only when you explicitly want an OS-assigned ephemeral port for
 isolated test or lab runs. Local clients such as the future Web UI can

--- a/README.md
+++ b/README.md
@@ -619,10 +619,13 @@ The current gateway slice now includes:
 concurrent CLI host attached to the same runtime owner.
 
 When `gateway run` is active, it also binds a loopback-only control endpoint on
-an ephemeral localhost port and writes the actual `bind_address`, `port`, and
-`token_path` into `loongclaw gateway status --json`. Local clients such as the
-future Web UI can discover the running owner through that persisted state
-without introducing a second service lifecycle.
+`127.0.0.1:26306` by default and writes the actual `bind_address`, `port`, and
+`token_path` into `loongclaw gateway status --json`. Use `--port` or
+`LOONGCLAW_GATEWAY_PORT` when you need a different localhost port; use
+`--port 0` only when you explicitly want an OS-assigned ephemeral port for
+isolated test or lab runs. Local clients such as the future Web UI can
+discover the running owner through that persisted state without introducing a
+second service lifecycle.
 
 The daemon now also carries a reusable localhost gateway client/discovery layer
 that centralizes loopback validation, bearer-token loading, and route helpers

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -103,7 +103,7 @@ pub(crate) use runtime::inject_test_config_write_failure;
 pub use runtime::{
     AcpBackendProfilesConfig, AcpConfig, AcpConversationRoutingMode, AcpDispatchConfig,
     AcpDispatchThreadRoutingMode, AcpxBackendConfig, AcpxMcpServerConfig,
-    ConfigValidationDiagnostic, ControlPlaneConfig, LoongClawConfig,
+    ConfigValidationDiagnostic, ControlPlaneConfig, GatewayConfig, LoongClawConfig,
     PROVIDER_SELECTOR_COMPACT_NOTE, PROVIDER_SELECTOR_HUMAN_SUMMARY, PROVIDER_SELECTOR_NOTE,
     PROVIDER_SELECTOR_PLACEHOLDER, PROVIDER_SELECTOR_TARGET_SUMMARY, ProviderSelectorProfileRef,
     ProviderSelectorResolution, accepted_provider_selectors, default_config_path,
@@ -2832,6 +2832,28 @@ MCP_LOG = "warn"
         let config = ControlPlaneConfig::default();
         assert!(!config.allow_remote);
         assert_eq!(config.resolved_shared_token(), Ok(None));
+    }
+
+    #[test]
+    fn gateway_defaults_use_port_26306() {
+        let config = GatewayConfig::default();
+        let actual_port = config.port;
+
+        assert_eq!(actual_port, 26_306);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn gateway_port_parses_from_toml() {
+        let raw = r#"
+[gateway]
+port = 26316
+"#;
+
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse gateway config");
+        let actual_port = parsed.gateway.port;
+
+        assert_eq!(actual_port, 26_316);
     }
 
     #[test]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -185,10 +185,31 @@ pub struct LoongClawConfig {
     pub memory: MemoryConfig,
     #[serde(default)]
     pub audit: AuditConfig,
+    #[serde(default, skip_serializing_if = "GatewayConfig::is_default")]
+    pub gateway: GatewayConfig,
     #[serde(default, skip_serializing_if = "ControlPlaneConfig::is_default")]
     pub control_plane: ControlPlaneConfig,
     #[serde(default)]
     pub acp: AcpConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GatewayConfig {
+    #[serde(default = "default_gateway_port")]
+    pub port: u16,
+}
+
+impl GatewayConfig {
+    fn is_default(config: &Self) -> bool {
+        *config == Self::default()
+    }
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        let port = default_gateway_port();
+        Self { port }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -608,6 +629,10 @@ pub struct AcpxMcpServerConfig {
     pub args: Vec<String>,
     #[serde(default)]
     pub env: BTreeMap<String, String>,
+}
+
+const fn default_gateway_port() -> u16 {
+    26_306
 }
 
 const fn default_acp_max_concurrent_sessions() -> usize {

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -1007,6 +1007,15 @@ pub struct ControlPlanePairingRequestRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlaneApprovedDeviceSummary {
+    pub device_id: String,
+    pub public_key: String,
+    pub role: String,
+    pub approved_scopes: BTreeSet<String>,
+    pub issued_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ControlPlanePairingConnectDecision {
     Authorized,
     PairingRequired {
@@ -1208,6 +1217,30 @@ impl ControlPlanePairingRegistry {
             .read()
             .unwrap_or_else(|error| error.into_inner())
             .len()
+    }
+
+    pub fn list_approved_devices(&self, limit: usize) -> Vec<ControlPlaneApprovedDeviceSummary> {
+        let mut approved_devices = self
+            .approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        approved_devices.sort_by(|left, right| {
+            right
+                .approved_at_ms
+                .cmp(&left.approved_at_ms)
+                .then_with(|| left.device_id.cmp(&right.device_id))
+        });
+        approved_devices.truncate(limit.max(1));
+
+        let mut summaries = Vec::with_capacity(approved_devices.len());
+        for approved_device in approved_devices {
+            let summary = approved_device_summary_from_record(&approved_device);
+            summaries.push(summary);
+        }
+        summaries
     }
 
     pub fn last_activity_ms(&self) -> Option<u64> {
@@ -1505,6 +1538,18 @@ fn approved_device_requires_pairing(
     }
     let scopes_within_approved = requested_scopes.is_subset(&approved.approved_scopes);
     !scopes_within_approved
+}
+
+fn approved_device_summary_from_record(
+    approved_device: &ControlPlaneApprovedDeviceRecord,
+) -> ControlPlaneApprovedDeviceSummary {
+    ControlPlaneApprovedDeviceSummary {
+        device_id: approved_device.device_id.clone(),
+        public_key: approved_device.public_key.clone(),
+        role: approved_device.role.clone(),
+        approved_scopes: approved_device.approved_scopes.clone(),
+        issued_at_ms: approved_device.approved_at_ms,
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2583,6 +2628,63 @@ mod tests {
         assert_eq!(
             approved_last_activity,
             approved
+                .resolved_at_ms
+                .expect("approved request should resolve")
+        );
+    }
+
+    #[test]
+    fn pairing_registry_lists_approved_devices_in_reverse_chronological_order() {
+        let registry = ControlPlanePairingRegistry::new();
+        let first_scopes = BTreeSet::from(["operator.read".to_owned()]);
+        let second_scopes = BTreeSet::from(["operator.write".to_owned()]);
+
+        let first_request = registry
+            .evaluate_connect(
+                "device-a",
+                "cli-a",
+                "public-key-a",
+                "operator",
+                &first_scopes,
+                None,
+            )
+            .expect("evaluate first connect");
+        let first_request = match first_request {
+            ControlPlanePairingConnectDecision::PairingRequired { request, .. } => request,
+            other => panic!("expected first pairing request, got {other:?}"),
+        };
+        let _first_approved = registry
+            .resolve_request(&first_request.pairing_request_id, true)
+            .expect("approve first request")
+            .expect("first request should exist");
+
+        let second_request = registry
+            .evaluate_connect(
+                "device-b",
+                "cli-b",
+                "public-key-b",
+                "operator",
+                &second_scopes,
+                None,
+            )
+            .expect("evaluate second connect");
+        let second_request = match second_request {
+            ControlPlanePairingConnectDecision::PairingRequired { request, .. } => request,
+            other => panic!("expected second pairing request, got {other:?}"),
+        };
+        let second_approved = registry
+            .resolve_request(&second_request.pairing_request_id, true)
+            .expect("approve second request")
+            .expect("second request should exist");
+
+        let summaries = registry.list_approved_devices(10);
+
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].device_id, "device-b");
+        assert_eq!(summaries[0].approved_scopes, second_scopes);
+        assert_eq!(
+            summaries[0].issued_at_ms,
+            second_approved
                 .resolved_at_ms
                 .expect("approved request should resolve")
         );

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -1194,6 +1194,47 @@ impl ControlPlanePairingRegistry {
         requests
     }
 
+    pub fn pending_request_count(&self) -> usize {
+        self.requests
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .filter(|record| record.status == ControlPlanePairingStatus::Pending)
+            .count()
+    }
+
+    pub fn approved_device_count(&self) -> usize {
+        self.approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .len()
+    }
+
+    pub fn last_activity_ms(&self) -> Option<u64> {
+        let requests_last_activity = self
+            .requests
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .flat_map(|record| [Some(record.requested_at_ms), record.resolved_at_ms])
+            .flatten()
+            .max();
+        let devices_last_activity = self
+            .approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .map(|device| device.approved_at_ms)
+            .max();
+
+        match (requests_last_activity, devices_last_activity) {
+            (Some(left), Some(right)) => Some(left.max(right)),
+            (Some(left), None) => Some(left),
+            (None, Some(right)) => Some(right),
+            (None, None) => None,
+        }
+    }
+
     pub fn resolve_request(
         &self,
         pairing_request_id: &str,
@@ -2501,6 +2542,50 @@ mod tests {
 
         assert_eq!(reparing_request.role, "node");
         assert_eq!(reparing_request.requested_scopes, scopes);
+    }
+
+    #[test]
+    fn pairing_registry_summary_counts_and_last_activity_follow_request_lifecycle() {
+        let registry = ControlPlanePairingRegistry::new();
+        let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);
+        let decision = registry
+            .evaluate_connect(
+                "device-summary",
+                "cli",
+                "public-key-summary",
+                "operator",
+                &requested_scopes,
+                None,
+            )
+            .expect("evaluate connect");
+        let request = match decision {
+            ControlPlanePairingConnectDecision::PairingRequired { request, .. } => request,
+            other => panic!("expected pairing request, got {other:?}"),
+        };
+
+        assert_eq!(registry.pending_request_count(), 1);
+        assert_eq!(registry.approved_device_count(), 0);
+        let pending_last_activity = registry
+            .last_activity_ms()
+            .expect("pending request should count as activity");
+        assert_eq!(pending_last_activity, request.requested_at_ms);
+
+        let approved = registry
+            .resolve_request(&request.pairing_request_id, true)
+            .expect("approve pairing request")
+            .expect("pairing request should exist");
+
+        assert_eq!(registry.pending_request_count(), 0);
+        assert_eq!(registry.approved_device_count(), 1);
+        let approved_last_activity = registry
+            .last_activity_ms()
+            .expect("approved device should count as activity");
+        assert_eq!(
+            approved_last_activity,
+            approved
+                .resolved_at_ms
+                .expect("approved request should resolve")
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -481,6 +481,7 @@ async fn decode_gateway_error_message(response: Response) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::gateway::state::GatewayPortSource;
     use std::{
         fs,
         path::PathBuf,
@@ -509,6 +510,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: Some("127.0.0.1".to_owned()),
             port: Some(7777),
+            port_source: Some(GatewayPortSource::Default),
             token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
         }
     }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -4,6 +4,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use loongclaw_protocol::{
+    ControlPlanePairingListResponse, ControlPlanePairingResolveRequest,
+    ControlPlanePairingResolveResponse,
+};
 use reqwest::blocking::Client as BlockingClient;
 use reqwest::{Client, Method, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -41,6 +45,14 @@ pub struct GatewayAcpStatusRequest<'a> {
     pub route_session_id: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GatewayPairingRequestsRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
 #[derive(Debug, Clone)]
 pub struct GatewayLocalDiscovery {
     runtime_dir: PathBuf,
@@ -48,6 +60,15 @@ pub struct GatewayLocalDiscovery {
     socket_address: SocketAddr,
     base_url: String,
     bearer_token: String,
+    source: GatewayLocalDiscoverySource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayLocalDiscoverySource {
+    OwnerState,
+    DefaultBootstrap,
+    OwnerStateFallback,
 }
 
 impl GatewayLocalDiscovery {
@@ -77,6 +98,7 @@ impl GatewayLocalDiscovery {
             socket_address,
             base_url,
             bearer_token,
+            source: GatewayLocalDiscoverySource::OwnerState,
         })
     }
 
@@ -96,6 +118,10 @@ impl GatewayLocalDiscovery {
         self.base_url.as_str()
     }
 
+    pub fn source(&self) -> GatewayLocalDiscoverySource {
+        self.source
+    }
+
     fn bearer_token(&self) -> &str {
         self.bearer_token.as_str()
     }
@@ -112,7 +138,10 @@ fn discover_prefer_bootstrap(
 
     let owner_state_result = GatewayLocalDiscovery::discover(runtime_dir);
     match owner_state_result {
-        Ok(discovery) => Ok(discovery),
+        Ok(mut discovery) => {
+            discovery.source = GatewayLocalDiscoverySource::OwnerStateFallback;
+            Ok(discovery)
+        }
         Err(owner_state_error) => {
             let bootstrap_error = bootstrap_result.expect_err("bootstrap result should be err");
             let runtime_dir_text = runtime_dir.display().to_string();
@@ -142,6 +171,7 @@ fn discover_with_bootstrap(
         socket_address,
         base_url,
         bearer_token,
+        source: GatewayLocalDiscoverySource::DefaultBootstrap,
     })
 }
 
@@ -302,6 +332,31 @@ impl GatewayLocalClient {
     pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
         let path = "/api/gateway/stop";
         self.request_json(Method::POST, path).await
+    }
+
+    pub async fn pairing_requests(
+        &self,
+        request: &GatewayPairingRequestsRequest<'_>,
+    ) -> CliResult<ControlPlanePairingListResponse> {
+        let path = "/v1/pairing/requests";
+        self.request_json_with_query(Method::GET, path, request)
+            .await
+    }
+
+    pub async fn pairing_resolve(
+        &self,
+        request: &ControlPlanePairingResolveRequest,
+    ) -> CliResult<ControlPlanePairingResolveResponse> {
+        let path = "/v1/pairing/resolve";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.post(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let request_builder = request_builder.json(request);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
+            .await
     }
 
     pub async fn health(&self) -> CliResult<Value> {
@@ -759,6 +814,10 @@ mod tests {
 
         assert_eq!(discovery.socket_address(), socket_address);
         assert_eq!(discovery.owner_status().port, Some(socket_address.port()));
+        assert_eq!(
+            discovery.source(),
+            GatewayLocalDiscoverySource::DefaultBootstrap
+        );
 
         server.join().expect("bootstrap server join");
         fs::remove_dir_all(runtime_dir).ok();
@@ -784,6 +843,10 @@ mod tests {
 
         assert_eq!(discovery.socket_address().port(), 7_777);
         assert_eq!(discovery.owner_status().port, Some(7_777));
+        assert_eq!(
+            discovery.source(),
+            GatewayLocalDiscoverySource::OwnerStateFallback
+        );
 
         fs::remove_dir_all(runtime_dir).ok();
     }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use reqwest::blocking::Client as BlockingClient;
 use reqwest::{Client, Method, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -12,8 +13,17 @@ use crate::CliResult;
 
 use super::{
     read_models::GatewayOperatorSummaryReadModel,
-    state::{GatewayOwnerStatus, default_gateway_runtime_state_dir, load_gateway_owner_status},
+    state::{
+        GatewayOwnerStatus, default_gateway_runtime_state_dir, gateway_control_token_path,
+        load_gateway_owner_status,
+    },
 };
+
+const DEFAULT_GATEWAY_BOOTSTRAP_HOST: &str = "127.0.0.1";
+const DEFAULT_GATEWAY_BOOTSTRAP_CONNECT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_millis(500);
+const DEFAULT_GATEWAY_BOOTSTRAP_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(2);
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GatewayAcpSessionsRequest {
@@ -43,7 +53,8 @@ pub struct GatewayLocalDiscovery {
 impl GatewayLocalDiscovery {
     pub fn discover_default() -> CliResult<Self> {
         let runtime_dir = default_gateway_runtime_state_dir();
-        Self::discover(runtime_dir.as_path())
+        let bootstrap_address = default_gateway_bootstrap_socket_address();
+        discover_prefer_bootstrap(runtime_dir.as_path(), bootstrap_address)
     }
 
     pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
@@ -88,6 +99,93 @@ impl GatewayLocalDiscovery {
     fn bearer_token(&self) -> &str {
         self.bearer_token.as_str()
     }
+}
+
+fn discover_prefer_bootstrap(
+    runtime_dir: &Path,
+    bootstrap_address: SocketAddr,
+) -> CliResult<GatewayLocalDiscovery> {
+    let bootstrap_result = discover_with_bootstrap(runtime_dir, bootstrap_address);
+    if let Ok(discovery) = bootstrap_result {
+        return Ok(discovery);
+    }
+
+    let owner_state_result = GatewayLocalDiscovery::discover(runtime_dir);
+    match owner_state_result {
+        Ok(discovery) => Ok(discovery),
+        Err(owner_state_error) => {
+            let bootstrap_error = bootstrap_result.expect_err("bootstrap result should be err");
+            let runtime_dir_text = runtime_dir.display().to_string();
+            let error = format!(
+                "gateway bootstrap discovery failed in {runtime_dir_text}: {bootstrap_error}; owner-state fallback failed: {owner_state_error}"
+            );
+            Err(error)
+        }
+    }
+}
+
+fn discover_with_bootstrap(
+    runtime_dir: &Path,
+    bootstrap_address: SocketAddr,
+) -> CliResult<GatewayLocalDiscovery> {
+    let token_path = gateway_control_token_path(runtime_dir);
+    let bearer_token = load_gateway_bearer_token(token_path.as_path())?;
+    let owner_status =
+        request_gateway_owner_status_from_bootstrap(bootstrap_address, bearer_token.as_str())?;
+    let socket_address = validate_gateway_local_owner_status(&owner_status)?;
+    let base_url = format!("http://{socket_address}");
+    let runtime_dir = runtime_dir.to_path_buf();
+
+    Ok(GatewayLocalDiscovery {
+        runtime_dir,
+        owner_status,
+        socket_address,
+        base_url,
+        bearer_token,
+    })
+}
+
+fn default_gateway_bootstrap_socket_address() -> SocketAddr {
+    let gateway_config = crate::mvp::config::GatewayConfig::default();
+    let bootstrap_port = gateway_config.port;
+    let bootstrap_host = DEFAULT_GATEWAY_BOOTSTRAP_HOST
+        .parse::<IpAddr>()
+        .expect("default gateway bootstrap host should stay valid");
+    SocketAddr::new(bootstrap_host, bootstrap_port)
+}
+
+fn request_gateway_owner_status_from_bootstrap(
+    socket_address: SocketAddr,
+    bearer_token: &str,
+) -> CliResult<GatewayOwnerStatus> {
+    let bootstrap_url = format!("http://{socket_address}/v1/status");
+    let http_client = BlockingClient::builder()
+        .connect_timeout(DEFAULT_GATEWAY_BOOTSTRAP_CONNECT_TIMEOUT)
+        .timeout(DEFAULT_GATEWAY_BOOTSTRAP_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|error| format!("build gateway bootstrap client failed: {error}"))?;
+    let response = http_client
+        .get(bootstrap_url.as_str())
+        .bearer_auth(bearer_token)
+        .send()
+        .map_err(|error| {
+            format!("gateway bootstrap request failed for {bootstrap_url}: {error}")
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let response_text = response
+            .text()
+            .unwrap_or_else(|_| "unable to read gateway bootstrap error body".to_owned());
+        let error = format!(
+            "gateway bootstrap request failed for {bootstrap_url} with status {status}: {}",
+            response_text.trim()
+        );
+        return Err(error);
+    }
+
+    response.json::<GatewayOwnerStatus>().map_err(|error| {
+        format!("decode gateway bootstrap response failed for {bootstrap_url}: {error}")
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -484,13 +582,20 @@ mod tests {
     use crate::gateway::state::GatewayPortSource;
     use std::{
         fs,
+        io::{Read, Write},
+        net::TcpListener,
         path::PathBuf,
+        thread,
         time::{SystemTime, UNIX_EPOCH},
     };
 
     use super::*;
 
     fn gateway_owner_status_fixture() -> GatewayOwnerStatus {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis() as u64;
         GatewayOwnerStatus {
             runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
             phase: "running".to_owned(),
@@ -501,8 +606,8 @@ mod tests {
             version: "0.1.0".to_owned(),
             config_path: "/tmp/loongclaw.toml".to_owned(),
             attached_cli_session: None,
-            started_at_ms: 100,
-            last_heartbeat_at: 200,
+            started_at_ms: now_ms.saturating_sub(100),
+            last_heartbeat_at: now_ms,
             stopped_at_ms: None,
             shutdown_reason: None,
             last_error: None,
@@ -522,6 +627,62 @@ mod tests {
             .as_nanos();
         let temp_dir = std::env::temp_dir();
         temp_dir.join(format!("loongclaw-gateway-client-{label}-{suffix}"))
+    }
+
+    fn write_gateway_token_for_test(runtime_dir: &Path, token: &str) -> PathBuf {
+        let token_path = gateway_control_token_path(runtime_dir);
+        if let Some(parent) = token_path.parent() {
+            fs::create_dir_all(parent).expect("create gateway runtime dir");
+        }
+        fs::write(token_path.as_path(), token).expect("write gateway token");
+        token_path
+    }
+
+    fn spawn_gateway_status_server_once(
+        mut status: GatewayOwnerStatus,
+        expected_token: &str,
+    ) -> (SocketAddr, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind bootstrap server");
+        let socket_address = listener.local_addr().expect("bootstrap server addr");
+        if status.bind_address.is_none() {
+            status.bind_address = Some("127.0.0.1".to_owned());
+        }
+        if status.port.is_none() {
+            status.port = Some(socket_address.port());
+        }
+        let expected_header = format!("Authorization: Bearer {expected_token}");
+        let server = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut request_buffer = [0_u8; 8192];
+                let read = stream
+                    .read(&mut request_buffer)
+                    .expect("read bootstrap request");
+                let request_text = String::from_utf8_lossy(&request_buffer[..read]).into_owned();
+                let request_text_lower = request_text.to_ascii_lowercase();
+                let expected_header_lower = expected_header.to_ascii_lowercase();
+                assert!(
+                    request_text_lower.contains(expected_header_lower.as_str()),
+                    "expected bearer token in bootstrap request: {request_text}"
+                );
+                let body = serde_json::to_string(&status).expect("serialize gateway status");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write bootstrap response");
+            }
+        });
+        (socket_address, server)
+    }
+
+    fn unused_loopback_socket_address() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral probe");
+        let socket_address = listener.local_addr().expect("ephemeral probe addr");
+        drop(listener);
+        socket_address
     }
 
     #[test]
@@ -581,5 +742,49 @@ mod tests {
         assert!(error.contains("empty"), "unexpected error: {error}");
 
         fs::remove_file(token_path).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_prefers_bootstrap_when_owner_status_is_missing() {
+        let runtime_dir = unique_temp_path("bootstrap-runtime");
+        fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
+        let token_path = write_gateway_token_for_test(runtime_dir.as_path(), "bootstrap-token");
+        let mut status = gateway_owner_status_fixture();
+        status.token_path = Some(token_path.display().to_string());
+        status.port = None;
+        let (socket_address, server) = spawn_gateway_status_server_once(status, "bootstrap-token");
+
+        let discovery =
+            discover_prefer_bootstrap(runtime_dir.as_path(), socket_address).expect("bootstrap");
+
+        assert_eq!(discovery.socket_address(), socket_address);
+        assert_eq!(discovery.owner_status().port, Some(socket_address.port()));
+
+        server.join().expect("bootstrap server join");
+        fs::remove_dir_all(runtime_dir).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_falls_back_to_owner_status_when_bootstrap_is_unavailable() {
+        let runtime_dir = unique_temp_path("fallback-runtime");
+        fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
+        let token_path = write_gateway_token_for_test(runtime_dir.as_path(), "fallback-token");
+        let mut status = gateway_owner_status_fixture();
+        status.port = Some(7_777);
+        status.token_path = Some(token_path.display().to_string());
+        crate::gateway::state::write_gateway_owner_snapshot_for_test(
+            runtime_dir.as_path(),
+            &status,
+        )
+        .expect("write gateway owner snapshot");
+        let unused_bootstrap = unused_loopback_socket_address();
+
+        let discovery =
+            discover_prefer_bootstrap(runtime_dir.as_path(), unused_bootstrap).expect("fallback");
+
+        assert_eq!(discovery.socket_address().port(), 7_777);
+        assert_eq!(discovery.owner_status().port, Some(7_777));
+
+        fs::remove_dir_all(runtime_dir).ok();
     }
 }

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -41,8 +41,8 @@ use super::read_models::{
     build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use super::state::{
-    GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
-    load_gateway_owner_status, request_gateway_stop,
+    GatewayControlSurfaceBinding, GatewayPortSource, GatewayStopRequestOutcome,
+    gateway_control_token_path, load_gateway_owner_status, request_gateway_stop,
 };
 
 const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
@@ -52,6 +52,12 @@ const GATEWAY_ACP_SESSION_LIST_MAX_LIMIT: usize = 200;
 const GATEWAY_CONTROL_PORT_ENV: &str = "LOONGCLAW_GATEWAY_PORT";
 
 type GatewayControlJsonResponse = (StatusCode, Json<Value>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GatewayPortResolution {
+    port: u16,
+    source: GatewayPortSource,
+}
 
 #[derive(Debug, Default, Deserialize)]
 struct GatewayAcpSessionsQuery {
@@ -225,8 +231,9 @@ pub async fn start_gateway_control_surface(
 
     write_gateway_control_token_file(token_path.as_path(), bearer_token.as_str())?;
 
-    let listener_address =
-        resolve_gateway_control_listener_address(&loaded_config.config, port_override)?;
+    let port_resolution =
+        resolve_gateway_control_listener_port(&loaded_config.config, port_override)?;
+    let listener_address = gateway_control_listener_address_from_port_resolution(port_resolution);
     let listener_result = TcpListener::bind(listener_address).await;
     let listener = match listener_result {
         Ok(listener) => listener,
@@ -258,6 +265,7 @@ pub async fn start_gateway_control_surface(
     let binding = GatewayControlSurfaceBinding {
         bind_address,
         port,
+        port_source: port_resolution.source,
         token_path: token_path.clone(),
     };
 
@@ -790,29 +798,56 @@ fn default_gateway_control_listener_address(config: &LoongClawConfig) -> SocketA
     SocketAddrV4::new(bind_address, bind_port)
 }
 
-fn resolve_gateway_control_listener_address(
-    config: &LoongClawConfig,
-    port_override: Option<u16>,
-) -> CliResult<SocketAddrV4> {
+fn gateway_control_listener_address_from_port_resolution(
+    resolution: GatewayPortResolution,
+) -> SocketAddrV4 {
     let bind_address = Ipv4Addr::LOCALHOST;
-    let bind_port = resolve_gateway_control_listener_port(config, port_override)?;
-    let listener_address = SocketAddrV4::new(bind_address, bind_port);
-    Ok(listener_address)
+    let bind_port = resolution.port;
+    SocketAddrV4::new(bind_address, bind_port)
 }
 
 fn resolve_gateway_control_listener_port(
     config: &LoongClawConfig,
     port_override: Option<u16>,
-) -> CliResult<u16> {
-    let env_port = resolve_gateway_control_listener_port_from_env()?;
-    let resolved_port = port_override.or(env_port);
-    let Some(port_value) = resolved_port else {
-        let default_address = default_gateway_control_listener_address(config);
-        let default_port = default_address.port();
-        return Ok(default_port);
-    };
+) -> CliResult<GatewayPortResolution> {
+    if let Some(port_override) = port_override {
+        let source = if port_override == 0 {
+            GatewayPortSource::EphemeralCli
+        } else {
+            GatewayPortSource::Cli
+        };
+        let resolution = GatewayPortResolution {
+            port: port_override,
+            source,
+        };
+        return Ok(resolution);
+    }
 
-    Ok(port_value)
+    let env_port = resolve_gateway_control_listener_port_from_env()?;
+    if let Some(port) = env_port {
+        let resolution = GatewayPortResolution {
+            port,
+            source: GatewayPortSource::Env,
+        };
+        return Ok(resolution);
+    }
+
+    let configured_port = config.gateway.port;
+    if configured_port != 26_306 {
+        let resolution = GatewayPortResolution {
+            port: configured_port,
+            source: GatewayPortSource::Config,
+        };
+        return Ok(resolution);
+    }
+
+    let default_address = default_gateway_control_listener_address(config);
+    let default_port = default_address.port();
+    let resolution = GatewayPortResolution {
+        port: default_port,
+        source: GatewayPortSource::Default,
+    };
+    Ok(resolution)
 }
 
 fn resolve_gateway_control_listener_port_from_env() -> CliResult<Option<u16>> {
@@ -1063,9 +1098,10 @@ pub fn build_gateway_acp_test_router(
 #[cfg(test)]
 mod tests {
     use super::{
-        GATEWAY_CONTROL_PORT_ENV, resolve_gateway_control_listener_address,
+        GATEWAY_CONTROL_PORT_ENV, gateway_control_listener_address_from_port_resolution,
         resolve_gateway_control_listener_port,
     };
+    use crate::gateway::state::GatewayPortSource;
     use crate::mvp::config::LoongClawConfig;
     use crate::test_support::ScopedEnv;
 
@@ -1075,13 +1111,14 @@ mod tests {
         env.remove(GATEWAY_CONTROL_PORT_ENV);
 
         let config = LoongClawConfig::default();
-        let listener_address =
-            resolve_gateway_control_listener_address(&config, None).expect("address");
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let listener_address = gateway_control_listener_address_from_port_resolution(resolution);
         let actual_ip = *listener_address.ip();
         let actual_port = listener_address.port();
 
         assert_eq!(actual_ip, std::net::Ipv4Addr::LOCALHOST);
         assert_eq!(actual_port, 26_306);
+        assert_eq!(resolution.source, GatewayPortSource::Default);
     }
 
     #[test]
@@ -1090,9 +1127,11 @@ mod tests {
         env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
 
         let config = LoongClawConfig::default();
-        let resolved_port = resolve_gateway_control_listener_port(&config, None).expect("port");
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let resolved_port = resolution.port;
 
         assert_eq!(resolved_port, 26_316);
+        assert_eq!(resolution.source, GatewayPortSource::Env);
     }
 
     #[test]
@@ -1103,9 +1142,11 @@ mod tests {
         let mut config = LoongClawConfig::default();
         config.gateway.port = 26_346;
 
-        let resolved_port = resolve_gateway_control_listener_port(&config, None).expect("port");
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let resolved_port = resolution.port;
 
         assert_eq!(resolved_port, 26_346);
+        assert_eq!(resolution.source, GatewayPortSource::Config);
     }
 
     #[test]
@@ -1114,10 +1155,12 @@ mod tests {
         env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
 
         let config = LoongClawConfig::default();
-        let resolved_port =
-            resolve_gateway_control_listener_port(&config, Some(26_326)).expect("port");
+        let resolution =
+            resolve_gateway_control_listener_port(&config, Some(26_326)).expect("resolution");
+        let resolved_port = resolution.port;
 
         assert_eq!(resolved_port, 26_326);
+        assert_eq!(resolution.source, GatewayPortSource::Cli);
     }
 
     #[test]
@@ -1126,9 +1169,12 @@ mod tests {
         env.remove(GATEWAY_CONTROL_PORT_ENV);
 
         let config = LoongClawConfig::default();
-        let resolved_port = resolve_gateway_control_listener_port(&config, Some(0)).expect("port");
+        let resolution =
+            resolve_gateway_control_listener_port(&config, Some(0)).expect("resolution");
+        let resolved_port = resolution.port;
 
         assert_eq!(resolved_port, 0);
+        assert_eq!(resolution.source, GatewayPortSource::EphemeralCli);
     }
 
     #[test]

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -40,10 +40,11 @@ use super::api_health::handle_health;
 use super::api_turn::handle_turn;
 use super::event_bus::GatewayEventBus;
 use super::read_models::{
-    GatewayChannelInventoryReadModel, GatewayOperatorSummaryReadModel,
-    GatewayRuntimeSnapshotReadModel, build_acp_observability_read_model,
-    build_acp_session_list_read_model, build_acp_status_read_model,
-    build_operator_summary_read_model, build_runtime_snapshot_read_model,
+    GatewayChannelInventoryReadModel, GatewayOperatorPairingSummaryReadModel,
+    GatewayOperatorSummaryReadModel, GatewayRuntimeSnapshotReadModel,
+    build_acp_observability_read_model, build_acp_session_list_read_model,
+    build_acp_status_read_model, build_operator_summary_read_model,
+    build_runtime_snapshot_read_model,
 };
 use super::state::{
     GatewayControlSurfaceBinding, GatewayPortSource, GatewayStopRequestOutcome,
@@ -464,6 +465,7 @@ async fn handle_gateway_operator_summary(
         &status,
         app_state.channel_inventory.as_ref(),
         app_state.runtime_snapshot.as_ref(),
+        app_state.as_ref(),
     );
     let payload = serialize_json_value(&summary, "gateway operator summary payload");
     match payload {
@@ -884,8 +886,28 @@ fn build_gateway_operator_summary_read_model(
     status: &super::state::GatewayOwnerStatus,
     channel_inventory: &GatewayChannelInventoryReadModel,
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+    app_state: &GatewayControlAppState,
 ) -> GatewayOperatorSummaryReadModel {
-    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot)
+    let pairing_summary = build_gateway_pairing_summary_read_model(app_state);
+    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot, pairing_summary)
+}
+
+fn build_gateway_pairing_summary_read_model(
+    app_state: &GatewayControlAppState,
+) -> GatewayOperatorPairingSummaryReadModel {
+    let pairing_registry_result = gateway_pairing_registry(app_state);
+    match pairing_registry_result {
+        Ok(pairing_registry) => GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: pairing_registry.pending_request_count(),
+            approved_device_count: pairing_registry.approved_device_count(),
+            last_activity_ms: pairing_registry.last_activity_ms(),
+        },
+        Err(_error) => GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 0,
+            approved_device_count: 0,
+            last_activity_ms: None,
+        },
+    }
 }
 
 fn gateway_control_config(app_state: &GatewayControlAppState) -> CliResult<&LoongClawConfig> {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -1096,6 +1096,19 @@ mod tests {
     }
 
     #[test]
+    fn gateway_control_listener_port_uses_config_default_when_no_override_is_present() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let mut config = LoongClawConfig::default();
+        config.gateway.port = 26_346;
+
+        let resolved_port = resolve_gateway_control_listener_port(&config, None).expect("port");
+
+        assert_eq!(resolved_port, 26_346);
+    }
+
+    #[test]
     fn gateway_control_listener_port_prefers_explicit_override() {
         let mut env = ScopedEnv::new();
         env.set(GATEWAY_CONTROL_PORT_ENV, "26316");

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -14,6 +14,11 @@ use axum::{
     routing::{get, post},
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use loongclaw_protocol::{
+    ControlPlanePairingListResponse, ControlPlanePairingRequestSummary,
+    ControlPlanePairingResolveRequest, ControlPlanePairingResolveResponse,
+    ControlPlanePairingStatus, ControlPlaneRole, ControlPlaneScope,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::{
@@ -69,6 +74,12 @@ struct GatewayAcpStatusQuery {
     session: Option<String>,
     conversation_id: Option<String>,
     route_session_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayPairingListQuery {
+    status: Option<String>,
+    limit: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -337,6 +348,14 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
             "/api/gateway/acp/observability",
             get(handle_gateway_acp_observability),
         )
+        .route(
+            "/api/gateway/pairing/requests",
+            get(handle_gateway_pairing_requests),
+        )
+        .route(
+            "/api/gateway/pairing/resolve",
+            post(handle_gateway_pairing_resolve),
+        )
         .route("/api/gateway/stop", post(handle_gateway_stop))
         .route("/v1/status", get(handle_gateway_status))
         .route("/v1/channels", get(handle_gateway_channels))
@@ -344,6 +363,8 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route("/v1/acp/status", get(handle_acp_status))
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
         .route("/v1/events", get(handle_events))
         .route("/v1/turn", post(handle_turn))
         .route("/health", get(handle_health))
@@ -652,6 +673,118 @@ async fn handle_gateway_acp_observability(
     json_response(StatusCode::OK, payload)
 }
 
+async fn handle_gateway_pairing_requests(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Query(query): Query<GatewayPairingListQuery>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let parsed_status = match query.status.as_deref() {
+        Some(raw_status) => match parse_gateway_pairing_status(raw_status) {
+            Ok(status) => Some(status),
+            Err(error) => {
+                return json_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_pairing_status",
+                    error.as_str(),
+                );
+            }
+        },
+        None => None,
+    };
+    let limit = query.limit.unwrap_or(50);
+    let requests = pairing_registry.list_requests(parsed_status, limit);
+    let matched_count = requests.len();
+    let returned_count = matched_count;
+    let payload = ControlPlanePairingListResponse {
+        matched_count,
+        returned_count,
+        requests: requests
+            .into_iter()
+            .map(map_gateway_pairing_request)
+            .collect::<Vec<_>>(),
+    };
+    let payload = match serialize_json_value(&payload, "gateway pairing list payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_pairing_resolve(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Json(request): Json<ControlPlanePairingResolveRequest>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    match pairing_registry.resolve_request(request.pairing_request_id.as_str(), request.approve) {
+        Ok(Some(record)) => {
+            let payload = ControlPlanePairingResolveResponse {
+                request: map_gateway_pairing_request(record.clone()),
+                device_token: record.device_token,
+            };
+            let payload = match serialize_json_value(&payload, "gateway pairing resolve payload") {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return json_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "serialize_failed",
+                        error.as_str(),
+                    );
+                }
+            };
+            json_response(StatusCode::OK, payload)
+        }
+        Ok(None) => {
+            let message = format!(
+                "pairing request `{}` not found",
+                request.pairing_request_id.trim()
+            );
+            json_error(StatusCode::NOT_FOUND, "pairing_not_found", message.as_str())
+        }
+        Err(error) => json_error(
+            StatusCode::BAD_REQUEST,
+            "pairing_resolve_failed",
+            error.as_str(),
+        ),
+    }
+}
+
 async fn handle_gateway_stop(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
@@ -771,6 +904,76 @@ fn gateway_control_acp_manager(
         .as_deref()
         .ok_or_else(|| "gateway ACP session manager is unavailable".to_owned())?;
     Ok(manager)
+}
+
+fn gateway_pairing_registry(
+    app_state: &GatewayControlAppState,
+) -> CliResult<mvp::control_plane::ControlPlanePairingRegistry> {
+    let config = gateway_control_config(app_state)?;
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+    }
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = config;
+        Err("gateway pairing requires sqlite memory support".to_owned())
+    }
+}
+
+fn map_gateway_pairing_status(
+    status: mvp::control_plane::ControlPlanePairingStatus,
+) -> ControlPlanePairingStatus {
+    match status {
+        mvp::control_plane::ControlPlanePairingStatus::Pending => {
+            ControlPlanePairingStatus::Pending
+        }
+        mvp::control_plane::ControlPlanePairingStatus::Approved => {
+            ControlPlanePairingStatus::Approved
+        }
+        mvp::control_plane::ControlPlanePairingStatus::Rejected => {
+            ControlPlanePairingStatus::Rejected
+        }
+    }
+}
+
+fn map_gateway_pairing_request(
+    request: mvp::control_plane::ControlPlanePairingRequestRecord,
+) -> ControlPlanePairingRequestSummary {
+    let requested_scopes = request
+        .requested_scopes
+        .into_iter()
+        .filter_map(|scope| ControlPlaneScope::parse(scope.as_str()))
+        .collect::<std::collections::BTreeSet<_>>();
+    let role = match request.role.as_str() {
+        "operator" => ControlPlaneRole::Operator,
+        _ => ControlPlaneRole::Node,
+    };
+
+    ControlPlanePairingRequestSummary {
+        pairing_request_id: request.pairing_request_id,
+        device_id: request.device_id,
+        client_id: request.client_id,
+        public_key: request.public_key,
+        role,
+        requested_scopes,
+        status: map_gateway_pairing_status(request.status),
+        requested_at_ms: request.requested_at_ms,
+        resolved_at_ms: request.resolved_at_ms,
+    }
+}
+
+fn parse_gateway_pairing_status(
+    raw: &str,
+) -> Result<mvp::control_plane::ControlPlanePairingStatus, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "pending" => Ok(mvp::control_plane::ControlPlanePairingStatus::Pending),
+        "approved" => Ok(mvp::control_plane::ControlPlanePairingStatus::Approved),
+        "rejected" => Ok(mvp::control_plane::ControlPlanePairingStatus::Rejected),
+        _ => Err(format!("unknown pairing status `{raw}`")),
+    }
 }
 
 fn gateway_acp_session_list_limit(requested_limit: Option<usize>) -> usize {
@@ -1092,6 +1295,18 @@ pub fn build_gateway_acp_test_router(
         .route("/v1/acp/status", get(handle_acp_status))
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
+        .with_state(app_state)
+}
+
+/// Minimal router for gateway pairing endpoint integration tests.
+#[doc(hidden)]
+pub fn build_gateway_pairing_test_router(bearer_token: String, config: LoongClawConfig) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
         .with_state(app_state)
 }
 

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -49,6 +49,7 @@ const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
 const GATEWAY_CONTROL_RUNTIME_DIR_MODE: u32 = 0o700;
 const GATEWAY_ACP_SESSION_LIST_DEFAULT_LIMIT: usize = 50;
 const GATEWAY_ACP_SESSION_LIST_MAX_LIMIT: usize = 200;
+const GATEWAY_CONTROL_PORT_ENV: &str = "LOONGCLAW_GATEWAY_PORT";
 
 type GatewayControlJsonResponse = (StatusCode, Json<Value>);
 
@@ -215,6 +216,7 @@ pub async fn start_gateway_control_surface(
     runtime_dir: &Path,
     loaded_config: &LoadedSupervisorConfig,
     acp_manager: Option<Arc<AcpSessionManager>>,
+    port_override: Option<u16>,
 ) -> CliResult<GatewayControlSurface> {
     let channel_inventory = build_gateway_channel_inventory_read_model(loaded_config)?;
     let runtime_snapshot = build_gateway_runtime_snapshot_read_model(loaded_config)?;
@@ -223,12 +225,16 @@ pub async fn start_gateway_control_surface(
 
     write_gateway_control_token_file(token_path.as_path(), bearer_token.as_str())?;
 
-    let listener_address = gateway_control_listener_address();
+    let listener_address =
+        resolve_gateway_control_listener_address(&loaded_config.config, port_override)?;
     let listener_result = TcpListener::bind(listener_address).await;
     let listener = match listener_result {
         Ok(listener) => listener,
         Err(error) => {
-            let bind_error = format!("bind gateway control surface failed: {error}");
+            let bind_error = format!(
+                "bind gateway control surface failed on {}: {error}",
+                listener_address
+            );
             let cleanup_result = remove_gateway_control_token_file(token_path.as_path());
             let final_error = merge_gateway_control_errors(bind_error, cleanup_result.err());
             return Err(final_error);
@@ -778,10 +784,53 @@ fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Val
     serde_json::to_value(value).map_err(|error| format!("serialize {context} failed: {error}"))
 }
 
-fn gateway_control_listener_address() -> SocketAddrV4 {
+fn default_gateway_control_listener_address(config: &LoongClawConfig) -> SocketAddrV4 {
     let bind_address = Ipv4Addr::LOCALHOST;
-    let bind_port = 0_u16;
+    let bind_port = config.gateway.port;
     SocketAddrV4::new(bind_address, bind_port)
+}
+
+fn resolve_gateway_control_listener_address(
+    config: &LoongClawConfig,
+    port_override: Option<u16>,
+) -> CliResult<SocketAddrV4> {
+    let bind_address = Ipv4Addr::LOCALHOST;
+    let bind_port = resolve_gateway_control_listener_port(config, port_override)?;
+    let listener_address = SocketAddrV4::new(bind_address, bind_port);
+    Ok(listener_address)
+}
+
+fn resolve_gateway_control_listener_port(
+    config: &LoongClawConfig,
+    port_override: Option<u16>,
+) -> CliResult<u16> {
+    let env_port = resolve_gateway_control_listener_port_from_env()?;
+    let resolved_port = port_override.or(env_port);
+    let Some(port_value) = resolved_port else {
+        let default_address = default_gateway_control_listener_address(config);
+        let default_port = default_address.port();
+        return Ok(default_port);
+    };
+
+    Ok(port_value)
+}
+
+fn resolve_gateway_control_listener_port_from_env() -> CliResult<Option<u16>> {
+    let raw_value = std::env::var_os(GATEWAY_CONTROL_PORT_ENV);
+    let Some(raw_value) = raw_value else {
+        return Ok(None);
+    };
+
+    let raw_value = raw_value.to_string_lossy();
+    let trimmed_value = raw_value.trim();
+    if trimmed_value.is_empty() {
+        return Ok(None);
+    }
+
+    let parsed_port = trimmed_value.parse::<u16>().map_err(|error| {
+        format!("parse {GATEWAY_CONTROL_PORT_ENV}=`{trimmed_value}` failed: {error}")
+    })?;
+    Ok(Some(parsed_port))
 }
 
 fn new_gateway_control_bearer_token() -> String {
@@ -1009,4 +1058,74 @@ pub fn build_gateway_acp_test_router(
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
         .with_state(app_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GATEWAY_CONTROL_PORT_ENV, resolve_gateway_control_listener_address,
+        resolve_gateway_control_listener_port,
+    };
+    use crate::mvp::config::LoongClawConfig;
+    use crate::test_support::ScopedEnv;
+
+    #[test]
+    fn gateway_control_listener_port_defaults_to_26306() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let config = LoongClawConfig::default();
+        let listener_address =
+            resolve_gateway_control_listener_address(&config, None).expect("address");
+        let actual_ip = *listener_address.ip();
+        let actual_port = listener_address.port();
+
+        assert_eq!(actual_ip, std::net::Ipv4Addr::LOCALHOST);
+        assert_eq!(actual_port, 26_306);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_uses_env_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
+
+        let config = LoongClawConfig::default();
+        let resolved_port = resolve_gateway_control_listener_port(&config, None).expect("port");
+
+        assert_eq!(resolved_port, 26_316);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_prefers_explicit_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
+
+        let config = LoongClawConfig::default();
+        let resolved_port =
+            resolve_gateway_control_listener_port(&config, Some(26_326)).expect("port");
+
+        assert_eq!(resolved_port, 26_326);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_accepts_ephemeral_zero() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let config = LoongClawConfig::default();
+        let resolved_port = resolve_gateway_control_listener_port(&config, Some(0)).expect("port");
+
+        assert_eq!(resolved_port, 0);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_rejects_invalid_env_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "invalid");
+
+        let config = LoongClawConfig::default();
+        let error = resolve_gateway_control_listener_port(&config, None).expect_err("invalid env");
+
+        assert!(error.contains(GATEWAY_CONTROL_PORT_ENV));
+    }
 }

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -299,6 +299,13 @@ pub struct GatewayOperatorRuntimeSummaryReadModel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorPairingSummaryReadModel {
+    pub pending_request_count: usize,
+    pub approved_device_count: usize,
+    pub last_activity_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayToolCallingReadModel {
     pub availability: String,
     pub structured_tool_schema_enabled: bool,
@@ -313,6 +320,7 @@ pub struct GatewayOperatorSummaryReadModel {
     pub control_surface: GatewayOperatorControlSurfaceReadModel,
     pub channels: GatewayOperatorChannelsSummaryReadModel,
     pub runtime: GatewayOperatorRuntimeSummaryReadModel,
+    pub pairing: GatewayOperatorPairingSummaryReadModel,
 }
 
 pub fn build_channel_inventory_read_model(
@@ -485,6 +493,7 @@ pub fn build_operator_summary_read_model(
     owner_status: &GatewayOwnerStatus,
     channel_inventory: &GatewayChannelInventoryReadModel,
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+    pairing: GatewayOperatorPairingSummaryReadModel,
 ) -> GatewayOperatorSummaryReadModel {
     let owner = owner_status.clone();
     let control_surface = build_operator_control_surface_read_model(owner_status);
@@ -496,6 +505,7 @@ pub fn build_operator_summary_read_model(
         control_surface,
         channels,
         runtime,
+        pairing,
     }
 }
 

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -14,9 +14,9 @@ use crate::mvp::acp::AcpSessionManager;
 
 use super::control::start_gateway_control_surface;
 use super::state::{
-    GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayStopRequestOutcome,
-    default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
-    wait_for_gateway_stop_request,
+    GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayPortSource,
+    GatewayStopRequestOutcome, default_gateway_runtime_state_dir, load_gateway_owner_status,
+    request_gateway_stop, wait_for_gateway_stop_request,
 };
 
 #[derive(Subcommand, Debug)]
@@ -197,6 +197,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
 #[doc(hidden)]
 pub async fn run_gateway_run_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -204,7 +205,7 @@ pub async fn run_gateway_run_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
-        None,
+        port,
         session,
         channel_accounts,
         runtime_dir,
@@ -217,6 +218,7 @@ pub async fn run_gateway_run_with_hooks_for_test(
 #[doc(hidden)]
 pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: &str,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -224,7 +226,7 @@ pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
-        None,
+        port,
         Some(session),
         channel_accounts,
         runtime_dir,
@@ -338,6 +340,7 @@ pub(crate) fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerSt
         running_surface_count: 0,
         bind_address: None,
         port: None,
+        port_source: None,
         token_path: None,
     }
 }
@@ -382,10 +385,14 @@ fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
         .port
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_owned());
+    let port_source = status
+        .port_source
+        .map(GatewayPortSource::as_str)
+        .unwrap_or("-");
     let token_path = status.token_path.as_deref().unwrap_or("-");
 
     format!(
-        "runtime_dir={}\nphase={} running={} stale={} pid={} mode={} config={} session={} version={}\nstarted_at_ms={} last_heartbeat_at_ms={} stopped_at_ms={}\nsurfaces configured={} running={}\nshutdown_reason={}\nlast_error={}\nbind_address={} port={} token_path={}",
+        "runtime_dir={}\nphase={} running={} stale={} pid={} mode={} config={} session={} version={}\nstarted_at_ms={} last_heartbeat_at_ms={} stopped_at_ms={}\nsurfaces configured={} running={}\nshutdown_reason={}\nlast_error={}\nbind_address={} port={} port_source={} token_path={}",
         status.runtime_dir,
         status.phase,
         status.running,
@@ -404,6 +411,7 @@ fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
         last_error,
         bind_address,
         port,
+        port_source,
         token_path,
     )
 }
@@ -486,5 +494,36 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(runtime_dir.as_path());
+    }
+
+    #[test]
+    fn render_gateway_status_text_surfaces_port_source() {
+        let status = GatewayOwnerStatus {
+            runtime_dir: "/tmp/runtime".to_owned(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: "0.0.0-test".to_owned(),
+            config_path: "/tmp/config.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1,
+            last_heartbeat_at: 2,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 0,
+            running_surface_count: 0,
+            bind_address: Some("127.0.0.1".to_owned()),
+            port: Some(26_306),
+            port_source: Some(GatewayPortSource::Default),
+            token_path: Some("/tmp/token".to_owned()),
+        };
+
+        let rendered = render_gateway_status_text(&status);
+
+        assert!(rendered.contains("port=26306"));
+        assert!(rendered.contains("port_source=default"));
     }
 }

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -25,6 +25,11 @@ pub enum GatewayCommand {
     Run {
         #[arg(long)]
         config: Option<String>,
+        #[arg(
+            long,
+            help = "Gateway control-surface port (default 26306; use 0 for an ephemeral OS-assigned port)"
+        )]
+        port: Option<u16>,
         #[arg(long)]
         session: Option<String>,
         #[arg(long = "channel-account", value_name = "CHANNEL=ACCOUNT")]
@@ -49,9 +54,12 @@ pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
     match command {
         GatewayCommand::Run {
             config,
+            port,
             session,
             channel_account,
-        } => run_gateway_run_cli(config.as_deref(), session.as_deref(), channel_account).await,
+        } => {
+            run_gateway_run_cli(config.as_deref(), port, session.as_deref(), channel_account).await
+        }
         GatewayCommand::Status { json } => run_gateway_status_cli(json),
         GatewayCommand::Stop => run_gateway_stop_cli(),
     }
@@ -59,12 +67,14 @@ pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
 
 pub async fn run_gateway_run_cli(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
 ) -> CliResult<()> {
     let runtime_dir = default_gateway_runtime_state_dir();
     let supervisor = run_gateway_runtime_with_hooks_for_test(
         config_path,
+        port,
         session,
         channel_accounts,
         runtime_dir.as_path(),
@@ -83,6 +93,7 @@ pub async fn run_multi_channel_serve_gateway_compat_cli(
     let runtime_dir = default_gateway_runtime_state_dir();
     let supervisor = run_gateway_runtime_with_hooks_for_test(
         config_path,
+        None,
         Some(session),
         channel_accounts,
         runtime_dir.as_path(),
@@ -95,6 +106,7 @@ pub async fn run_multi_channel_serve_gateway_compat_cli(
 
 async fn run_gateway_runtime_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -120,7 +132,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
         build_gateway_acp_session_manager,
     )?;
     let control_surface_result =
-        start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager)).await;
+        start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager), port).await;
     let control_surface = match control_surface_result {
         Ok(control_surface) => control_surface,
         Err(error) => {
@@ -192,6 +204,7 @@ pub async fn run_gateway_run_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
+        None,
         session,
         channel_accounts,
         runtime_dir,
@@ -211,6 +224,7 @@ pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
+        None,
         Some(session),
         channel_accounts,
         runtime_dir,

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -60,6 +60,7 @@ pub struct GatewayOwnerStatus {
     pub running_surface_count: usize,
     pub bind_address: Option<String>,
     pub port: Option<u16>,
+    pub port_source: Option<GatewayPortSource>,
     pub token_path: Option<String>,
 }
 
@@ -67,7 +68,30 @@ pub struct GatewayOwnerStatus {
 pub struct GatewayControlSurfaceBinding {
     pub bind_address: String,
     pub port: u16,
+    pub port_source: GatewayPortSource,
     pub token_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayPortSource {
+    Default,
+    Config,
+    Env,
+    Cli,
+    EphemeralCli,
+}
+
+impl GatewayPortSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Config => "config",
+            Self::Env => "env",
+            Self::Cli => "cli",
+            Self::EphemeralCli => "ephemeral_cli",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,6 +119,7 @@ struct PersistedGatewayOwnerState {
     running_surface_count: usize,
     bind_address: Option<String>,
     port: Option<u16>,
+    port_source: Option<GatewayPortSource>,
     token_path: Option<String>,
     owner_token: String,
 }
@@ -149,6 +174,7 @@ impl GatewayOwnerTracker {
             running_surface_count: 0,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
             owner_token: owner_token.clone(),
         };
@@ -240,6 +266,7 @@ impl GatewayOwnerTracker {
                 .map_err(|error| format!("gateway owner state lock poisoned: {error}"))?;
             state_guard.bind_address = Some(binding.bind_address.clone());
             state_guard.port = Some(binding.port);
+            state_guard.port_source = Some(binding.port_source);
             state_guard.token_path = Some(binding.token_path.display().to_string());
             state_guard.last_heartbeat_at = now_ms();
             state_guard.clone()
@@ -333,6 +360,7 @@ impl GatewayOwnerTracker {
             if !running {
                 state_guard.bind_address = None;
                 state_guard.port = None;
+                state_guard.port_source = None;
                 state_guard.token_path = None;
             }
             state_guard.clone()
@@ -448,6 +476,7 @@ pub(crate) fn write_gateway_owner_snapshot_for_test(
         running_surface_count: persisted_state.running_surface_count,
         bind_address: persisted_state.bind_address.clone(),
         port: persisted_state.port,
+        port_source: persisted_state.port_source,
         token_path: persisted_state.token_path.clone(),
         owner_token,
     };
@@ -498,6 +527,7 @@ fn build_gateway_owner_status(
         running_surface_count: persisted_state.running_surface_count,
         bind_address: persisted_state.bind_address.clone(),
         port: persisted_state.port,
+        port_source: persisted_state.port_source,
         token_path: persisted_state.token_path.clone(),
     }
 }
@@ -806,6 +836,7 @@ mod tests {
             running_surface_count: if running { 2 } else { 0 },
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         }
     }
@@ -887,6 +918,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
             owner_token: "stale-owner".to_owned(),
         };

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -4,9 +4,9 @@ use serde::Serialize;
 use std::path::Path;
 
 use crate::gateway::read_models::{
-    GatewayAcpObservabilityReadModel, GatewayOperatorSummaryReadModel,
-    build_acp_observability_read_model, build_operator_summary_read_model,
-    build_runtime_snapshot_read_model,
+    GatewayAcpObservabilityReadModel, GatewayOperatorPairingSummaryReadModel,
+    GatewayOperatorSummaryReadModel, build_acp_observability_read_model,
+    build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use crate::gateway::service::default_gateway_owner_status;
 use crate::gateway::state::{default_gateway_runtime_state_dir, load_gateway_owner_status};
@@ -91,8 +91,17 @@ pub async fn collect_status_cli_read_model(
         config_path_text,
         owner_status_option,
     );
-    let gateway =
-        build_operator_summary_read_model(&owner_status, &channel_inventory, &runtime_snapshot);
+    let pairing = GatewayOperatorPairingSummaryReadModel {
+        pending_request_count: 0,
+        approved_device_count: 0,
+        last_activity_ms: None,
+    };
+    let gateway = build_operator_summary_read_model(
+        &owner_status,
+        &channel_inventory,
+        &runtime_snapshot,
+        pairing,
+    );
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
     let recipes = build_status_cli_recipes(config_path_text);
@@ -287,6 +296,7 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
     let control_surface = &gateway.control_surface;
     let channels = &gateway.channels;
     let runtime = &gateway.runtime;
+    let pairing = &gateway.pairing;
     let base_url_option = control_surface.base_url.as_deref();
     let base_url = base_url_option.unwrap_or("-");
     let owner_pid = render_optional_u32(owner.pid);
@@ -347,6 +357,15 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
         tool_calling.effective_tool_schema_mode,
         tool_calling.active_model,
         tool_calling.reason,
+    ));
+    lines.push(format!(
+        "pairing pending={} approved_devices={} last_activity_ms={}",
+        pairing.pending_request_count,
+        pairing.approved_device_count,
+        pairing
+            .last_activity_ms
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
     ));
     lines.push(render_status_cli_acp_text(&status.acp));
     lines.push(render_status_cli_work_units_text(&status.work_units));
@@ -434,7 +453,7 @@ mod tests {
     use super::*;
     use crate::gateway::read_models::{
         GatewayOperatorChannelsSummaryReadModel, GatewayOperatorControlSurfaceReadModel,
-        GatewayOperatorRuntimeSummaryReadModel,
+        GatewayOperatorPairingSummaryReadModel, GatewayOperatorRuntimeSummaryReadModel,
     };
     use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus, GatewayPortSource};
 
@@ -495,6 +514,11 @@ mod tests {
                             .to_owned(),
                 },
             },
+            pairing: GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: 1,
+                approved_device_count: 2,
+                last_activity_ms: Some(3),
+            },
         };
         let status = StatusCliReadModel {
             config: "/tmp/config.toml".to_owned(),
@@ -533,6 +557,7 @@ mod tests {
 
         assert!(rendered.contains("gateway phase=running"));
         assert!(rendered.contains("tool_calling availability=ready"));
+        assert!(rendered.contains("pairing pending=1 approved_devices=2"));
         assert!(rendered.contains("acp enabled=false availability=disabled"));
         assert!(rendered.contains("work_units availability=available total_count=0"));
         assert!(rendered.contains("recipes:\n- loong gateway status"));

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -436,7 +436,7 @@ mod tests {
         GatewayOperatorChannelsSummaryReadModel, GatewayOperatorControlSurfaceReadModel,
         GatewayOperatorRuntimeSummaryReadModel,
     };
-    use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus};
+    use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus, GatewayPortSource};
 
     #[test]
     fn render_status_cli_text_surfaces_drill_down_recipes() {
@@ -460,6 +460,7 @@ mod tests {
                 running_surface_count: 1,
                 bind_address: Some("127.0.0.1".to_owned()),
                 port: Some(7777),
+                port_source: Some(GatewayPortSource::Default),
                 token_path: Some("/tmp/token".to_owned()),
             },
             control_surface: GatewayOperatorControlSurfaceReadModel {
@@ -559,6 +560,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         };
 
@@ -595,6 +597,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         };
 

--- a/crates/daemon/tests/integration/gateway_api_pairing.rs
+++ b/crates/daemon/tests/integration/gateway_api_pairing.rs
@@ -1,0 +1,192 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use loongclaw_protocol::{
+    ControlPlanePairingListResponse, ControlPlanePairingResolveRequest,
+    ControlPlanePairingResolveResponse, ControlPlanePairingStatus,
+};
+use tower::ServiceExt;
+
+use super::*;
+
+fn gateway_pairing_test_config(label: &str) -> (mvp::config::LoongClawConfig, PathBuf) {
+    let root_dir = unique_temp_dir(label);
+    std::fs::create_dir_all(root_dir.as_path()).expect("create gateway pairing test dir");
+
+    let sqlite_path = root_dir.join("memory.sqlite3");
+    let sqlite_path_text = sqlite_path.display().to_string();
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.sqlite_path = sqlite_path_text;
+
+    (config, root_dir)
+}
+
+fn seed_pending_pairing_request(config: &mvp::config::LoongClawConfig) -> String {
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let registry =
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+            .expect("pairing registry");
+    let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "device-1",
+            "cli",
+            "public-key-1",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    match decision {
+        mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request, ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    }
+}
+
+async fn json_body(response: axum::response::Response) -> serde_json::Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("decode json")
+}
+
+#[tokio::test]
+async fn gateway_pairing_requests_reject_missing_auth() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-auth");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/requests")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_requests_return_pending_request_records() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-list");
+    let pairing_request_id = seed_pending_pairing_request(&config);
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/requests?status=pending&limit=10")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let list: ControlPlanePairingListResponse =
+        serde_json::from_slice(&body).expect("pairing list json");
+
+    assert_eq!(list.matched_count, 1);
+    assert_eq!(list.returned_count, 1);
+    assert_eq!(list.requests[0].pairing_request_id, pairing_request_id);
+    assert_eq!(list.requests[0].status, ControlPlanePairingStatus::Pending);
+    assert_eq!(list.requests[0].device_id, "device-1");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_resolve_approves_request_and_returns_device_token() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-resolve");
+    let pairing_request_id = seed_pending_pairing_request(&config);
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/resolve")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&ControlPlanePairingResolveRequest {
+                        pairing_request_id,
+                        approve: true,
+                    })
+                    .expect("encode pairing resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let resolved: ControlPlanePairingResolveResponse =
+        serde_json::from_slice(&body).expect("pairing resolve json");
+
+    assert_eq!(resolved.request.status, ControlPlanePairingStatus::Approved);
+    assert!(resolved.device_token.is_some());
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_resolve_returns_not_found_for_unknown_request() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-missing");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/resolve")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&ControlPlanePairingResolveRequest {
+                        pairing_request_id: "missing-request".to_owned(),
+                        approve: true,
+                    })
+                    .expect("encode pairing resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = json_body(response).await;
+    assert_eq!(body["error"]["code"], "pairing_not_found");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -368,6 +368,7 @@ async fn gateway_run_turn_persists_acp_session_metadata_into_configured_sqlite_s
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -439,6 +440,7 @@ async fn gateway_acp_operator_endpoints_surface_shared_session_truth() {
 
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -170,6 +170,7 @@ fn gateway_turn_loaded_config_fixture(
     backend_id: &str,
 ) -> LoadedSupervisorConfig {
     let mut config = LoongClawConfig::default();
+    config.gateway.port = 0;
     let sqlite_path_text = sqlite_path.display().to_string();
     config.memory.sqlite_path = sqlite_path_text;
     config.acp = AcpConfig {

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -62,6 +62,7 @@ fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
     let config_path = runtime_root.join("loongclaw.toml");
     let sqlite_path = runtime_root.join("memory.sqlite3");
     let mut config = mvp::config::LoongClawConfig::default();
+    config.gateway.port = 0;
     config.memory.sqlite_path = sqlite_path.display().to_string();
 
     LoadedSupervisorConfig {
@@ -75,6 +76,7 @@ fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
     let config_path = runtime_root.join("loongclaw.toml");
     let sqlite_path = runtime_root.join("memory.sqlite3");
     let mut config = mvp::config::LoongClawConfig::default();
+    config.gateway.port = 0;
     config.telegram.enabled = true;
     config.memory.sqlite_path = sqlite_path.display().to_string();
     LoadedSupervisorConfig {
@@ -84,7 +86,8 @@ fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
 }
 
 fn plugin_backed_loaded_config_fixture() -> LoadedSupervisorConfig {
-    let config = super::mixed_account_weixin_plugin_bridge_config();
+    let mut config = super::mixed_account_weixin_plugin_bridge_config();
+    config.gateway.port = 0;
 
     LoadedSupervisorConfig {
         resolved_path: PathBuf::from("/tmp/loongclaw.toml"),

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -273,6 +273,115 @@ async fn gateway_owner_state_uses_configured_gateway_port_when_no_override_is_pr
 }
 
 #[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_uses_cli_gateway_port_override_when_present() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("cli-port");
+    let configured_port = unique_gateway_port();
+    let cli_port = unique_gateway_port();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            Some(cli_port),
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
+
+    assert_eq!(actual_port, cli_port);
+    assert_eq!(port_source.as_str(), "cli");
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_marks_explicit_ephemeral_cli_port_source() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("ephemeral-cli-port");
+    let configured_port = unique_gateway_port();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            Some(0),
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
+
+    assert!(actual_port > 0);
+    assert_eq!(port_source.as_str(), "ephemeral_cli");
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn gateway_owner_state_rejects_second_active_owner_slot() {
     let runtime_dir = unique_runtime_dir("exclusive-slot");
     let hooks = SupervisorRuntimeHooks {

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -57,6 +57,12 @@ fn unique_runtime_dir(label: &str) -> PathBuf {
     runtime_dir
 }
 
+fn unique_gateway_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port probe");
+    let local_address = listener.local_addr().expect("read ephemeral port probe");
+    local_address.port()
+}
+
 fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
     let runtime_root = unique_runtime_dir("headless-config");
     let config_path = runtime_root.join("loongclaw.toml");
@@ -208,6 +214,56 @@ async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request
         stopped_status.shutdown_reason.as_deref(),
         Some("shutdown requested: gateway stop requested")
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_uses_configured_gateway_port_when_no_override_is_present() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("config-port");
+    let configured_port = unique_gateway_port();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+
+    assert_eq!(actual_port, configured_port);
+    assert_eq!(running_status.bind_address.as_deref(), Some("127.0.0.1"));
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -175,6 +175,7 @@ async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -242,6 +243,7 @@ async fn gateway_owner_state_uses_configured_gateway_port_when_no_override_is_pr
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -253,9 +255,13 @@ async fn gateway_owner_state_uses_configured_gateway_port_when_no_override_is_pr
     let actual_port = running_status
         .port
         .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
 
     assert_eq!(actual_port, configured_port);
     assert_eq!(running_status.bind_address.as_deref(), Some("127.0.0.1"));
+    assert_eq!(port_source.as_str(), "config");
 
     request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
     let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
@@ -285,6 +291,7 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -310,6 +317,7 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
         observe_state: Arc::new(|_| Ok(())),
     };
     let second_result = run_gateway_run_with_hooks_for_test(
+        None,
         None,
         None,
         Vec::new(),
@@ -350,6 +358,7 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -378,6 +387,7 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
         observe_state: Arc::new(|_| Ok(())),
     };
     let second_result = run_gateway_run_with_hooks_for_test(
+        None,
         None,
         None,
         Vec::new(),
@@ -424,6 +434,7 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_multi_channel_serve_gateway_compat_with_hooks_for_test(
+            None,
             None,
             "cli-supervisor",
             Vec::new(),
@@ -478,6 +489,7 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -755,6 +767,7 @@ async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy()
         run_gateway_run_with_hooks_for_test(
             None,
             None,
+            None,
             Vec::new(),
             runtime_dir_for_run.as_path(),
             hooks,
@@ -821,6 +834,7 @@ async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stop
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -925,6 +939,7 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -455,6 +455,7 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         running_surface_count: 0,
         bind_address: Some("127.0.0.1".to_owned()),
         port: Some(7777),
+        port_source: Some(gateway::state::GatewayPortSource::Default),
         token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
     };
 

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -463,10 +463,17 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         &owner_status,
         &inventory,
         &runtime_snapshot,
+        gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 1,
+            approved_device_count: 2,
+            last_activity_ms: Some(300),
+        },
     );
     let encoded = serde_json::to_value(&summary).expect("serialize operator summary read model");
 
     assert_eq!(summary.owner.phase, "running");
+    assert_eq!(summary.pairing.pending_request_count, 1);
+    assert_eq!(summary.pairing.approved_device_count, 2);
     assert_eq!(
         summary.control_surface.base_url.as_deref(),
         Some("http://127.0.0.1:7777")

--- a/crates/daemon/tests/integration/managed_bridge_parity.rs
+++ b/crates/daemon/tests/integration/managed_bridge_parity.rs
@@ -88,6 +88,11 @@ fn managed_bridge_parity_keeps_summary_aligned_across_text_json_and_operator_vie
             &owner_status,
             &channels_payload,
             &runtime_snapshot,
+            loongclaw_daemon::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: 0,
+                approved_device_count: 0,
+                last_activity_ms: None,
+            },
         );
     let weixin_channels_surface = channels_payload
         .channel_surfaces

--- a/crates/daemon/tests/integration/managed_bridge_parity.rs
+++ b/crates/daemon/tests/integration/managed_bridge_parity.rs
@@ -25,6 +25,7 @@ fn gateway_owner_status_fixture() -> loongclaw_daemon::gateway::state::GatewayOw
         running_surface_count: 0,
         bind_address: Some("127.0.0.1".to_owned()),
         port: Some(31337),
+        port_source: Some(loongclaw_daemon::gateway::state::GatewayPortSource::Default),
         token_path: Some("/tmp/loongclaw.token".to_owned()),
     }
 }

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -132,6 +132,7 @@ mod feishu_cli;
 mod gateway_api_acp;
 mod gateway_api_events;
 mod gateway_api_health;
+mod gateway_api_pairing;
 mod gateway_api_turn;
 mod gateway_owner_state;
 mod gateway_read_models;

--- a/docs/design-docs/local-product-control-plane.md
+++ b/docs/design-docs/local-product-control-plane.md
@@ -179,6 +179,17 @@ That means:
 - no silent widening into LAN or public exposure
 - no multi-user or hosted assumptions in the first contract
 
+The current gateway-owned local front door should therefore stay predictable:
+
+- default control-surface address: `127.0.0.1:26306`
+- config seam: `[gateway].port`
+- operator overrides: `loongclaw gateway run --port <PORT>` and
+  `LOONGCLAW_GATEWAY_PORT=<PORT>`
+- explicit ephemeral-only escape hatch for labs/tests: `--port 0`
+
+That keeps local product surfaces bootstrap-friendly without turning persisted
+owner-state files into the primary source of configuration truth.
+
 This keeps the platform layer aligned with LoongClaw's current trust model:
 private, operator-owned, and local-first.
 

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -549,6 +549,9 @@ the attached compatibility wrapper rather than the long-term product noun:
 
 - `gateway run` can claim the persisted owner slot headless or attach a CLI
   host when `--session` is provided
+- the loopback control surface defaults to `127.0.0.1:26306`, while
+  `--port`, `LOONGCLAW_GATEWAY_PORT`, or an explicit `--port 0` lab override
+  can change the effective listener without changing the single-owner contract
 - `gateway status` can inspect the persisted owner snapshot from another CLI
   process
 - `gateway stop` can request cooperative shutdown from another CLI process

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -57,6 +57,9 @@ turns for replay and final-result fetch.
 - [ ] The local product control plane exposes one stable default loopback
       address so browser shells and operator tooling do not need ad-hoc file
       reads just to discover the default gateway endpoint.
+- [ ] Shared local gateway clients bootstrap against the stable default
+      front door first and only fall back to persisted owner-state discovery
+      when the operator explicitly chose an override or ephemeral port.
 - [ ] Operator-facing status surfaces explain whether the active control-surface
       port came from the built-in default, config, env, or CLI override.
 - [ ] The control plane remains a thin product layer above the runtime and does

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -33,6 +33,8 @@ The current localhost control-plane slice now includes:
 - a stable loopback gateway front door at `127.0.0.1:26306` by default, with
   explicit operator overrides through `--port`, `LOONGCLAW_GATEWAY_PORT`, and
   the deliberate ephemeral escape hatch `--port 0`
+- local pairing inbox and resolve routes so trusted operators can review and
+  approve pending device pairing requests without leaving the gateway surface
 
 Turn execution still reuses the existing ACP conversation preparation path and
 the current session/runtime addressing model. The first turn-result cache stays

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -57,6 +57,8 @@ turns for replay and final-result fetch.
 - [ ] The local product control plane exposes one stable default loopback
       address so browser shells and operator tooling do not need ad-hoc file
       reads just to discover the default gateway endpoint.
+- [ ] Operator-facing status surfaces explain whether the active control-surface
+      port came from the built-in default, config, env, or CLI override.
 - [ ] The control plane remains a thin product layer above the runtime and does
       not become a second policy authority above the kernel.
 

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -30,6 +30,9 @@ The current localhost control-plane slice now includes:
 - authenticated turn submission
 - SSE turn-event streaming for submitted turns
 - non-streaming final turn-result fetch for submitted turns
+- a stable loopback gateway front door at `127.0.0.1:26306` by default, with
+  explicit operator overrides through `--port`, `LOONGCLAW_GATEWAY_PORT`, and
+  the deliberate ephemeral escape hatch `--port 0`
 
 Turn execution still reuses the existing ACP conversation preparation path and
 the current session/runtime addressing model. The first turn-result cache stays
@@ -51,6 +54,9 @@ turns for replay and final-result fetch.
       plane operations instead of staying terminal-only behavior.
 - [ ] The first browser-facing surfaces remain localhost-only by default and do
       not imply that public exposure is supported or safe.
+- [ ] The local product control plane exposes one stable default loopback
+      address so browser shells and operator tooling do not need ad-hoc file
+      reads just to discover the default gateway endpoint.
 - [ ] The control plane remains a thin product layer above the runtime and does
       not become a second policy authority above the kernel.
 

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -43,6 +43,12 @@ control surface for gateway owner status, channel inventory, runtime snapshot,
 operator summary, and cooperative stop. The Web UI should consume that control
 surface instead of inventing a second browser-only runtime contract.
 
+That control surface now has a stable loopback default at
+`127.0.0.1:26306`. Browser-facing local product flows should treat that stable
+gateway endpoint as the normal bootstrap path and only fall back to persisted
+owner-state discovery when operators intentionally override the port with
+`--port`, `LOONGCLAW_GATEWAY_PORT`, or `--port 0`.
+
 The current daemon slice also includes a reusable localhost discovery/client
 contract that validates loopback binding, loads the local bearer token, and
 offers route-scoped helpers for the current gateway API. The Web UI dashboard

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -49,6 +49,10 @@ gateway endpoint as the normal bootstrap path and only fall back to persisted
 owner-state discovery when operators intentionally override the port with
 `--port`, `LOONGCLAW_GATEWAY_PORT`, or `--port 0`.
 
+The shared local gateway client should reflect the same rule: try the stable
+front door first, then use persisted owner-state discovery only for override
+and explicit ephemeral cases.
+
 The current daemon slice also includes a reusable localhost discovery/client
 contract that validates loopback binding, loads the local bearer token, and
 offers route-scoped helpers for the current gateway API. The Web UI dashboard


### PR DESCRIPTION
## Summary

- Problem:
  - the gateway owner contract existed, but the loopback control surface still defaulted to an ephemeral port
- Why it matters:
  - a stable local gateway boundary is easier to operate, easier to bootstrap local UI/tooling against, and closer to the intended single gateway noun
- What changed:
  - added a first-class gateway config seam with default port `26306`
  - wired gateway runtime startup so the control surface resolves precedence as CLI `--port` > env `LOONGCLAW_GATEWAY_PORT` > config `[gateway].port` > default `26306`
  - preserved explicit ephemeral mode via `--port 0`
  - updated docs and gateway regression tests
- What did not change (scope boundary):
  - no remote bind expansion
  - no ACP contract redesign
  - no new public gateway surface beyond the existing localhost control plane

## Linked Issues

- Closes #1231
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - changes the default gateway control-surface port from ephemeral to stable loopback `26306`
  - introduces explicit port precedence and an ephemeral escape hatch
- Rollout / guardrails:
  - loopback-only bind stays unchanged
  - local clients still discover the effective binding from persisted owner state
  - `--port 0` preserves explicit ephemeral behavior for tests and labs
- Rollback path:
  - revert the gateway port resolver and docs while keeping owner-state discovery intact

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw gateway_ -- --test-threads=1
cargo test -p loongclaw-app gateway_ -- --test-threads=1
./scripts/check_architecture_boundaries.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh
cargo test --workspace --locked --quiet
cargo test --workspace --all-features --locked --quiet
```

Validation notes:
- `cargo fmt` passed.
- `cargo clippy` passed.
- Targeted gateway and config regression suites passed.
- `./scripts/check_architecture_boundaries.sh` passed.
- `./scripts/check-docs.sh` failed on pre-existing release debug/trace artifact gaps unrelated to this slice.
- `cargo test --workspace --locked --quiet` still fails on a pre-existing `loongclaw-app` full-suite instability (observed failures included `conversation::announce::tests::delegate_announce_queue_batches_children_completed_within_debounce_window` on the feature branch and safe-lane session-dispatcher tests on the unmodified base worktree).
- `cargo test --workspace --all-features --locked --quiet` still fails on a pre-existing `loongclaw-app` shell-exec test family unrelated to the gateway slice.

## User-visible / Operator-visible Changes

- `loongclaw gateway run` now defaults to `127.0.0.1:26306` instead of an ephemeral loopback port.
- Operators can override with `--port` or `LOONGCLAW_GATEWAY_PORT`.
- `--port 0` remains available for explicit ephemeral lab/test runs.

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR to restore ephemeral default binding
  - operators can also force an alternate port with `--port` or `LOONGCLAW_GATEWAY_PORT` if `26306` is occupied locally
- Observable failure symptoms reviewers should watch for:
  - gateway status reports the wrong persisted port
  - local clients fail to discover the token or loopback endpoint
  - targeted gateway tests regress on port precedence or explicit ephemeral mode

## Reviewer Focus

- `crates/app/src/config/runtime.rs`
- `crates/daemon/src/gateway/control.rs`
- `crates/daemon/src/gateway/service.rs`
- `crates/daemon/tests/integration/gateway_owner_state.rs`
- `crates/daemon/tests/integration/gateway_api_turn.rs`
- `README.md`
- `docs/product-specs/channel-setup.md`
