### PR TITLE
feat(channel): distinguish standalone native-serve surfaces

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -135,10 +135,12 @@ pub use runtime::turn_feedback::ChannelTurnFeedbackPolicy;
 ))]
 pub use runtime::types::{ResolvedKnownChannelSessionTarget, resolve_known_channel_session_target};
 pub use sdk::{
-    ChannelDescriptor, ChannelRuntimeKind, background_channel_runtime_descriptors,
-    catalog_only_channel_descriptors, channel_descriptor, is_background_channel_surface_enabled,
+    ChannelDescriptor, ChannelOperationalModel, ChannelRuntimeKind,
+    background_channel_runtime_descriptors, catalog_only_channel_descriptors, channel_descriptor,
+    gateway_supervised_channel_descriptors, is_background_channel_surface_enabled,
     outbound_only_channel_descriptors, plugin_backed_channel_descriptors,
     runtime_backed_channel_descriptors, service_channel_descriptors,
+    standalone_runtime_channel_descriptors,
 };
 pub(crate) use sdk::{collect_channel_validation_issues, enabled_channel_ids};
 pub use tlon_command::run_tlon_send;

--- a/crates/app/src/channel/sdk.rs
+++ b/crates/app/src/channel/sdk.rs
@@ -35,11 +35,35 @@ pub enum ChannelRuntimeKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelOperationalModel {
+    Interactive,
+    GatewaySupervised,
+    StandaloneRuntime,
+    PluginBacked,
+    OutboundOnly,
+    CatalogOnly,
+}
+
+impl ChannelOperationalModel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Interactive => "interactive",
+            Self::GatewaySupervised => "gateway_supervised",
+            Self::StandaloneRuntime => "standalone_runtime",
+            Self::PluginBacked => "plugin_backed",
+            Self::OutboundOnly => "outbound_only",
+            Self::CatalogOnly => "catalog_only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChannelDescriptor {
     pub id: &'static str,
     pub label: &'static str,
     pub surface_label: &'static str,
     pub runtime_kind: ChannelRuntimeKind,
+    pub operational_model: ChannelOperationalModel,
     pub serve_subcommand: Option<&'static str>,
 }
 
@@ -360,12 +384,13 @@ fn build_channel_descriptors() -> Vec<ChannelDescriptor> {
 
 fn build_channel_descriptor(
     channel_id: &'static str,
-    _background_runtime: Option<ChannelRuntimeCommandDescriptor>,
+    background_runtime: Option<ChannelRuntimeCommandDescriptor>,
 ) -> ChannelDescriptor {
     let label = channel_display_label(channel_id);
     let surface_label_text = channel_surface_label_text(channel_id);
     let surface_label = leak_channel_string(surface_label_text);
     let runtime_kind = channel_runtime_kind(channel_id);
+    let operational_model = channel_operational_model(channel_id, runtime_kind, background_runtime);
     let serve_subcommand = channel_serve_subcommand(channel_id);
 
     ChannelDescriptor {
@@ -373,6 +398,7 @@ fn build_channel_descriptor(
         label,
         surface_label,
         runtime_kind,
+        operational_model,
         serve_subcommand,
     }
 }
@@ -428,6 +454,30 @@ fn channel_runtime_kind(channel_id: &str) -> ChannelRuntimeKind {
             ChannelRuntimeKind::OutboundOnly
         }
         crate::channel::ChannelCatalogImplementationStatus::Stub => ChannelRuntimeKind::CatalogOnly,
+    }
+}
+
+fn channel_operational_model(
+    channel_id: &str,
+    runtime_kind: ChannelRuntimeKind,
+    background_runtime: Option<ChannelRuntimeCommandDescriptor>,
+) -> ChannelOperationalModel {
+    if channel_id == "cli" {
+        return ChannelOperationalModel::Interactive;
+    }
+
+    match runtime_kind {
+        ChannelRuntimeKind::Interactive => ChannelOperationalModel::Interactive,
+        ChannelRuntimeKind::RuntimeBacked => {
+            if background_runtime.is_some() {
+                return ChannelOperationalModel::GatewaySupervised;
+            }
+
+            ChannelOperationalModel::StandaloneRuntime
+        }
+        ChannelRuntimeKind::PluginBacked => ChannelOperationalModel::PluginBacked,
+        ChannelRuntimeKind::OutboundOnly => ChannelOperationalModel::OutboundOnly,
+        ChannelRuntimeKind::CatalogOnly => ChannelOperationalModel::CatalogOnly,
     }
 }
 
@@ -496,6 +546,26 @@ pub fn runtime_backed_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
         .collect()
 }
 
+pub fn gateway_supervised_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
+    ordered_channel_integrations()
+        .into_iter()
+        .filter_map(|integration| channel_descriptor(integration.channel_id))
+        .filter(|descriptor| {
+            descriptor.operational_model == ChannelOperationalModel::GatewaySupervised
+        })
+        .collect()
+}
+
+pub fn standalone_runtime_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
+    ordered_channel_integrations()
+        .into_iter()
+        .filter_map(|integration| channel_descriptor(integration.channel_id))
+        .filter(|descriptor| {
+            descriptor.operational_model == ChannelOperationalModel::StandaloneRuntime
+        })
+        .collect()
+}
+
 pub fn plugin_backed_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
     ordered_channel_integrations()
         .into_iter()
@@ -527,6 +597,7 @@ pub fn catalog_only_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
                 label,
                 surface_label,
                 runtime_kind: ChannelRuntimeKind::CatalogOnly,
+                operational_model: ChannelOperationalModel::CatalogOnly,
                 serve_subcommand: None,
             }
         })
@@ -909,7 +980,8 @@ mod tests {
                 continue;
             }
 
-            let Some(descriptor) = channel_descriptor(integration.channel_id) else {
+            let maybe_descriptor = channel_descriptor(integration.channel_id);
+            let Some(descriptor) = maybe_descriptor else {
                 continue;
             };
             if descriptor.runtime_kind != ChannelRuntimeKind::RuntimeBacked {
@@ -920,6 +992,14 @@ mod tests {
         }
 
         channel_ids
+    }
+
+    fn expected_gateway_supervised_channel_ids() -> Vec<&'static str> {
+        vec!["telegram", "feishu", "matrix", "wecom", "whatsapp"]
+    }
+
+    fn expected_standalone_runtime_channel_ids() -> Vec<&'static str> {
+        vec!["line", "webhook"]
     }
 
     #[test]
@@ -951,6 +1031,30 @@ mod tests {
     }
 
     #[test]
+    fn gateway_supervised_channel_descriptors_follow_background_runtime_contracts() {
+        let descriptors = gateway_supervised_channel_descriptors();
+        let ids = descriptors
+            .into_iter()
+            .map(|descriptor| descriptor.id)
+            .collect::<Vec<_>>();
+        let expected_ids = expected_gateway_supervised_channel_ids();
+
+        assert_eq!(ids, expected_ids);
+    }
+
+    #[test]
+    fn standalone_runtime_channel_descriptors_track_native_serve_without_gateway_supervision() {
+        let descriptors = standalone_runtime_channel_descriptors();
+        let ids = descriptors
+            .into_iter()
+            .map(|descriptor| descriptor.id)
+            .collect::<Vec<_>>();
+        let expected_ids = expected_standalone_runtime_channel_ids();
+
+        assert_eq!(ids, expected_ids);
+    }
+
+    #[test]
     fn unsupported_background_channels_are_rejected() {
         let config = LoongConfig::default();
         let error = is_background_channel_surface_enabled("cli", &config, None)
@@ -975,6 +1079,10 @@ mod tests {
         assert_eq!(weixin.label, "Weixin");
         assert_eq!(weixin.surface_label, "weixin channel");
         assert_eq!(weixin.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            weixin.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(weixin.serve_subcommand, None);
 
         let qqbot = channel_descriptor("qq").expect("qq alias should resolve");
@@ -982,6 +1090,10 @@ mod tests {
         assert_eq!(qqbot.label, "QQ Bot");
         assert_eq!(qqbot.surface_label, "qq bot channel");
         assert_eq!(qqbot.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            qqbot.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(qqbot.serve_subcommand, None);
 
         let onebot = channel_descriptor("onebot-v11").expect("onebot alias should resolve");
@@ -989,6 +1101,10 @@ mod tests {
         assert_eq!(onebot.label, "OneBot");
         assert_eq!(onebot.surface_label, "onebot channel");
         assert_eq!(onebot.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            onebot.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(onebot.serve_subcommand, None);
     }
 
@@ -997,10 +1113,26 @@ mod tests {
         let feishu = channel_descriptor("feishu").expect("feishu descriptor");
         assert_eq!(feishu.label, "Feishu/Lark");
         assert_eq!(feishu.surface_label, "feishu channel");
+        assert_eq!(
+            feishu.operational_model,
+            ChannelOperationalModel::GatewaySupervised
+        );
+
+        let line = channel_descriptor("line").expect("line descriptor");
+        assert_eq!(line.label, "LINE");
+        assert_eq!(line.surface_label, "line channel");
+        assert_eq!(
+            line.operational_model,
+            ChannelOperationalModel::StandaloneRuntime
+        );
 
         let google_chat = channel_descriptor("google-chat").expect("google chat descriptor");
         assert_eq!(google_chat.label, "Google Chat");
         assert_eq!(google_chat.surface_label, "google chat channel");
+        assert_eq!(
+            google_chat.operational_model,
+            ChannelOperationalModel::OutboundOnly
+        );
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -11,12 +11,13 @@ mod shared;
 mod tools;
 
 #[allow(unused_imports)]
-pub use crate::channel::{ChannelDescriptor, ChannelRuntimeKind};
+pub use crate::channel::{ChannelDescriptor, ChannelOperationalModel, ChannelRuntimeKind};
 #[allow(unused_imports)]
 pub use crate::channel::{
-    catalog_only_channel_descriptors, channel_descriptor, outbound_only_channel_descriptors,
-    plugin_backed_channel_descriptors, runtime_backed_channel_descriptors,
-    service_channel_descriptors,
+    catalog_only_channel_descriptors, channel_descriptor, gateway_supervised_channel_descriptors,
+    outbound_only_channel_descriptors, plugin_backed_channel_descriptors,
+    runtime_backed_channel_descriptors, service_channel_descriptors,
+    standalone_runtime_channel_descriptors,
 };
 pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
@@ -190,6 +191,14 @@ mod tests {
         ]
     }
 
+    fn expected_gateway_supervised_channel_ids() -> Vec<&'static str> {
+        vec!["telegram", "feishu", "matrix", "wecom", "whatsapp"]
+    }
+
+    fn expected_standalone_runtime_channel_ids() -> Vec<&'static str> {
+        vec!["line", "webhook"]
+    }
+
     fn expected_plugin_backed_channel_ids() -> Vec<&'static str> {
         vec!["weixin", "qqbot", "onebot"]
     }
@@ -239,54 +248,90 @@ mod tests {
         assert_eq!(telegram.id, "telegram");
         assert_eq!(telegram.surface_label, "telegram channel");
         assert_eq!(telegram.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            telegram.operational_model,
+            ChannelOperationalModel::GatewaySupervised
+        );
         assert_eq!(telegram.serve_subcommand, Some("telegram-serve"));
 
         let feishu = channel_descriptor("feishu").expect("feishu descriptor");
         assert_eq!(feishu.id, "feishu");
         assert_eq!(feishu.surface_label, "feishu channel");
         assert_eq!(feishu.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            feishu.operational_model,
+            ChannelOperationalModel::GatewaySupervised
+        );
         assert_eq!(feishu.serve_subcommand, Some("feishu-serve"));
 
         let wecom = channel_descriptor("wecom").expect("wecom descriptor");
         assert_eq!(wecom.id, "wecom");
         assert_eq!(wecom.surface_label, "wecom channel");
         assert_eq!(wecom.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            wecom.operational_model,
+            ChannelOperationalModel::GatewaySupervised
+        );
         assert_eq!(wecom.serve_subcommand, Some("wecom-serve"));
 
         let weixin = channel_descriptor("wechat").expect("weixin descriptor");
         assert_eq!(weixin.id, "weixin");
         assert_eq!(weixin.surface_label, "weixin channel");
         assert_eq!(weixin.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            weixin.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(weixin.serve_subcommand, None);
 
         let qqbot = channel_descriptor("qq").expect("qqbot descriptor");
         assert_eq!(qqbot.id, "qqbot");
         assert_eq!(qqbot.surface_label, "qq bot channel");
         assert_eq!(qqbot.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            qqbot.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(qqbot.serve_subcommand, None);
 
         let onebot = channel_descriptor("onebot-v11").expect("onebot descriptor");
         assert_eq!(onebot.id, "onebot");
         assert_eq!(onebot.surface_label, "onebot channel");
         assert_eq!(onebot.runtime_kind, ChannelRuntimeKind::PluginBacked);
+        assert_eq!(
+            onebot.operational_model,
+            ChannelOperationalModel::PluginBacked
+        );
         assert_eq!(onebot.serve_subcommand, None);
 
         let discord = channel_descriptor("discord").expect("discord descriptor");
         assert_eq!(discord.id, "discord");
         assert_eq!(discord.surface_label, "discord channel");
         assert_eq!(discord.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(
+            discord.operational_model,
+            ChannelOperationalModel::OutboundOnly
+        );
         assert_eq!(discord.serve_subcommand, None);
 
         let slack = channel_descriptor("slack").expect("slack descriptor");
         assert_eq!(slack.id, "slack");
         assert_eq!(slack.surface_label, "slack channel");
         assert_eq!(slack.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(
+            slack.operational_model,
+            ChannelOperationalModel::OutboundOnly
+        );
         assert_eq!(slack.serve_subcommand, None);
 
         let line = channel_descriptor("line").expect("line descriptor");
         assert_eq!(line.id, "line");
         assert_eq!(line.surface_label, "line channel");
         assert_eq!(line.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            line.operational_model,
+            ChannelOperationalModel::StandaloneRuntime
+        );
         assert_eq!(line.serve_subcommand, Some("line-serve"));
 
         let dingtalk = channel_descriptor("dingtalk").expect("dingtalk descriptor");
@@ -299,6 +344,10 @@ mod tests {
         assert_eq!(whatsapp.id, "whatsapp");
         assert_eq!(whatsapp.surface_label, "whatsapp channel");
         assert_eq!(whatsapp.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            whatsapp.operational_model,
+            ChannelOperationalModel::GatewaySupervised
+        );
         assert_eq!(whatsapp.serve_subcommand, Some("whatsapp-serve"));
 
         let email = channel_descriptor("email").expect("email descriptor");
@@ -311,6 +360,10 @@ mod tests {
         assert_eq!(webhook.id, "webhook");
         assert_eq!(webhook.surface_label, "webhook channel");
         assert_eq!(webhook.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(
+            webhook.operational_model,
+            ChannelOperationalModel::StandaloneRuntime
+        );
         assert_eq!(webhook.serve_subcommand, Some("webhook-serve"));
 
         let google_chat = channel_descriptor("google-chat").expect("google chat descriptor");
@@ -463,6 +516,14 @@ mod tests {
             .into_iter()
             .map(|descriptor| descriptor.id)
             .collect::<Vec<_>>();
+        let gateway_supervised_ids = gateway_supervised_channel_descriptors()
+            .into_iter()
+            .map(|descriptor| descriptor.id)
+            .collect::<Vec<_>>();
+        let standalone_runtime_ids = standalone_runtime_channel_descriptors()
+            .into_iter()
+            .map(|descriptor| descriptor.id)
+            .collect::<Vec<_>>();
         let plugin_backed_ids = plugin_backed_channel_descriptors()
             .into_iter()
             .map(|descriptor| descriptor.id)
@@ -477,6 +538,14 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(runtime_backed_ids, expected_service_channel_ids());
+        assert_eq!(
+            gateway_supervised_ids,
+            expected_gateway_supervised_channel_ids()
+        );
+        assert_eq!(
+            standalone_runtime_ids,
+            expected_standalone_runtime_channel_ids()
+        );
         assert_eq!(plugin_backed_ids, expected_plugin_backed_channel_ids());
         assert_eq!(outbound_only_ids, expected_outbound_channel_ids());
         assert_eq!(catalog_only_ids, vec!["zalo", "zalo-personal", "webchat"]);

--- a/crates/daemon/src/migration/channels/feishu.rs
+++ b/crates/daemon/src/migration/channels/feishu.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "feishu",
     surface_label: "feishu channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::GatewaySupervised,
     serve_subcommand: Some("feishu-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/line.rs
+++ b/crates/daemon/src/migration/channels/line.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "line",
     surface_label: "line channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::StandaloneRuntime,
     serve_subcommand: Some("line-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/matrix.rs
+++ b/crates/daemon/src/migration/channels/matrix.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "matrix",
     surface_label: "matrix channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::GatewaySupervised,
     serve_subcommand: Some("matrix-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/telegram.rs
+++ b/crates/daemon/src/migration/channels/telegram.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "telegram",
     surface_label: "telegram channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::GatewaySupervised,
     serve_subcommand: Some("telegram-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/webhook.rs
+++ b/crates/daemon/src/migration/channels/webhook.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "webhook",
     surface_label: "webhook channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::StandaloneRuntime,
     serve_subcommand: Some("webhook-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/wecom.rs
+++ b/crates/daemon/src/migration/channels/wecom.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "wecom",
     surface_label: "wecom channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::GatewaySupervised,
     serve_subcommand: Some("wecom-serve"),
 };
 

--- a/crates/daemon/src/migration/channels/whatsapp.rs
+++ b/crates/daemon/src/migration/channels/whatsapp.rs
@@ -13,6 +13,7 @@ const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::Channel
     label: "whatsapp",
     surface_label: "whatsapp channel",
     runtime_kind: mvp::config::ChannelRuntimeKind::RuntimeBacked,
+    operational_model: mvp::config::ChannelOperationalModel::GatewaySupervised,
     serve_subcommand: Some("whatsapp-serve"),
 };
 

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -1287,6 +1287,7 @@ fn migration_classify_current_setup_treats_enabled_managed_bridge_without_ready_
 
 #[test]
 fn migration_classify_current_setup_treats_blocked_outbound_only_channel_as_repairable() {
+    let _env = MigrationEnvironmentGuard::set(&[("DISCORD_BOT_TOKEN", None)]);
     let path = unique_temp_dir("outbound-only-repairable").join("config.toml");
     let mut config = mvp::config::LoongConfig::default();
 
@@ -1303,8 +1304,8 @@ fn migration_classify_current_setup_treats_blocked_outbound_only_channel_as_repa
 
     assert_eq!(
         loong_daemon::migration::discovery::classify_current_setup(&path),
-        loong_daemon::migration::types::CurrentSetupState::Healthy,
-        "configured outbound-only channels currently keep the current setup in the healthy bucket: {path:?}"
+        loong_daemon::migration::types::CurrentSetupState::Repairable,
+        "blocked outbound-only channels should stay repairable once ambient env fallback is removed: {path:?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -2558,6 +2558,7 @@ fn channel_preflight_checks_report_configured_outbound_channels() {
 
 #[test]
 fn channel_preflight_checks_summarize_outbound_multi_account_state_and_reserved_runtime_fields() {
+    let _env = super::MigrationEnvironmentGuard::set(&[("DISCORD_BOT_TOKEN", None)]);
     let config: mvp::config::LoongConfig = serde_json::from_value(json!({
         "discord": {
             "enabled": true,
@@ -2578,16 +2579,17 @@ fn channel_preflight_checks_summarize_outbound_multi_account_state_and_reserved_
     assert!(
         checks.iter().any(|check| {
             check.name == "discord channel"
-                && check.level == loong_daemon::onboard_cli::OnboardCheckLevel::Pass
-                && check.detail.contains("direct send ready on 2 account(s)")
+                && check.level == loong_daemon::onboard_cli::OnboardCheckLevel::Warn
+                && check.detail.contains("direct send ready on 1/2 account(s)")
                 && check.detail.contains("ops ready")
-                && check.detail.contains("alerts ready")
+                && check
+                    .detail
+                    .contains("alerts needs review (bot_token is missing)")
                 && check.detail.contains(
                     "reserved future runtime fields: ops [application_id, allowed_guild_ids:2]",
                 )
-                && check.detail.contains("outbound-only surface")
         }),
-        "configured outbound multi-account channels should surface per-account readiness and reserved future runtime fields in preflight detail: {checks:#?}"
+        "configured outbound multi-account channels should surface partial readiness and reserved future runtime fields in preflight detail: {checks:#?}"
     );
 }
 

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -40,7 +40,7 @@ release review. It is not part of the primary public release trail.
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10113 | 10500 | 387 | 78 | 90 | 12 | 96.3% | TIGHT | 9922 | 1.9% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8917 | 9800 | 883 | 17 | 90 | 73 | 91.0% | WATCH | 9796 | -9.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6734 | 7300 | 566 | 95 | 160 | 65 | 92.2% | WATCH | 6936 | -2.9% | PASS | 146 |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2109 | 6400 | 4291 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.5% | BREACH | 0 |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2111 | 6400 | 4289 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.7% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10017 | 11200 | 1183 | 62 | 120 | 58 | 89.4% | WATCH | 10831 | -7.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14366 | 15000 | 634 | 44 | 70 | 26 | 95.8% | TIGHT | 14472 | -0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5880 | 6500 | 620 | 176 | 210 | 34 | 90.5% | WATCH | 6324 | -7.0% | PASS | 210 |
@@ -94,7 +94,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=channel_registry lines=10113 functions=78 -->
 <!-- arch-hotspot key=channel_config lines=8917 functions=17 -->
 <!-- arch-hotspot key=chat_runtime lines=6734 functions=95 -->
-<!-- arch-hotspot key=channel_mod lines=2109 functions=0 -->
+<!-- arch-hotspot key=channel_mod lines=2111 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10017 functions=62 -->
 <!-- arch-hotspot key=tools_mod lines=14366 functions=44 -->
 <!-- arch-hotspot key=daemon_lib lines=5880 functions=176 -->

--- a/site/use-loong/channel-guides/index.mdx
+++ b/site/use-loong/channel-guides/index.mdx
@@ -5,7 +5,7 @@ description: One setup page per actionable Loong channel surface.
 
 # Channel Guides
 
-Loong currently exposes 28 cataloged channel surfaces. Of those, 25 are already actionable public surfaces: 5 runtime-backed surfaces, 17 config-backed outbound surfaces, and 3 plugin-backed bridge surfaces. The remaining 3 surfaces stay catalog-only planned entries. This hub keeps the full matrix visible while the higher-level chooser pages stay compact.
+Loong currently exposes 28 cataloged channel surfaces. Of those, 25 are already actionable public surfaces: 5 gateway-supervised runtime surfaces, 2 standalone native-serve surfaces, 15 config-backed outbound surfaces, and 3 plugin-backed bridge surfaces. The remaining 3 surfaces stay catalog-only planned entries. This hub keeps the full matrix visible while the higher-level chooser pages stay compact.
 
 Use [Channels](/use-loong/channels) when you still need the conceptual model first. Use this hub when you already know the surface and want the exact config, command, and support boundary for that one channel. Keep [Channel Recipes](/use-loong/channel-recipes) for representative rollout patterns rather than the full channel inventory.
 
@@ -20,11 +20,12 @@ Use this short list when you want a practical starting point before scanning the
 | a Cloud API plus webhook runtime | [WhatsApp](/use-loong/channel-guides/whatsapp) | send and serve are both shipped on the same surface |
 | the official enterprise AIBot lane | [WeCom](/use-loong/channel-guides/wecom) | the public docs keep the long-connection contract explicit |
 | a WeChat / QQ bridge-first lane | [Weixin](/use-loong/channel-guides/weixin), [QQ Bot](/use-loong/channel-guides/qqbot), or [OneBot](/use-loong/channel-guides/onebot) | plugin-backed bridge surfaces stay visible and actionable instead of being flattened into placeholders |
-| one-way governed delivery | [Webhook](/use-loong/channel-guides/webhook) or [Email](/use-loong/channel-guides/email) | outbound-only delivery stays visible without being marketed as a reply-loop runtime |
+| one operator-owned inbound webhook edge or one-way governed delivery | [Webhook](/use-loong/channel-guides/webhook) or [Email](/use-loong/channel-guides/email) | Webhook now covers the standalone native-serve lane, while Email remains a clean outbound-only example |
 
-## Runtime-Backed Surfaces
+## Gateway-Supervised Runtime Surfaces
 
-These are the shipped send plus serve lanes.
+These are the shipped send plus serve lanes that can currently join `gateway run`
+or `multi-channel-serve`.
 
 | Surface | Transport | Send | Serve |
 | --- | --- | --- | --- |
@@ -33,6 +34,16 @@ These are the shipped send plus serve lanes.
 | [Matrix](/use-loong/channel-guides/matrix) | matrix_client_server_sync | `matrix-send` | `matrix-serve` |
 | [WhatsApp](/use-loong/channel-guides/whatsapp) | whatsapp_cloud_api | `whatsapp-send` | `whatsapp-serve` |
 | [WeCom](/use-loong/channel-guides/wecom) | wecom_aibot_long_connection | `wecom-send` | `wecom-serve` |
+
+## Standalone Native-Serve Surfaces
+
+These surfaces ship send plus serve today, but their built-in runtime still
+stays on the direct `*-serve` command instead of gateway supervision.
+
+| Surface | Transport | Send | Serve | Runtime owner |
+| --- | --- | --- | --- | --- |
+| [LINE](/use-loong/channel-guides/line) | line_messaging_api | `line-send` | `line-serve` | standalone native serve |
+| [Webhook](/use-loong/channel-guides/webhook) | generic_webhook | `webhook-send` | `webhook-serve` | standalone native serve |
 
 ## Plugin-Backed Bridge Surfaces
 
@@ -52,10 +63,8 @@ These surfaces ship direct sends today and keep serve in the catalog without ove
 | --- | --- | --- | --- |
 | [Discord](/use-loong/channel-guides/discord) | discord_http_api | `discord-send` | outbound-only |
 | [Slack](/use-loong/channel-guides/slack) | slack_web_api | `slack-send` | outbound-only |
-| [LINE](/use-loong/channel-guides/line) | line_messaging_api | `line-send` | outbound-only |
 | [DingTalk](/use-loong/channel-guides/dingtalk) | dingtalk_custom_robot_webhook | `dingtalk-send` | outbound-only |
 | [Email](/use-loong/channel-guides/email) | smtp_imap | `email-send` | outbound-only |
-| [Webhook](/use-loong/channel-guides/webhook) | generic_webhook | `webhook-send` | outbound-only |
 | [Google Chat](/use-loong/channel-guides/google-chat) | google_chat_incoming_webhook | `google-chat-send` | outbound-only |
 | [Signal](/use-loong/channel-guides/signal) | signal_cli_rest_api | `signal-send` | outbound-only |
 | [Twitch](/use-loong/channel-guides/twitch) | twitch_chat_api | `twitch-send` | outbound-only |
@@ -80,8 +89,8 @@ These surfaces stay visible in the internal registry, but they are not yet publi
 
 ## Reading Rule
 
-- Start with [Channels](/use-loong/channels) when you still need to choose between runtime-backed, plugin-backed, and outbound-only delivery.
+- Start with [Channels](/use-loong/channels) when you still need to choose between gateway-supervised, standalone native-serve, plugin-backed, and outbound-only delivery.
 - Use an individual guide page when the surface is already decided and you need the exact config and smoke-test path.
 - Plugin-backed guides are the right next stop when the transport is real but Loong intentionally leaves upstream login and listener ownership to an external bridge.
 - Keep [Channel Recipes](/use-loong/channel-recipes) for representative rollout paths instead of the full surface inventory.
-- Keep [Gateway And Supervision](/use-loong/gateway-and-supervision) open whenever the chosen surface is runtime-backed and needs long-lived ownership.
+- Keep [Gateway And Supervision](/use-loong/gateway-and-supervision) open whenever the chosen surface is gateway-supervised and needs long-lived ownership.

--- a/site/use-loong/channel-guides/line.mdx
+++ b/site/use-loong/channel-guides/line.mdx
@@ -5,7 +5,7 @@ description: Configure the LINE channel surface in Loong.
 
 # LINE
 
-This is a shipped config-backed outbound surface. Line serve runtime is not implemented yet
+This is a shipped standalone native-serve surface: direct sends are implemented, the signed webhook reply loop is implemented, and the runtime stays on `line-serve` instead of `gateway run` today.
 
 ## At A Glance
 
@@ -13,7 +13,7 @@ This is a shipped config-backed outbound surface. Line serve runtime is not impl
 | --- | --- |
 | Catalog id | `line` |
 | Config key | `line` |
-| Implementation status | `config_backed` |
+| Implementation status | `runtime_backed` |
 | Transport | `line_messaging_api` |
 | Aliases | `line-bot` |
 | Default send target kind | `address` |
@@ -24,12 +24,14 @@ This is a shipped config-backed outbound surface. Line serve runtime is not impl
 [line]
 enabled = true
 channel_access_token_env = "LINE_CHANNEL_ACCESS_TOKEN"
+channel_secret_env = "LINE_CHANNEL_SECRET"
 ```
 
 ## Smoke Test
 
 ```bash
 loong line-send --target "U4af4980629..." --text "hello from loong"
+loong line-serve --bind 127.0.0.1:6401
 ```
 
 ## Command Surface
@@ -37,7 +39,7 @@ loong line-send --target "U4af4980629..." --text "hello from loong"
 | Operation | Command | Usage or status |
 | --- | --- | --- |
 | push send | `line-send` | Usage: loong line-send [OPTIONS] --target &lt;TARGET&gt; --text &lt;TEXT&gt; |
-| webhook reply loop | `line-serve` | line serve runtime is not implemented yet |
+| webhook reply loop | `line-serve` | Usage: loong line-serve --bind &lt;HOST:PORT&gt; [--path &lt;PATH&gt;] |
 
 ## Required Fields For Send
 
@@ -46,9 +48,23 @@ loong line-send --target "U4af4980629..." --text "hello from loong"
 | channel enabled | `line.enabled`<br/>`line.accounts.<account>.enabled` | none | none |
 | channel access token | `line.channel_access_token`<br/>`line.accounts.<account>.channel_access_token` | `line.channel_access_token_env`<br/>`line.accounts.<account>.channel_access_token_env` | `LINE_CHANNEL_ACCESS_TOKEN` |
 
+## Required Fields For Serve
+
+| Requirement | Config paths | Env pointer paths | Default env |
+| --- | --- | --- | --- |
+| channel enabled | `line.enabled`<br/>`line.accounts.<account>.enabled` | none | none |
+| channel access token | `line.channel_access_token`<br/>`line.accounts.<account>.channel_access_token` | `line.channel_access_token_env`<br/>`line.accounts.<account>.channel_access_token_env` | `LINE_CHANNEL_ACCESS_TOKEN` |
+| channel secret | `line.channel_secret`<br/>`line.accounts.<account>.channel_secret` | `line.channel_secret_env`<br/>`line.accounts.<account>.channel_secret_env` | `LINE_CHANNEL_SECRET` |
+
 ## Gateway And Ownership
 
-This surface is a direct-send delivery lane. It does not join `multi-channel-serve` or the gateway-owned reply-loop contract today.
+This surface ships a real built-in serve loop, but it remains a standalone native-serve lane today. Use `line-serve` directly; it does not join `multi-channel-serve` or the gateway-owned reply-loop contract yet.
+
+## Operator Notes
+
+- `line-serve` requires `--bind` because the local listener address stays an explicit operator decision.
+- `--path` is optional when the default webhook path already matches the LINE console setup.
+- Treat this as a native serve lane, not as an outbound-only sink.
 
 ## Related Docs
 

--- a/site/use-loong/channel-guides/webhook.mdx
+++ b/site/use-loong/channel-guides/webhook.mdx
@@ -5,7 +5,7 @@ description: Configure the Webhook channel surface in Loong.
 
 # Webhook
 
-This is a shipped config-backed outbound surface. Generic webhook serve runtime is not implemented yet
+This is a shipped standalone native-serve surface: outbound POST delivery is implemented, the signed inbound webhook service is implemented, and the runtime stays on `webhook-serve` instead of gateway supervision today.
 
 ## At A Glance
 
@@ -13,7 +13,7 @@ This is a shipped config-backed outbound surface. Generic webhook serve runtime 
 | --- | --- |
 | Catalog id | `webhook` |
 | Config key | `webhook` |
-| Implementation status | `config_backed` |
+| Implementation status | `runtime_backed` |
 | Transport | `generic_webhook` |
 | Aliases | `http-webhook` |
 | Default send target kind | `endpoint` |
@@ -26,12 +26,14 @@ enabled = true
 payload_format = "json_text"
 payload_text_field = "text"
 endpoint_url_env = "WEBHOOK_ENDPOINT_URL"
+signing_secret_env = "WEBHOOK_SIGNING_SECRET"
 ```
 
 ## Smoke Test
 
 ```bash
 loong webhook-send --text "hello from loong"
+loong webhook-serve --bind 127.0.0.1:7401
 ```
 
 ## Command Surface
@@ -39,7 +41,7 @@ loong webhook-send --text "hello from loong"
 | Operation | Command | Usage or status |
 | --- | --- | --- |
 | http post send | `webhook-send` | Usage: loong webhook-send [OPTIONS] --text &lt;TEXT&gt; |
-| inbound webhook service | `webhook-serve` | generic webhook serve runtime is not implemented yet |
+| inbound webhook service | `webhook-serve` | Usage: loong webhook-serve --bind &lt;HOST:PORT&gt; [--path &lt;PATH&gt;] |
 
 ## Required Fields For Send
 
@@ -48,13 +50,22 @@ loong webhook-send --text "hello from loong"
 | channel enabled | `webhook.enabled`<br/>`webhook.accounts.<account>.enabled` | none | none |
 | endpoint url | `webhook.endpoint_url`<br/>`webhook.accounts.<account>.endpoint_url` | `webhook.endpoint_url_env`<br/>`webhook.accounts.<account>.endpoint_url_env` | `WEBHOOK_ENDPOINT_URL` |
 
+## Required Fields For Serve
+
+| Requirement | Config paths | Env pointer paths | Default env |
+| --- | --- | --- | --- |
+| channel enabled | `webhook.enabled`<br/>`webhook.accounts.<account>.enabled` | none | none |
+| signing secret | `webhook.signing_secret`<br/>`webhook.accounts.<account>.signing_secret` | `webhook.signing_secret_env`<br/>`webhook.accounts.<account>.signing_secret_env` | `WEBHOOK_SIGNING_SECRET` |
+
 ## Gateway And Ownership
 
-This surface is a direct-send delivery lane. It does not join `multi-channel-serve` or the gateway-owned reply-loop contract today.
+This surface ships a real built-in inbound service, but it remains a standalone native-serve lane today. Use `webhook-serve` directly; it does not join `multi-channel-serve` or the gateway-owned reply-loop contract yet.
 
 ## Operator Notes
 
+- `webhook-serve` requires `--bind` because the local listener address stays operator-owned instead of coming from static config.
 - Use `[outbound_http] allow_private_hosts = true` when you intentionally post to a loopback or private bridge endpoint.
+- Treat this as a native serve lane, not as an outbound-only sink.
 
 ## Related Docs
 

--- a/site/use-loong/channel-recipes.mdx
+++ b/site/use-loong/channel-recipes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Channel Recipes
-description: Tutorial-style paths for runtime-backed service channels, outbound-only sends, and multi-channel rollout.
+description: Tutorial-style paths for gateway-supervised service channels, standalone native-serve lanes, outbound-only sends, and multi-channel rollout.
 ---
 
 # Channel Recipes
@@ -33,7 +33,7 @@ Most operators should start in one of these places:
 | Matrix should own a self-hosted or federated room runtime | Recipe 3 |
 | WeCom should own the official enterprise lane | Recipe 4 |
 | WhatsApp should own a Cloud API reply loop | [WhatsApp guide](/use-loong/channel-guides/whatsapp) |
-| you only need governed outbound delivery | Recipe 6 |
+| you need one standalone native-serve lane or governed outbound delivery | Recipe 6 |
 | several identities or several runtime-backed channels are already in scope | Recipe 5 or Recipe 7 |
 
 ## Pick The Right Recipe
@@ -46,6 +46,7 @@ Most operators should start in one of these places:
 | a WhatsApp Cloud runtime | [WhatsApp guide](/use-loong/channel-guides/whatsapp) | shipped Cloud API send plus verified webhook reply loop |
 | official WeCom runtime lane | WeCom | shipped AIBot long-connection flow |
 | several Feishu / Lark or WeCom identities in one config | Recipe 5 | explicit default account plus stable account selectors |
+| one LINE or generic webhook lane with a real built-in serve loop | Recipe 6 | native serve without overclaiming gateway supervision |
 | proactive delivery without a reply loop | Recipe 6 | outbound-only sends without overclaiming runtime support |
 | one host supervising several runtime-backed channels | Recipe 7 | explicit owner contract for long-lived service lanes |
 
@@ -56,10 +57,11 @@ surface map visible.
 
 | Surface family | Current examples | Best next page |
 | --- | --- | --- |
-| runtime-backed service channels | Feishu / Lark, Telegram, Matrix, WhatsApp, WeCom | Recipes 1 to 4 plus the [WhatsApp guide](/use-loong/channel-guides/whatsapp) |
+| gateway-supervised service channels | Feishu / Lark, Telegram, Matrix, WhatsApp, WeCom | Recipes 1 to 4 plus the [WhatsApp guide](/use-loong/channel-guides/whatsapp) |
+| standalone native-serve surfaces | LINE, Webhook | Recipe 6 |
 | workplace outbound surfaces | Slack, Discord, Microsoft Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat | Recipe 6 |
-| messaging and bridge outbound surfaces | LINE, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon | Recipe 6 |
-| direct delivery and alerting surfaces | Webhook, Email, Twitch | Recipe 6 |
+| messaging and bridge outbound surfaces | DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon | Recipe 6 |
+| direct delivery and alerting surfaces | Email, Twitch | Recipe 6 |
 | multi-account runtime-backed rollout | Feishu / Lark and WeCom account sets | Recipe 5 |
 | multi-channel runtime-backed supervision | several shipped runtime-backed channels on one host | Recipe 7 |
 
@@ -84,8 +86,9 @@ surface.
   want the shared `default_account`, `accounts.<id>`, and trust-toggle shape
   before the per-surface walkthroughs.
 - Start with one surface only; do not jump to multi-channel supervision first.
-- Keep Feishu / Lark, Telegram, Matrix, WhatsApp, and WeCom in the runtime-backed lane.
-- Keep webhook, email, Slack, Discord, Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat, LINE, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon, and similar sinks in the outbound-only lane.
+- Keep Feishu / Lark, Telegram, Matrix, WhatsApp, and WeCom in the gateway-supervised runtime lane.
+- Keep LINE and Webhook in the standalone native-serve lane.
+- Keep email, Slack, Discord, Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon, and similar sinks in the outbound-only lane.
 - Jump to [Common Setups](/use-loong/common-setups) when the provider and channel should be chosen together.
 
 ## Need A Full Rollout Instead?
@@ -317,12 +320,27 @@ Operational notes:
 - keep shared settings at the top level and override only the account-specific secrets or allowlists
 - channel-account selectors can target those configured ids directly, for example `lark=work` or `wecom=alerts`
 
-## Recipe 6: Outbound-Only Delivery Families
+## Recipe 6: Standalone Native-Serve And Outbound-Only Delivery Families
 
-Outbound-only surfaces are the right choice when you want governed delivery
-without pretending a reply loop already ships.
+Some surfaces now sit between the gateway-supervised and outbound-only stories:
+Loong ships a real built-in serve loop, but the runtime still belongs to the
+individual `*-serve` command.
 
-This recipe uses a few representative examples, but the same pattern covers the broader outbound-only catalog: Slack, Discord, Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat, LINE, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon, Webhook, Email, and Twitch.
+Standalone native-serve examples:
+
+LINE example:
+
+```toml
+[line]
+enabled = true
+channel_access_token_env = "LINE_CHANNEL_ACCESS_TOKEN"
+channel_secret_env = "LINE_CHANNEL_SECRET"
+```
+
+```bash
+loong line-send --target "U4af4980629..." --text "hello from loong"
+loong line-serve --bind 127.0.0.1:6401
+```
 
 Webhook example:
 
@@ -338,6 +356,7 @@ payload_text_field = "text"
 ```bash
 loong webhook-send --text "deployment finished"
 loong webhook-send --target "https://example.test/override" --text "one-off delivery"
+loong webhook-serve --bind 127.0.0.1:7401
 ```
 
 Email example:
@@ -370,9 +389,9 @@ loong dingtalk-send --text "robot delivery is healthy"
 
 Use these when:
 
-- you need delivery now, but not a reply-loop runtime
-- the target system is a webhook, SMTP relay, or other outbound sink
-- the surface should remain truthful as outbound-only in public docs
+- you need one standalone native-serve lane or one outbound-only delivery surface
+- the target system is a messaging webhook, SMTP relay, or other operator-owned delivery edge
+- the surface should remain truthful as standalone native-serve or outbound-only in public docs
 
 Workplace-platform variant:
 
@@ -394,14 +413,15 @@ surfaces follow the same direct-send pattern: keep the config explicit, use
 call the corresponding `loong <surface>-send` command instead of treating them
 as reply-loop runtimes.
 
-More outbound-only starting points:
+More delivery starting points:
 
 | Surface family | Current examples | What to configure first | Command shape |
 | --- | --- | --- | --- |
 | workplace chat sinks | Slack, Discord, Microsoft Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat | bot token or webhook URL, plus `default_account` / `accounts.<id>` when you need several identities | `loong <surface>-send` |
-| messaging and robot lanes | LINE, DingTalk, Signal | channel token, robot webhook, or account identity plus any required secret material | `loong <surface>-send` |
+| standalone native-serve lanes | LINE, Webhook | token or signing secret plus an explicit `*-serve --bind` address when you need inbound behavior | `loong <surface>-send`, `loong <surface>-serve` |
+| messaging and robot lanes | DingTalk, Signal | channel token, robot webhook, or account identity plus any required secret material | `loong <surface>-send` |
 | bridge and relay lanes | Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon | bridge URL, relay URLs, or server identity plus the account or key material that owns the lane | `loong <surface>-send` |
-| direct delivery and alerting lanes | Webhook, Email, Twitch | endpoint URL, SMTP relay, or OAuth/token material for the target delivery path | `loong <surface>-send` |
+| direct delivery and alerting lanes | Email, Twitch | endpoint URL, SMTP relay, or OAuth/token material for the target delivery path | `loong <surface>-send` |
 
 Trust-boundary note:
 
@@ -447,17 +467,17 @@ Use this when:
 
 Important boundary:
 
-- this lane is for runtime-backed service channels only
+- this lane is for gateway-supervised runtime-backed service channels only
 - `lark=` is the accepted alias for the Feishu channel family, and `feishu=` works too
 - selectors should reference configured account ids such as `work`, `alerts`, or `bot_123456`
-- outbound-only surfaces such as webhook, email, Slack, Discord, or Teams should not be described as if they join the same reply-loop supervisor
+- standalone native-serve or outbound-only surfaces such as LINE, Webhook, Email, Slack, Discord, or Teams should not be described as if they join the same reply-loop supervisor
 - when you need the ownership and inspection model without the recipe framing,
   switch to [Gateway And Supervision](/use-loong/gateway-and-supervision)
 
 ## Channel Rollout Order
 
 1. Get `loong ask` or `loong chat` healthy first.
-2. Add one runtime-backed service channel or one outbound-only surface.
+2. Add one gateway-supervised service channel, one standalone native-serve surface, or one outbound-only surface.
 3. Verify with `loong doctor` and `loong channels`.
 4. Only then graduate to `gateway run` or `multi-channel-serve`.
 

--- a/site/use-loong/channel-setup.mdx
+++ b/site/use-loong/channel-setup.mdx
@@ -1,12 +1,13 @@
 ---
 title: Channel Setup
-description: Practical setup guidance for runtime-backed, plugin-backed, and outbound-only delivery surfaces.
+description: Practical setup guidance for gateway-supervised, standalone native-serve, plugin-backed, and outbound-only delivery surfaces.
 ---
 
 # Channel Setup
 
 Loong keeps channel setup explicit so operators can tell what is actually
-shipped, what is bridge-owned, what is outbound-only, and what still depends on
+shipped, what is gateway-supervised, what stays on a standalone native serve
+loop, what is bridge-owned, what is outbound-only, and what still depends on
 future runtime work.
 
 Use this page when you want the practical setup contract. If you want step-by-step
@@ -22,7 +23,8 @@ headless supervision, or `--channel-account` selectors, continue to
 | If you need... | Start with... |
 | --- | --- |
 | a local assistant only | `onboard`, `ask`, `chat`, and `doctor` |
-| inbound or reply-loop automation | one shipped runtime-backed service channel |
+| inbound or reply-loop automation that should join `gateway run` later | one shipped gateway-supervised service channel |
+| one built-in serve loop that should stay on its own command for now | one standalone native-serve surface |
 | a real channel contract whose login/runtime stays in an external bridge | one plugin-backed bridge surface |
 | proactive delivery without a reply loop | one outbound-only surface |
 | the shared account and selector config shape first | [Configuration Patterns](/use-loong/configuration-patterns) |
@@ -36,7 +38,7 @@ Before any channel is really ready:
 - the base CLI path should already work locally
 - provider credentials should already be healthy
 - channel-specific credentials should already resolve
-- the surface should be described truthfully as runtime-backed, plugin-backed, or outbound-only
+- the surface should be described truthfully as gateway-supervised, standalone native-serve, plugin-backed, or outbound-only
 - setup should point to a concrete operator path instead of a vague support claim
 
 ## Common Rollout Shapes
@@ -48,13 +50,15 @@ Before any channel is really ready:
 | one Matrix bot should own a room sync loop | configure `matrix` and run `loong matrix-serve` | the homeserver, room ids, and sync boundary stay explicit |
 | one WhatsApp business account should own a Cloud API reply loop | configure `whatsapp` and run `loong whatsapp-serve` | send and serve are both shipped on the verified webhook path |
 | one WeCom bot should own the official long connection | configure `wecom` and run `loong wecom-serve` | this matches the shipped AIBot contract |
+| one LINE or generic webhook lane should use a real built-in serve loop without gateway supervision yet | configure the standalone native-serve block and run `loong <surface>-serve --bind ...` | the runtime is real, but the owner is still the direct `*-serve` command |
 | one WeChat / QQ / OneBot bridge should stay external but visible | configure the plugin-backed channel block and run `loong doctor` plus `loong channels` | bridge-owned surfaces are real but should not pretend the gateway already owns the upstream login stack |
 | you need several accounts in one channel family | add `default_account` plus `accounts.<id>` before adding gateway selectors | stable account ids make later supervision and routing legible |
 | you only need governed direct sends | configure one outbound-only surface and use `loong <surface>-send` | this avoids pretending a reply loop already ships |
 
-## Runtime-Backed Service Channels
+## Gateway-Supervised Service Channels
 
-These are the shipped reply-loop surfaces today.
+These are the shipped reply-loop surfaces that can join `gateway run` or
+`multi-channel-serve` today.
 
 | Surface | What you configure first | Run loop |
 | --- | --- | --- |
@@ -63,6 +67,16 @@ These are the shipped reply-loop surfaces today.
 | Matrix | homeserver base URL, access token, and trusted room ids | `loong matrix-serve` |
 | WhatsApp | Cloud API credentials plus verified webhook material | `loong whatsapp-serve` |
 | WeCom | bot id, secret, and trusted conversation ids | `loong wecom-serve` |
+
+## Standalone Native-Serve Surfaces
+
+These surfaces ship real built-in serve loops, but the runtime still stays on
+the direct `*-serve` command instead of gateway supervision.
+
+| Surface | What you configure first | Run loop |
+| --- | --- | --- |
+| LINE | channel access token, channel secret, and a chosen local bind address | `loong line-serve --bind <HOST:PORT>` |
+| Webhook | signing secret plus a chosen local bind address | `loong webhook-serve --bind <HOST:PORT>` |
 
 ## Plugin-Backed Bridge Surfaces
 
@@ -180,9 +194,9 @@ metadata without claiming a full reply-loop runtime.
 
 | Surface family | Current examples | Primary command shape |
 | --- | --- | --- |
-| chat and workplace platforms | Discord, Slack, LINE, DingTalk, Microsoft Teams, Mattermost, Google Chat | `loong <surface>-send` |
+| chat and workplace platforms | Discord, Slack, DingTalk, Microsoft Teams, Mattermost, Google Chat | `loong <surface>-send` |
 | messaging and communication bridges | Signal, IRC, iMessage / BlueBubbles, Nostr | `loong <surface>-send` |
-| generic or self-hosted delivery | Webhook, Email, Nextcloud Talk, Synology Chat, Tlon | `loong <surface>-send` |
+| generic or self-hosted delivery | Email, Nextcloud Talk, Synology Chat, Tlon | `loong <surface>-send` |
 | community-facing outbound integrations | Twitch and similar outbound-only integrations | `loong <surface>-send` |
 
 ## Outbound HTTP Trust Rules
@@ -202,7 +216,8 @@ the runtime can widen that boundary explicitly instead of silently assuming it.
 When you move beyond one local surface:
 
 - `gateway run`, `gateway status`, and `gateway stop` are the explicit owner contract
-- `multi-channel-serve` is the compatibility wrapper for the shipped runtime-backed subset
+- `multi-channel-serve` is the compatibility wrapper for the shipped gateway-supervised subset
+- standalone native-serve surfaces use their own `*-serve` loop instead of joining the same reply-loop runtime contract
 - plugin-backed surfaces are inspected through `doctor` and `channels`, not supervised through the same reply-loop runtime contract
 - outbound-only surfaces should not be described as if they are supervised by the same reply-loop runtime contract
 - the detailed command model, selector syntax, and recovery loop live in
@@ -211,10 +226,11 @@ When you move beyond one local surface:
 ## Recommended Progression
 
 1. Get the local assistant path healthy first.
-2. Add one runtime-backed service channel if you need inbound or reply-loop behavior.
-3. Add one plugin-backed bridge surface when the ecosystem is real but the runtime owner should stay external.
-4. Add outbound-only surfaces when you need governed direct sends.
-5. Reach for gateway and `multi-channel-serve` only after one runtime-backed channel already works cleanly.
+2. Add one gateway-supervised service channel if you need the shortest path into `gateway run` or `multi-channel-serve`.
+3. Add one standalone native-serve surface when you need a real built-in serve loop without gateway supervision yet.
+4. Add one plugin-backed bridge surface when the ecosystem is real but the runtime owner should stay external.
+5. Add outbound-only surfaces when you need governed direct sends.
+6. Reach for gateway and `multi-channel-serve` only after one gateway-supervised channel already works cleanly.
 
 ## Deep References
 

--- a/site/use-loong/channels.mdx
+++ b/site/use-loong/channels.mdx
@@ -48,6 +48,7 @@ straight to the matching playbook.
 | WhatsApp should own a Cloud API reply loop | [WhatsApp](/use-loong/channel-guides/whatsapp) | direct sends and the webhook reply loop are both shipped |
 | WeCom should own the official enterprise AIBot lane | [WeCom](/use-loong/channel-guides/wecom) | it aligns with the shipped long-connection contract |
 | WeChat / QQ ecosystems should route through an external bridge | [Weixin](/use-loong/channel-guides/weixin), [QQ Bot](/use-loong/channel-guides/qqbot), or [OneBot](/use-loong/channel-guides/onebot) | plugin-backed surfaces keep bridge ownership explicit instead of pretending a native runtime exists |
+| one LINE or generic inbound webhook lane should run a built-in serve loop without gateway supervision | [LINE](/use-loong/channel-guides/line) or [Webhook](/use-loong/channel-guides/webhook) | standalone native-serve surfaces are real runtimes, but their owner is still the direct `*-serve` command |
 | outbound notifications without a reply loop | [Channel Guides](/use-loong/channel-guides/index) and [Channel Setup](/use-loong/channel-setup) | outbound-only surfaces stay visible without being overclaimed as runtimes |
 | one host supervising several runtime-backed channels | [Gateway And Supervision](/use-loong/gateway-and-supervision) | owner commands, selectors, and rollout order live there |
 
@@ -65,23 +66,26 @@ straight to the matching playbook.
 | --- | --- | --- |
 | Base assistant loop | local operator-first path | `onboard`, `ask`, `chat`, `doctor` |
 | Gateway owner contract | daemon-owned runtime control for longer-lived surfaces | `gateway run`, `gateway status`, `gateway stop` |
-| Runtime-backed service channels | shipped reply-loop runtimes | Feishu / Lark, Telegram, Matrix, WhatsApp, WeCom |
+| Gateway-supervised service channels | shipped reply-loop runtimes that can join `gateway run` or `multi-channel-serve` | Feishu / Lark, Telegram, Matrix, WhatsApp, WeCom |
+| Standalone native-serve channels | shipped send plus serve lanes whose runtime still stays on their own `*-serve` command instead of gateway supervision | LINE, Webhook |
 | Plugin-backed bridge surfaces | shipped channel contracts whose upstream session lifecycle stays in an external bridge or managed plugin | Weixin, QQ Bot, OneBot |
-| Config-backed outbound surfaces | shipped direct-send surfaces without a full reply-loop runtime | Discord, Slack, LINE, DingTalk, Webhook, Email, Teams, Google Chat, Signal, Twitch, and similar outbound integrations |
+| Config-backed outbound surfaces | shipped direct-send surfaces without a full reply-loop runtime | Discord, Slack, DingTalk, Email, Teams, Google Chat, Signal, Twitch, and similar outbound integrations |
 | Catalog or planned surfaces | inventory or future direction only | Zalo, Zalo Personal, WebChat |
 
 ## Gateway And Runtime Ownership
 
 - `gateway run`, `gateway status`, and `gateway stop` are the current explicit owner contract for longer-lived delivery surfaces.
-- `multi-channel-serve` is the compatibility wrapper that supervises the shipped runtime-backed service-channel subset.
-- Loong does not flatten gateway ownership, reply-loop runtimes, plugin-backed bridge surfaces, and outbound-only sends into one vague "channel support" story.
+- `multi-channel-serve` is the compatibility wrapper that supervises the shipped gateway-supervised service-channel subset.
+- LINE and Webhook have native serve commands, but they are still standalone native-serve lanes rather than gateway-supervised ones.
+- Loong does not flatten gateway ownership, standalone native serves, plugin-backed bridge surfaces, and outbound-only sends into one vague "channel support" story.
 - Use [Gateway And Supervision](/use-loong/gateway-and-supervision) when you
   need the command-by-command ownership model, selector syntax, and rollout
   order in one place.
 
-## Runtime-Backed Service Channels
+## Gateway-Supervised Service Channels
 
-These are the shipped reply-loop runtimes today.
+These are the shipped reply-loop runtimes that can currently join `gateway run`
+or `multi-channel-serve`.
 
 | Surface | Transport shape | Primary commands |
 | --- | --- | --- |
@@ -90,6 +94,16 @@ These are the shipped reply-loop runtimes today.
 | Matrix | Client-Server sync loop | `loong matrix-send`, `loong matrix-serve` |
 | WhatsApp | Cloud API plus verified webhook service | `loong whatsapp-send`, `loong whatsapp-serve` |
 | WeCom | official AIBot long connection | `loong wecom-send`, `loong wecom-serve` |
+
+## Standalone Native-Serve Channels
+
+These are shipped send plus serve lanes, but their runtime owner is still the
+individual `*-serve` command instead of gateway supervision.
+
+| Surface | Transport shape | Primary commands |
+| --- | --- | --- |
+| LINE | Messaging API push plus signed webhook reply loop | `loong line-send`, `loong line-serve` |
+| Webhook | outbound POST plus signed inbound webhook service | `loong webhook-send`, `loong webhook-serve` |
 
 ## Plugin-Backed Bridge Surfaces
 
@@ -111,15 +125,16 @@ short on purpose; the fuller field-level inventory remains in
 | Surface family | Current examples | Typical command shape |
 | --- | --- | --- |
 | workplace chat sinks | Slack, Discord, Microsoft Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat | `loong <surface>-send` |
-| messaging and bridge targets | LINE, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon | `loong <surface>-send` |
-| direct delivery and alerting lanes | Webhook, Email, Twitch | `loong <surface>-send` |
+| messaging and bridge targets | DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon | `loong <surface>-send` |
+| direct delivery and alerting lanes | Email, Twitch | `loong <surface>-send` |
 
 ## Public Documentation Rule
 
 Loong tries to keep the public channel story truthful:
 
 - the gateway contract is documented as the runtime owner contract
-- shipped runtime-backed surfaces are documented as shipped
+- shipped gateway-supervised surfaces are documented as gateway-supervised
+- shipped standalone native-serve surfaces are documented as native serve lanes without overclaiming gateway supervision
 - shipped plugin-backed surfaces are documented as bridge-owned rather than pretending the gateway already owns their listener lifecycle
 - outbound-only surfaces are documented as outbound-only
 - catalog entries are not overclaimed as runtime support
@@ -127,15 +142,16 @@ Loong tries to keep the public channel story truthful:
 ## Typical Progression
 
 1. Get the local assistant path healthy first.
-2. Add one shipped service channel if you need inbound or reply-loop automation.
-3. Reach for a plugin-backed bridge surface when the ecosystem is real but Loong intentionally delegates login and listener ownership to an external bridge.
-4. Use outbound-only surfaces when you need governed direct sends without pretending they are full runtime surfaces.
-5. Reach for `multi-channel-serve` only when you want multiple shipped service channels attached to the same CLI host.
+2. Add one gateway-supervised service channel if you need the shortest path into `gateway run` or `multi-channel-serve`.
+3. Use a standalone native-serve channel when you need a real built-in serve loop but do not need gateway supervision yet.
+4. Reach for a plugin-backed bridge surface when the ecosystem is real but Loong intentionally delegates login and listener ownership to an external bridge.
+5. Use outbound-only surfaces when you need governed direct sends without pretending they are full runtime surfaces.
+6. Reach for `multi-channel-serve` only when you want multiple gateway-supervised service channels attached to the same CLI host.
 
 ## Where To Go Next
 
 - Continue to [Channel Guides](/use-loong/channel-guides/index) for the full actionable channel matrix.
-- Continue to [Channel Recipes](/use-loong/channel-recipes) for representative runtime-backed and outbound rollout examples.
+- Continue to [Channel Recipes](/use-loong/channel-recipes) for representative gateway-supervised, standalone native-serve, and outbound rollout examples.
 - Continue to [Channel Setup](/use-loong/channel-setup) for the practical public setup guide.
 - Continue to [Gateway And Supervision](/use-loong/gateway-and-supervision)
   for the longer-lived owner contract and channel-account selection rules.

--- a/site/use-loong/gateway-and-supervision.mdx
+++ b/site/use-loong/gateway-and-supervision.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gateway And Supervision
-description: Choose the right ownership model for longer-lived runtime-backed service channels.
+description: Choose the right ownership model for longer-lived gateway-supervised service channels.
 ---
 
 # Gateway And Supervision
@@ -22,20 +22,20 @@ trust config shape, start with
 | Need | Best command | Why |
 | --- | --- | --- |
 | keep one service channel in the foreground while you verify it | `loong <surface>-serve` | simplest single-surface loop; no cross-channel supervisor yet |
-| keep several runtime-backed channels attached to one foreground shell | `loong multi-channel-serve --session <name>` | compatibility wrapper for operators who want one visible CLI-first session |
+| keep several gateway-supervised runtime-backed channels attached to one foreground shell | `loong multi-channel-serve --session <name>` | compatibility wrapper for operators who want one visible CLI-first session |
 | claim the persisted owner slot and manage it from another process | `loong gateway run` | explicit owner contract with `status` and `stop` |
 | claim gateway ownership and also attach a named CLI host | `loong gateway run --session <name>` | same owner contract, plus an attached concurrent CLI session |
 
 ## Current Public Ownership Model
 
 - `gateway run`, `gateway status`, and `gateway stop` are the current explicit
-  owner contract for longer-lived runtime-backed delivery.
+  owner contract for longer-lived gateway-supervised delivery.
 - `multi-channel-serve` uses the same ownership model while preserving the
   attached foreground workflow many operators want during rollout.
 - `multi-channel-serve` is still the compatibility wrapper, not the long-term
   product noun.
-- This ownership model is for runtime-backed service channels. It is not the
-  umbrella story for every outbound integration in the catalog.
+- This ownership model is for gateway-supervised service channels. It is not
+  the umbrella story for every outbound integration in the catalog.
 
 ## What Gateway Supervision Includes Today
 
@@ -49,17 +49,17 @@ Included in runtime supervision today:
 
 Not part of runtime supervision today:
 
-- Webhook and Email
-- Slack, Discord, Teams, Google Chat, Mattermost, Nextcloud Talk, and Synology Chat
-- LINE, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon, Twitch, and similar outbound-only surfaces
+- Standalone native-serve surfaces: LINE and Webhook
+- Outbound-only surfaces: Email, Slack, Discord, Teams, Google Chat, Mattermost, Nextcloud Talk, Synology Chat, DingTalk, Signal, IRC, iMessage / BlueBubbles, Nostr, Tlon, Twitch, and similar direct-send integrations
 
-If a surface is outbound-only, it should stay documented as outbound-only
-instead of being described as if it joins the same reply-loop supervisor.
+If a surface is standalone native-serve or outbound-only, it should stay
+documented that way instead of being described as if it joins the same
+reply-loop supervisor.
 
 ## Channel-Account Selectors
 
 Use repeatable `--channel-account <CHANNEL=ACCOUNT>` selectors when you want to
-pin a specific account for a runtime-backed channel family.
+pin a specific account for a gateway-supervised channel family.
 
 Rules that matter:
 
@@ -114,7 +114,7 @@ loong gateway stop
 ## Rollout Order
 
 1. Get `onboard`, `ask` or `chat`, and `doctor` healthy first.
-2. Bring up one runtime-backed surface with its own `loong <surface>-serve`
+2. Bring up one gateway-supervised surface with its own `loong <surface>-serve`
    loop before you introduce supervision.
 3. Add `default_account` plus `accounts.<id>` before you rely on multi-account
    supervision.
@@ -141,8 +141,8 @@ That combination answers three different questions:
 
 If the runtime still does not start cleanly:
 
-- confirm that the selected surface is actually runtime-backed, not
-  outbound-only
+- confirm that the selected surface is actually gateway-supervised, not a
+  standalone native-serve or outbound-only lane
 - confirm that the selected account id exists under `accounts.<id>`
 - rerun with explicit `--channel-account` selectors when a channel family has
   more than one configured account
@@ -156,8 +156,8 @@ If the runtime still does not start cleanly:
   provider, channel, and gateway choices combined into one setup path.
 - Continue to [Configuration Patterns](/use-loong/configuration-patterns)
   for the shared public account, selector, and trust-toggle config shapes.
-- Go back to [Channels](/use-loong/channels) for the surface model and
-  runtime-backed versus outbound-only boundary.
+- Go back to [Channels](/use-loong/channels) for the surface model and the
+  gateway-supervised versus standalone native-serve versus outbound-only boundary.
 - Continue to [Channel Guides](/use-loong/channel-guides/index) for the
   exact built-in contract of one shipped channel surface.
 - Continue to [Channel Setup](/use-loong/channel-setup) for the practical


### PR DESCRIPTION
## Summary

- Problem:
  - LINE and Webhook ship real native `*-serve` runtimes, but internal/operator projections and public docs still flattened them into the outbound-only story or the generic runtime-backed bucket.
  - Managed-bridge discovery fixtures in daemon tests also drifted behind the current bridge runtime metadata contract, which kept CI from passing on fresh `dev`.
- Why it matters:
  - Operators need a truthful answer to “does this surface have a real serve loop?” and “does it join `gateway run` / `multi-channel-serve`?”.
  - The channel SDK, migration/onboarding surfaces, and public docs should describe the same runtime ownership model.
- What changed:
  - Added `ChannelOperationalModel` to the internal channel SDK and projected gateway-supervised vs standalone native-serve runtime groupings without hardcoded surface ids.
  - Updated fallback channel descriptors used by migration/onboarding paths to preserve the richer runtime ownership truth.
  - Reclassified public docs so LINE and Webhook are documented as shipped standalone native-serve lanes rather than outbound-only placeholders.
  - Repaired managed-bridge discovery test fixtures so they include the current runtime contract metadata (`channel_runtime_contract` + runtime operations JSON).
  - Hardened two integration tests that were inheriting process-global Discord env state instead of isolating it.
- What did not change (scope boundary):
  - Did not make LINE or Webhook join `gateway run` / `multi-channel-serve`.
  - Did not add new channel families.
  - Did not widen the plugin-bridge runtime contract beyond the fixture drift needed to keep tests aligned.

## Linked Issues

- Closes #1293
- Related #1291

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test --workspace
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test --workspace --all-features
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong managed_bridge -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong -p loong-app channel_descriptor -- --nocapture

Result: all commands passed in the feature worktree after the channel taxonomy changes, managed-bridge fixture repair, and env-isolated integration test updates.
```

## User-visible / Operator-visible Changes

- `loong` docs now distinguish:
  - gateway-supervised service channels
  - standalone native-serve channels
  - plugin-backed bridge surfaces
  - outbound-only surfaces
- LINE and Webhook are now documented as shipped native serve lanes with explicit `*-serve --bind` guidance instead of placeholder “not implemented yet” wording.

## Failure Recovery

- Fast rollback or disable path:
  - Revert this PR to restore the previous channel taxonomy and docs together.
- Observable failure symptoms reviewers should watch for:
  - onboarding/migration summaries unexpectedly classify LINE or Webhook as outbound-only again
  - managed-bridge discovery tests start reporting `managed bridge setup incomplete` for fixtures that should be ready

## Reviewer Focus

- `crates/app/src/channel/sdk.rs`: verify the new operational model is derived from existing runtime signals instead of hardcoded channel ids.
- `crates/daemon/src/doctor_cli.rs` and `crates/daemon/tests/integration/managed_bridge_fixtures.rs`: verify the managed-bridge fixture repair matches the current runtime contract shape and keeps doctor/onboarding views aligned.
- `site/use-loong/*`: verify the public docs now keep the gateway-supervised vs standalone native-serve boundary truthful for LINE and Webhook.
