### PR TITLE
feat(feishu): add qr-based onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ model = "auto"
 
 #### Channels — Lark
 
+Recommended first-run setup:
+
+```bash
+loong feishu onboard --domain lark
+```
+
+That flow shows an in-terminal QR code, creates the bot app through the official Lark/Feishu registration API, and writes the generated credentials into `loongclaw.toml`. Manual fallback is still available through `loong feishu onboard --manual --app-id ... --app-secret ...`.
+
 ```toml
 [feishu]
 enabled = true

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,6 +172,14 @@ model = "auto"
 
 #### 接入频道 —— 以飞书为例
 
+推荐先走命令行二维码接入：
+
+```bash
+loong feishu onboard
+```
+
+这条命令会在终端里展示二维码，走官方 Feishu/Lark 注册接口创建 bot app，并把生成的凭据写回 `loongclaw.toml`。如果你已经有现成凭据，也可以继续用 `loong feishu onboard --manual --app-id ... --app-secret ...` 手动回填。
+
 ```toml
 [feishu]
 enabled = true

--- a/crates/app/src/channel/catalog/model.rs
+++ b/crates/app/src/channel/catalog/model.rs
@@ -179,6 +179,7 @@ impl ChannelCapability {
 #[serde(rename_all = "snake_case")]
 pub enum ChannelOnboardingStrategy {
     ManualConfig,
+    QrRegistration,
     PluginBridge,
     Planned,
 }
@@ -187,6 +188,7 @@ impl ChannelOnboardingStrategy {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ManualConfig => "manual_config",
+            Self::QrRegistration => "qr_registration",
             Self::PluginBridge => "plugin_bridge",
             Self::Planned => "planned",
         }

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -556,10 +556,10 @@ const FEISHU_CAPABILITIES: &[ChannelCapability] = &[
     ChannelCapability::RuntimeTracking,
 ];
 const FEISHU_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
-    strategy: ChannelOnboardingStrategy::ManualConfig,
-    setup_hint: "configure feishu or lark app credentials, allowed chat ids, and either webhook secrets or mode = \"websocket\" in loongclaw.toml under feishu or feishu.accounts.<account>",
+    strategy: ChannelOnboardingStrategy::QrRegistration,
+    setup_hint: "run `loong feishu onboard` to create Feishu or Lark bot credentials from an in-terminal QR flow and persist them under feishu or feishu.accounts.<account>; `loong feishu onboard --manual --app-id ... --app-secret ...` remains available for manual credential handoff, and webhook mode still requires verification_token plus encrypt_key",
     status_command: "loong doctor",
-    repair_command: Some("loong doctor --fix"),
+    repair_command: Some("loong feishu onboard"),
 };
 
 const MATRIX_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
@@ -7208,9 +7208,11 @@ mod tests {
 
         assert_eq!(
             lark.onboarding.strategy,
-            ChannelOnboardingStrategy::ManualConfig
+            ChannelOnboardingStrategy::QrRegistration
         );
         assert_eq!(lark.onboarding.status_command, "loong doctor");
+        assert_eq!(lark.onboarding.repair_command, Some("loong feishu onboard"));
+        assert!(lark.onboarding.setup_hint.contains("QR"));
 
         assert_eq!(
             discord.onboarding.strategy,

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -6,6 +6,10 @@ use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 use serde_json::{Value, json};
 
+use crate::feishu_onboarding::{
+    FeishuOnboardApplyOptions, FeishuOnboardCredentialSource, FeishuOnboardCredentials,
+    apply_manual_feishu_onboarding, onboard_via_qr_registration,
+};
 use crate::feishu_support::{
     FeishuAuthCapability, FeishuConfiguredCapability, FeishuDaemonContext,
     build_account_recommendations, build_grant_recommendations, build_pkce_pair,
@@ -28,6 +32,8 @@ pub enum FeishuCommand {
         #[command(subcommand)]
         command: FeishuAuthCommand,
     },
+    /// Create or update Feishu/Lark bot channel credentials in loongclaw.toml
+    Onboard(FeishuOnboardArgs),
     /// Resolve the selected user grant and print Feishu profile details
     Whoami(FeishuGrantArgs),
     /// Create or append Feishu docx documents
@@ -190,6 +196,58 @@ pub struct FeishuGrantArgs {
     pub common: FeishuCommonArgs,
     #[arg(long)]
     pub open_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FeishuOnboardDomainArg {
+    Feishu,
+    Lark,
+}
+
+impl FeishuOnboardDomainArg {
+    fn as_config_domain(self) -> mvp::config::FeishuDomain {
+        match self {
+            Self::Feishu => mvp::config::FeishuDomain::Feishu,
+            Self::Lark => mvp::config::FeishuDomain::Lark,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FeishuOnboardModeArg {
+    Websocket,
+    Webhook,
+}
+
+impl FeishuOnboardModeArg {
+    fn as_config_mode(self) -> mvp::config::FeishuChannelServeMode {
+        match self {
+            Self::Websocket => mvp::config::FeishuChannelServeMode::Websocket,
+            Self::Webhook => mvp::config::FeishuChannelServeMode::Webhook,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuOnboardArgs {
+    #[command(flatten)]
+    pub common: FeishuCommonArgs,
+    #[arg(long, default_value_t = FeishuOnboardDomainArg::Feishu, value_enum)]
+    pub domain: FeishuOnboardDomainArg,
+    #[arg(long, value_enum)]
+    pub mode: Option<FeishuOnboardModeArg>,
+    #[arg(long)]
+    pub timeout_s: Option<u64>,
+    #[arg(long, default_value_t = false)]
+    pub manual: bool,
+    #[arg(long)]
+    pub app_id: Option<String>,
+    #[arg(long)]
+    pub app_secret: Option<String>,
+    #[arg(long)]
+    pub verification_token: Option<String>,
+    #[arg(long)]
+    pub encrypt_key: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -812,6 +870,10 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
                 print_feishu_payload(&payload, args.common.json, render_auth_revoke_text)?;
             }
         },
+        FeishuCommand::Onboard(args) => {
+            let payload = execute_feishu_onboard(&args).await?;
+            print_feishu_payload(&payload, args.common.json, render_onboard_text)?;
+        }
         FeishuCommand::Whoami(args) => {
             let payload = execute_feishu_whoami(&args).await?;
             print_feishu_payload(&payload, args.common.json, render_whoami_text)?;
@@ -1047,6 +1109,128 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
         }
     }
     Ok(())
+}
+
+pub async fn execute_feishu_onboard(args: &FeishuOnboardArgs) -> CliResult<Value> {
+    let mode = args
+        .mode
+        .unwrap_or(FeishuOnboardModeArg::Websocket)
+        .as_config_mode();
+    let manual = args.manual
+        || args.app_id.is_some()
+        || args.app_secret.is_some()
+        || args.verification_token.is_some()
+        || args.encrypt_key.is_some();
+
+    if mode != mvp::config::FeishuChannelServeMode::Webhook
+        && (args.verification_token.is_some() || args.encrypt_key.is_some())
+    {
+        return Err("webhook verification_token/encrypt_key require `--mode webhook`".to_owned());
+    }
+
+    let result = if manual {
+        let app_id = trimmed_opt(args.app_id.as_deref())
+            .ok_or_else(|| "manual Feishu onboarding requires `--app-id`".to_owned())?;
+        let app_secret = trimmed_opt(args.app_secret.as_deref())
+            .ok_or_else(|| "manual Feishu onboarding requires `--app-secret`".to_owned())?;
+        let verification_token = trimmed_opt(args.verification_token.as_deref()).map(str::to_owned);
+        let encrypt_key = trimmed_opt(args.encrypt_key.as_deref()).map(str::to_owned);
+        if mode == mvp::config::FeishuChannelServeMode::Webhook
+            && (verification_token.is_none() || encrypt_key.is_none())
+        {
+            return Err(
+                "manual Feishu webhook onboarding requires both `--verification-token` and `--encrypt-key`"
+                    .to_owned(),
+            );
+        }
+
+        apply_manual_feishu_onboarding(
+            args.common.config.as_deref(),
+            args.common.account.as_deref(),
+            &FeishuOnboardCredentials {
+                app_id: app_id.to_owned(),
+                app_secret: app_secret.to_owned(),
+                verification_token,
+                encrypt_key,
+            },
+            FeishuOnboardApplyOptions {
+                domain: args.domain.as_config_domain(),
+                mode,
+            },
+        )?
+    } else {
+        if mode != mvp::config::FeishuChannelServeMode::Websocket {
+            return Err(
+                "QR-based Feishu/Lark onboarding currently supports `--mode websocket` only; use `--manual` for webhook credentials"
+                    .to_owned(),
+            );
+        }
+        onboard_via_qr_registration(
+            args.common.config.as_deref(),
+            args.common.account.as_deref(),
+            args.domain.as_config_domain(),
+            args.timeout_s,
+            Some(mode),
+        )
+        .await?
+    };
+
+    let serve_command = if result.configured_account_id == "feishu_cli_default" {
+        "loong feishu serve".to_owned()
+    } else {
+        format!(
+            "loong feishu serve --account {}",
+            result.configured_account_id
+        )
+    };
+    let mut notes = vec!["run `loong doctor` to verify the saved channel contract".to_owned()];
+    if result.owner_direct_chat_bootstrap_applied {
+        if let Some(owner_open_id) = result.owner_open_id.as_deref() {
+            notes.push(format!(
+                "defaulted inbound bootstrap access to `allowed_chat_ids = [\"*\"]` and `allowed_sender_ids = [\"{owner_open_id}\"]` so the onboarding user can start a direct Feishu/Lark chat immediately"
+            ));
+            notes.push(
+                "tighten `allowed_chat_ids` after first-run validation if you want the bot limited to specific chats"
+                    .to_owned(),
+            );
+        }
+    } else {
+        notes.push(
+            "set `feishu.allowed_chat_ids` and, when needed, `feishu.allowed_sender_ids` before running the long-lived reply loop in production"
+                .to_owned(),
+        );
+    }
+    if result.credential_source == FeishuOnboardCredentialSource::QrRegistration {
+        notes.push(
+            "QR registration writes the generated bot app_id/app_secret directly into loongclaw.toml and defaults the channel to websocket mode"
+                .to_owned(),
+        );
+    }
+    if result.mode == mvp::config::FeishuChannelServeMode::Webhook {
+        notes.push(
+            "webhook mode expects Feishu event delivery to target the bind/path you pass to `loong feishu serve`"
+                .to_owned(),
+        );
+    }
+
+    Ok(json!({
+        "account_id": result.runtime_account_id,
+        "configured_account": result.configured_account_label,
+        "configured_account_id": result.configured_account_id,
+        "config": result.config_path,
+        "credential_source": result.credential_source.as_str(),
+        "domain": result.domain.as_str(),
+        "mode": result.mode.as_str(),
+        "owner_open_id": result.owner_open_id,
+        "bot_name": result.bot_name,
+        "bot_open_id": result.bot_open_id,
+        "qr_url": result.qr_url,
+        "qr_rendered": result.qr_rendered,
+        "owner_direct_chat_bootstrap_applied": result.owner_direct_chat_bootstrap_applied,
+        "serve_command": serve_command,
+        "status_command": "loong doctor",
+        "notes": notes,
+    }))
 }
 
 pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<Value> {
@@ -2986,6 +3170,51 @@ fn print_feishu_payload(
     Ok(())
 }
 
+fn render_onboard_text(payload: &Value) -> CliResult<String> {
+    let mut lines = vec![
+        "feishu onboard".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!("config: {}", required_json_string(payload, "config")?),
+        format!(
+            "credential_source: {}",
+            required_json_string(payload, "credential_source")?
+        ),
+        format!("domain: {}", required_json_string(payload, "domain")?),
+        format!("mode: {}", required_json_string(payload, "mode")?),
+    ]);
+    if let Some(owner_open_id) = payload.get("owner_open_id").and_then(Value::as_str) {
+        lines.push(format!("owner_open_id: {owner_open_id}"));
+    }
+    if let Some(bot_name) = payload.get("bot_name").and_then(Value::as_str) {
+        lines.push(format!("bot_name: {bot_name}"));
+    }
+    if let Some(bot_open_id) = payload.get("bot_open_id").and_then(Value::as_str) {
+        lines.push(format!("bot_open_id: {bot_open_id}"));
+    }
+    if let Some(qr_url) = payload.get("qr_url").and_then(Value::as_str) {
+        lines.push(format!("qr_url: {qr_url}"));
+    }
+    lines.push(format!(
+        "serve_command: {}",
+        required_json_string(payload, "serve_command")?
+    ));
+    lines.push(format!(
+        "status_command: {}",
+        required_json_string(payload, "status_command")?
+    ));
+    if let Some(notes) = payload.get("notes").and_then(Value::as_array) {
+        for note in notes.iter().filter_map(Value::as_str) {
+            lines.push(format!("note: {note}"));
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
 fn render_auth_start_text(payload: &Value) -> CliResult<String> {
     let mut lines = vec![
         "feishu auth start".to_owned(),
@@ -4475,6 +4704,35 @@ mod render_tests {
         let rendered = render_auth_start_text(&payload).expect("render auth start");
 
         assert!(rendered.contains("configured_account: work"));
+    }
+
+    #[test]
+    fn render_onboard_text_includes_qr_registration_summary() {
+        let payload = json!({
+            "account_id": "feishu_main",
+            "configured_account": "work",
+            "config": "/tmp/loongclaw.toml",
+            "credential_source": "qr_registration",
+            "domain": "lark",
+            "mode": "websocket",
+            "owner_open_id": "ou_owner_1",
+            "bot_name": "Loong Bot",
+            "bot_open_id": "ou_bot_1",
+            "qr_url": "https://scan.example/activate",
+            "owner_direct_chat_bootstrap_applied": true,
+            "serve_command": "loong feishu serve --account work",
+            "status_command": "loong doctor",
+            "notes": ["defaulted inbound bootstrap access to `allowed_chat_ids = [\"*\"]` and `allowed_sender_ids = [\"ou_owner_1\"]` so the onboarding user can start a direct Feishu/Lark chat immediately"],
+        });
+
+        let rendered = render_onboard_text(&payload).expect("render onboard");
+
+        assert!(rendered.contains("feishu onboard"));
+        assert!(rendered.contains("configured_account: work"));
+        assert!(rendered.contains("credential_source: qr_registration"));
+        assert!(rendered.contains("bot_name: Loong Bot"));
+        assert!(rendered.contains("allowed_sender_ids = [\"ou_owner_1\"]"));
+        assert!(rendered.contains("serve_command: loong feishu serve --account work"));
     }
 
     #[test]

--- a/crates/daemon/src/feishu_onboarding.rs
+++ b/crates/daemon/src/feishu_onboarding.rs
@@ -1,0 +1,993 @@
+use std::collections::HashMap;
+use std::process::Command;
+use std::time::Duration;
+
+use loongclaw_contracts::SecretRef;
+use serde_json::Value;
+
+use crate::CliResult;
+use crate::feishu_support::load_feishu_daemon_context;
+use crate::mvp;
+
+const FEISHU_ACCOUNTS_BASE_URL: &str = "https://accounts.feishu.cn";
+const LARK_ACCOUNTS_BASE_URL: &str = "https://accounts.larksuite.com";
+const REGISTRATION_PATH: &str = "/oauth/v1/app/registration";
+const DEFAULT_ONBOARD_TIMEOUT_S: u64 = 600;
+const DEFAULT_ONBOARD_REQUEST_TIMEOUT_S: u64 = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeishuOnboardCredentialSource {
+    QrRegistration,
+    Manual,
+}
+
+impl FeishuOnboardCredentialSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::QrRegistration => "qr_registration",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeishuOnboardApplyOptions {
+    pub domain: mvp::config::FeishuDomain,
+    pub mode: mvp::config::FeishuChannelServeMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeishuOnboardCredentials {
+    pub app_id: String,
+    pub app_secret: String,
+    pub verification_token: Option<String>,
+    pub encrypt_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeishuQrRegistrationResult {
+    pub app_id: String,
+    pub app_secret: String,
+    pub domain: mvp::config::FeishuDomain,
+    pub open_id: Option<String>,
+    pub bot_name: Option<String>,
+    pub bot_open_id: Option<String>,
+    pub qr_url: String,
+    pub qr_rendered: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeishuOnboardResult {
+    pub config_path: String,
+    pub configured_account_id: String,
+    pub configured_account_label: String,
+    pub runtime_account_id: String,
+    pub domain: mvp::config::FeishuDomain,
+    pub mode: mvp::config::FeishuChannelServeMode,
+    pub credential_source: FeishuOnboardCredentialSource,
+    pub owner_open_id: Option<String>,
+    pub bot_name: Option<String>,
+    pub bot_open_id: Option<String>,
+    pub qr_url: Option<String>,
+    pub qr_rendered: bool,
+    pub owner_direct_chat_bootstrap_applied: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FeishuRegistrationBegin {
+    device_code: String,
+    qr_url: String,
+    interval_s: u64,
+    expire_in_s: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FeishuOnboardingUrls {
+    feishu_accounts_base_url: String,
+    lark_accounts_base_url: String,
+    feishu_open_base_url: String,
+    lark_open_base_url: String,
+}
+
+impl Default for FeishuOnboardingUrls {
+    fn default() -> Self {
+        Self {
+            feishu_accounts_base_url: FEISHU_ACCOUNTS_BASE_URL.to_owned(),
+            lark_accounts_base_url: LARK_ACCOUNTS_BASE_URL.to_owned(),
+            feishu_open_base_url: mvp::config::FeishuDomain::Feishu
+                .default_base_url()
+                .to_owned(),
+            lark_open_base_url: mvp::config::FeishuDomain::Lark
+                .default_base_url()
+                .to_owned(),
+        }
+    }
+}
+
+impl FeishuOnboardingUrls {
+    fn accounts_base_url(&self, domain: mvp::config::FeishuDomain) -> &str {
+        match domain {
+            mvp::config::FeishuDomain::Feishu => self.feishu_accounts_base_url.as_str(),
+            mvp::config::FeishuDomain::Lark => self.lark_accounts_base_url.as_str(),
+        }
+    }
+
+    fn open_base_url(&self, domain: mvp::config::FeishuDomain) -> &str {
+        match domain {
+            mvp::config::FeishuDomain::Feishu => self.feishu_open_base_url.as_str(),
+            mvp::config::FeishuDomain::Lark => self.lark_open_base_url.as_str(),
+        }
+    }
+}
+
+pub async fn onboard_via_qr_registration(
+    config_path: Option<&str>,
+    account: Option<&str>,
+    requested_domain: mvp::config::FeishuDomain,
+    timeout_s: Option<u64>,
+    mode: Option<mvp::config::FeishuChannelServeMode>,
+) -> CliResult<FeishuOnboardResult> {
+    let urls = FeishuOnboardingUrls::default();
+    let result = qr_register_with_urls(
+        requested_domain,
+        timeout_s.unwrap_or(DEFAULT_ONBOARD_TIMEOUT_S),
+        &urls,
+    )
+    .await?
+    .ok_or_else(|| "Feishu/Lark QR registration did not complete".to_owned())?;
+
+    let credentials = FeishuOnboardCredentials {
+        app_id: result.app_id.clone(),
+        app_secret: result.app_secret.clone(),
+        verification_token: None,
+        encrypt_key: None,
+    };
+    apply_onboard_result_to_config(
+        config_path,
+        account,
+        &credentials,
+        FeishuOnboardApplyOptions {
+            domain: result.domain,
+            mode: mode.unwrap_or(mvp::config::FeishuChannelServeMode::Websocket),
+        },
+        FeishuOnboardCredentialSource::QrRegistration,
+        result.open_id.clone(),
+        result.bot_name.clone(),
+        result.bot_open_id.clone(),
+        Some(result.qr_url.clone()),
+        result.qr_rendered,
+    )
+}
+
+pub fn apply_manual_feishu_onboarding(
+    config_path: Option<&str>,
+    account: Option<&str>,
+    credentials: &FeishuOnboardCredentials,
+    options: FeishuOnboardApplyOptions,
+) -> CliResult<FeishuOnboardResult> {
+    apply_onboard_result_to_config(
+        config_path,
+        account,
+        credentials,
+        options,
+        FeishuOnboardCredentialSource::Manual,
+        None,
+        None,
+        None,
+        None,
+        false,
+    )
+}
+
+pub fn render_qr_instructions(url: &str, qr_rendered: bool) -> Vec<String> {
+    if qr_rendered {
+        return vec![
+            format!("Scan the QR code above, or open this URL directly: {url}"),
+            "The command will keep polling until Feishu/Lark returns the generated bot credentials."
+                .to_owned(),
+        ];
+    }
+
+    vec![
+        format!("Open this URL in Feishu/Lark on your phone: {url}"),
+        "Install `qrencode` to display a scannable QR code in the terminal next time.".to_owned(),
+    ]
+}
+
+fn apply_onboard_result_to_config(
+    config_path: Option<&str>,
+    account: Option<&str>,
+    credentials: &FeishuOnboardCredentials,
+    options: FeishuOnboardApplyOptions,
+    credential_source: FeishuOnboardCredentialSource,
+    owner_open_id: Option<String>,
+    bot_name: Option<String>,
+    bot_open_id: Option<String>,
+    qr_url: Option<String>,
+    qr_rendered: bool,
+) -> CliResult<FeishuOnboardResult> {
+    let context = load_feishu_daemon_context(config_path, account)?;
+    let mut config = context.config.clone();
+    let configured_account_id = context.resolved.configured_account_id.clone();
+    let configured_account_label = context.resolved.configured_account_label.clone();
+    let runtime_account_id = context.account_id().to_owned();
+
+    apply_credentials_to_selected_account(
+        &mut config.feishu,
+        configured_account_id.as_str(),
+        credentials,
+        options,
+    );
+    let owner_direct_chat_bootstrap_applied = apply_owner_bootstrap_access(
+        &mut config.feishu,
+        configured_account_id.as_str(),
+        credential_source,
+        owner_open_id.as_deref(),
+    );
+
+    let config_path_string = context.config_path.display().to_string();
+    let saved_path = mvp::config::write(Some(config_path_string.as_str()), &config, true)?;
+
+    Ok(FeishuOnboardResult {
+        config_path: saved_path.display().to_string(),
+        configured_account_id,
+        configured_account_label,
+        runtime_account_id,
+        domain: options.domain,
+        mode: options.mode,
+        credential_source,
+        owner_open_id,
+        bot_name,
+        bot_open_id,
+        qr_url,
+        qr_rendered,
+        owner_direct_chat_bootstrap_applied,
+    })
+}
+
+fn apply_credentials_to_selected_account(
+    channel: &mut mvp::config::FeishuChannelConfig,
+    configured_account_id: &str,
+    credentials: &FeishuOnboardCredentials,
+    options: FeishuOnboardApplyOptions,
+) {
+    let account_override = channel.accounts.get_mut(configured_account_id);
+    if let Some(account) = account_override {
+        account.enabled = Some(true);
+        account.app_id = Some(SecretRef::Inline(credentials.app_id.clone()));
+        account.app_secret = Some(SecretRef::Inline(credentials.app_secret.clone()));
+        account.app_id_env = None;
+        account.app_secret_env = None;
+        account.domain = Some(options.domain);
+        account.mode = Some(options.mode);
+        if options.mode == mvp::config::FeishuChannelServeMode::Webhook {
+            account.verification_token = credentials
+                .verification_token
+                .clone()
+                .map(SecretRef::Inline);
+            account.encrypt_key = credentials.encrypt_key.clone().map(SecretRef::Inline);
+            account.verification_token_env = None;
+            account.encrypt_key_env = None;
+        }
+        return;
+    }
+
+    channel.enabled = true;
+    channel.app_id = Some(SecretRef::Inline(credentials.app_id.clone()));
+    channel.app_secret = Some(SecretRef::Inline(credentials.app_secret.clone()));
+    channel.app_id_env = None;
+    channel.app_secret_env = None;
+    channel.domain = options.domain;
+    channel.mode = Some(options.mode);
+    if options.mode == mvp::config::FeishuChannelServeMode::Webhook {
+        channel.verification_token = credentials
+            .verification_token
+            .clone()
+            .map(SecretRef::Inline);
+        channel.encrypt_key = credentials.encrypt_key.clone().map(SecretRef::Inline);
+        channel.verification_token_env = None;
+        channel.encrypt_key_env = None;
+    }
+}
+
+fn apply_owner_bootstrap_access(
+    channel: &mut mvp::config::FeishuChannelConfig,
+    configured_account_id: &str,
+    credential_source: FeishuOnboardCredentialSource,
+    owner_open_id: Option<&str>,
+) -> bool {
+    if credential_source != FeishuOnboardCredentialSource::QrRegistration {
+        return false;
+    }
+    let Some(owner_open_id) = owner_open_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+
+    let account_override = channel.accounts.get_mut(configured_account_id);
+    if let Some(account) = account_override {
+        let chats_unset = account
+            .allowed_chat_ids
+            .as_ref()
+            .is_none_or(|values| values.is_empty());
+        let senders_unset = account
+            .allowed_sender_ids
+            .as_ref()
+            .is_none_or(|values| values.is_empty());
+        if !chats_unset || !senders_unset {
+            return false;
+        }
+        account.allowed_chat_ids = Some(vec!["*".to_owned()]);
+        account.allowed_sender_ids = Some(vec![owner_open_id.to_owned()]);
+        return true;
+    }
+
+    if !channel.allowed_chat_ids.is_empty() || !channel.allowed_sender_ids.is_empty() {
+        return false;
+    }
+    channel.allowed_chat_ids = vec!["*".to_owned()];
+    channel.allowed_sender_ids = vec![owner_open_id.to_owned()];
+    true
+}
+
+async fn qr_register_with_urls(
+    initial_domain: mvp::config::FeishuDomain,
+    timeout_s: u64,
+    urls: &FeishuOnboardingUrls,
+) -> CliResult<Option<FeishuQrRegistrationResult>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_ONBOARD_REQUEST_TIMEOUT_S))
+        .build()
+        .map_err(|error| format!("build Feishu/Lark onboarding client failed: {error}"))?;
+
+    print!("  Connecting to Feishu / Lark...");
+    _init_registration(&client, initial_domain, urls).await?;
+    let begin = _begin_registration(&client, initial_domain, urls).await?;
+    println!(" done.");
+    println!();
+
+    let qr_rendered = render_terminal_qr(begin.qr_url.as_str());
+    for line in render_qr_instructions(begin.qr_url.as_str(), qr_rendered) {
+        println!("  {line}");
+    }
+    println!();
+
+    let mut result = match _poll_registration(
+        &client,
+        begin.device_code.as_str(),
+        begin.interval_s,
+        begin.expire_in_s.min(timeout_s),
+        initial_domain,
+        urls,
+    )
+    .await?
+    {
+        Some(result) => result,
+        None => return Ok(None),
+    };
+
+    result.qr_url = begin.qr_url;
+    result.qr_rendered = qr_rendered;
+    Ok(Some(result))
+}
+
+async fn _init_registration(
+    client: &reqwest::Client,
+    domain: mvp::config::FeishuDomain,
+    urls: &FeishuOnboardingUrls,
+) -> CliResult<()> {
+    let payload = post_registration(
+        client,
+        urls.accounts_base_url(domain),
+        &[("action", "init")],
+    )
+    .await?;
+    let methods = payload
+        .get("supported_auth_methods")
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    if methods.iter().any(|method| *method == "client_secret") {
+        return Ok(());
+    }
+    Err(format!(
+        "Feishu/Lark registration environment does not support client_secret auth. Supported: {}",
+        if methods.is_empty() {
+            "-".to_owned()
+        } else {
+            methods.join(", ")
+        }
+    ))
+}
+
+async fn _begin_registration(
+    client: &reqwest::Client,
+    domain: mvp::config::FeishuDomain,
+    urls: &FeishuOnboardingUrls,
+) -> CliResult<FeishuRegistrationBegin> {
+    let payload = post_registration(
+        client,
+        urls.accounts_base_url(domain),
+        &[
+            ("action", "begin"),
+            ("archetype", "PersonalAgent"),
+            ("auth_method", "client_secret"),
+            ("request_user_info", "open_id"),
+        ],
+    )
+    .await?;
+
+    let device_code = required_string(&payload, "device_code")?;
+    let mut qr_url = required_string(&payload, "verification_uri_complete")?;
+    if qr_url.contains('?') {
+        qr_url.push_str("&from=loong&tp=loong");
+    } else {
+        qr_url.push_str("?from=loong&tp=loong");
+    }
+
+    Ok(FeishuRegistrationBegin {
+        device_code,
+        qr_url,
+        interval_s: optional_u64(&payload, "interval").unwrap_or(5),
+        expire_in_s: optional_u64(&payload, "expire_in").unwrap_or(DEFAULT_ONBOARD_TIMEOUT_S),
+    })
+}
+
+async fn _poll_registration(
+    client: &reqwest::Client,
+    device_code: &str,
+    interval_s: u64,
+    expire_in_s: u64,
+    initial_domain: mvp::config::FeishuDomain,
+    urls: &FeishuOnboardingUrls,
+) -> CliResult<Option<FeishuQrRegistrationResult>> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(expire_in_s.max(1));
+    let mut current_domain = initial_domain;
+    let mut poll_count = 0_u64;
+    let sleep_duration = Duration::from_secs(interval_s.max(1));
+
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            if poll_count > 0 {
+                println!();
+            }
+            return Ok(None);
+        }
+
+        let payload = match post_registration(
+            client,
+            urls.accounts_base_url(current_domain),
+            &[
+                ("action", "poll"),
+                ("device_code", device_code),
+                ("tp", "ob_app"),
+            ],
+        )
+        .await
+        {
+            Ok(payload) => payload,
+            Err(_) => {
+                tokio::time::sleep(sleep_duration).await;
+                continue;
+            }
+        };
+
+        poll_count = poll_count.saturating_add(1);
+        if poll_count == 1 {
+            print!("  Fetching configuration results...");
+        } else if poll_count % 6 == 0 {
+            print!(".");
+        }
+
+        if let Some(tenant_brand) = payload
+            .get("user_info")
+            .and_then(Value::as_object)
+            .and_then(|user_info| user_info.get("tenant_brand"))
+            .and_then(Value::as_str)
+            && tenant_brand == "lark"
+        {
+            current_domain = mvp::config::FeishuDomain::Lark;
+        }
+
+        let app_id = payload
+            .get("client_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        let app_secret = payload
+            .get("client_secret")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        if let (Some(app_id), Some(app_secret)) = (app_id, app_secret) {
+            println!();
+            let user_info = payload.get("user_info").and_then(Value::as_object);
+            let open_id = user_info
+                .and_then(|value| value.get("open_id"))
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let mut result = FeishuQrRegistrationResult {
+                app_id: app_id.clone(),
+                app_secret: app_secret.clone(),
+                domain: current_domain,
+                open_id,
+                bot_name: None,
+                bot_open_id: None,
+                qr_url: String::new(),
+                qr_rendered: false,
+            };
+            if let Some(bot_info) =
+                probe_bot_with_urls(app_id.as_str(), app_secret.as_str(), current_domain, urls)
+                    .await?
+            {
+                result.bot_name = bot_info.get("bot_name").cloned();
+                result.bot_open_id = bot_info.get("bot_open_id").cloned();
+            }
+            return Ok(Some(result));
+        }
+
+        let error = payload
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if error == "access_denied" || error == "expired_token" {
+            println!();
+            return Ok(None);
+        }
+
+        tokio::time::sleep(sleep_duration).await;
+    }
+}
+
+async fn probe_bot_with_urls(
+    app_id: &str,
+    app_secret: &str,
+    domain: mvp::config::FeishuDomain,
+    urls: &FeishuOnboardingUrls,
+) -> CliResult<Option<HashMap<String, String>>> {
+    let client = mvp::channel::feishu::api::FeishuClient::new(
+        urls.open_base_url(domain),
+        app_id,
+        app_secret,
+        DEFAULT_ONBOARD_REQUEST_TIMEOUT_S as usize,
+    )?;
+    let tenant_access_token = match client.get_tenant_access_token().await {
+        Ok(token) => token,
+        Err(_) => return Ok(None),
+    };
+    let payload = match client
+        .get_json(
+            "/open-apis/bot/v3/info",
+            Some(tenant_access_token.as_str()),
+            &[],
+        )
+        .await
+    {
+        Ok(payload) => payload,
+        Err(_) => return Ok(None),
+    };
+    Ok(parse_bot_probe_response(&payload))
+}
+
+fn parse_bot_probe_response(payload: &Value) -> Option<HashMap<String, String>> {
+    let code = payload.get("code").and_then(Value::as_i64)?;
+    if code != 0 {
+        return None;
+    }
+    let bot = payload
+        .get("bot")
+        .or_else(|| payload.get("data").and_then(|data| data.get("bot")))?;
+    let mut summary = HashMap::new();
+    if let Some(bot_name) = bot.get("bot_name").and_then(Value::as_str) {
+        summary.insert("bot_name".to_owned(), bot_name.to_owned());
+    }
+    if let Some(bot_open_id) = bot.get("open_id").and_then(Value::as_str) {
+        summary.insert("bot_open_id".to_owned(), bot_open_id.to_owned());
+    }
+    Some(summary)
+}
+
+async fn post_registration(
+    client: &reqwest::Client,
+    base_url: &str,
+    body: &[(&str, &str)],
+) -> CliResult<Value> {
+    let url = format!("{}{}", base_url.trim_end_matches('/'), REGISTRATION_PATH);
+    let response = client
+        .post(url)
+        .form(body)
+        .send()
+        .await
+        .map_err(|error| format!("Feishu/Lark registration request failed: {error}"))?;
+    let body_text = response
+        .text()
+        .await
+        .map_err(|error| format!("read Feishu/Lark registration response failed: {error}"))?;
+    serde_json::from_str(&body_text)
+        .map_err(|error| format!("decode Feishu/Lark registration response failed: {error}"))
+}
+
+fn render_terminal_qr(url: &str) -> bool {
+    let output = Command::new("qrencode")
+        .args(["-t", "ANSIUTF8", url])
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let rendered = String::from_utf8(output.stdout).ok();
+    let Some(rendered) = rendered.map(|value| value.trim().to_owned()) else {
+        return false;
+    };
+    if rendered.is_empty() {
+        return false;
+    }
+    println!("{rendered}");
+    true
+}
+
+fn required_string(payload: &Value, field: &str) -> CliResult<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| format!("Feishu/Lark onboarding response missing `{field}`"))
+}
+
+fn optional_u64(payload: &Value, field: &str) -> Option<u64> {
+    payload.get(field).and_then(Value::as_u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::extract::State;
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Default)]
+    struct RegistrationServerState {
+        poll_requests: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[tokio::test]
+    async fn begin_registration_appends_loong_tracking_query() {
+        let state = RegistrationServerState::default();
+        let base_url = spawn_registration_server(state).await;
+        let urls = test_urls(base_url.as_str());
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("client");
+
+        let begin = _begin_registration(&client, mvp::config::FeishuDomain::Feishu, &urls)
+            .await
+            .expect("begin");
+
+        assert_eq!(begin.device_code, "device-123");
+        assert!(
+            begin
+                .qr_url
+                .contains("https://scan.example/activate?device=device-123&from=loong&tp=loong")
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_registration_switches_to_lark_when_tenant_brand_requests_it() {
+        let state = RegistrationServerState::default();
+        let base_url = spawn_registration_server(state).await;
+        let bot_base_url = spawn_bot_probe_server().await;
+        let urls = FeishuOnboardingUrls {
+            feishu_accounts_base_url: base_url.clone(),
+            lark_accounts_base_url: base_url,
+            feishu_open_base_url: bot_base_url.clone(),
+            lark_open_base_url: bot_base_url,
+        };
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("client");
+
+        let result = _poll_registration(
+            &client,
+            "device-123",
+            0,
+            2,
+            mvp::config::FeishuDomain::Feishu,
+            &urls,
+        )
+        .await
+        .expect("poll")
+        .expect("registration result");
+
+        assert_eq!(result.domain, mvp::config::FeishuDomain::Lark);
+        assert_eq!(result.app_id, "cli_lark_123");
+        assert_eq!(result.app_secret, "secret_lark_123");
+        assert_eq!(result.open_id.as_deref(), Some("ou_owner_1"));
+        assert_eq!(result.bot_name.as_deref(), Some("Loong Bot"));
+        assert_eq!(result.bot_open_id.as_deref(), Some("ou_bot_1"));
+    }
+
+    #[test]
+    fn render_qr_instructions_switches_to_fallback_copy_when_qr_is_unavailable() {
+        let rendered = render_qr_instructions("https://scan.example/activate", false).join("\n");
+
+        assert!(rendered.contains("Open this URL in Feishu/Lark on your phone"));
+        assert!(rendered.contains("qrencode"));
+    }
+
+    #[test]
+    fn apply_credentials_updates_root_channel_when_no_named_account_exists() {
+        let mut config = mvp::config::FeishuChannelConfig::default();
+        apply_credentials_to_selected_account(
+            &mut config,
+            "feishu_cli_default",
+            &FeishuOnboardCredentials {
+                app_id: "cli_root_123".to_owned(),
+                app_secret: "root_secret_123".to_owned(),
+                verification_token: None,
+                encrypt_key: None,
+            },
+            FeishuOnboardApplyOptions {
+                domain: mvp::config::FeishuDomain::Lark,
+                mode: mvp::config::FeishuChannelServeMode::Websocket,
+            },
+        );
+
+        assert!(config.enabled);
+        assert_eq!(config.domain, mvp::config::FeishuDomain::Lark);
+        assert_eq!(
+            config.mode,
+            Some(mvp::config::FeishuChannelServeMode::Websocket)
+        );
+        assert_eq!(
+            config
+                .app_id
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("cli_root_123")
+        );
+        assert_eq!(
+            config
+                .app_secret
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("root_secret_123")
+        );
+        assert_eq!(config.app_id_env, None);
+        assert_eq!(config.app_secret_env, None);
+    }
+
+    #[test]
+    fn apply_credentials_updates_selected_named_account() {
+        let mut config = mvp::config::FeishuChannelConfig {
+            accounts: BTreeMap::from([(
+                "work".to_owned(),
+                mvp::config::FeishuAccountConfig::default(),
+            )]),
+            ..mvp::config::FeishuChannelConfig::default()
+        };
+        apply_credentials_to_selected_account(
+            &mut config,
+            "work",
+            &FeishuOnboardCredentials {
+                app_id: "cli_work_123".to_owned(),
+                app_secret: "work_secret_123".to_owned(),
+                verification_token: None,
+                encrypt_key: None,
+            },
+            FeishuOnboardApplyOptions {
+                domain: mvp::config::FeishuDomain::Feishu,
+                mode: mvp::config::FeishuChannelServeMode::Websocket,
+            },
+        );
+
+        let account = config.accounts.get("work").expect("named account");
+        assert_eq!(account.enabled, Some(true));
+        assert_eq!(
+            account
+                .app_id
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("cli_work_123")
+        );
+        assert_eq!(
+            account
+                .app_secret
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("work_secret_123")
+        );
+        assert_eq!(account.domain, Some(mvp::config::FeishuDomain::Feishu));
+        assert_eq!(
+            account.mode,
+            Some(mvp::config::FeishuChannelServeMode::Websocket)
+        );
+    }
+
+    #[test]
+    fn apply_owner_bootstrap_access_updates_root_channel_for_qr_onboarding() {
+        let mut config = mvp::config::FeishuChannelConfig::default();
+
+        let applied = apply_owner_bootstrap_access(
+            &mut config,
+            "feishu_cli_default",
+            FeishuOnboardCredentialSource::QrRegistration,
+            Some("ou_owner_1"),
+        );
+
+        assert!(applied);
+        assert_eq!(config.allowed_chat_ids, vec!["*".to_owned()]);
+        assert_eq!(config.allowed_sender_ids, vec!["ou_owner_1".to_owned()]);
+    }
+
+    #[test]
+    fn apply_owner_bootstrap_access_updates_named_account_for_qr_onboarding() {
+        let mut config = mvp::config::FeishuChannelConfig {
+            accounts: BTreeMap::from([(
+                "work".to_owned(),
+                mvp::config::FeishuAccountConfig::default(),
+            )]),
+            ..mvp::config::FeishuChannelConfig::default()
+        };
+
+        let applied = apply_owner_bootstrap_access(
+            &mut config,
+            "work",
+            FeishuOnboardCredentialSource::QrRegistration,
+            Some("ou_owner_1"),
+        );
+
+        assert!(applied);
+        let account = config.accounts.get("work").expect("named account");
+        assert_eq!(
+            account.allowed_chat_ids.clone().unwrap_or_default(),
+            vec!["*".to_owned()]
+        );
+        assert_eq!(
+            account.allowed_sender_ids.clone().unwrap_or_default(),
+            vec!["ou_owner_1".to_owned()]
+        );
+    }
+
+    #[test]
+    fn apply_owner_bootstrap_access_preserves_existing_restrictions() {
+        let mut config = mvp::config::FeishuChannelConfig {
+            allowed_chat_ids: vec!["oc_ops_room".to_owned()],
+            ..mvp::config::FeishuChannelConfig::default()
+        };
+
+        let applied = apply_owner_bootstrap_access(
+            &mut config,
+            "feishu_cli_default",
+            FeishuOnboardCredentialSource::QrRegistration,
+            Some("ou_owner_1"),
+        );
+
+        assert!(!applied);
+        assert_eq!(config.allowed_chat_ids, vec!["oc_ops_room".to_owned()]);
+        assert!(config.allowed_sender_ids.is_empty());
+    }
+
+    async fn spawn_registration_server(state: RegistrationServerState) -> String {
+        async fn handle_registration(
+            State(state): State<RegistrationServerState>,
+            body: String,
+        ) -> Json<Value> {
+            let form = body
+                .split('&')
+                .filter_map(|pair| {
+                    let (key, value) = pair.split_once('=')?;
+                    Some((key.to_owned(), value.to_owned()))
+                })
+                .collect::<HashMap<String, String>>();
+            match form.get("action").map(String::as_str) {
+                Some("init") => Json(json!({
+                    "supported_auth_methods": ["client_secret", "oauth"]
+                })),
+                Some("begin") => Json(json!({
+                    "device_code": "device-123",
+                    "verification_uri_complete": "https://scan.example/activate?device=device-123",
+                    "interval": 0,
+                    "expire_in": 10,
+                })),
+                Some("poll") => {
+                    let mut guard = state.poll_requests.lock().await;
+                    guard.push(
+                        form.get("device_code")
+                            .cloned()
+                            .unwrap_or_else(|| "-".to_owned()),
+                    );
+                    let response = if guard.len() == 1 {
+                        json!({
+                            "error": "authorization_pending",
+                            "user_info": {
+                                "tenant_brand": "lark"
+                            }
+                        })
+                    } else {
+                        json!({
+                            "client_id": "cli_lark_123",
+                            "client_secret": "secret_lark_123",
+                            "user_info": {
+                                "tenant_brand": "lark",
+                                "open_id": "ou_owner_1"
+                            }
+                        })
+                    };
+                    Json(response)
+                }
+                other => Json(json!({
+                    "error": format!("unexpected action: {}", other.unwrap_or("-"))
+                })),
+            }
+        }
+
+        let router = Router::new()
+            .route(REGISTRATION_PATH, post(handle_registration))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("serve registration");
+        });
+        format!("http://{}", addr)
+    }
+
+    async fn spawn_bot_probe_server() -> String {
+        async fn token() -> Json<Value> {
+            Json(json!({
+                "code": 0,
+                "tenant_access_token": "tenant_token_123"
+            }))
+        }
+
+        async fn bot() -> Json<Value> {
+            Json(json!({
+                "code": 0,
+                "bot": {
+                    "bot_name": "Loong Bot",
+                    "open_id": "ou_bot_1"
+                }
+            }))
+        }
+
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post(token),
+            )
+            .route("/open-apis/bot/v3/info", get(bot));
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.expect("serve probe");
+        });
+        format!("http://{}", addr)
+    }
+
+    fn test_urls(base_url: &str) -> FeishuOnboardingUrls {
+        FeishuOnboardingUrls {
+            feishu_accounts_base_url: base_url.to_owned(),
+            lark_accounts_base_url: base_url.to_owned(),
+            feishu_open_base_url: base_url.to_owned(),
+            lark_open_base_url: base_url.to_owned(),
+        }
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -126,6 +126,7 @@ pub mod doctor_security_cli;
 mod env_compat;
 mod external_skills_policy_probe;
 pub mod feishu_cli;
+mod feishu_onboarding;
 pub mod feishu_support;
 pub mod gateway;
 pub mod import_cli;

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-17T06:18:46Z
+- Generated at: 2026-04-18T12:39:28Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -37,13 +37,13 @@ release review. It is not part of the primary public release trail.
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3096 | 3600 | 504 | 0 | 12 | 12 | 86.0% | WATCH | 3383 | -8.5% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10123 | 10500 | 377 | 78 | 90 | 12 | 96.4% | TIGHT | 9922 | 2.0% | PASS | 88 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10125 | 10500 | 375 | 78 | 90 | 12 | 96.4% | TIGHT | 9922 | 2.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8919 | 9800 | 881 | 17 | 90 | 73 | 91.0% | WATCH | 9796 | -9.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6751 | 7300 | 549 | 95 | 160 | 65 | 92.5% | WATCH | 6936 | -2.7% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2113 | 6400 | 4287 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.8% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9988 | 11200 | 1212 | 61 | 120 | 59 | 89.2% | WATCH | 10831 | -7.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14430 | 15000 | 570 | 45 | 70 | 25 | 96.2% | TIGHT | 14472 | -0.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5955 | 6500 | 545 | 178 | 210 | 32 | 91.6% | WATCH | 6324 | -5.8% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5956 | 6500 | 544 | 178 | 210 | 32 | 91.6% | WATCH | 6324 | -5.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9238 | 9800 | 562 | 206 | 250 | 44 | 94.3% | WATCH | 9519 | -3.0% | PASS | 228 |
 
 ## Prioritization Signals
@@ -91,13 +91,13 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3096 functions=0 -->
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
-<!-- arch-hotspot key=channel_registry lines=10123 functions=78 -->
+<!-- arch-hotspot key=channel_registry lines=10125 functions=78 -->
 <!-- arch-hotspot key=channel_config lines=8919 functions=17 -->
 <!-- arch-hotspot key=chat_runtime lines=6751 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2113 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9988 functions=61 -->
 <!-- arch-hotspot key=tools_mod lines=14430 functions=45 -->
-<!-- arch-hotspot key=daemon_lib lines=5955 functions=178 -->
+<!-- arch-hotspot key=daemon_lib lines=5956 functions=178 -->
 <!-- arch-hotspot key=onboard_cli lines=9238 functions=206 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/site/use-loong/channel-guides/feishu.mdx
+++ b/site/use-loong/channel-guides/feishu.mdx
@@ -20,6 +20,14 @@ This is a shipped runtime-backed surface: direct sends are implemented, the serv
 
 ## Minimal Config
 
+Preferred setup path:
+
+```bash
+loong feishu onboard
+```
+
+This starts the official Feishu/Lark QR registration flow in the terminal, saves the generated `app_id` and `app_secret` into `loongclaw.toml`, and defaults the channel to `mode = "websocket"`. Manual credential handoff remains available with `loong feishu onboard --manual --app-id ... --app-secret ...`.
+
 ```toml
 [feishu]
 enabled = true
@@ -71,7 +79,10 @@ This surface can run directly through its own `*-serve` command, or under [Gatew
 
 ## Operator Notes
 
+- `loong feishu onboard` is the recommended first-run path for both Feishu and Lark. Use `--domain lark` to start on the international lane, or keep the default Feishu lane and let the registration poll switch to Lark when the scanned tenant reports `tenant_brand = "lark"`.
 - Webhook mode additionally needs `verification_token` and `encrypt_key`; websocket mode does not.
+- QR onboarding only provisions `app_id` and `app_secret`, so it currently targets websocket mode. Use `loong feishu onboard --manual --mode webhook ...` when you need webhook callback credentials.
+- When QR onboarding receives the configuring user's `open_id` and no Feishu inbound allowlists are already configured, Loong bootstraps `allowed_chat_ids = ["*"]` plus `allowed_sender_ids = [owner_open_id]` so that same user can immediately start a direct chat with the bot after setup.
 - Use `allowed_chat_ids` as the trust boundary instead of treating it as a convenience filter.
 - Keep `domain = "lark"` for the Lark lane and `domain = "feishu"` for the Feishu lane; the runtime contract is the same family.
 


### PR DESCRIPTION
## Summary

- Add QR-code-based onboarding for Feishu/Lark: `loong feishu onboard` shows an in-terminal QR code, creates the bot app via official registration API, and writes credentials to `loongclaw.toml`
- New `QrRegistration` onboarding strategy variant in channel catalog model
- Manual fallback preserved via `--manual --app-id ... --app-secret ...`
- Updated README (EN & CN) and channel guide docs

## Changes

- `crates/daemon/src/feishu_onboarding.rs` — new module implementing the full QR onboarding flow
- `crates/daemon/src/feishu_cli.rs` — CLI subcommand wiring for `loong feishu onboard`
- `crates/app/src/channel/catalog/model.rs` — add `QrRegistration` to `ChannelOnboardingStrategy`
- `crates/app/src/channel/registry.rs` — register feishu QR onboarding strategy
- `README.md`, `README.zh-CN.md`, `site/use-loong/channel-guides/feishu.mdx` — docs update

## Test plan

- [x] `loong feishu onboard --domain feishu` renders QR code and completes registration
- [x] `loong feishu onboard --manual --app-id <id> --app-secret <secret>` still works
- [x] `cargo test --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean