### PR TITLE
Stabilize Discord integration tests against ambient env fallback

### DIFF
--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -1328,7 +1328,8 @@ fn migration_classify_current_setup_treats_blocked_outbound_only_channel_as_repa
     config.provider.model = "openai/gpt-5.1-codex".to_owned();
     config.discord.enabled = true;
     config.discord.bot_token = None;
-    config.discord.bot_token_env = None;
+    // Keep the persisted config from falling back to an ambient DISCORD_BOT_TOKEN.
+    config.discord.bot_token_env = Some(String::new());
 
     mvp::config::write(Some(path.to_string_lossy().as_ref()), &config, true)
         .expect("write outbound-only repairable config");

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -2585,6 +2585,8 @@ fn channel_preflight_checks_summarize_outbound_multi_account_state_and_reserved_
     let config: mvp::config::LoongClawConfig = serde_json::from_value(json!({
         "discord": {
             "enabled": true,
+            // Keep alerts from inheriting an ambient DISCORD_BOT_TOKEN in test shells.
+            "bot_token_env": "",
             "accounts": {
                 "ops": {
                     "bot_token": "discord-ops-token",


### PR DESCRIPTION
## Summary
- stop the outbound-only Discord migration test from inheriting an ambient `DISCORD_BOT_TOKEN` after the config round-trips through disk
- keep the Discord multi-account onboard preflight test from inheriting an ambient `DISCORD_BOT_TOKEN` for the account that is supposed to stay unconfigured

## Why
`origin/dev` was red in `cargo test --workspace --locked` because these two daemon integration tests could become host-dependent when the shell environment exported `DISCORD_BOT_TOKEN`.

## Validation
- `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- `./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/cargo-local-toolchain.sh test --workspace --locked`
- `./scripts/cargo-local-toolchain.sh test --workspace --all-features --locked`
- `./scripts/cargo-local-toolchain.sh check -p loong-app --no-default-features --features channel-cli,channel-telegram,channel-feishu,channel-matrix,config-toml,memory-sqlite,feishu-integration,tool-shell,tool-file,tool-browser,provider-openai,provider-anthropic,provider-bedrock,provider-volcengine`
