### PR TITLE
Feat/969 agent mailbox

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -227,6 +227,8 @@ pub struct DelegateToolConfig {
     pub announce_debounce_ms: u64,
     #[serde(default = "default_delegate_announce_max_batch")]
     pub announce_max_batch: usize,
+    #[serde(default = "default_delegate_max_pending")]
+    pub max_pending: Option<usize>,
     #[serde(default)]
     pub child_runtime: DelegateChildRuntimeConfig,
 }
@@ -623,6 +625,7 @@ impl Default for DelegateToolConfig {
             max_frozen_bytes: default_delegate_max_frozen_bytes(),
             announce_debounce_ms: default_delegate_announce_debounce_ms(),
             announce_max_batch: default_delegate_announce_max_batch(),
+            max_pending: default_delegate_max_pending(),
             child_runtime: DelegateChildRuntimeConfig::default(),
         }
     }
@@ -1360,6 +1363,9 @@ const fn default_delegate_announce_debounce_ms() -> u64 {
 
 const fn default_delegate_announce_max_batch() -> usize {
     20
+}
+const fn default_delegate_max_pending() -> Option<usize> {
+    None
 }
 
 const fn default_browser_max_sessions() -> usize {

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -20,6 +20,7 @@ mod runtime_binding;
 mod safe_lane_failure;
 mod session_address;
 mod session_history;
+mod session_state;
 mod subagent;
 mod tool_discovery_state;
 mod tool_input_contract;
@@ -106,6 +107,7 @@ pub use session_history::{
     load_fast_lane_tool_batch_event_summary, load_safe_lane_event_summary,
     load_turn_checkpoint_event_summary,
 };
+pub(crate) use session_state::{InterAgentMessage, mailbox_for_session};
 pub use subagent::{
     ConstrainedSubagentBudgetSnapshot, ConstrainedSubagentContractView,
     ConstrainedSubagentControlScope, ConstrainedSubagentCoordinationAction,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -27,6 +27,7 @@ use super::context_engine_registry::{
     DEFAULT_CONTEXT_ENGINE_ID, context_engine_id_from_env, describe_context_engine,
     list_context_engine_metadata, resolve_context_engine,
 };
+use super::mailbox_for_session;
 use super::prompt_orchestrator::seed_prompt_fragments_from_context;
 use super::prompt_orchestrator::sync_prompt_fragments_into_context;
 use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
@@ -67,8 +68,10 @@ pub struct SessionContext {
 
 impl SessionContext {
     pub fn root_with_tool_view(session_id: impl Into<String>, tool_view: ToolView) -> Self {
+        let session_id = normalize_session_id(session_id.into());
+        let _ = mailbox_for_session(&session_id);
         Self {
-            session_id: normalize_session_id(session_id.into()),
+            session_id,
             parent_session_id: None,
             profile: None,
             tool_view,
@@ -85,9 +88,13 @@ impl SessionContext {
         parent_session_id: impl Into<String>,
         tool_view: ToolView,
     ) -> Self {
+        let session_id = normalize_session_id(session_id.into());
+        let parent_session_id = normalize_session_id(parent_session_id.into());
+        let _ = mailbox_for_session(&session_id);
+        let _ = mailbox_for_session(&parent_session_id);
         Self {
-            session_id: normalize_session_id(session_id.into()),
-            parent_session_id: Some(normalize_session_id(parent_session_id.into())),
+            session_id,
+            parent_session_id: Some(parent_session_id),
             profile: None,
             tool_view,
             workspace_root: None,

--- a/crates/app/src/conversation/session_state.rs
+++ b/crates/app/src/conversation/session_state.rs
@@ -1,0 +1,60 @@
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use loong_kernel::mailbox::AgentMailbox;
+
+#[cfg(test)]
+use loong_kernel::mailbox::AgentPath;
+pub(crate) use loong_kernel::mailbox::InterAgentMessage;
+#[cfg(test)]
+use loong_kernel::mailbox::MailboxContent;
+
+fn normalize_session_id(session_id: &str) -> String {
+    let trimmed = session_id.trim();
+    if trimmed.is_empty() {
+        "default".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+fn mailboxes() -> &'static std::sync::Mutex<BTreeMap<String, AgentMailbox>> {
+    static SESSION_MAILBOXES: OnceLock<std::sync::Mutex<BTreeMap<String, AgentMailbox>>> =
+        OnceLock::new();
+    SESSION_MAILBOXES.get_or_init(|| std::sync::Mutex::new(BTreeMap::new()))
+}
+
+pub(crate) fn mailbox_for_session(session_id: &str) -> AgentMailbox {
+    let normalized = normalize_session_id(session_id);
+    let mut guard = mailboxes()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    guard.entry(normalized).or_default().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn mailbox_registry_reuses_same_session_mailbox() {
+        let mailbox_a = mailbox_for_session("session-a");
+        let mailbox_b = mailbox_for_session("session-a");
+
+        let send_result = mailbox_a.send(InterAgentMessage {
+            author: AgentPath::root(),
+            recipient: AgentPath::root(),
+            content: MailboxContent::DelegateResult {
+                session_id: "child-1".to_owned(),
+                frozen_result: json!({"status": "ok"}),
+            },
+            trigger_turn: true,
+        });
+        assert!(send_result.is_ok());
+
+        let drained = mailbox_b.drain().await;
+        assert_eq!(drained.len(), 1);
+    }
+}

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -63,6 +63,8 @@ use super::delegate_support::{
 };
 use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
+#[cfg(feature = "memory-sqlite")]
+use super::mailbox_for_session;
 use super::persistence::{
     format_provider_error_reply, persist_acp_runtime_events, persist_conversation_event,
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode, persist_tool_decision,
@@ -161,6 +163,8 @@ use crate::session::repository::{
     ApprovalDecision, ApprovalRequestStatus, NewSessionEvent, NewSessionRecord, SessionKind,
     SessionRepository, SessionState,
 };
+#[cfg(feature = "memory-sqlite")]
+use loong_kernel::mailbox::{AgentPath, InterAgentMessage, MailboxContent};
 use support::{
     ProviderTurnPreparation, ProviderTurnReplyTailPhase, ProviderTurnSessionState,
     emit_async_delegate_child_queued_event, emit_discovery_first_event, emit_prompt_frame_event,
@@ -4768,6 +4772,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 )
                 .await;
             }
+            notify_parent_delegate_result(parent_session_id, child_session_id, &outcome);
             Ok(outcome)
         }
         Ok(Ok(Err(error))) => {
@@ -4824,6 +4829,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 )
                 .await;
             }
+            notify_parent_delegate_result(parent_session_id, child_session_id, &outcome);
             Ok(outcome)
         }
         Ok(Err(panic_payload)) => {
@@ -4881,6 +4887,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 )
                 .await;
             }
+            notify_parent_delegate_result(parent_session_id, child_session_id, &outcome);
             Ok(outcome)
         }
         Err(_) => {
@@ -4937,9 +4944,35 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 )
                 .await;
             }
+            notify_parent_delegate_result(parent_session_id, child_session_id, &outcome);
             Ok(outcome)
         }
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn notify_parent_delegate_result(
+    parent_session_id: &str,
+    child_session_id: &str,
+    outcome: &loong_contracts::ToolCoreOutcome,
+) {
+    let mailbox = mailbox_for_session(parent_session_id);
+    let author = AgentPath::root()
+        .join(child_session_id)
+        .unwrap_or_else(|_| AgentPath::root());
+    let message = InterAgentMessage {
+        author,
+        recipient: AgentPath::root(),
+        content: MailboxContent::DelegateResult {
+            session_id: child_session_id.to_owned(),
+            frozen_result: json!({
+                "status": outcome.status,
+                "payload": outcome.payload,
+            }),
+        },
+        trigger_turn: true,
+    };
+    let _ = mailbox.send(message);
 }
 
 async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 #[cfg(feature = "memory-sqlite")]
-use tokio::time::{Duration, Instant, sleep};
+use tokio::time::{Duration, Instant, timeout};
 
 use loong_contracts::{
     GovernedSessionMode, GovernedWorkflowPhase, ToolCoreOutcome, ToolCoreRequest,
@@ -24,6 +24,8 @@ use crate::conversation::{
     ConstrainedSubagentIdentity, ConstrainedSubagentProfile, DelegateBuiltinProfile,
     coordination_actions_for_subagent_handle, subagent_surface_fields,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::conversation::{InterAgentMessage, mailbox_for_session};
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
@@ -1506,6 +1508,8 @@ async fn wait_for_single_session_with_policies(
     let started_at = Instant::now();
     let mut next_after_id = after_id.unwrap_or(0).max(0);
     let mut observed_events = Vec::new();
+    let mailbox = mailbox_for_session(current_session_id);
+    let mut mailbox_subscription = mailbox.subscribe();
 
     loop {
         let observation = observe_visible_session_with_policies(
@@ -1557,7 +1561,19 @@ async fn wait_for_single_session_with_policies(
         }
 
         let remaining_ms = timeout_ms - elapsed_ms;
-        sleep(Duration::from_millis(remaining_ms.min(25))).await;
+        let drained: Vec<InterAgentMessage> = mailbox.drain().await;
+        if !drained.is_empty() {
+            continue;
+        }
+
+        let wait_result = timeout(
+            Duration::from_millis(remaining_ms),
+            mailbox_subscription.changed(),
+        )
+        .await;
+        if let Ok(Err(_)) = wait_result {
+            return Err("session_wait_internal_error: mailbox subscription closed".to_owned());
+        }
     }
 }
 
@@ -1573,6 +1589,8 @@ async fn wait_for_session_batch_with_policies(
     event_limit: usize,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
+    let mailbox = mailbox_for_session(current_session_id);
+    let mut mailbox_subscription = mailbox.subscribe();
     let mut results = vec![None; target_session_ids.len()];
     let mut pending = Vec::new();
     for (index, target_session_id) in target_session_ids.into_iter().enumerate() {
@@ -1729,7 +1747,19 @@ async fn wait_for_session_batch_with_policies(
         }
 
         let remaining_ms = timeout_ms - elapsed_ms;
-        sleep(Duration::from_millis(remaining_ms.min(25))).await;
+        let drained: Vec<InterAgentMessage> = mailbox.drain().await;
+        if !drained.is_empty() {
+            continue;
+        }
+
+        let wait_result = timeout(
+            Duration::from_millis(remaining_ms),
+            mailbox_subscription.changed(),
+        )
+        .await;
+        if let Ok(Err(_)) = wait_result {
+            return Err("session_wait_internal_error: mailbox subscription closed".to_owned());
+        }
     }
 }
 
@@ -3963,10 +3993,13 @@ mod tests {
     use std::fs;
 
     use loong_contracts::{ToolCoreOutcome, ToolCoreRequest};
+    use loong_kernel::mailbox::{AgentPath, MailboxContent};
     use rusqlite::params;
     use serde_json::{Value, json};
+    use tokio::time::{Duration, Instant, sleep};
 
     use crate::config::{SessionVisibility, ToolConfig};
+    use crate::conversation::{InterAgentMessage, mailbox_for_session};
     use crate::memory::append_turn_direct;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
@@ -3974,7 +4007,10 @@ mod tests {
         SessionKind, SessionRepository, SessionState, SessionSummaryRecord,
     };
 
-    use super::{execute_session_tool_with_config, execute_session_tool_with_policies};
+    use super::{
+        execute_session_tool_with_config, execute_session_tool_with_policies,
+        wait_for_single_session_with_policies,
+    };
 
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
         let base = std::env::temp_dir().join(format!(
@@ -7451,6 +7487,86 @@ mod tests {
                 .archived_at,
             None
         );
+    }
+
+    #[tokio::test]
+    async fn session_wait_wakes_when_parent_mailbox_receives_delegate_result() {
+        let config = isolated_memory_config("session-wait-mailbox-wake");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let config_for_completion = config.clone();
+        let completion = tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            let repo = SessionRepository::new(&config_for_completion).expect("completion repo");
+            repo.finalize_session_terminal(
+                "child-session",
+                FinalizeSessionTerminalRequest {
+                    state: SessionState::Completed,
+                    last_error: None,
+                    event_kind: "delegate_completed".to_owned(),
+                    actor_session_id: Some("root-session".to_owned()),
+                    event_payload_json: json!({
+                        "result": "ok"
+                    }),
+                    outcome_status: "ok".to_owned(),
+                    outcome_payload_json: json!({
+                        "child_session_id": "child-session",
+                        "result": "ok"
+                    }),
+                    frozen_result: None,
+                },
+            )
+            .expect("finalize child");
+
+            let mailbox = mailbox_for_session("root-session");
+            let send_result = mailbox.send(InterAgentMessage {
+                author: AgentPath::root(),
+                recipient: AgentPath::root(),
+                content: MailboxContent::DelegateResult {
+                    session_id: "child-session".to_owned(),
+                    frozen_result: json!({
+                        "status": "ok"
+                    }),
+                },
+                trigger_turn: true,
+            });
+            assert!(send_result.is_ok());
+        });
+
+        let started_at = Instant::now();
+        let outcome = wait_for_single_session_with_policies(
+            "child-session",
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+            None,
+            1_000,
+            10,
+        )
+        .await
+        .expect("session_wait outcome");
+        completion.await.expect("completion task");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["wait_status"], "completed");
+        assert_eq!(outcome.payload["session"]["state"], "completed");
+        assert!(started_at.elapsed() < Duration::from_millis(500));
     }
 
     #[test]

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 semver.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 
 [features]
 test-support = []

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -11,6 +11,7 @@ pub mod errors;
 pub mod harness;
 pub mod integration;
 pub mod kernel;
+pub mod mailbox;
 pub mod memory;
 pub mod pack;
 pub mod plugin;

--- a/crates/kernel/src/mailbox.rs
+++ b/crates/kernel/src/mailbox.rs
@@ -1,0 +1,274 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::{Mutex, mpsc, watch};
+
+pub const ROOT_AGENT_PATH: &str = "/root";
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentPath(String);
+
+impl AgentPath {
+    pub fn from_string(raw: impl AsRef<str>) -> Result<Self, String> {
+        let normalized = normalize_agent_path(raw.as_ref())?;
+        Ok(Self(normalized))
+    }
+
+    pub fn root() -> Self {
+        Self(ROOT_AGENT_PATH.to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn join(&self, child: impl AsRef<str>) -> Result<Self, String> {
+        let child = child.as_ref().trim();
+        if child.is_empty() {
+            return Err("agent_path_invalid: child segment must not be empty".to_owned());
+        }
+        if child.contains('/') {
+            return Err("agent_path_invalid: child segment must not contain `/`".to_owned());
+        }
+        if !is_valid_segment(child) {
+            return Err(format!(
+                "agent_path_invalid: child segment `{child}` contains unsupported characters"
+            ));
+        }
+        Self::from_string(format!("{}/{}", self.0, child))
+    }
+}
+
+impl Default for AgentPath {
+    fn default() -> Self {
+        Self::root()
+    }
+}
+
+impl AsRef<str> for AgentPath {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum MailboxContent {
+    DelegateResult {
+        session_id: String,
+        frozen_result: Value,
+    },
+    StatusNotification {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InterAgentMessage {
+    pub author: AgentPath,
+    pub recipient: AgentPath,
+    pub content: MailboxContent,
+    pub trigger_turn: bool,
+}
+
+#[derive(Debug)]
+struct AgentMailboxState {
+    receiver: Mutex<mpsc::UnboundedReceiver<InterAgentMessage>>,
+    sequence: AtomicU64,
+    notifier: watch::Sender<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentMailbox {
+    sender: mpsc::UnboundedSender<InterAgentMessage>,
+    state: Arc<AgentMailboxState>,
+}
+
+impl AgentMailbox {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let (notifier, _) = watch::channel(0_u64);
+        Self {
+            sender,
+            state: Arc::new(AgentMailboxState {
+                receiver: Mutex::new(receiver),
+                sequence: AtomicU64::new(0),
+                notifier,
+            }),
+        }
+    }
+
+    pub fn send(&self, msg: InterAgentMessage) -> Result<(), String> {
+        self.sender
+            .send(msg)
+            .map_err(|error| format!("agent_mailbox_closed: {error}"))?;
+        let next_seq = self.state.sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        let _ = self.state.notifier.send(next_seq);
+        Ok(())
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.state.notifier.subscribe()
+    }
+
+    pub async fn drain(&self) -> Vec<InterAgentMessage> {
+        let mut receiver = self.state.receiver.lock().await;
+        let mut drained = VecDeque::new();
+        while let Ok(message) = receiver.try_recv() {
+            drained.push_back(message);
+        }
+        drained.into_iter().collect()
+    }
+}
+
+impl Default for AgentMailbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn normalize_agent_path(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("agent_path_invalid: path must not be empty".to_owned());
+    }
+    if !trimmed.starts_with('/') {
+        return Err("agent_path_invalid: path must start with `/`".to_owned());
+    }
+
+    let mut segments = Vec::new();
+    for segment in trimmed.split('/').skip(1) {
+        if segment.is_empty() {
+            return Err("agent_path_invalid: empty path segment".to_owned());
+        }
+        if !is_valid_segment(segment) {
+            return Err(format!(
+                "agent_path_invalid: segment `{segment}` contains unsupported characters"
+            ));
+        }
+        segments.push(segment);
+    }
+
+    if segments.is_empty() {
+        return Err("agent_path_invalid: root segment is required".to_owned());
+    }
+
+    Ok(format!("/{}", segments.join("/")))
+}
+
+fn is_valid_segment(segment: &str) -> bool {
+    segment
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' || ch == ':')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn mailbox_send_subscribe_drain_lifecycle() {
+        let mailbox = AgentMailbox::new();
+        let mut subscription = mailbox.subscribe();
+
+        let author = AgentPath::root();
+        let recipient = author.join("task").unwrap_or_else(|_| AgentPath::root());
+        let send_result = mailbox.send(InterAgentMessage {
+            author,
+            recipient,
+            content: MailboxContent::StatusNotification {
+                reason: "child_completed".to_owned(),
+            },
+            trigger_turn: true,
+        });
+        assert!(send_result.is_ok());
+
+        let changed_result = subscription.changed().await;
+        assert!(changed_result.is_ok());
+
+        let drained = mailbox.drain().await;
+        assert_eq!(drained.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mailbox_sequence_increments() {
+        let mailbox = AgentMailbox::new();
+        let mut subscription = mailbox.subscribe();
+
+        let first = mailbox.send(InterAgentMessage {
+            author: AgentPath::root(),
+            recipient: AgentPath::root(),
+            content: MailboxContent::StatusNotification {
+                reason: "first".to_owned(),
+            },
+            trigger_turn: false,
+        });
+        assert!(first.is_ok());
+        let first_changed = subscription.changed().await;
+        assert!(first_changed.is_ok());
+        let first_seq = *subscription.borrow();
+
+        let second = mailbox.send(InterAgentMessage {
+            author: AgentPath::root(),
+            recipient: AgentPath::root(),
+            content: MailboxContent::DelegateResult {
+                session_id: "child-1".to_owned(),
+                frozen_result: json!({"status": "ok"}),
+            },
+            trigger_turn: true,
+        });
+        assert!(second.is_ok());
+        let second_changed = subscription.changed().await;
+        assert!(second_changed.is_ok());
+        let second_seq = *subscription.borrow();
+
+        assert!(second_seq > first_seq);
+    }
+
+    #[tokio::test]
+    async fn mailbox_supports_multiple_senders() {
+        let mailbox = AgentMailbox::new();
+        let mailbox_2 = mailbox.clone();
+
+        let send_1 = mailbox.send(InterAgentMessage {
+            author: AgentPath::root(),
+            recipient: AgentPath::root(),
+            content: MailboxContent::StatusNotification {
+                reason: "a".to_owned(),
+            },
+            trigger_turn: false,
+        });
+        assert!(send_1.is_ok());
+
+        let send_2 = mailbox_2.send(InterAgentMessage {
+            author: AgentPath::root(),
+            recipient: AgentPath::root(),
+            content: MailboxContent::StatusNotification {
+                reason: "b".to_owned(),
+            },
+            trigger_turn: false,
+        });
+        assert!(send_2.is_ok());
+
+        let drained = mailbox.drain().await;
+        assert_eq!(drained.len(), 2);
+    }
+
+    #[test]
+    fn agent_path_validates_and_joins() {
+        let root = AgentPath::from_string(ROOT_AGENT_PATH);
+        assert!(root.is_ok());
+        let root = root.unwrap_or_else(|_| AgentPath::root());
+
+        let child = root.join("subtask");
+        assert!(child.is_ok());
+        let child = child.unwrap_or_else(|_| AgentPath::root());
+
+        assert_eq!(child.as_str(), "/root/subtask");
+        assert!(AgentPath::from_string("root/subtask").is_err());
+        assert!(AgentPath::from_string("/root//subtask").is_err());
+    }
+}

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-18T16:52:47Z
+- Generated at: 2026-04-18T18:18:36Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -41,7 +41,7 @@ release review. It is not part of the primary public release trail.
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8917 | 9800 | 883 | 17 | 90 | 73 | 91.0% | WATCH | 9796 | -9.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6734 | 7300 | 566 | 95 | 160 | 65 | 92.2% | WATCH | 6936 | -2.9% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2109 | 6400 | 4291 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.5% | BREACH | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9984 | 11200 | 1216 | 61 | 120 | 59 | 89.1% | WATCH | 10831 | -7.8% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10017 | 11200 | 1183 | 62 | 120 | 58 | 89.4% | WATCH | 10831 | -7.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14366 | 15000 | 634 | 44 | 70 | 26 | 95.8% | TIGHT | 14472 | -0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5880 | 6500 | 620 | 176 | 210 | 34 | 90.5% | WATCH | 6324 | -7.0% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9222 | 9800 | 578 | 206 | 250 | 44 | 94.1% | WATCH | 9519 | -3.1% | PASS | 228 |
@@ -49,7 +49,7 @@ release review. It is not part of the primary public release trail.
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), memory_mod (100.0%), channel_registry (96.3%), tools_mod (95.8%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): channel_config (91.0%), chat_runtime (92.2%), turn_coordinator (89.1%), daemon_lib (90.5%), onboard_cli (94.1%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): channel_config (91.0%), chat_runtime (92.2%), turn_coordinator (89.4%), daemon_lib (90.5%), onboard_cli (94.1%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -95,7 +95,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=channel_config lines=8917 functions=17 -->
 <!-- arch-hotspot key=chat_runtime lines=6734 functions=95 -->
 <!-- arch-hotspot key=channel_mod lines=2109 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=9984 functions=61 -->
+<!-- arch-hotspot key=turn_coordinator lines=10017 functions=62 -->
 <!-- arch-hotspot key=tools_mod lines=14366 functions=44 -->
 <!-- arch-hotspot key=daemon_lib lines=5880 functions=176 -->
 <!-- arch-hotspot key=onboard_cli lines=9222 functions=206 -->


### PR DESCRIPTION
## Summary

- **Problem**: LoongClaw's subagent system requires the parent agent to poll for child results via `session_wait` looping with `sleep(25ms)`. There is no push-based delivery — when a delegate completes, the result sits in the session repository until the parent explicitly asks for it. This poll-based model adds latency, wastes turns, and makes multi-delegate orchestration awkward.

- **Why it matters**: Parent agents currently burn CPU and turns polling the database. In multi-delegate workflows, the parent must maintain its own bookkeeping of which children have finished. A push-based mailbox eliminates the polling delay and simplifies orchestration.

- **What changed**:
  - Add `AgentMailbox` primitive in `kernel` crate (`AgentPath`, `InterAgentMessage`, `MailboxContent`, `ROOT_AGENT_PATH`)
  - Add session-level mailbox registry via `mailbox_for_session()`
  - Replace poll-based `session_wait` internals with mailbox `subscribe() + drain()` (async wait instead of `sleep(25)`)
  - Push `InterAgentMessage::DelegateResult` to parent mailbox on child completion (success / error / panic / timeout paths)
  - Add `DelegateToolConfig.max_pending` config knob for future backpressure control
  - Fix pre-existing `clippy::collapsible_else_if` lint in `tools/mod.rs` that blocked strict lint on dev branch

- **What did not change (scope boundary)**:
  - `max_pending` is only a config field; backpressure enforcement logic is **not** implemented yet (Phase 1 per issue)
  - `crates/contracts` does **not** re-export `AgentPath` (contracts is a zero-internal-deps leaf crate; adding a dependency on kernel would violate the architecture contract)
  - `delegate.rs` itself is untouched; the delegate completion path lives in `turn_coordinator.rs`

## Linked Issues

- Closes #969
- Related #1002

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- **Risk notes**: `session_wait` is a core waiting path. Replacing the simple `sleep(25)` loop with `mailbox.subscribe().changed()` means that if the watch channel closes unexpectedly, `session_wait` will return an internal error. The global mailbox registry uses `std::sync::Mutex`, which may become a bottleneck under extreme concurrency.
- **Rollout / guardrails**: Monitor delegate completion-to-parent-perception latency after deploy. Watch for any increase in `session_wait` timeout or internal-error rates.
- **Rollback path**: Fast — revert this commit. No schema or data migration is involved.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
$ cargo fmt --all -- --check
# passed

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
# passed

$ cargo test -p loong-app --lib
# test result: ok. 3456 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.88s  

$ cargo test -p loong-kernel
# test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

$ bash scripts/check_dep_graph.sh
# [dep-graph] workspace edges:
# [dep-graph] PASSED: all workspace edges match architecture contract