### PR TITLE
Converge turn ingress on the real runtime substrate

### DIFF
--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -50,7 +50,9 @@ pub use runtime::{
     resolve_acp_backend_selection, shared_acp_session_manager,
     should_route_conversation_turn_via_acp, should_route_conversation_turn_via_acp_for_address,
 };
-pub(crate) use runtime::{FinalizedAcpConversationTurn, execute_acp_conversation_turn_for_address};
+pub(crate) use runtime::{
+    consume_finalized_acp_conversation_turn, execute_acp_conversation_turn_for_address,
+};
 #[cfg(feature = "memory-sqlite")]
 pub use store::AcpSqliteSessionStore;
 pub use store::{AcpSessionStore, InMemoryAcpSessionStore};

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -50,9 +50,7 @@ pub use runtime::{
     resolve_acp_backend_selection, shared_acp_session_manager,
     should_route_conversation_turn_via_acp, should_route_conversation_turn_via_acp_for_address,
 };
-pub(crate) use runtime::{
-    AcpConversationTurnExecutionOutcome, execute_acp_conversation_turn_for_address,
-};
+pub(crate) use runtime::{FinalizedAcpConversationTurn, execute_acp_conversation_turn_for_address};
 #[cfg(feature = "memory-sqlite")]
 pub use store::AcpSqliteSessionStore;
 pub use store::{AcpSessionStore, InMemoryAcpSessionStore};

--- a/crates/app/src/acp/mod.rs
+++ b/crates/app/src/acp/mod.rs
@@ -52,7 +52,6 @@ pub use runtime::{
 };
 pub(crate) use runtime::{
     AcpConversationTurnExecutionOutcome, execute_acp_conversation_turn_for_address,
-    execute_acp_conversation_turn_for_address_with_manager,
 };
 #[cfg(feature = "memory-sqlite")]
 pub use store::AcpSqliteSessionStore;

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -114,6 +114,12 @@ pub(crate) struct ExecutedAcpConversationTurn {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub(crate) enum FinalizedAcpConversationTurn {
+    Succeeded(FinalizedAcpConversationTurnSuccess),
+    Failed(FinalizedAcpConversationTurnFailure),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum AcpConversationTurnExecutionOutcome {
     Succeeded(AcpConversationTurnSuccess),
     Failed(AcpConversationTurnFailure),
@@ -129,6 +135,53 @@ pub(crate) struct AcpConversationTurnSuccess {
 pub(crate) struct AcpConversationTurnFailure {
     pub error: String,
     pub runtime_events: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct FinalizedAcpConversationTurnSuccess {
+    pub prepared: PreparedAcpConversationTurn,
+    pub backend_selection: AcpBackendSelection,
+    pub persistence_context: PersistedAcpRuntimeEventContext,
+    pub result: AcpTurnResult,
+    pub runtime_events: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalizedAcpConversationTurnFailure {
+    pub prepared: PreparedAcpConversationTurn,
+    pub backend_selection: AcpBackendSelection,
+    pub persistence_context: PersistedAcpRuntimeEventContext,
+    pub error: String,
+    pub runtime_events: Vec<Value>,
+}
+
+impl ExecutedAcpConversationTurn {
+    pub(crate) fn into_finalized(self) -> FinalizedAcpConversationTurn {
+        let prepared = self.prepared;
+        let backend_selection = self.backend_selection;
+        let persistence_context = self.persistence_context;
+
+        match self.outcome {
+            AcpConversationTurnExecutionOutcome::Succeeded(success) => {
+                FinalizedAcpConversationTurn::Succeeded(FinalizedAcpConversationTurnSuccess {
+                    prepared,
+                    backend_selection,
+                    persistence_context,
+                    result: success.result,
+                    runtime_events: success.runtime_events,
+                })
+            }
+            AcpConversationTurnExecutionOutcome::Failed(failure) => {
+                FinalizedAcpConversationTurn::Failed(FinalizedAcpConversationTurnFailure {
+                    prepared,
+                    backend_selection,
+                    persistence_context,
+                    error: failure.error,
+                    runtime_events: failure.runtime_events,
+                })
+            }
+        }
+    }
 }
 
 static ACP_SESSION_MANAGER_REGISTRY: OnceLock<RwLock<BTreeMap<String, Arc<AcpSessionManager>>>> =

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -414,7 +414,7 @@ pub fn evaluate_acp_conversation_turn_entry_for_address(
 }
 
 fn resolve_acp_turn_execution_manager(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     manager: Option<Arc<AcpSessionManager>>,
 ) -> CliResult<Arc<AcpSessionManager>> {
     match manager {

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -395,26 +395,27 @@ pub fn evaluate_acp_conversation_turn_entry_for_address(
     }
 }
 
+fn resolve_acp_turn_execution_manager(
+    config: &LoongClawConfig,
+    manager: Option<Arc<AcpSessionManager>>,
+) -> CliResult<Arc<AcpSessionManager>> {
+    match manager {
+        Some(manager) => Ok(manager),
+        None => shared_acp_session_manager(config),
+    }
+}
+
 pub(crate) async fn execute_acp_conversation_turn_for_address(
     config: &LoongConfig,
     address: &ConversationSessionAddress,
     user_input: &str,
     options: &AcpConversationTurnOptions<'_>,
+    manager: Option<Arc<AcpSessionManager>>,
 ) -> CliResult<ExecutedAcpConversationTurn> {
     let prepared = prepare_acp_conversation_turn_for_address(config, address, user_input, options)?;
-    let manager = shared_acp_session_manager(config)?;
-    execute_prepared_acp_conversation_turn(config, prepared, options, manager).await
-}
+    let effective_manager = resolve_acp_turn_execution_manager(config, manager)?;
 
-pub(crate) async fn execute_acp_conversation_turn_for_address_with_manager(
-    config: &LoongConfig,
-    address: &ConversationSessionAddress,
-    user_input: &str,
-    options: &AcpConversationTurnOptions<'_>,
-    manager: Arc<AcpSessionManager>,
-) -> CliResult<ExecutedAcpConversationTurn> {
-    let prepared = prepare_acp_conversation_turn_for_address(config, address, user_input, options)?;
-    execute_prepared_acp_conversation_turn(config, prepared, options, manager).await
+    execute_prepared_acp_conversation_turn(config, prepared, options, effective_manager).await
 }
 
 async fn execute_prepared_acp_conversation_turn(

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -106,35 +106,9 @@ impl AcpConversationTurnEntryDecision {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ExecutedAcpConversationTurn {
-    pub prepared: PreparedAcpConversationTurn,
-    pub backend_selection: AcpBackendSelection,
-    pub persistence_context: PersistedAcpRuntimeEventContext,
-    pub outcome: AcpConversationTurnExecutionOutcome,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum FinalizedAcpConversationTurn {
     Succeeded(FinalizedAcpConversationTurnSuccess),
     Failed(FinalizedAcpConversationTurnFailure),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum AcpConversationTurnExecutionOutcome {
-    Succeeded(AcpConversationTurnSuccess),
-    Failed(AcpConversationTurnFailure),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct AcpConversationTurnSuccess {
-    pub result: AcpTurnResult,
-    pub runtime_events: Vec<Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct AcpConversationTurnFailure {
-    pub error: String,
-    pub runtime_events: Vec<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -153,35 +127,6 @@ pub(crate) struct FinalizedAcpConversationTurnFailure {
     pub persistence_context: PersistedAcpRuntimeEventContext,
     pub error: String,
     pub runtime_events: Vec<Value>,
-}
-
-impl ExecutedAcpConversationTurn {
-    pub(crate) fn into_finalized(self) -> FinalizedAcpConversationTurn {
-        let prepared = self.prepared;
-        let backend_selection = self.backend_selection;
-        let persistence_context = self.persistence_context;
-
-        match self.outcome {
-            AcpConversationTurnExecutionOutcome::Succeeded(success) => {
-                FinalizedAcpConversationTurn::Succeeded(FinalizedAcpConversationTurnSuccess {
-                    prepared,
-                    backend_selection,
-                    persistence_context,
-                    result: success.result,
-                    runtime_events: success.runtime_events,
-                })
-            }
-            AcpConversationTurnExecutionOutcome::Failed(failure) => {
-                FinalizedAcpConversationTurn::Failed(FinalizedAcpConversationTurnFailure {
-                    prepared,
-                    backend_selection,
-                    persistence_context,
-                    error: failure.error,
-                    runtime_events: failure.runtime_events,
-                })
-            }
-        }
-    }
 }
 
 static ACP_SESSION_MANAGER_REGISTRY: OnceLock<RwLock<BTreeMap<String, Arc<AcpSessionManager>>>> =
@@ -464,7 +409,7 @@ pub(crate) async fn execute_acp_conversation_turn_for_address(
     user_input: &str,
     options: &AcpConversationTurnOptions<'_>,
     manager: Option<Arc<AcpSessionManager>>,
-) -> CliResult<ExecutedAcpConversationTurn> {
+) -> CliResult<FinalizedAcpConversationTurn> {
     let prepared = prepare_acp_conversation_turn_for_address(config, address, user_input, options)?;
     let effective_manager = resolve_acp_turn_execution_manager(config, manager)?;
 
@@ -476,7 +421,7 @@ async fn execute_prepared_acp_conversation_turn(
     prepared: PreparedAcpConversationTurn,
     options: &AcpConversationTurnOptions<'_>,
     manager: Arc<AcpSessionManager>,
-) -> CliResult<ExecutedAcpConversationTurn> {
+) -> CliResult<FinalizedAcpConversationTurn> {
     let backend_selection = resolve_acp_backend_selection(config);
     let persistence_event_sink = config
         .acp
@@ -525,7 +470,16 @@ async fn execute_prepared_acp_conversation_turn(
         }
     };
 
-    let outcome = match turn_result {
+    let persistence_context = PersistedAcpRuntimeEventContext {
+        backend_id: backend_selection.id.clone(),
+        agent_id: prepared.route.agent_id.clone(),
+        session_key: prepared.request.session_key.clone(),
+        conversation_id: Some(prepared.route.conversation_id.clone()),
+        binding: prepared.route.binding.clone(),
+        request_metadata: prepared.request.metadata.clone(),
+    };
+
+    let finalized = match turn_result {
         Ok(result) => {
             let runtime_events = if let Some(persistence_sink) = persistence_event_sink.as_ref() {
                 let streamed_events = persistence_sink.snapshot()?;
@@ -533,7 +487,10 @@ async fn execute_prepared_acp_conversation_turn(
             } else {
                 result.events.clone()
             };
-            AcpConversationTurnExecutionOutcome::Succeeded(AcpConversationTurnSuccess {
+            FinalizedAcpConversationTurn::Succeeded(FinalizedAcpConversationTurnSuccess {
+                prepared,
+                backend_selection,
+                persistence_context,
                 result,
                 runtime_events,
             })
@@ -544,28 +501,17 @@ async fn execute_prepared_acp_conversation_turn(
                 .map(BufferedAcpTurnEventSink::snapshot)
                 .transpose()?
                 .unwrap_or_default();
-            AcpConversationTurnExecutionOutcome::Failed(AcpConversationTurnFailure {
+            FinalizedAcpConversationTurn::Failed(FinalizedAcpConversationTurnFailure {
+                prepared,
+                backend_selection,
+                persistence_context,
                 error,
                 runtime_events,
             })
         }
     };
 
-    let persistence_context = PersistedAcpRuntimeEventContext {
-        backend_id: backend_selection.id.clone(),
-        agent_id: prepared.route.agent_id.clone(),
-        session_key: prepared.request.session_key.clone(),
-        conversation_id: Some(prepared.route.conversation_id.clone()),
-        binding: prepared.route.binding.clone(),
-        request_metadata: prepared.request.metadata.clone(),
-    };
-
-    Ok(ExecutedAcpConversationTurn {
-        prepared,
-        backend_selection,
-        persistence_context,
-        outcome,
-    })
+    Ok(finalized)
 }
 
 pub fn derive_automatic_acp_routing_origin_for_address(

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -113,8 +113,6 @@ pub(crate) enum FinalizedAcpConversationTurn {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct FinalizedAcpConversationTurnSuccess {
-    pub prepared: PreparedAcpConversationTurn,
-    pub backend_selection: AcpBackendSelection,
     pub persistence_context: PersistedAcpRuntimeEventContext,
     pub result: AcpTurnResult,
     pub runtime_events: Vec<Value>,
@@ -122,8 +120,6 @@ pub(crate) struct FinalizedAcpConversationTurnSuccess {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FinalizedAcpConversationTurnFailure {
-    pub prepared: PreparedAcpConversationTurn,
-    pub backend_selection: AcpBackendSelection,
     pub persistence_context: PersistedAcpRuntimeEventContext,
     pub error: String,
     pub runtime_events: Vec<Value>,
@@ -488,8 +484,6 @@ async fn execute_prepared_acp_conversation_turn(
                 result.events.clone()
             };
             FinalizedAcpConversationTurn::Succeeded(FinalizedAcpConversationTurnSuccess {
-                prepared,
-                backend_selection,
                 persistence_context,
                 result,
                 runtime_events,
@@ -502,8 +496,6 @@ async fn execute_prepared_acp_conversation_turn(
                 .transpose()?
                 .unwrap_or_default();
             FinalizedAcpConversationTurn::Failed(FinalizedAcpConversationTurnFailure {
-                prepared,
-                backend_selection,
                 persistence_context,
                 error,
                 runtime_events,

--- a/crates/app/src/acp/runtime.rs
+++ b/crates/app/src/acp/runtime.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use serde_json::Value;
@@ -123,6 +124,29 @@ pub(crate) struct FinalizedAcpConversationTurnFailure {
     pub persistence_context: PersistedAcpRuntimeEventContext,
     pub error: String,
     pub runtime_events: Vec<Value>,
+}
+
+pub(crate) async fn consume_finalized_acp_conversation_turn<
+    T,
+    SuccessFuture,
+    FailureFuture,
+    OnSuccess,
+    OnFailure,
+>(
+    finalized: FinalizedAcpConversationTurn,
+    on_success: OnSuccess,
+    on_failure: OnFailure,
+) -> CliResult<T>
+where
+    SuccessFuture: Future<Output = CliResult<T>>,
+    FailureFuture: Future<Output = CliResult<T>>,
+    OnSuccess: FnOnce(FinalizedAcpConversationTurnSuccess) -> SuccessFuture,
+    OnFailure: FnOnce(FinalizedAcpConversationTurnFailure) -> FailureFuture,
+{
+    match finalized {
+        FinalizedAcpConversationTurn::Succeeded(success) => on_success(success).await,
+        FinalizedAcpConversationTurn::Failed(failure) => on_failure(failure).await,
+    }
 }
 
 static ACP_SESSION_MANAGER_REGISTRY: OnceLock<RwLock<BTreeMap<String, Arc<AcpSessionManager>>>> =

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -187,11 +187,12 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                     acp_manager,
                 )
                 .await?;
+                let finalized = execution.into_finalized();
                 let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
                 let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
-                return match execution.outcome {
-                    crate::acp::AcpConversationTurnExecutionOutcome::Succeeded(success) => {
+                return match finalized {
+                    crate::acp::FinalizedAcpConversationTurn::Succeeded(success) => {
                         Ok(AgentTurnResult {
                             session_id: runtime.session_id.clone(),
                             output_text: success.result.output_text,
@@ -212,9 +213,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                             prompt_cache,
                         })
                     }
-                    crate::acp::AcpConversationTurnExecutionOutcome::Failed(failure) => {
-                        Err(failure.error)
-                    }
+                    crate::acp::FinalizedAcpConversationTurn::Failed(failure) => Err(failure.error),
                 };
             }
 

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -156,7 +156,6 @@ impl<'a> RuntimeTurnExecutionService<'a> {
         request: &'a AgentTurnRequest,
         options: TurnExecutionOptions<'a>,
     ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + Send + 'a>> {
-        let runtime = AgentRuntime::new();
         let event_sink = options.event_sink;
         let observer = options.observer;
         let ingress = options.ingress;
@@ -165,18 +164,97 @@ impl<'a> RuntimeTurnExecutionService<'a> {
         let acp_manager = self.acp_manager.clone();
 
         Box::pin(async move {
-            runtime
-                .run_turn_with_runtime_and_context_and_manager(
-                    self.runtime,
-                    request,
+            if request.message.trim().is_empty() {
+                return Err("agent runtime message must not be empty".to_owned());
+            }
+
+            let runtime = self.runtime;
+            let message = request.message.as_str();
+            let turn_address = resolved_session_address(runtime, request);
+            let explicit_acp_request = runtime.explicit_acp_request
+                || request.acp
+                || matches!(request.turn_mode, AgentTurnMode::Acp);
+
+            if explicit_acp_request {
+                let turn_config = load_runtime_turn_config(runtime)?;
+                let effective_acp_manager = match acp_manager {
+                    Some(manager) => manager,
+                    None => crate::acp::shared_acp_session_manager(&turn_config)?,
+                };
+                let acp_options = acp_turn_options_from_runtime(runtime, event_sink, request)
+                    .with_provenance(provenance);
+                let execution = crate::acp::execute_acp_conversation_turn_for_address_with_manager(
+                    &turn_config,
+                    &turn_address,
+                    message,
+                    &acp_options,
+                    effective_acp_manager,
+                )
+                .await?;
+                let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+                let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+
+                return match execution.outcome {
+                    crate::acp::AcpConversationTurnExecutionOutcome::Succeeded(success) => {
+                        Ok(AgentTurnResult {
+                            session_id: runtime.session_id.clone(),
+                            output_text: success.result.output_text,
+                            turn_mode: request.turn_mode,
+                            governed_session_mode: ConversationRuntimeBinding::kernel(
+                                &runtime.kernel_ctx,
+                            )
+                            .session_mode(),
+                            state: Some(acp_session_state_label(success.result.state).to_owned()),
+                            stop_reason: success
+                                .result
+                                .stop_reason
+                                .map(acp_turn_stop_reason_label)
+                                .map(ToOwned::to_owned),
+                            usage: success.result.usage,
+                            event_count: success.runtime_events.len(),
+                            prompt_assembly,
+                            prompt_cache,
+                        })
+                    }
+                    crate::acp::AcpConversationTurnExecutionOutcome::Failed(failure) => {
+                        Err(failure.error)
+                    }
+                };
+            }
+
+            let (effective_ingress, effective_provenance) =
+                effective_turn_context(ingress, provenance);
+            let output_text =
+                crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_and_acp_manager(
+                    runtime,
+                    &turn_address,
+                    message,
                     event_sink,
-                    observer,
-                    ingress,
-                    provenance,
+                    request.live_surface_enabled,
+                    Some(&request.metadata),
+                    effective_ingress,
+                    effective_provenance,
                     provider_error_mode,
+                    observer,
                     acp_manager,
                 )
-                .await
+                .await?;
+            let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+            let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+
+            Ok(AgentTurnResult {
+                session_id: runtime.session_id.clone(),
+                output_text,
+                turn_mode: request.turn_mode,
+                governed_session_mode: ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)
+                    .session_mode(),
+                state: None,
+                stop_reason: None,
+                usage: None,
+                event_count: 0,
+                prompt_assembly,
+                prompt_cache,
+            })
         })
     }
 }
@@ -298,106 +376,6 @@ impl AgentRuntime {
         turn_service
             .execute(session_hint, request, turn_options)
             .await
-    }
-
-    async fn run_turn_with_runtime_and_context_and_manager(
-        &self,
-        runtime: &crate::chat::CliTurnRuntime,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
-        ingress: Option<&ConversationIngressContext>,
-        provenance: AcpTurnProvenance<'_>,
-        provider_error_mode: crate::conversation::ProviderErrorMode,
-        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
-    ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-        let message = request.message.as_str();
-
-        let turn_address = resolved_session_address(runtime, request);
-        let explicit_acp_request = runtime.explicit_acp_request
-            || request.acp
-            || matches!(request.turn_mode, AgentTurnMode::Acp);
-
-        if explicit_acp_request {
-            // ACP turns reuse the same runtime shell/session identity but swap
-            // the execution lane entirely: they reload provider-facing config,
-            // resolve ACP routing metadata, and bypass the normal provider
-            // coordinator path below.
-            let turn_config = load_runtime_turn_config(runtime)?;
-            let acp_manager = match acp_manager {
-                Some(manager) => manager,
-                None => crate::acp::shared_acp_session_manager(&turn_config)?,
-            };
-            let acp_options = acp_turn_options_from_runtime(runtime, event_sink, request)
-                .with_provenance(provenance);
-            let execution = crate::acp::execute_acp_conversation_turn_for_address_with_manager(
-                &turn_config,
-                &turn_address,
-                message,
-                &acp_options,
-                acp_manager,
-            )
-            .await?;
-            let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-            let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
-            return match execution.outcome {
-                crate::acp::AcpConversationTurnExecutionOutcome::Succeeded(success) => {
-                    Ok(AgentTurnResult {
-                        session_id: runtime.session_id.clone(),
-                        output_text: success.result.output_text,
-                        turn_mode: request.turn_mode,
-                        governed_session_mode: runtime.conversation_binding().session_mode(),
-                        state: Some(acp_session_state_label(success.result.state).to_owned()),
-                        stop_reason: success
-                            .result
-                            .stop_reason
-                            .map(acp_turn_stop_reason_label)
-                            .map(ToOwned::to_owned),
-                        usage: success.result.usage,
-                        event_count: success.runtime_events.len(),
-                        prompt_assembly,
-                        prompt_cache,
-                    })
-                }
-                crate::acp::AcpConversationTurnExecutionOutcome::Failed(failure) => {
-                    Err(failure.error)
-                }
-            };
-        }
-
-        let (effective_ingress, effective_provenance) = effective_turn_context(ingress, provenance);
-        let turn_outcome = crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
-            runtime,
-            &turn_address,
-            message,
-            event_sink,
-            request.live_surface_enabled,
-            Some(&request.metadata),
-            effective_ingress,
-            effective_provenance,
-            provider_error_mode,
-            observer,
-            acp_manager,
-        )
-        .await?;
-        let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-        let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
-
-        Ok(AgentTurnResult {
-            session_id: runtime.session_id.clone(),
-            output_text: turn_outcome.reply,
-            turn_mode: request.turn_mode,
-            governed_session_mode: runtime.conversation_binding().session_mode(),
-            state: None,
-            stop_reason: None,
-            usage: turn_outcome.usage,
-            event_count: 0,
-            prompt_assembly,
-            prompt_cache,
-        })
     }
 
     pub async fn resume_turn(

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -190,30 +190,38 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                 let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
                 let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
-                return match execution {
-                    crate::acp::FinalizedAcpConversationTurn::Succeeded(success) => {
+                let governed_session_mode =
+                    ConversationRuntimeBinding::kernel(&runtime.kernel_ctx).session_mode();
+
+                return crate::acp::consume_finalized_acp_conversation_turn(
+                    execution,
+                    |success| async move {
+                        let result = success.result;
+                        let output_text = result.output_text;
+                        let state = Some(acp_session_state_label(result.state).to_owned());
+                        let stop_reason = result
+                            .stop_reason
+                            .map(acp_turn_stop_reason_label)
+                            .map(ToOwned::to_owned);
+                        let usage = result.usage;
+                        let event_count = success.runtime_events.len();
+
                         Ok(AgentTurnResult {
                             session_id: runtime.session_id.clone(),
-                            output_text: success.result.output_text,
+                            output_text,
                             turn_mode: request.turn_mode,
-                            governed_session_mode: ConversationRuntimeBinding::kernel(
-                                &runtime.kernel_ctx,
-                            )
-                            .session_mode(),
-                            state: Some(acp_session_state_label(success.result.state).to_owned()),
-                            stop_reason: success
-                                .result
-                                .stop_reason
-                                .map(acp_turn_stop_reason_label)
-                                .map(ToOwned::to_owned),
-                            usage: success.result.usage,
-                            event_count: success.runtime_events.len(),
+                            governed_session_mode,
+                            state,
+                            stop_reason,
+                            usage,
+                            event_count,
                             prompt_assembly,
                             prompt_cache,
                         })
-                    }
-                    crate::acp::FinalizedAcpConversationTurn::Failed(failure) => Err(failure.error),
-                };
+                    },
+                    |failure| async move { Err(failure.error) },
+                )
+                .await;
             }
 
             let (effective_ingress, effective_provenance) =

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -1,13 +1,16 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::CliResult;
 use crate::acp::{AcpTurnEventSink, AcpTurnProvenance, JsonlAcpTurnEventSink};
 use crate::chat::{
     CliChatOptions, initialize_cli_turn_runtime, initialize_cli_turn_runtime_with_loaded_config,
+    initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx,
 };
 use crate::config::load as load_config;
 use crate::conversation::{
@@ -98,6 +101,156 @@ pub struct AgentRuntimeEvent {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AgentRuntime;
+
+#[derive(Clone)]
+pub struct TurnExecutionService {
+    resolved_path: PathBuf,
+    config: crate::config::LoongClawConfig,
+    kernel_ctx: Option<crate::KernelContext>,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+}
+
+pub struct TurnExecutionOptions<'a> {
+    pub event_sink: Option<&'a dyn AcpTurnEventSink>,
+    pub observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+    pub ingress: Option<&'a ConversationIngressContext>,
+    pub provenance: AcpTurnProvenance<'a>,
+    pub provider_error_mode: crate::conversation::ProviderErrorMode,
+}
+
+impl Default for TurnExecutionOptions<'_> {
+    fn default() -> Self {
+        Self {
+            event_sink: None,
+            observer: None,
+            ingress: None,
+            provenance: AcpTurnProvenance::default(),
+            provider_error_mode: crate::conversation::ProviderErrorMode::InlineMessage,
+        }
+    }
+}
+
+impl TurnExecutionService {
+    pub fn new(resolved_path: PathBuf, config: crate::config::LoongClawConfig) -> Self {
+        Self {
+            resolved_path,
+            config,
+            kernel_ctx: None,
+            acp_manager: None,
+        }
+    }
+
+    pub fn with_kernel_ctx(mut self, kernel_ctx: crate::KernelContext) -> Self {
+        self.kernel_ctx = Some(kernel_ctx);
+        self
+    }
+
+    pub fn with_acp_manager(mut self, acp_manager: Arc<crate::acp::AcpSessionManager>) -> Self {
+        self.acp_manager = Some(acp_manager);
+        self
+    }
+
+    pub fn config(&self) -> &crate::config::LoongClawConfig {
+        &self.config
+    }
+
+    pub fn execute<'a>(
+        &'a self,
+        session_hint: Option<&'a str>,
+        request: &'a AgentTurnRequest,
+        options: TurnExecutionOptions<'a>,
+    ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + Send + 'a>> {
+        let runtime = AgentRuntime::new();
+        let resolved_path = self.resolved_path.clone();
+        let config = self.config.clone();
+        let kernel_ctx = self.kernel_ctx.clone();
+        let acp_manager = self.acp_manager.clone();
+        let event_sink = options.event_sink;
+        let observer = options.observer;
+        let ingress = options.ingress;
+        let provenance = options.provenance;
+        let provider_error_mode = options.provider_error_mode;
+
+        Box::pin(async move {
+            match (kernel_ctx, acp_manager) {
+                (Some(kernel_ctx), Some(acp_manager)) => {
+                    let options = cli_chat_options_for_turn_request(request);
+                    let cli_runtime =
+                        initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+                            resolved_path,
+                            config,
+                            session_hint,
+                            &options,
+                            kernel_ctx,
+                            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+                        )?;
+                    let execution_future = runtime.run_turn_with_runtime_and_context_and_manager(
+                        &cli_runtime,
+                        request,
+                        event_sink,
+                        observer,
+                        ingress,
+                        provenance,
+                        provider_error_mode,
+                        Some(acp_manager),
+                    );
+                    let execution_future = Box::pin(execution_future);
+
+                    execution_future.await
+                }
+                (Some(kernel_ctx), None) => {
+                    let execution_future = runtime
+                        .run_turn_with_loaded_config_and_kernel_ctx_and_observer_and_context_and_error_mode(
+                        resolved_path,
+                        config,
+                        session_hint,
+                        request,
+                        event_sink,
+                        observer,
+                        ingress,
+                        provenance,
+                        provider_error_mode,
+                        kernel_ctx,
+                    );
+                    let execution_future = Box::pin(execution_future);
+
+                    execution_future.await
+                }
+                (None, Some(acp_manager)) => {
+                    runtime
+                        .run_turn_with_loaded_config_and_acp_manager(
+                            resolved_path,
+                            config,
+                            session_hint,
+                            request,
+                            event_sink,
+                            acp_manager,
+                        )
+                        .await
+                }
+                (None, None) => {
+                    runtime
+                        .run_turn_with_loaded_config(
+                            resolved_path,
+                            config,
+                            session_hint,
+                            request,
+                            event_sink,
+                        )
+                        .await
+                }
+            }
+        })
+    }
+}
+
+pub fn load_turn_execution_service(config_path: Option<&str>) -> CliResult<TurnExecutionService> {
+    let loaded = crate::config::load(config_path)?;
+    let resolved_path = loaded.0;
+    let config = loaded.1;
+    let service = TurnExecutionService::new(resolved_path, config);
+    Ok(service)
+}
 
 impl AgentRuntime {
     pub const fn new() -> Self {
@@ -284,20 +437,20 @@ impl AgentRuntime {
         }
 
         let (effective_ingress, effective_provenance) = effective_turn_context(ingress, provenance);
-        let turn_outcome =
-            crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
-                runtime,
-                &turn_address,
-                message,
-                event_sink,
-                request.live_surface_enabled,
-                Some(&request.metadata),
-                effective_ingress,
-                effective_provenance,
-                provider_error_mode,
-                observer,
-            )
-            .await?;
+        let turn_outcome = crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
+            runtime,
+            &turn_address,
+            message,
+            event_sink,
+            request.live_surface_enabled,
+            Some(&request.metadata),
+            effective_ingress,
+            effective_provenance,
+            provider_error_mode,
+            observer,
+            acp_manager,
+        )
+        .await?;
         let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
         let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
@@ -433,6 +586,46 @@ impl AgentRuntime {
             AcpTurnProvenance::default(),
             crate::conversation::ProviderErrorMode::InlineMessage,
             Some(acp_manager),
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_loaded_config_and_kernel_ctx_and_observer_and_context_and_error_mode(
+        &self,
+        resolved_path: PathBuf,
+        config: crate::config::LoongClawConfig,
+        session_hint: Option<&str>,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+        provider_error_mode: crate::conversation::ProviderErrorMode,
+        kernel_ctx: crate::KernelContext,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_ctx,
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+        )?;
+
+        self.run_turn_with_runtime_and_context_and_manager(
+            &runtime,
+            request,
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            provider_error_mode,
+            None,
         )
         .await
     }

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -187,11 +187,10 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                     acp_manager,
                 )
                 .await?;
-                let finalized = execution.into_finalized();
                 let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
                 let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
-                return match finalized {
+                return match execution {
                     crate::acp::FinalizedAcpConversationTurn::Succeeded(success) => {
                         Ok(AgentTurnResult {
                             session_id: runtime.session_id.clone(),

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -118,6 +118,11 @@ pub struct TurnExecutionOptions<'a> {
     pub provider_error_mode: crate::conversation::ProviderErrorMode,
 }
 
+pub(crate) struct RuntimeTurnExecutionService<'a> {
+    runtime: &'a crate::chat::CliTurnRuntime,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+}
+
 impl Default for TurnExecutionOptions<'_> {
     fn default() -> Self {
         Self {
@@ -127,6 +132,44 @@ impl Default for TurnExecutionOptions<'_> {
             provenance: AcpTurnProvenance::default(),
             provider_error_mode: crate::conversation::ProviderErrorMode::InlineMessage,
         }
+    }
+}
+
+impl<'a> RuntimeTurnExecutionService<'a> {
+    pub(crate) fn new(runtime: &'a crate::chat::CliTurnRuntime) -> Self {
+        Self {
+            runtime,
+            acp_manager: None,
+        }
+    }
+
+    pub(crate) fn execute(
+        &'a self,
+        request: &'a AgentTurnRequest,
+        options: TurnExecutionOptions<'a>,
+    ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + 'a>> {
+        let runtime = AgentRuntime::new();
+        let event_sink = options.event_sink;
+        let observer = options.observer;
+        let ingress = options.ingress;
+        let provenance = options.provenance;
+        let provider_error_mode = options.provider_error_mode;
+        let acp_manager = self.acp_manager.clone();
+
+        Box::pin(async move {
+            runtime
+                .run_turn_with_runtime_and_context_and_manager(
+                    self.runtime,
+                    request,
+                    event_sink,
+                    observer,
+                    ingress,
+                    provenance,
+                    provider_error_mode,
+                    acp_manager,
+                )
+                .await
+        })
     }
 }
 
@@ -301,68 +344,6 @@ impl AgentRuntime {
             None,
             AcpTurnProvenance::default(),
             crate::conversation::ProviderErrorMode::InlineMessage,
-            None,
-        )
-        .await
-    }
-
-    pub(crate) async fn run_turn_with_runtime_and_observer(
-        &self,
-        runtime: &crate::chat::CliTurnRuntime,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
-    ) -> CliResult<AgentTurnResult> {
-        self.run_turn_with_runtime_and_observer_and_context(
-            runtime,
-            request,
-            event_sink,
-            observer,
-            None,
-            AcpTurnProvenance::default(),
-        )
-        .await
-    }
-
-    pub(crate) async fn run_turn_with_runtime_and_observer_and_context(
-        &self,
-        runtime: &crate::chat::CliTurnRuntime,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
-        ingress: Option<&ConversationIngressContext>,
-        provenance: AcpTurnProvenance<'_>,
-    ) -> CliResult<AgentTurnResult> {
-        self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
-            runtime,
-            request,
-            event_sink,
-            observer,
-            ingress,
-            provenance,
-            crate::conversation::ProviderErrorMode::InlineMessage,
-        )
-        .await
-    }
-
-    pub(crate) async fn run_turn_with_runtime_and_observer_and_context_and_error_mode(
-        &self,
-        runtime: &crate::chat::CliTurnRuntime,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
-        ingress: Option<&ConversationIngressContext>,
-        provenance: AcpTurnProvenance<'_>,
-        provider_error_mode: crate::conversation::ProviderErrorMode,
-    ) -> CliResult<AgentTurnResult> {
-        self.run_turn_with_runtime_and_context_and_manager(
-            runtime,
-            request,
-            event_sink,
-            observer,
-            ingress,
-            provenance,
-            provider_error_mode,
             None,
         )
         .await

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -177,18 +177,14 @@ impl<'a> RuntimeTurnExecutionService<'a> {
 
             if explicit_acp_request {
                 let turn_config = load_runtime_turn_config(runtime)?;
-                let effective_acp_manager = match acp_manager {
-                    Some(manager) => manager,
-                    None => crate::acp::shared_acp_session_manager(&turn_config)?,
-                };
                 let acp_options = acp_turn_options_from_runtime(runtime, event_sink, request)
                     .with_provenance(provenance);
-                let execution = crate::acp::execute_acp_conversation_turn_for_address_with_manager(
+                let execution = crate::acp::execute_acp_conversation_turn_for_address(
                     &turn_config,
                     &turn_address,
                     message,
                     &acp_options,
-                    effective_acp_manager,
+                    acp_manager,
                 )
                 .await?;
                 let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -108,6 +108,7 @@ pub struct TurnExecutionService {
     config: crate::config::LoongClawConfig,
     kernel_ctx: Option<crate::KernelContext>,
     acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    initialize_runtime_environment: bool,
 }
 
 pub struct TurnExecutionOptions<'a> {
@@ -226,8 +227,8 @@ impl<'a> RuntimeTurnExecutionService<'a> {
 
             let (effective_ingress, effective_provenance) =
                 effective_turn_context(ingress, provenance);
-            let output_text =
-                crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_and_acp_manager(
+            let turn_outcome =
+                crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
                     runtime,
                     &turn_address,
                     message,
@@ -246,13 +247,13 @@ impl<'a> RuntimeTurnExecutionService<'a> {
 
             Ok(AgentTurnResult {
                 session_id: runtime.session_id.clone(),
-                output_text,
+                output_text: turn_outcome.reply,
                 turn_mode: request.turn_mode,
                 governed_session_mode: ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)
                     .session_mode(),
                 state: None,
                 stop_reason: None,
-                usage: None,
+                usage: turn_outcome.usage,
                 event_count: 0,
                 prompt_assembly,
                 prompt_cache,
@@ -268,6 +269,7 @@ impl TurnExecutionService {
             config,
             kernel_ctx: None,
             acp_manager: None,
+            initialize_runtime_environment: true,
         }
     }
 
@@ -278,6 +280,11 @@ impl TurnExecutionService {
 
     pub fn with_acp_manager(mut self, acp_manager: Arc<crate::acp::AcpSessionManager>) -> Self {
         self.acp_manager = Some(acp_manager);
+        self
+    }
+
+    pub fn without_runtime_environment_init(mut self) -> Self {
+        self.initialize_runtime_environment = false;
         self
     }
 
@@ -300,6 +307,7 @@ impl TurnExecutionService {
         let ingress = options.ingress;
         let provenance = options.provenance;
         let provider_error_mode = options.provider_error_mode;
+        let initialize_runtime_environment = self.initialize_runtime_environment;
 
         Box::pin(async move {
             let cli_options = cli_chat_options_for_turn_request(request);
@@ -319,7 +327,7 @@ impl TurnExecutionService {
                     &cli_options,
                     kernel_scope_for_turn_mode(request.turn_mode),
                     crate::chat::CliSessionRequirement::AllowImplicitDefault,
-                    true,
+                    initialize_runtime_environment,
                 )?,
             };
             let turn_options = TurnExecutionOptions {
@@ -407,7 +415,8 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let turn_service = TurnExecutionService::new(resolved_path, config);
+        let turn_service =
+            TurnExecutionService::new(resolved_path, config).without_runtime_environment_init();
         let turn_options = TurnExecutionOptions {
             event_sink,
             ..Default::default()
@@ -432,27 +441,18 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            resolved_path,
-            config,
-            session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )?;
-
-        self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
-            &runtime,
-            request,
+        let turn_service =
+            TurnExecutionService::new(resolved_path, config).without_runtime_environment_init();
+        let turn_options = TurnExecutionOptions {
             event_sink,
             observer,
-            None,
-            AcpTurnProvenance::default(),
             provider_error_mode,
-        )
-        .await
+            ..Default::default()
+        };
+
+        turn_service
+            .execute(session_hint, request, turn_options)
+            .await
     }
 
     /// Execute a turn with a preloaded config while reusing an existing ACP
@@ -474,8 +474,9 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let turn_service =
-            TurnExecutionService::new(resolved_path, config).with_acp_manager(acp_manager);
+        let turn_service = TurnExecutionService::new(resolved_path, config)
+            .with_acp_manager(acp_manager)
+            .without_runtime_environment_init();
         let turn_options = TurnExecutionOptions {
             event_sink,
             ..Default::default()

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -105,7 +105,7 @@ pub struct AgentRuntime;
 #[derive(Clone)]
 pub struct TurnExecutionService {
     resolved_path: PathBuf,
-    config: crate::config::LoongClawConfig,
+    config: crate::config::LoongConfig,
     kernel_ctx: Option<crate::KernelContext>,
     acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     initialize_runtime_environment: bool,
@@ -117,6 +117,7 @@ pub struct TurnExecutionOptions<'a> {
     pub ingress: Option<&'a ConversationIngressContext>,
     pub provenance: AcpTurnProvenance<'a>,
     pub provider_error_mode: crate::conversation::ProviderErrorMode,
+    pub retry_progress: crate::provider::ProviderRetryProgressCallback,
 }
 
 pub(crate) struct RuntimeTurnExecutionService<'a> {
@@ -132,6 +133,7 @@ impl Default for TurnExecutionOptions<'_> {
             ingress: None,
             provenance: AcpTurnProvenance::default(),
             provider_error_mode: crate::conversation::ProviderErrorMode::InlineMessage,
+            retry_progress: None,
         }
     }
 }
@@ -162,6 +164,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
         let ingress = options.ingress;
         let provenance = options.provenance;
         let provider_error_mode = options.provider_error_mode;
+        let retry_progress = options.retry_progress;
         let acp_manager = self.acp_manager.clone();
 
         Box::pin(async move {
@@ -191,8 +194,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                 let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
                 let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
 
-                let governed_session_mode =
-                    ConversationRuntimeBinding::kernel(&runtime.kernel_ctx).session_mode();
+                let governed_session_mode = runtime.conversation_binding().session_mode();
 
                 return crate::acp::consume_finalized_acp_conversation_turn(
                     execution,
@@ -239,6 +241,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                     effective_provenance,
                     provider_error_mode,
                     observer,
+                    retry_progress,
                     acp_manager,
                 )
                 .await?;
@@ -249,8 +252,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                 session_id: runtime.session_id.clone(),
                 output_text: turn_outcome.reply,
                 turn_mode: request.turn_mode,
-                governed_session_mode: ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)
-                    .session_mode(),
+                governed_session_mode: runtime.conversation_binding().session_mode(),
                 state: None,
                 stop_reason: None,
                 usage: turn_outcome.usage,
@@ -263,7 +265,7 @@ impl<'a> RuntimeTurnExecutionService<'a> {
 }
 
 impl TurnExecutionService {
-    pub fn new(resolved_path: PathBuf, config: crate::config::LoongClawConfig) -> Self {
+    pub fn new(resolved_path: PathBuf, config: crate::config::LoongConfig) -> Self {
         Self {
             resolved_path,
             config,
@@ -288,7 +290,7 @@ impl TurnExecutionService {
         self
     }
 
-    pub fn config(&self) -> &crate::config::LoongClawConfig {
+    pub fn config(&self) -> &crate::config::LoongConfig {
         &self.config
     }
 
@@ -307,6 +309,7 @@ impl TurnExecutionService {
         let ingress = options.ingress;
         let provenance = options.provenance;
         let provider_error_mode = options.provider_error_mode;
+        let retry_progress = options.retry_progress;
         let initialize_runtime_environment = self.initialize_runtime_environment;
 
         Box::pin(async move {
@@ -336,6 +339,7 @@ impl TurnExecutionService {
                 ingress,
                 provenance,
                 provider_error_mode,
+                retry_progress,
             };
             let runtime_service = match acp_manager {
                 Some(acp_manager) => {
@@ -388,6 +392,122 @@ impl AgentRuntime {
             .await
     }
 
+    pub(crate) async fn run_turn_with_runtime(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_context_and_manager(
+            runtime,
+            request,
+            event_sink,
+            None,
+            None,
+            AcpTurnProvenance::default(),
+            crate::conversation::ProviderErrorMode::InlineMessage,
+            None,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn run_turn_with_runtime_and_observer(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_observer_and_context(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            None,
+            AcpTurnProvenance::default(),
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn run_turn_with_runtime_and_observer_and_context(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            crate::conversation::ProviderErrorMode::InlineMessage,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_turn_with_runtime_and_observer_and_context_and_error_mode(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+        provider_error_mode: crate::conversation::ProviderErrorMode,
+    ) -> CliResult<AgentTurnResult> {
+        self.run_turn_with_runtime_and_context_and_manager(
+            runtime,
+            request,
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            provider_error_mode,
+            None,
+        )
+        .await
+    }
+
+    async fn run_turn_with_runtime_and_context_and_manager(
+        &self,
+        runtime: &crate::chat::CliTurnRuntime,
+        request: &AgentTurnRequest,
+        event_sink: Option<&dyn AcpTurnEventSink>,
+        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+        ingress: Option<&ConversationIngressContext>,
+        provenance: AcpTurnProvenance<'_>,
+        provider_error_mode: crate::conversation::ProviderErrorMode,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<AgentTurnResult> {
+        if request.message.trim().is_empty() {
+            return Err("agent runtime message must not be empty".to_owned());
+        }
+
+        let turn_options = TurnExecutionOptions {
+            event_sink,
+            observer,
+            ingress,
+            provenance,
+            provider_error_mode,
+            retry_progress: None,
+        };
+        let runtime_service = match acp_manager {
+            Some(acp_manager) => {
+                RuntimeTurnExecutionService::new(runtime).with_acp_manager(acp_manager)
+            }
+            None => RuntimeTurnExecutionService::new(runtime),
+        };
+
+        runtime_service.execute(request, turn_options).await
+    }
+
     pub async fn resume_turn(
         &self,
         config_path: Option<&str>,
@@ -415,15 +535,18 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let turn_service =
-            TurnExecutionService::new(resolved_path, config).without_runtime_environment_init();
-        let turn_options = TurnExecutionOptions {
-            event_sink,
-            ..Default::default()
-        };
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )?;
 
-        turn_service
-            .execute(session_hint, request, turn_options)
+        self.run_turn_with_runtime(&runtime, request, event_sink)
             .await
     }
 
@@ -441,18 +564,27 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let turn_service =
-            TurnExecutionService::new(resolved_path, config).without_runtime_environment_init();
-        let turn_options = TurnExecutionOptions {
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )?;
+
+        self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
+            &runtime,
+            request,
             event_sink,
             observer,
+            None,
+            AcpTurnProvenance::default(),
             provider_error_mode,
-            ..Default::default()
-        };
-
-        turn_service
-            .execute(session_hint, request, turn_options)
-            .await
+        )
+        .await
     }
 
     /// Execute a turn with a preloaded config while reusing an existing ACP
@@ -474,17 +606,28 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let turn_service = TurnExecutionService::new(resolved_path, config)
-            .with_acp_manager(acp_manager)
-            .without_runtime_environment_init();
-        let turn_options = TurnExecutionOptions {
-            event_sink,
-            ..Default::default()
-        };
+        let options = cli_chat_options_for_turn_request(request);
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            resolved_path,
+            config,
+            session_hint,
+            &options,
+            kernel_scope_for_turn_mode(request.turn_mode),
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )?;
 
-        turn_service
-            .execute(session_hint, request, turn_options)
-            .await
+        self.run_turn_with_runtime_and_context_and_manager(
+            &runtime,
+            request,
+            event_sink,
+            None,
+            None,
+            AcpTurnProvenance::default(),
+            crate::conversation::ProviderErrorMode::InlineMessage,
+            Some(acp_manager),
+        )
+        .await
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -143,11 +143,19 @@ impl<'a> RuntimeTurnExecutionService<'a> {
         }
     }
 
+    pub(crate) fn with_acp_manager(
+        mut self,
+        acp_manager: Arc<crate::acp::AcpSessionManager>,
+    ) -> Self {
+        self.acp_manager = Some(acp_manager);
+        self
+    }
+
     pub(crate) fn execute(
         &'a self,
         request: &'a AgentTurnRequest,
         options: TurnExecutionOptions<'a>,
-    ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + Send + 'a>> {
         let runtime = AgentRuntime::new();
         let event_sink = options.event_sink;
         let observer = options.observer;
@@ -203,7 +211,6 @@ impl TurnExecutionService {
         request: &'a AgentTurnRequest,
         options: TurnExecutionOptions<'a>,
     ) -> Pin<Box<dyn Future<Output = CliResult<AgentTurnResult>> + Send + 'a>> {
-        let runtime = AgentRuntime::new();
         let resolved_path = self.resolved_path.clone();
         let config = self.config.clone();
         let kernel_ctx = self.kernel_ctx.clone();
@@ -215,74 +222,41 @@ impl TurnExecutionService {
         let provider_error_mode = options.provider_error_mode;
 
         Box::pin(async move {
-            match (kernel_ctx, acp_manager) {
-                (Some(kernel_ctx), Some(acp_manager)) => {
-                    let options = cli_chat_options_for_turn_request(request);
-                    let cli_runtime =
-                        initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
-                            resolved_path,
-                            config,
-                            session_hint,
-                            &options,
-                            kernel_ctx,
-                            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-                        )?;
-                    let execution_future = runtime.run_turn_with_runtime_and_context_and_manager(
-                        &cli_runtime,
-                        request,
-                        event_sink,
-                        observer,
-                        ingress,
-                        provenance,
-                        provider_error_mode,
-                        Some(acp_manager),
-                    );
-                    let execution_future = Box::pin(execution_future);
+            let cli_options = cli_chat_options_for_turn_request(request);
+            let cli_runtime = match kernel_ctx {
+                Some(kernel_ctx) => initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
+                    resolved_path,
+                    config,
+                    session_hint,
+                    &cli_options,
+                    kernel_ctx,
+                    crate::chat::CliSessionRequirement::AllowImplicitDefault,
+                )?,
+                None => initialize_cli_turn_runtime_with_loaded_config(
+                    resolved_path,
+                    config,
+                    session_hint,
+                    &cli_options,
+                    kernel_scope_for_turn_mode(request.turn_mode),
+                    crate::chat::CliSessionRequirement::AllowImplicitDefault,
+                    true,
+                )?,
+            };
+            let turn_options = TurnExecutionOptions {
+                event_sink,
+                observer,
+                ingress,
+                provenance,
+                provider_error_mode,
+            };
+            let runtime_service = match acp_manager {
+                Some(acp_manager) => {
+                    RuntimeTurnExecutionService::new(&cli_runtime).with_acp_manager(acp_manager)
+                }
+                None => RuntimeTurnExecutionService::new(&cli_runtime),
+            };
 
-                    execution_future.await
-                }
-                (Some(kernel_ctx), None) => {
-                    let execution_future = runtime
-                        .run_turn_with_loaded_config_and_kernel_ctx_and_observer_and_context_and_error_mode(
-                        resolved_path,
-                        config,
-                        session_hint,
-                        request,
-                        event_sink,
-                        observer,
-                        ingress,
-                        provenance,
-                        provider_error_mode,
-                        kernel_ctx,
-                    );
-                    let execution_future = Box::pin(execution_future);
-
-                    execution_future.await
-                }
-                (None, Some(acp_manager)) => {
-                    runtime
-                        .run_turn_with_loaded_config_and_acp_manager(
-                            resolved_path,
-                            config,
-                            session_hint,
-                            request,
-                            event_sink,
-                            acp_manager,
-                        )
-                        .await
-                }
-                (None, None) => {
-                    runtime
-                        .run_turn_with_loaded_config(
-                            resolved_path,
-                            config,
-                            session_hint,
-                            request,
-                            event_sink,
-                        )
-                        .await
-                }
-            }
+            runtime_service.execute(request, turn_options).await
         })
     }
 }
@@ -310,43 +284,20 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime(
-            config_path,
-            session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-        )?;
+        let turn_service = load_turn_execution_service(config_path)?;
         let acp_event_printer = request
             .acp_event_stream
             .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
-        self.run_turn_with_runtime(
-            &runtime,
-            request,
-            acp_event_printer
+        let turn_options = TurnExecutionOptions {
+            event_sink: acp_event_printer
                 .as_ref()
                 .map(|printer| printer as &dyn AcpTurnEventSink),
-        )
-        .await
-    }
+            ..Default::default()
+        };
 
-    pub(crate) async fn run_turn_with_runtime(
-        &self,
-        runtime: &crate::chat::CliTurnRuntime,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-    ) -> CliResult<AgentTurnResult> {
-        self.run_turn_with_runtime_and_context_and_manager(
-            runtime,
-            request,
-            event_sink,
-            None,
-            None,
-            AcpTurnProvenance::default(),
-            crate::conversation::ProviderErrorMode::InlineMessage,
-            None,
-        )
-        .await
+        turn_service
+            .execute(session_hint, request, turn_options)
+            .await
     }
 
     async fn run_turn_with_runtime_and_context_and_manager(
@@ -476,18 +427,14 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            resolved_path,
-            config,
-            session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )?;
+        let turn_service = TurnExecutionService::new(resolved_path, config);
+        let turn_options = TurnExecutionOptions {
+            event_sink,
+            ..Default::default()
+        };
 
-        self.run_turn_with_runtime(&runtime, request, event_sink)
+        turn_service
+            .execute(session_hint, request, turn_options)
             .await
     }
 
@@ -547,68 +494,16 @@ impl AgentRuntime {
             return Err("agent runtime message must not be empty".to_owned());
         }
 
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            resolved_path,
-            config,
-            session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )?;
-
-        self.run_turn_with_runtime_and_context_and_manager(
-            &runtime,
-            request,
+        let turn_service =
+            TurnExecutionService::new(resolved_path, config).with_acp_manager(acp_manager);
+        let turn_options = TurnExecutionOptions {
             event_sink,
-            None,
-            None,
-            AcpTurnProvenance::default(),
-            crate::conversation::ProviderErrorMode::InlineMessage,
-            Some(acp_manager),
-        )
-        .await
-    }
+            ..Default::default()
+        };
 
-    pub(crate) async fn run_turn_with_loaded_config_and_kernel_ctx_and_observer_and_context_and_error_mode(
-        &self,
-        resolved_path: PathBuf,
-        config: crate::config::LoongClawConfig,
-        session_hint: Option<&str>,
-        request: &AgentTurnRequest,
-        event_sink: Option<&dyn AcpTurnEventSink>,
-        observer: Option<crate::conversation::ConversationTurnObserverHandle>,
-        ingress: Option<&ConversationIngressContext>,
-        provenance: AcpTurnProvenance<'_>,
-        provider_error_mode: crate::conversation::ProviderErrorMode,
-        kernel_ctx: crate::KernelContext,
-    ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
-            resolved_path,
-            config,
-            session_hint,
-            &options,
-            kernel_ctx,
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-        )?;
-
-        self.run_turn_with_runtime_and_context_and_manager(
-            &runtime,
-            request,
-            event_sink,
-            observer,
-            ingress,
-            provenance,
-            provider_error_mode,
-            None,
-        )
-        .await
+        turn_service
+            .execute(session_hint, request, turn_options)
+            .await
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -8,7 +8,6 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -30,8 +29,9 @@ use crate::CliResult;
     feature = "channel-imessage",
 ))]
 use crate::KernelContext;
+#[cfg(test)]
+use crate::acp::AcpConversationTurnOptions;
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -52,10 +52,9 @@ use crate::KernelContext;
     feature = "channel-whatsapp",
     feature = "channel-imessage",
 ))]
-use crate::acp::{AcpConversationTurnOptions, AcpTurnProvenance};
-use crate::config::LoongConfig;
+use crate::acp::AcpTurnProvenance;
+use crate::config::LoongClawConfig;
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -140,7 +139,6 @@ use crate::config::ResolvedWecomChannelConfig;
 use crate::config::ResolvedWhatsappChannelConfig;
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -152,11 +150,9 @@ use crate::config::ResolvedWhatsappChannelConfig;
 use crate::conversation::{
     ConversationIngressChannel, ConversationIngressContext, ConversationIngressDelivery,
     ConversationIngressDeliveryResource, ConversationIngressFeishuCallbackContext,
-    ConversationIngressPrivateContext, ConversationRuntime, ConversationRuntimeBinding,
-    DefaultConversationRuntime,
+    ConversationIngressPrivateContext, ConversationSessionAddress,
 };
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -165,13 +161,29 @@ use crate::conversation::{
     feature = "channel-whatsapp",
     feature = "channel-webhook",
 ))]
+#[cfg(test)]
+use crate::conversation::{ConversationRuntime, ConversationRuntimeBinding};
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp",
+))]
+#[cfg(test)]
 use crate::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom"
+))]
+use super::access_policy::ChannelInboundAccessPolicy;
 pub(super) use super::commands::{
     ChannelCommandContext, ChannelSendCommandSpec, run_channel_send_command,
 };
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -209,29 +221,11 @@ use super::registry::{
     CHANNEL_OPERATION_SERVE_ID, FEISHU_COMMAND_FAMILY_DESCRIPTOR, MATRIX_COMMAND_FAMILY_DESCRIPTOR,
     WECOM_COMMAND_FAMILY_DESCRIPTOR,
 };
-#[cfg(not(any(
-    feature = "channel-plugin-bridge",
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-)))]
-use super::runtime::serve::ChannelServeStopHandle;
-#[cfg(any(
-    feature = "channel-plugin-bridge",
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-))]
 use super::runtime::serve::{
     ChannelServeRuntimeSpec, ChannelServeStopHandle, with_channel_serve_runtime_with_stop,
 };
 use super::runtime::state;
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -243,7 +237,6 @@ use super::runtime::state;
 ))]
 use super::runtime::turn_feedback::ChannelTurnFeedbackCapture;
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -273,30 +266,12 @@ use super::wecom;
 use super::whatsapp;
 
 use super::runtime::state::ChannelOperationRuntime;
-use super::types::FeishuChannelSendRequest;
-#[cfg(any(
-    feature = "channel-plugin-bridge",
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-))]
 use super::types::{
     ChannelAdapter, ChannelDeliveryFeishuCallback, ChannelDeliveryResource, ChannelInboundMessage,
     ChannelOutboundTargetKind, ChannelPlatform, ChannelSendReceipt, ChannelSession,
+    FeishuChannelSendRequest,
 };
-#[cfg(not(any(
-    feature = "channel-plugin-bridge",
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-    feature = "channel-whatsapp"
-)))]
-use super::types::{ChannelOutboundTargetKind, ChannelPlatform, ChannelSendReceipt};
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -305,14 +280,10 @@ use super::types::{ChannelOutboundTargetKind, ChannelPlatform, ChannelSendReceip
     feature = "channel-whatsapp",
     feature = "channel-webhook",
 ))]
-use super::types::{ChannelResolvedAcpTurnHints, process_channel_batch};
-#[cfg(any(
-    feature = "channel-telegram",
-    feature = "channel-feishu",
-    feature = "channel-matrix",
-    feature = "channel-wecom",
-))]
-use super::types::{KnownChannelSessionSendTarget, parse_known_channel_session_send_target};
+use super::types::{
+    ChannelResolvedAcpTurnHints, KnownChannelSessionSendTarget,
+    parse_known_channel_session_send_target, process_channel_batch,
+};
 
 #[cfg(any(
     feature = "channel-dingtalk",
@@ -3024,10 +2995,14 @@ pub(crate) async fn send_text_to_known_session(
                             .to_owned(),
                     );
                 }
-                if !crate::channel::feishu::feishu_allowlist_allows_chat(
-                    &resolved.allowed_chat_ids,
-                    &conversation_id,
-                ) {
+                let access_policy = ChannelInboundAccessPolicy::from_string_lists(
+                    resolved.allowed_chat_ids.as_slice(),
+                    resolved.allowed_sender_ids.as_slice(),
+                    true,
+                );
+                let target_allowed =
+                    access_policy.allows_conversation_str(conversation_id.as_str());
+                if !target_allowed {
                     return Err(format!(
                         "sessions_send_target_not_allowed: feishu target `{conversation_id}` is not present in feishu.allowed_chat_ids"
                     ));
@@ -3245,7 +3220,6 @@ pub(crate) async fn send_text_to_known_session(
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3254,58 +3228,65 @@ pub(crate) async fn send_text_to_known_session(
     feature = "channel-whatsapp",
     feature = "channel-webhook"
 ))]
-#[cfg_attr(not(test), allow(dead_code))]
-pub async fn process_inbound_with_runtime_and_feedback<R: ConversationRuntime + ?Sized>(
-    config: &LoongConfig,
-    runtime: &R,
-    message: &ChannelInboundMessage,
-    binding: ConversationRuntimeBinding<'_>,
-    feedback_policy: ChannelTurnFeedbackPolicy,
-) -> CliResult<String> {
-    process_inbound_with_runtime_and_feedback_and_error_mode(
-        config,
-        runtime,
-        message,
-        binding,
-        feedback_policy,
-        ProviderErrorMode::Propagate,
-        None,
-    )
-    .await
+struct PreparedChannelInboundTurn {
+    address: ConversationSessionAddress,
+    acp_turn_hints: ChannelResolvedAcpTurnHints,
+    ingress: Option<ConversationIngressContext>,
+    feedback_capture: ChannelTurnFeedbackCapture,
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
-    feature = "channel-line",
     feature = "channel-matrix",
     feature = "channel-wecom",
-    feature = "channel-whatsapp",
-    feature = "channel-webhook"
+    feature = "channel-whatsapp"
 ))]
-pub async fn process_inbound_with_runtime_and_feedback_and_error_mode<
-    R: ConversationRuntime + ?Sized,
->(
-    config: &LoongConfig,
+fn prepare_channel_inbound_turn(
+    config: &LoongClawConfig,
+    message: &ChannelInboundMessage,
+    feedback_policy: ChannelTurnFeedbackPolicy,
+) -> CliResult<PreparedChannelInboundTurn> {
+    let address = message.session.conversation_address();
+    let acp_turn_hints = resolve_channel_acp_turn_hints(config, &message.session)?;
+    let ingress = channel_message_ingress_context(message);
+    let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
+
+    Ok(PreparedChannelInboundTurn {
+        address,
+        acp_turn_hints,
+        ingress,
+        feedback_capture,
+    })
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp"
+))]
+#[cfg(test)]
+pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
     runtime: &R,
     message: &ChannelInboundMessage,
     binding: ConversationRuntimeBinding<'_>,
     feedback_policy: ChannelTurnFeedbackPolicy,
-    error_mode: ProviderErrorMode,
-    retry_progress: crate::provider::ProviderRetryProgressCallback,
 ) -> CliResult<String> {
-    let address = message.session.conversation_address();
-    let acp_turn_hints = resolve_channel_acp_turn_hints(config, &message.session)?;
+    let prepared = prepare_channel_inbound_turn(config, message, feedback_policy)?;
+    let address = prepared.address;
+    let acp_turn_hints = prepared.acp_turn_hints;
+    let ingress = prepared.ingress;
+    let feedback_capture = prepared.feedback_capture;
     let acp_options = AcpConversationTurnOptions::automatic()
         .with_additional_bootstrap_mcp_servers(&acp_turn_hints.bootstrap_mcp_servers)
         .with_working_directory(acp_turn_hints.working_directory.as_deref())
         .with_provenance(channel_message_acp_turn_provenance(message));
-    let ingress = channel_message_ingress_context(message);
-    let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
     let observer = feedback_capture.observer_handle();
     let reply = ConversationTurnCoordinator::new()
-        .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        .handle_production_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
             config,
             &address,
             &message.text,
@@ -3322,7 +3303,6 @@ pub async fn process_inbound_with_runtime_and_feedback_and_error_mode<
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3331,8 +3311,16 @@ pub async fn process_inbound_with_runtime_and_feedback_and_error_mode<
     feature = "channel-whatsapp",
     feature = "channel-webhook"
 ))]
-pub async fn process_inbound_with_provider(
-    config: &LoongConfig,
+/// Bridge an inbound channel message into the shared chat/provider turn
+/// runtime.
+///
+/// Unlike the CLI entrypoints, channel surfaces already own the surrounding
+/// kernel authority for the serve loop. This helper therefore reloads
+/// provider-facing config, derives channel-specific ACP hints, reuses the
+/// supplied `kernel_ctx`, and assembles a one-shot chat runtime around the
+/// channel session address before handing execution to `AgentRuntime`.
+pub(crate) async fn process_inbound_with_provider(
+    config: &LoongClawConfig,
     resolved_path: Option<&std::path::Path>,
     message: &ChannelInboundMessage,
     kernel_ctx: &KernelContext,
@@ -3403,8 +3391,11 @@ pub async fn process_inbound_with_provider_and_error_mode(
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
         Ok(turn_config) => {
-            let address = message.session.conversation_address();
-            let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
+            let prepared = prepare_channel_inbound_turn(&turn_config, message, feedback_policy)?;
+            let address = prepared.address;
+            let acp_turn_hints = prepared.acp_turn_hints;
+            let ingress = prepared.ingress;
+            let feedback_capture = prepared.feedback_capture;
             let request = crate::agent_runtime::AgentTurnRequest {
                 message: message.text.clone(),
                 turn_mode: crate::agent_runtime::AgentTurnMode::Oneshot,
@@ -3423,8 +3414,6 @@ pub async fn process_inbound_with_provider_and_error_mode(
             let resolved_turn_path = resolved_path
                 .map(std::path::Path::to_path_buf)
                 .unwrap_or_default();
-            let ingress = channel_message_ingress_context(message);
-            let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
             let observer = feedback_capture.observer_handle();
             let turn_service =
                 crate::agent_runtime::TurnExecutionService::new(resolved_turn_path, turn_config)
@@ -3527,7 +3516,6 @@ pub async fn process_inbound_with_provider_and_error_mode(
 /// mutate the long-lived channel loop state; it only refreshes the provider
 /// data that turn execution depends on.
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3536,8 +3524,8 @@ pub async fn process_inbound_with_provider_and_error_mode(
     feature = "channel-whatsapp",
     feature = "channel-webhook"
 ))]
-pub fn reload_channel_turn_config(
-    config: &LoongConfig,
+pub(super) fn reload_channel_turn_config(
+    config: &LoongClawConfig,
     resolved_path: Option<&std::path::Path>,
 ) -> CliResult<LoongConfig> {
     match resolved_path {
@@ -3547,7 +3535,6 @@ pub fn reload_channel_turn_config(
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3607,16 +3594,12 @@ fn resolve_channel_acp_turn_hints(
             })
         }
         ChannelPlatform::Webhook => Ok(ChannelResolvedAcpTurnHints::default()),
-        ChannelPlatform::Weixin => Ok(ChannelResolvedAcpTurnHints::default()),
-        ChannelPlatform::Qqbot => Ok(ChannelResolvedAcpTurnHints::default()),
-        ChannelPlatform::Onebot => Ok(ChannelResolvedAcpTurnHints::default()),
         ChannelPlatform::WhatsApp => Ok(ChannelResolvedAcpTurnHints::default()),
         ChannelPlatform::Irc => Ok(ChannelResolvedAcpTurnHints::default()),
     }
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3635,7 +3618,6 @@ fn channel_message_acp_turn_provenance(message: &ChannelInboundMessage) -> AcpTu
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3696,7 +3678,6 @@ pub(super) fn channel_message_ingress_context(
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3713,7 +3694,6 @@ fn trimmed_non_empty(value: Option<&str>) -> Option<String> {
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3739,7 +3719,6 @@ fn normalized_channel_delivery_resource(
 }
 
 #[cfg(any(
-    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3774,7 +3753,12 @@ fn normalized_feishu_callback_context(
 pub(super) fn validate_telegram_security_config(
     config: &ResolvedTelegramChannelConfig,
 ) -> CliResult<()> {
-    if config.allowed_chat_ids.is_empty() {
+    let access_policy = ChannelInboundAccessPolicy::from_i64_lists(
+        config.allowed_chat_ids.as_slice(),
+        config.allowed_sender_ids.as_slice(),
+    );
+    let has_allowlist = access_policy.has_conversation_restrictions();
+    if !has_allowlist {
         return Err(
             "telegram.allowed_chat_ids is empty; configure at least one trusted chat id".to_owned(),
         );
@@ -3786,10 +3770,12 @@ pub(super) fn validate_telegram_security_config(
 pub(super) fn validate_feishu_security_config(
     config: &ResolvedFeishuChannelConfig,
 ) -> CliResult<()> {
-    let has_allowlist = config
-        .allowed_chat_ids
-        .iter()
-        .any(|value| !value.trim().is_empty());
+    let access_policy = ChannelInboundAccessPolicy::from_string_lists(
+        config.allowed_chat_ids.as_slice(),
+        config.allowed_sender_ids.as_slice(),
+        true,
+    );
+    let has_allowlist = access_policy.has_conversation_restrictions();
     if !has_allowlist {
         return Err(
             "feishu.allowed_chat_ids is empty; configure at least one trusted chat id".to_owned(),
@@ -3826,10 +3812,12 @@ pub(super) fn validate_feishu_security_config(
 pub(super) fn validate_matrix_security_config(
     config: &ResolvedMatrixChannelConfig,
 ) -> CliResult<()> {
-    let has_allowlist = config
-        .allowed_room_ids
-        .iter()
-        .any(|value| !value.trim().is_empty());
+    let access_policy = ChannelInboundAccessPolicy::from_string_lists(
+        config.allowed_room_ids.as_slice(),
+        config.allowed_sender_ids.as_slice(),
+        false,
+    );
+    let has_allowlist = access_policy.has_conversation_restrictions();
     if !has_allowlist {
         return Err(
             "matrix.allowed_room_ids is empty; configure at least one trusted room id".to_owned(),
@@ -3860,16 +3848,24 @@ pub(super) fn validate_matrix_security_config(
                 .to_owned(),
         );
     }
+    if config.require_mention && !has_user_id {
+        return Err(
+            "matrix.user_id is missing; configure user_id when require_mention is enabled"
+                .to_owned(),
+        );
+    }
 
     Ok(())
 }
 
 #[cfg(feature = "channel-wecom")]
 pub(super) fn validate_wecom_security_config(config: &ResolvedWecomChannelConfig) -> CliResult<()> {
-    let has_allowlist = config
-        .allowed_conversation_ids
-        .iter()
-        .any(|value| !value.trim().is_empty());
+    let access_policy = ChannelInboundAccessPolicy::from_string_lists(
+        config.allowed_conversation_ids.as_slice(),
+        config.allowed_sender_ids.as_slice(),
+        false,
+    );
+    let has_allowlist = access_policy.has_conversation_restrictions();
     if !has_allowlist {
         return Err(
             "wecom.allowed_conversation_ids is empty; configure at least one trusted conversation id"

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -8,6 +8,7 @@ use tokio::time::sleep;
 
 use crate::CliResult;
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -32,6 +33,7 @@ use crate::KernelContext;
 #[cfg(test)]
 use crate::acp::AcpConversationTurnOptions;
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -55,6 +57,7 @@ use crate::acp::AcpConversationTurnOptions;
 use crate::acp::AcpTurnProvenance;
 use crate::config::LoongClawConfig;
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -78,6 +81,7 @@ use crate::config::LoongClawConfig;
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "channel-dingtalk",
@@ -139,6 +143,7 @@ use crate::config::ResolvedWecomChannelConfig;
 use crate::config::ResolvedWhatsappChannelConfig;
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -153,6 +158,7 @@ use crate::conversation::{
     ConversationIngressPrivateContext, ConversationSessionAddress,
 };
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -164,6 +170,7 @@ use crate::conversation::{
 #[cfg(test)]
 use crate::conversation::{ConversationRuntime, ConversationRuntimeBinding};
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-matrix",
@@ -174,6 +181,7 @@ use crate::conversation::{ConversationRuntime, ConversationRuntimeBinding};
 use crate::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-matrix",
@@ -184,6 +192,7 @@ pub(super) use super::commands::{
     ChannelCommandContext, ChannelSendCommandSpec, run_channel_send_command,
 };
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -226,6 +235,7 @@ use super::runtime::serve::{
 };
 use super::runtime::state;
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -237,6 +247,7 @@ use super::runtime::state;
 ))]
 use super::runtime::turn_feedback::ChannelTurnFeedbackCapture;
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -272,6 +283,7 @@ use super::types::{
     FeishuChannelSendRequest,
 };
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -286,6 +298,7 @@ use super::types::{
 };
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-dingtalk",
     feature = "channel-webhook",
     feature = "channel-google-chat",
@@ -298,6 +311,7 @@ enum EndpointBackedSendTargetSource {
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-dingtalk",
     feature = "channel-webhook",
     feature = "channel-google-chat",
@@ -310,6 +324,7 @@ struct EndpointBackedSendTarget {
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-dingtalk",
     feature = "channel-webhook",
     feature = "channel-google-chat",
@@ -2408,6 +2423,7 @@ pub async fn run_feishu_channel_with_stop(
 
 #[doc(hidden)]
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -2907,6 +2923,7 @@ pub async fn run_background_channel_with_stop(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -2995,13 +3012,10 @@ pub(crate) async fn send_text_to_known_session(
                             .to_owned(),
                     );
                 }
-                let access_policy = ChannelInboundAccessPolicy::from_string_lists(
-                    resolved.allowed_chat_ids.as_slice(),
-                    resolved.allowed_sender_ids.as_slice(),
-                    true,
+                let target_allowed = crate::channel::feishu::feishu_allowlist_allows_chat(
+                    resolved.allowed_chat_ids.iter(),
+                    conversation_id.as_str(),
                 );
-                let target_allowed =
-                    access_policy.allows_conversation_str(conversation_id.as_str());
                 if !target_allowed {
                     return Err(format!(
                         "sessions_send_target_not_allowed: feishu target `{conversation_id}` is not present in feishu.allowed_chat_ids"
@@ -3220,6 +3234,7 @@ pub(crate) async fn send_text_to_known_session(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3236,6 +3251,7 @@ struct PreparedChannelInboundTurn {
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-matrix",
@@ -3261,6 +3277,7 @@ fn prepare_channel_inbound_turn(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-matrix",
@@ -3303,6 +3320,7 @@ pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRun
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3319,7 +3337,7 @@ pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRun
 /// provider-facing config, derives channel-specific ACP hints, reuses the
 /// supplied `kernel_ctx`, and assembles a one-shot chat runtime around the
 /// channel session address before handing execution to `AgentRuntime`.
-pub(crate) async fn process_inbound_with_provider(
+pub async fn process_inbound_with_provider(
     config: &LoongClawConfig,
     resolved_path: Option<&std::path::Path>,
     message: &ChannelInboundMessage,
@@ -3516,6 +3534,7 @@ pub async fn process_inbound_with_provider_and_error_mode(
 /// mutate the long-lived channel loop state; it only refreshes the provider
 /// data that turn execution depends on.
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3535,6 +3554,7 @@ pub(super) fn reload_channel_turn_config(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3594,12 +3614,16 @@ fn resolve_channel_acp_turn_hints(
             })
         }
         ChannelPlatform::Webhook => Ok(ChannelResolvedAcpTurnHints::default()),
+        ChannelPlatform::Weixin => Ok(ChannelResolvedAcpTurnHints::default()),
+        ChannelPlatform::Qqbot => Ok(ChannelResolvedAcpTurnHints::default()),
+        ChannelPlatform::Onebot => Ok(ChannelResolvedAcpTurnHints::default()),
         ChannelPlatform::WhatsApp => Ok(ChannelResolvedAcpTurnHints::default()),
         ChannelPlatform::Irc => Ok(ChannelResolvedAcpTurnHints::default()),
     }
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3618,6 +3642,7 @@ fn channel_message_acp_turn_provenance(message: &ChannelInboundMessage) -> AcpTu
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3678,6 +3703,7 @@ pub(super) fn channel_message_ingress_context(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3694,6 +3720,7 @@ fn trimmed_non_empty(value: Option<&str>) -> Option<String> {
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",
@@ -3719,6 +3746,7 @@ fn normalized_channel_delivery_resource(
 }
 
 #[cfg(any(
+    feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
     feature = "channel-line",

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -273,9 +273,15 @@ use super::wecom;
 use super::whatsapp;
 
 use super::runtime::state::ChannelOperationRuntime;
-#[cfg(any(feature = "channel-telegram", feature = "channel-matrix"))]
-use super::types::ChannelProcessFuture;
 use super::types::FeishuChannelSendRequest;
+#[cfg(any(
+    feature = "channel-plugin-bridge",
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp"
+))]
 use super::types::{
     ChannelAdapter, ChannelDeliveryFeishuCallback, ChannelDeliveryResource, ChannelInboundMessage,
     ChannelOutboundTargetKind, ChannelPlatform, ChannelSendReceipt, ChannelSession,
@@ -318,26 +324,6 @@ use super::types::{KnownChannelSessionSendTarget, parse_known_channel_session_se
 enum EndpointBackedSendTargetSource {
     CliTarget,
     ConfiguredEndpoint,
-}
-
-#[cfg(any(feature = "channel-telegram", feature = "channel-matrix"))]
-fn process_inbound_with_provider_future(
-    config: LoongConfig,
-    resolved_path: PathBuf,
-    message: ChannelInboundMessage,
-    kernel_ctx: Arc<crate::KernelContext>,
-    turn_feedback_policy: ChannelTurnFeedbackPolicy,
-) -> ChannelProcessFuture {
-    Box::pin(async move {
-        Box::pin(process_inbound_with_provider(
-            &config,
-            Some(resolved_path.as_path()),
-            &message,
-            kernel_ctx.as_ref(),
-            turn_feedback_policy,
-        ))
-        .await
-    })
 }
 
 #[cfg(any(
@@ -1025,116 +1011,118 @@ fn build_nostr_command_context(
 
 #[cfg(feature = "channel-telegram")]
 #[allow(clippy::print_stdout)] // CLI startup banner
-fn run_telegram_channel_with_context(
+async fn run_telegram_channel_with_context(
     context: ChannelCommandContext<ResolvedTelegramChannelConfig>,
     once: bool,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    Box::pin(async move {
-        validate_telegram_security_config(&context.resolved)?;
-        if initialize_runtime_environment {
-            crate::runtime_env::initialize_runtime_environment(
-                &context.config,
-                Some(context.resolved_path.as_path()),
-            );
-        }
-        let kernel_ctx = bootstrap_kernel_context_with_config(
-            "channel-telegram",
-            DEFAULT_TOKEN_TTL_S,
+) -> CliResult<()> {
+    validate_telegram_security_config(&context.resolved)?;
+    if initialize_runtime_environment {
+        crate::runtime_env::initialize_runtime_environment(
             &context.config,
-        )?;
-        let token = context.resolved.bot_token().ok_or_else(|| {
-            "telegram bot token missing (set telegram.bot_token or env)".to_owned()
-        })?;
-        let route = context.route.clone();
-        let resolved_path = context.resolved_path.clone();
-        let resolved = context.resolved.clone();
-        let batch_config = context.config.clone();
-        let batch_kernel_ctx = Arc::new(crate::KernelContext {
-            kernel: kernel_ctx.kernel.clone(),
-            token: kernel_ctx.token.clone(),
-        });
-        let runtime_account_id = resolved.account.id.clone();
-        let runtime_account_label = resolved.account.label.clone();
+            Some(context.resolved_path.as_path()),
+        );
+    }
+    let kernel_ctx = bootstrap_kernel_context_with_config(
+        "channel-telegram",
+        DEFAULT_TOKEN_TTL_S,
+        &context.config,
+    )?;
+    let token = context
+        .resolved
+        .bot_token()
+        .ok_or_else(|| "telegram bot token missing (set telegram.bot_token or env)".to_owned())?;
+    let route = context.route.clone();
+    let resolved_path = context.resolved_path.clone();
+    let resolved = context.resolved.clone();
+    let batch_config = context.config.clone();
+    let batch_kernel_ctx = Arc::new(crate::KernelContext {
+        kernel: kernel_ctx.kernel.clone(),
+        token: kernel_ctx.token.clone(),
+    });
+    let runtime_account_id = resolved.account.id.clone();
+    let runtime_account_label = resolved.account.label.clone();
 
-        Box::pin(with_channel_serve_runtime_with_stop(
-            ChannelServeRuntimeSpec {
-                platform: ChannelPlatform::Telegram,
-                operation_id: CHANNEL_OPERATION_SERVE_ID,
-                account_id: runtime_account_id.as_str(),
-                account_label: runtime_account_label.as_str(),
-            },
-            stop,
-            move |runtime, stop| async move {
-                let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
-                context.emit_route_notice("telegram");
+    with_channel_serve_runtime_with_stop(
+        ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Telegram,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id: runtime_account_id.as_str(),
+            account_label: runtime_account_label.as_str(),
+        },
+        stop,
+        move |runtime, stop| async move {
+            let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
+            context.emit_route_notice("telegram");
 
-                println!(
-                    "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
-                    adapter.name(),
-                    resolved_path.display(),
-                    resolved.configured_account_id,
-                    resolved.account.label,
-                    route.selected_by_default(),
-                    route.default_account_source.as_str(),
-                    resolved.polling_timeout_s
-                );
+            println!(
+                "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
+                adapter.name(),
+                resolved_path.display(),
+                resolved.configured_account_id,
+                resolved.account.label,
+                route.selected_by_default(),
+                route.default_account_source.as_str(),
+                resolved.polling_timeout_s
+            );
 
-                loop {
-                    let batch = tokio::select! {
-                        _ = stop.wait() => break,
-                        batch = adapter.receive_batch() => batch?,
-                    };
-                    let config = batch_config.clone();
-                    let kernel_ctx = batch_kernel_ctx.clone();
-                    let had_messages = process_channel_batch(
-                        &mut adapter,
-                        batch,
-                        Some(runtime.as_ref()),
-                        |message, turn_feedback_policy| {
-                            process_inbound_with_provider_future(
-                                config.clone(),
-                                resolved_path.clone(),
-                                message,
-                                kernel_ctx.clone(),
+            loop {
+                let batch = tokio::select! {
+                    _ = stop.wait() => break,
+                    batch = adapter.receive_batch() => batch?,
+                };
+                let config = batch_config.clone();
+                let kernel_ctx = batch_kernel_ctx.clone();
+                let had_messages = process_channel_batch(
+                    &mut adapter,
+                    batch,
+                    Some(runtime.as_ref()),
+                    |message, turn_feedback_policy| {
+                        let config = config.clone();
+                        let kernel_ctx = kernel_ctx.clone();
+                        let resolved_path = resolved_path.clone();
+                        Box::pin(async move {
+                            process_inbound_with_provider(
+                                &config,
+                                Some(resolved_path.as_path()),
+                                &message,
+                                kernel_ctx.as_ref(),
                                 turn_feedback_policy,
                             )
-                        },
-                    )
-                    .await?;
-                    if !had_messages && once {
-                        break;
-                    }
-                    if once {
-                        break;
-                    }
-                    tokio::select! {
-                        _ = stop.wait() => break,
-                        _ = sleep(Duration::from_millis(250)) => {}
-                    }
+                            .await
+                        })
+                    },
+                )
+                .await?;
+                if !had_messages && once {
+                    break;
                 }
-                Ok(())
-            },
-        ))
-        .await
-    })
+                if once {
+                    break;
+                }
+                tokio::select! {
+                    _ = stop.wait() => break,
+                    _ = sleep(Duration::from_millis(250)) => {}
+                }
+            }
+            Ok(())
+        },
+    )
+    .await
 }
 
 #[cfg(feature = "channel-telegram")]
-pub fn run_telegram_channel_with_stop(
+pub async fn run_telegram_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongConfig,
     once: bool,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    let account_id = account_id.map(str::to_owned);
-    Box::pin(async move {
-        let context = build_telegram_command_context(resolved_path, config, account_id.as_deref())?;
-        run_telegram_channel_with_context(context, once, stop, initialize_runtime_environment).await
-    })
+) -> CliResult<()> {
+    let context = build_telegram_command_context(resolved_path, config, account_id)?;
+    run_telegram_channel_with_context(context, once, stop, initialize_runtime_environment).await
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -1603,13 +1591,13 @@ pub async fn run_whatsapp_channel(
     #[cfg(feature = "channel-whatsapp")]
     {
         let context = load_whatsapp_command_context(config_path, account_id)?;
-        Box::pin(whatsapp::run_whatsapp_channel_with_context(
+        whatsapp::run_whatsapp_channel_with_context(
             context,
             bind_override,
             path_override,
             ChannelServeStopHandle::new(),
             true,
-        ))
+        )
         .await
     }
 }
@@ -1622,13 +1610,13 @@ pub async fn run_whatsapp_channel_with_stop(
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
 ) -> CliResult<()> {
-    Box::pin(whatsapp::run_whatsapp_channel_with_stop(
+    whatsapp::run_whatsapp_channel_with_stop(
         resolved_path,
         config,
         account_id,
         stop,
         initialize_runtime_environment,
-    ))
+    )
     .await
 }
 
@@ -2236,13 +2224,7 @@ pub async fn run_telegram_channel(
     #[cfg(feature = "channel-telegram")]
     {
         let context = load_telegram_command_context(config_path, account_id)?;
-        Box::pin(run_telegram_channel_with_context(
-            context,
-            once,
-            ChannelServeStopHandle::new(),
-            true,
-        ))
-        .await
+        run_telegram_channel_with_context(context, once, ChannelServeStopHandle::new(), true).await
     }
 }
 
@@ -2378,28 +2360,28 @@ pub async fn run_feishu_channel(
     #[cfg(feature = "channel-feishu")]
     {
         let context = load_feishu_command_context(config_path, account_id)?;
-        Box::pin(run_feishu_channel_with_context(
+        run_feishu_channel_with_context(
             context,
             bind_override,
             path_override,
             ChannelServeStopHandle::new(),
             true,
-        ))
+        )
         .await
     }
 }
 
 #[cfg(feature = "channel-feishu")]
-fn run_feishu_channel_with_context(
+async fn run_feishu_channel_with_context(
     context: ChannelCommandContext<ResolvedFeishuChannelConfig>,
     bind_override: Option<&str>,
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+) -> CliResult<()> {
     let bind_override = bind_override.map(str::to_owned);
     let path_override = path_override.map(str::to_owned);
-    Box::pin(run_channel_serve_command_with_stop(
+    run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: FEISHU_COMMAND_FAMILY_DESCRIPTOR,
@@ -2413,7 +2395,7 @@ fn run_feishu_channel_with_context(
                 let resolved_path = context.resolved_path.clone();
                 let resolved = context.resolved.clone();
                 let config = context.config.clone();
-                Box::pin(feishu::run_feishu_channel(
+                feishu::run_feishu_channel(
                     &config,
                     &resolved,
                     &resolved_path,
@@ -2424,15 +2406,16 @@ fn run_feishu_channel_with_context(
                     kernel_ctx,
                     runtime,
                     stop,
-                ))
+                )
                 .await
             })
         },
-    ))
+    )
+    .await
 }
 
 #[cfg(feature = "channel-feishu")]
-pub fn run_feishu_channel_with_stop(
+pub async fn run_feishu_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongConfig,
     account_id: Option<&str>,
@@ -2440,21 +2423,16 @@ pub fn run_feishu_channel_with_stop(
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    let account_id = account_id.map(str::to_owned);
-    let bind_override = bind_override.map(str::to_owned);
-    let path_override = path_override.map(str::to_owned);
-    Box::pin(async move {
-        let context = build_feishu_command_context(resolved_path, config, account_id.as_deref())?;
-        run_feishu_channel_with_context(
-            context,
-            bind_override.as_deref(),
-            path_override.as_deref(),
-            stop,
-            initialize_runtime_environment,
-        )
-        .await
-    })
+) -> CliResult<()> {
+    let context = build_feishu_command_context(resolved_path, config, account_id)?;
+    run_feishu_channel_with_context(
+        context,
+        bind_override,
+        path_override,
+        stop,
+        initialize_runtime_environment,
+    )
+    .await
 }
 
 #[doc(hidden)]
@@ -2587,25 +2565,19 @@ pub async fn run_matrix_channel(
     #[cfg(feature = "channel-matrix")]
     {
         let context = load_matrix_command_context(config_path, account_id)?;
-        Box::pin(run_matrix_channel_with_context(
-            context,
-            once,
-            ChannelServeStopHandle::new(),
-            true,
-        ))
-        .await
+        run_matrix_channel_with_context(context, once, ChannelServeStopHandle::new(), true).await
     }
 }
 
 #[cfg(feature = "channel-matrix")]
 #[allow(clippy::print_stdout)]
-fn run_matrix_channel_with_context(
+async fn run_matrix_channel_with_context(
     context: ChannelCommandContext<ResolvedMatrixChannelConfig>,
     once: bool,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    Box::pin(run_channel_serve_command_with_stop(
+) -> CliResult<()> {
+    run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: MATRIX_COMMAND_FAMILY_DESCRIPTOR,
@@ -2652,13 +2624,16 @@ fn run_matrix_channel_with_context(
                             let config = config.clone();
                             let kernel_ctx = batch_kernel_ctx.clone();
                             let resolved_path = resolved_path.clone();
-                            process_inbound_with_provider_future(
-                                config,
-                                resolved_path,
-                                message,
-                                kernel_ctx,
-                                turn_feedback_policy,
-                            )
+                            Box::pin(async move {
+                                process_inbound_with_provider(
+                                    &config,
+                                    Some(resolved_path.as_path()),
+                                    &message,
+                                    kernel_ctx.as_ref(),
+                                    turn_feedback_policy,
+                                )
+                                .await
+                            })
                         },
                     )
                     .await?;
@@ -2672,23 +2647,21 @@ fn run_matrix_channel_with_context(
                 Ok(())
             })
         },
-    ))
+    )
+    .await
 }
 
 #[cfg(feature = "channel-matrix")]
-pub fn run_matrix_channel_with_stop(
+pub async fn run_matrix_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongConfig,
     once: bool,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    let account_id = account_id.map(str::to_owned);
-    Box::pin(async move {
-        let context = build_matrix_command_context(resolved_path, config, account_id.as_deref())?;
-        run_matrix_channel_with_context(context, once, stop, initialize_runtime_environment).await
-    })
+) -> CliResult<()> {
+    let context = build_matrix_command_context(resolved_path, config, account_id)?;
+    run_matrix_channel_with_context(context, once, stop, initialize_runtime_environment).await
 }
 
 #[allow(clippy::print_stdout)]
@@ -2764,22 +2737,17 @@ pub async fn run_wecom_channel(
     #[cfg(feature = "channel-wecom")]
     {
         let context = load_wecom_command_context(config_path, account_id)?;
-        Box::pin(run_wecom_channel_with_context(
-            context,
-            ChannelServeStopHandle::new(),
-            true,
-        ))
-        .await
+        run_wecom_channel_with_context(context, ChannelServeStopHandle::new(), true).await
     }
 }
 
 #[cfg(feature = "channel-wecom")]
-fn run_wecom_channel_with_context(
+async fn run_wecom_channel_with_context(
     context: ChannelCommandContext<ResolvedWecomChannelConfig>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    Box::pin(run_channel_serve_command_with_stop(
+) -> CliResult<()> {
+    run_channel_serve_command_with_stop(
         context,
         ChannelServeCommandSpec {
             family: WECOM_COMMAND_FAMILY_DESCRIPTOR,
@@ -2793,7 +2761,7 @@ fn run_wecom_channel_with_context(
                 let resolved_path = context.resolved_path.clone();
                 let resolved = context.resolved.clone();
                 let config = context.config.clone();
-                Box::pin(wecom::run_wecom_channel(
+                wecom::run_wecom_channel(
                     &config,
                     &resolved,
                     &resolved_path,
@@ -2802,57 +2770,47 @@ fn run_wecom_channel_with_context(
                     kernel_ctx,
                     runtime,
                     stop,
-                ))
+                )
                 .await
             })
         },
-    ))
+    )
+    .await
 }
 
 #[cfg(feature = "channel-wecom")]
-pub fn run_wecom_channel_with_stop(
+pub async fn run_wecom_channel_with_stop(
     resolved_path: PathBuf,
     config: LoongConfig,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
-    let account_id = account_id.map(str::to_owned);
-    Box::pin(async move {
-        let context = build_wecom_command_context(resolved_path, config, account_id.as_deref())?;
-        run_wecom_channel_with_context(context, stop, initialize_runtime_environment).await
-    })
+) -> CliResult<()> {
+    let context = build_wecom_command_context(resolved_path, config, account_id)?;
+    run_wecom_channel_with_context(context, stop, initialize_runtime_environment).await
 }
 
-/// Keep this as a plain dispatcher that returns boxed per-channel futures.
-///
-/// A monolithic `async fn` match across every compiled background channel can
-/// produce one very large debug-only state machine. Returning boxed branch
-/// futures keeps the dispatch frame shallow and prevents multi-channel serve
-/// startup from consuming excessive Tokio worker stack.
-pub fn run_background_channel_with_stop(
+pub async fn run_background_channel_with_stop(
     channel_id: &str,
     resolved_path: PathBuf,
-    config: LoongConfig,
-    account_id: Option<String>,
+    config: LoongClawConfig,
+    account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
-) -> crate::channel::core::types::ChannelCommandFuture<'static> {
+) -> CliResult<()> {
     match channel_id {
         "telegram" => {
             #[cfg(feature = "channel-telegram")]
             {
-                Box::pin(async move {
-                    run_telegram_channel_with_stop(
-                        resolved_path,
-                        config,
-                        false,
-                        account_id.as_deref(),
-                        stop,
-                        initialize_runtime_environment,
-                    )
-                    .await
-                })
+                return run_telegram_channel_with_stop(
+                    resolved_path,
+                    config,
+                    false,
+                    account_id,
+                    stop,
+                    initialize_runtime_environment,
+                )
+                .await;
             }
             #[cfg(not(feature = "channel-telegram"))]
             {
@@ -2863,29 +2821,24 @@ pub fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                Box::pin(async {
-                    Err(
-                        "telegram channel is disabled (enable feature `channel-telegram`)"
-                            .to_owned(),
-                    )
-                })
+                return Err(
+                    "telegram channel is disabled (enable feature `channel-telegram`)".to_owned(),
+                );
             }
         }
         "feishu" => {
             #[cfg(feature = "channel-feishu")]
             {
-                Box::pin(async move {
-                    run_feishu_channel_with_stop(
-                        resolved_path,
-                        config,
-                        account_id.as_deref(),
-                        None,
-                        None,
-                        stop,
-                        initialize_runtime_environment,
-                    )
-                    .await
-                })
+                return run_feishu_channel_with_stop(
+                    resolved_path,
+                    config,
+                    account_id,
+                    None,
+                    None,
+                    stop,
+                    initialize_runtime_environment,
+                )
+                .await;
             }
             #[cfg(not(feature = "channel-feishu"))]
             {
@@ -2896,25 +2849,23 @@ pub fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                Box::pin(async {
-                    Err("feishu channel is disabled (enable feature `channel-feishu`)".to_owned())
-                })
+                return Err(
+                    "feishu channel is disabled (enable feature `channel-feishu`)".to_owned(),
+                );
             }
         }
         "matrix" => {
             #[cfg(feature = "channel-matrix")]
             {
-                Box::pin(async move {
-                    run_matrix_channel_with_stop(
-                        resolved_path,
-                        config,
-                        false,
-                        account_id.as_deref(),
-                        stop,
-                        initialize_runtime_environment,
-                    )
-                    .await
-                })
+                return run_matrix_channel_with_stop(
+                    resolved_path,
+                    config,
+                    false,
+                    account_id,
+                    stop,
+                    initialize_runtime_environment,
+                )
+                .await;
             }
             #[cfg(not(feature = "channel-matrix"))]
             {
@@ -2925,24 +2876,22 @@ pub fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                Box::pin(async {
-                    Err("matrix channel is disabled (enable feature `channel-matrix`)".to_owned())
-                })
+                return Err(
+                    "matrix channel is disabled (enable feature `channel-matrix`)".to_owned(),
+                );
             }
         }
         "wecom" => {
             #[cfg(feature = "channel-wecom")]
             {
-                Box::pin(async move {
-                    run_wecom_channel_with_stop(
-                        resolved_path,
-                        config,
-                        account_id.as_deref(),
-                        stop,
-                        initialize_runtime_environment,
-                    )
-                    .await
-                })
+                return run_wecom_channel_with_stop(
+                    resolved_path,
+                    config,
+                    account_id,
+                    stop,
+                    initialize_runtime_environment,
+                )
+                .await;
             }
             #[cfg(not(feature = "channel-wecom"))]
             {
@@ -2953,24 +2902,20 @@ pub fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                Box::pin(async {
-                    Err("wecom channel is disabled (enable feature `channel-wecom`)".to_owned())
-                })
+                return Err("wecom channel is disabled (enable feature `channel-wecom`)".to_owned());
             }
         }
         "whatsapp" => {
             #[cfg(feature = "channel-whatsapp")]
             {
-                Box::pin(async move {
-                    run_whatsapp_channel_with_stop(
-                        resolved_path,
-                        config,
-                        account_id.as_deref(),
-                        stop,
-                        initialize_runtime_environment,
-                    )
-                    .await
-                })
+                return run_whatsapp_channel_with_stop(
+                    resolved_path,
+                    config,
+                    account_id,
+                    stop,
+                    initialize_runtime_environment,
+                )
+                .await;
             }
             #[cfg(not(feature = "channel-whatsapp"))]
             {
@@ -2981,22 +2926,12 @@ pub fn run_background_channel_with_stop(
                     stop,
                     initialize_runtime_environment,
                 );
-                Box::pin(async {
-                    Err(
-                        "whatsapp channel is disabled (enable feature `channel-whatsapp`)"
-                            .to_owned(),
-                    )
-                })
+                return Err(
+                    "whatsapp channel is disabled (enable feature `channel-whatsapp`)".to_owned(),
+                );
             }
         }
-        _ => {
-            let unsupported_channel_id = channel_id.to_owned();
-            Box::pin(async move {
-                Err(format!(
-                    "unsupported background channel `{unsupported_channel_id}`"
-                ))
-            })
-        }
+        _ => Err(format!("unsupported background channel `{channel_id}`")),
     }
 }
 
@@ -3467,21 +3402,45 @@ pub async fn process_inbound_with_provider_and_error_mode(
 ) -> CliResult<String> {
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
-        Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
-            Ok(runtime) => {
-                Box::pin(process_inbound_with_runtime_and_feedback_and_error_mode(
-                    &turn_config,
-                    &runtime,
-                    message,
-                    ConversationRuntimeBinding::kernel(kernel_ctx),
-                    feedback_policy,
-                    error_mode,
-                    retry_progress,
-                ))
-                .await
-            }
-            Err(error) => Err(error),
-        },
+        Ok(turn_config) => {
+            let address = message.session.conversation_address();
+            let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
+            let request = crate::agent_runtime::AgentTurnRequest {
+                message: message.text.clone(),
+                turn_mode: crate::agent_runtime::AgentTurnMode::Oneshot,
+                channel_id: address.channel_id.clone(),
+                account_id: address.account_id.clone(),
+                conversation_id: address.conversation_id.clone(),
+                participant_id: address.participant_id.clone(),
+                thread_id: address.thread_id.clone(),
+                acp_bootstrap_mcp_servers: acp_turn_hints.bootstrap_mcp_servers.clone(),
+                acp_cwd: acp_turn_hints
+                    .working_directory
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                ..Default::default()
+            };
+            let resolved_turn_path = resolved_path
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_default();
+            let ingress = channel_message_ingress_context(message);
+            let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
+            let observer = feedback_capture.observer_handle();
+            let turn_service =
+                crate::agent_runtime::TurnExecutionService::new(resolved_turn_path, turn_config)
+                    .with_kernel_ctx(kernel_ctx.clone());
+            let turn_options = crate::agent_runtime::TurnExecutionOptions {
+                observer,
+                ingress: ingress.as_ref(),
+                provenance: channel_message_acp_turn_provenance(message),
+                provider_error_mode: crate::conversation::ProviderErrorMode::Propagate,
+                ..Default::default()
+            };
+            let result = turn_service
+                .execute(Some(address.session_id.as_str()), &request, turn_options)
+                .await?;
+            Ok(feedback_capture.render_reply(result.output_text))
+        }
         Err(error) => Err(error),
     };
     let duration_ms = started_at.elapsed().as_millis();
@@ -3978,28 +3937,5 @@ mod tests {
             !result,
             "non-matched chat_id should be rejected without wildcard"
         );
-    }
-}
-
-#[cfg(test)]
-mod background_dispatch_tests {
-    use super::run_background_channel_with_stop;
-    use crate::{channel::ChannelServeStopHandle, config::LoongConfig};
-    use std::path::PathBuf;
-
-    #[tokio::test]
-    async fn run_background_channel_with_stop_rejects_unknown_channel() {
-        let error = run_background_channel_with_stop(
-            "unknown",
-            PathBuf::from("/tmp/loong-channel-unknown.toml"),
-            LoongConfig::default(),
-            Some("account-1".to_owned()),
-            ChannelServeStopHandle::new(),
-            false,
-        )
-        .await
-        .expect_err("unknown channel should fail");
-
-        assert_eq!(error, "unsupported background channel `unknown`");
     }
 }

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -30,7 +30,16 @@ use crate::CliResult;
     feature = "channel-imessage",
 ))]
 use crate::KernelContext;
-#[cfg(test)]
+#[cfg(any(
+    feature = "channel-plugin-bridge",
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-line",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp",
+    feature = "channel-webhook",
+))]
 use crate::acp::AcpConversationTurnOptions;
 #[cfg(any(
     feature = "channel-plugin-bridge",
@@ -55,7 +64,7 @@ use crate::acp::AcpConversationTurnOptions;
     feature = "channel-imessage",
 ))]
 use crate::acp::AcpTurnProvenance;
-use crate::config::LoongClawConfig;
+use crate::config::LoongConfig;
 #[cfg(any(
     feature = "channel-plugin-bridge",
     feature = "channel-telegram",
@@ -167,17 +176,17 @@ use crate::conversation::{
     feature = "channel-whatsapp",
     feature = "channel-webhook",
 ))]
-#[cfg(test)]
 use crate::conversation::{ConversationRuntime, ConversationRuntimeBinding};
 #[cfg(any(
     feature = "channel-plugin-bridge",
     feature = "channel-telegram",
     feature = "channel-feishu",
+    feature = "channel-line",
     feature = "channel-matrix",
     feature = "channel-wecom",
     feature = "channel-whatsapp",
+    feature = "channel-webhook",
 ))]
-#[cfg(test)]
 use crate::conversation::{ConversationTurnCoordinator, ProviderErrorMode};
 
 #[cfg(any(
@@ -2780,7 +2789,7 @@ pub async fn run_wecom_channel_with_stop(
 pub async fn run_background_channel_with_stop(
     channel_id: &str,
     resolved_path: PathBuf,
-    config: LoongClawConfig,
+    config: LoongConfig,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
     initialize_runtime_environment: bool,
@@ -3259,7 +3268,7 @@ struct PreparedChannelInboundTurn {
     feature = "channel-whatsapp"
 ))]
 fn prepare_channel_inbound_turn(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     message: &ChannelInboundMessage,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<PreparedChannelInboundTurn> {
@@ -3286,11 +3295,45 @@ fn prepare_channel_inbound_turn(
 ))]
 #[cfg(test)]
 pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRuntime + ?Sized>(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     runtime: &R,
     message: &ChannelInboundMessage,
     binding: ConversationRuntimeBinding<'_>,
     feedback_policy: ChannelTurnFeedbackPolicy,
+) -> CliResult<String> {
+    process_inbound_with_runtime_and_feedback_and_error_mode(
+        config,
+        runtime,
+        message,
+        binding,
+        feedback_policy,
+        ProviderErrorMode::Propagate,
+        None,
+    )
+    .await
+}
+
+#[cfg(any(
+    feature = "channel-plugin-bridge",
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-line",
+    feature = "channel-matrix",
+    feature = "channel-wecom",
+    feature = "channel-whatsapp",
+    feature = "channel-webhook"
+))]
+#[cfg_attr(not(test), allow(dead_code))]
+pub async fn process_inbound_with_runtime_and_feedback_and_error_mode<
+    R: ConversationRuntime + ?Sized,
+>(
+    config: &LoongConfig,
+    runtime: &R,
+    message: &ChannelInboundMessage,
+    binding: ConversationRuntimeBinding<'_>,
+    feedback_policy: ChannelTurnFeedbackPolicy,
+    error_mode: ProviderErrorMode,
+    retry_progress: crate::provider::ProviderRetryProgressCallback,
 ) -> CliResult<String> {
     let prepared = prepare_channel_inbound_turn(config, message, feedback_policy)?;
     let address = prepared.address;
@@ -3303,7 +3346,7 @@ pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRun
         .with_provenance(channel_message_acp_turn_provenance(message));
     let observer = feedback_capture.observer_handle();
     let reply = ConversationTurnCoordinator::new()
-        .handle_production_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        .handle_production_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             &address,
             &message.text,
@@ -3314,6 +3357,7 @@ pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRun
             ingress.as_ref(),
             observer,
             retry_progress,
+            None,
         )
         .await?;
     Ok(feedback_capture.render_reply(reply))
@@ -3338,7 +3382,7 @@ pub(super) async fn process_inbound_with_runtime_and_feedback<R: ConversationRun
 /// supplied `kernel_ctx`, and assembles a one-shot chat runtime around the
 /// channel session address before handing execution to `AgentRuntime`.
 pub async fn process_inbound_with_provider(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     resolved_path: Option<&std::path::Path>,
     message: &ChannelInboundMessage,
     kernel_ctx: &KernelContext,
@@ -3440,7 +3484,8 @@ pub async fn process_inbound_with_provider_and_error_mode(
                 observer,
                 ingress: ingress.as_ref(),
                 provenance: channel_message_acp_turn_provenance(message),
-                provider_error_mode: crate::conversation::ProviderErrorMode::Propagate,
+                provider_error_mode: error_mode,
+                retry_progress,
                 ..Default::default()
             };
             let result = turn_service
@@ -3544,7 +3589,7 @@ pub async fn process_inbound_with_provider_and_error_mode(
     feature = "channel-webhook"
 ))]
 pub(super) fn reload_channel_turn_config(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     resolved_path: Option<&std::path::Path>,
 ) -> CliResult<LoongConfig> {
     match resolved_path {

--- a/crates/app/src/channel/registry_plugin_bridge.rs
+++ b/crates/app/src/channel/registry_plugin_bridge.rs
@@ -863,15 +863,17 @@ fn managed_bridge_runtime_is_ready(
     let runtime_contract = channel_bridge.runtime_contract.as_deref();
     let runtime_contract = runtime_contract.map(str::trim);
     let runtime_contract = runtime_contract.filter(|value| !value.is_empty());
-    let runtime_contract_is_ready = runtime_contract.is_some();
-    if !runtime_contract_is_ready {
-        return false;
-    }
-
-    channel_bridge
+    let has_runtime_contract = runtime_contract.is_some();
+    let has_runtime_operations = channel_bridge
         .runtime_operations
         .iter()
-        .any(|operation| !operation.trim().is_empty())
+        .any(|operation| !operation.trim().is_empty());
+
+    if !has_runtime_contract && !has_runtime_operations {
+        return true;
+    }
+
+    has_runtime_contract && has_runtime_operations
 }
 
 fn plugin_ir_channel_bridge(

--- a/crates/app/src/channel/registry_plugin_bridge_tests.rs
+++ b/crates/app/src/channel/registry_plugin_bridge_tests.rs
@@ -200,7 +200,7 @@ fn metadata_only_channel_bridge_manifest_is_discovery_ready_without_runtime_meta
             ("target_contract".to_owned(), "weixin_reply_loop".to_owned()),
         ]),
     );
-    let mut config = LoongClawConfig::default();
+    let mut config = LoongConfig::default();
 
     write_plugin_package_manifest(install_root.path(), "weixin-metadata-only", &manifest);
 

--- a/crates/app/src/channel/registry_plugin_bridge_tests.rs
+++ b/crates/app/src/channel/registry_plugin_bridge_tests.rs
@@ -186,6 +186,50 @@ fn bridge_setup_with_docs_and_remediation(
 }
 
 #[test]
+fn metadata_only_channel_bridge_manifest_is_discovery_ready_without_runtime_metadata() {
+    let install_root = TempDir::new().expect("create managed install root");
+    let manifest = sample_channel_bridge_manifest_with_metadata(
+        Some("weixin"),
+        Some("channel"),
+        BTreeMap::from([
+            ("adapter_family".to_owned(), "channel-bridge".to_owned()),
+            (
+                "transport_family".to_owned(),
+                "wechat_clawbot_ilink_bridge".to_owned(),
+            ),
+            ("target_contract".to_owned(), "weixin_reply_loop".to_owned()),
+        ]),
+    );
+    let mut config = LoongClawConfig::default();
+
+    write_plugin_package_manifest(install_root.path(), "weixin-metadata-only", &manifest);
+
+    config.external_skills.install_root = Some(install_root.path().display().to_string());
+
+    let inventory = channel_inventory(&config);
+    let weixin = inventory
+        .channel_surfaces
+        .iter()
+        .find(|surface| surface.catalog.id == "weixin")
+        .expect("weixin surface");
+    let discovery = weixin
+        .plugin_bridge_discovery
+        .as_ref()
+        .expect("weixin managed discovery");
+    let plugin = discovery.plugins.first().expect("discovered plugin");
+
+    assert_eq!(
+        plugin.status,
+        ChannelDiscoveredPluginBridgeStatus::CompatibleReady
+    );
+    assert_eq!(discovery.compatible_plugins, 1);
+    assert_eq!(
+        discovery.selection_status,
+        Some(ChannelPluginBridgeSelectionStatus::SingleCompatibleMatch)
+    );
+}
+
+#[test]
 fn resolve_channel_catalog_entry_exposes_plugin_bridge_contracts() {
     let telegram = resolve_channel_catalog_entry("telegram").expect("telegram entry");
     let weixin = resolve_channel_catalog_entry("weixin").expect("weixin entry");

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -940,31 +940,29 @@ async fn process_cli_chat_input(
         ChatCommandMatchResult::NotMatched => {}
     }
 
-    let agent_runtime = crate::agent_runtime::AgentRuntime::new();
-    let turn_result = agent_runtime
-        .run_turn_with_runtime(
-            runtime,
-            &crate::agent_runtime::AgentTurnRequest {
-                message: input.to_owned(),
-                turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
-                channel_id: runtime.session_address.channel_id.clone(),
-                account_id: runtime.session_address.account_id.clone(),
-                conversation_id: runtime.session_address.conversation_id.clone(),
-                participant_id: runtime.session_address.participant_id.clone(),
-                thread_id: runtime.session_address.thread_id.clone(),
-                metadata: BTreeMap::new(),
-                acp: runtime.explicit_acp_request,
-                acp_event_stream: event_sink.is_some(),
-                acp_bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
-                acp_cwd: runtime
-                    .effective_working_directory
-                    .as_ref()
-                    .map(|path| path.display().to_string()),
-                live_surface_enabled: true,
-            },
-            event_sink,
-        )
-        .await?;
+    let turn_request = crate::agent_runtime::AgentTurnRequest {
+        message: input.to_owned(),
+        turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
+        channel_id: runtime.session_address.channel_id.clone(),
+        account_id: runtime.session_address.account_id.clone(),
+        conversation_id: runtime.session_address.conversation_id.clone(),
+        thread_id: runtime.session_address.thread_id.clone(),
+        metadata: BTreeMap::new(),
+        acp: runtime.explicit_acp_request,
+        acp_event_stream: event_sink.is_some(),
+        acp_bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
+        acp_cwd: runtime
+            .effective_working_directory
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        live_surface_enabled: true,
+    };
+    let turn_options = crate::agent_runtime::TurnExecutionOptions {
+        event_sink,
+        ..Default::default()
+    };
+    let turn_service = crate::agent_runtime::RuntimeTurnExecutionService::new(runtime);
+    let turn_result = turn_service.execute(&turn_request, turn_options).await?;
 
     Ok(CliChatLoopControl::AssistantText(turn_result.output_text))
 }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -947,6 +947,7 @@ async fn process_cli_chat_input(
         channel_id: runtime.session_address.channel_id.clone(),
         account_id: runtime.session_address.account_id.clone(),
         conversation_id: runtime.session_address.conversation_id.clone(),
+        participant_id: runtime.session_address.participant_id.clone(),
         thread_id: runtime.session_address.thread_id.clone(),
         metadata: BTreeMap::new(),
         acp: runtime.explicit_acp_request,
@@ -1034,36 +1035,6 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode(
         provider_error_mode,
         observer_override,
         None,
-    )
-    .await
-    .map(|outcome| outcome.reply)
-}
-
-pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_and_acp_manager(
-    runtime: &CliTurnRuntime,
-    address: &ConversationSessionAddress,
-    input: &str,
-    event_sink: Option<&dyn AcpTurnEventSink>,
-    live_surface_enabled: bool,
-    metadata: Option<&BTreeMap<String, String>>,
-    ingress: Option<&ConversationIngressContext>,
-    provenance: AcpTurnProvenance<'_>,
-    provider_error_mode: ProviderErrorMode,
-    observer_override: Option<ConversationTurnObserverHandle>,
-    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
-) -> CliResult<String> {
-    run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
-        runtime,
-        address,
-        input,
-        event_sink,
-        live_surface_enabled,
-        metadata,
-        ingress,
-        provenance,
-        provider_error_mode,
-        observer_override,
-        acp_manager,
     )
     .await
     .map(|outcome| outcome.reply)

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1034,6 +1034,37 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode(
         provenance,
         provider_error_mode,
         observer_override,
+        None,
+    )
+    .await
+    .map(|outcome| outcome.reply)
+}
+
+pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_and_acp_manager(
+    runtime: &CliTurnRuntime,
+    address: &ConversationSessionAddress,
+    input: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+    live_surface_enabled: bool,
+    metadata: Option<&BTreeMap<String, String>>,
+    ingress: Option<&ConversationIngressContext>,
+    provenance: AcpTurnProvenance<'_>,
+    provider_error_mode: ProviderErrorMode,
+    observer_override: Option<ConversationTurnObserverHandle>,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+) -> CliResult<String> {
+    run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
+        runtime,
+        address,
+        input,
+        event_sink,
+        live_surface_enabled,
+        metadata,
+        ingress,
+        provenance,
+        provider_error_mode,
+        observer_override,
+        acp_manager,
     )
     .await
     .map(|outcome| outcome.reply)
@@ -1050,6 +1081,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     provenance: AcpTurnProvenance<'_>,
     provider_error_mode: ProviderErrorMode,
     observer_override: Option<ConversationTurnObserverHandle>,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
 ) -> CliResult<crate::conversation::ConversationTurnOutcome> {
     let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
     let acp_options = if runtime.explicit_acp_request {
@@ -1070,18 +1102,20 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     } else {
         None
     };
+    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
     if let Some(ingress) = ingress {
         runtime
             .turn_coordinator
-            .handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+            .handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &turn_config,
                 address,
                 input,
                 provider_error_mode,
                 &acp_options,
-                runtime.conversation_binding(),
+                binding,
                 Some(ingress),
                 live_surface_observer,
+                acp_manager,
             )
             .await
             .map(|reply| crate::conversation::ConversationTurnOutcome { reply, usage: None })
@@ -1095,10 +1129,10 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
                 provider_error_mode,
                 &crate::conversation::DefaultConversationRuntime::from_config_or_env(&turn_config)?,
                 &acp_options,
-                runtime.conversation_binding(),
+                binding,
                 None,
                 live_surface_observer,
-                None,
+                acp_manager,
             )
             .await
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -70,7 +70,8 @@ use self::operator_surfaces::render_cli_chat_status_lines_with_width;
 #[cfg(test)]
 use self::operator_surfaces::render_manual_compaction_lines_with_width;
 use self::operator_surfaces::should_run_missing_config_onboard;
-use self::render_support::*;
+#[cfg(test)]
+use crate::conversation::DefaultConversationRuntime;
 
 use super::config::{self, ConversationConfig, LoongConfig};
 #[cfg(test)]
@@ -2085,9 +2086,17 @@ async fn load_turn_checkpoint_summary_output(
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<String> {
-    let diagnostics = turn_coordinator
-        .load_turn_checkpoint_diagnostics_with_limit(config, session_id, limit, binding)
-        .await?;
+    let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+    let runtime_ref = &runtime;
+    let diagnostics_future = turn_coordinator
+        .load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            config,
+            session_id,
+            limit,
+            runtime_ref,
+            binding,
+        );
+    let diagnostics = diagnostics_future.await?;
 
     Ok(format_turn_checkpoint_summary_output(
         session_id,

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -70,6 +70,7 @@ use self::operator_surfaces::render_cli_chat_status_lines_with_width;
 #[cfg(test)]
 use self::operator_surfaces::render_manual_compaction_lines_with_width;
 use self::operator_surfaces::should_run_missing_config_onboard;
+use self::render_support::*;
 #[cfg(test)]
 use crate::conversation::DefaultConversationRuntime;
 
@@ -1007,6 +1008,8 @@ pub(crate) async fn run_cli_turn_with_address(
         AcpTurnProvenance::default(),
         ProviderErrorMode::InlineMessage,
         observer_override,
+        None,
+        None,
     )
     .await
 }
@@ -1022,6 +1025,8 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode(
     provenance: AcpTurnProvenance<'_>,
     provider_error_mode: ProviderErrorMode,
     observer_override: Option<ConversationTurnObserverHandle>,
+    retry_progress: crate::provider::ProviderRetryProgressCallback,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
 ) -> CliResult<String> {
     run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
         runtime,
@@ -1034,7 +1039,8 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode(
         provenance,
         provider_error_mode,
         observer_override,
-        None,
+        retry_progress,
+        acp_manager,
     )
     .await
     .map(|outcome| outcome.reply)
@@ -1051,6 +1057,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     provenance: AcpTurnProvenance<'_>,
     provider_error_mode: ProviderErrorMode,
     observer_override: Option<ConversationTurnObserverHandle>,
+    retry_progress: crate::provider::ProviderRetryProgressCallback,
     acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
 ) -> CliResult<crate::conversation::ConversationTurnOutcome> {
     let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
@@ -1072,7 +1079,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     } else {
         None
     };
-    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
+    let binding = runtime.conversation_binding();
     if let Some(ingress) = ingress {
         runtime
             .turn_coordinator
@@ -1085,6 +1092,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
                 binding,
                 Some(ingress),
                 live_surface_observer,
+                retry_progress,
                 acp_manager,
             )
             .await
@@ -1102,6 +1110,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
                 binding,
                 None,
                 live_surface_observer,
+                retry_progress,
                 acp_manager,
             )
             .await

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -158,7 +158,7 @@ pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntim
             &runtime.config,
             &runtime.session_id,
             limit,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            runtime.conversation_binding(),
         )
         .await
     {
@@ -212,7 +212,7 @@ async fn print_turn_checkpoint_status_health(runtime: &CliTurnRuntime) {
             &runtime.config,
             &runtime.session_id,
             limit,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            runtime.conversation_binding(),
         )
         .await
     {

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -149,12 +149,16 @@ pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntim
     let render_width = detect_cli_chat_render_width();
 
     #[cfg(feature = "memory-sqlite")]
+    let limit = runtime.config.memory.sliding_window;
+
+    #[cfg(feature = "memory-sqlite")]
     match runtime
         .turn_coordinator
-        .load_production_turn_checkpoint_diagnostics(
+        .load_production_turn_checkpoint_diagnostics_with_limit(
             &runtime.config,
             &runtime.session_id,
-            runtime.conversation_binding(),
+            limit,
+            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
         )
         .await
     {
@@ -199,12 +203,16 @@ async fn print_turn_checkpoint_status_health(runtime: &CliTurnRuntime) {
     let render_width = detect_cli_chat_render_width();
 
     #[cfg(feature = "memory-sqlite")]
+    let limit = runtime.config.memory.sliding_window;
+
+    #[cfg(feature = "memory-sqlite")]
     match runtime
         .turn_coordinator
-        .load_production_turn_checkpoint_diagnostics(
+        .load_production_turn_checkpoint_diagnostics_with_limit(
             &runtime.config,
             &runtime.session_id,
-            runtime.conversation_binding(),
+            limit,
+            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
         )
         .await
     {

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -2241,7 +2241,7 @@ impl ChatSessionSurface {
                                             let outcome = self
                                                 .runtime
                                                 .turn_coordinator
-                                                .repair_turn_checkpoint_tail(
+                                                .repair_production_turn_checkpoint_tail(
                                                     &self.runtime.config,
                                                     &self.runtime.session_id,
                                                     self.runtime.conversation_binding(),
@@ -2698,6 +2698,7 @@ impl ChatSessionSurface {
         self.render()?;
         Ok(SurfaceLoopAction::Continue)
     }
+
 
     fn submit_input_overlay(&self, kind: OverlayInputKind, value: String) -> CliResult<()> {
         let trimmed = value.trim();

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -2652,6 +2652,7 @@ impl ChatSessionSurface {
             channel_id: self.runtime.session_address.channel_id.clone(),
             account_id: self.runtime.session_address.account_id.clone(),
             conversation_id: self.runtime.session_address.conversation_id.clone(),
+            participant_id: self.runtime.session_address.participant_id.clone(),
             thread_id: self.runtime.session_address.thread_id.clone(),
             metadata: std::collections::BTreeMap::new(),
             acp: self.runtime.explicit_acp_request,
@@ -2698,7 +2699,6 @@ impl ChatSessionSurface {
         self.render()?;
         Ok(SurfaceLoopAction::Continue)
     }
-
 
     fn submit_input_overlay(&self, kind: OverlayInputKind, value: String) -> CliResult<()> {
         let trimmed = value.trim();

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -1830,6 +1830,8 @@ impl ChatSessionSurface {
             CommandPaletteAction::Exit => return Ok(SurfaceLoopAction::Exit),
         }
         state.command_palette = None;
+        drop(state);
+        self.render()?;
         Ok(SurfaceLoopAction::Continue)
     }
 
@@ -2644,31 +2646,31 @@ impl ChatSessionSurface {
         self.render()?;
 
         let observer = build_surface_live_observer(self.state.clone(), self.term.clone());
-        let assistant_text = crate::agent_runtime::AgentRuntime::new()
-            .run_turn_with_runtime_and_observer(
-                &self.runtime,
-                &crate::agent_runtime::AgentTurnRequest {
-                    message: trimmed.to_owned(),
-                    turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
-                    channel_id: self.runtime.session_address.channel_id.clone(),
-                    account_id: self.runtime.session_address.account_id.clone(),
-                    conversation_id: self.runtime.session_address.conversation_id.clone(),
-                    participant_id: self.runtime.session_address.participant_id.clone(),
-                    thread_id: self.runtime.session_address.thread_id.clone(),
-                    metadata: std::collections::BTreeMap::new(),
-                    acp: self.runtime.explicit_acp_request,
-                    acp_event_stream: false,
-                    acp_bootstrap_mcp_servers: self.runtime.effective_bootstrap_mcp_servers.clone(),
-                    acp_cwd: self
-                        .runtime
-                        .effective_working_directory
-                        .as_ref()
-                        .map(|path| path.display().to_string()),
-                    live_surface_enabled: true,
-                },
-                None,
-                Some(observer),
-            )
+        let turn_request = crate::agent_runtime::AgentTurnRequest {
+            message: trimmed.to_owned(),
+            turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
+            channel_id: self.runtime.session_address.channel_id.clone(),
+            account_id: self.runtime.session_address.account_id.clone(),
+            conversation_id: self.runtime.session_address.conversation_id.clone(),
+            thread_id: self.runtime.session_address.thread_id.clone(),
+            metadata: std::collections::BTreeMap::new(),
+            acp: self.runtime.explicit_acp_request,
+            acp_event_stream: false,
+            acp_bootstrap_mcp_servers: self.runtime.effective_bootstrap_mcp_servers.clone(),
+            acp_cwd: self
+                .runtime
+                .effective_working_directory
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            live_surface_enabled: true,
+        };
+        let turn_options = crate::agent_runtime::TurnExecutionOptions {
+            observer: Some(observer),
+            ..Default::default()
+        };
+        let turn_service = crate::agent_runtime::RuntimeTurnExecutionService::new(&self.runtime);
+        let assistant_text = turn_service
+            .execute(&turn_request, turn_options)
             .await?
             .output_text;
 

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -488,6 +488,7 @@ pub(crate) fn enqueue_delegate_result_announce_without_spawn_for_tests(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use serde_json::json;
     use tokio::time::{Duration, sleep};
@@ -509,9 +510,14 @@ mod tests {
 
     const DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT: Duration = Duration::from_secs(20);
 
-    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
-        let base =
-            std::env::temp_dir().join(format!("loong-announce-{test_name}-{}", std::process::id()));
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        static NEXT_ISOLATED_MEMORY_ID: AtomicU64 = AtomicU64::new(1);
+
+        let isolated_id = NEXT_ISOLATED_MEMORY_ID.fetch_add(1, Ordering::Relaxed);
+        let base = std::env::temp_dir().join(format!(
+            "loongclaw-announce-{test_name}-{}-{isolated_id}",
+            std::process::id(),
+        ));
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -510,7 +510,7 @@ mod tests {
 
     const DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT: Duration = Duration::from_secs(20);
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         static NEXT_ISOLATED_MEMORY_ID: AtomicU64 = AtomicU64::new(1);
 
         let isolated_id = NEXT_ISOLATED_MEMORY_ID.fetch_add(1, Ordering::Relaxed);

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -337,7 +337,7 @@ impl SessionContext {
     }
 }
 
-fn configured_root_session_workspace_root(config: &LoongClawConfig) -> Option<PathBuf> {
+fn configured_root_session_workspace_root(config: &LoongConfig) -> Option<PathBuf> {
     config
         .tools
         .configured_runtime_workspace_root()
@@ -351,7 +351,7 @@ fn configured_root_session_workspace_root(config: &LoongClawConfig) -> Option<Pa
 }
 
 fn root_session_context_from_config(
-    config: &LoongClawConfig,
+    config: &LoongConfig,
     session_id: impl Into<String>,
     tool_view: ToolView,
 ) -> SessionContext {

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -337,6 +337,31 @@ impl SessionContext {
     }
 }
 
+fn configured_root_session_workspace_root(config: &LoongClawConfig) -> Option<PathBuf> {
+    config
+        .tools
+        .configured_runtime_workspace_root()
+        .or_else(|| config.tools.configured_file_root())
+        .and_then(|workspace_root| {
+            let canonical_workspace_root = dunce::canonicalize(&workspace_root).ok()?;
+            canonical_workspace_root
+                .is_dir()
+                .then_some(canonical_workspace_root)
+        })
+}
+
+fn root_session_context_from_config(
+    config: &LoongClawConfig,
+    session_id: impl Into<String>,
+    tool_view: ToolView,
+) -> SessionContext {
+    let mut session_context = SessionContext::root_with_tool_view(session_id, tool_view);
+    if let Some(workspace_root) = configured_root_session_workspace_root(config) {
+        session_context = session_context.with_workspace_root(workspace_root);
+    }
+    session_context
+}
+
 fn non_empty_runtime_narrowing_ref(
     runtime_narrowing: Option<&ToolRuntimeNarrowing>,
 ) -> Option<&ToolRuntimeNarrowing> {
@@ -761,7 +786,7 @@ fn build_session_context_from_snapshot(
         Some(parent_session_id) => {
             SessionContext::child(snapshot.session_id.clone(), parent_session_id, tool_view)
         }
-        None => SessionContext::root_with_tool_view(snapshot.session_id.clone(), tool_view),
+        None => root_session_context_from_config(config, snapshot.session_id.clone(), tool_view),
     };
     if let Some(profile) = snapshot.delegate_profile {
         session_context = session_context.with_profile(profile);
@@ -1506,13 +1531,9 @@ pub trait ConversationRuntime: Send + Sync {
             return Ok(session_context);
         }
 
-        let visible_external_skill_roots = model_visible_external_skill_roots_from_config(config);
-        let mut session_context = SessionContext::root_with_tool_view(session_id, tool_view);
-        if !visible_external_skill_roots.is_empty() {
-            session_context =
-                session_context.with_visible_external_skill_roots(visible_external_skill_roots);
-        }
-        Ok(session_context)
+        Ok(root_session_context_from_config(
+            config, session_id, tool_view,
+        ))
     }
 
     fn tool_view(
@@ -1934,28 +1955,19 @@ where
                 );
             }
 
-            let visible_external_skill_roots =
-                model_visible_external_skill_roots_from_config(config);
-            let mut session_context =
-                SessionContext::root_with_tool_view(session_id, base_tool_view);
-            if !visible_external_skill_roots.is_empty() {
-                session_context =
-                    session_context.with_visible_external_skill_roots(visible_external_skill_roots);
-            }
-            Ok(session_context)
+            Ok(root_session_context_from_config(
+                config,
+                session_id,
+                base_tool_view,
+            ))
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
             let tool_view = self.tool_view(config, session_id, _binding)?;
-            let visible_external_skill_roots =
-                model_visible_external_skill_roots_from_config(config);
-            let mut session_context = SessionContext::root_with_tool_view(session_id, tool_view);
-            if !visible_external_skill_roots.is_empty() {
-                session_context =
-                    session_context.with_visible_external_skill_roots(visible_external_skill_roots);
-            }
-            Ok(session_context)
+            Ok(root_session_context_from_config(
+                config, session_id, tool_view,
+            ))
         }
     }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -6429,6 +6429,64 @@ async fn handle_turn_with_runtime_streams_and_persists_acp_runtime_events_when_b
 }
 
 #[tokio::test]
+async fn handle_turn_with_runtime_automatic_acp_uses_injected_manager() {
+    let (backend_id, _backend_state) =
+        register_routed_acp_backend_with_events("injected-manager", false, Vec::new());
+    let runtime = FakeRuntime::new(Vec::new(), Ok("provider-should-not-run".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config();
+    let memory_path = unique_acp_sqlite_path("injected-manager");
+    let provided_manager = Arc::new(crate::acp::AcpSessionManager::default());
+
+    config.acp.enabled = true;
+    config.acp.backend = Some(backend_id.to_owned());
+    config.acp.dispatch.conversation_routing =
+        crate::config::AcpConversationRoutingMode::AgentPrefixedOnly;
+    config.memory.sqlite_path = memory_path;
+
+    let shared_manager =
+        crate::acp::shared_acp_session_manager(&config).expect("load shared ACP session manager");
+    let shared_snapshot_before = shared_manager
+        .observability_snapshot(&config)
+        .await
+        .expect("shared snapshot before turn");
+
+    assert_eq!(shared_snapshot_before.runtime_cache.active_sessions, 0);
+
+    let acp_options = AcpConversationTurnOptions::automatic();
+    let address = ConversationSessionAddress::from_session_id("agent:codex:acp-injected-manager");
+    let reply = coordinator
+        .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
+            &config,
+            &address,
+            "hello injected manager",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            &acp_options,
+            ConversationRuntimeBinding::direct(),
+            None,
+            None,
+            Some(provided_manager.clone()),
+        )
+        .await
+        .expect("automatic ACP turn with injected manager should succeed");
+
+    assert_eq!(reply, "acp: hello injected manager");
+
+    let provided_snapshot = provided_manager
+        .observability_snapshot(&config)
+        .await
+        .expect("provided snapshot after turn");
+    let shared_snapshot_after = shared_manager
+        .observability_snapshot(&config)
+        .await
+        .expect("shared snapshot after turn");
+
+    assert_eq!(provided_snapshot.runtime_cache.active_sessions, 1);
+    assert_eq!(shared_snapshot_after.runtime_cache.active_sessions, 0);
+}
+
+#[tokio::test]
 async fn handle_turn_with_runtime_skips_compaction_when_disabled() {
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
@@ -20878,6 +20936,137 @@ async fn session_context_preserves_child_workspace_root_from_delegate_execution_
     assert!(
         system_content.contains("Child workspace identity"),
         "expected child workspace identity to be read from restored workspace root, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_root_session_prefers_runtime_workspace_root_over_file_root() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-root-runtime", "runtime-workspace-root")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let workspace_root = create_runtime_self_workspace(
+        "root-runtime-workspace-root",
+        "# Identity\n\n- Name: Root runtime workspace identity",
+    );
+    let fallback_root = crate::test_support::unique_temp_dir("root-runtime-fallback-file-root");
+    std::fs::create_dir_all(&fallback_root).expect("create fallback file root");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.file_root = Some(fallback_root.display().to_string());
+    config.tools.runtime_workspace_root = Some(workspace_root.display().to_string());
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load root session context");
+    let expected_workspace_root =
+        dunce::canonicalize(&workspace_root).unwrap_or_else(|_| workspace_root.clone());
+
+    assert_eq!(session_context.parent_session_id, None);
+    assert_eq!(
+        session_context.workspace_root.as_ref(),
+        Some(&expected_workspace_root),
+        "runtime workspace root should be preferred for root sessions"
+    );
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            "root-session",
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build root context from runtime workspace root");
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should be text");
+
+    assert!(
+        system_content.contains("Root runtime workspace identity"),
+        "expected root runtime workspace identity to be read from runtime workspace root, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn trait_default_root_session_falls_back_to_configured_file_root() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-root-runtime", "file-root-fallback")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let file_root = create_runtime_self_workspace(
+        "root-file-root-fallback",
+        "# Identity\n\n- Name: Root file root fallback identity",
+    );
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.file_root = Some(file_root.display().to_string());
+    config.tools.runtime_workspace_root = None;
+
+    let runtime = TraitDefaultToolViewRuntime;
+    let session_context = runtime
+        .session_context(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load trait-default root session context");
+    let expected_file_root = dunce::canonicalize(&file_root).unwrap_or_else(|_| file_root.clone());
+
+    assert_eq!(session_context.parent_session_id, None);
+    assert_eq!(
+        session_context.workspace_root.as_ref(),
+        Some(&expected_file_root),
+        "configured file root should backfill root session workspace scope"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn root_session_ignores_nonexistent_configured_file_root_for_workspace_scope() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-root-runtime", "nonexistent-file-root")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let missing_root = std::env::temp_dir().join(format!(
+        "loongclaw-missing-root-{}",
+        unique_acp_test_id("conversation-root-runtime", "missing-root-path")
+    ));
+    let _ = std::fs::remove_dir_all(&missing_root);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.file_root = Some(missing_root.display().to_string());
+    config.tools.runtime_workspace_root = None;
+
+    let runtime = TraitDefaultToolViewRuntime;
+    let session_context = runtime
+        .session_context(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load root session context with missing file root");
+
+    assert_eq!(session_context.parent_session_id, None);
+    assert_eq!(
+        session_context.workspace_root, None,
+        "nonexistent configured file root should not become trusted workspace scope"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -19753,11 +19753,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_reports_preparation_content_mis
             system_prompt_addition: None,
         });
     let coordinator = ConversationTurnCoordinator::new();
+    let limit = config.memory.sliding_window;
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             &config,
             session_id,
+            limit,
             &runtime,
             ConversationRuntimeBinding::direct(),
         )
@@ -19855,11 +19857,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_when_repair_not_ne
         vec![],
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let limit = config.memory.sliding_window;
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             &config,
             session_id,
+            limit,
             &runtime,
             ConversationRuntimeBinding::direct(),
         )
@@ -19950,11 +19954,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_summary_manual
         vec![],
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let limit = config.memory.sliding_window;
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             &config,
             session_id,
+            limit,
             &runtime,
             ConversationRuntimeBinding::direct(),
         )
@@ -20047,11 +20053,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_runnable_repai
         vec![],
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let limit = config.memory.sliding_window;
 
     let probe = coordinator
-        .probe_turn_checkpoint_tail_runtime_gate_with_runtime(
+        .probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             &config,
             session_id,
+            limit,
             &runtime,
             ConversationRuntimeBinding::direct(),
         )

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5186,14 +5186,16 @@ async fn handle_turn_with_observer_routes_explicit_acp_turns_through_acp() {
         ..AcpConversationTurnOptions::default()
     };
     let reply = coordinator
-        .handle_turn_with_address_and_acp_options_and_observer(
+        .handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
             &config,
             &address,
             "hello from channel",
             ProviderErrorMode::Propagate,
             &acp_options,
             ConversationRuntimeBinding::direct(),
+            None,
             Some(observer_handle),
+            None,
         )
         .await
         .expect("explicit ACP turn with observer should route through ACP");
@@ -5950,12 +5952,13 @@ async fn handle_turn_with_runtime_and_address_routes_structured_channel_scope_in
         .with_channel_scope("telegram", "100");
 
     let reply = coordinator
-        .handle_turn_with_runtime_and_address(
+        .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &address,
             "hello structured route",
             ProviderErrorMode::Propagate,
             &runtime,
+            &AcpConversationTurnOptions::automatic(),
             ConversationRuntimeBinding::direct(),
         )
         .await
@@ -6028,12 +6031,13 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
         .with_account_id("lark-prod");
 
     let allowed_reply = coordinator
-        .handle_turn_with_runtime_and_address(
+        .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &allowed,
             "hello allowed",
             ProviderErrorMode::Propagate,
             &runtime,
+            &AcpConversationTurnOptions::automatic(),
             ConversationRuntimeBinding::direct(),
         )
         .await
@@ -6041,12 +6045,13 @@ async fn handle_turn_with_runtime_and_address_enforces_account_and_thread_dispat
     assert_eq!(allowed_reply, "acp: hello allowed");
 
     let blocked_reply = coordinator
-        .handle_turn_with_runtime_and_address(
+        .handle_turn_with_runtime_and_address_and_acp_options(
             &config,
             &blocked,
             "hello blocked",
             ProviderErrorMode::Propagate,
             &runtime,
+            &AcpConversationTurnOptions::automatic(),
             ConversationRuntimeBinding::direct(),
         )
         .await

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5196,6 +5196,7 @@ async fn handle_turn_with_observer_routes_explicit_acp_turns_through_acp() {
             None,
             Some(observer_handle),
             None,
+            None,
         )
         .await
         .expect("explicit ACP turn with observer should route through ACP");
@@ -6469,6 +6470,7 @@ async fn handle_turn_with_runtime_automatic_acp_uses_injected_manager() {
             &runtime,
             &acp_options,
             ConversationRuntimeBinding::direct(),
+            None,
             None,
             None,
             Some(provided_manager.clone()),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1188,27 +1188,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn probe_production_turn_checkpoint_tail_runtime_gate_with_limit(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        limit: usize,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let production_binding = prepared.1;
-
-        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config,
-            session_id,
-            limit,
-            &runtime,
-            production_binding,
-        )
-        .await
-    }
-
     async fn handle_turn_with_session_and_acp_options_and_ingress(
         &self,
         config: &LoongClawConfig,
@@ -7240,30 +7219,6 @@ mod tests {
         let limit = config.memory.sliding_window;
         let result = coordinator
             .load_production_turn_checkpoint_diagnostics_with_limit(
-                &config,
-                "maintenance-session",
-                limit,
-                ConversationRuntimeBinding::direct(),
-            )
-            .await;
-        let error = result.expect_err("direct production maintenance binding should fail");
-
-        assert_eq!(
-            error,
-            PRODUCTION_CONVERSATION_RUNTIME_REQUIRES_KERNEL_BINDING
-        );
-    }
-
-    #[tokio::test]
-    async fn probe_production_turn_checkpoint_tail_runtime_gate_rejects_direct_binding_before_runtime_bootstrap()
-     {
-        let mut config = LoongConfig::default();
-        config.conversation.context_engine = Some("missing-maintenance-runtime".to_owned());
-
-        let coordinator = ConversationTurnCoordinator::new();
-        let limit = config.memory.sliding_window;
-        let result = coordinator
-            .probe_production_turn_checkpoint_tail_runtime_gate_with_limit(
                 &config,
                 "maintenance-session",
                 limit,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1146,28 +1146,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_ingress(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            &acp_options,
-            binding,
-            ingress,
-        )
-        .await
-    }
-
     pub(crate) async fn repair_turn_checkpoint_tail(
         &self,
         config: &LoongConfig,
@@ -1201,25 +1179,6 @@ impl ConversationTurnCoordinator {
             session_id,
             &runtime,
             production_binding,
-        )
-        .await
-    }
-
-    pub(crate) async fn load_turn_checkpoint_diagnostics(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<TurnCheckpointDiagnostics> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            config,
-            session_id,
-            config.memory.sliding_window,
-            &runtime,
-            effective_binding,
         )
         .await
     }
@@ -1283,25 +1242,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn probe_turn_checkpoint_tail_runtime_gate(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config,
-            session_id,
-            config.memory.sliding_window,
-            &runtime,
-            effective_binding,
-        )
-        .await
-    }
-
     pub async fn probe_production_turn_checkpoint_tail_runtime_gate(
         &self,
         config: &LoongConfig,
@@ -1316,47 +1256,6 @@ impl ConversationTurnCoordinator {
             config,
             session_id,
             config.memory.sliding_window,
-            &runtime,
-            production_binding,
-        )
-        .await
-    }
-
-    pub(crate) async fn probe_turn_checkpoint_tail_runtime_gate_with_limit(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        limit: usize,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config,
-            session_id,
-            limit,
-            &runtime,
-            effective_binding,
-        )
-        .await
-    }
-
-    pub async fn probe_production_turn_checkpoint_tail_runtime_gate_with_limit(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        limit: usize,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let production_binding = prepared.1;
-
-        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config,
-            session_id,
-            limit,
             &runtime,
             production_binding,
         )

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1134,13 +1134,14 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_acp_options(
+        self.handle_turn_with_session_and_acp_options_and_ingress(
             config,
             session_id,
             user_input,
             error_mode,
             &acp_options,
             binding,
+            None,
         )
         .await
     }
@@ -1155,18 +1156,13 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
-        let address = ConversationSessionAddress::from_session_id(session_id);
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+        self.handle_turn_with_session_and_acp_options_and_ingress(
             config,
-            &address,
+            session_id,
             user_input,
             error_mode,
-            &runtime,
             &acp_options,
-            effective_binding,
+            binding,
             ingress,
         )
         .await
@@ -1181,14 +1177,14 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        let address = ConversationSessionAddress::from_session_id(session_id);
-        self.handle_turn_with_address_and_acp_options(
+        self.handle_turn_with_session_and_acp_options_and_ingress(
             config,
-            &address,
+            session_id,
             user_input,
             error_mode,
             acp_options,
             binding,
+            None,
         )
         .await
     }
@@ -1398,13 +1394,37 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_acp_options(
+        self.handle_turn_with_session_and_acp_options_and_ingress(
             config,
             session_id,
             user_input,
             error_mode,
             &acp_options,
             binding,
+            None,
+        )
+        .await
+    }
+
+    async fn handle_turn_with_session_and_acp_options_and_ingress(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+    ) -> CliResult<String> {
+        let address = ConversationSessionAddress::from_session_id(session_id);
+        self.handle_turn_with_address_and_acp_options_and_ingress(
+            config,
+            &address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            ingress,
         )
         .await
     }
@@ -1679,7 +1699,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_runtime_and_acp_options(
+        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
             config,
             session_id,
             user_input,
@@ -1687,6 +1707,7 @@ impl ConversationTurnCoordinator {
             runtime,
             &acp_options,
             binding,
+            None,
         )
         .await
     }
@@ -1702,10 +1723,9 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
-        let address = ConversationSessionAddress::from_session_id(session_id);
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
             config,
-            &address,
+            session_id,
             user_input,
             error_mode,
             runtime,
@@ -1860,10 +1880,9 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        let address = ConversationSessionAddress::from_session_id(session_id);
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
             config,
-            &address,
+            session_id,
             user_input,
             error_mode,
             runtime,
@@ -1887,7 +1906,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_runtime_and_acp_options(
+        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
             config,
             session_id,
             user_input,
@@ -1895,6 +1914,34 @@ impl ConversationTurnCoordinator {
             runtime,
             &acp_options,
             binding,
+            None,
+        )
+        .await
+    }
+
+    async fn handle_turn_with_runtime_and_session_and_acp_options_and_ingress<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+    ) -> CliResult<String> {
+        let address = ConversationSessionAddress::from_session_id(session_id);
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+            config,
+            &address,
+            user_input,
+            error_mode,
+            runtime,
+            acp_options,
+            binding,
+            ingress,
         )
         .await
     }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -32,9 +32,8 @@ use crate::CliResult;
 #[cfg(test)]
 use crate::KernelContext;
 use crate::acp::{
-    AcpConversationTurnEntryDecision, AcpConversationTurnExecutionOutcome,
-    AcpConversationTurnOptions, evaluate_acp_conversation_turn_entry_for_address,
-    execute_acp_conversation_turn_for_address,
+    AcpConversationTurnEntryDecision, AcpConversationTurnOptions, FinalizedAcpConversationTurn,
+    evaluate_acp_conversation_turn_entry_for_address, execute_acp_conversation_turn_for_address,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -2188,10 +2187,10 @@ impl ConversationTurnCoordinator {
             acp_manager,
         )
         .await?;
-        let persistence_context = &executed.persistence_context;
+        let finalized = executed.into_finalized();
 
-        match executed.outcome {
-            AcpConversationTurnExecutionOutcome::Succeeded(success) => {
+        match finalized {
+            FinalizedAcpConversationTurn::Succeeded(success) => {
                 let reply = success.result.output_text.clone();
                 persist_reply_turns_raw_with_mode(
                     runtime,
@@ -2206,7 +2205,7 @@ impl ConversationTurnCoordinator {
                     let _ = persist_acp_runtime_events(
                         runtime,
                         session_id,
-                        persistence_context,
+                        &success.persistence_context,
                         &success.runtime_events,
                         Some(&success.result),
                         None,
@@ -2216,12 +2215,12 @@ impl ConversationTurnCoordinator {
                 }
                 Ok(reply)
             }
-            AcpConversationTurnExecutionOutcome::Failed(failure) => {
+            FinalizedAcpConversationTurn::Failed(failure) => {
                 if config.acp.emit_runtime_events {
                     let _ = persist_acp_runtime_events(
                         runtime,
                         session_id,
-                        persistence_context,
+                        &failure.persistence_context,
                         &failure.runtime_events,
                         None,
                         Some(failure.error.as_str()),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2187,9 +2187,8 @@ impl ConversationTurnCoordinator {
             acp_manager,
         )
         .await?;
-        let finalized = executed.into_finalized();
 
-        match finalized {
+        match executed {
             FinalizedAcpConversationTurn::Succeeded(success) => {
                 let reply = success.result.output_text.clone();
                 persist_reply_turns_raw_with_mode(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1035,19 +1035,6 @@ impl ConversationTurnCoordinator {
         Self
     }
 
-    pub(crate) async fn compact_session(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<ContextCompactionReport> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.compact_session_with_runtime(config, session_id, &runtime, effective_binding)
-            .await
-    }
-
     pub async fn compact_production_session(
         &self,
         config: &LoongConfig,
@@ -1122,27 +1109,6 @@ impl ConversationTurnCoordinator {
         };
 
         Ok(report)
-    }
-
-    pub(crate) async fn handle_turn(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            &acp_options,
-            binding,
-            None,
-        )
-        .await
     }
 
     pub(crate) async fn repair_turn_checkpoint_tail(
@@ -7335,9 +7301,7 @@ mod tests {
     fn generic_direct_capable_coordinator_entrypoints_are_not_public_api() {
         let source = include_str!("turn_coordinator.rs");
         let function_names = [
-            "compact_session",
             "compact_session_with_runtime",
-            "handle_turn",
             "handle_turn_with_ingress",
             "handle_turn_with_acp_options",
             "repair_turn_checkpoint_tail",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1443,25 +1443,6 @@ impl ConversationTurnCoordinator {
         }
     }
 
-    pub(crate) async fn probe_turn_checkpoint_tail_runtime_gate_with_runtime<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        runtime: &R,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config,
-            session_id,
-            config.memory.sliding_window,
-            runtime,
-            binding,
-        )
-        .await
-    }
-
     pub(crate) async fn probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit<
         R: ConversationRuntime + ?Sized,
     >(
@@ -7317,7 +7298,6 @@ mod tests {
             "handle_turn_with_runtime",
             "handle_turn_with_runtime_and_ingress",
             "repair_turn_checkpoint_tail_with_runtime",
-            "probe_turn_checkpoint_tail_runtime_gate_with_runtime",
             "probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit",
             "handle_turn_with_runtime_and_acp_options",
             "handle_turn_with_runtime_and_acp_event_sink",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1181,25 +1181,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn load_production_turn_checkpoint_diagnostics(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<TurnCheckpointDiagnostics> {
-        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let production_binding = prepared.1;
-        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            config,
-            session_id,
-            config.memory.sliding_window,
-            &runtime,
-            production_binding,
-        )
-        .await
-    }
-
     pub(crate) async fn load_turn_checkpoint_diagnostics_with_limit(
         &self,
         config: &LoongConfig,
@@ -1240,10 +1221,11 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub async fn probe_production_turn_checkpoint_tail_runtime_gate(
+    pub(crate) async fn probe_production_turn_checkpoint_tail_runtime_gate_with_limit(
         &self,
         config: &LoongConfig,
         session_id: &str,
+        limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
         let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
@@ -1253,7 +1235,7 @@ impl ConversationTurnCoordinator {
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
             session_id,
-            config.memory.sliding_window,
+            limit,
             &runtime,
             production_binding,
         )
@@ -7289,10 +7271,12 @@ mod tests {
         config.conversation.context_engine = Some("missing-maintenance-runtime".to_owned());
 
         let coordinator = ConversationTurnCoordinator::new();
+        let limit = config.memory.sliding_window;
         let result = coordinator
-            .load_production_turn_checkpoint_diagnostics(
+            .load_production_turn_checkpoint_diagnostics_with_limit(
                 &config,
                 "maintenance-session",
+                limit,
                 ConversationRuntimeBinding::direct(),
             )
             .await;
@@ -7311,10 +7295,12 @@ mod tests {
         config.conversation.context_engine = Some("missing-maintenance-runtime".to_owned());
 
         let coordinator = ConversationTurnCoordinator::new();
+        let limit = config.memory.sliding_window;
         let result = coordinator
-            .probe_production_turn_checkpoint_tail_runtime_gate(
+            .probe_production_turn_checkpoint_tail_runtime_gate_with_limit(
                 &config,
                 "maintenance-session",
+                limit,
                 ConversationRuntimeBinding::direct(),
             )
             .await;

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -71,7 +71,7 @@ use super::analytics::{
 use super::announce::DelegateAnnounceSettings;
 #[cfg(feature = "memory-sqlite")]
 use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
-use super::context_engine::AssembledConversationContext;
+use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 #[cfg(feature = "memory-sqlite")]
 use super::delegate_support::{
     enqueue_delegate_result_announce_with_memory_config,
@@ -100,8 +100,7 @@ use super::plan_verifier::{
     PlanVerificationReport, verify_output,
 };
 use super::runtime::{
-    AsyncDelegateSpawnRequest, BoxedDefaultConversationRuntime, ConversationRuntime,
-    SessionContext, load_default_conversation_runtime,
+    AsyncDelegateSpawnRequest, ConversationRuntime, DefaultConversationRuntime, SessionContext,
 };
 use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::safe_lane_failure::{
@@ -115,8 +114,7 @@ use super::session_history::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::subagent::{
-    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentOwnerKind,
-    ConstrainedSubagentTerminalReason,
+    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
 };
 use super::tool_discovery_state::{TOOL_DISCOVERY_REFRESHED_EVENT_NAME, ToolDiscoveryState};
 use super::trust_projection::{
@@ -126,6 +124,10 @@ use super::turn_budget::{
     EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
 };
+
+type DefaultTurnRuntime = DefaultConversationRuntime<Box<dyn ConversationContextEngine>>;
+#[cfg(test)]
+use super::turn_checkpoint::TurnCheckpointResultKind;
 use super::turn_checkpoint::{
     ContextCompactionOutcome, TurnCheckpointDiagnostics, TurnCheckpointFailure,
     TurnCheckpointFailureStep, TurnCheckpointFinalizationProgress, TurnCheckpointIdentity,
@@ -1040,8 +1042,10 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
-        self.compact_session_with_runtime(config, session_id, &runtime, binding)
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
+        self.compact_session_with_runtime(config, session_id, &runtime, effective_binding)
             .await
     }
 
@@ -1051,8 +1055,9 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ContextCompactionReport> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
 
         self.compact_session_with_runtime(config, session_id, &runtime, production_binding)
             .await
@@ -1151,7 +1156,9 @@ impl ConversationTurnCoordinator {
     ) -> CliResult<String> {
         let acp_options = AcpConversationTurnOptions::automatic();
         let address = ConversationSessionAddress::from_session_id(session_id);
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             &address,
@@ -1159,7 +1166,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             &acp_options,
-            binding,
+            effective_binding,
             ingress,
         )
         .await
@@ -1192,9 +1199,16 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
-        self.repair_turn_checkpoint_tail_with_runtime(config, session_id, &runtime, binding)
-            .await
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
+        self.repair_turn_checkpoint_tail_with_runtime(
+            config,
+            session_id,
+            &runtime,
+            effective_binding,
+        )
+        .await
     }
 
     pub async fn repair_production_turn_checkpoint_tail(
@@ -1203,8 +1217,9 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
 
         self.repair_turn_checkpoint_tail_with_runtime(
             config,
@@ -1221,13 +1236,15 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
             config,
             session_id,
             config.memory.sliding_window,
             &runtime,
-            binding,
+            effective_binding,
         )
         .await
     }
@@ -1238,10 +1255,17 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-
-        self.load_turn_checkpoint_diagnostics(config, session_id, production_binding)
-            .await
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
+        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
+            config,
+            session_id,
+            config.memory.sliding_window,
+            &runtime,
+            production_binding,
+        )
+        .await
     }
 
     pub(crate) async fn load_turn_checkpoint_diagnostics_with_limit(
@@ -1251,9 +1275,15 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            config, session_id, limit, &runtime, binding,
+            config,
+            session_id,
+            limit,
+            &runtime,
+            effective_binding,
         )
         .await
     }
@@ -1265,12 +1295,14 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<TurnCheckpointDiagnostics> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-
-        self.load_turn_checkpoint_diagnostics_with_limit(
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
+        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
             config,
             session_id,
             limit,
+            &runtime,
             production_binding,
         )
         .await
@@ -1282,13 +1314,15 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
             session_id,
             config.memory.sliding_window,
             &runtime,
-            binding,
+            effective_binding,
         )
         .await
     }
@@ -1299,8 +1333,9 @@ impl ConversationTurnCoordinator {
         session_id: &str,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
 
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
@@ -1319,9 +1354,15 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
-            config, session_id, limit, &runtime, binding,
+            config,
+            session_id,
+            limit,
+            &runtime,
+            effective_binding,
         )
         .await
     }
@@ -1333,8 +1374,9 @@ impl ConversationTurnCoordinator {
         limit: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-        let production_binding = require_production_kernel_binding(binding, None)?;
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_production_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let production_binding = prepared.1;
 
         self.probe_turn_checkpoint_tail_runtime_gate_with_runtime_and_limit(
             config,
@@ -1418,7 +1460,9 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             address,
@@ -1426,7 +1470,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             acp_options,
-            binding,
+            effective_binding,
             ingress,
         )
         .await
@@ -1441,7 +1485,9 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, None)?;
+        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
             config,
             address,
@@ -1449,7 +1495,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             acp_options,
-            binding,
+            effective_binding,
             None,
         )
         .await
@@ -1492,7 +1538,10 @@ impl ConversationTurnCoordinator {
         observer: Option<ConversationTurnObserverHandle>,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
-        let runtime = Self::build_default_runtime_or_observe_failure(config, observer.as_ref())?;
+        let prepared =
+            Self::build_default_runtime_with_binding(config, binding, observer.as_ref())?;
+        let runtime = prepared.0;
+        let effective_binding = prepared.1;
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
@@ -1500,7 +1549,7 @@ impl ConversationTurnCoordinator {
             error_mode,
             &runtime,
             acp_options,
-            binding,
+            effective_binding,
             ingress,
             observer,
             acp_manager,
@@ -1565,16 +1614,13 @@ impl ConversationTurnCoordinator {
         observer: Option<ConversationTurnObserverHandle>,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
-        let observer_ref = observer.as_ref();
-        let production_binding = require_production_kernel_binding(binding, observer_ref)?;
-
         self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
             error_mode,
             acp_options,
-            production_binding,
+            require_production_kernel_binding(binding, observer.as_ref())?,
             None,
             observer,
             acp_manager,
@@ -1585,11 +1631,11 @@ impl ConversationTurnCoordinator {
     fn build_default_runtime_or_observe_failure(
         config: &LoongConfig,
         observer: Option<&ConversationTurnObserverHandle>,
-    ) -> CliResult<BoxedDefaultConversationRuntime> {
+    ) -> CliResult<DefaultTurnRuntime> {
         // Keep runtime-construction failures visible to the turn observer so
         // operator surfaces receive the same failed phase signal as execution
         // errors later in the turn pipeline.
-        let runtime_result = load_default_conversation_runtime(config);
+        let runtime_result = DefaultConversationRuntime::from_config_or_env(config);
         let runtime = match runtime_result {
             Ok(runtime) => runtime,
             Err(error) => {
@@ -1599,6 +1645,28 @@ impl ConversationTurnCoordinator {
             }
         };
         Ok(runtime)
+    }
+
+    fn build_default_runtime_with_binding<'a>(
+        config: &LoongClawConfig,
+        binding: ConversationRuntimeBinding<'a>,
+        observer: Option<&ConversationTurnObserverHandle>,
+    ) -> CliResult<(DefaultTurnRuntime, ConversationRuntimeBinding<'a>)> {
+        let runtime = Self::build_default_runtime_or_observe_failure(config, observer)?;
+        let effective_binding = binding;
+
+        Ok((runtime, effective_binding))
+    }
+
+    fn build_default_runtime_with_production_binding<'a>(
+        config: &LoongClawConfig,
+        binding: ConversationRuntimeBinding<'a>,
+        observer: Option<&ConversationTurnObserverHandle>,
+    ) -> CliResult<(DefaultTurnRuntime, ConversationRuntimeBinding<'a>)> {
+        let production_binding = require_production_kernel_binding(binding, observer)?;
+        let runtime = Self::build_default_runtime_or_observe_failure(config, observer)?;
+
+        Ok((runtime, production_binding))
     }
 
     pub(crate) async fn handle_turn_with_runtime<R: ConversationRuntime + ?Sized>(
@@ -2468,8 +2536,7 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
-        let observer_ref = observer.as_ref();
-        let production_binding = require_production_kernel_binding(binding, observer_ref)?;
+        let production_binding = require_production_kernel_binding(binding, observer.as_ref())?;
 
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
             config,
@@ -3096,8 +3163,7 @@ async fn request_provider_turn_with_observer<R: ConversationRuntime + ?Sized>(
     if let Some(observer) = observer
         && provider_turn_observer_supports_streaming(config, Some(observer))
     {
-        let request_started_at = std::time::Instant::now();
-        let on_token = build_observer_streaming_token_callback(observer, request_started_at);
+        let on_token = build_observer_streaming_token_callback(observer);
         return runtime
             .request_turn_streaming_with_retry_progress(
                 config,
@@ -4844,7 +4910,6 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                     let execution_policy = DelegateChildExecutionPolicy {
                         isolation: delegate_policy.isolation,
                         profile: delegate_policy.profile,
-                        owner_kind: None,
                         timeout_seconds: delegate_policy.timeout_seconds,
                         allow_shell_in_child: delegate_policy.allow_shell_in_child,
                         child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -4925,7 +4990,6 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         runtime,
         session_context,
         delegate_request,
-        ConstrainedSubagentOwnerKind::AsyncDelegateSpawner,
         binding,
     )
     .await?;
@@ -4966,7 +5030,6 @@ async fn enqueue_background_task_with_runtime<R: ConversationRuntime + ?Sized>(
         runtime,
         session_context,
         delegate_request,
-        ConstrainedSubagentOwnerKind::BackgroundTaskHost,
         binding,
     )
     .await?;
@@ -5025,7 +5088,6 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
     runtime: &R,
     session_context: &SessionContext,
     delegate_request: crate::tools::delegate::DelegateRequest,
-    owner_kind: ConstrainedSubagentOwnerKind,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<PreparedAsyncDelegateEnqueue, String> {
     let delegate_policy =
@@ -5054,7 +5116,6 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
                 let execution_policy = DelegateChildExecutionPolicy {
                     isolation: delegate_policy.isolation,
                     profile: delegate_policy.profile,
-                    owner_kind: Some(owner_kind),
                     timeout_seconds: delegate_policy.timeout_seconds,
                     allow_shell_in_child: delegate_policy.allow_shell_in_child,
                     child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -7321,7 +7382,6 @@ mod tests {
         assert_eq!(token_events.len(), 1);
         assert_eq!(token_events[0].event_type, "text_delta");
         assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
-        assert!(token_events[0].elapsed_ms.is_some());
     }
 
     #[tokio::test]
@@ -8040,7 +8100,6 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
-            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,
@@ -8173,7 +8232,6 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
-            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "memory-sqlite")]
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 #[cfg(feature = "memory-sqlite")]
@@ -34,6 +35,7 @@ use crate::acp::{
     AcpConversationTurnEntryDecision, AcpConversationTurnExecutionOutcome,
     AcpConversationTurnOptions, AcpTurnEventSink, evaluate_acp_conversation_turn_entry_for_address,
     execute_acp_conversation_turn_for_address,
+    execute_acp_conversation_turn_for_address_with_manager,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -1464,8 +1466,34 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<String> {
         let runtime = Self::build_default_runtime_or_observe_failure(config, observer.as_ref())?;
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
@@ -1475,7 +1503,7 @@ impl ConversationTurnCoordinator {
             binding,
             ingress,
             observer,
-            None,
+            acp_manager,
         )
         .await
     }
@@ -1513,17 +1541,43 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
+        self.handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            observer,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        observer: Option<ConversationTurnObserverHandle>,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<String> {
         let observer_ref = observer.as_ref();
         let production_binding = require_production_kernel_binding(binding, observer_ref)?;
 
-        self.handle_turn_with_address_and_acp_options_and_observer(
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
             error_mode,
             acp_options,
             production_binding,
+            None,
             observer,
+            acp_manager,
         )
         .await
     }
@@ -1878,7 +1932,38 @@ impl ConversationTurnCoordinator {
             binding,
             ingress,
             observer,
-            retry_progress,
+            None,
+        )
+        .await
+        .map(|outcome| outcome.reply)
+    }
+
+    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<String> {
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_outcome(
+            config,
+            address,
+            user_input,
+            error_mode,
+            runtime,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+            acp_manager,
         )
         .await
         .map(|outcome| outcome.reply)
@@ -1897,7 +1982,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
-        retry_progress: crate::provider::ProviderRetryProgressCallback,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<ConversationTurnOutcome> {
         let turn_result: CliResult<(ConversationTurnOutcome, bool)> = async {
             let session_id = address.session_id.as_str();
@@ -1966,7 +2051,7 @@ impl ConversationTurnCoordinator {
                 }
                 AcpConversationTurnEntryDecision::RouteViaAcp => {
                     let reply = self
-                        .handle_turn_via_acp(
+                        .handle_turn_via_acp_with_manager(
                             config,
                             address,
                             user_input,
@@ -1974,6 +2059,7 @@ impl ConversationTurnCoordinator {
                             runtime,
                             acp_options,
                             binding,
+                            acp_manager.clone(),
                         )
                         .await?;
                     return Ok((ConversationTurnOutcome { reply, usage: None }, true));
@@ -2069,18 +2155,11 @@ impl ConversationTurnCoordinator {
         .await;
 
         match turn_result {
-            Ok((reply, true)) => {
-                #[cfg(feature = "memory-sqlite")]
-                persist_task_progress_event_best_effort(
-                    config,
-                    address.session_id.as_str(),
-                    "turn_completed",
-                    completed_task_progress_record(config, address.session_id.as_str(), user_input),
-                );
+            Ok((outcome, true)) => {
                 observe_non_provider_turn_terminal_success_phases(observer.as_ref());
-                Ok(reply)
+                Ok(outcome)
             }
-            Ok((reply, false)) => Ok(reply),
+            Ok((outcome, false)) => Ok(outcome),
             Err(error) => {
                 let failed_event = ConversationTurnPhaseEvent::failed();
                 observe_turn_phase(observer.as_ref(), failed_event);
@@ -2443,10 +2522,47 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
+        self.handle_turn_via_acp_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            runtime,
+            acp_options,
+            binding,
+            None,
+        )
+        .await
+    }
+
+    async fn handle_turn_via_acp_with_manager<R: ConversationRuntime + ?Sized>(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<String> {
         let session_id = address.session_id.as_str();
-        let executed =
-            execute_acp_conversation_turn_for_address(config, address, user_input, acp_options)
-                .await?;
+        let executed = match acp_manager {
+            Some(manager) => {
+                execute_acp_conversation_turn_for_address_with_manager(
+                    config,
+                    address,
+                    user_input,
+                    acp_options,
+                    manager,
+                )
+                .await?
+            }
+            None => {
+                execute_acp_conversation_turn_for_address(config, address, user_input, acp_options)
+                    .await?
+            }
+        };
         let persistence_context = &executed.persistence_context;
 
         match executed.outcome {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1111,24 +1111,6 @@ impl ConversationTurnCoordinator {
         Ok(report)
     }
 
-    pub(crate) async fn repair_turn_checkpoint_tail(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<TurnCheckpointTailRepairOutcome> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.repair_turn_checkpoint_tail_with_runtime(
-            config,
-            session_id,
-            &runtime,
-            effective_binding,
-        )
-        .await
-    }
-
     pub async fn repair_production_turn_checkpoint_tail(
         &self,
         config: &LoongConfig,
@@ -7240,7 +7222,6 @@ mod tests {
             "compact_session_with_runtime",
             "handle_turn_with_ingress",
             "handle_turn_with_acp_options",
-            "repair_turn_checkpoint_tail",
             "probe_turn_checkpoint_tail_runtime_gate",
             "probe_turn_checkpoint_tail_runtime_gate_with_limit",
             "handle_turn_with_acp_event_sink",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2608,7 +2608,8 @@ async fn request_provider_turn_with_observer<R: ConversationRuntime + ?Sized>(
     if let Some(observer) = observer
         && provider_turn_observer_supports_streaming(config, Some(observer))
     {
-        let on_token = build_observer_streaming_token_callback(observer);
+        let request_started_at = std::time::Instant::now();
+        let on_token = build_observer_streaming_token_callback(observer, request_started_at);
         return runtime
             .request_turn_streaming_with_retry_progress(
                 config,
@@ -4355,6 +4356,7 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                     let execution_policy = DelegateChildExecutionPolicy {
                         isolation: delegate_policy.isolation,
                         profile: delegate_policy.profile,
+                        owner_kind: None,
                         timeout_seconds: delegate_policy.timeout_seconds,
                         allow_shell_in_child: delegate_policy.allow_shell_in_child,
                         child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -4436,6 +4438,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         session_context,
         delegate_request,
         binding,
+        Some(crate::conversation::ConstrainedSubagentOwnerKind::AsyncDelegateSpawner),
     )
     .await?;
     let detached_config = std::sync::Arc::new(config.clone());
@@ -4476,6 +4479,7 @@ async fn enqueue_background_task_with_runtime<R: ConversationRuntime + ?Sized>(
         session_context,
         delegate_request,
         binding,
+        Some(crate::conversation::ConstrainedSubagentOwnerKind::BackgroundTaskHost),
     )
     .await?;
     let spawn_result = spawner.spawn(delegate_request.request.clone()).await;
@@ -4534,6 +4538,7 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
     session_context: &SessionContext,
     delegate_request: crate::tools::delegate::DelegateRequest,
     binding: ConversationRuntimeBinding<'_>,
+    owner_kind: Option<crate::conversation::ConstrainedSubagentOwnerKind>,
 ) -> Result<PreparedAsyncDelegateEnqueue, String> {
     let delegate_policy =
         crate::tools::delegate::resolve_delegate_policy(&delegate_request, &config.tools.delegate);
@@ -4561,6 +4566,7 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
                 let execution_policy = DelegateChildExecutionPolicy {
                     isolation: delegate_policy.isolation,
                     profile: delegate_policy.profile,
+                    owner_kind,
                     timeout_seconds: delegate_policy.timeout_seconds,
                     allow_shell_in_child: delegate_policy.allow_shell_in_child,
                     child_tool_allowlist: delegate_policy.child_tool_allowlist.clone(),
@@ -7522,6 +7528,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,
@@ -7654,6 +7661,7 @@ mod tests {
         let execution = ConstrainedSubagentExecution {
             mode: ConstrainedSubagentMode::Async,
             isolation: crate::conversation::ConstrainedSubagentIsolation::Shared,
+            owner_kind: None,
             depth: 1,
             max_depth: 1,
             active_children: 0,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -33,7 +33,7 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::acp::{
     AcpConversationTurnEntryDecision, AcpConversationTurnExecutionOutcome,
-    AcpConversationTurnOptions, AcpTurnEventSink, evaluate_acp_conversation_turn_entry_for_address,
+    AcpConversationTurnOptions, evaluate_acp_conversation_turn_entry_for_address,
     execute_acp_conversation_turn_for_address,
     execute_acp_conversation_turn_for_address_with_manager,
 };
@@ -1384,28 +1384,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_acp_event_sink(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            &acp_options,
-            binding,
-            None,
-        )
-        .await
-    }
-
     async fn handle_turn_with_session_and_acp_options_and_ingress(
         &self,
         config: &LoongClawConfig,
@@ -1425,47 +1403,6 @@ impl ConversationTurnCoordinator {
             acp_options,
             binding,
             ingress,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_address(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_address_and_acp_options(
-            config,
-            address,
-            user_input,
-            error_mode,
-            &acp_options,
-            binding,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_address_and_acp_event_sink(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_address_and_acp_options(
-            config,
-            address,
-            user_input,
-            error_mode,
-            &acp_options,
-            binding,
         )
         .await
     }
@@ -1866,57 +1803,6 @@ impl ConversationTurnCoordinator {
                     .to_owned(),
             )
         }
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_acp_options<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            runtime,
-            acp_options,
-            binding,
-            None,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_acp_event_sink<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            runtime,
-            &acp_options,
-            binding,
-            None,
-        )
-        .await
     }
 
     async fn handle_turn_with_runtime_and_session_and_acp_options_and_ingress<
@@ -2595,32 +2481,6 @@ impl ConversationTurnCoordinator {
             production_binding,
             ingress,
             observer,
-            None,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_event_sink<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        acp_event_sink: Option<&dyn AcpTurnEventSink>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::from_event_sink(acp_event_sink);
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
-            config,
-            address,
-            user_input,
-            error_mode,
-            runtime,
-            &acp_options,
-            binding,
             None,
         )
         .await

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1311,31 +1311,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-        observer: Option<ConversationTurnObserverHandle>,
-    ) -> CliResult<String> {
-        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
-            config,
-            address,
-            user_input,
-            error_mode,
-            acp_options,
-            binding,
-            ingress,
-            observer,
-            None,
-        )
-        .await
-    }
-
     pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
         &self,
         config: &LoongClawConfig,
@@ -1377,7 +1352,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
-        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
@@ -1386,6 +1361,7 @@ impl ConversationTurnCoordinator {
             binding,
             None,
             observer,
+            None,
         )
         .await
     }
@@ -1722,7 +1698,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
@@ -1735,37 +1711,6 @@ impl ConversationTurnCoordinator {
             None,
         )
         .await
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-        observer: Option<ConversationTurnObserverHandle>,
-        retry_progress: crate::provider::ProviderRetryProgressCallback,
-    ) -> CliResult<String> {
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_outcome(
-            config,
-            address,
-            user_input,
-            error_mode,
-            runtime,
-            acp_options,
-            binding,
-            ingress,
-            observer,
-            None,
-        )
-        .await
-        .map(|outcome| outcome.reply)
     }
 
     pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager<
@@ -2300,7 +2245,7 @@ impl ConversationTurnCoordinator {
     ) -> CliResult<String> {
         let production_binding = require_production_kernel_binding(binding, observer.as_ref())?;
 
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
             user_input,
@@ -7068,8 +7013,7 @@ mod tests {
         let observer_handle: ConversationTurnObserverHandle = observer.clone();
         let acp_options = AcpConversationTurnOptions::automatic();
         let address = ConversationSessionAddress::from_session_id("observer-session");
-        let reply = ConversationTurnCoordinator::new()
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        let reply = ConversationTurnCoordinator::new().handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
@@ -7131,8 +7075,7 @@ mod tests {
         let observer_handle: ConversationTurnObserverHandle = observer.clone();
         let acp_options = AcpConversationTurnOptions::automatic();
         let address = ConversationSessionAddress::from_session_id("observer-session");
-        let reply = ConversationTurnCoordinator::new()
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        let reply = ConversationTurnCoordinator::new().handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
@@ -7198,8 +7141,7 @@ mod tests {
         let observer_handle: ConversationTurnObserverHandle = observer.clone();
         let acp_options = AcpConversationTurnOptions::explicit();
         let address = ConversationSessionAddress::from_session_id("observer-session");
-        let reply = ConversationTurnCoordinator::new()
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        let reply = ConversationTurnCoordinator::new().handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
@@ -7266,7 +7208,7 @@ mod tests {
         let address = ConversationSessionAddress::from_session_id("observer-session");
 
         let result = coordinator
-            .handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+            .handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
@@ -7275,6 +7217,7 @@ mod tests {
                 ConversationRuntimeBinding::direct(),
                 None,
                 Some(observer_handle),
+                None,
             )
             .await;
         let _error = result.expect_err("missing runtime bootstrap should fail");
@@ -8863,7 +8806,7 @@ mod tests {
                 .expect("kernel context");
 
         let reply = coordinator
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "esc",
@@ -8958,7 +8901,7 @@ mod tests {
         let acp_options = AcpConversationTurnOptions::automatic();
         let address = ConversationSessionAddress::from_session_id("root-session");
         let result = coordinator
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "auto",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -125,8 +125,6 @@ use super::turn_budget::{
 };
 
 type DefaultTurnRuntime = DefaultConversationRuntime<Box<dyn ConversationContextEngine>>;
-#[cfg(test)]
-use super::turn_checkpoint::TurnCheckpointResultKind;
 use super::turn_checkpoint::{
     ContextCompactionOutcome, TurnCheckpointDiagnostics, TurnCheckpointFailure,
     TurnCheckpointFailureStep, TurnCheckpointFinalizationProgress, TurnCheckpointIdentity,
@@ -1152,7 +1150,7 @@ impl ConversationTurnCoordinator {
 
     async fn handle_turn_with_session_and_acp_options_and_ingress(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         user_input: &str,
         error_mode: ProviderErrorMode,
@@ -1175,13 +1173,14 @@ impl ConversationTurnCoordinator {
             ingress,
             None,
             None,
+            None,
         )
         .await
     }
 
-    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
+    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         address: &ConversationSessionAddress,
         user_input: &str,
         error_mode: ProviderErrorMode,
@@ -1189,6 +1188,33 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
+        &self,
+        config: &LoongConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
         let prepared =
@@ -1205,20 +1231,69 @@ impl ConversationTurnCoordinator {
             effective_binding,
             ingress,
             observer,
+            retry_progress,
             acp_manager,
         )
         .await
     }
 
-    pub(crate) async fn handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
+    pub(crate) async fn handle_turn_with_address_and_acp_options_and_observer(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         address: &ConversationSessionAddress,
         user_input: &str,
         error_mode: ProviderErrorMode,
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
         observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+            config,
+            address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            None,
+            observer,
+        )
+        .await
+    }
+
+    pub async fn handle_production_turn_with_address_and_acp_options_and_observer(
+        &self,
+        config: &LoongConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        self.handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            acp_options,
+            binding,
+            observer,
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
+        &self,
+        config: &LoongConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
         self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
@@ -1230,6 +1305,7 @@ impl ConversationTurnCoordinator {
             require_production_kernel_binding(binding, observer.as_ref())?,
             None,
             observer,
+            retry_progress,
             acp_manager,
         )
         .await
@@ -1255,7 +1331,7 @@ impl ConversationTurnCoordinator {
     }
 
     fn build_default_runtime_with_binding<'a>(
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         binding: ConversationRuntimeBinding<'a>,
         observer: Option<&ConversationTurnObserverHandle>,
     ) -> CliResult<(DefaultTurnRuntime, ConversationRuntimeBinding<'a>)> {
@@ -1266,7 +1342,7 @@ impl ConversationTurnCoordinator {
     }
 
     fn build_default_runtime_with_production_binding<'a>(
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         binding: ConversationRuntimeBinding<'a>,
         observer: Option<&ConversationTurnObserverHandle>,
     ) -> CliResult<(DefaultTurnRuntime, ConversationRuntimeBinding<'a>)> {
@@ -1416,7 +1492,7 @@ impl ConversationTurnCoordinator {
         R: ConversationRuntime + ?Sized,
     >(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         session_id: &str,
         user_input: &str,
         error_mode: ProviderErrorMode,
@@ -1435,6 +1511,7 @@ impl ConversationTurnCoordinator {
             acp_options,
             binding,
             ingress,
+            None,
             None,
             None,
         )
@@ -1464,15 +1541,16 @@ impl ConversationTurnCoordinator {
             None,
             None,
             None,
+            None,
         )
         .await
     }
 
-    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager<
+    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer<
         R: ConversationRuntime + ?Sized,
     >(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         address: &ConversationSessionAddress,
         user_input: &str,
         error_mode: ProviderErrorMode,
@@ -1481,6 +1559,38 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
+    ) -> CliResult<String> {
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            runtime,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+            retry_progress,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_outcome(
@@ -1493,6 +1603,7 @@ impl ConversationTurnCoordinator {
             binding,
             ingress,
             observer,
+            retry_progress,
             acp_manager,
         )
         .await
@@ -1512,6 +1623,7 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<ConversationTurnOutcome> {
         let turn_result: CliResult<(ConversationTurnOutcome, bool)> = async {
@@ -1998,6 +2110,38 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
+        self.handle_production_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
+            config,
+            address,
+            user_input,
+            error_mode,
+            runtime,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn handle_production_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+        retry_progress: crate::provider::ProviderRetryProgressCallback,
+        acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+    ) -> CliResult<String> {
         let production_binding = require_production_kernel_binding(binding, observer.as_ref())?;
 
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
@@ -2010,7 +2154,8 @@ impl ConversationTurnCoordinator {
             production_binding,
             ingress,
             observer,
-            None,
+            retry_progress,
+            acp_manager,
         )
         .await
     }
@@ -2040,7 +2185,7 @@ impl ConversationTurnCoordinator {
 
     async fn handle_turn_via_acp_with_manager<R: ConversationRuntime + ?Sized>(
         &self,
-        config: &LoongClawConfig,
+        config: &LoongConfig,
         address: &ConversationSessionAddress,
         user_input: &str,
         error_mode: ProviderErrorMode,
@@ -6794,6 +6939,7 @@ mod tests {
                 None,
                 Some(observer_handle),
                 None,
+                None,
             )
             .await
             .expect("observer turn should succeed");
@@ -6855,6 +7001,7 @@ mod tests {
                 ConversationRuntimeBinding::direct(),
                 None,
                 Some(observer_handle),
+                None,
                 None,
             )
             .await
@@ -6922,6 +7069,7 @@ mod tests {
                 None,
                 Some(observer_handle),
                 None,
+                None,
             )
             .await
             .expect("ACP inline reply should succeed");
@@ -6988,6 +7136,7 @@ mod tests {
                 None,
                 Some(observer_handle),
                 None,
+                None,
             )
             .await;
         let _error = result.expect_err("missing runtime bootstrap should fail");
@@ -7025,6 +7174,7 @@ mod tests {
                 None,
                 Some(observer_handle),
                 None,
+                None,
             )
             .await;
         let _error = result.expect_err("missing runtime bootstrap should fail");
@@ -7061,6 +7211,7 @@ mod tests {
                 &acp_options,
                 ConversationRuntimeBinding::direct(),
                 Some(observer_handle),
+                None,
                 None,
             )
             .await;
@@ -8568,6 +8719,7 @@ mod tests {
                 None,
                 Some(observer_handle),
                 None,
+                None,
             )
             .await
             .expect("approval control turn should succeed");
@@ -8660,6 +8812,7 @@ mod tests {
                 &runtime,
                 &acp_options,
                 ConversationRuntimeBinding::direct(),
+                None,
                 None,
                 None,
                 None,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -32,8 +32,9 @@ use crate::CliResult;
 #[cfg(test)]
 use crate::KernelContext;
 use crate::acp::{
-    AcpConversationTurnEntryDecision, AcpConversationTurnOptions, FinalizedAcpConversationTurn,
-    evaluate_acp_conversation_turn_entry_for_address, execute_acp_conversation_turn_for_address,
+    AcpConversationTurnEntryDecision, AcpConversationTurnOptions,
+    consume_finalized_acp_conversation_turn, evaluate_acp_conversation_turn_entry_for_address,
+    execute_acp_conversation_turn_for_address,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -2170,9 +2171,11 @@ impl ConversationTurnCoordinator {
         )
         .await?;
 
-        match executed {
-            FinalizedAcpConversationTurn::Succeeded(success) => {
+        consume_finalized_acp_conversation_turn(
+            executed,
+            |success| async move {
                 let reply = success.result.output_text.clone();
+
                 persist_reply_turns_raw_with_mode(
                     runtime,
                     session_id,
@@ -2182,37 +2185,51 @@ impl ConversationTurnCoordinator {
                     binding,
                 )
                 .await?;
+
                 if config.acp.emit_runtime_events {
+                    let runtime_events = &success.runtime_events;
+                    let persistence_context = &success.persistence_context;
+                    let result = &success.result;
+
                     let _ = persist_acp_runtime_events(
                         runtime,
                         session_id,
-                        &success.persistence_context,
-                        &success.runtime_events,
-                        Some(&success.result),
+                        persistence_context,
+                        runtime_events,
+                        Some(result),
                         None,
                         binding,
                     )
                     .await;
                 }
+
                 Ok(reply)
-            }
-            FinalizedAcpConversationTurn::Failed(failure) => {
+            },
+            |failure| async move {
+                let error = failure.error;
+
                 if config.acp.emit_runtime_events {
+                    let error_text = error.as_str();
+                    let runtime_events = &failure.runtime_events;
+                    let persistence_context = &failure.persistence_context;
+
                     let _ = persist_acp_runtime_events(
                         runtime,
                         session_id,
-                        &failure.persistence_context,
-                        &failure.runtime_events,
+                        persistence_context,
+                        runtime_events,
                         None,
-                        Some(failure.error.as_str()),
+                        Some(error_text),
                         binding,
                     )
                     .await;
                 }
+
                 match error_mode {
-                    ProviderErrorMode::Propagate => Err(failure.error),
+                    ProviderErrorMode::Propagate => Err(error),
                     ProviderErrorMode::InlineMessage => {
-                        let synthetic = format_provider_error_reply(&failure.error);
+                        let synthetic = format_provider_error_reply(&error);
+
                         persist_reply_turns_raw_with_mode(
                             runtime,
                             session_id,
@@ -2222,11 +2239,13 @@ impl ConversationTurnCoordinator {
                             binding,
                         )
                         .await?;
+
                         Ok(synthetic)
                     }
                 }
-            }
-        }
+            },
+        )
+        .await
     }
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1342,53 +1342,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_address_and_acp_options_and_observer(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        observer: Option<ConversationTurnObserverHandle>,
-    ) -> CliResult<String> {
-        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
-            config,
-            address,
-            user_input,
-            error_mode,
-            acp_options,
-            binding,
-            None,
-            observer,
-            None,
-        )
-        .await
-    }
-
-    pub async fn handle_production_turn_with_address_and_acp_options_and_observer(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        observer: Option<ConversationTurnObserverHandle>,
-    ) -> CliResult<String> {
-        self.handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
-            config,
-            address,
-            user_input,
-            error_mode,
-            acp_options,
-            binding,
-            observer,
-            None,
-        )
-        .await
-    }
-
     pub(crate) async fn handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
         &self,
         config: &LoongClawConfig,
@@ -1633,29 +1586,6 @@ impl ConversationTurnCoordinator {
             acp_options,
             binding,
             ingress,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_address<R: ConversationRuntime + ?Sized>(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
-            config,
-            address,
-            user_input,
-            error_mode,
-            runtime,
-            &acp_options,
-            binding,
-            None,
         )
         .await
     }
@@ -7245,14 +7175,16 @@ mod tests {
         let address = ConversationSessionAddress::from_session_id("observer-session");
 
         let result = coordinator
-            .handle_turn_with_address_and_acp_options_and_observer(
+            .handle_turn_with_address_and_acp_options_and_ingress_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
                 ProviderErrorMode::Propagate,
                 &acp_options,
                 ConversationRuntimeBinding::direct(),
+                None,
                 Some(observer_handle),
+                None,
             )
             .await;
         let _error = result.expect_err("missing runtime bootstrap should fail");
@@ -7281,7 +7213,7 @@ mod tests {
         let address = ConversationSessionAddress::from_session_id("observer-session");
 
         let result = coordinator
-            .handle_production_turn_with_address_and_acp_options_and_observer(
+            .handle_production_turn_with_address_and_acp_options_and_observer_with_manager(
                 &config,
                 &address,
                 "say hello",
@@ -7289,6 +7221,7 @@ mod tests {
                 &acp_options,
                 ConversationRuntimeBinding::direct(),
                 Some(observer_handle),
+                None,
             )
             .await;
         let error = result.expect_err("direct production binding should fail");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1168,27 +1168,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_acp_options(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        self.handle_turn_with_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            acp_options,
-            binding,
-            None,
-        )
-        .await
-    }
-
     pub(crate) async fn repair_turn_checkpoint_tail(
         &self,
         config: &LoongConfig,
@@ -1433,31 +1412,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn handle_turn_with_address_and_acp_options(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<String> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
-            config,
-            address,
-            user_input,
-            error_mode,
-            &runtime,
-            acp_options,
-            effective_binding,
-            None,
-        )
-        .await
-    }
-
     pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer(
         &self,
         config: &LoongConfig,
@@ -1645,30 +1599,6 @@ impl ConversationTurnCoordinator {
             &acp_options,
             binding,
             None,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_runtime_and_ingress<R: ConversationRuntime + ?Sized>(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-    ) -> CliResult<String> {
-        let acp_options = AcpConversationTurnOptions::automatic();
-        self.handle_turn_with_runtime_and_session_and_acp_options_and_ingress(
-            config,
-            session_id,
-            user_input,
-            error_mode,
-            runtime,
-            &acp_options,
-            binding,
-            ingress,
         )
         .await
     }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1130,26 +1130,6 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    pub(crate) async fn load_turn_checkpoint_diagnostics_with_limit(
-        &self,
-        config: &LoongConfig,
-        session_id: &str,
-        limit: usize,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> CliResult<TurnCheckpointDiagnostics> {
-        let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
-        let runtime = prepared.0;
-        let effective_binding = prepared.1;
-        self.load_turn_checkpoint_diagnostics_with_runtime_and_limit(
-            config,
-            session_id,
-            limit,
-            &runtime,
-            effective_binding,
-        )
-        .await
-    }
-
     pub(crate) async fn load_production_turn_checkpoint_diagnostics_with_limit(
         &self,
         config: &LoongConfig,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1273,40 +1273,20 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let address = ConversationSessionAddress::from_session_id(session_id);
-        self.handle_turn_with_address_and_acp_options_and_ingress(
-            config,
-            &address,
-            user_input,
-            error_mode,
-            acp_options,
-            binding,
-            ingress,
-        )
-        .await
-    }
-
-    pub(crate) async fn handle_turn_with_address_and_acp_options_and_ingress(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-    ) -> CliResult<String> {
         let prepared = Self::build_default_runtime_with_binding(config, binding, None)?;
         let runtime = prepared.0;
         let effective_binding = prepared.1;
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
-            address,
+            &address,
             user_input,
             error_mode,
             &runtime,
             acp_options,
             effective_binding,
             ingress,
+            None,
+            None,
         )
         .await
     }
@@ -1577,7 +1557,7 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
         let address = ConversationSessionAddress::from_session_id(session_id);
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             &address,
             user_input,
@@ -1586,6 +1566,8 @@ impl ConversationTurnCoordinator {
             acp_options,
             binding,
             ingress,
+            None,
+            None,
         )
         .await
     }
@@ -1602,32 +1584,6 @@ impl ConversationTurnCoordinator {
         acp_options: &AcpConversationTurnOptions<'_>,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<String> {
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress(
-            config,
-            address,
-            user_input,
-            error_mode,
-            runtime,
-            acp_options,
-            binding,
-            None,
-        )
-        .await
-    }
-
-    async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress<
-        R: ConversationRuntime + ?Sized,
-    >(
-        &self,
-        config: &LoongConfig,
-        address: &ConversationSessionAddress,
-        user_input: &str,
-        error_mode: ProviderErrorMode,
-        runtime: &R,
-        acp_options: &AcpConversationTurnOptions<'_>,
-        binding: ConversationRuntimeBinding<'_>,
-        ingress: Option<&ConversationIngressContext>,
-    ) -> CliResult<String> {
         self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_with_manager(
             config,
             address,
@@ -1636,7 +1592,7 @@ impl ConversationTurnCoordinator {
             runtime,
             acp_options,
             binding,
-            ingress,
+            None,
             None,
             None,
         )

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -35,7 +35,6 @@ use crate::acp::{
     AcpConversationTurnEntryDecision, AcpConversationTurnExecutionOutcome,
     AcpConversationTurnOptions, evaluate_acp_conversation_turn_entry_for_address,
     execute_acp_conversation_turn_for_address,
-    execute_acp_conversation_turn_for_address_with_manager,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -2181,22 +2180,14 @@ impl ConversationTurnCoordinator {
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<String> {
         let session_id = address.session_id.as_str();
-        let executed = match acp_manager {
-            Some(manager) => {
-                execute_acp_conversation_turn_for_address_with_manager(
-                    config,
-                    address,
-                    user_input,
-                    acp_options,
-                    manager,
-                )
-                .await?
-            }
-            None => {
-                execute_acp_conversation_turn_for_address(config, address, user_input, acp_options)
-                    .await?
-            }
-        };
+        let executed = execute_acp_conversation_turn_for_address(
+            config,
+            address,
+            user_input,
+            acp_options,
+            acp_manager,
+        )
+        .await?;
         let persistence_context = &executed.persistence_context;
 
         match executed.outcome {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -879,10 +879,14 @@ pub fn execute_tool_core_with_config(
     let payload = request.payload;
     let workspace_root = trusted_workspace_root_from_payload(&payload)?;
     let runtime_narrowing = trusted_runtime_narrowing_from_payload(&payload)?;
-    let mut effective_config = match workspace_root {
-        Some(workspace_root) => config.with_file_root_override(workspace_root),
-        None => config.clone(),
-    };
+    let mut effective_config = config
+        .workspace_root
+        .clone()
+        .map(|workspace_root| config.with_file_root_override(workspace_root))
+        .unwrap_or_else(|| config.clone());
+    if let Some(workspace_root) = workspace_root {
+        effective_config = effective_config.with_file_root_override(workspace_root);
+    }
     if let Some(runtime_narrowing) = runtime_narrowing {
         effective_config = effective_config.narrowed(&runtime_narrowing);
     }

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -346,6 +346,7 @@ enum ReadToolLeaseSecretFileError {
 }
 
 impl ReadToolLeaseSecretFileError {
+    #[allow(dead_code)]
     fn is_retryable_publication_state(&self) -> bool {
         matches!(
             self,

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -261,11 +261,13 @@ fn read_tool_lease_secret_after_competitor_publish(secret_path: &Path) -> Result
     let mut attempt_index = 0usize;
 
     while attempt_index < retry_attempts {
-        match read_tool_lease_secret_file_detail(secret_path) {
-            Ok(Some(existing_secret)) => return Ok(existing_secret),
-            Ok(None) => {}
-            Err(error) if error.is_retryable_publication_state() => {}
-            Err(error) => return Err(error.render(secret_path)),
+        let existing_secret = match read_tool_lease_secret_file(secret_path) {
+            Ok(existing_secret) => existing_secret,
+            Err(error) if tool_lease_secret_publication_error_is_retryable(error.as_str()) => None,
+            Err(error) => return Err(error),
+        };
+        if let Some(existing_secret) = existing_secret {
+            return Ok(existing_secret);
         }
 
         attempt_index += 1;
@@ -283,6 +285,12 @@ fn read_tool_lease_secret_after_competitor_publish(secret_path: &Path) -> Result
         secret_path.display()
     );
     Err(message)
+}
+
+fn tool_lease_secret_publication_error_is_retryable(error: &str) -> bool {
+    error.contains(" is empty")
+        || error.contains(" is not valid hex")
+        || (error.contains(" has ") && error.contains(" bytes; expected "))
 }
 
 fn ensure_tool_lease_secret_parent_dir(secret_path: &Path) -> Result<(), String> {

--- a/crates/app/src/tools/workspace_root_tests.rs
+++ b/crates/app/src/tools/workspace_root_tests.rs
@@ -36,6 +36,46 @@ fn execute_tool_core_with_test_context(
 
 #[cfg(feature = "tool-file")]
 #[test]
+fn file_read_uses_runtime_workspace_root_from_runtime_config() {
+    let outer_root = std::env::temp_dir().join(format!(
+        "loongclaw-file-read-runtime-workspace-root-outer-{}",
+        std::process::id()
+    ));
+    let runtime_root = std::env::temp_dir().join(format!(
+        "loongclaw-file-read-runtime-workspace-root-runtime-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&outer_root).expect("create outer root");
+    std::fs::create_dir_all(&runtime_root).expect("create runtime root");
+    std::fs::write(outer_root.join("note.txt"), "outer").expect("write outer note");
+    std::fs::write(runtime_root.join("note.txt"), "runtime").expect("write runtime note");
+
+    let mut config = test_tool_runtime_config(outer_root.clone());
+    config.workspace_root = Some(runtime_root.clone());
+
+    let outcome = execute_tool_core_with_test_context(
+        ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({
+                "path": "note.txt"
+            }),
+        },
+        &config,
+    )
+    .expect("runtime workspace root should be used for default resolution");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["content"], "runtime");
+    let expected_path =
+        dunce::canonicalize(runtime_root.join("note.txt")).expect("canonicalize runtime note");
+    assert_eq!(outcome.payload["path"], expected_path.display().to_string());
+
+    std::fs::remove_dir_all(&outer_root).ok();
+    std::fs::remove_dir_all(&runtime_root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
 fn file_read_uses_workspace_root_from_trusted_internal_payload() {
     let outer_root = std::env::temp_dir().join(format!(
         "loong-file-read-workspace-root-outer-{}",

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -2399,7 +2399,8 @@ async fn turn_submit(
         };
         let turn_service =
             crate::mvp::agent_runtime::TurnExecutionService::new(resolved_path, config)
-                .with_acp_manager(acp_manager);
+                .with_acp_manager(acp_manager)
+                .without_runtime_environment_init();
         let turn_options = crate::mvp::agent_runtime::TurnExecutionOptions {
             event_sink: Some(&event_forwarder),
             ..Default::default()

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -2397,15 +2397,15 @@ async fn turn_submit(
             acp_cwd: working_directory,
             live_surface_enabled: false,
         };
-        let execution_result = mvp::agent_runtime::AgentRuntime::new()
-            .run_turn_with_loaded_config_and_acp_manager(
-                resolved_path,
-                config,
-                Some(session_id.as_str()),
-                &turn_request,
-                Some(&event_forwarder),
-                acp_manager,
-            )
+        let turn_service =
+            crate::mvp::agent_runtime::TurnExecutionService::new(resolved_path, config)
+                .with_acp_manager(acp_manager);
+        let turn_options = crate::mvp::agent_runtime::TurnExecutionOptions {
+            event_sink: Some(&event_forwarder),
+            ..Default::default()
+        };
+        let execution_result = turn_service
+            .execute(Some(session_id.as_str()), &turn_request, turn_options)
             .await;
 
         match execution_result {

--- a/crates/daemon/src/gateway/api_turn.rs
+++ b/crates/daemon/src/gateway/api_turn.rs
@@ -133,6 +133,7 @@ pub(crate) async fn handle_turn(
         channel_id: turn_request.channel_id.clone(),
         account_id: turn_request.account_id.clone(),
         conversation_id: turn_request.conversation_id.clone(),
+        participant_id: turn_request.participant_id.clone(),
         thread_id: turn_request.thread_id.clone(),
         metadata: turn_request.metadata.clone(),
         acp: true,
@@ -145,7 +146,8 @@ pub(crate) async fn handle_turn(
         PathBuf::from(app_state.config_path.clone()),
         config.clone(),
     )
-    .with_acp_manager(acp_manager.clone());
+    .with_acp_manager(acp_manager.clone())
+    .without_runtime_environment_init();
     let turn_options = crate::mvp::agent_runtime::TurnExecutionOptions {
         event_sink: event_sink
             .as_ref()

--- a/crates/daemon/src/gateway/api_turn.rs
+++ b/crates/daemon/src/gateway/api_turn.rs
@@ -127,30 +127,36 @@ pub(crate) async fn handle_turn(
         .map(ToOwned::to_owned);
 
     let event_sink = app_state.event_bus.as_ref().map(|bus| bus.sink());
-    let result = crate::mvp::agent_runtime::AgentRuntime::new()
-        .run_turn_with_loaded_config_and_acp_manager(
-            PathBuf::from(app_state.config_path.clone()),
-            config.clone(),
+    let turn_runtime_request = crate::mvp::agent_runtime::AgentTurnRequest {
+        message: turn_request.input.clone(),
+        turn_mode: crate::mvp::agent_runtime::AgentTurnMode::Acp,
+        channel_id: turn_request.channel_id.clone(),
+        account_id: turn_request.account_id.clone(),
+        conversation_id: turn_request.conversation_id.clone(),
+        thread_id: turn_request.thread_id.clone(),
+        metadata: turn_request.metadata.clone(),
+        acp: true,
+        acp_event_stream: event_sink.is_some(),
+        acp_bootstrap_mcp_servers: Vec::new(),
+        acp_cwd: working_directory,
+        live_surface_enabled: false,
+    };
+    let turn_service = crate::mvp::agent_runtime::TurnExecutionService::new(
+        PathBuf::from(app_state.config_path.clone()),
+        config.clone(),
+    )
+    .with_acp_manager(acp_manager.clone());
+    let turn_options = crate::mvp::agent_runtime::TurnExecutionOptions {
+        event_sink: event_sink
+            .as_ref()
+            .map(|sink| sink as &dyn crate::mvp::acp::AcpTurnEventSink),
+        ..Default::default()
+    };
+    let result = turn_service
+        .execute(
             Some(turn_request.session_id.as_str()),
-            &crate::mvp::agent_runtime::AgentTurnRequest {
-                message: turn_request.input.clone(),
-                turn_mode: crate::mvp::agent_runtime::AgentTurnMode::Acp,
-                channel_id: turn_request.channel_id.clone(),
-                account_id: turn_request.account_id.clone(),
-                conversation_id: turn_request.conversation_id.clone(),
-                participant_id: turn_request.participant_id.clone(),
-                thread_id: turn_request.thread_id.clone(),
-                metadata: turn_request.metadata.clone(),
-                acp: true,
-                acp_event_stream: event_sink.is_some(),
-                acp_bootstrap_mcp_servers: Vec::new(),
-                acp_cwd: working_directory,
-                live_surface_enabled: false,
-            },
-            event_sink
-                .as_ref()
-                .map(|sink| sink as &dyn crate::mvp::acp::AcpTurnEventSink),
-            acp_manager.clone(),
+            &turn_runtime_request,
+            turn_options,
         )
         .await;
 

--- a/crates/daemon/src/gateway/openai_compat.rs
+++ b/crates/daemon/src/gateway/openai_compat.rs
@@ -469,7 +469,7 @@ fn build_gateway_turn_seed(
     )]);
     run_config.active_provider = Some(bound_profile_id);
     run_config.last_provider = None;
-    let memory_config = crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+    let memory_config = crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config_without_env_overrides(
         &run_config.memory,
     );
     crate::mvp::memory::execute_memory_core_with_config(
@@ -695,7 +695,9 @@ fn prepare_openai_compat_test_runtime(config: LoongConfig) -> (std::path::PathBu
         .expect("write openai compat test config");
 
     let session_store_config =
-        crate::mvp::session::store::session_store_config_from_memory_config(&config.memory);
+        crate::mvp::session::store::session_store_config_from_memory_config_without_env_overrides(
+            &config.memory,
+        );
     crate::mvp::session::store::ensure_session_store_ready(
         Some(config.memory.resolved_sqlite_path()),
         &session_store_config,
@@ -1558,7 +1560,7 @@ mod tests {
         let mut config = openai_compat_provider_config(base_url);
         config.memory.sqlite_path = sqlite_path.display().to_string();
         let memory_config =
-            crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+            crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config_without_env_overrides(
                 &config.memory,
             );
         let app = build_openai_compat_test_router_no_backend(config, "tok".to_owned());
@@ -1642,7 +1644,7 @@ mod tests {
         let mut config = openai_compat_provider_config(base_url);
         config.memory.sqlite_path = sqlite_path.display().to_string();
         let memory_config =
-            crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+            crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config_without_env_overrides(
                 &config.memory,
             );
         let app = build_openai_compat_test_router_no_backend(config, "tok".to_owned());

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1016,20 +1016,11 @@ fn default_onboard_command() -> Commands {
 }
 
 pub fn resolve_default_entry_command() -> Commands {
-    let config_path = resolved_default_entry_config_path();
-    if config_path.is_file() {
-        return Commands::Welcome;
+    if resolved_default_entry_config_path().is_file() {
+        Commands::Welcome
+    } else {
+        default_onboard_command()
     }
-
-    if default_entry_config_path_override().is_some() {
-        return default_onboard_command();
-    }
-
-    if detected_legacy_home_for_default_entry().is_some() {
-        return default_import_preview_command();
-    }
-
-    default_onboard_command()
 }
 
 pub fn redacted_command_name(command: &Commands) -> &'static str {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -987,11 +987,14 @@ fn supported_multi_channel_serve_channel_ids() -> Vec<&'static str> {
 #[path = "lib_multi_channel_serve_tests.rs"]
 mod multi_channel_serve_tests;
 
-fn resolved_default_entry_config_path() -> PathBuf {
+fn default_entry_config_path_override() -> Option<PathBuf> {
     std::env::var_os("LOONG_CONFIG_PATH")
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())
-        .unwrap_or_else(mvp::config::default_config_path)
+}
+
+fn resolved_default_entry_config_path() -> PathBuf {
+    default_entry_config_path_override().unwrap_or_else(mvp::config::default_config_path)
 }
 
 fn default_onboard_command() -> Commands {
@@ -1013,11 +1016,20 @@ fn default_onboard_command() -> Commands {
 }
 
 pub fn resolve_default_entry_command() -> Commands {
-    if resolved_default_entry_config_path().is_file() {
-        Commands::Welcome
-    } else {
-        default_onboard_command()
+    let config_path = resolved_default_entry_config_path();
+    if config_path.is_file() {
+        return Commands::Welcome;
     }
+
+    if default_entry_config_path_override().is_some() {
+        return default_onboard_command();
+    }
+
+    if detected_legacy_home_for_default_entry().is_some() {
+        return default_import_preview_command();
+    }
+
+    default_onboard_command()
 }
 
 pub fn redacted_command_name(command: &Commands) -> &'static str {

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -648,14 +648,18 @@ impl SupervisorRuntimeHooks {
             let channel_id = runtime_descriptor.channel_id;
             let runner: BackgroundChannelRunner = Arc::new(
                 move |request: BackgroundChannelRunnerRequest| -> BoxedSupervisorFuture {
-                    mvp::channel::run_background_channel_with_stop(
-                        channel_id,
-                        request.resolved_path,
-                        request.config,
-                        request.account_id,
-                        request.stop,
-                        request.initialize_runtime_environment,
-                    )
+                    Box::pin(async move {
+                        let account_id = request.account_id;
+                        mvp::channel::run_background_channel_with_stop(
+                            channel_id,
+                            request.resolved_path,
+                            request.config,
+                            account_id.as_deref(),
+                            request.stop,
+                            request.initialize_runtime_environment,
+                        )
+                        .await
+                    })
                 },
             );
             runners.insert(channel_id, runner);

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -93,6 +93,7 @@ impl HarnessAdapter for EmbeddedAgentHarness {
             channel_id: None,
             account_id: None,
             conversation_id: None,
+            participant_id: None,
             thread_id: None,
             metadata: payload.metadata,
             acp: payload.acp,

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -1,10 +1,13 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use kernel::{
-    Capability, CapabilityToken, ConnectorCommand, ExecutionRoute, HarnessAdapter, HarnessError,
-    HarnessKind, HarnessOutcome, HarnessRequest, LoongKernel, PolicyEngine, StaticPolicyEngine,
-    TaskIntent, TaskState, TaskSupervisor,
+    AuditSink, Capability, CapabilityToken, ConnectorCommand, ExecutionRoute, HarnessAdapter,
+    HarnessError, HarnessKind, HarnessOutcome, HarnessRequest, InMemoryAuditSink, LoongClawKernel,
+    PolicyEngine, StaticPolicyEngine, SystemClock, TaskIntent, TaskState, TaskSupervisor,
+    VerticalPackManifest,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -84,30 +87,30 @@ impl HarnessAdapter for EmbeddedAgentHarness {
         let payload = serde_json::from_value::<DaemonTurnTaskPayload>(request.payload)
             .map_err(|error| HarnessError::Execution(format!("invalid_turn_payload: {error}")))?;
         let message = payload.message.unwrap_or(request.objective);
-        let runtime = loong_app::agent_runtime::AgentRuntime::new();
-        let turn_result = runtime
-            .run_turn(
-                payload.config_path.as_deref(),
-                payload.session_hint.as_deref(),
-                &loong_app::agent_runtime::AgentTurnRequest {
-                    message,
-                    turn_mode: payload.turn_mode,
-                    channel_id: None,
-                    account_id: None,
-                    conversation_id: None,
-                    participant_id: None,
-                    thread_id: None,
-                    metadata: payload.metadata,
-                    acp: payload.acp,
-                    acp_event_stream: payload.acp_event_stream,
-                    acp_bootstrap_mcp_servers: payload.acp_bootstrap_mcp_servers,
-                    acp_cwd: payload.acp_cwd,
-                    live_surface_enabled: matches!(
-                        payload.turn_mode,
-                        loong_app::agent_runtime::AgentTurnMode::Interactive
-                    ),
-                },
-            )
+        let turn_request = loongclaw_app::agent_runtime::AgentTurnRequest {
+            message,
+            turn_mode: payload.turn_mode,
+            channel_id: None,
+            account_id: None,
+            conversation_id: None,
+            thread_id: None,
+            metadata: payload.metadata,
+            acp: payload.acp,
+            acp_event_stream: payload.acp_event_stream,
+            acp_bootstrap_mcp_servers: payload.acp_bootstrap_mcp_servers,
+            acp_cwd: payload.acp_cwd,
+            live_surface_enabled: matches!(
+                payload.turn_mode,
+                loongclaw_app::agent_runtime::AgentTurnMode::Interactive
+            ),
+        };
+        let turn_service = loongclaw_app::agent_runtime::load_turn_execution_service(
+            payload.config_path.as_deref(),
+        )
+        .map_err(HarnessError::Execution)?;
+        let turn_options = loongclaw_app::agent_runtime::TurnExecutionOptions::default();
+        let turn_result = turn_service
+            .execute(payload.session_hint.as_deref(), &turn_request, turn_options)
             .await
             .map_err(HarnessError::Execution)?;
 
@@ -125,10 +128,44 @@ impl HarnessAdapter for EmbeddedAgentHarness {
 /// This starts from the spec/kernel bootstrap defaults and then registers the
 /// embedded agent harness so daemon task intents can route back into the shared
 /// `AgentRuntime` pipeline without spawning an external process.
-fn build_daemon_runtime_kernel() -> LoongKernel<StaticPolicyEngine> {
-    let mut kernel = kernel_bootstrap::BootstrapBuilder::default().into_builder();
+fn build_daemon_runtime_kernel() -> LoongClawKernel<StaticPolicyEngine> {
+    let audit_sink = Arc::new(InMemoryAuditSink::default());
+    let audit_sink = audit_sink as Arc<dyn AuditSink>;
+    let clock = Arc::new(SystemClock) as Arc<dyn kernel::Clock>;
+    let mut kernel =
+        LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit_sink);
+    let pack = daemon_runtime_pack_manifest();
+    let register_pack_result = kernel.register_pack(pack);
+    register_pack_result.expect("daemon runtime pack should register");
     kernel.register_harness_adapter(EmbeddedAgentHarness);
     kernel
+}
+
+fn daemon_runtime_pack_manifest() -> VerticalPackManifest {
+    let allowed_connectors = BTreeSet::new();
+    let granted_capabilities = BTreeSet::from([
+        Capability::InvokeTool,
+        Capability::MemoryRead,
+        Capability::MemoryWrite,
+    ]);
+    let metadata = BTreeMap::from([
+        ("owner".to_owned(), "daemon-runtime".to_owned()),
+        ("stage".to_owned(), "runtime".to_owned()),
+    ]);
+    let default_route = ExecutionRoute {
+        harness_kind: HarnessKind::EmbeddedPi,
+        adapter: Some("pi-local".to_owned()),
+    };
+
+    VerticalPackManifest {
+        pack_id: DEFAULT_PACK_ID.to_owned(),
+        domain: "engineering".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route,
+        allowed_connectors,
+        granted_capabilities,
+        metadata,
+    }
 }
 
 fn require_successful_daemon_task_execution(
@@ -189,7 +226,7 @@ pub async fn run_demo() -> CliResult<()> {
 pub async fn run_task_cli(objective: &str, payload_raw: &str) -> CliResult<()> {
     let payload = crate::cli_json::parse_json_payload(payload_raw, "run-task payload")?;
 
-    let kernel = kernel_bootstrap::KernelBuilder::default().build();
+    let kernel = build_daemon_runtime_kernel();
     let token = kernel
         .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
         .map_err(|error| format!("token issue failed: {error}"))?;
@@ -232,19 +269,14 @@ pub(crate) async fn run_turn_cli(
     if message.trim().is_empty() {
         return Err("turn message must not be empty".to_owned());
     }
-    let (_resolved_path, config) = loong_app::config::load(config_path)?;
+    let turn_service = loongclaw_app::agent_runtime::load_turn_execution_service(config_path)?;
+    let config = turn_service.config();
     if !config.cli.enabled {
         return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
-    let kernel = build_daemon_runtime_kernel();
-    let token = kernel
-        .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
-        .map_err(|error| format!("token issue failed: {error}"))?;
-    let payload = serde_json::to_value(DaemonTurnTaskPayload {
-        config_path: config_path.map(ToOwned::to_owned),
-        session_hint: session_hint.map(ToOwned::to_owned),
-        message: Some(message.to_owned()),
+    let turn_request = loongclaw_app::agent_runtime::AgentTurnRequest {
+        message: message.to_owned(),
         turn_mode: if acp {
             loong_app::agent_runtime::AgentTurnMode::Acp
         } else {
@@ -255,29 +287,12 @@ pub(crate) async fn run_turn_cli(
         acp_event_stream,
         acp_bootstrap_mcp_servers: acp_bootstrap_mcp_server.to_vec(),
         acp_cwd: acp_cwd.map(ToOwned::to_owned),
-    })
-    .map_err(|error| format!("serialize turn payload failed: {error}"))?;
-
-    let dispatch = execute_daemon_task_with_supervisor(
-        &kernel,
-        DEFAULT_PACK_ID,
-        &token,
-        TaskIntent {
-            task_id: "turn-run-01".to_owned(),
-            objective: message.to_owned(),
-            required_capabilities: BTreeSet::from([
-                Capability::InvokeTool,
-                Capability::MemoryRead,
-                Capability::MemoryWrite,
-            ]),
-            payload,
-        },
-    )
-    .await?;
-    let (_, outcome) = require_successful_daemon_task_execution(&dispatch)?;
-    let result =
-        serde_json::from_value::<loong_app::agent_runtime::AgentTurnResult>(outcome.output.clone())
-            .map_err(|error| format!("parse turn result failed: {error}"))?;
+        ..Default::default()
+    };
+    let turn_options = loongclaw_app::agent_runtime::TurnExecutionOptions::default();
+    let result = turn_service
+        .execute(session_hint, &turn_request, turn_options)
+        .await?;
     println!("{}", result.output_text);
     Ok(())
 }
@@ -396,27 +411,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn daemon_runtime_kernel_overrides_pi_local_stub_harness() {
-        let mut env = crate::test_support::ScopedEnv::new();
-        let home = std::env::temp_dir().join(format!(
-            "loong-daemon-runtime-harness-home-{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&home).expect("create isolated daemon home");
-        env.set("HOME", &home);
-        env.remove("LOONG_HOME");
-        env.remove("LOONG_CONFIG_PATH");
-        env.remove("LOONGCLAW_CONFIG_PATH");
-
+    async fn daemon_runtime_kernel_rejects_invalid_turn_payload_instead_of_using_stub_echo() {
         let kernel = build_daemon_runtime_kernel();
         let token = kernel
             .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)
             .expect("issue token");
-        let payload = serde_json::to_value(DaemonTurnTaskPayload {
-            message: Some("hello".to_owned()),
-            ..DaemonTurnTaskPayload::default()
-        })
-        .expect("serialize turn payload");
+        let payload = json!({
+            "message": 42
+        });
 
         let execution = execute_daemon_task_with_supervisor(
             &kernel,
@@ -439,11 +441,11 @@ mod tests {
         let error = execution
             .error
             .as_deref()
-            .expect("missing config should fail through the real runtime harness");
+            .expect("invalid payload should fail through the real runtime harness");
 
         assert!(execution.outcome.is_none());
         assert!(
-            error.contains("failed to read config"),
+            error.contains("invalid_turn_payload"),
             "expected unified runtime harness failure, got: {error}"
         );
     }

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use kernel::{
     AuditSink, Capability, CapabilityToken, ConnectorCommand, ExecutionRoute, HarnessAdapter,
-    HarnessError, HarnessKind, HarnessOutcome, HarnessRequest, InMemoryAuditSink, LoongClawKernel,
+    HarnessError, HarnessKind, HarnessOutcome, HarnessRequest, InMemoryAuditSink, LoongKernel,
     PolicyEngine, StaticPolicyEngine, SystemClock, TaskIntent, TaskState, TaskSupervisor,
     VerticalPackManifest,
 };
@@ -87,7 +87,7 @@ impl HarnessAdapter for EmbeddedAgentHarness {
         let payload = serde_json::from_value::<DaemonTurnTaskPayload>(request.payload)
             .map_err(|error| HarnessError::Execution(format!("invalid_turn_payload: {error}")))?;
         let message = payload.message.unwrap_or(request.objective);
-        let turn_request = loongclaw_app::agent_runtime::AgentTurnRequest {
+        let turn_request = loong_app::agent_runtime::AgentTurnRequest {
             message,
             turn_mode: payload.turn_mode,
             channel_id: None,
@@ -102,14 +102,13 @@ impl HarnessAdapter for EmbeddedAgentHarness {
             acp_cwd: payload.acp_cwd,
             live_surface_enabled: matches!(
                 payload.turn_mode,
-                loongclaw_app::agent_runtime::AgentTurnMode::Interactive
+                loong_app::agent_runtime::AgentTurnMode::Interactive
             ),
         };
-        let turn_service = loongclaw_app::agent_runtime::load_turn_execution_service(
-            payload.config_path.as_deref(),
-        )
-        .map_err(HarnessError::Execution)?;
-        let turn_options = loongclaw_app::agent_runtime::TurnExecutionOptions::default();
+        let turn_service =
+            loong_app::agent_runtime::load_turn_execution_service(payload.config_path.as_deref())
+                .map_err(HarnessError::Execution)?;
+        let turn_options = loong_app::agent_runtime::TurnExecutionOptions::default();
         let turn_result = turn_service
             .execute(payload.session_hint.as_deref(), &turn_request, turn_options)
             .await
@@ -129,12 +128,11 @@ impl HarnessAdapter for EmbeddedAgentHarness {
 /// This starts from the spec/kernel bootstrap defaults and then registers the
 /// embedded agent harness so daemon task intents can route back into the shared
 /// `AgentRuntime` pipeline without spawning an external process.
-fn build_daemon_runtime_kernel() -> LoongClawKernel<StaticPolicyEngine> {
+fn build_daemon_runtime_kernel() -> LoongKernel<StaticPolicyEngine> {
     let audit_sink = Arc::new(InMemoryAuditSink::default());
     let audit_sink = audit_sink as Arc<dyn AuditSink>;
     let clock = Arc::new(SystemClock) as Arc<dyn kernel::Clock>;
-    let mut kernel =
-        LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit_sink);
+    let mut kernel = LoongKernel::with_runtime(StaticPolicyEngine::default(), clock, audit_sink);
     let pack = daemon_runtime_pack_manifest();
     let register_pack_result = kernel.register_pack(pack);
     register_pack_result.expect("daemon runtime pack should register");
@@ -270,13 +268,13 @@ pub(crate) async fn run_turn_cli(
     if message.trim().is_empty() {
         return Err("turn message must not be empty".to_owned());
     }
-    let turn_service = loongclaw_app::agent_runtime::load_turn_execution_service(config_path)?;
+    let turn_service = loong_app::agent_runtime::load_turn_execution_service(config_path)?;
     let config = turn_service.config();
     if !config.cli.enabled {
         return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
-    let turn_request = loongclaw_app::agent_runtime::AgentTurnRequest {
+    let turn_request = loong_app::agent_runtime::AgentTurnRequest {
         message: message.to_owned(),
         turn_mode: if acp {
             loong_app::agent_runtime::AgentTurnMode::Acp
@@ -290,7 +288,7 @@ pub(crate) async fn run_turn_cli(
         acp_cwd: acp_cwd.map(ToOwned::to_owned),
         ..Default::default()
     };
-    let turn_options = loongclaw_app::agent_runtime::TurnExecutionOptions::default();
+    let turn_options = loong_app::agent_runtime::TurnExecutionOptions::default();
     let result = turn_service
         .execute(session_hint, &turn_request, turn_options)
         .await?;

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -67,7 +67,7 @@ impl KernelBuilder {
 
     /// Build and return a fully configured kernel with all builtin adapters
     /// and the default pack manifest registered.
-    pub fn build(self) -> LoongClawKernel<StaticPolicyEngine> {
+    pub fn build(self) -> LoongKernel<StaticPolicyEngine> {
         configured_builder(
             self.clock,
             self.audit,

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -26,14 +26,23 @@ pub(crate) fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
 /// By default the builder uses `SystemClock` and the spec layer's named
 /// in-memory audit helper. Override either with the corresponding setter before
 /// calling `build()`.
-#[derive(Default)]
 pub struct KernelBuilder {
     clock: Option<Arc<dyn Clock>>,
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
+    register_default_embedded_harness: bool,
 }
 
 impl KernelBuilder {
+    pub fn new() -> Self {
+        Self {
+            clock: None,
+            audit: None,
+            native_tool_executor: None,
+            register_default_embedded_harness: true,
+        }
+    }
+
     /// Set a custom `Clock` implementation.
     pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = Some(clock);
@@ -51,10 +60,26 @@ impl KernelBuilder {
         self
     }
 
+    pub fn without_default_embedded_harness(mut self) -> Self {
+        self.register_default_embedded_harness = false;
+        self
+    }
+
     /// Build and return a fully configured kernel with all builtin adapters
     /// and the default pack manifest registered.
-    pub fn build(self) -> LoongKernel<StaticPolicyEngine> {
-        configured_builder(self.clock, self.audit, self.native_tool_executor)
+    pub fn build(self) -> LoongClawKernel<StaticPolicyEngine> {
+        configured_builder(
+            self.clock,
+            self.audit,
+            self.native_tool_executor,
+            self.register_default_embedded_harness,
+        )
+    }
+}
+
+impl Default for KernelBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -64,14 +89,23 @@ impl KernelBuilder {
 /// The returned runtime handle dereferences to the legacy kernel surface so
 /// helper code typed against `&LoongKernel<_>` can continue to work while
 /// callers migrate toward the explicit `Kernel<P>` name.
-#[derive(Default)]
 pub struct BootstrapBuilder {
     clock: Option<Arc<dyn Clock>>,
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
+    register_default_embedded_harness: bool,
 }
 
 impl BootstrapBuilder {
+    pub fn new() -> Self {
+        Self {
+            clock: None,
+            audit: None,
+            native_tool_executor: None,
+            register_default_embedded_harness: true,
+        }
+    }
+
     pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = Some(clock);
         self
@@ -87,6 +121,11 @@ impl BootstrapBuilder {
         self
     }
 
+    pub fn without_default_embedded_harness(mut self) -> Self {
+        self.register_default_embedded_harness = false;
+        self
+    }
+
     pub fn build(self) -> FrozenKernel<StaticPolicyEngine> {
         self.into_builder().build()
     }
@@ -97,7 +136,18 @@ impl BootstrapBuilder {
     /// the legacy executable API while also supporting `.build()` into
     /// `Kernel<P>`.
     pub fn into_builder(self) -> RuntimeKernelBuilder<StaticPolicyEngine> {
-        configured_builder(self.clock, self.audit, self.native_tool_executor)
+        configured_builder(
+            self.clock,
+            self.audit,
+            self.native_tool_executor,
+            self.register_default_embedded_harness,
+        )
+    }
+}
+
+impl Default for BootstrapBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -105,14 +155,22 @@ fn configured_builder(
     clock: Option<Arc<dyn Clock>>,
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
+    register_default_embedded_harness: bool,
 ) -> RuntimeKernelBuilder<StaticPolicyEngine> {
-    configured_builder_with_default_audit(clock, audit, native_tool_executor).0
+    configured_builder_with_default_audit(
+        clock,
+        audit,
+        native_tool_executor,
+        register_default_embedded_harness,
+    )
+    .0
 }
 
 fn configured_builder_with_default_audit(
     clock: Option<Arc<dyn Clock>>,
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
+    register_default_embedded_harness: bool,
 ) -> (
     RuntimeKernelBuilder<StaticPolicyEngine>,
     Option<Arc<InMemoryAuditSink>>,
@@ -153,7 +211,11 @@ fn configured_builder_with_default_audit(
             )
         }
     };
-    register_builtin_adapters(&mut kernel, native_tool_executor);
+    register_builtin_adapters(
+        &mut kernel,
+        native_tool_executor,
+        register_default_embedded_harness,
+    );
     // The default pack manifest is hardcoded and always valid; ignore the
     // impossible error branch to avoid panicking in production.
     let _ = kernel.register_pack(default_pack_manifest());
@@ -163,10 +225,13 @@ fn configured_builder_with_default_audit(
 fn register_builtin_adapters(
     kernel: &mut RuntimeKernelBuilder<StaticPolicyEngine>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
+    register_default_embedded_harness: bool,
 ) {
-    kernel.register_harness_adapter(EmbeddedPiHarness {
-        seen: Mutex::new(Vec::new()),
-    });
+    if register_default_embedded_harness {
+        kernel.register_harness_adapter(EmbeddedPiHarness {
+            seen: Mutex::new(Vec::new()),
+        });
+    }
     kernel.register_core_connector_adapter(WebhookConnector);
     kernel.register_core_connector_adapter(CrmCoreConnector);
     kernel.register_core_connector_adapter(CrmGrpcCoreConnector);
@@ -245,7 +310,7 @@ mod tests {
 
     #[test]
     fn builder_default_fallback_records_token_audit_events() {
-        let (kernel, audit) = configured_builder_with_default_audit(None, None, None);
+        let (kernel, audit) = configured_builder_with_default_audit(None, None, None, true);
         let audit =
             audit.expect("default builder should surface the fallback in-memory audit sink");
 
@@ -265,7 +330,7 @@ mod tests {
     #[test]
     fn builder_clock_only_fallback_records_token_audit_events() {
         let clock = Arc::new(FixedClock::new(1_700_000_000));
-        let (kernel, audit) = configured_builder_with_default_audit(Some(clock), None, None);
+        let (kernel, audit) = configured_builder_with_default_audit(Some(clock), None, None, true);
         let audit =
             audit.expect("clock-only builder should surface the fallback in-memory audit sink");
 
@@ -320,5 +385,88 @@ mod tests {
         let kernel = BootstrapBuilder::default().build();
         let token = issue_default_pack_token(&kernel);
         assert!(!token.token_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn default_builder_registers_stub_embedded_harness() {
+        let kernel = KernelBuilder::default().build();
+        let token = kernel
+            .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
+            .expect("token issue should succeed");
+
+        let dispatch = kernel
+            .execute_task(
+                DEFAULT_PACK_ID,
+                &token,
+                kernel::TaskIntent {
+                    task_id: "stub-harness-task".to_owned(),
+                    objective: "stub objective".to_owned(),
+                    required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                    payload: serde_json::json!({}),
+                },
+            )
+            .await
+            .expect("default builder should dispatch through stub harness");
+
+        assert_eq!(dispatch.adapter_route.adapter.as_deref(), Some("pi-local"));
+        assert_eq!(dispatch.outcome.output["adapter"], "pi-local");
+        assert_eq!(dispatch.outcome.output["task"], "stub-harness-task");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_builder_can_skip_default_embedded_harness_and_register_explicit_one() {
+        struct MarkerHarness;
+
+        #[async_trait::async_trait]
+        impl kernel::HarnessAdapter for MarkerHarness {
+            fn name(&self) -> &str {
+                "pi-local"
+            }
+
+            fn kind(&self) -> HarnessKind {
+                HarnessKind::EmbeddedPi
+            }
+
+            async fn execute(
+                &self,
+                request: kernel::HarnessRequest,
+            ) -> Result<kernel::HarnessOutcome, kernel::HarnessError> {
+                Ok(kernel::HarnessOutcome {
+                    status: "ok".to_owned(),
+                    output: serde_json::json!({
+                        "adapter": "explicit-marker",
+                        "task": request.task_id,
+                        "objective": request.objective,
+                    }),
+                })
+            }
+        }
+
+        let mut builder = BootstrapBuilder::default()
+            .without_default_embedded_harness()
+            .into_builder();
+        builder.register_harness_adapter(MarkerHarness);
+        let kernel = builder.build();
+        let token = kernel
+            .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
+            .expect("token issue should succeed");
+
+        let dispatch = kernel
+            .execute_task(
+                DEFAULT_PACK_ID,
+                &token,
+                kernel::TaskIntent {
+                    task_id: "marker-harness-task".to_owned(),
+                    objective: "marker objective".to_owned(),
+                    required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                    payload: serde_json::json!({}),
+                },
+            )
+            .await
+            .expect("explicit marker harness should dispatch");
+
+        assert_eq!(dispatch.adapter_route.adapter.as_deref(), Some("pi-local"));
+        assert_eq!(dispatch.outcome.output["adapter"], "explicit-marker");
+        assert_eq!(dispatch.outcome.output["task"], "marker-harness-task");
     }
 }


### PR DESCRIPTION
## Summary

- Problem: daemon `run-task`, gateway `/v1/turn`, control-plane `turn_submit`, provider-backed channel turns, and interactive chat surfaces still carried partially divergent runtime entry paths; runtime-selected workspace roots did not consistently reach tool execution, and automatic ACP turns could ignore an injected session manager.
- Why it matters: the split made the real agent loop harder to reason about, left the daemon harness path too far from production execution, and let reconnect-sensitive channel tests overflow the stack when contextual execution futures grew too large.
- What changed: moved those ingress paths onto the app-level execution service contract, made bootstrap harness selection explicit, propagated runtime workspace scope into tool execution, threaded injected ACP managers through automatic ACP routing, collapsed service routing onto one structured execution-options contract, added a runtime-bound execution service so interactive chat and session-surface turns also reuse the same contract without rebuilding prepared runtime state, rewired the remaining loaded-config AgentRuntime helper variants back through the shared turn-service contract, moved the prepared-runtime execution body itself into `RuntimeTurnExecutionService`, collapsed large coordinator wrapper seams by centralizing default-runtime setup plus production-binding enforcement for compaction/checkpoint/default-runtime turn flows and by unifying session-id-to-address delegation for both default-runtime and injected-runtime turn helpers, unified channel inbound-turn preparation so provider-backed and runtime-backed paths now share the same address/ACP-hint/ingress/feedback setup before execution, and then deleted the last obviously dead coordinator session/checkpoint wrapper methods whose workspace callsites had fully collapsed away, followed by trimming the remaining no-op forwarding wrappers so surviving coordinator entries more directly reflect the real core runtime/address/manager semantics, and finally centralized ACP manager selection inside the ACP runtime core so explicit and automatic ACP execution no longer duplicate manager-resolution logic in upper layers, then simplified the ACP runtime boundary one step further by returning the finalized runtime-core handoff shape directly instead of making upper layers re-finalize intermediate execution results. The latest cleanup slice also removes the remaining no-limit production checkpoint maintenance aliases by routing live CLI/status callers through the explicit limit-bearing checkpoint APIs and keeping only the production helper that still adds distinct production-binding setup. This follow-up also centralizes finalized ACP result consumption behind one runtime-core helper so AgentRuntime and the conversation coordinator no longer maintain separate success/failure matches over the same ACP handoff enum. The newest cleanup slice then removes two dead crate-private coordinator aliases whose callsites had already disappeared, keeping the coordinator surface closer to the remaining live runtime entrypoints. A follow-up cleanup now removes the no-limit runtime checkpoint probe alias as well, so both production and runtime checkpoint probing consistently use the explicit limit-bearing path. The next cleanup then drops the last dead production checkpoint probe alias and its redundant direct-binding test, because adjacent production checkpoint tests already cover the same kernel-binding gate. The newest slice also routes the session-surface repair command through the production checkpoint repair helper and deletes the now-dead generic repair alias. The latest cleanup then removes the last test-only checkpoint diagnostics wrapper by having the chat summary test build `DefaultConversationRuntime` directly and call the runtime-and-limit diagnostics entrypoint.
- What did not change (scope boundary): this PR does not rewrite the entire conversation coordinator or ACP backend arbitration stack, and spec bootstrap still keeps the deterministic stub harness by default.

## Linked Issues

- Closes #1239
- Related #1236

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: turn ingress routing, workspace root propagation, automatic ACP manager selection, and interactive runtime execution now converge on the shared runtime service contract.
- Rollout / guardrails: regression coverage exercises daemon harness routing, workspace-root propagation, automatic ACP manager injection, interactive runtime contract convergence, and reconnect-sensitive channel tests; spec bootstrap keeps the stub harness unless runtime explicitly opts out.
- Rollback path: revert commits `d164d0a40` and `21f5a6d1d` to restore the previous ingress split; no persisted schema or release artifact format changed.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
./scripts/check_architecture_boundaries.sh
cargo test --workspace --quiet
cargo test --workspace --all-features --quiet
cargo test -p loongclaw-app run_wecom_channel_reconnects_after_transport_drop -- --nocapture
cargo test -p loongclaw-app handle_turn_with_runtime_automatic_acp_uses_injected_manager -- --nocapture
```

Result: all commands passed on the isolated `agent-runtime-deep-audit-maturity` worktree with the shared target cache.

## User-visible / Operator-visible Changes

- `run-task`, daemon turn endpoints, provider-backed channel turns, interactive CLI chat, and the terminal session surface now share the same runtime execution contract.
- Runtime-selected workspace roots now become the default execution root for real tool calls.
- Automatic ACP turns can honor an injected session manager when one is supplied by the caller.

## Failure Recovery

- Fast rollback or disable path: revert commits `d164d0a40` and `21f5a6d1d`.
- Observable failure symptoms reviewers should watch for: wrong workspace root in tool execution, ACP turns creating sessions in the shared manager instead of the injected manager, or interactive/channel regressions around observer updates or reconnect stack growth.

## Reviewer Focus

- `crates/app/src/agent_runtime.rs`: the unified execution contracts (`TurnExecutionService`, `TurnExecutionOptions`, and `RuntimeTurnExecutionService`).
- `crates/app/src/chat.rs` + `crates/app/src/chat/session_surface.rs`: interactive ingress convergence onto the runtime-bound service.
- `crates/app/src/conversation/turn_coordinator.rs`: automatic ACP manager propagation.
- `crates/daemon/src/task_execution.rs`, `crates/daemon/src/gateway/api_turn.rs`, `crates/daemon/src/control_plane_server.rs`: daemon/control-plane ingress convergence on the shared service.
- `crates/app/src/conversation/runtime.rs`, `crates/app/src/tools/mod.rs`, and regression tests: workspace-root propagation and trusted-root filtering.
- `crates/app/src/chat/operator_surfaces.rs` + `crates/app/src/conversation/turn_coordinator.rs`: checkpoint maintenance entrypoints now prefer the explicit limit-bearing production APIs instead of no-limit aliases.
- `crates/app/src/acp/runtime.rs`, `crates/app/src/agent_runtime.rs`, and `crates/app/src/conversation/turn_coordinator.rs`: ACP finalized-result consumption now flows through one shared runtime-core helper instead of separate upper-layer enum matches.
- `crates/app/src/conversation/turn_coordinator.rs`: two dead crate-private aliases (`compact_session` and `handle_turn`) are gone, so the remaining coordinator API surface better matches the live runtime paths.
- `crates/app/src/conversation/tests.rs` + `crates/app/src/conversation/turn_coordinator.rs`: runtime checkpoint probe tests now call the explicit limit-bearing helper directly, matching the cleaned-up coordinator surface.
- `crates/app/src/conversation/turn_coordinator.rs`: the last dead production checkpoint probe alias is gone; reviewers can confirm neighboring production checkpoint tests still cover the direct-binding kernel gate.
- `crates/app/src/chat/session_surface.rs` + `crates/app/src/conversation/turn_coordinator.rs`: session-surface checkpoint repair now uses the production helper directly, and the generic repair alias has been removed.
- `crates/app/src/chat.rs` + `crates/app/src/conversation/turn_coordinator.rs`: checkpoint summary tests now instantiate `DefaultConversationRuntime` directly and use the explicit runtime-and-limit diagnostics helper instead of a dedicated wrapper.


















