### PR TITLE
test(feishu): lock interactive card payloads to the repaired shape

### DIFF
--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9805,6 +9805,107 @@ mod tests {
 
     #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn feishu_messages_send_tool_uses_tenant_token_and_card_mode() {
+        use std::fs;
+
+        use axum::{
+            Json, Router,
+            extract::{Request, State},
+            routing::post,
+        };
+
+        let temp_dir = unique_feishu_tool_temp_dir("messages-send-card");
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let requests =
+            std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<FeishuToolMockRequest>::new()));
+        let state = FeishuToolMockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request: Request| {
+                        let state = state.clone();
+                        async move {
+                            record_feishu_tool_request(State(state), request).await;
+                            Json(serde_json::json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-send-card"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages",
+                post({
+                    let state = state.clone();
+                    move |request: Request| {
+                        let state = state.clone();
+                        async move {
+                            record_feishu_tool_request(State(state), request).await;
+                            Json(serde_json::json!({
+                                "code": 0,
+                                "data": {
+                                    "message_id": "om_sent_card_1",
+                                    "root_id": "om_sent_card_1"
+                                }
+                            }))
+                        }
+                    }
+                }),
+            );
+        let (base_url, server) = spawn_feishu_tool_mock_server(router).await;
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-send-card",
+            &["offline_access", "im:message:send_as_bot"],
+        );
+        let config = build_feishu_tool_runtime_config(base_url, &sqlite_path);
+
+        let outcome = execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "feishu.messages.send".to_owned(),
+                payload: serde_json::json!({
+                    "receive_id": "oc_demo",
+                    "text": "ship it",
+                    "as_card": true
+                }),
+            },
+            &config,
+        )
+        .expect("feishu messages send tool should succeed in card mode");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["delivery"]["message_id"], "om_sent_card_1");
+        assert_eq!(outcome.payload["delivery"]["mode"], "send");
+        assert_eq!(outcome.payload["delivery"]["msg_type"], "interactive");
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[1].path, "/open-apis/im/v1/messages");
+        assert_eq!(
+            requests[1].authorization.as_deref(),
+            Some("Bearer t-token-send-card")
+        );
+        let request_body = requests[1].body.as_str();
+        assert!(request_body.contains("\"msg_type\":\"interactive\""));
+        assert!(request_body.contains("\\\"schema\\\":\\\"2.0\\\""));
+        assert!(request_body.contains("\\\"tag\\\":\\\"markdown\\\""));
+        assert!(request_body.contains("\\\"content\\\":\\\"ship it\\\""));
+        assert!(
+            !request_body.contains("\\\"card\\\":"),
+            "interactive send should serialize the card directly without a card wrapper"
+        );
+
+        server.abort();
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn feishu_messages_send_tool_defaults_receive_id_and_account_from_internal_ingress() {
         use std::fs;
 
@@ -10832,9 +10933,15 @@ mod tests {
             requests[1].authorization.as_deref(),
             Some("Bearer t-token-reply")
         );
-        assert!(requests[1].body.contains("\"msg_type\":\"interactive\""));
-        assert!(requests[1].body.contains("\\\"tag\\\":\\\"markdown\\\""));
-        assert!(requests[1].body.contains("\\\"content\\\":\\\"on it\\\""));
+        let request_body = requests[1].body.as_str();
+        assert!(request_body.contains("\"msg_type\":\"interactive\""));
+        assert!(request_body.contains("\\\"schema\\\":\\\"2.0\\\""));
+        assert!(request_body.contains("\\\"tag\\\":\\\"markdown\\\""));
+        assert!(request_body.contains("\\\"content\\\":\\\"on it\\\""));
+        assert!(
+            !request_body.contains("\\\"card\\\":"),
+            "interactive reply should serialize the card directly without a card wrapper"
+        );
 
         server.abort();
     }

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-17T06:03:03Z
+- Generated at: 2026-04-17T06:12:36Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -42,13 +42,13 @@ release review. It is not part of the primary public release trail.
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6725 | 7300 | 575 | 95 | 160 | 65 | 92.1% | WATCH | 6936 | -3.0% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2113 | 6400 | 4287 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.8% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9977 | 11200 | 1223 | 61 | 120 | 59 | 89.1% | WATCH | 10831 | -7.9% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14323 | 15000 | 677 | 45 | 70 | 25 | 95.5% | TIGHT | 14472 | -1.0% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14430 | 15000 | 570 | 45 | 70 | 25 | 96.2% | TIGHT | 14472 | -0.3% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5972 | 6500 | 528 | 178 | 210 | 32 | 91.9% | WATCH | 6324 | -5.6% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9238 | 9800 | 562 | 206 | 250 | 44 | 94.3% | WATCH | 9519 | -3.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), channel_registry (96.4%), tools_mod (95.5%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), channel_registry (96.4%), tools_mod (96.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): acp_manager (86.0%), channel_config (91.0%), chat_runtime (92.1%), turn_coordinator (89.1%), daemon_lib (91.9%), onboard_cli (94.3%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -96,7 +96,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=chat_runtime lines=6725 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2113 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9977 functions=61 -->
-<!-- arch-hotspot key=tools_mod lines=14323 functions=45 -->
+<!-- arch-hotspot key=tools_mod lines=14430 functions=45 -->
 <!-- arch-hotspot key=daemon_lib lines=5972 functions=178 -->
 <!-- arch-hotspot key=onboard_cli lines=9238 functions=206 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## summary

- problem:
  issue #697 stayed open even though the Feishu interactive-card production fix already landed. what was still missing was a regression lock on the exact outbound send/reply payload seam, where the original bug showed up.
- why it matters:
  if the card wrapper or schema shape regresses again, Feishu will reject interactive replies and the bot will look silent to users.
- what changed:
  added send-path and reply-path regression checks that assert the real Feishu HTTP payload contains a schema 2.0 card and does not reintroduce the old top-level `card` wrapper.
- what did not change (scope boundary):
  no production Feishu runtime behavior changed in this PR.

## linked issues

- closes #697
- related #699

## change type

- [x] bug fix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] security hardening
- [ ] ci / workflow / release

## touched areas

- [ ] kernel / policy / approvals
- [ ] contracts / protocol / spec
- [ ] daemon / cli / install
- [ ] providers / routing
- [x] tools
- [ ] browser automation
- [x] channels / integrations
- [ ] acp / conversation / session runtime
- [ ] memory / context assembly
- [ ] config / migration / onboarding
- [ ] docs / contributor workflow
- [ ] ci / release / workflows

## risk track

- [x] track a (routine / low-risk)
- [ ] track b (higher-risk / policy-impacting)

## validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] relevant architecture / dep-graph / docs checks for touched areas
- [x] additional scenario, benchmark, or manual checks when behavior changed
- [ ] if this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] if tests mutate process-global env: document how state is restored or serialized

commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy -p loongclaw-app --all-features --tests -- -D warnings
cargo test -p loongclaw-app build_markdown_card_wraps_standard_markdown_layout -- --nocapture
cargo test -p loongclaw-app feishu_messages_send_tool_uses_tenant_token_and_card_mode -- --nocapture
cargo test -p loongclaw-app feishu_messages_reply_tool_uses_tenant_token_and_card_mode -- --nocapture
cargo test -p loongclaw-app --all-features --tests

results:
- fmt passed
- package-scoped clippy passed
- the targeted Feishu regression tests passed
- the full loongclaw-app all-features test sweep could not complete cleanly in the temporary worktree because the local tmp target relink hit `no space left on device`
```

## user-visible / operator-visible changes

- none in runtime behavior; this locks the already-restored Feishu interactive card contract with regression coverage.

## failure recovery

- fast rollback or disable path:
  revert this test-only commit.
- observable failure symptoms reviewers should watch for:
  if these tests ever fail again, expect the outbound Feishu `content` payload to lose `schema: "2.0"` or regain an extra top-level `card` wrapper.

## reviewer focus

- `crates/app/src/tools/mod.rs` send/reply Feishu card assertions
- whether the new checks are strict enough to catch the historical wrapper regression without overfitting unrelated payload details
