### PR TITLE
docs(config): clarify loong home defaults and cwd workspace guidance

### DIFF
--- a/docs/product-specs/config-schema.md
+++ b/docs/product-specs/config-schema.md
@@ -8,8 +8,8 @@ This document describes the complete configuration schema for LoongClaw. Configu
 
 The default configuration file is located at:
 
-- **Linux/macOS**: `~/.loongclaw/config.toml`
-- **Windows**: `%USERPROFILE%\.loongclaw\config.toml`
+- **Linux/macOS**: `~/.loong/config.toml`
+- **Windows**: `%USERPROFILE%\.loong\config.toml`
 
 You can specify a custom path with the `--config` flag:
 
@@ -222,6 +222,7 @@ Notes:
 
 - `tools` includes strict numeric/domain diagnostics for browser/web/web_search/delegate child runtime limits.
 - `shell_default_mode` is documented with supported operational values (`"deny"`, `"allow"`).
+- `file_root` defaults to the current working directory on purpose. loong home (`~/.loong`) stores config and local runtime state, while workspace guidance and file operations still follow the current directory unless you set `tools.file_root` explicitly.
 
 ### tools.approval
 
@@ -350,7 +351,7 @@ Configuration for conversation memory and history management.
 | `system` | string | `"builtin"` | `"builtin"` | Memory system implementation |
 | `fail_open` | boolean | `true` | `true`, `false` | Allow fallback on memory errors |
 | `ingest_mode` | string | `"sync_minimal"` | `"sync_minimal"`, `"async_background"` | Message ingestion mode |
-| `sqlite_path` | string | `~/.loongclaw/memory.sqlite3` | Path | SQLite database location |
+| `sqlite_path` | string | `~/.loong/memory.sqlite3` | Path | SQLite database location |
 | `sliding_window` | integer | `12` | `1` - `128` | Turns to retain in window |
 | `summary_max_chars` | integer | `1200` | `256`+ (effective floor) | Summary character budget |
 | `profile_note` | string? | `null` | Text | Optional profile description |
@@ -372,7 +373,7 @@ Note: `memory.summary_max_chars` values below `256` are accepted but normalized 
 profile = "window_plus_summary"
 sliding_window = 24
 summary_max_chars = 2000
-sqlite_path = "~/.loongclaw/memory.sqlite3"
+sqlite_path = "~/.loong/memory.sqlite3"
 ```
 
 ---
@@ -612,7 +613,7 @@ Configuration for audit logging.
 | Field | Type | Default | Valid Values | Description |
 |-------|------|---------|--------------|-------------|
 | `mode` | string | `"fanout"` | `"in_memory"`, `"jsonl"`, `"fanout"` | Audit mode |
-| `path` | string | `~/.loongclaw/audit/events.jsonl` | Path | Log file path |
+| `path` | string | `~/.loong/audit/events.jsonl` | Path | Log file path |
 | `retain_in_memory` | boolean | `true` | `true`, `false` | Keep events in memory |
 
 ### Audit Modes
@@ -628,7 +629,7 @@ Configuration for audit logging.
 ```toml
 [audit]
 mode = "jsonl"
-path = "~/.loongclaw/audit/events.jsonl"
+path = "~/.loong/audit/events.jsonl"
 ```
 
 ---
@@ -785,7 +786,7 @@ Configuration for Feishu OAuth integration.
 
 | Field | Type | Default | Valid Range | Description |
 |-------|------|---------|-------------|-------------|
-| `sqlite_path` | string | `~/.loongclaw/feishu.sqlite3` | Path | SQLite database path |
+| `sqlite_path` | string | `~/.loong/feishu.sqlite3` | Path | SQLite database path |
 | `oauth_state_ttl_s` | integer | `600` | `60` - `86400` | OAuth state TTL |
 | `request_timeout_s` | integer | `20` | `3` - `120` | Request timeout |
 | `retry_max_attempts` | integer | `4` | `1` - `8` | Max retry attempts |


### PR DESCRIPTION
## Summary

- Problem:
  Issue #1043 mixed shipped runtime behavior with stale public docs: current `dev` already moved the default home to `~/.loong`, but the public config schema still documented legacy `~/.loongclaw` defaults and did not clearly distinguish loong home from the intentional cwd-based `tools.file_root` fallback.
- Why it matters:
  That doc drift makes the remaining onboarding/workspace-root behavior look more broken than it is, and it keeps confusing follow-up triage around what should live under loong home versus what should follow the current workspace.
- What changed:
  Updated `docs/product-specs/config-schema.md` to use the shipped `~/.loong` defaults for config, memory, audit, and feishu state, and added an explicit note that `tools.file_root` intentionally defaults to the current directory while loong home stores config and local runtime state.
- What did not change (scope boundary):
  No runtime behavior changed. `tools.file_root` still defaults to the current directory, and earlier merged fixes remain the code path that moved the default home and removed the noisy optional runtime-self warning path.

## Linked Issues

- Closes #1043
- Related #1054
- Related #1160

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
# passed

cargo test -p loongclaw-app default_loongclaw_home_reads_loong_home_env -- --nocapture
# passed

cargo test -p loongclaw-app initialize_runtime_environment_leaves_file_root_unset_when_not_configured -- --nocapture
# passed

cargo test -p loongclaw-app resolve_runtime_self_continuity_for_config_does_not_treat_cwd_as_explicit_workspace_root -- --nocapture
# passed

cargo test -p loongclaw-app build_base_messages_with_binding_reads_only_existing_runtime_self_sources -- --nocapture
# passed
```

## User-visible / Operator-visible Changes

- The public config schema now matches the shipped `~/.loong` defaults.
- The docs now explicitly explain that loong home stores config/runtime state, while workspace guidance and file operations still follow the current directory unless `tools.file_root` is set.

## Failure Recovery

- Fast rollback or disable path:
  Revert this docs-only commit.
- Observable failure symptoms reviewers should watch for:
  Config docs drifting back to `~/.loongclaw` defaults or re-blurring loong home with the cwd-based workspace-root behavior.

## Reviewer Focus

- `docs/product-specs/config-schema.md` for the default-path updates and the new home-vs-workspace note under `tools.file_root`.
