### PR TITLE
test(doctor): align managed bridge fixtures with runtime contract

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -3209,10 +3209,26 @@ mod tests {
         target_contract: &str,
     ) -> BTreeMap<String, String> {
         let mut metadata = BTreeMap::new();
+        let runtime_operations = vec![
+            "send_message".to_owned(),
+            "receive_batch".to_owned(),
+            "ack_inbound".to_owned(),
+            "complete_batch".to_owned(),
+        ];
+        let runtime_operations_json =
+            serde_json::to_string(&runtime_operations).expect("serialize runtime operations");
 
         metadata.insert("adapter_family".to_owned(), "channel-bridge".to_owned());
         metadata.insert("transport_family".to_owned(), transport_family.to_owned());
         metadata.insert("target_contract".to_owned(), target_contract.to_owned());
+        metadata.insert(
+            "channel_runtime_contract".to_owned(),
+            "loongclaw_channel_bridge_v1".to_owned(),
+        );
+        metadata.insert(
+            "channel_runtime_operations_json".to_owned(),
+            runtime_operations_json,
+        );
 
         metadata
     }
@@ -3683,6 +3699,47 @@ mod tests {
                 && check.detail.contains(
                     "setup_remediation=\"Run the QQ bridge setup flow before enabling this bridge.\\nThen confirm exactly one managed bridge remains.\"",
                 )
+        }));
+    }
+
+    #[test]
+    fn check_channel_surfaces_marks_missing_runtime_metadata_as_incomplete_managed_bridge_setup() {
+        let install_root = browser_companion_temp_dir("managed-bridge-missing-runtime-contract");
+        let mut metadata =
+            compatible_managed_bridge_metadata("wechat_clawbot_ilink_bridge", "weixin_reply_loop");
+        let removed_runtime_contract = metadata.remove("channel_runtime_contract");
+        let manifest = managed_bridge_manifest("weixin", Some("channel"), metadata);
+        let mut config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "weixin": {
+                "enabled": true,
+                "bridge_url": "https://bridge.example.test/weixin",
+                "bridge_access_token": "weixin-token",
+                "allowed_contact_ids": ["wxid_alice"]
+            }
+        }))
+        .expect("deserialize weixin config");
+
+        assert_eq!(
+            removed_runtime_contract.as_deref(),
+            Some("loongclaw_channel_bridge_v1")
+        );
+
+        write_managed_bridge_manifest(
+            install_root.as_path(),
+            "weixin-runtime-incomplete",
+            &manifest,
+        );
+        config.external_skills.install_root = Some(install_root.display().to_string());
+
+        let checks = check_channel_surfaces(&config);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "weixin managed bridge discovery"
+                && check.level == DoctorCheckLevel::Warn
+                && check.detail.contains("incomplete=1")
+                && check
+                    .detail
+                    .contains("status=compatible_incomplete_contract")
         }));
     }
 


### PR DESCRIPTION
## Summary

- Problem: `doctor_cli` managed-bridge tests were still building "compatible" plugin fixtures with only legacy bridge metadata, while current managed-bridge readiness also expects runtime contract metadata.
- Why it matters: the `doctor_cli::tests::` slice was red on current `dev`, which obscured real regressions in managed bridge diagnostics and next-step guidance.
- What changed: updated the managed-bridge test helper to emit runtime-ready fixture metadata, and added a regression test that proves missing runtime contract metadata is still treated as incomplete setup.
- What did not change (scope boundary): no production doctor logic or runtime selection behavior changed; this patch only fixes stale test fixtures and adds coverage for the newer readiness seam.

## Linked Issues

- Closes #1282
- Related #1192

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> rustup run stable cargo test -p loong --lib doctor_cli::tests::check_channel_surfaces_ -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> rustup run stable cargo test -p loong --lib doctor_cli::tests::build_doctor_next_steps_ -- --test-threads=1
CARGO_TARGET_DIR=<redacted-target-dir> rustup run stable cargo test -p loong --lib doctor_cli::tests:: -- --test-threads=1

All listed commands passed locally.
```

## User-visible / Operator-visible Changes

- None. This restores local regression coverage for managed bridge diagnostics.

## Failure Recovery

- Fast rollback or disable path: revert this test-only commit.
- Observable failure symptoms reviewers should watch for: the managed-bridge `doctor_cli::tests::` slice going red again, especially the compatibility / ambiguity / next-step cases.

## Reviewer Focus

- `crates/daemon/src/doctor_cli.rs` test helper alignment with current managed-bridge runtime metadata expectations.
- The new regression test covering missing `channel_runtime_contract` metadata as incomplete setup rather than a compatible match.
