### PR TITLE
fix(onboard): collect custom provider base URLs during setup

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1781,7 +1781,85 @@ fn resolve_provider_selection(
         provider_config.set_base_url(selected_base_url);
     }
 
+    prompt_provider_base_url_if_needed(options, kind, &mut provider_config, ui)?;
+
     Ok(provider_config)
+}
+
+fn prompt_provider_base_url_if_needed(
+    options: &OnboardCommandOptions,
+    kind: mvp::config::ProviderKind,
+    provider_config: &mut mvp::config::ProviderConfig,
+    ui: &mut impl OnboardUi,
+) -> CliResult<()> {
+    let requires_custom_base_url = kind.requires_custom_base_url();
+    if !requires_custom_base_url || options.non_interactive {
+        return Ok(());
+    }
+
+    let configured_base_url = provider_config.base_url.trim().to_owned();
+    let has_configured_base_url = !configured_base_url.is_empty();
+    let has_unresolved_custom_base_url = provider_config.has_unresolved_custom_base_url();
+    let prompt_lines = build_provider_base_url_prompt_lines(
+        kind,
+        configured_base_url.as_str(),
+        has_unresolved_custom_base_url,
+    );
+    print_lines(ui, prompt_lines)?;
+
+    let selected_base_url = if has_unresolved_custom_base_url || !has_configured_base_url {
+        ui.prompt_required("Provider base URL")?
+    } else {
+        ui.prompt_with_default("Provider base URL", configured_base_url.as_str())?
+    };
+    let validated_base_url = validate_onboard_provider_base_url(selected_base_url.as_str())?;
+    provider_config.set_base_url(validated_base_url);
+
+    Ok(())
+}
+
+fn build_provider_base_url_prompt_lines(
+    kind: mvp::config::ProviderKind,
+    configured_base_url: &str,
+    has_unresolved_custom_base_url: bool,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    let provider_label = provider_kind_display_name(kind);
+    let intro_line = format!("Set the {} API base URL:", provider_label);
+    lines.push(intro_line);
+
+    if let Some(configuration_hint) = kind.configuration_hint() {
+        lines.push(configuration_hint.to_owned());
+    }
+
+    if has_unresolved_custom_base_url {
+        let template_line = format!("Current template: {}", configured_base_url.trim());
+        lines.push(template_line);
+    }
+
+    lines
+}
+
+fn validate_onboard_provider_base_url(raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("provider base URL cannot be empty".to_owned());
+    }
+
+    let parsed_url = reqwest::Url::parse(trimmed)
+        .map_err(|error| format!("provider base URL is invalid: {error}"))?;
+    let scheme = parsed_url.scheme();
+    let valid_scheme = scheme == "http" || scheme == "https";
+    if !valid_scheme {
+        return Err("provider base URL must use http or https".to_owned());
+    }
+
+    let has_host = parsed_url.host_str().is_some();
+    if !has_host {
+        return Err("provider base URL must include a host".to_owned());
+    }
+
+    Ok(trimmed.to_owned())
 }
 
 pub fn resolve_provider_config_from_selector(

--- a/crates/daemon/src/onboard_cli_tests.rs
+++ b/crates/daemon/src/onboard_cli_tests.rs
@@ -2090,6 +2090,75 @@ fn resolve_provider_selection_allows_switching_step_plan_region_endpoint() {
 }
 
 #[test]
+fn resolve_provider_selection_prompts_for_custom_base_url_when_unresolved() {
+    let config = mvp::config::LoongConfig::default();
+    let options = interactive_onboard_options();
+    let provider_selection = crate::migration::ProviderSelectionPlan::default();
+    let context = onboard_test_context();
+    let mut ui = TestOnboardUi::with_inputs(["custom", "https://api.example.com/v1"]);
+
+    let selected = resolve_provider_selection(
+        &options,
+        &config,
+        &provider_selection,
+        GuidedPromptPath::NativePromptPack,
+        &mut ui,
+        &context,
+    )
+    .expect("custom provider selection should accept an explicit base URL");
+
+    assert_eq!(selected.kind, mvp::config::ProviderKind::Custom);
+    assert_eq!(selected.base_url, "https://api.example.com/v1");
+}
+
+#[test]
+fn resolve_provider_selection_preserves_existing_custom_base_url_by_default() {
+    let mut config = mvp::config::LoongConfig::default();
+    let options = interactive_onboard_options();
+    let provider_selection = crate::migration::ProviderSelectionPlan::default();
+    let context = onboard_test_context();
+    let mut ui = TestOnboardUi::with_inputs(["", ""]);
+
+    config.provider =
+        mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Custom);
+    config.provider.base_url = "https://api.example.com/v1".to_owned();
+
+    let selected = resolve_provider_selection(
+        &options,
+        &config,
+        &provider_selection,
+        GuidedPromptPath::NativePromptPack,
+        &mut ui,
+        &context,
+    )
+    .expect("custom provider selection should keep the existing base URL on default accept");
+
+    assert_eq!(selected.kind, mvp::config::ProviderKind::Custom);
+    assert_eq!(selected.base_url, "https://api.example.com/v1");
+}
+
+#[test]
+fn resolve_provider_selection_rejects_invalid_custom_base_url() {
+    let config = mvp::config::LoongConfig::default();
+    let options = interactive_onboard_options();
+    let provider_selection = crate::migration::ProviderSelectionPlan::default();
+    let context = onboard_test_context();
+    let mut ui = TestOnboardUi::with_inputs(["custom", "not-a-url"]);
+
+    let error = resolve_provider_selection(
+        &options,
+        &config,
+        &provider_selection,
+        GuidedPromptPath::NativePromptPack,
+        &mut ui,
+        &context,
+    )
+    .expect_err("custom provider selection should reject invalid base URLs");
+
+    assert!(error.contains("provider base URL is invalid"));
+}
+
+#[test]
 fn preinstalled_skills_screen_only_surfaces_the_onboarding_subset() {
     let lines = render_preinstalled_skills_selection_screen_lines_with_style(100, false);
     let joined = lines.join("\n");

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-19T11:04:13Z
+- Generated at: 2026-04-19T11:10:18Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -44,7 +44,7 @@ release review. It is not part of the primary public release trail.
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9529 | 11200 | 1671 | 50 | 120 | 70 | 85.1% | WATCH | 10831 | -12.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 1556 | 15000 | 13444 | 45 | 70 | 25 | 64.3% | HEALTHY | 14472 | -89.2% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 4877 | 6500 | 1623 | 162 | 210 | 48 | 77.1% | HEALTHY | 6324 | -22.9% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 5705 | 9800 | 4095 | 206 | 250 | 44 | 82.4% | HEALTHY | 9519 | -40.1% | PASS | 228 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 5783 | 9800 | 4017 | 209 | 250 | 41 | 83.6% | HEALTHY | 9519 | -39.2% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
@@ -98,7 +98,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=turn_coordinator lines=9529 functions=50 -->
 <!-- arch-hotspot key=tools_mod lines=1556 functions=45 -->
 <!-- arch-hotspot key=daemon_lib lines=4877 functions=162 -->
-<!-- arch-hotspot key=onboard_cli lines=5705 functions=206 -->
+<!-- arch-hotspot key=onboard_cli lines=5783 functions=209 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## summary

- problem:
  interactive onboarding let operators choose the custom provider, model, and credential env name, but it never collected the custom provider base URL. the first-run flow reached review with the unresolved `<openai-compatible-host>` placeholder still in place.
- why it matters:
  onboarding could not produce a truthful transport summary or a usable custom-provider config on the first pass.
- what changed:
  providers that require an operator-supplied base URL now prompt for it during interactive provider selection, preserve an existing value by default, and reject malformed URLs before later onboarding steps depend on them.
- what did not change (scope boundary):
  no provider runtime semantics, model-selection rules, or non-interactive onboarding flags changed.

## linked issues

- closes #1238
- related #1234

## change type

- [x] bug fix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] security hardening
- [ ] ci / workflow / release

## touched areas

- [ ] kernel / policy / approvals
- [ ] contracts / protocol / spec
- [x] daemon / cli / install
- [ ] providers / routing
- [ ] tools
- [ ] browser automation
- [ ] channels / integrations
- [ ] acp / conversation / session runtime
- [ ] memory / context assembly
- [x] config / migration / onboarding
- [ ] docs / contributor workflow
- [ ] ci / release / workflows

## risk track

- [x] track a (routine / low-risk)
- [ ] track b (higher-risk / policy-impacting)

## validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] relevant architecture / dep-graph / docs checks for touched areas
- [x] additional scenario, benchmark, or manual checks when behavior changed
- [ ] if this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] if tests mutate process-global env: document how state is restored or serialized

commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy -p loongclaw --all-features --tests -- -D warnings
cargo test -p loongclaw --lib resolve_provider_selection_prompts_for_custom_base_url_when_unresolved -- --nocapture
cargo test -p loongclaw --lib resolve_provider_selection_preserves_existing_custom_base_url_by_default -- --nocapture
cargo test -p loongclaw --lib resolve_provider_selection_rejects_invalid_custom_base_url -- --nocapture
```

results:
- fmt passed
- package-scoped clippy for the touched daemon package passed
- the new onboarding regression tests passed

## user-visible / operator-visible changes

- interactive onboarding now asks for the API base URL when the selected provider requires one, so custom-provider setup no longer reaches review with the placeholder host template by default.

## failure recovery

- fast rollback or disable path:
  revert this commit to restore the previous onboarding prompt flow.
- observable failure symptoms reviewers should watch for:
  custom-provider onboarding still reaching review with `https://<openai-compatible-host>/v1` in the transport summary, or invalid URLs being accepted without an early onboarding error.

## reviewer focus

- `crates/daemon/src/onboard_cli.rs` provider-selection flow and the new base-url prompt helper
- whether the validation is strict enough to catch malformed URLs without blocking valid custom endpoints
- regression tests covering unresolved, preserved, and invalid custom base URL inputs
