### PR TITLE
app: mature memory search indexing and Chinese recall, add jieba-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aes"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1450,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "data-encoding"
@@ -2478,6 +2499,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e233413926ef735f7d87024466cfda5a4b87467730846bd82ea7d504121347"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7148f24ef8922cc0e5574ebb908729ccdd3a110c440a45165733fedadd9969"
+dependencies = [
+ "include-flate-compress",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74783a9ed407e844e99d5e7a57bd650acbfa124cf6e97ffd790ba59d8ab8e7ff"
+dependencies = [
+ "libflate",
+ "zstd",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2676,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jieba-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348294e44ee7e3c42685da656490f8febc7359632544019621588902216da95c"
+dependencies = [
+ "phf_codegen 0.13.1",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766bd7012aa5ba49411ebdf4e93bddd59b182d2918e085d58dec5bb9b54b7105"
+dependencies = [
+ "cedarwood",
+ "include-flate",
+ "jieba-macros",
+ "phf 0.13.1",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2812,30 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libflate"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -2897,6 +2998,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "include_dir",
+ "jieba-rs",
  "lettre",
  "libc",
  "loong-contracts",
@@ -3225,6 +3327,15 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3636,6 +3747,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4147,6 +4280,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -6659,4 +6798,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -94,6 +94,7 @@ tempfile = "3"
 which.workspace = true
 unicode-normalization = "0.1"
 unicode-segmentation = "1.13"
+jieba-rs = "0.8"
 tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
 starlark = "0.13"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -20,6 +20,7 @@ pub mod runtime_env;
 mod runtime_identity;
 mod runtime_self;
 mod runtime_self_continuity;
+pub(crate) mod search_text;
 mod secrets;
 pub mod session;
 pub mod tools;

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -58,7 +58,7 @@ pub use protocol::{
     decode_window_turns, encode_stage_envelope_payload, parse_exact_memory_core_operation,
 };
 #[cfg(feature = "memory-sqlite")]
-pub(crate) use sqlite::CanonicalMemorySearchHit;
+pub(crate) use sqlite::{CanonicalMemorySearchHit, WorkspaceMemoryIndexedSearchHit};
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
 pub use stage::{
@@ -336,6 +336,23 @@ pub(crate) fn search_canonical_memory(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<Vec<CanonicalMemorySearchHit>, String> {
     sqlite::search_canonical_records_for_recall(query, limit, exclude_session_id, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn search_workspace_memory_documents(
+    query: &str,
+    limit: usize,
+    workspace_root: &std::path::Path,
+    memory_system_id: &str,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<WorkspaceMemoryIndexedSearchHit>, String> {
+    sqlite::search_workspace_memory_documents(
+        query,
+        limit,
+        workspace_root,
+        memory_system_id,
+        config,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -14,10 +14,15 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::{
-    CanonicalMemoryKind, CanonicalMemoryRecord, MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION,
-    MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryScope, WindowTurn,
-    canonical_memory_record_from_persisted_turn, runtime_config::MemoryRuntimeConfig,
+    CanonicalMemoryKind, CanonicalMemoryRecord, DerivedMemoryKind, MEMORY_OP_APPEND_TURN,
+    MEMORY_OP_CLEAR_SESSION, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryAuthority,
+    MemoryRecallMode, MemoryRecordStatus, MemoryScope, MemoryTrustLevel,
+    ParsedWorkspaceMemoryDocument, WindowTurn, WorkspaceMemoryDocumentKind,
+    WorkspaceMemoryDocumentLocation, canonical_memory_record_from_persisted_turn,
+    collect_workspace_memory_document_locations, parse_workspace_memory_document,
+    runtime_config::MemoryRuntimeConfig,
 };
+use crate::search_text::build_search_index_text;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConversationTurn {
@@ -113,9 +118,9 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 10;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 12;
 const CANONICAL_REBUILD_BATCH_SIZE: i64 = 256;
-const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 18;
+const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 24;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SESSION_TOOL_CONSENT_MODE_CHECK_SQL: &str = "CHECK (mode IN ('prompt', 'auto', 'full'))";
@@ -151,8 +156,9 @@ const SQL_INSERT_CANONICAL_RECORD: &str = "INSERT INTO memory_canonical_records(
              role,
              content,
              metadata_json,
+             search_text,
              ts
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
 const SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD: &str =
     "SELECT id, session_id, session_turn_index, role, content, ts
              FROM turns
@@ -216,6 +222,9 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                         'memory_summary_checkpoint_bodies',
                         'memory_canonical_records',
                         'memory_canonical_records_fts',
+                        'workspace_memory_documents',
+                        'workspace_memory_documents_fts',
+                        'session_events_fts',
                         'approval_requests',
                         'approval_grants',
                         'session_tool_consent',
@@ -231,7 +240,10 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                 OR (type = 'trigger' AND name IN (
                         'memory_canonical_records_ai',
                         'memory_canonical_records_ad',
-                        'memory_canonical_records_au'
+                        'memory_canonical_records_au',
+                        'session_events_ai',
+                        'session_events_ad',
+                        'session_events_au'
                     ))";
 const SQL_QUERY_RECENT_PROMPT_TURNS_WITH_CHECKPOINT_META: &str = "SELECT turns.id,
              turns.role,
@@ -438,6 +450,22 @@ struct AppendTurnResult {
 pub(crate) struct CanonicalMemorySearchHit {
     pub record: CanonicalMemoryRecord,
     pub session_turn_index: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkspaceMemoryIndexedSearchHit {
+    pub label: String,
+    pub path: String,
+    pub document_kind: WorkspaceMemoryDocumentKind,
+    pub body: String,
+    pub body_line_offset: usize,
+    pub freshness_ts: Option<i64>,
+    pub content_hash: String,
+    pub record_status: MemoryRecordStatus,
+    pub trust_level: MemoryTrustLevel,
+    pub authority: MemoryAuthority,
+    pub derived_kind: DerivedMemoryKind,
+    pub superseded_by: Option<String>,
 }
 
 struct WindowLoadResult {
@@ -1210,6 +1238,7 @@ struct CanonicalInsertInput {
     role: Option<String>,
     content: String,
     metadata_json: String,
+    search_text: String,
     ts: i64,
 }
 
@@ -1221,6 +1250,15 @@ fn build_canonical_insert_input(
     ts: i64,
 ) -> CanonicalInsertInput {
     let record = canonical_memory_record_from_persisted_turn(session_id, role, content);
+    let metadata_json = record.metadata.to_string();
+    let search_text = canonical_record_search_text(
+        session_id,
+        record.scope.as_str(),
+        record.kind.as_str(),
+        record.role.as_deref(),
+        record.content.as_str(),
+        metadata_json.as_str(),
+    );
     CanonicalInsertInput {
         session_id: session_id.to_owned(),
         session_turn_index,
@@ -1228,7 +1266,8 @@ fn build_canonical_insert_input(
         kind: record.kind,
         role: record.role,
         content: record.content,
-        metadata_json: record.metadata.to_string(),
+        metadata_json,
+        search_text,
         ts,
     }
 }
@@ -1248,10 +1287,27 @@ fn insert_canonical_record(conn: &Connection, input: CanonicalInsertInput) -> Re
             input.role,
             input.content,
             input.metadata_json,
+            input.search_text,
             input.ts,
         ])
         .map(|_| ())
         .map_err(|error| format!("insert canonical memory record failed: {error}"))
+}
+
+fn canonical_record_search_text(
+    session_id: &str,
+    scope: &str,
+    kind: &str,
+    role: Option<&str>,
+    content: &str,
+    metadata_json: &str,
+) -> String {
+    let mut fragments = vec![session_id, scope, kind, content, metadata_json];
+    if let Some(role) = role {
+        fragments.push(role);
+    }
+
+    build_search_index_text(fragments.as_slice())
 }
 
 fn replace_turns_internal(
@@ -1602,6 +1658,7 @@ fn open_sqlite_connection_with_diagnostics(
               role TEXT NULL,
               content TEXT NOT NULL,
               metadata_json TEXT NOT NULL,
+              search_text TEXT NOT NULL DEFAULT '',
               ts INTEGER NOT NULL
             );
             CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_canonical_records_session_turn
@@ -1616,6 +1673,7 @@ fn open_sqlite_connection_with_diagnostics(
                 kind,
                 role,
                 metadata_json,
+                search_text,
                 content='memory_canonical_records',
                 content_rowid='record_id'
               );
@@ -1629,7 +1687,8 @@ fn open_sqlite_connection_with_diagnostics(
                 scope,
                 kind,
                 role,
-                metadata_json
+                metadata_json,
+                search_text
               )
               VALUES (
                 new.record_id,
@@ -1638,7 +1697,8 @@ fn open_sqlite_connection_with_diagnostics(
                 new.scope,
                 new.kind,
                 COALESCE(new.role, ''),
-                new.metadata_json
+                new.metadata_json,
+                new.search_text
               );
             END;
             CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
@@ -1652,7 +1712,8 @@ fn open_sqlite_connection_with_diagnostics(
                 scope,
                 kind,
                 role,
-                metadata_json
+                metadata_json,
+                search_text
               )
               VALUES (
                 'delete',
@@ -1662,7 +1723,8 @@ fn open_sqlite_connection_with_diagnostics(
                 old.scope,
                 old.kind,
                 COALESCE(old.role, ''),
-                old.metadata_json
+                old.metadata_json,
+                old.search_text
               );
             END;
             CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
@@ -1676,7 +1738,8 @@ fn open_sqlite_connection_with_diagnostics(
                 scope,
                 kind,
                 role,
-                metadata_json
+                metadata_json,
+                search_text
               )
               VALUES (
                 'delete',
@@ -1686,7 +1749,8 @@ fn open_sqlite_connection_with_diagnostics(
                 old.scope,
                 old.kind,
                 COALESCE(old.role, ''),
-                old.metadata_json
+                old.metadata_json,
+                old.search_text
               );
               INSERT INTO memory_canonical_records_fts(
                 rowid,
@@ -1695,7 +1759,8 @@ fn open_sqlite_connection_with_diagnostics(
                 scope,
                 kind,
                 role,
-                metadata_json
+                metadata_json,
+                search_text
               )
               VALUES (
                 new.record_id,
@@ -1704,7 +1769,8 @@ fn open_sqlite_connection_with_diagnostics(
                 new.scope,
                 new.kind,
                 COALESCE(new.role, ''),
-                new.metadata_json
+                new.metadata_json,
+                new.search_text
               );
             END;
             CREATE TABLE IF NOT EXISTS approval_requests(
@@ -1826,11 +1892,13 @@ fn ensure_sqlite_schema_repairs_if_needed(conn: &mut Connection) -> Result<(), S
 
     ensure_turn_session_index_and_state_metadata(conn)?;
     ensure_session_terminal_outcome_storage(conn)?;
+    ensure_session_event_search_storage(conn)?;
     ensure_approval_lifecycle_tables(conn)?;
     ensure_session_tool_consent_storage(conn)?;
     ensure_session_tool_policy_storage(conn)?;
     ensure_summary_checkpoint_storage_layout(conn)?;
     ensure_canonical_record_storage(conn)?;
+    ensure_workspace_memory_search_storage(conn)?;
     write_sqlite_user_version(conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
 
     Ok(())
@@ -1850,10 +1918,16 @@ fn sqlite_current_schema_objects_ready(conn: &Connection) -> Result<bool, String
         .map_err(|error| format!("probe sqlite current schema objects failed: {error}"))?;
     let object_count_ready = object_count == SQLITE_CURRENT_SCHEMA_OBJECT_COUNT;
     let canonical_fts_ready = !canonical_record_fts_needs_rebuild(conn)?;
+    let session_event_fts_ready = !session_event_fts_needs_rebuild(conn)?;
+    let workspace_memory_search_ready = !workspace_memory_search_storage_needs_rebuild(conn)?;
     let terminal_outcome_storage_ready =
         sqlite_table_has_column(conn, "session_terminal_outcomes", "frozen_result_json")?;
 
-    Ok(object_count_ready && canonical_fts_ready && terminal_outcome_storage_ready)
+    Ok(object_count_ready
+        && canonical_fts_ready
+        && session_event_fts_ready
+        && workspace_memory_search_ready
+        && terminal_outcome_storage_ready)
 }
 
 fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(), String> {
@@ -1909,6 +1983,7 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
           event_kind TEXT NOT NULL,
           actor_session_id TEXT NULL,
           payload_json TEXT NOT NULL,
+          search_text TEXT NOT NULL DEFAULT '',
           ts INTEGER NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_session_events_session_id
@@ -1969,6 +2044,871 @@ fn ensure_session_terminal_outcome_storage(conn: &Connection) -> Result<(), Stri
     }
 
     Ok(())
+}
+
+fn ensure_session_event_search_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("session_event_search");
+
+    if !sqlite_table_has_column(conn, "session_events", "search_text")? {
+        conn.execute(
+            "ALTER TABLE session_events
+             ADD COLUMN search_text TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .map_err(|error| format!("add session event search_text column failed: {error}"))?;
+    }
+
+    backfill_session_event_search_text(conn)?;
+    create_session_event_fts_index(conn)?;
+
+    if session_event_fts_needs_rebuild(conn)? {
+        rebuild_session_event_search_storage(conn)?;
+        return Ok(());
+    }
+
+    rebuild_session_event_search_storage_if_needed(conn)
+}
+
+fn backfill_session_event_search_text(conn: &Connection) -> Result<(), String> {
+    let mut select_stmt = conn
+        .prepare(
+            "SELECT id, event_kind, payload_json
+             FROM session_events
+             WHERE search_text = '' OR search_text IS NULL",
+        )
+        .map_err(|error| format!("prepare session event search_text backfill failed: {error}"))?;
+    let rows = select_stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|error| format!("query session event search_text backfill failed: {error}"))?;
+
+    let mut pending_updates = Vec::new();
+    for row in rows {
+        let (event_id, event_kind, payload_json) = row.map_err(|error| {
+            format!("decode session event search_text backfill row failed: {error}")
+        })?;
+        let search_text = session_event_search_text(event_kind.as_str(), payload_json.as_str());
+        pending_updates.push((event_id, search_text));
+    }
+    drop(select_stmt);
+
+    let mut update_stmt = conn
+        .prepare(
+            "UPDATE session_events
+             SET search_text = ?2
+             WHERE id = ?1",
+        )
+        .map_err(|error| format!("prepare session event search_text update failed: {error}"))?;
+    for (event_id, search_text) in pending_updates {
+        update_stmt
+            .execute(rusqlite::params![event_id, search_text])
+            .map_err(|error| format!("update session event search_text failed: {error}"))?;
+    }
+
+    Ok(())
+}
+
+fn session_event_fts_needs_rebuild(conn: &Connection) -> Result<bool, String> {
+    let columns = sqlite_table_columns(conn, "session_events_fts")?;
+    if columns.is_empty() {
+        return Ok(false);
+    }
+
+    let required_columns = ["event_kind", "payload_json", "search_text"];
+    let has_all_required_columns = required_columns.iter().all(|required_column| {
+        columns
+            .iter()
+            .any(|current_column| current_column == required_column)
+    });
+
+    Ok(!has_all_required_columns)
+}
+
+fn drop_session_event_fts_index(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        DROP TRIGGER IF EXISTS session_events_ai;
+        DROP TRIGGER IF EXISTS session_events_ad;
+        DROP TRIGGER IF EXISTS session_events_au;
+        DROP TABLE IF EXISTS session_events_fts;
+        ",
+    )
+    .map_err(|error| format!("drop session event FTS index failed: {error}"))?;
+
+    Ok(())
+}
+
+fn create_session_event_fts_index(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        CREATE VIRTUAL TABLE IF NOT EXISTS session_events_fts
+          USING fts5(
+            event_kind,
+            payload_json,
+            search_text
+          );
+        CREATE TRIGGER IF NOT EXISTS session_events_ai
+          AFTER INSERT ON session_events
+        BEGIN
+          INSERT INTO session_events_fts(
+            rowid,
+            event_kind,
+            payload_json,
+            search_text
+          )
+          VALUES (
+            new.id,
+            new.event_kind,
+            new.payload_json,
+            new.search_text
+          );
+        END;
+        CREATE TRIGGER IF NOT EXISTS session_events_ad
+          AFTER DELETE ON session_events
+        BEGIN
+          DELETE FROM session_events_fts
+          WHERE rowid = old.id;
+        END;
+        CREATE TRIGGER IF NOT EXISTS session_events_au
+          AFTER UPDATE ON session_events
+        BEGIN
+          DELETE FROM session_events_fts
+          WHERE rowid = old.id;
+          INSERT INTO session_events_fts(
+            rowid,
+            event_kind,
+            payload_json,
+            search_text
+          )
+          VALUES (
+            new.id,
+            new.event_kind,
+            new.payload_json,
+            new.search_text
+          );
+        END;
+        ",
+    )
+    .map_err(|error| format!("create session event FTS index failed: {error}"))?;
+
+    Ok(())
+}
+
+fn rebuild_session_event_fts_index_contents(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "
+        INSERT INTO session_events_fts(
+          rowid,
+          event_kind,
+          payload_json,
+          search_text
+        )
+        SELECT id, event_kind, payload_json, search_text
+        FROM session_events
+        ",
+        [],
+    )
+    .map(|_| ())
+    .map_err(|error| format!("rebuild session event FTS contents failed: {error}"))?;
+
+    Ok(())
+}
+
+fn rebuild_session_event_search_storage(conn: &Connection) -> Result<(), String> {
+    drop_session_event_fts_index(conn)?;
+    create_session_event_fts_index(conn)?;
+    rebuild_session_event_fts_index_contents(conn)
+}
+
+fn rebuild_session_event_search_storage_if_needed(conn: &Connection) -> Result<(), String> {
+    let session_event_count = conn
+        .query_row("SELECT COUNT(*) FROM session_events", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| format!("count session events failed: {error}"))?;
+    let session_event_fts_count = conn
+        .query_row("SELECT COUNT(*) FROM session_events_fts", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| format!("count session event FTS rows failed: {error}"))?;
+
+    if session_event_count == session_event_fts_count {
+        return Ok(());
+    }
+
+    rebuild_session_event_search_storage(conn)
+}
+
+fn session_event_search_text(event_kind: &str, payload_json: &str) -> String {
+    build_search_index_text(&[event_kind, payload_json])
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceMemoryDocumentIndexRow {
+    document_id: i64,
+    label: String,
+    modified_at_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceMemoryDocumentIndexEntry {
+    workspace_root: String,
+    path: String,
+    label: String,
+    document_kind: WorkspaceMemoryDocumentKind,
+    modified_at_ms: i64,
+    freshness_ts: Option<i64>,
+    content_hash: String,
+    record_status: MemoryRecordStatus,
+    trust_level: MemoryTrustLevel,
+    authority: MemoryAuthority,
+    derived_kind: DerivedMemoryKind,
+    superseded_by: Option<String>,
+    body_line_offset: i64,
+    body: String,
+    search_text: String,
+}
+
+fn ensure_workspace_memory_search_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("workspace_memory_search");
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS workspace_memory_documents(
+          document_id INTEGER PRIMARY KEY AUTOINCREMENT,
+          workspace_root TEXT NOT NULL,
+          path TEXT NOT NULL,
+          label TEXT NOT NULL,
+          document_kind TEXT NOT NULL,
+          modified_at_ms INTEGER NOT NULL,
+          freshness_ts INTEGER NULL,
+          content_hash TEXT NOT NULL,
+          record_status TEXT NOT NULL,
+          trust_level TEXT NOT NULL,
+          authority TEXT NOT NULL,
+          derived_kind TEXT NOT NULL,
+          superseded_by TEXT NULL,
+          body_line_offset INTEGER NOT NULL,
+          body TEXT NOT NULL,
+          search_text TEXT NOT NULL,
+          UNIQUE(workspace_root, path)
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS workspace_memory_documents_fts
+          USING fts5(
+            label,
+            body,
+            search_text
+          );
+        ",
+    )
+    .map_err(|error| format!("ensure workspace memory search storage failed: {error}"))?;
+
+    if workspace_memory_search_storage_needs_rebuild(conn)? {
+        rebuild_workspace_memory_search_storage(conn)?;
+    }
+
+    Ok(())
+}
+
+fn workspace_memory_search_storage_needs_rebuild(conn: &Connection) -> Result<bool, String> {
+    let document_columns = sqlite_table_columns(conn, "workspace_memory_documents")?;
+    let fts_columns = sqlite_table_columns(conn, "workspace_memory_documents_fts")?;
+    if document_columns.is_empty() || fts_columns.is_empty() {
+        return Ok(false);
+    }
+
+    let required_document_columns = [
+        "workspace_root",
+        "path",
+        "label",
+        "document_kind",
+        "modified_at_ms",
+        "freshness_ts",
+        "content_hash",
+        "record_status",
+        "trust_level",
+        "authority",
+        "derived_kind",
+        "superseded_by",
+        "body_line_offset",
+        "body",
+        "search_text",
+    ];
+    let documents_ready = required_document_columns.iter().all(|required_column| {
+        document_columns
+            .iter()
+            .any(|current_column| current_column == required_column)
+    });
+    let required_fts_columns = ["label", "body", "search_text"];
+    let fts_ready = required_fts_columns.iter().all(|required_column| {
+        fts_columns
+            .iter()
+            .any(|current_column| current_column == required_column)
+    });
+
+    Ok(!(documents_ready && fts_ready))
+}
+
+fn rebuild_workspace_memory_search_storage(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS workspace_memory_documents_fts;
+        DROP TABLE IF EXISTS workspace_memory_documents;
+        ",
+    )
+    .map_err(|error| format!("drop workspace memory search storage failed: {error}"))?;
+
+    conn.execute_batch(
+        "
+        CREATE TABLE workspace_memory_documents(
+          document_id INTEGER PRIMARY KEY AUTOINCREMENT,
+          workspace_root TEXT NOT NULL,
+          path TEXT NOT NULL,
+          label TEXT NOT NULL,
+          document_kind TEXT NOT NULL,
+          modified_at_ms INTEGER NOT NULL,
+          freshness_ts INTEGER NULL,
+          content_hash TEXT NOT NULL,
+          record_status TEXT NOT NULL,
+          trust_level TEXT NOT NULL,
+          authority TEXT NOT NULL,
+          derived_kind TEXT NOT NULL,
+          superseded_by TEXT NULL,
+          body_line_offset INTEGER NOT NULL,
+          body TEXT NOT NULL,
+          search_text TEXT NOT NULL,
+          UNIQUE(workspace_root, path)
+        );
+        CREATE VIRTUAL TABLE workspace_memory_documents_fts
+          USING fts5(
+            label,
+            body,
+            search_text
+          );
+        ",
+    )
+    .map_err(|error| format!("recreate workspace memory search storage failed: {error}"))?;
+
+    Ok(())
+}
+
+fn workspace_memory_root_key(workspace_root: &Path) -> Result<String, String> {
+    let canonical_root = workspace_root.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize workspace memory root {} failed: {error}",
+            workspace_root.display()
+        )
+    })?;
+    Ok(canonical_root.display().to_string())
+}
+
+fn workspace_document_modified_at_ms(path: &Path) -> Result<i64, String> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        format!(
+            "read workspace memory metadata {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let modified = metadata.modified().map_err(|error| {
+        format!(
+            "read workspace memory modified time {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let duration_since_epoch = modified.duration_since(UNIX_EPOCH).map_err(|error| {
+        format!(
+            "read workspace memory modified time {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let modified_ms = duration_since_epoch.as_millis();
+    i64::try_from(modified_ms).map_err(|error| {
+        format!(
+            "workspace memory modified time {} exceeds i64 milliseconds: {error}",
+            path.display()
+        )
+    })
+}
+
+fn read_workspace_memory_text_lossy(path: &Path) -> Result<String, String> {
+    let bytes = fs::read(path)
+        .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
+    Ok(String::from_utf8_lossy(bytes.as_slice()).into_owned())
+}
+
+fn workspace_memory_search_text(
+    label: &str,
+    body: &str,
+    derived_kind: DerivedMemoryKind,
+    trust_level: MemoryTrustLevel,
+    superseded_by: Option<&str>,
+) -> String {
+    let mut fragments = vec![label, body, derived_kind.as_str(), trust_level.as_str()];
+    if let Some(superseded_by) = superseded_by {
+        fragments.push(superseded_by);
+    }
+
+    build_search_index_text(fragments.as_slice())
+}
+
+fn build_workspace_memory_document_index_entry(
+    workspace_root_key: &str,
+    location: &WorkspaceMemoryDocumentLocation,
+    modified_at_ms: i64,
+    parsed_document: ParsedWorkspaceMemoryDocument,
+) -> Result<Option<WorkspaceMemoryDocumentIndexEntry>, String> {
+    let record_status = parsed_document
+        .provenance
+        .record_status
+        .unwrap_or(MemoryRecordStatus::Active);
+    if !record_status.is_active() {
+        return Ok(None);
+    }
+
+    let derived_kind = parsed_document
+        .provenance
+        .derived_kind
+        .unwrap_or(DerivedMemoryKind::Overview);
+    let trust_level = parsed_document
+        .provenance
+        .trust_level
+        .unwrap_or(MemoryTrustLevel::WorkspaceCurated);
+    let authority = parsed_document
+        .provenance
+        .authority
+        .unwrap_or(MemoryAuthority::Advisory);
+    let content_hash = parsed_document
+        .provenance
+        .content_hash
+        .clone()
+        .unwrap_or_default();
+    let superseded_by = parsed_document.provenance.superseded_by.clone();
+    let search_text = workspace_memory_search_text(
+        location.label.as_str(),
+        parsed_document.body.as_str(),
+        derived_kind,
+        trust_level,
+        superseded_by.as_deref(),
+    );
+    let body_line_offset = i64::try_from(parsed_document.body_line_offset).map_err(|error| {
+        format!(
+            "workspace memory body_line_offset for {} exceeds i64: {error}",
+            location.label
+        )
+    })?;
+
+    Ok(Some(WorkspaceMemoryDocumentIndexEntry {
+        workspace_root: workspace_root_key.to_owned(),
+        path: location.path.display().to_string(),
+        label: location.label.clone(),
+        document_kind: location.kind,
+        modified_at_ms,
+        freshness_ts: parsed_document.provenance.freshness_ts,
+        content_hash,
+        record_status,
+        trust_level,
+        authority,
+        derived_kind,
+        superseded_by,
+        body_line_offset,
+        body: parsed_document.body,
+        search_text,
+    }))
+}
+
+fn load_workspace_memory_document_index_rows(
+    conn: &Connection,
+    workspace_root_key: &str,
+) -> Result<HashMap<String, WorkspaceMemoryDocumentIndexRow>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT document_id, path, label, modified_at_ms
+             FROM workspace_memory_documents
+             WHERE workspace_root = ?1",
+        )
+        .map_err(|error| format!("prepare workspace memory index row query failed: {error}"))?;
+    let rows = stmt
+        .query_map(rusqlite::params![workspace_root_key], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(|error| format!("query workspace memory index rows failed: {error}"))?;
+
+    let mut index_rows = HashMap::new();
+    for row in rows {
+        let (document_id, path, label, modified_at_ms) =
+            row.map_err(|error| format!("decode workspace memory index row failed: {error}"))?;
+        index_rows.insert(
+            path,
+            WorkspaceMemoryDocumentIndexRow {
+                document_id,
+                label,
+                modified_at_ms,
+            },
+        );
+    }
+
+    Ok(index_rows)
+}
+
+fn upsert_workspace_memory_document_index_entry(
+    conn: &Connection,
+    existing_document_id: Option<i64>,
+    entry: WorkspaceMemoryDocumentIndexEntry,
+) -> Result<(), String> {
+    let WorkspaceMemoryDocumentIndexEntry {
+        workspace_root,
+        path,
+        label,
+        document_kind,
+        modified_at_ms,
+        freshness_ts,
+        content_hash,
+        record_status,
+        trust_level,
+        authority,
+        derived_kind,
+        superseded_by,
+        body_line_offset,
+        body,
+        search_text,
+    } = entry;
+
+    let document_id = if let Some(existing_document_id) = existing_document_id {
+        conn.execute(
+            "UPDATE workspace_memory_documents
+             SET label = ?2,
+                 document_kind = ?3,
+                 modified_at_ms = ?4,
+                 freshness_ts = ?5,
+                 content_hash = ?6,
+                 record_status = ?7,
+                 trust_level = ?8,
+                 authority = ?9,
+                 derived_kind = ?10,
+                 superseded_by = ?11,
+                 body_line_offset = ?12,
+                 body = ?13,
+                 search_text = ?14
+             WHERE document_id = ?1",
+            rusqlite::params![
+                existing_document_id,
+                label,
+                document_kind.as_str(),
+                modified_at_ms,
+                freshness_ts,
+                content_hash,
+                record_status.as_str(),
+                trust_level.as_str(),
+                authority.as_str(),
+                derived_kind.as_str(),
+                superseded_by,
+                body_line_offset,
+                body,
+                search_text,
+            ],
+        )
+        .map_err(|error| format!("update workspace memory index row failed: {error}"))?;
+        existing_document_id
+    } else {
+        conn.execute(
+            "INSERT INTO workspace_memory_documents(
+                workspace_root,
+                path,
+                label,
+                document_kind,
+                modified_at_ms,
+                freshness_ts,
+                content_hash,
+                record_status,
+                trust_level,
+                authority,
+                derived_kind,
+                superseded_by,
+                body_line_offset,
+                body,
+                search_text
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            rusqlite::params![
+                workspace_root,
+                path,
+                label,
+                document_kind.as_str(),
+                modified_at_ms,
+                freshness_ts,
+                content_hash,
+                record_status.as_str(),
+                trust_level.as_str(),
+                authority.as_str(),
+                derived_kind.as_str(),
+                superseded_by,
+                body_line_offset,
+                body,
+                search_text,
+            ],
+        )
+        .map_err(|error| format!("insert workspace memory index row failed: {error}"))?;
+        conn.last_insert_rowid()
+    };
+
+    conn.execute(
+        "DELETE FROM workspace_memory_documents_fts WHERE rowid = ?1",
+        rusqlite::params![document_id],
+    )
+    .map_err(|error| format!("delete stale workspace memory FTS row failed: {error}"))?;
+    let (label, body, search_text) = conn
+        .query_row(
+            "SELECT label, body, search_text
+             FROM workspace_memory_documents
+             WHERE document_id = ?1",
+            rusqlite::params![document_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .map_err(|error| {
+            format!("reload workspace memory index row for FTS sync failed: {error}")
+        })?;
+    conn.execute(
+        "INSERT INTO workspace_memory_documents_fts(rowid, label, body, search_text)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![document_id, label, body, search_text],
+    )
+    .map_err(|error| format!("insert workspace memory FTS row failed: {error}"))?;
+
+    Ok(())
+}
+
+fn delete_workspace_memory_document_index_row(
+    conn: &Connection,
+    document_id: i64,
+) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM workspace_memory_documents_fts WHERE rowid = ?1",
+        rusqlite::params![document_id],
+    )
+    .map_err(|error| format!("delete workspace memory FTS row failed: {error}"))?;
+    conn.execute(
+        "DELETE FROM workspace_memory_documents WHERE document_id = ?1",
+        rusqlite::params![document_id],
+    )
+    .map_err(|error| format!("delete workspace memory index row failed: {error}"))?;
+    Ok(())
+}
+
+fn sync_workspace_memory_search_index(
+    workspace_root: &Path,
+    memory_system_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<(), String> {
+    let workspace_root_key = workspace_memory_root_key(workspace_root)?;
+    let locations = collect_workspace_memory_document_locations(workspace_root)?;
+    let runtime = acquire_memory_runtime(config)?;
+
+    runtime.with_connection_mut("memory.sync_workspace_memory_search_index", |conn| {
+        ensure_workspace_memory_search_storage(conn)?;
+        let mut existing_rows =
+            load_workspace_memory_document_index_rows(conn, workspace_root_key.as_str())?;
+
+        for location in locations {
+            let path_key = location.path.display().to_string();
+            let modified_at_ms = workspace_document_modified_at_ms(location.path.as_path())?;
+            let existing_row = existing_rows.remove(path_key.as_str());
+            let can_reuse_existing = existing_row.as_ref().is_some_and(|row| {
+                row.modified_at_ms == modified_at_ms && row.label == location.label
+            });
+            if can_reuse_existing {
+                continue;
+            }
+
+            let raw_content = read_workspace_memory_text_lossy(location.path.as_path())?;
+            let maybe_parsed_document = parse_workspace_memory_document(
+                raw_content.as_str(),
+                &location,
+                memory_system_id,
+                MemoryRecallMode::OperatorInspection,
+            )?;
+            let Some(parsed_document) = maybe_parsed_document else {
+                if let Some(existing_row) = existing_row {
+                    delete_workspace_memory_document_index_row(conn, existing_row.document_id)?;
+                }
+                continue;
+            };
+
+            let maybe_entry = build_workspace_memory_document_index_entry(
+                workspace_root_key.as_str(),
+                &location,
+                modified_at_ms,
+                parsed_document,
+            )?;
+            let Some(entry) = maybe_entry else {
+                if let Some(existing_row) = existing_row {
+                    delete_workspace_memory_document_index_row(conn, existing_row.document_id)?;
+                }
+                continue;
+            };
+
+            upsert_workspace_memory_document_index_entry(
+                conn,
+                existing_row.as_ref().map(|row| row.document_id),
+                entry,
+            )?;
+        }
+
+        for stale_row in existing_rows.into_values() {
+            delete_workspace_memory_document_index_row(conn, stale_row.document_id)?;
+        }
+
+        Ok(())
+    })
+}
+
+pub(crate) fn search_workspace_memory_documents(
+    query: &str,
+    limit: usize,
+    workspace_root: &Path,
+    memory_system_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<WorkspaceMemoryIndexedSearchHit>, String> {
+    let Some(match_query) = crate::search_text::build_search_fts_query(query, 6) else {
+        return Ok(Vec::new());
+    };
+
+    sync_workspace_memory_search_index(workspace_root, memory_system_id, config)?;
+    let workspace_root_key = workspace_memory_root_key(workspace_root)?;
+    let runtime = acquire_memory_runtime(config)?;
+
+    runtime.with_connection("memory.search_workspace_memory_documents", |conn| {
+        ensure_workspace_memory_search_storage(conn)?;
+        let mut stmt = prepare_cached_sqlite_statement(
+            conn,
+            "SELECT doc.label,
+                    doc.path,
+                    doc.document_kind,
+                    doc.body,
+                    doc.body_line_offset,
+                    doc.freshness_ts,
+                    doc.content_hash,
+                    doc.record_status,
+                    doc.trust_level,
+                    doc.authority,
+                    doc.derived_kind,
+                    doc.superseded_by
+             FROM workspace_memory_documents_fts AS fts
+             JOIN workspace_memory_documents AS doc
+               ON doc.document_id = fts.rowid
+             WHERE workspace_memory_documents_fts MATCH ?1
+               AND doc.workspace_root = ?2
+             ORDER BY bm25(workspace_memory_documents_fts),
+                      COALESCE(doc.freshness_ts, 0) DESC,
+                      doc.label ASC
+             LIMIT ?3",
+            "prepare workspace memory search statement failed",
+        )?;
+        let mut rows = stmt
+            .query(rusqlite::params![
+                match_query,
+                workspace_root_key,
+                limit.clamp(1, 16) as i64
+            ])
+            .map_err(|error| format!("query workspace memory search failed: {error}"))?;
+        let mut hits = Vec::new();
+
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| format!("read workspace memory search row failed: {error}"))?
+        {
+            let label = row
+                .get::<_, String>(0)
+                .map_err(|error| format!("decode workspace memory label failed: {error}"))?;
+            let path = row
+                .get::<_, String>(1)
+                .map_err(|error| format!("decode workspace memory path failed: {error}"))?;
+            let document_kind_text = row.get::<_, String>(2).map_err(|error| {
+                format!("decode workspace memory document kind failed: {error}")
+            })?;
+            let Some(document_kind) =
+                WorkspaceMemoryDocumentKind::parse_id(document_kind_text.as_str())
+            else {
+                continue;
+            };
+            let body = row
+                .get::<_, String>(3)
+                .map_err(|error| format!("decode workspace memory body failed: {error}"))?;
+            let body_line_offset = row.get::<_, i64>(4).map_err(|error| {
+                format!("decode workspace memory body line offset failed: {error}")
+            })?;
+            let freshness_ts = row
+                .get::<_, Option<i64>>(5)
+                .map_err(|error| format!("decode workspace memory freshness failed: {error}"))?;
+            let content_hash = row
+                .get::<_, String>(6)
+                .map_err(|error| format!("decode workspace memory content hash failed: {error}"))?;
+            let record_status_text = row.get::<_, String>(7).map_err(|error| {
+                format!("decode workspace memory record status failed: {error}")
+            })?;
+            let Some(record_status) = MemoryRecordStatus::parse_id(record_status_text.as_str())
+            else {
+                continue;
+            };
+            let trust_level_text = row
+                .get::<_, String>(8)
+                .map_err(|error| format!("decode workspace memory trust level failed: {error}"))?;
+            let Some(trust_level) = MemoryTrustLevel::parse_id(trust_level_text.as_str()) else {
+                continue;
+            };
+            let authority_text = row
+                .get::<_, String>(9)
+                .map_err(|error| format!("decode workspace memory authority failed: {error}"))?;
+            let Some(authority) = MemoryAuthority::parse_id(authority_text.as_str()) else {
+                continue;
+            };
+            let derived_kind_text = row
+                .get::<_, String>(10)
+                .map_err(|error| format!("decode workspace memory derived kind failed: {error}"))?;
+            let Some(derived_kind) = DerivedMemoryKind::parse_id(derived_kind_text.as_str()) else {
+                continue;
+            };
+            let superseded_by = row.get::<_, Option<String>>(11).map_err(|error| {
+                format!("decode workspace memory superseded_by failed: {error}")
+            })?;
+            let body_line_offset = usize::try_from(body_line_offset).map_err(|error| {
+                format!("decode workspace memory body line offset failed: {error}")
+            })?;
+
+            hits.push(WorkspaceMemoryIndexedSearchHit {
+                label,
+                path,
+                document_kind,
+                body,
+                body_line_offset,
+                freshness_ts,
+                content_hash,
+                record_status,
+                trust_level,
+                authority,
+                derived_kind,
+                superseded_by,
+            });
+        }
+
+        Ok(hits)
+    })
 }
 
 fn ensure_approval_lifecycle_tables(conn: &Connection) -> Result<(), String> {
@@ -2117,6 +3057,7 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
           role TEXT NULL,
           content TEXT NOT NULL,
           metadata_json TEXT NOT NULL,
+          search_text TEXT NOT NULL DEFAULT '',
           ts INTEGER NOT NULL
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_canonical_records_session_turn
@@ -2131,6 +3072,7 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             kind,
             role,
             metadata_json,
+            search_text,
             content='memory_canonical_records',
             content_rowid='record_id'
           );
@@ -2144,7 +3086,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             new.record_id,
@@ -2153,7 +3096,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             new.scope,
             new.kind,
             COALESCE(new.role, ''),
-            new.metadata_json
+            new.metadata_json,
+            new.search_text
           );
         END;
         CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
@@ -2167,7 +3111,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             'delete',
@@ -2177,7 +3122,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             old.scope,
             old.kind,
             COALESCE(old.role, ''),
-            old.metadata_json
+            old.metadata_json,
+            old.search_text
           );
         END;
         CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
@@ -2191,7 +3137,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             'delete',
@@ -2201,7 +3148,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             old.scope,
             old.kind,
             COALESCE(old.role, ''),
-            old.metadata_json
+            old.metadata_json,
+            old.search_text
           );
           INSERT INTO memory_canonical_records_fts(
             rowid,
@@ -2210,7 +3158,8 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             new.record_id,
@@ -2219,12 +3168,24 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
             new.scope,
             new.kind,
             COALESCE(new.role, ''),
-            new.metadata_json
+            new.metadata_json,
+            new.search_text
           );
         END;
         ",
     )
     .map_err(|error| format!("ensure canonical memory storage failed: {error}"))?;
+
+    if !sqlite_table_has_column(conn, "memory_canonical_records", "search_text")? {
+        conn.execute(
+            "ALTER TABLE memory_canonical_records
+             ADD COLUMN search_text TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .map_err(|error| format!("add canonical memory search_text column failed: {error}"))?;
+    }
+
+    backfill_canonical_record_search_text(conn)?;
 
     let needs_canonical_fts_rebuild = canonical_record_fts_needs_rebuild(conn)?;
     if needs_canonical_fts_rebuild {
@@ -2233,6 +3194,62 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
     }
 
     rebuild_canonical_record_storage_if_needed(conn)?;
+
+    Ok(())
+}
+
+fn backfill_canonical_record_search_text(conn: &Connection) -> Result<(), String> {
+    let mut select_stmt = conn
+        .prepare(
+            "SELECT record_id, session_id, scope, kind, role, content, metadata_json
+             FROM memory_canonical_records
+             WHERE search_text = '' OR search_text IS NULL",
+        )
+        .map_err(|error| format!("prepare canonical search_text backfill failed: {error}"))?;
+    let rows = select_stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+            ))
+        })
+        .map_err(|error| format!("query canonical search_text backfill failed: {error}"))?;
+
+    let mut pending_updates = Vec::new();
+    for row in rows {
+        let (record_id, session_id, scope, kind, role, content, metadata_json) =
+            row.map_err(|error| {
+                format!("decode canonical search_text backfill row failed: {error}")
+            })?;
+        let search_text = canonical_record_search_text(
+            session_id.as_str(),
+            scope.as_str(),
+            kind.as_str(),
+            role.as_deref(),
+            content.as_str(),
+            metadata_json.as_str(),
+        );
+        pending_updates.push((record_id, search_text));
+    }
+    drop(select_stmt);
+
+    let mut update_stmt = conn
+        .prepare(
+            "UPDATE memory_canonical_records
+             SET search_text = ?2
+             WHERE record_id = ?1",
+        )
+        .map_err(|error| format!("prepare canonical search_text update failed: {error}"))?;
+    for (record_id, search_text) in pending_updates {
+        update_stmt
+            .execute(rusqlite::params![record_id, search_text])
+            .map_err(|error| format!("update canonical search_text failed: {error}"))?;
+    }
 
     Ok(())
 }
@@ -2250,6 +3267,7 @@ fn canonical_record_fts_needs_rebuild(conn: &Connection) -> Result<bool, String>
         "kind",
         "role",
         "metadata_json",
+        "search_text",
     ];
     let has_all_required_columns = required_columns.iter().all(|required_column| {
         columns
@@ -2285,6 +3303,7 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             kind,
             role,
             metadata_json,
+            search_text,
             content='memory_canonical_records',
             content_rowid='record_id'
           );
@@ -2298,7 +3317,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             new.record_id,
@@ -2307,7 +3327,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             new.scope,
             new.kind,
             COALESCE(new.role, ''),
-            new.metadata_json
+            new.metadata_json,
+            new.search_text
           );
         END;
         CREATE TRIGGER memory_canonical_records_ad
@@ -2321,7 +3342,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             'delete',
@@ -2331,7 +3353,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             old.scope,
             old.kind,
             COALESCE(old.role, ''),
-            old.metadata_json
+            old.metadata_json,
+            old.search_text
           );
         END;
         CREATE TRIGGER memory_canonical_records_au
@@ -2345,7 +3368,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             'delete',
@@ -2355,7 +3379,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             old.scope,
             old.kind,
             COALESCE(old.role, ''),
-            old.metadata_json
+            old.metadata_json,
+            old.search_text
           );
           INSERT INTO memory_canonical_records_fts(
             rowid,
@@ -2364,7 +3389,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             scope,
             kind,
             role,
-            metadata_json
+            metadata_json,
+            search_text
           )
           VALUES (
             new.record_id,
@@ -2373,7 +3399,8 @@ fn create_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
             new.scope,
             new.kind,
             COALESCE(new.role, ''),
-            new.metadata_json
+            new.metadata_json,
+            new.search_text
           );
         END;
         ",
@@ -2393,7 +3420,8 @@ fn rebuild_canonical_record_fts_index_contents(conn: &Connection) -> Result<(), 
           scope,
           kind,
           role,
-          metadata_json
+          metadata_json,
+          search_text
         )
         SELECT
           record_id,
@@ -2402,7 +3430,8 @@ fn rebuild_canonical_record_fts_index_contents(conn: &Connection) -> Result<(), 
           scope,
           kind,
           COALESCE(role, ''),
-          metadata_json
+          metadata_json,
+          search_text
         FROM memory_canonical_records
         ",
         [],
@@ -3935,41 +4964,7 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
 }
 
 fn build_canonical_fts_query(query: &str) -> Option<String> {
-    let mut terms = Vec::new();
-    let mut current = String::new();
-    let push_term = |value: &mut String, terms: &mut Vec<String>| {
-        let trimmed = value.trim();
-        if trimmed.chars().count() >= 2 {
-            let candidate = trimmed.to_owned();
-            if !terms.contains(&candidate) {
-                terms.push(candidate);
-            }
-        }
-        value.clear();
-    };
-
-    for ch in query.chars() {
-        if ch.is_alphanumeric() || ch == '_' || ch == '-' {
-            current.push(ch);
-        } else if !current.is_empty() {
-            push_term(&mut current, &mut terms);
-        }
-    }
-    if !current.is_empty() {
-        push_term(&mut current, &mut terms);
-    }
-
-    if terms.is_empty() {
-        return None;
-    }
-
-    let query = terms
-        .into_iter()
-        .take(6)
-        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
-        .collect::<Vec<_>>()
-        .join(" OR ");
-    if query.is_empty() { None } else { Some(query) }
+    crate::search_text::build_search_fts_query(query, 6)
 }
 
 pub(super) fn search_canonical_records_for_recall(
@@ -5380,6 +6375,92 @@ mod tests {
             .expect("session_terminal_outcomes columns");
 
         assert!(columns.iter().any(|column| column == "frozen_result_json"));
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_memory_db_ready_repairs_session_event_search_storage() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-session-event-search-storage-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("session-event-search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let conn = Connection::open(&db_path).expect("open legacy sqlite db");
+        configure_sqlite_connection(&conn).expect("configure legacy sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE turns(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              ts INTEGER NOT NULL
+            );
+            CREATE INDEX idx_turns_session_id ON turns(session_id, id);
+            CREATE TABLE session_events(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              event_kind TEXT NOT NULL,
+              actor_session_id TEXT NULL,
+              payload_json TEXT NOT NULL,
+              ts INTEGER NOT NULL
+            );
+            INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, ts)
+            VALUES ('root-session', 'memory_indexed', NULL, '{\"summary\":\"中文分词已经启用\"}', 100);
+            PRAGMA user_version = 10;
+            ",
+        )
+        .expect("create legacy session event schema");
+        drop(conn);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        ensure_memory_db_ready(Some(db_path.clone()), &config).expect("repair sqlite db");
+
+        let conn = Connection::open(&db_path).expect("open repaired sqlite db");
+        let columns =
+            sqlite_table_columns(&conn, "session_events").expect("session_events columns");
+        assert!(columns.iter().any(|column| column == "search_text"));
+
+        let search_text = conn
+            .query_row(
+                "SELECT search_text FROM session_events WHERE id = 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("load session event search_text");
+        assert!(search_text.contains("中文"), "search_text={search_text}");
+        assert!(search_text.contains("分词"), "search_text={search_text}");
+
+        let match_query = crate::search_text::build_search_fts_query("中文 分词", 6)
+            .expect("session event search query");
+        let fts_count = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events_fts WHERE session_events_fts MATCH ?1",
+                rusqlite::params![match_query],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("query session event FTS");
+        assert_eq!(fts_count, 1);
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);
@@ -9026,6 +10107,41 @@ mod tests {
         assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
         assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
         assert_eq!(hits[0].record.metadata["source"], "workspace-import");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn canonical_memory_search_matches_segmented_chinese_queries() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-chinese-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("canonical-chinese-search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(
+            "workspace-session",
+            "assistant",
+            "中文分词用于数据库搜索和记忆召回。",
+            &config,
+        )
+        .expect("append chinese canonical payload");
+
+        let hits = search_canonical_records_for_recall("中文 分词", 4, None, &config)
+            .expect("search canonical memory by segmented chinese query");
+
+        assert_eq!(hits.len(), 1, "hits={hits:?}");
+        assert_eq!(hits[0].record.session_id, "workspace-session");
+        assert!(hits[0].record.content.contains("数据库搜索"));
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -180,6 +180,16 @@ impl MemoryTrustLevel {
             Self::WorkspaceLog => "workspace_log",
         }
     }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "session" => Some(Self::Session),
+            "derived" => Some(Self::Derived),
+            "workspace_curated" => Some(Self::WorkspaceCurated),
+            "workspace_log" => Some(Self::WorkspaceLog),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -194,6 +204,14 @@ impl MemoryAuthority {
         match self {
             Self::Advisory => "advisory",
             Self::IdentityForbidden => "identity_forbidden",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "advisory" => Some(Self::Advisory),
+            "identity_forbidden" => Some(Self::IdentityForbidden),
+            _ => None,
         }
     }
 }
@@ -214,6 +232,16 @@ impl MemoryRecordStatus {
             Self::Superseded => "superseded",
             Self::Tombstoned => "tombstoned",
             Self::Archived => "archived",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "active" => Some(Self::Active),
+            "superseded" => Some(Self::Superseded),
+            "tombstoned" => Some(Self::Tombstoned),
+            "archived" => Some(Self::Archived),
+            _ => None,
         }
     }
 

--- a/crates/app/src/memory/workspace_document.rs
+++ b/crates/app/src/memory/workspace_document.rs
@@ -220,14 +220,7 @@ fn resolve_workspace_memory_trust(
     source_label: &str,
 ) -> Result<MemoryTrustLevel, String> {
     if let Some(trust_text) = frontmatter.trust.as_deref() {
-        let maybe_parsed_trust = match trust_text {
-            "session" => Some(MemoryTrustLevel::Session),
-            "derived" => Some(MemoryTrustLevel::Derived),
-            "workspace_curated" => Some(MemoryTrustLevel::WorkspaceCurated),
-            "workspace_log" => Some(MemoryTrustLevel::WorkspaceLog),
-            _ => None,
-        };
-        let Some(parsed_trust) = maybe_parsed_trust else {
+        let Some(parsed_trust) = MemoryTrustLevel::parse_id(trust_text) else {
             return Err(format!(
                 "workspace memory file {source_label} declares unsupported frontmatter trust `{trust_text}`"
             ));
@@ -251,14 +244,7 @@ fn resolve_workspace_memory_status(
         return Ok(MemoryRecordStatus::Active);
     };
 
-    let maybe_parsed_status = match status_text {
-        "active" => Some(MemoryRecordStatus::Active),
-        "superseded" => Some(MemoryRecordStatus::Superseded),
-        "tombstoned" => Some(MemoryRecordStatus::Tombstoned),
-        "archived" => Some(MemoryRecordStatus::Archived),
-        _ => None,
-    };
-    let Some(parsed_status) = maybe_parsed_status else {
+    let Some(parsed_status) = MemoryRecordStatus::parse_id(status_text) else {
         return Err(format!(
             "workspace memory file {source_label} declares unsupported frontmatter status `{status_text}`"
         ));

--- a/crates/app/src/memory/workspace_files.rs
+++ b/crates/app/src/memory/workspace_files.rs
@@ -14,6 +14,23 @@ pub(crate) enum WorkspaceMemoryDocumentKind {
     DailyLog,
 }
 
+impl WorkspaceMemoryDocumentKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Curated => "curated",
+            Self::DailyLog => "daily_log",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "curated" => Some(Self::Curated),
+            "daily_log" => Some(Self::DailyLog),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceMemoryDocumentLocation {
     pub label: String,

--- a/crates/app/src/search_text.rs
+++ b/crates/app/src/search_text.rs
@@ -1,0 +1,287 @@
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use jieba_rs::Jieba;
+use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::char::is_combining_mark;
+use unicode_segmentation::UnicodeSegmentation;
+
+pub(crate) fn normalize_search_text(raw: &str) -> String {
+    let compatibility = raw.nfkc().collect::<String>();
+    let lowercased = compatibility.to_lowercase();
+
+    let mut normalized = String::new();
+    let mut last_was_space = false;
+
+    for character in lowercased.nfd() {
+        if is_combining_mark(character) {
+            continue;
+        }
+
+        let normalized_character = if character.is_whitespace() {
+            ' '
+        } else {
+            character
+        };
+        if normalized_character == ' ' {
+            if last_was_space {
+                continue;
+            }
+
+            last_was_space = true;
+            normalized.push(' ');
+            continue;
+        }
+
+        last_was_space = false;
+        normalized.push(normalized_character);
+    }
+
+    normalized.trim().to_owned()
+}
+
+#[cfg(test)]
+pub(crate) fn tokenize_search_text(raw: &str) -> Vec<String> {
+    let normalized = normalize_search_text(raw);
+    tokenize_normalized_search_text(normalized.as_str())
+}
+
+pub(crate) fn tokenize_normalized_search_text(normalized: &str) -> Vec<String> {
+    let surface = identifier_phrase_variant(normalized);
+    let mut tokens = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for word in UnicodeSegmentation::unicode_words(surface.as_str()) {
+        push_search_token(word, &mut tokens, &mut seen);
+    }
+
+    for han_sequence in extract_han_sequences(surface.as_str()) {
+        for token in jieba().cut_for_search(han_sequence.as_str(), true) {
+            push_search_token(token, &mut tokens, &mut seen);
+        }
+    }
+
+    tokens
+}
+
+pub(crate) fn build_search_fts_query(raw_query: &str, max_terms: usize) -> Option<String> {
+    let normalized_query = normalize_search_text(raw_query);
+    let trimmed_query = normalized_query.trim();
+    if trimmed_query.is_empty() {
+        return None;
+    }
+
+    let mut terms = Vec::new();
+    let mut seen_terms = BTreeSet::new();
+
+    push_quoted_fts_term(trimmed_query, &mut terms, &mut seen_terms);
+    for token in tokenize_normalized_search_text(trimmed_query)
+        .into_iter()
+        .take(max_terms)
+    {
+        push_quoted_fts_term(token.as_str(), &mut terms, &mut seen_terms);
+    }
+
+    if terms.is_empty() {
+        None
+    } else {
+        Some(terms.join(" OR "))
+    }
+}
+
+pub(crate) fn build_search_index_text(fragments: &[&str]) -> String {
+    let mut tokens = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for fragment in fragments {
+        let normalized = normalize_search_text(fragment);
+        if normalized.is_empty() {
+            continue;
+        }
+
+        for token in tokenize_normalized_search_text(normalized.as_str()) {
+            if seen.insert(token.clone()) {
+                tokens.push(token);
+            }
+        }
+    }
+
+    tokens.join(" ")
+}
+
+fn push_search_token(token: &str, tokens: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let normalized = normalize_search_text(trimmed);
+    if !should_keep_token(normalized.as_str()) {
+        return;
+    }
+
+    if seen.insert(normalized.clone()) {
+        tokens.push(normalized);
+    }
+}
+
+fn push_quoted_fts_term(term: &str, terms: &mut Vec<String>, seen_terms: &mut BTreeSet<String>) {
+    if term.is_empty() {
+        return;
+    }
+
+    let escaped_term = term.replace('"', "\"\"");
+    let quoted_term = format!("\"{escaped_term}\"");
+    if seen_terms.insert(quoted_term.clone()) {
+        terms.push(quoted_term);
+    }
+}
+
+fn should_keep_token(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+
+    let ascii_token = token
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric());
+    if ascii_token {
+        return token.len() >= 2;
+    }
+
+    token.chars().count() >= 2
+}
+
+fn identifier_phrase_variant(raw: &str) -> String {
+    let mut surface = String::with_capacity(raw.len());
+    let mut last_was_space = false;
+
+    for character in raw.chars() {
+        let normalized_character = if is_identifier_separator(character) {
+            ' '
+        } else {
+            character
+        };
+        if normalized_character.is_whitespace() {
+            if last_was_space {
+                continue;
+            }
+
+            last_was_space = true;
+            surface.push(' ');
+            continue;
+        }
+
+        last_was_space = false;
+        surface.push(normalized_character);
+    }
+
+    surface.trim().to_owned()
+}
+
+fn is_identifier_separator(character: char) -> bool {
+    matches!(
+        character,
+        '.' | '_' | '-' | '/' | '\\' | ':' | ',' | ';' | '|' | '(' | ')' | '[' | ']'
+    )
+}
+
+fn extract_han_sequences(raw: &str) -> Vec<String> {
+    let mut sequences = Vec::new();
+    let mut current = String::new();
+
+    for character in raw.chars() {
+        if is_han_character(character) {
+            current.push(character);
+            continue;
+        }
+
+        if !current.is_empty() {
+            sequences.push(std::mem::take(&mut current));
+        }
+    }
+
+    if !current.is_empty() {
+        sequences.push(current);
+    }
+
+    sequences
+}
+
+fn is_han_character(character: char) -> bool {
+    matches!(
+        u32::from(character),
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x20000..=0x2A6DF
+            | 0x2A700..=0x2B73F
+            | 0x2B740..=0x2B81F
+            | 0x2B820..=0x2CEAF
+            | 0x2CEB0..=0x2EBEF
+            | 0x30000..=0x3134F
+    )
+}
+
+fn jieba() -> &'static Jieba {
+    static JIEBA: OnceLock<Jieba> = OnceLock::new();
+    JIEBA.get_or_init(Jieba::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_search_text_folds_fullwidth_and_combining_marks() {
+        let normalized = normalize_search_text("Ｂúsqueda　中文分词");
+        assert_eq!(normalized, "busqueda 中文分词");
+    }
+
+    #[test]
+    fn tokenize_search_text_uses_jieba_for_han_queries() {
+        let tokens = tokenize_search_text("中文分词");
+
+        assert!(
+            tokens.iter().any(|token| token == "中文"),
+            "tokens={tokens:?}"
+        );
+        assert!(
+            tokens.iter().any(|token| token == "分词"),
+            "tokens={tokens:?}"
+        );
+    }
+
+    #[test]
+    fn build_search_fts_query_includes_segmented_han_terms() {
+        let query = build_search_fts_query("中文分词", 6).expect("fts query");
+
+        assert!(query.contains("\"中文分词\""), "query={query}");
+        assert!(query.contains("\"中文\""), "query={query}");
+        assert!(query.contains("\"分词\""), "query={query}");
+    }
+
+    #[test]
+    fn build_search_index_text_joins_segmented_terms() {
+        let index_text = build_search_index_text(&["中文分词用于数据库搜索", "memory_indexed"]);
+
+        assert!(index_text.contains("中文"), "index_text={index_text}");
+        assert!(index_text.contains("分词"), "index_text={index_text}");
+        assert!(index_text.contains("数据库"), "index_text={index_text}");
+        assert!(index_text.contains("memory"), "index_text={index_text}");
+        assert!(index_text.contains("indexed"), "index_text={index_text}");
+    }
+
+    #[test]
+    fn build_search_index_text_segments_chinese_inside_mixed_payloads() {
+        let index_text = build_search_index_text(&[
+            "{\"summary\":\"中文分词已经启用\"}",
+            "event_kind=memory_indexed",
+        ]);
+
+        assert!(index_text.contains("中文"), "index_text={index_text}");
+        assert!(index_text.contains("分词"), "index_text={index_text}");
+        assert!(index_text.contains("启用"), "index_text={index_text}");
+        assert!(index_text.contains("memory"), "index_text={index_text}");
+    }
+}

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::{
-    Connection, OptionalExtension, Transaction, TransactionBehavior, params, params_from_iter,
-};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde_json::Value;
 
 use super::frozen_result::FrozenResult;
@@ -12,6 +10,7 @@ use crate::config::ToolConsentMode;
 use crate::memory;
 use crate::memory::ConversationTurn;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::search_text::{build_search_index_text, normalize_search_text};
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
 pub(crate) const SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE: usize = 200;
@@ -756,6 +755,8 @@ impl SessionRepository {
         let event_payload_json = request.event_payload_json;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session transition event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), encoded_event_payload.as_str());
         let ts = unix_ts_now();
 
         let mut conn = self.open_connection()?;
@@ -783,13 +784,14 @@ impl SessionRepository {
         }
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id,
                 event_kind,
                 actor_session_id.as_deref(),
                 encoded_event_payload,
+                event_search_text,
                 ts
             ],
         )
@@ -826,6 +828,8 @@ impl SessionRepository {
         let event_payload_json = request.event_payload_json;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session transition event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), encoded_event_payload.as_str());
         let ts = unix_ts_now();
 
         let mut conn = self.open_connection()?;
@@ -858,13 +862,14 @@ impl SessionRepository {
         .map_err(|error| format!("clear session terminal outcome failed: {error}"))?;
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id,
                 event_kind,
                 actor_session_id.as_deref(),
                 encoded_event_payload,
+                event_search_text,
                 ts
             ],
         )
@@ -1183,7 +1188,8 @@ impl SessionRepository {
         limit: usize,
     ) -> Result<Vec<SessionSearchRecord>, String> {
         let session_id = normalize_required_text(session_id, "session_id")?;
-        let normalized_query = normalize_required_text(query, "query")?.to_ascii_lowercase();
+        let raw_query = normalize_required_text(query, "query")?;
+        let normalized_query = normalize_search_text(raw_query.as_str());
         let conn = self.open_connection()?;
         Self::search_session_content_with_conn(&conn, &session_id, &normalized_query, limit)
     }
@@ -2384,6 +2390,8 @@ impl SessionRepository {
         let frozen_result = request.frozen_result;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), encoded_event_payload.as_str());
         let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
             .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
         let encoded_frozen_result = encode_optional_frozen_result(&frozen_result)?;
@@ -2413,13 +2421,14 @@ impl SessionRepository {
         }
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id,
                 event_kind,
                 actor_session_id.as_deref(),
                 encoded_event_payload,
+                event_search_text,
                 ts
             ],
         )
@@ -2490,6 +2499,8 @@ impl SessionRepository {
         let frozen_result = request.frozen_result;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session terminal event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), encoded_event_payload.as_str());
         let encoded_outcome_payload = serde_json::to_string(&outcome_payload_json)
             .map_err(|error| format!("encode session terminal outcome payload failed: {error}"))?;
         let encoded_frozen_result = encode_optional_frozen_result(&frozen_result)?;
@@ -2520,13 +2531,14 @@ impl SessionRepository {
         }
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id,
                 event_kind,
                 actor_session_id.as_deref(),
                 encoded_event_payload,
+                event_search_text,
                 ts
             ],
         )
@@ -2593,6 +2605,8 @@ impl SessionRepository {
         let ts = unix_ts_now();
         let payload_json = serde_json::to_string(&event.payload_json)
             .map_err(|error| format!("encode session event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), payload_json.as_str());
         let actor_session_id = normalize_optional_text(event.actor_session_id);
 
         let conn = self.open_connection()?;
@@ -2609,9 +2623,16 @@ impl SessionRepository {
 
         conn.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![session_id, event_kind, actor_session_id, payload_json, ts],
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json,
+                event_search_text,
+                ts,
+            ],
         )
         .map_err(|error| format!("insert session event failed: {error}"))?;
 
@@ -2636,6 +2657,8 @@ impl SessionRepository {
         let payload_value = event.payload_json;
         let payload_json = serde_json::to_string(&payload_value)
             .map_err(|error| format!("encode session event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), payload_json.as_str());
 
         let mut conn = self.open_connection()?;
         let tx = conn
@@ -2663,13 +2686,14 @@ impl SessionRepository {
 
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id.as_str(),
                 event_kind.as_str(),
                 actor_session_id.as_deref(),
                 payload_json.as_str(),
+                event_search_text.as_str(),
                 ts,
             ],
         )
@@ -2705,6 +2729,8 @@ impl SessionRepository {
         let event_payload_json = request.event_payload_json;
         let encoded_event_payload = serde_json::to_string(&event_payload_json)
             .map_err(|error| format!("encode session event payload failed: {error}"))?;
+        let event_search_text =
+            session_event_search_text(event_kind.as_str(), encoded_event_payload.as_str());
         let ts = unix_ts_now();
 
         tx.execute(
@@ -2724,13 +2750,14 @@ impl SessionRepository {
         .map_err(|error| format!("insert session row failed: {error}"))?;
         tx.execute(
             "INSERT INTO session_events(
-                session_id, event_kind, actor_session_id, payload_json, ts
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                session_id, event_kind, actor_session_id, payload_json, search_text, ts
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 session_id,
                 event_kind,
                 actor_session_id.as_deref(),
                 encoded_event_payload,
+                event_search_text,
                 ts
             ],
         )
@@ -3137,27 +3164,17 @@ impl SessionRepository {
             return Ok(Vec::new());
         }
 
-        let turn_match_query = build_search_fts_query(normalized_query);
-        let patterns = build_search_like_patterns(normalized_query);
-        if turn_match_query.is_none() && patterns.is_empty() {
+        let Some(match_query) = build_search_fts_query(normalized_query) else {
             return Ok(Vec::new());
-        }
+        };
 
         let mut hits = Vec::new();
-        if let Some(turn_match_query) = turn_match_query.as_deref() {
-            let turn_hits =
-                Self::search_session_turns_with_conn(conn, session_id, turn_match_query, limit)?;
-            hits.extend(turn_hits);
-        }
-        if !patterns.is_empty() {
-            let event_hits = Self::search_session_events_with_conn(
-                conn,
-                session_id,
-                patterns.as_slice(),
-                limit,
-            )?;
-            hits.extend(event_hits);
-        }
+        let turn_hits =
+            Self::search_session_turns_with_conn(conn, session_id, &match_query, limit)?;
+        hits.extend(turn_hits);
+        let event_hits =
+            Self::search_session_events_with_conn(conn, session_id, &match_query, limit)?;
+        hits.extend(event_hits);
         Ok(hits)
     }
 
@@ -3221,32 +3238,30 @@ impl SessionRepository {
     fn search_session_events_with_conn(
         conn: &Connection,
         session_id: &str,
-        patterns: &[String],
+        match_query: &str,
         limit: usize,
     ) -> Result<Vec<SessionSearchRecord>, String> {
-        let where_clause = build_search_where_clause(
-            "lower(event_kind || ' ' || payload_json)",
-            patterns.len(),
-            2,
-        );
-        let sql = format!(
-            "SELECT id, session_id, event_kind, payload_json, ts
-             FROM session_events
-             WHERE session_id = ?1
-               AND ({where_clause})
-             ORDER BY id DESC
-             LIMIT {limit}"
-        );
-
         let mut stmt = conn
-            .prepare(sql.as_str())
+            .prepare(
+                "SELECT event.id,
+                        event.session_id,
+                        event.event_kind,
+                        event.payload_json,
+                        event.ts
+                 FROM session_events_fts AS fts
+                 JOIN session_events AS event
+                   ON event.id = fts.rowid
+                 WHERE session_events_fts MATCH ?1
+                   AND event.session_id = ?2
+                 ORDER BY bm25(session_events_fts),
+                          event.ts DESC,
+                          event.id DESC
+                 LIMIT ?3",
+            )
             .map_err(|error| format!("prepare session search events query failed: {error}"))?;
-        let mut bindings = Vec::with_capacity(patterns.len().saturating_add(1));
-        bindings.push(session_id.to_owned());
-        bindings.extend(patterns.iter().cloned());
 
         let rows = stmt
-            .query_map(params_from_iter(bindings.iter()), |row| {
+            .query_map(params![match_query, session_id, limit as i64], |row| {
                 Ok(RawSessionSearchEventRecord {
                     id: row.get(0)?,
                     session_id: row.get(1)?,
@@ -3839,87 +3854,12 @@ fn sort_session_summaries(sessions: &mut [SessionSummaryRecord]) {
     });
 }
 
-fn build_search_where_clause(
-    expression: &str,
-    pattern_count: usize,
-    first_placeholder_index: usize,
-) -> String {
-    let mut clauses = Vec::with_capacity(pattern_count);
-    for offset in 0..pattern_count {
-        let placeholder = first_placeholder_index.saturating_add(offset);
-        clauses.push(format!("{expression} LIKE ?{placeholder} ESCAPE '\\'"));
-    }
-    clauses.join(" OR ")
-}
-
-fn build_search_like_patterns(normalized_query: &str) -> Vec<String> {
-    let mut patterns = Vec::new();
-    patterns.push(like_pattern(normalized_query));
-
-    for token in tokenize_search_query(normalized_query) {
-        let pattern = like_pattern(token.as_str());
-        if patterns.iter().any(|existing| existing == &pattern) {
-            continue;
-        }
-        patterns.push(pattern);
-    }
-
-    patterns
-}
-
 fn build_search_fts_query(normalized_query: &str) -> Option<String> {
-    let trimmed_query = normalized_query.trim();
-    if trimmed_query.is_empty() {
-        return None;
-    }
-
-    let mut terms = Vec::new();
-    let mut seen_terms = BTreeSet::new();
-
-    let escaped_query = trimmed_query.replace('"', "\"\"");
-    let quoted_query = format!("\"{escaped_query}\"");
-    if seen_terms.insert(quoted_query.clone()) {
-        terms.push(quoted_query);
-    }
-
-    for token in tokenize_search_query(normalized_query).into_iter().take(6) {
-        let escaped_token = token.replace('"', "\"\"");
-        let quoted_token = format!("\"{escaped_token}\"");
-        if seen_terms.insert(quoted_token.clone()) {
-            terms.push(quoted_token);
-        }
-    }
-
-    if terms.is_empty() {
-        return None;
-    }
-
-    Some(terms.join(" OR "))
+    crate::search_text::build_search_fts_query(normalized_query, 6)
 }
 
-fn tokenize_search_query(query: &str) -> Vec<String> {
-    query
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
-fn like_pattern(raw: &str) -> String {
-    let mut escaped = String::with_capacity(raw.len().saturating_add(4));
-    escaped.push('%');
-    for ch in raw.chars() {
-        match ch {
-            '%' | '_' | '\\' => {
-                escaped.push('\\');
-                escaped.push(ch);
-            }
-            _ => escaped.push(ch),
-        }
-    }
-    escaped.push('%');
-    escaped
+fn session_event_search_text(event_kind: &str, payload_json: &str) -> String {
+    build_search_index_text(&[event_kind, payload_json])
 }
 
 #[cfg(test)]

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -6,9 +6,10 @@ use serde_json::{Map, Value, json};
 
 use crate::memory::{
     MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
-    ParsedWorkspaceMemoryDocument, WorkspaceMemoryDocumentLocation,
+    ParsedWorkspaceMemoryDocument, WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
     collect_workspace_memory_document_locations, parse_workspace_memory_document,
 };
+use crate::search_text::{normalize_search_text, tokenize_normalized_search_text};
 
 const DEFAULT_MEMORY_SEARCH_MAX_RESULTS: usize = 5;
 const MAX_MEMORY_SEARCH_RESULTS: usize = 8;
@@ -70,23 +71,33 @@ pub(super) fn execute_memory_search_tool_with_config(
         Some(MAX_MEMORY_SEARCH_RESULTS),
     )?;
 
-    let query_normalized = query.to_ascii_lowercase();
+    let query_normalized = normalize_search_text(query);
     let query_tokens = tokenize_memory_query(query_normalized.as_str());
 
     let mut results = Vec::new();
     if let Some(workspace_root) = config.file_root.as_deref() {
-        let locations = collect_workspace_memory_document_locations(workspace_root)?;
-        for location in locations {
-            let maybe_result = search_memory_location(
-                query_normalized.as_str(),
-                query_tokens.as_slice(),
-                config,
-                &location,
-            )?;
-            let Some(result) = maybe_result else {
-                continue;
-            };
-            results.push(result);
+        if let Some(indexed_results) = search_indexed_workspace_memory_results(
+            query_normalized.as_str(),
+            query_tokens.as_slice(),
+            max_results,
+            config,
+            workspace_root,
+        )? {
+            results.extend(indexed_results);
+        } else {
+            let locations = collect_workspace_memory_document_locations(workspace_root)?;
+            for location in locations {
+                let maybe_result = search_memory_location(
+                    query_normalized.as_str(),
+                    query_tokens.as_slice(),
+                    config,
+                    &location,
+                )?;
+                let Some(result) = maybe_result else {
+                    continue;
+                };
+                results.push(result);
+            }
         }
     }
     results.extend(search_canonical_memory_results(
@@ -372,35 +383,59 @@ fn search_memory_location(
         return Ok(None);
     }
 
-    let maybe_match = best_line_match(query, query_tokens, lines.as_slice());
-    let Some(best_match) = maybe_match else {
+    let scope = parsed_document
+        .provenance
+        .scope
+        .map(|scope| scope.as_str().to_owned());
+    let kind = parsed_document
+        .provenance
+        .derived_kind
+        .map(|kind| kind.as_str().to_owned());
+    let metadata = memory_document_metadata_payload(&parsed_document);
+    let metadata_score = workspace_memory_match_score(
+        query,
+        query_tokens,
+        location.label.as_str(),
+        scope.as_deref(),
+        kind.as_deref(),
+        &metadata,
+    );
+    let best_body_match = best_line_match(query, query_tokens, lines.as_slice());
+    let focus_line = best_body_match
+        .map(|matched| matched.line_number)
+        .or_else(|| (metadata_score > 0).then_some(1));
+    let Some(focus_line) = focus_line else {
         return Ok(None);
     };
 
     let total_lines = lines.len();
     let context_radius = MEMORY_SEARCH_CONTEXT_RADIUS_LINES;
-    let (start_line, end_line) =
-        snippet_window(total_lines, best_match.line_number, context_radius);
+    let (start_line, end_line) = snippet_window(total_lines, focus_line, context_radius);
     let start_index = start_line.saturating_sub(1);
     let end_index = end_line;
     let snippet_lines = lines
         .get(start_index..end_index)
         .ok_or_else(|| "memory_search selected snippet window is out of bounds".to_owned())?;
     let snippet = snippet_lines.join("\n");
+    let score = best_body_match
+        .map(|matched| matched.score)
+        .unwrap_or(0)
+        .max(metadata_score)
+        .max(1);
 
     let result = MemorySearchResult {
         source: "workspace_file",
         path: Some(location.label.clone()),
         session_id: None,
-        scope: None,
-        kind: None,
+        scope,
+        kind,
         role: None,
         start_line: Some(start_line),
         end_line: Some(end_line),
         snippet,
-        score: best_match.score,
+        score,
         provenance: parsed_document.provenance.clone(),
-        metadata: Some(memory_document_metadata_payload(&parsed_document)),
+        metadata: Some(metadata),
     };
 
     Ok(Some(result))
@@ -434,7 +469,7 @@ fn best_line_match(query: &str, query_tokens: &[String], lines: &[&str]) -> Opti
 }
 
 fn line_match_score(query: &str, query_tokens: &[String], line: &str) -> u32 {
-    let normalized_line = line.to_ascii_lowercase();
+    let normalized_line = normalize_search_text(line);
     let mut score = 0u32;
 
     if normalized_line.contains(query) {
@@ -457,12 +492,7 @@ fn line_match_score(query: &str, query_tokens: &[String], line: &str) -> u32 {
 }
 
 fn tokenize_memory_query(query: &str) -> Vec<String> {
-    query
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-        .map(str::to_owned)
-        .collect()
+    tokenize_normalized_search_text(query)
 }
 
 fn snippet_window(total_lines: usize, focus_line: usize, context_radius: usize) -> (usize, usize) {
@@ -592,6 +622,189 @@ fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
         "score": result.score,
         "provenance": result.provenance,
         "metadata": result.metadata,
+    })
+}
+
+fn workspace_memory_match_score(
+    query: &str,
+    query_tokens: &[String],
+    label: &str,
+    scope: Option<&str>,
+    kind: Option<&str>,
+    metadata: &Value,
+) -> u32 {
+    let label_score = line_match_score(query, query_tokens, label);
+    let scope_score = scope
+        .map(|scope| line_match_score(query, query_tokens, scope))
+        .unwrap_or(0);
+    let kind_score = kind
+        .map(|kind| line_match_score(query, query_tokens, kind))
+        .unwrap_or(0);
+    let metadata_text = metadata.to_string();
+    let metadata_score = line_match_score(query, query_tokens, metadata_text.as_str());
+
+    label_score
+        .max(scope_score)
+        .max(kind_score)
+        .max(metadata_score)
+}
+
+fn search_indexed_workspace_memory_results(
+    query: &str,
+    query_tokens: &[String],
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+    workspace_root: &Path,
+) -> Result<Option<Vec<MemorySearchResult>>, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (query, query_tokens, max_results, config, workspace_root);
+        Ok(None)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let Some(sqlite_path) = config.memory_sqlite_path.as_ref() else {
+            return Ok(None);
+        };
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(sqlite_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        let hits = crate::memory::search_workspace_memory_documents(
+            query,
+            max_results,
+            workspace_root,
+            config.selected_memory_system_id.as_str(),
+            &memory_config,
+        )?;
+
+        let mut results = Vec::new();
+        for hit in hits {
+            let maybe_result =
+                indexed_workspace_memory_hit_to_result(query, query_tokens, config, &hit)?;
+            let Some(result) = maybe_result else {
+                continue;
+            };
+            results.push(result);
+        }
+
+        Ok(Some(results))
+    }
+}
+
+fn indexed_workspace_memory_hit_to_result(
+    query: &str,
+    query_tokens: &[String],
+    config: &super::runtime_config::ToolRuntimeConfig,
+    hit: &crate::memory::WorkspaceMemoryIndexedSearchHit,
+) -> Result<Option<MemorySearchResult>, String> {
+    let lines = hit.body.lines().collect::<Vec<_>>();
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    let scope = workspace_memory_scope(hit.document_kind)
+        .as_str()
+        .to_owned();
+    let kind = hit.derived_kind.as_str().to_owned();
+    let metadata = indexed_workspace_memory_metadata_payload(hit);
+    let metadata_score = workspace_memory_match_score(
+        query,
+        query_tokens,
+        hit.label.as_str(),
+        Some(scope.as_str()),
+        Some(kind.as_str()),
+        &metadata,
+    );
+    let best_body_match = best_line_match(query, query_tokens, lines.as_slice());
+    let focus_line = best_body_match
+        .map(|matched| matched.line_number)
+        .or_else(|| (metadata_score > 0).then_some(1));
+    let Some(focus_line) = focus_line else {
+        return Ok(None);
+    };
+    let total_lines = lines.len();
+    let (start_line, end_line) =
+        snippet_window(total_lines, focus_line, MEMORY_SEARCH_CONTEXT_RADIUS_LINES);
+    let snippet_lines = lines
+        .get(start_line.saturating_sub(1)..end_line)
+        .ok_or_else(|| {
+            "memory_search selected indexed workspace snippet window is out of bounds".to_owned()
+        })?;
+    let snippet = snippet_lines.join("\n");
+    let score = best_body_match
+        .map(|matched| matched.score)
+        .unwrap_or(0)
+        .max(metadata_score)
+        .max(1);
+
+    Ok(Some(MemorySearchResult {
+        source: "workspace_file",
+        path: Some(hit.label.clone()),
+        session_id: None,
+        scope: Some(scope),
+        kind: Some(kind),
+        role: None,
+        start_line: Some(start_line),
+        end_line: Some(end_line),
+        snippet,
+        score,
+        provenance: indexed_workspace_memory_hit_provenance(config, hit),
+        metadata: Some(metadata),
+    }))
+}
+
+fn workspace_memory_scope(
+    document_kind: WorkspaceMemoryDocumentKind,
+) -> crate::memory::MemoryScope {
+    match document_kind {
+        WorkspaceMemoryDocumentKind::Curated => crate::memory::MemoryScope::Workspace,
+        WorkspaceMemoryDocumentKind::DailyLog => crate::memory::MemoryScope::Session,
+    }
+}
+
+fn indexed_workspace_memory_hit_provenance(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    hit: &crate::memory::WorkspaceMemoryIndexedSearchHit,
+) -> MemoryContextProvenance {
+    let scope = Some(workspace_memory_scope(hit.document_kind));
+
+    let mut provenance = MemoryContextProvenance::new(
+        config.selected_memory_system_id.as_str(),
+        MemoryProvenanceSourceKind::WorkspaceDocument,
+        Some(hit.label.clone()),
+        Some(hit.path.clone()),
+        scope,
+        MemoryRecallMode::OperatorInspection,
+    )
+    .with_trust_level(hit.trust_level)
+    .with_authority(hit.authority)
+    .with_derived_kind(hit.derived_kind)
+    .with_content_hash(hit.content_hash.clone())
+    .with_record_status(hit.record_status);
+
+    if let Some(freshness_ts) = hit.freshness_ts {
+        provenance = provenance.with_freshness_ts(freshness_ts);
+    }
+    if let Some(ref superseded_by) = hit.superseded_by {
+        provenance = provenance.with_superseded_by(superseded_by.clone());
+    }
+
+    provenance
+}
+
+fn indexed_workspace_memory_metadata_payload(
+    hit: &crate::memory::WorkspaceMemoryIndexedSearchHit,
+) -> Value {
+    json!({
+        "derived_kind": hit.derived_kind.as_str(),
+        "freshness_ts": hit.freshness_ts,
+        "record_status": hit.record_status.as_str(),
+        "trust_level": hit.trust_level.as_str(),
+        "authority": hit.authority.as_str(),
+        "superseded_by": hit.superseded_by,
+        "body_line_offset": hit.body_line_offset,
     })
 }
 
@@ -792,6 +1005,273 @@ mod tests {
 
     #[cfg(feature = "tool-file")]
     #[test]
+    fn memory_search_tool_matches_workspace_metadata_only_queries() {
+        let root = unique_temp_dir("loong-memory-search-workspace-metadata");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(
+            root.join("MEMORY.md"),
+            concat!(
+                "---\n",
+                "kind: procedure\n",
+                "trust: workspace_curated\n",
+                "status: active\n",
+                "---\n",
+                "发布窗口需要双人复核。\n",
+            ),
+        )
+        .expect("write root memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "procedure",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1, "results={results:?}");
+        assert_eq!(results[0]["source"], "workspace_file");
+        assert_eq!(results[0]["path"], "MEMORY.md");
+        assert_eq!(results[0]["scope"], "workspace");
+        assert_eq!(results[0]["kind"], "procedure");
+        assert!(
+            results[0]["snippet"]
+                .as_str()
+                .is_some_and(|value| value.contains("双人复核")),
+            "results={results:?}"
+        );
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_uses_indexed_workspace_memory_when_sqlite_is_available() {
+        let root = unique_temp_dir("loongclaw-memory-search-indexed-workspace");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(root.join("MEMORY.md"), "中文分词用于数据库搜索。\n")
+            .expect("write root memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "中文 分词",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1, "results={results:?}");
+        assert_eq!(results[0]["source"], "workspace_file");
+        assert_eq!(results[0]["path"], "MEMORY.md");
+        assert_eq!(
+            results[0]["provenance"]["source_kind"],
+            "workspace_document"
+        );
+        assert_eq!(results[0]["metadata"]["derived_kind"], "overview");
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_matches_indexed_workspace_metadata_only_queries() {
+        let root = unique_temp_dir("loong-memory-search-indexed-workspace-metadata");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(
+            root.join("MEMORY.md"),
+            concat!(
+                "---\n",
+                "kind: procedure\n",
+                "trust: workspace_curated\n",
+                "status: active\n",
+                "---\n",
+                "发布窗口需要双人复核。\n",
+            ),
+        )
+        .expect("write root memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "workspace_curated",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1, "results={results:?}");
+        assert_eq!(results[0]["source"], "workspace_file");
+        assert_eq!(results[0]["path"], "MEMORY.md");
+        assert_eq!(results[0]["scope"], "workspace");
+        assert_eq!(results[0]["kind"], "procedure");
+        assert_eq!(results[0]["metadata"]["trust_level"], "workspace_curated");
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_refreshes_indexed_workspace_memory_after_file_changes() {
+        let root = unique_temp_dir("loongclaw-memory-search-index-refresh");
+        let db_path = root.join("memory.sqlite3");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(&memory_path, "旧部署窗口记录。\n").expect("write initial memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let first = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "部署 窗口",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("initial memory search should succeed");
+        assert_eq!(first.payload["returned"], 1);
+
+        let initial_modified = std::fs::metadata(&memory_path)
+            .expect("memory metadata before rewrite")
+            .modified()
+            .expect("memory modified time before rewrite");
+        loop {
+            std::fs::write(&memory_path, "新的回滚检查清单。\n").expect("rewrite memory file");
+            let rewritten_modified = std::fs::metadata(&memory_path)
+                .expect("memory metadata after rewrite")
+                .modified()
+                .expect("memory modified time after rewrite");
+            if rewritten_modified > initial_modified {
+                break;
+            }
+            std::hint::spin_loop();
+        }
+
+        let refreshed = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "回滚 检查",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("refreshed memory search should succeed");
+        assert_eq!(
+            refreshed.payload["returned"], 1,
+            "payload={:?}",
+            refreshed.payload
+        );
+        assert!(
+            refreshed.payload["results"][0]["snippet"]
+                .as_str()
+                .is_some_and(|value| value.contains("回滚检查清单")),
+            "payload={:?}",
+            refreshed.payload
+        );
+
+        let stale = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "部署 窗口",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("stale query memory search should succeed");
+        assert_eq!(stale.payload["returned"], 0, "payload={:?}", stale.payload);
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_drops_deleted_workspace_documents_from_index() {
+        let root = unique_temp_dir("loongclaw-memory-search-index-delete");
+        let db_path = root.join("memory.sqlite3");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(&memory_path, "发布清单需要双人复核。\n").expect("write memory file");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let initial = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "发布 清单",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("initial memory search should succeed");
+        assert_eq!(
+            initial.payload["returned"], 1,
+            "payload={:?}",
+            initial.payload
+        );
+
+        std::fs::remove_file(&memory_path).expect("delete memory file");
+
+        let after_delete = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "发布 清单",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("post-delete memory search should succeed");
+        assert_eq!(
+            after_delete.payload["returned"], 0,
+            "payload={:?}",
+            after_delete.payload
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
     fn memory_search_tool_skips_tombstoned_workspace_memory_files() {
         let root = unique_temp_dir("loong-memory-search-tombstoned");
         let memory_dir = root.join("memory");
@@ -840,6 +1320,37 @@ mod tests {
             results.iter().all(|entry| entry["path"] != "MEMORY.md"),
             "tombstoned documents should be filtered from search results: {results:?}"
         );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_search_tool_matches_segmented_chinese_workspace_queries() {
+        let root = unique_temp_dir("loongclaw-memory-search-chinese-workspace");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(root.join("MEMORY.md"), "中文分词用于数据库搜索。\n")
+            .expect("write root memory");
+
+        let config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "中文 分词",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1, "results={results:?}");
+        assert_eq!(results[0]["source"], "workspace_file");
+        assert_eq!(results[0]["path"], "MEMORY.md");
     }
 
     #[cfg(feature = "tool-file")]

--- a/crates/app/src/tools/session_search.rs
+++ b/crates/app/src/tools/session_search.rs
@@ -8,6 +8,7 @@ use super::payload::{optional_payload_limit, optional_payload_string, required_p
 
 use crate::config::{SessionVisibility, ToolConfig};
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::search_text::{normalize_search_text, tokenize_normalized_search_text};
 use crate::session::repository::{SessionRepository, SessionSearchSourceKind};
 
 const DEFAULT_SESSION_SEARCH_MAX_RESULTS: usize = 5;
@@ -103,7 +104,7 @@ pub(super) fn execute_session_search_with_policies(
         });
     }
 
-    let normalized_query = query.to_ascii_lowercase();
+    let normalized_query = normalize_search_text(query.as_str());
     let query_tokens = tokenize_search_query(normalized_query.as_str());
     let per_session_limit = max_results
         .min(SESSION_SEARCH_PER_SESSION_LIMIT_CAP)
@@ -223,7 +224,7 @@ fn ensure_session_search_target_visible(
 }
 
 fn session_search_score(query: &str, query_tokens: &[String], content: &str) -> u32 {
-    let normalized_content = content.to_ascii_lowercase();
+    let normalized_content = normalize_search_text(content);
     let mut score = 0u32;
 
     if normalized_content.contains(query) {
@@ -246,12 +247,7 @@ fn session_search_score(query: &str, query_tokens: &[String], content: &str) -> 
 }
 
 fn tokenize_search_query(query: &str) -> Vec<String> {
-    query
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-        .map(str::to_owned)
-        .collect()
+    tokenize_normalized_search_text(query)
 }
 
 fn build_search_snippet(content: &str, query: &str, query_tokens: &[String]) -> String {
@@ -414,6 +410,41 @@ mod tests {
                 .iter()
                 .any(|entry| entry["source"] == "event" && entry["session_id"] == "child-session")
         );
+    }
+
+    #[test]
+    fn session_search_matches_segmented_chinese_event_queries() {
+        let config = isolated_memory_config("chinese-event-query");
+        let repo = SessionRepository::new(&config).expect("repository");
+        create_root_and_child(&repo);
+
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "memory_indexed".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "summary": "中文分词已经启用到数据库搜索"
+            }),
+        })
+        .expect("append child event");
+
+        let outcome = execute_session_search_with_policies(
+            json!({
+                "query": "中文 分词",
+                "max_results": 4,
+                "include_turns": false,
+                "include_events": true
+            }),
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("session_search outcome");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1, "results={results:?}");
+        assert_eq!(results[0]["source"], "event");
+        assert_eq!(results[0]["session_id"], "child-session");
     }
 
     #[test]

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -17,7 +17,7 @@ Domain grades for Loong. Updated periodically to track gaps, prioritize cleanup,
 | Plugin IR (L7) | B- | 2026-03-13 | Bridge inference works; multi-language support limited |
 | Self-Awareness (L8) | B- | 2026-03-13 | Snapshots generated but not continuous; no drift detection agent |
 | Bootstrap (L9) | B | 2026-03-13 | Activation plans work; no policy-bounded bootstrap validation |
-| Context/Memory | B- | 2026-04-05 | Canonical recall now has scope/kind/metadata-backed FTS retrieval, the operator-facing `memory_search` surface spans workspace and cross-session recall, but trust scoring, TTL/hash, and richer derived-memory ranking are still limited |
+| Context/Memory | B | 2026-04-18 | Canonical, session-event, and workspace durable memory recall now share normalized FTS-backed retrieval with indexed `search_text` storage and Chinese tokenization support, but trust scoring, TTL policy, and richer derived-memory ranking are still limited |
 | Documentation | A- | 2026-03-13 | Strong coverage across design docs, security, product sense, and quality tracking |
 | CI/Enforcement | A | 2026-03-13 | 8 CI workflows, convention-engineering (14 files, 11 checks), check:harness mirror gate |
 | Contributor Experience | A- | 2026-03-13 | Clear tracks and recipes; could add more examples |

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-18T15:01:02Z
+- Generated at: 2026-04-18T16:52:47Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -34,7 +34,7 @@ release review. It is not part of the primary public release trail.
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3513 | 3600 | 87 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 1.7% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3574 | 3700 | 126 | 48 | 80 | 32 | 96.6% | TIGHT | 3547 | 0.8% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 416 | 1000 | 584 | 13 | 20 | 7 | 65.0% | HEALTHY | 375 | 10.9% | BREACH | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 456 | 650 | 194 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 28.1% | BREACH | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 473 | 650 | 177 | 16 | 16 | 0 | 100.0% | TIGHT | 356 | 32.9% | BREACH | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3058 | 3600 | 542 | 0 | 12 | 12 | 84.9% | HEALTHY | 3383 | -9.6% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 1776 | 2800 | 1024 | 7 | 65 | 58 | 63.4% | HEALTHY | 2698 | -34.2% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10113 | 10500 | 387 | 78 | 90 | 12 | 96.3% | TIGHT | 9922 | 1.9% | PASS | 88 |
@@ -88,7 +88,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=spec_runtime lines=3513 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3574 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=416 functions=13 -->
-<!-- arch-hotspot key=memory_mod lines=456 functions=16 -->
+<!-- arch-hotspot key=memory_mod lines=473 functions=16 -->
 <!-- arch-hotspot key=acp_manager lines=3058 functions=0 -->
 <!-- arch-hotspot key=acpx_runtime lines=1776 functions=7 -->
 <!-- arch-hotspot key=channel_registry lines=10113 functions=78 -->

--- a/site/use-loong/memory-profiles.mdx
+++ b/site/use-loong/memory-profiles.mdx
@@ -58,6 +58,7 @@ itself remains a normal operator-facing runtime setting.
 That matters because:
 
 - profile memory can preserve preferences, working habits, or imported context
+- recall over durable memory can stay grounded in the actual stored corpus instead of hidden prompt-only state
 - it should enrich the assistant without becoming a second authority over the runtime
 - future richer recall can build on this lane without changing the public truth
   that operator-visible runtime identity stays explicit

--- a/site/use-loong/tools-and-memory.mdx
+++ b/site/use-loong/tools-and-memory.mdx
@@ -26,6 +26,7 @@ The public repository keeps memory documentation focused on shipped behavior:
 - selectable memory profiles
 - advisory continuity rather than identity override
 - operator-visible setup and first-run expectations
+- continuity and recall that follow the actual indexed durable corpus instead of hidden prompt-only state
 - continuity that helps the operator without pretending memory is a second authority for runtime identity
 
 The current public profiles include:


### PR DESCRIPTION
## Summary
- add a shared search text pipeline for normalization, tokenization, FTS query building, and indexed `search_text` generation
- integrate `jieba-rs` for Chinese/Han segmentation instead of hardcoded multilingual synonym expansion
- unify workspace durable memory, canonical memory, and session event recall on SQLite FTS-backed retrieval
- add SQLite indexing for workspace memory with incremental refresh, delete cleanup, and metadata-aware recall

## What changed
- add `crates/app/src/search_text.rs` and route memory/session search paths through it
- upgrade canonical memory search to indexed `search_text` + shared FTS query construction
- upgrade session event search from `LIKE`-style lookup to `session_events_fts`
- add `search_text` storage/backfill/repair for canonical records and session events
- add `workspace_memory_documents` and `workspace_memory_documents_fts`
- make `memory_search` use indexed workspace-memory recall when sqlite is available
- return structured workspace search metadata including `scope`, `kind`, trust/status metadata, and metadata-only matches
- update quality/public docs to reflect the shipped recall surface

## Why
The previous search stack was fragmented and still too ASCII-leaning in practice. This change moves memory/session search onto a shared infrastructure path built around normalization, Chinese segmentation, pretokenized index text, and FTS retrieval, without introducing hardcoded multilingual query dictionaries.

## Testing
- `./scripts/cargo-local-toolchain.sh fmt --all`
- `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- `./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/cargo-local-toolchain.sh test --workspace`
- `./scripts/cargo-local-toolchain.sh test --workspace --all-features`
- `./scripts/cargo-local-toolchain.sh test -p loong-app`
- `./scripts/cargo-local-toolchain.sh test -p loong-app --all-features`
- `./scripts/cargo-local-toolchain.sh test -p loong-app memory_search`
- `./scripts/cargo-local-toolchain.sh clippy -p loong-app --tests -- -D warnings`
- `./scripts/cargo-local-toolchain.sh clippy -p loong-app --all-features --tests -- -D warnings`

## Notes
- `test --workspace --all-features` hit one `tools::tool_lease_authority` flake on the first run, then passed on immediate rerun.
- This branch is rebased onto the latest `origin/dev` and reduced to a single reviewable commit.
