### PR TITLE
Remove provider-error turn from message history for session context

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -414,13 +414,19 @@ pub async fn run_cli_ask(
     let acp_event_printer = options
         .acp_event_stream
         .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
-    let assistant_text = run_cli_turn(
+    let assistant_text = run_cli_turn_with_address_and_ingress_and_error_mode(
         &runtime,
+        &runtime.session_address,
         input,
         acp_event_printer
             .as_ref()
             .map(|printer| printer as &dyn AcpTurnEventSink),
         false,
+        None,
+        None,
+        AcpTurnProvenance::default(),
+        ProviderErrorMode::Propagate,
+        None,
     )
     .await?;
     println!("{assistant_text}");

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -414,19 +414,13 @@ pub async fn run_cli_ask(
     let acp_event_printer = options
         .acp_event_stream
         .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
-    let assistant_text = run_cli_turn_with_address_and_ingress_and_error_mode(
+    let assistant_text = run_cli_turn(
         &runtime,
-        &runtime.session_address,
         input,
         acp_event_printer
             .as_ref()
             .map(|printer| printer as &dyn AcpTurnEventSink),
         false,
-        None,
-        None,
-        AcpTurnProvenance::default(),
-        ProviderErrorMode::Propagate,
-        None,
     )
     .await?;
     println!("{assistant_text}");

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -846,6 +846,9 @@ fn should_skip_history_turn(role: &str, content: &str) -> bool {
     if role != "assistant" {
         return false;
     }
+    if content.trim_start().starts_with("[provider_error] ") {
+        return true;
+    }
     let parsed = match serde_json::from_str::<Value>(content) {
         Ok(value) => value,
         Err(_) => return false,
@@ -1262,6 +1265,17 @@ mod tests {
         }))
         .expect("serialize");
         push_history_message(&mut messages, "assistant", payload.as_str());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn push_history_message_skips_inline_provider_errors() {
+        let mut messages = Vec::new();
+        push_history_message(
+            &mut messages,
+            "assistant",
+            "[provider_error] provider credentials are missing",
+        );
         assert!(messages.is_empty());
     }
 


### PR DESCRIPTION
## Summary

- Problem:
I start with `loong ask --message "how are you?"`, and there's a provider error like 
> [provider_error] provider credentials are missing; configured provider api key env `DEEPSEEK_API_KEY` is unset, empty, or not visible to the current process; configure provider credentials or set DEEPSEEK_API_KEY in env

I solved this error by setting the env key, and this key can be printed in terminal. However, I keep getting the same error still with the default session. Starting the cli with a new session can work.

This also happened when I once had the error with open-ai provider. Then I changed the provider to deepseek, yet llm still returned the open-api endpoint timeout error. The http response status code is 200 for llm post request. So llm post call is okay. Just the llm reason output is always the previous turn's provider-error.

- Why it matters:
This is pretty confusing. The provider error seems not solvable at all once it happens.

- What changed:
Remove the provider error turn from the message history for conversation runtime's memory context.
- What did not change (scope boundary):
Other turns are not affected.

## Linked Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check    
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

## User-visible / Operator-visible Changes

- None, or describe the exact change:

## Failure Recovery

- Fast rollback or disable path:
- Observable failure symptoms reviewers should watch for:

## Reviewer Focus

- `cargo test --workspace --locked` has failed. I wonder whether this PR's change is desirable. If this change is approved, I can work on the failed tests.
