### PR TITLE
fix(feishu): async event processing and increase daemon stack size #1273

### DIFF
--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -287,7 +287,7 @@ async fn run_feishu_websocket_session(
     ping_interval.tick().await;
 
     let mut fragments = FeishuWsFragments::default();
-    let mut tasks: JoinSet<Result<Vec<u8>, String>> = JoinSet::new();
+    let mut tasks: JoinSet<Result<FeishuWsCompletedTask, String>> = JoinSet::new();
 
     loop {
         tokio::select! {
@@ -295,10 +295,13 @@ async fn run_feishu_websocket_session(
             task = tasks.join_next(), if !tasks.is_empty() => {
                 if let Some(result) = task {
                     match result {
-                        Ok(Ok(response_bytes)) => {
+                        Ok(Ok(completed_task)) => {
+                            let response_bytes = completed_task.response_bytes;
+                            let deferred_updates = completed_task.deferred_updates;
                             writer.send(Message::Binary(response_bytes.into()))
                                 .await
                                 .map_err(|error| format!("send Feishu websocket response failed: {error}"))?;
+                            state.dispatch_deferred_updates(deferred_updates);
                         }
                         Ok(Err(error)) => return Err(error),
                         Err(error) => {
@@ -391,7 +394,7 @@ async fn handle_ws_data_frame(
     state: Arc<FeishuWebhookState>,
     payload_bytes: Vec<u8>,
     mut frame: FeishuWsFrame,
-) -> Result<Vec<u8>, String> {
+) -> Result<FeishuWsCompletedTask, String> {
     let started_at = Instant::now();
     let payload = serde_json::from_slice::<Value>(&payload_bytes)
         .map_err(|error| format!("decode Feishu websocket event payload failed: {error}"))?;
@@ -409,8 +412,10 @@ async fn handle_ws_data_frame(
     };
 
     let response_bytes = encode_ws_response_frame(&mut frame, &response)?;
-    state.dispatch_deferred_updates(response.deferred_updates);
-    Ok(response_bytes)
+    Ok(FeishuWsCompletedTask {
+        response_bytes,
+        deferred_updates: response.deferred_updates,
+    })
 }
 
 fn build_ws_success_response(
@@ -436,6 +441,11 @@ fn build_ws_error_response(
         deferred_updates: Vec::new(),
         biz_rt_ms: elapsed.as_millis() as u64,
     }
+}
+
+struct FeishuWsCompletedTask {
+    response_bytes: Vec<u8>,
+    deferred_updates: Vec<crate::tools::DeferredFeishuCardUpdate>,
 }
 
 struct FeishuWsOutboundResponse {
@@ -668,6 +678,31 @@ data: [DONE]\n\n",
         spawn_mock_http_server(router).await
     }
 
+    async fn spawn_mock_provider_delayed_success_server(
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        response_delay: Duration,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = MockServerState { requests };
+        let router = Router::new().route(
+            "/v1/chat/completions",
+            post({
+                let state = state.clone();
+                move |request| {
+                    let state = state.clone();
+                    async move {
+                        let request_body = record_request(State(state), request).await;
+                        tokio::time::sleep(response_delay).await;
+                        mock_provider_success_response(
+                            request_body.as_str(),
+                            MOCK_PROVIDER_MARKDOWN_REPLY,
+                        )
+                    }
+                }
+            }),
+        );
+        spawn_mock_http_server(router).await
+    }
+
     async fn spawn_mock_feishu_api_server(
         requests: Arc<Mutex<Vec<MockRequest>>>,
         reply_message_id: &'static str,
@@ -825,6 +860,97 @@ data: [DONE]\n\n",
                             .await
                             .map_err(|error| format!("close websocket server failed: {error}"))?;
                         return Ok(response);
+                    }
+                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {}
+                    Message::Close(_) => {
+                        return Err("websocket client closed before sending a reply".to_owned());
+                    }
+                }
+            }
+        });
+        (format!("ws://{address}/events?service_id=42"), handle)
+    }
+
+    struct MockWsObservedResponse {
+        saw_ping_before_response: bool,
+        response_frame: FeishuWsFrame,
+    }
+
+    async fn spawn_mock_ws_server_tracking_ping(
+        payload: Value,
+    ) -> (
+        String,
+        tokio::task::JoinHandle<CliResult<MockWsObservedResponse>>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock websocket server");
+        let address = listener.local_addr().expect("mock websocket server addr");
+        let handle = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.map_err(|error| error.to_string())?;
+            let mut stream = accept_async(socket)
+                .await
+                .map_err(|error| format!("accept websocket failed: {error}"))?;
+            let request_frame = FeishuWsFrame {
+                seq_id: 1,
+                log_id: 1,
+                service: 42,
+                method: FRAME_TYPE_DATA,
+                headers: vec![
+                    FeishuWsHeader {
+                        key: HEADER_MESSAGE_ID.to_owned(),
+                        value: "evt_ws_inbound_1".to_owned(),
+                    },
+                    FeishuWsHeader {
+                        key: HEADER_SEQ.to_owned(),
+                        value: "0".to_owned(),
+                    },
+                    FeishuWsHeader {
+                        key: HEADER_SUM.to_owned(),
+                        value: "1".to_owned(),
+                    },
+                ],
+                payload_encoding: "json".to_owned(),
+                payload_type: "event".to_owned(),
+                payload: serde_json::to_vec(&payload)
+                    .map_err(|error| format!("encode websocket payload failed: {error}"))?,
+                log_id_new: String::new(),
+            };
+            let mut bytes = Vec::new();
+            request_frame
+                .encode(&mut bytes)
+                .map_err(|error| format!("encode websocket frame failed: {error}"))?;
+            stream
+                .send(Message::Binary(bytes.into()))
+                .await
+                .map_err(|error| format!("send websocket frame failed: {error}"))?;
+
+            let mut saw_ping_before_response = false;
+            loop {
+                let message = stream
+                    .next()
+                    .await
+                    .ok_or_else(|| "websocket client disconnected before replying".to_owned())?
+                    .map_err(|error| format!("read websocket reply failed: {error}"))?;
+                match message {
+                    Message::Binary(bytes) => {
+                        let frame = FeishuWsFrame::decode(bytes.as_ref()).map_err(|error| {
+                            format!("decode websocket reply frame failed: {error}")
+                        })?;
+                        let is_control_ping = frame.method == FRAME_TYPE_CONTROL
+                            && frame.header_value(HEADER_TYPE) == Some(MESSAGE_TYPE_PING);
+                        if is_control_ping {
+                            saw_ping_before_response = true;
+                            continue;
+                        }
+                        stream
+                            .close(None)
+                            .await
+                            .map_err(|error| format!("close websocket server failed: {error}"))?;
+                        return Ok(MockWsObservedResponse {
+                            saw_ping_before_response,
+                            response_frame: frame,
+                        });
                     }
                     Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {}
                     Message::Close(_) => {
@@ -1117,6 +1243,113 @@ data: [DONE]\n\n",
 
         release_socket.notify_waiters();
         let _ = server.await;
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[test]
+    fn feishu_websocket_session_keeps_pinging_during_long_provider_turn() {
+        run_feishu_websocket_test_on_large_stack(
+            "feishu-websocket-ping-during-turn",
+            || async move {
+                feishu_websocket_session_keeps_pinging_during_long_provider_turn_impl().await;
+            },
+        );
+    }
+
+    async fn feishu_websocket_session_keeps_pinging_during_long_provider_turn_impl() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let response_delay = Duration::from_millis(2_200);
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_delayed_success_server(provider_requests.clone(), response_delay)
+                .await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_ws_ping_1").await;
+
+        let config = test_websocket_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve websocket feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before websocket ping test");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-websocket-ping-during-turn-test",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = Arc::new(FeishuWebhookState::new(
+            config, &resolved, adapter, kernel_ctx, runtime,
+        ));
+
+        let payload = json!({
+            "header": {
+                "event_id": "evt_ws_inbound_ping_1",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_ws_ping_1"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_inbound_ws_ping_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hello over websocket with delayed provider\"}"
+                }
+            }
+        });
+        let (url, ws_server) = spawn_mock_ws_server_tracking_ping(payload).await;
+
+        let session_error = run_feishu_websocket_session(
+            &state,
+            url.as_str(),
+            &FeishuWsEndpointClientConfig {
+                ping_interval_s: Some(1),
+                ..FeishuWsEndpointClientConfig::default()
+            },
+            ChannelServeStopHandle::new(),
+        )
+        .await
+        .expect_err("session should end after the mock server closes");
+        assert!(
+            session_error.contains("closed by remote peer"),
+            "unexpected websocket session result: {session_error}"
+        );
+
+        let observed = ws_server
+            .await
+            .expect("join websocket server")
+            .expect("capture websocket response frame");
+        assert!(
+            observed.saw_ping_before_response,
+            "client should keep sending ping frames while a provider turn is still running"
+        );
+
+        let response_envelope = serde_json::from_slice::<Value>(&observed.response_frame.payload)
+            .expect("response envelope");
+        assert_eq!(response_envelope["code"], json!(200));
+
+        let provider_requests = provider_requests.lock().await.clone();
+        assert_eq!(provider_requests.len(), 1);
+
         provider_server.abort();
         feishu_server.abort();
     }

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -22,6 +22,7 @@ use crate::config::{
 
 use super::adapter::FeishuAdapter;
 use super::webhook::{FeishuParsedActionResponse, FeishuWebhookState, handle_feishu_parsed_action};
+use tokio::task::JoinSet;
 
 const HEADER_BIZ_RT: &str = "biz_rt";
 const HEADER_MESSAGE_ID: &str = "message_id";
@@ -186,14 +187,14 @@ pub(super) async fn run_feishu_websocket_channel(
 ) -> CliResult<()> {
     let mut adapter = FeishuAdapter::new(resolved)?;
     adapter.refresh_tenant_token().await?;
-    let state = FeishuWebhookState::new_with_resolved_path(
+    let state = Arc::new(FeishuWebhookState::new_with_resolved_path(
         config.clone(),
         resolved_path.to_path_buf(),
         resolved,
         adapter,
         kernel_ctx,
         runtime,
-    );
+    ));
     let client = FeishuClient::from_configs(resolved, &config.feishu_integration)?;
 
     #[allow(clippy::print_stdout)]
@@ -251,7 +252,7 @@ pub(super) async fn run_feishu_websocket_channel(
 }
 
 async fn run_feishu_websocket_session(
-    state: &FeishuWebhookState,
+    state: &Arc<FeishuWebhookState>,
     url: &str,
     ws_config: &FeishuWsEndpointClientConfig,
     stop: ChannelServeStopHandle,
@@ -277,15 +278,35 @@ async fn run_feishu_websocket_session(
         _ = stop.wait() => return Ok(()),
         result = connect_async(parsed_url.as_str()) => result,
     };
-    let (mut stream, _) =
-        connect_result.map_err(|error| format!("connect Feishu websocket failed: {error}"))?;
+    let (mut writer, mut reader) = connect_result
+        .map_err(|error| format!("connect Feishu websocket failed: {error}"))?
+        .0
+        .split();
+
     let mut ping_interval = tokio::time::interval(Duration::from_secs(ping_interval_s));
     ping_interval.tick().await;
+
     let mut fragments = FeishuWsFragments::default();
+    let mut tasks: JoinSet<Result<Vec<u8>, String>> = JoinSet::new();
 
     loop {
         tokio::select! {
             _ = stop.wait() => return Ok(()),
+            task = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(result) = task {
+                    match result {
+                        Ok(Ok(response_bytes)) => {
+                            writer.send(Message::Binary(response_bytes.into()))
+                                .await
+                                .map_err(|error| format!("send Feishu websocket response failed: {error}"))?;
+                        }
+                        Ok(Err(error)) => return Err(error),
+                        Err(error) => {
+                            return Err(format!("Feishu websocket background task failed: {error}"));
+                        }
+                    }
+                }
+            }
             _ = ping_interval.tick() => {
                 let ping_frame = FeishuWsFrame {
                     seq_id: 0,
@@ -305,12 +326,13 @@ async fn run_feishu_websocket_session(
                 ping_frame
                     .encode(&mut bytes)
                     .map_err(|error| format!("encode Feishu websocket ping frame failed: {error}"))?;
-                stream
+                writer
                     .send(Message::Binary(bytes.into()))
                     .await
                     .map_err(|error| format!("send Feishu websocket ping failed: {error}"))?;
             }
-            maybe_message = stream.next() => {
+
+            maybe_message = reader.next() => {
                 let message = match maybe_message {
                     Some(Ok(message)) => message,
                     Some(Err(error)) => {
@@ -321,7 +343,7 @@ async fn run_feishu_websocket_session(
 
                 match message {
                     Message::Binary(bytes) => {
-                        let mut frame = FeishuWsFrame::decode(bytes.as_ref())
+                        let frame = FeishuWsFrame::decode(bytes.as_ref())
                             .map_err(|error| format!("decode Feishu websocket frame failed: {error}"))?;
                         if frame.method == FRAME_TYPE_CONTROL {
                             if frame.header_value(HEADER_TYPE) == Some(MESSAGE_TYPE_PONG)
@@ -346,31 +368,49 @@ async fn run_feishu_websocket_session(
                             continue;
                         };
 
-                        let started_at = Instant::now();
-                        let payload = serde_json::from_slice::<Value>(&payload_bytes).map_err(|error| {
-                            format!("decode Feishu websocket event payload failed: {error}")
-                        })?;
-                        let response: FeishuWsOutboundResponse = match state.parse_websocket_payload(&payload) {
-                            Ok(parsed) => match handle_feishu_parsed_action(state, parsed).await {
-                                Ok(response) => build_ws_success_response(response, started_at.elapsed()),
-                                Err((status, message)) => build_ws_error_response(status, started_at.elapsed(), message),
-                            },
-                            Err(error) => build_ws_error_response(map_parse_error_status(&error), started_at.elapsed(), error),
-                        };
-                        let response_bytes = encode_ws_response_frame(&mut frame, &response)?;
-                        let deferred_updates = response.deferred_updates;
-                        stream
-                            .send(Message::Binary(response_bytes.into()))
-                            .await
-                            .map_err(|error| format!("send Feishu websocket response failed: {error}"))?;
-                        state.dispatch_deferred_updates(deferred_updates);
+                        let state = state.clone();
+                        tasks.spawn(handle_ws_data_frame(state, payload_bytes, frame));
                     }
                     Message::Close(_) => return Err("Feishu websocket closed by remote peer".to_owned()),
                     Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {}
                 }
             }
+
         }
     }
+}
+
+/// Process a single Feishu websocket data frame in a background task.
+///
+/// This is extracted as a standalone `async fn` to keep the future size
+/// manageable when spawned onto `JoinSet`.  An inline `async move { … }` block
+/// would let the compiler inline the entire `handle_feishu_parsed_action` call
+/// tree into a single, enormous future that easily overflows the default tokio
+/// worker-thread stack.
+async fn handle_ws_data_frame(
+    state: Arc<FeishuWebhookState>,
+    payload_bytes: Vec<u8>,
+    mut frame: FeishuWsFrame,
+) -> Result<Vec<u8>, String> {
+    let started_at = Instant::now();
+    let payload = serde_json::from_slice::<Value>(&payload_bytes)
+        .map_err(|error| format!("decode Feishu websocket event payload failed: {error}"))?;
+
+    let response: FeishuWsOutboundResponse = match state.parse_websocket_payload(&payload) {
+        Ok(parsed) => match handle_feishu_parsed_action(&state, parsed).await {
+            Ok(response) => build_ws_success_response(response, started_at.elapsed()),
+            Err((status, message)) => {
+                build_ws_error_response(status, started_at.elapsed(), message)
+            }
+        },
+        Err(error) => {
+            build_ws_error_response(map_parse_error_status(&error), started_at.elapsed(), error)
+        }
+    };
+
+    let response_bytes = encode_ws_response_frame(&mut frame, &response)?;
+    state.dispatch_deferred_updates(response.deferred_updates);
+    Ok(response_bytes)
 }
 
 fn build_ws_success_response(
@@ -938,7 +978,9 @@ data: [DONE]\n\n",
             .await
             .expect("start runtime tracker"),
         );
-        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+        let state = Arc::new(FeishuWebhookState::new(
+            config, &resolved, adapter, kernel_ctx, runtime,
+        ));
 
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -1022,7 +1064,9 @@ data: [DONE]\n\n",
             .await
             .expect("start runtime tracker"),
         );
-        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+        let state = Arc::new(FeishuWebhookState::new(
+            config, &resolved, adapter, kernel_ctx, runtime,
+        ));
 
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -1117,7 +1161,9 @@ data: [DONE]\n\n",
             .await
             .expect("start runtime tracker"),
         );
-        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+        let state = Arc::new(FeishuWebhookState::new(
+            config, &resolved, adapter, kernel_ctx, runtime,
+        ));
 
         let payload = json!({
             "header": {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -87,17 +87,26 @@ fn check_legacy_home_migration() {
 // This avoids `STATUS_STACK_OVERFLOW` on Windows in debug builds, where
 // the default tokio worker stack size is often insufficient for deep
 // async future chains (e.g., Feishu websocket processing).
-fn main() {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
+fn main() -> std::process::ExitCode {
+    let _stdin_guard = StdinGuard;
+    let runtime_result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(DAEMON_STACK_SIZE_BYTES)
-        .build()
-        .expect("build daemon tokio runtime");
-    runtime.block_on(async_main());
+        .build();
+    let runtime = match runtime_result {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("error: failed to build daemon tokio runtime: {error}");
+            }
+            return std::process::ExitCode::from(2);
+        }
+    };
+    runtime.block_on(async_main())
 }
 
-async fn async_main() {
-    let _stdin_guard = StdinGuard;
+async fn async_main() -> std::process::ExitCode {
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
     loongclaw_daemon::make_env_compatible();
@@ -1204,9 +1213,10 @@ async fn async_main() {
         {
             eprintln!("error: {error}");
         }
-        flush_stdin();
-        std::process::exit(2);
+        return std::process::ExitCode::from(2);
     }
+
+    std::process::ExitCode::SUCCESS
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)] // CLI daemon binary
 use loongclaw_daemon::*;
 
+const DAEMON_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
+
 /// Discard any unread input from the terminal's tty input queue.
 ///
 /// When a user pastes multi-line text at an interactive prompt, `read_line()`
@@ -81,8 +83,20 @@ fn check_legacy_home_migration() {
     }
 }
 
-#[tokio::main]
-async fn main() {
+// We use a manual runtime builder to set a larger thread stack size (16MB).
+// This avoids `STATUS_STACK_OVERFLOW` on Windows in debug builds, where
+// the default tokio worker stack size is often insufficient for deep
+// async future chains (e.g., Feishu websocket processing).
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(DAEMON_STACK_SIZE_BYTES)
+        .build()
+        .expect("build daemon tokio runtime");
+    runtime.block_on(async_main());
+}
+
+async fn async_main() {
     let _stdin_guard = StdinGuard;
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());


### PR DESCRIPTION
- Problem:
  - The Feishu WebSocket channel blocks the main loop's heartbeat (Ping) maintenance and subsequent message reading when executing long model turns (Provider turns).
  - The Feishu server actively closes the connection due to not receiving heartbeats or responses for a long time. Subsequent messages cannot be delivered unless the process is restarted or a long retry cycle passes.
  - In Windows debug builds, deep async Future chains can easily trigger `STATUS_STACK_OVERFLOW`.
- Why it matters:
  - Feishu WebSocket mode is impractical for normal interactive use, severely impacting UX.
  - Stack overflows compromise the stability of the program.
- What changed:
  - **Async data frame processing**: Introduced `tokio::task::JoinSet` to move Feishu event processing (`handle_feishu_parsed_action`) to background tasks. This ensures the main session loop can continue reading network data and sending heartbeats on time.
  - **Stack size optimization**: Switched to a manually built Tokio Runtime in [crates/daemon/src/main.rs](file:///h:/gitee/loongclaw/crates/daemon/src/main.rs), increasing the main thread stack size to 16MB. This effectively avoids stack overflow issues in Windows environments.
- What did not change (scope boundary):
  - The core Webhook handling logic and message formats remain unchanged.

## Linked Issues

- Closes #1273

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Manually verified Feishu channel starts correctly via `cargo run --bin loong -- feishu-serve`.
- [x] Verified WebSocket connection survives after long turns.

Commands and evidence:

```bash
cargo run --bin loong -- feishu-serve
```

## User-visible / Operator-visible Changes

- Feishu WebSocket channel is now more stable when handling time-consuming requests.

## Failure Recovery

- Standard reconnection mechanisms remain intact.

## Reviewer Focus

- Lifecycle management of `JoinSet` in [crates/app/src/channel/feishu/websocket.rs]
- Whether the stack size modification in [crates/daemon/src/main.rs]
- meets expectations.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did not change (scope boundary):

## Linked Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
Paste the exact commands you ran and summarize the result.
```

## User-visible / Operator-visible Changes

- None, or describe the exact change:

## Failure Recovery

- Fast rollback or disable path:
- Observable failure symptoms reviewers should watch for:

## Reviewer Focus

- Point reviewers at the files, edge cases, or risk seams that deserve the most attention.
