### PR TITLE
Introduce a small runtime kernel owner seam for host-owned bootstrap paths

### DIFF
--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -11,8 +11,8 @@ use crate::chat::{
 };
 use crate::config::load as load_config;
 use crate::conversation::{
-    ConversationIngressContext, ConversationRuntimeBinding, ConversationSessionAddress,
-    PromptFrameEventSummary, load_prompt_frame_event_summary,
+    ConversationIngressContext, ConversationSessionAddress, PromptFrameEventSummary,
+    load_prompt_frame_event_summary,
 };
 use crate::tools;
 use loong_contracts::ToolCoreRequest;
@@ -264,10 +264,7 @@ impl AgentRuntime {
                         session_id: runtime.session_id.clone(),
                         output_text: success.result.output_text,
                         turn_mode: request.turn_mode,
-                        governed_session_mode: ConversationRuntimeBinding::kernel(
-                            &runtime.kernel_ctx,
-                        )
-                        .session_mode(),
+                        governed_session_mode: runtime.conversation_binding().session_mode(),
                         state: Some(acp_session_state_label(success.result.state).to_owned()),
                         stop_reason: success
                             .result
@@ -308,8 +305,7 @@ impl AgentRuntime {
             session_id: runtime.session_id.clone(),
             output_text: turn_outcome.reply,
             turn_mode: request.turn_mode,
-            governed_session_mode: ConversationRuntimeBinding::kernel(&runtime.kernel_ctx)
-                .session_mode(),
+            governed_session_mode: runtime.conversation_binding().session_mode(),
             state: None,
             stop_reason: None,
             usage: turn_outcome.usage,
@@ -642,7 +638,7 @@ async fn load_runtime_prompt_frame_summary(
         return load_prompt_frame_event_summary(
             &runtime.session_id,
             32,
-            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            runtime.conversation_binding(),
             &runtime.memory_config,
         )
         .await

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -14,7 +14,6 @@ use crate::CliResult;
 use crate::acp::{
     AcpConversationTurnOptions, AcpTurnEventSink, AcpTurnProvenance, JsonlAcpTurnEventSink,
 };
-use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 mod cli_input;
 mod cli_render;
@@ -260,13 +259,19 @@ pub(crate) struct CliTurnRuntime {
     pub(crate) session_id: String,
     pub(crate) session_address: ConversationSessionAddress,
     pub(crate) turn_coordinator: ConversationTurnCoordinator,
-    pub(crate) kernel_ctx: crate::KernelContext,
+    pub(crate) runtime_kernel: crate::runtime_bridge::RuntimeKernelOwner,
     pub(crate) explicit_acp_request: bool,
     pub(crate) effective_bootstrap_mcp_servers: Vec<String>,
     pub(crate) effective_working_directory: Option<PathBuf>,
     pub(crate) memory_label: String,
     #[cfg(feature = "memory-sqlite")]
     pub(crate) memory_config: SessionStoreConfig,
+}
+
+impl CliTurnRuntime {
+    pub(crate) fn conversation_binding(&self) -> ConversationRuntimeBinding<'_> {
+        self.runtime_kernel.conversation_binding()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -545,8 +550,9 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config(
     if initialize_runtime_environment {
         crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
     }
-    let kernel_ctx =
-        bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
+    let runtime_kernel =
+        crate::runtime_bridge::RuntimeKernelOwner::bootstrap(kernel_scope, &config)?;
+    let kernel_ctx = runtime_kernel.cloned_kernel_context();
     initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
         resolved_path,
         config,
@@ -605,6 +611,7 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
     let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
 
     let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
+    let runtime_kernel = crate::runtime_bridge::RuntimeKernelOwner::new(kernel_ctx);
 
     Ok(CliTurnRuntime {
         resolved_path,
@@ -612,7 +619,7 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
         session_id,
         session_address,
         turn_coordinator: ConversationTurnCoordinator::new(),
-        kernel_ctx,
+        runtime_kernel,
         explicit_acp_request,
         effective_bootstrap_mcp_servers,
         effective_working_directory,
@@ -793,7 +800,7 @@ async fn process_cli_chat_input(
             print_history(
                 &runtime.session_id,
                 runtime.config.memory.sliding_window,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 &runtime.memory_config,
             )
             .await?;
@@ -801,7 +808,7 @@ async fn process_cli_chat_input(
             print_history(
                 &runtime.session_id,
                 runtime.config.memory.sliding_window,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
             )
             .await?;
             return Ok(CliChatLoopControl::Continue);
@@ -824,17 +831,13 @@ async fn process_cli_chat_input(
             print_fast_lane_summary(
                 &runtime.session_id,
                 limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 &runtime.memory_config,
             )
             .await?;
             #[cfg(not(feature = "memory-sqlite"))]
-            print_fast_lane_summary(
-                &runtime.session_id,
-                limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
+            print_fast_lane_summary(&runtime.session_id, limit, runtime.conversation_binding())
+                .await?;
             return Ok(CliChatLoopControl::Continue);
         }
         Ok(None) => {}
@@ -857,7 +860,7 @@ async fn process_cli_chat_input(
                 &runtime.session_id,
                 limit,
                 &runtime.config.conversation,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 &runtime.memory_config,
             )
             .await?;
@@ -866,7 +869,7 @@ async fn process_cli_chat_input(
                 &runtime.session_id,
                 limit,
                 &runtime.config.conversation,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
             )
             .await?;
             return Ok(CliChatLoopControl::Continue);
@@ -892,7 +895,7 @@ async fn process_cli_chat_input(
                 &runtime.config,
                 &runtime.session_id,
                 limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 &runtime.memory_config,
             )
             .await?;
@@ -902,7 +905,7 @@ async fn process_cli_chat_input(
                 &runtime.config,
                 &runtime.session_id,
                 limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
             )
             .await?;
             return Ok(CliChatLoopControl::Continue);
@@ -923,7 +926,7 @@ async fn process_cli_chat_input(
                 &runtime.turn_coordinator,
                 &runtime.config,
                 &runtime.session_id,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
             )
             .await?;
             return Ok(CliChatLoopControl::Continue);
@@ -1076,7 +1079,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
                 input,
                 provider_error_mode,
                 &acp_options,
-                crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 Some(ingress),
                 live_surface_observer,
             )
@@ -1092,7 +1095,7 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
                 provider_error_mode,
                 &crate::conversation::DefaultConversationRuntime::from_config_or_env(&turn_config)?,
                 &acp_options,
-                crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+                runtime.conversation_binding(),
                 None,
                 live_surface_observer,
             )
@@ -3402,6 +3405,11 @@ mod tests {
             false,
         )
         .expect("concurrent host runtime");
+        assert!(runtime.conversation_binding().is_kernel_bound());
+        assert_eq!(
+            runtime.runtime_kernel.kernel_context().agent_id(),
+            "cli-chat-concurrent-test"
+        );
         let shutdown = ConcurrentCliShutdown::new();
         shutdown.request_shutdown();
 

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -154,7 +154,7 @@ pub(super) async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntim
         .load_production_turn_checkpoint_diagnostics(
             &runtime.config,
             &runtime.session_id,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            runtime.conversation_binding(),
         )
         .await
     {
@@ -204,7 +204,7 @@ async fn print_turn_checkpoint_status_health(runtime: &CliTurnRuntime) {
         .load_production_turn_checkpoint_diagnostics(
             &runtime.config,
             &runtime.session_id,
-            crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            runtime.conversation_binding(),
         )
         .await
     {
@@ -789,7 +789,7 @@ pub(super) fn print_help() {
 pub(super) async fn print_manual_compaction(runtime: &CliTurnRuntime) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let binding = ConversationRuntimeBinding::kernel(&runtime.kernel_ctx);
+        let binding = runtime.conversation_binding();
         let result = load_manual_compaction_result(
             &runtime.config,
             &runtime.session_id,

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -2022,7 +2022,7 @@ impl ChatSessionSurface {
                         #[cfg(feature = "memory-sqlite")]
                         {
                             let binding =
-                                ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx);
+                                self.runtime.conversation_binding();
                             let result = operator_surfaces::load_manual_compaction_result(
                                 &self.runtime.config,
                                 &self.runtime.session_id,
@@ -2055,7 +2055,7 @@ impl ChatSessionSurface {
                                 let history_lines = operator_surfaces::load_history_lines(
                                     &self.runtime.session_id,
                                     self.runtime.config.memory.sliding_window,
-                                    ConversationRuntimeBinding::kernel(&self.runtime.kernel_ctx),
+                                    self.runtime.conversation_binding(),
                                     &self.runtime.memory_config,
                                 )
                                 .await?;
@@ -2242,9 +2242,7 @@ impl ChatSessionSurface {
                                                 .repair_turn_checkpoint_tail(
                                                     &self.runtime.config,
                                                     &self.runtime.session_id,
-                                                    ConversationRuntimeBinding::kernel(
-                                                        &self.runtime.kernel_ctx,
-                                                    ),
+                                                    self.runtime.conversation_binding(),
                                                 )
                                                 .await?;
                                             render_turn_checkpoint_repair_lines_with_width(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod operator;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;
+pub mod runtime_bridge;
 pub mod runtime_env;
 mod runtime_identity;
 mod runtime_self;

--- a/crates/app/src/runtime_bridge/kernel_owner.rs
+++ b/crates/app/src/runtime_bridge/kernel_owner.rs
@@ -1,0 +1,103 @@
+use crate::CliResult;
+use crate::KernelContext;
+use crate::config::LoongConfig;
+use crate::context::DEFAULT_TOKEN_TTL_S;
+use crate::context::bootstrap_kernel_context_with_config;
+use crate::conversation::ConversationRuntimeBinding;
+use crate::provider::ProviderRuntimeBinding;
+
+/// Owns the kernel-governed runtime context for a host surface.
+///
+/// This seam intentionally stays small.
+/// It owns `KernelContext`, and it vends borrowed bindings on demand.
+/// It does not try to own config loading, runtime environment mutation,
+/// or conversation-runtime construction.
+#[derive(Clone)]
+pub struct RuntimeKernelOwner {
+    kernel_context: KernelContext,
+}
+
+impl RuntimeKernelOwner {
+    #[must_use]
+    pub fn new(kernel_context: KernelContext) -> Self {
+        Self { kernel_context }
+    }
+
+    pub fn bootstrap(agent_id: &str, config: &LoongConfig) -> CliResult<Self> {
+        let ttl_seconds = DEFAULT_TOKEN_TTL_S;
+        let kernel_context = bootstrap_kernel_context_with_config(agent_id, ttl_seconds, config)?;
+        let owner = Self::new(kernel_context);
+        Ok(owner)
+    }
+
+    #[must_use]
+    pub fn kernel_context(&self) -> &KernelContext {
+        &self.kernel_context
+    }
+
+    #[must_use]
+    pub fn cloned_kernel_context(&self) -> KernelContext {
+        self.kernel_context.clone()
+    }
+
+    #[must_use]
+    pub fn conversation_binding(&self) -> ConversationRuntimeBinding<'_> {
+        let kernel_context = self.kernel_context();
+        ConversationRuntimeBinding::kernel(kernel_context)
+    }
+
+    #[must_use]
+    pub fn provider_binding(&self) -> ProviderRuntimeBinding<'_> {
+        let kernel_context = self.kernel_context();
+        ProviderRuntimeBinding::kernel(kernel_context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::AuditMode;
+    use crate::config::LoongConfig;
+    use crate::runtime_bridge::RuntimeKernelOwner;
+
+    #[test]
+    fn runtime_kernel_owner_bootstrap_provides_kernel_bound_bindings() {
+        let mut config = LoongConfig::default();
+        config.audit.mode = AuditMode::InMemory;
+
+        let owner = RuntimeKernelOwner::bootstrap("runtime-kernel-owner-test", &config)
+            .expect("bootstrap runtime kernel owner");
+
+        let conversation_binding = owner.conversation_binding();
+        let provider_binding = owner.provider_binding();
+
+        assert!(conversation_binding.is_kernel_bound());
+        assert!(provider_binding.is_kernel_bound());
+        assert_eq!(
+            owner.kernel_context().agent_id(),
+            "runtime-kernel-owner-test"
+        );
+    }
+
+    #[test]
+    fn runtime_kernel_owner_cloned_context_preserves_identity() {
+        let mut config = LoongConfig::default();
+        config.audit.mode = AuditMode::InMemory;
+
+        let owner = RuntimeKernelOwner::bootstrap("runtime-kernel-owner-clone", &config)
+            .expect("bootstrap runtime kernel owner");
+
+        let cloned_kernel_context = owner.cloned_kernel_context();
+        let original_token_id = owner.kernel_context().token.token_id.clone();
+        let cloned_token_id = cloned_kernel_context.token.token_id.clone();
+
+        assert_eq!(original_token_id, cloned_token_id);
+        assert_eq!(
+            owner.kernel_context().pack_id(),
+            cloned_kernel_context.pack_id()
+        );
+        assert_eq!(
+            owner.kernel_context().agent_id(),
+            cloned_kernel_context.agent_id()
+        );
+    }
+}

--- a/crates/app/src/runtime_bridge/mod.rs
+++ b/crates/app/src/runtime_bridge/mod.rs
@@ -1,0 +1,3 @@
+mod kernel_owner;
+
+pub use kernel_owner::RuntimeKernelOwner;

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -64,17 +64,14 @@ pub fn run_migrate_cli(options: MigrateCommandOptions) -> CliResult<()> {
 async fn run_migrate_cli_async(options: MigrateCommandOptions) -> CliResult<()> {
     validate_migrate_cli_options(&options)?;
     let config = load_migrate_cli_runtime_config(&options)?;
-    let kernel_ctx = mvp::context::bootstrap_kernel_context_with_config(
-        "daemon-migrate-cli",
-        mvp::context::DEFAULT_TOKEN_TTL_S,
-        &config,
-    )?;
+    let runtime_kernel = bootstrap_migrate_runtime_kernel(&config)?;
+    let kernel_ctx = runtime_kernel.kernel_context();
     let outcome = mvp::tools::execute_tool(
         ToolCoreRequest {
             tool_name: "config.import".to_owned(),
             payload: build_migrate_tool_payload(&options),
         },
-        &kernel_ctx,
+        kernel_ctx,
     )
     .await
     .map_err(|error| translate_migrate_cli_error(&options, error))?;
@@ -114,6 +111,14 @@ fn require_flag_value(value: Option<&str>, flag: &str, mode: MigrateMode) -> Cli
         command_name,
         mode.as_id()
     ))
+}
+
+fn bootstrap_migrate_runtime_kernel(
+    config: &mvp::config::LoongConfig,
+) -> CliResult<mvp::runtime_bridge::RuntimeKernelOwner> {
+    let agent_id = "daemon-migrate-cli";
+    let runtime_kernel = mvp::runtime_bridge::RuntimeKernelOwner::bootstrap(agent_id, config)?;
+    Ok(runtime_kernel)
 }
 
 fn block_on_migrate_cli<F>(future: F) -> CliResult<()>
@@ -845,6 +850,21 @@ fn yes_no(value: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mvp;
+
+    #[test]
+    fn bootstrap_migrate_runtime_kernel_provides_kernel_context() {
+        let mut config = mvp::config::LoongConfig::default();
+        config.audit.mode = mvp::config::AuditMode::InMemory;
+
+        let runtime_kernel =
+            bootstrap_migrate_runtime_kernel(&config).expect("bootstrap migrate runtime kernel");
+
+        assert_eq!(
+            runtime_kernel.kernel_context().agent_id(),
+            "daemon-migrate-cli"
+        );
+    }
 
     #[test]
     fn render_migrate_surface_text_uses_operator_header() {

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -246,12 +246,8 @@ async fn execute_create_command(
     timeout_seconds: Option<u64>,
 ) -> CliResult<Value> {
     let runtime = build_tasks_create_runtime(config)?;
-    let kernel_context = mvp::context::bootstrap_kernel_context_with_config(
-        "cli-tasks",
-        mvp::context::DEFAULT_TOKEN_TTL_S,
-        config,
-    )?;
-    let binding = mvp::conversation::ConversationRuntimeBinding::kernel(&kernel_context);
+    let runtime_kernel = bootstrap_tasks_runtime_kernel(config)?;
+    let binding = runtime_kernel.conversation_binding();
     let queued = mvp::conversation::spawn_background_delegate_with_runtime(
         config,
         &runtime,
@@ -280,6 +276,14 @@ async fn execute_create_command(
         "next_steps": next_steps,
     });
     Ok(payload)
+}
+
+fn bootstrap_tasks_runtime_kernel(
+    config: &mvp::config::LoongConfig,
+) -> CliResult<mvp::runtime_bridge::RuntimeKernelOwner> {
+    let agent_id = "cli-tasks";
+    let runtime_kernel = mvp::runtime_bridge::RuntimeKernelOwner::bootstrap(agent_id, config)?;
+    Ok(runtime_kernel)
 }
 
 fn build_tasks_create_runtime(
@@ -2157,6 +2161,7 @@ fn render_string_array(values: &[Value]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mvp;
 
     fn build_task_payload(
         session_state: &str,
@@ -2381,6 +2386,19 @@ mod tests {
                 .contains("session tools are disabled"),
             "expected degraded tool-policy lookup error, got: {lookup_error:?}"
         );
+    }
+
+    #[test]
+    fn bootstrap_tasks_runtime_kernel_provides_kernel_bound_binding() {
+        let mut config = mvp::config::LoongConfig::default();
+        config.audit.mode = mvp::config::AuditMode::InMemory;
+
+        let runtime_kernel =
+            bootstrap_tasks_runtime_kernel(&config).expect("bootstrap tasks runtime kernel");
+        let binding = runtime_kernel.conversation_binding();
+
+        assert!(binding.is_kernel_bound());
+        assert_eq!(runtime_kernel.kernel_context().agent_id(), "cli-tasks");
     }
 
     #[test]

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-19T08:38:34Z
+- Generated at: 2026-04-19T11:04:13Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -39,7 +39,7 @@ release review. It is not part of the primary public release trail.
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 8906 | 10500 | 1594 | 54 | 90 | 36 | 84.8% | HEALTHY | 9922 | -10.2% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8260 | 9800 | 1540 | 0 | 90 | 90 | 84.3% | HEALTHY | 9796 | -15.7% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6137 | 7300 | 1163 | 58 | 160 | 102 | 84.1% | HEALTHY | 6936 | -11.5% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6145 | 7300 | 1155 | 58 | 160 | 102 | 84.2% | HEALTHY | 6936 | -11.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2111 | 6400 | 4289 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.7% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9529 | 11200 | 1671 | 50 | 120 | 70 | 85.1% | WATCH | 10831 | -12.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 1556 | 15000 | 13444 | 45 | 70 | 25 | 64.3% | HEALTHY | 14472 | -89.2% | PASS | 54 |
@@ -93,7 +93,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
 <!-- arch-hotspot key=channel_registry lines=8906 functions=54 -->
 <!-- arch-hotspot key=channel_config lines=8260 functions=0 -->
-<!-- arch-hotspot key=chat_runtime lines=6137 functions=58 -->
+<!-- arch-hotspot key=chat_runtime lines=6145 functions=58 -->
 <!-- arch-hotspot key=channel_mod lines=2111 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9529 functions=50 -->
 <!-- arch-hotspot key=tools_mod lines=1556 functions=45 -->


### PR DESCRIPTION
## Summary

- Problem:
  Host-owned bootstrap paths still owned raw `KernelContext` directly in chat, tasks create, and migrate, which kept runtime ownership implicit and duplicated binding setup at the entrypoints.
- Why it matters:
  The next runtime-seam and gateway-owner phases need one explicit ownership seam before any larger crate or service refactor can land safely.
- What changed:
  Added a small `RuntimeKernelOwner` seam in `crates/app/src/runtime_bridge/`, switched CLI chat to store that owner instead of raw `KernelContext`, and routed the tasks-create and migrate bootstrap paths through the same seam. Added focused unit coverage for the new seam in app/daemon.
- What did not change (scope boundary):
  No crate split, no channel common-path migration yet, no broad `TurnService` abstraction, and no binding-type unification in this slice.

## Linked Issues

- Closes #1284
- Related #1239

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes the ownership seam around kernel-bound entrypoints. The behavior is intended to stay the same, but bootstrap and binding wiring are now centralized behind a new app-level owner.
- Rollout / guardrails:
  Keep the slice narrow. Do not extend it to channel common-path migration in the same PR. Preserve existing chat seam tests and the architecture/dep-graph checks.
- Rollback path:
  Revert this PR to restore direct `KernelContext` ownership in the three touched entrypoints.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app runtime_kernel_owner --all-features -- --nocapture
cargo test -p loongclaw-daemon bootstrap_tasks_runtime_kernel_provides_kernel_bound_binding --all-features -- --nocapture
cargo test -p loongclaw-daemon bootstrap_migrate_runtime_kernel_provides_kernel_context --all-features -- --nocapture
cargo test -p loongclaw-app print_history_accepts_explicit_runtime_binding --all-features -- --nocapture
cargo test -p loongclaw-app safe_lane_summary_output_accepts_explicit_runtime_binding --all-features -- --nocapture
cargo test -p loongclaw-app turn_checkpoint_summary_output_accepts_explicit_runtime_binding --all-features -- --nocapture
cargo test -p loongclaw-daemon run_migrate_cli_plan_mode_returns_preview_without_writing --all-features -- --nocapture
scripts/check_dep_graph.sh
scripts/check_architecture_boundaries.sh

Blocked local sandbox runs:
- cargo test --workspace --locked
- cargo test --workspace --all-features --locked

In this sandbox those broader runs fail in pre-existing environment-sensitive channel/audit/runtime-state tests outside the touched files (for example channel runtime state under <redacted-path> and unrelated readonly sqlite/audit-path assumptions). The new seam-specific tests listed above passed.
```

## User-visible / Operator-visible Changes

- None. This is an internal ownership-seam refactor.

## Failure Recovery

- Fast rollback or disable path:
  Revert the commit to restore raw `KernelContext` ownership in the touched entrypoints.
- Observable failure symptoms reviewers should watch for:
  Chat history/summary/checkpoint commands stop reading kernel-bound state, tasks create loses kernel-bound delegate context, or migrate stops invoking `claw.migrate` through the expected kernel-bound tool path.

## Reviewer Focus

- `crates/app/src/runtime_bridge/kernel_owner.rs`
- `crates/app/src/chat.rs`
- `crates/daemon/src/tasks_cli.rs`
- `crates/daemon/src/migrate_cli.rs`
- whether the new seam stays small and avoids pulling config reload or channel/common-path work into this slice
