### PR TITLE
Mature the local gateway into a durable paired-session front door

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.docs
 /.loong.local.toml
 /.env.local
+harbor/jobs/
 .worktrees/
 .idea
 .vscode

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -11,14 +11,9 @@ mod shared;
 mod tools;
 
 #[allow(unused_imports)]
-pub use crate::channel::{ChannelDescriptor, ChannelOperationalModel, ChannelRuntimeKind};
+pub use crate::channel::{ChannelDescriptor, ChannelRuntimeKind};
 #[allow(unused_imports)]
-pub use crate::channel::{
-    catalog_only_channel_descriptors, channel_descriptor, gateway_supervised_channel_descriptors,
-    outbound_only_channel_descriptors, plugin_backed_channel_descriptors,
-    runtime_backed_channel_descriptors, service_channel_descriptors,
-    standalone_runtime_channel_descriptors,
-};
+pub use crate::channel::{channel_descriptor, service_channel_descriptors};
 pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
 pub use audit::{AuditConfig, AuditMode};
@@ -76,7 +71,7 @@ pub(crate) use channels::{
 };
 #[allow(unused_imports)]
 pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};
-pub use feishu_integration::{FeishuCapabilityConfig, FeishuIntegrationConfig};
+pub use feishu_integration::FeishuIntegrationConfig;
 pub(crate) use irc::{
     IRC_NICKNAME_ENV, IRC_SERVER_ENV, IrcServerEndpoint, IrcServerTransport,
     parse_irc_server_endpoint,
@@ -108,11 +103,11 @@ pub(crate) use runtime::inject_test_config_write_failure;
 pub use runtime::{
     AcpBackendProfilesConfig, AcpConfig, AcpConversationRoutingMode, AcpDispatchConfig,
     AcpDispatchThreadRoutingMode, AcpxBackendConfig, AcpxMcpServerConfig,
-    ConfigValidationDiagnostic, ControlPlaneConfig, LoongConfig, PROVIDER_SELECTOR_COMPACT_NOTE,
-    PROVIDER_SELECTOR_HUMAN_SUMMARY, PROVIDER_SELECTOR_NOTE, PROVIDER_SELECTOR_PLACEHOLDER,
-    PROVIDER_SELECTOR_TARGET_SUMMARY, ProviderSelectorProfileRef, ProviderSelectorResolution,
-    accepted_provider_selectors, default_config_path, default_loong_home,
-    describe_provider_selector_target, load, normalize_validation_locale,
+    ConfigValidationDiagnostic, ControlPlaneConfig, GatewayConfig, LoongClawConfig,
+    PROVIDER_SELECTOR_COMPACT_NOTE, PROVIDER_SELECTOR_HUMAN_SUMMARY, PROVIDER_SELECTOR_NOTE,
+    PROVIDER_SELECTOR_PLACEHOLDER, PROVIDER_SELECTOR_TARGET_SUMMARY, ProviderSelectorProfileRef,
+    ProviderSelectorResolution, accepted_provider_selectors, default_config_path,
+    default_loongclaw_home, describe_provider_selector_target, load, normalize_validation_locale,
     preferred_provider_selector, provider_selector_catalog, provider_selector_recommendation_hint,
     render, resolve_provider_selector, supported_validation_locales, validate_file,
     validate_file_with_locale, write, write_template,
@@ -125,13 +120,6 @@ pub use shared::{
     PRODUCT_DISPLAY_NAME, active_cli_command_name, detect_invoked_cli_command_name,
     detect_invoked_cli_command_name_from_arg0, detect_legacy_home, expand_path,
     set_active_cli_command_name,
-};
-pub(crate) use shared::{
-    pop_default_loong_home_env_override_for_tests, push_default_loong_home_env_override_for_tests,
-};
-#[cfg(test)]
-pub(crate) use shared::{
-    pop_default_loong_home_override_for_tests, push_default_loong_home_override_for_tests,
 };
 #[allow(unused_imports)]
 pub use tools::{
@@ -147,13 +135,13 @@ pub use tools::{
     MAX_BROWSER_MAX_SESSIONS, MAX_BROWSER_MAX_TEXT_CHARS, MAX_RUNTIME_SELF_MAX_SOURCE_CHARS,
     MAX_RUNTIME_SELF_MAX_TOTAL_CHARS, MAX_WEB_FETCH_MAX_BYTES, RuntimePluginsConfig,
     RuntimeSelfToolConfig, SessionVisibility, ToolConfig, ToolConsentConfig, ToolConsentMode,
-    ToolFileRootResolution, WEB_SEARCH_BRAVE_API_KEY_ENV, WEB_SEARCH_EXA_API_KEY_ENV,
-    WEB_SEARCH_FIRECRAWL_API_KEY_ENV, WEB_SEARCH_JINA_API_KEY_ENV, WEB_SEARCH_JINA_AUTH_TOKEN_ENV,
-    WEB_SEARCH_PERPLEXITY_API_KEY_ENV, WEB_SEARCH_PROVIDER_BRAVE, WEB_SEARCH_PROVIDER_DUCKDUCKGO,
-    WEB_SEARCH_PROVIDER_EXA, WEB_SEARCH_PROVIDER_FIRECRAWL, WEB_SEARCH_PROVIDER_JINA,
-    WEB_SEARCH_PROVIDER_PERPLEXITY, WEB_SEARCH_PROVIDER_TAVILY, WEB_SEARCH_PROVIDER_VALID_VALUES,
-    WEB_SEARCH_TAVILY_API_KEY_ENV, WebSearchProviderDescriptor, WebSearchToolConfig, WebToolConfig,
-    normalize_web_search_provider, parse_autonomy_profile, web_search_provider_api_key_env_names,
+    WEB_SEARCH_BRAVE_API_KEY_ENV, WEB_SEARCH_EXA_API_KEY_ENV, WEB_SEARCH_FIRECRAWL_API_KEY_ENV,
+    WEB_SEARCH_JINA_API_KEY_ENV, WEB_SEARCH_JINA_AUTH_TOKEN_ENV, WEB_SEARCH_PERPLEXITY_API_KEY_ENV,
+    WEB_SEARCH_PROVIDER_BRAVE, WEB_SEARCH_PROVIDER_DUCKDUCKGO, WEB_SEARCH_PROVIDER_EXA,
+    WEB_SEARCH_PROVIDER_FIRECRAWL, WEB_SEARCH_PROVIDER_JINA, WEB_SEARCH_PROVIDER_PERPLEXITY,
+    WEB_SEARCH_PROVIDER_TAVILY, WEB_SEARCH_PROVIDER_VALID_VALUES, WEB_SEARCH_TAVILY_API_KEY_ENV,
+    WebSearchProviderDescriptor, WebSearchToolConfig, WebToolConfig, normalize_web_search_provider,
+    parse_autonomy_profile, web_search_provider_api_key_env_names,
     web_search_provider_default_api_key_env, web_search_provider_descriptor,
     web_search_provider_descriptors,
 };
@@ -167,19 +155,19 @@ pub(crate) use tools::{
 mod tests {
     use std::path::PathBuf;
 
-    use loong_contracts::SecretRef;
+    use loongclaw_contracts::SecretRef;
 
     use super::*;
-    use crate::test_support::{ScopedEnv, ScopedLoongHome};
+    use crate::test_support::ScopedEnv;
     use std::collections::BTreeSet;
 
     fn clear_config_test_secret_envs(env: &mut ScopedEnv) {
         for key in [
-            "LOONG_TEST_API_KEY_REF",
-            "LOONG_TEST_MISSING_API_KEY",
-            "LOONG_TEST_LEGACY_FALLBACK",
-            "LOONG_TEST_TYPED_SECRET_REF",
-            "LOONG_TEST_TELEGRAM_SECRET_REF",
+            "LOONGCLAW_TEST_API_KEY_REF",
+            "LOONGCLAW_TEST_MISSING_API_KEY",
+            "LOONGCLAW_TEST_LEGACY_FALLBACK",
+            "LOONGCLAW_TEST_TYPED_SECRET_REF",
+            "LOONGCLAW_TEST_TELEGRAM_SECRET_REF",
         ] {
             env.remove(key);
         }
@@ -187,28 +175,20 @@ mod tests {
 
     fn expected_service_channel_ids() -> Vec<&'static str> {
         vec![
-            "telegram", "feishu", "matrix", "wecom", "line", "whatsapp", "webhook",
-        ]
-    }
-
-    fn expected_gateway_supervised_channel_ids() -> Vec<&'static str> {
-        vec!["telegram", "feishu", "matrix", "wecom", "whatsapp"]
-    }
-
-    fn expected_standalone_runtime_channel_ids() -> Vec<&'static str> {
-        vec!["line", "webhook"]
-    }
-
-    fn expected_plugin_backed_channel_ids() -> Vec<&'static str> {
-        vec!["weixin", "qqbot", "onebot"]
-    }
-
-    fn expected_outbound_channel_ids() -> Vec<&'static str> {
-        vec![
+            "telegram",
+            "feishu",
+            "matrix",
+            "wecom",
+            "weixin",
+            "qqbot",
+            "onebot",
             "discord",
             "slack",
+            "line",
             "dingtalk",
+            "whatsapp",
             "email",
+            "webhook",
             "google-chat",
             "signal",
             "twitch",
@@ -247,181 +227,134 @@ mod tests {
         let telegram = channel_descriptor("telegram").expect("telegram descriptor");
         assert_eq!(telegram.id, "telegram");
         assert_eq!(telegram.surface_label, "telegram channel");
-        assert_eq!(telegram.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            telegram.operational_model,
-            ChannelOperationalModel::GatewaySupervised
-        );
+        assert_eq!(telegram.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(telegram.serve_subcommand, Some("telegram-serve"));
 
         let feishu = channel_descriptor("feishu").expect("feishu descriptor");
         assert_eq!(feishu.id, "feishu");
         assert_eq!(feishu.surface_label, "feishu channel");
-        assert_eq!(feishu.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            feishu.operational_model,
-            ChannelOperationalModel::GatewaySupervised
-        );
+        assert_eq!(feishu.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(feishu.serve_subcommand, Some("feishu-serve"));
 
         let wecom = channel_descriptor("wecom").expect("wecom descriptor");
         assert_eq!(wecom.id, "wecom");
         assert_eq!(wecom.surface_label, "wecom channel");
-        assert_eq!(wecom.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            wecom.operational_model,
-            ChannelOperationalModel::GatewaySupervised
-        );
+        assert_eq!(wecom.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(wecom.serve_subcommand, Some("wecom-serve"));
 
         let weixin = channel_descriptor("wechat").expect("weixin descriptor");
         assert_eq!(weixin.id, "weixin");
         assert_eq!(weixin.surface_label, "weixin channel");
-        assert_eq!(weixin.runtime_kind, ChannelRuntimeKind::PluginBacked);
-        assert_eq!(
-            weixin.operational_model,
-            ChannelOperationalModel::PluginBacked
-        );
+        assert_eq!(weixin.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(weixin.serve_subcommand, None);
 
         let qqbot = channel_descriptor("qq").expect("qqbot descriptor");
         assert_eq!(qqbot.id, "qqbot");
         assert_eq!(qqbot.surface_label, "qq bot channel");
-        assert_eq!(qqbot.runtime_kind, ChannelRuntimeKind::PluginBacked);
-        assert_eq!(
-            qqbot.operational_model,
-            ChannelOperationalModel::PluginBacked
-        );
+        assert_eq!(qqbot.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(qqbot.serve_subcommand, None);
 
         let onebot = channel_descriptor("onebot-v11").expect("onebot descriptor");
         assert_eq!(onebot.id, "onebot");
         assert_eq!(onebot.surface_label, "onebot channel");
-        assert_eq!(onebot.runtime_kind, ChannelRuntimeKind::PluginBacked);
-        assert_eq!(
-            onebot.operational_model,
-            ChannelOperationalModel::PluginBacked
-        );
+        assert_eq!(onebot.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(onebot.serve_subcommand, None);
 
         let discord = channel_descriptor("discord").expect("discord descriptor");
         assert_eq!(discord.id, "discord");
         assert_eq!(discord.surface_label, "discord channel");
-        assert_eq!(discord.runtime_kind, ChannelRuntimeKind::OutboundOnly);
-        assert_eq!(
-            discord.operational_model,
-            ChannelOperationalModel::OutboundOnly
-        );
+        assert_eq!(discord.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(discord.serve_subcommand, None);
 
         let slack = channel_descriptor("slack").expect("slack descriptor");
         assert_eq!(slack.id, "slack");
         assert_eq!(slack.surface_label, "slack channel");
-        assert_eq!(slack.runtime_kind, ChannelRuntimeKind::OutboundOnly);
-        assert_eq!(
-            slack.operational_model,
-            ChannelOperationalModel::OutboundOnly
-        );
+        assert_eq!(slack.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(slack.serve_subcommand, None);
 
         let line = channel_descriptor("line").expect("line descriptor");
         assert_eq!(line.id, "line");
         assert_eq!(line.surface_label, "line channel");
-        assert_eq!(line.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            line.operational_model,
-            ChannelOperationalModel::StandaloneRuntime
-        );
-        assert_eq!(line.serve_subcommand, Some("line-serve"));
+        assert_eq!(line.runtime_kind, ChannelRuntimeKind::Service);
+        assert_eq!(line.serve_subcommand, None);
 
         let dingtalk = channel_descriptor("dingtalk").expect("dingtalk descriptor");
         assert_eq!(dingtalk.id, "dingtalk");
         assert_eq!(dingtalk.surface_label, "dingtalk channel");
-        assert_eq!(dingtalk.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(dingtalk.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(dingtalk.serve_subcommand, None);
 
         let whatsapp = channel_descriptor("whatsapp").expect("whatsapp descriptor");
         assert_eq!(whatsapp.id, "whatsapp");
         assert_eq!(whatsapp.surface_label, "whatsapp channel");
-        assert_eq!(whatsapp.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            whatsapp.operational_model,
-            ChannelOperationalModel::GatewaySupervised
-        );
+        assert_eq!(whatsapp.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(whatsapp.serve_subcommand, Some("whatsapp-serve"));
 
         let email = channel_descriptor("email").expect("email descriptor");
         assert_eq!(email.id, "email");
         assert_eq!(email.surface_label, "email channel");
-        assert_eq!(email.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(email.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(email.serve_subcommand, None);
 
         let webhook = channel_descriptor("webhook").expect("webhook descriptor");
         assert_eq!(webhook.id, "webhook");
         assert_eq!(webhook.surface_label, "webhook channel");
-        assert_eq!(webhook.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
-        assert_eq!(
-            webhook.operational_model,
-            ChannelOperationalModel::StandaloneRuntime
-        );
-        assert_eq!(webhook.serve_subcommand, Some("webhook-serve"));
+        assert_eq!(webhook.runtime_kind, ChannelRuntimeKind::Service);
+        assert_eq!(webhook.serve_subcommand, None);
 
         let google_chat = channel_descriptor("google-chat").expect("google chat descriptor");
         assert_eq!(google_chat.id, "google-chat");
         assert_eq!(google_chat.surface_label, "google chat channel");
-        assert_eq!(google_chat.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(google_chat.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(google_chat.serve_subcommand, None);
 
         let signal = channel_descriptor("signal").expect("signal descriptor");
         assert_eq!(signal.id, "signal");
         assert_eq!(signal.surface_label, "signal channel");
-        assert_eq!(signal.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(signal.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(signal.serve_subcommand, None);
 
         let irc = channel_descriptor("irc").expect("irc descriptor");
         assert_eq!(irc.id, "irc");
         assert_eq!(irc.surface_label, "irc channel");
-        assert_eq!(irc.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(irc.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(irc.serve_subcommand, None);
 
         let twitch = channel_descriptor("twitch").expect("twitch descriptor");
         assert_eq!(twitch.id, "twitch");
         assert_eq!(twitch.surface_label, "twitch channel");
-        assert_eq!(twitch.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(twitch.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(twitch.serve_subcommand, None);
 
         let teams = channel_descriptor("teams").expect("teams descriptor");
         assert_eq!(teams.id, "teams");
         assert_eq!(teams.surface_label, "teams channel");
-        assert_eq!(teams.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(teams.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(teams.serve_subcommand, None);
 
         let mattermost = channel_descriptor("mattermost").expect("mattermost descriptor");
         assert_eq!(mattermost.id, "mattermost");
         assert_eq!(mattermost.surface_label, "mattermost channel");
-        assert_eq!(mattermost.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(mattermost.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(mattermost.serve_subcommand, None);
 
         let nextcloud_talk =
             channel_descriptor("nextcloud-talk").expect("nextcloud talk descriptor");
         assert_eq!(nextcloud_talk.id, "nextcloud-talk");
         assert_eq!(nextcloud_talk.surface_label, "nextcloud talk channel");
-        assert_eq!(
-            nextcloud_talk.runtime_kind,
-            ChannelRuntimeKind::OutboundOnly
-        );
+        assert_eq!(nextcloud_talk.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(nextcloud_talk.serve_subcommand, None);
 
         let synology_chat = channel_descriptor("synology-chat").expect("synology chat descriptor");
         assert_eq!(synology_chat.id, "synology-chat");
         assert_eq!(synology_chat.surface_label, "synology chat channel");
-        assert_eq!(synology_chat.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(synology_chat.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(synology_chat.serve_subcommand, None);
 
         let imessage = channel_descriptor("imessage").expect("imessage descriptor");
         assert_eq!(imessage.id, "imessage");
         assert_eq!(imessage.surface_label, "imessage channel");
-        assert_eq!(imessage.runtime_kind, ChannelRuntimeKind::OutboundOnly);
+        assert_eq!(imessage.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(imessage.serve_subcommand, None);
 
         assert!(channel_descriptor("unknown").is_none());
@@ -429,29 +362,17 @@ mod tests {
 
     #[test]
     fn enabled_channel_views_follow_shared_catalog_order() {
-        let default_config = LoongConfig::default();
+        let default_config = LoongClawConfig::default();
         assert_eq!(default_config.enabled_channel_ids(), vec!["cli"]);
         assert!(default_config.enabled_service_channel_ids().is_empty());
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         let expected_service_ids = expected_service_channel_ids();
-        let expected_plugin_backed_ids = expected_plugin_backed_channel_ids();
-        let expected_outbound_ids = expected_outbound_channel_ids();
         let expected_enabled_service_ids = expected_service_ids
             .iter()
             .map(|channel_id| (*channel_id).to_owned())
             .collect::<Vec<_>>();
         let mut expected_enabled_channel_ids = vec!["cli".to_owned()];
         expected_enabled_channel_ids.extend(expected_enabled_service_ids.iter().cloned());
-        expected_enabled_channel_ids.extend(
-            expected_plugin_backed_ids
-                .iter()
-                .map(|channel_id| (*channel_id).to_owned()),
-        );
-        expected_enabled_channel_ids.extend(
-            expected_outbound_ids
-                .iter()
-                .map(|channel_id| (*channel_id).to_owned()),
-        );
 
         config.telegram.enabled = true;
         config.feishu.enabled = true;
@@ -497,7 +418,7 @@ mod tests {
         let matrix = channel_descriptor("matrix").expect("matrix descriptor");
         assert_eq!(matrix.id, "matrix");
         assert_eq!(matrix.surface_label, "matrix channel");
-        assert_eq!(matrix.runtime_kind, ChannelRuntimeKind::RuntimeBacked);
+        assert_eq!(matrix.runtime_kind, ChannelRuntimeKind::Service);
         assert_eq!(matrix.serve_subcommand, Some("matrix-serve"));
     }
 
@@ -508,73 +429,6 @@ mod tests {
             .map(|descriptor| descriptor.id)
             .collect::<Vec<_>>();
         assert_eq!(service_ids, expected_service_channel_ids());
-    }
-
-    #[test]
-    fn channel_descriptor_helper_groups_follow_runtime_taxonomy() {
-        let runtime_backed_ids = runtime_backed_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-        let gateway_supervised_ids = gateway_supervised_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-        let standalone_runtime_ids = standalone_runtime_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-        let plugin_backed_ids = plugin_backed_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-        let outbound_only_ids = outbound_only_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-        let catalog_only_ids = catalog_only_channel_descriptors()
-            .into_iter()
-            .map(|descriptor| descriptor.id)
-            .collect::<Vec<_>>();
-
-        assert_eq!(runtime_backed_ids, expected_service_channel_ids());
-        assert_eq!(
-            gateway_supervised_ids,
-            expected_gateway_supervised_channel_ids()
-        );
-        assert_eq!(
-            standalone_runtime_ids,
-            expected_standalone_runtime_channel_ids()
-        );
-        assert_eq!(plugin_backed_ids, expected_plugin_backed_channel_ids());
-        assert_eq!(outbound_only_ids, expected_outbound_channel_ids());
-        assert_eq!(catalog_only_ids, vec!["zalo", "zalo-personal", "webchat"]);
-    }
-
-    #[test]
-    fn enabled_channel_runtime_groups_follow_runtime_taxonomy() {
-        let mut config = LoongConfig::default();
-        config.telegram.enabled = true;
-        config.weixin.enabled = true;
-        config.discord.enabled = true;
-
-        assert_eq!(
-            config.enabled_runtime_backed_channel_ids(),
-            vec!["telegram".to_owned()]
-        );
-        assert_eq!(
-            config.enabled_service_channel_ids(),
-            vec!["telegram".to_owned()]
-        );
-        assert_eq!(
-            config.enabled_plugin_backed_channel_ids(),
-            vec!["weixin".to_owned()]
-        );
-        assert_eq!(
-            config.enabled_outbound_only_channel_ids(),
-            vec!["discord".to_owned()]
-        );
-        assert!(config.enabled_catalog_only_channel_ids().is_empty());
     }
 
     #[test]
@@ -1056,9 +910,8 @@ mod tests {
             Some(std::path::PathBuf::from(":memory:"))
         );
 
-        let _home = ScopedLoongHome::new("loong-provider-profile-home");
         let profile_sqlite_default = ProviderConfig::default();
-        let expected_default = default_loong_home().join("provider-profile-state.sqlite3");
+        let expected_default = default_loongclaw_home().join("provider-profile-state.sqlite3");
         assert_eq!(
             profile_sqlite_default.resolved_profile_state_sqlite_path_with_default(),
             expected_default
@@ -1123,7 +976,7 @@ mod tests {
         // causing `api_key()` to return only the first segment.
         let mut env = ScopedEnv::new();
         clear_config_test_secret_envs(&mut env);
-        let env_key = "LOONG_TEST_API_KEY_REF";
+        let env_key = "LOONGCLAW_TEST_API_KEY_REF";
         let env_val = "test-secret-value-for-env-ref";
         env.set(env_key, env_val);
 
@@ -1162,7 +1015,7 @@ mod tests {
         let config = ProviderConfig {
             kind: ProviderKind::Ollama,
             api_key: Some(SecretRef::Inline(
-                "${LOONG_TEST_MISSING_API_KEY}".to_owned(),
+                "${LOONGCLAW_TEST_MISSING_API_KEY}".to_owned(),
             )),
             api_key_env: None,
             ..ProviderConfig::default()
@@ -1180,7 +1033,7 @@ mod tests {
         let config = ProviderConfig {
             kind: ProviderKind::Openai,
             api_key: Some(SecretRef::Inline(
-                "${LOONG_TEST_MISSING_API_KEY}".to_owned(),
+                "${LOONGCLAW_TEST_MISSING_API_KEY}".to_owned(),
             )),
             api_key_env: Some("PATH".to_owned()),
             ..ProviderConfig::default()
@@ -1196,7 +1049,7 @@ mod tests {
         // which `split_secret_candidates` treats as a candidate separator.
         let mut env = ScopedEnv::new();
         clear_config_test_secret_envs(&mut env);
-        let env_key = "LOONG_TEST_LEGACY_FALLBACK";
+        let env_key = "LOONGCLAW_TEST_LEGACY_FALLBACK";
         let env_val = "test-secret-value-for-legacy";
         env.set(env_key, env_val);
 
@@ -1214,7 +1067,7 @@ mod tests {
     fn provider_api_key_supports_typed_env_secret_ref() {
         let mut env = ScopedEnv::new();
         clear_config_test_secret_envs(&mut env);
-        let env_key = "LOONG_TEST_TYPED_SECRET_REF";
+        let env_key = "LOONGCLAW_TEST_TYPED_SECRET_REF";
         let env_val = "typed-secret-value";
         env.set(env_key, env_val);
 
@@ -1241,7 +1094,7 @@ mod tests {
 [provider]
 api_key = { file = "/run/secrets/openai" }
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("secret table should parse");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("secret table should parse");
 
         assert_eq!(
             parsed.provider.api_key,
@@ -1260,7 +1113,7 @@ kind = "volcengine_custom"
 model = "model-example"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse legacy kind alias should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse legacy kind alias should pass");
         assert_eq!(parsed.provider.kind, ProviderKind::Volcengine);
     }
 
@@ -1273,7 +1126,7 @@ kind = "xai_compatible"
 model = "model-example"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse compatible alias should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse compatible alias should pass");
         assert_eq!(parsed.provider.kind, ProviderKind::Xai);
     }
 
@@ -1286,7 +1139,7 @@ kind = "kimi_coding_compatible"
 model = "model-example"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse kimi coding alias should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse kimi coding alias should pass");
         assert_eq!(parsed.provider.kind, ProviderKind::KimiCoding);
     }
 
@@ -1297,7 +1150,8 @@ model = "model-example"
 [provider]
 kind = "kimi_coding"
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse minimal kimi coding config");
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse minimal kimi coding config");
         assert_eq!(parsed.provider.kind, ProviderKind::KimiCoding);
         assert_eq!(
             parsed.provider.endpoint(),
@@ -1322,7 +1176,7 @@ kind = "kimi_coding"
 kind = "bailian_coding"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse minimal bailian coding config");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse minimal bailian coding config");
         assert_eq!(parsed.provider.kind, ProviderKind::BailianCoding);
         assert_eq!(
             parsed.provider.endpoint(),
@@ -1362,8 +1216,8 @@ kind = "{kind}"
 model = "model-example"
 "#
             );
-            let parsed =
-                toml::from_str::<LoongConfig>(&raw).expect("parse provider alias should succeed");
+            let parsed = toml::from_str::<LoongClawConfig>(&raw)
+                .expect("parse provider alias should succeed");
             assert_eq!(parsed.provider.kind, expected, "kind={kind}");
         }
     }
@@ -1376,7 +1230,7 @@ model = "model-example"
 kind = "byteplus_coding"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse minimal byteplus coding config");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse minimal byteplus coding config");
         assert_eq!(parsed.provider.kind, ProviderKind::ByteplusCoding);
         assert_eq!(
             parsed.provider.endpoint(),
@@ -1400,7 +1254,7 @@ kind = "byteplus_coding"
 kind = "volcengine_coding"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse minimal volcengine coding config");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse minimal volcengine coding config");
         assert_eq!(parsed.provider.kind, ProviderKind::VolcengineCoding);
         assert_eq!(
             parsed.provider.endpoint(),
@@ -1667,7 +1521,7 @@ kind = "openrouter"
 profile_health_mode = "enforce"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse profile health mode should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse profile health mode should pass");
         assert_eq!(parsed.provider.kind, ProviderKind::Openrouter);
         assert_eq!(
             parsed.provider.resolved_profile_health_mode_config(),
@@ -1683,7 +1537,7 @@ profile_health_mode = "enforce"
 kind = "openai"
 profile_health_mode = "observe_only"
 "#;
-        let observe_only = toml::from_str::<LoongConfig>(observe_only_raw)
+        let observe_only = toml::from_str::<LoongClawConfig>(observe_only_raw)
             .expect("parse observe_only profile health mode should pass");
         assert_eq!(
             observe_only.provider.resolved_profile_health_mode_config(),
@@ -1695,7 +1549,7 @@ profile_health_mode = "observe_only"
 kind = "openrouter"
 profile_health_mode = "provider_default"
 "#;
-        let provider_default = toml::from_str::<LoongConfig>(provider_default_raw)
+        let provider_default = toml::from_str::<LoongClawConfig>(provider_default_raw)
             .expect("parse provider_default profile health mode should pass");
         assert_eq!(
             provider_default
@@ -1714,7 +1568,7 @@ kind = "openai"
 tool_schema_mode = "enabled_strict"
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse tool schema mode should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse tool schema mode should pass");
         assert_eq!(parsed.provider.kind, ProviderKind::Openai);
         assert_eq!(
             parsed.provider.resolved_tool_schema_mode_config(),
@@ -1730,7 +1584,7 @@ tool_schema_mode = "enabled_strict"
 kind = "openai"
 tool_schema_mode = "disabled"
 "#;
-        let disabled = toml::from_str::<LoongConfig>(disabled_raw)
+        let disabled = toml::from_str::<LoongClawConfig>(disabled_raw)
             .expect("parse disabled tool schema mode should pass");
         assert_eq!(
             disabled.provider.resolved_tool_schema_mode_config(),
@@ -1742,7 +1596,7 @@ tool_schema_mode = "disabled"
 kind = "openai"
 tool_schema_mode = "enabled_with_downgrade"
 "#;
-        let downgraded = toml::from_str::<LoongConfig>(downgraded_raw)
+        let downgraded = toml::from_str::<LoongClawConfig>(downgraded_raw)
             .expect("parse enabled_with_downgrade tool schema mode should pass");
         assert_eq!(
             downgraded.provider.resolved_tool_schema_mode_config(),
@@ -1754,7 +1608,7 @@ tool_schema_mode = "enabled_with_downgrade"
 kind = "openai"
 tool_schema_mode = "provider_default"
 "#;
-        let provider_default = toml::from_str::<LoongConfig>(provider_default_raw)
+        let provider_default = toml::from_str::<LoongClawConfig>(provider_default_raw)
             .expect("parse provider_default tool schema mode should pass");
         assert_eq!(
             provider_default.provider.resolved_tool_schema_mode_config(),
@@ -1770,7 +1624,7 @@ tool_schema_mode = "provider_default"
 kind = "openai"
 reasoning_extra_body_mode = "kimi_thinking"
 "#;
-        let kimi_thinking = toml::from_str::<LoongConfig>(kimi_thinking_raw)
+        let kimi_thinking = toml::from_str::<LoongClawConfig>(kimi_thinking_raw)
             .expect("parse kimi_thinking reasoning mode should pass");
         assert_eq!(
             kimi_thinking
@@ -1784,8 +1638,8 @@ reasoning_extra_body_mode = "kimi_thinking"
 kind = "openai"
 reasoning_extra_body_mode = "omit"
 "#;
-        let omit =
-            toml::from_str::<LoongConfig>(omit_raw).expect("parse omit reasoning mode should pass");
+        let omit = toml::from_str::<LoongClawConfig>(omit_raw)
+            .expect("parse omit reasoning mode should pass");
         assert_eq!(
             omit.provider.resolved_reasoning_extra_body_mode_config(),
             ProviderReasoningExtraBodyModeConfig::Omit
@@ -1796,7 +1650,7 @@ reasoning_extra_body_mode = "omit"
 kind = "openai"
 reasoning_extra_body_mode = "provider_default"
 "#;
-        let provider_default = toml::from_str::<LoongConfig>(provider_default_raw)
+        let provider_default = toml::from_str::<LoongClawConfig>(provider_default_raw)
             .expect("parse provider_default reasoning mode should pass");
         assert_eq!(
             provider_default
@@ -1817,7 +1671,7 @@ tool_schema_strict_model_hints = ["strict-schema"]
 reasoning_extra_body_kimi_model_hints = ["enable-thinking"]
 reasoning_extra_body_omit_model_hints = ["disable-thinking"]
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw)
+        let parsed = toml::from_str::<LoongClawConfig>(raw)
             .expect("parse provider capability model hints should pass");
 
         assert_eq!(
@@ -1878,7 +1732,7 @@ reasoning_extra_body_omit_model_hints = ["disable-thinking"]
     #[cfg(feature = "channel-telegram")]
     fn telegram_token_prefers_inline_secret() {
         let config = TelegramChannelConfig {
-            bot_token: Some(loong_contracts::SecretRef::Inline(
+            bot_token: Some(loongclaw_contracts::SecretRef::Inline(
                 "inline-token".to_owned(),
             )),
             bot_token_env: Some("SHOULD_NOT_BE_READ".to_owned()),
@@ -1892,7 +1746,7 @@ reasoning_extra_body_omit_model_hints = ["disable-thinking"]
     fn telegram_bot_token_supports_typed_env_secret_ref() {
         let mut env = ScopedEnv::new();
         clear_config_test_secret_envs(&mut env);
-        let env_key = "LOONG_TEST_TELEGRAM_SECRET_REF";
+        let env_key = "LOONGCLAW_TEST_TELEGRAM_SECRET_REF";
         let env_val = "123456789:telegram-secret";
         env.set(env_key, env_val);
 
@@ -1914,7 +1768,7 @@ reasoning_extra_body_omit_model_hints = ["disable-thinking"]
 [telegram]
 bot_token = { file = "/run/secrets/telegram" }
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("secret table should parse");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("secret table should parse");
 
         assert_eq!(
             parsed.telegram.bot_token,
@@ -1950,7 +1804,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_secret_literal_in_provider_api_key_env() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("sk-live-direct-secret-value".to_owned());
         config.provider.api_key = None;
 
@@ -1965,7 +1819,7 @@ bot_token = { file = "/run/secrets/telegram" }
     #[test]
     fn config_validation_message_does_not_echo_secret_literal() {
         let secret = "sk-live-direct-secret-value";
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some(secret.to_owned());
         config.provider.api_key = None;
 
@@ -1980,7 +1834,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_uses_provider_specific_example_env_name() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.kind = ProviderKind::Minimax;
         config.provider.api_key_env = Some("sk-minimax-inline-secret".to_owned());
 
@@ -1992,7 +1846,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_secret_literal_in_telegram_bot_token_env() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.telegram.bot_token_env = Some("123456789:telegram-secret-token-literal".to_owned());
         config.telegram.bot_token = None;
 
@@ -2006,7 +1860,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_duplicate_normalized_telegram_account_ids() {
-        let config: LoongConfig = serde_json::from_value(serde_json::json!({
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "telegram": {
                 "accounts": {
                     "Work Bot": {
@@ -2031,7 +1885,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_duplicate_normalized_feishu_account_ids() {
-        let config: LoongConfig = serde_json::from_value(serde_json::json!({
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "feishu": {
                 "accounts": {
                     "Lark Prod": {
@@ -2058,7 +1912,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_unknown_telegram_default_account() {
-        let config: LoongConfig = serde_json::from_value(serde_json::json!({
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "telegram": {
                 "default_account": "missing",
                 "accounts": {
@@ -2085,7 +1939,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_accepts_shell_style_env_names() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("KIMI_CODING_API_KEY".to_owned());
         config.telegram.bot_token_env = Some("TELEGRAM_BOT_TOKEN".to_owned());
 
@@ -2096,7 +1950,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_accepts_non_shell_env_names_for_compatibility() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("OPENAI-API-KEY".to_owned());
 
         config
@@ -2106,7 +1960,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_accepts_long_compatible_env_names() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("VERY-LONG-ENV-NAME-WITH-DASHES-AND-DOTS.v2".to_owned());
 
         config
@@ -2116,7 +1970,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_zero_memory_sliding_window() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.memory.sliding_window = 0;
 
         let error = config
@@ -2128,7 +1982,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_memory_sliding_window_above_adapter_cap() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.memory.sliding_window = 129;
 
         let error = config
@@ -2141,7 +1995,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_assignment_style_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("OPENAI_API_KEY=sk-1234567890".to_owned());
 
         let error = config
@@ -2153,7 +2007,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_export_assignment_style_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("export OPENAI_API_KEY=sk-1234567890".to_owned());
 
         let error = config
@@ -2165,7 +2019,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_set_assignment_style_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("set OPENAI_API_KEY=sk-1234567890".to_owned());
 
         let error = config
@@ -2177,7 +2031,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_dollar_prefixed_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("$OPENAI_API_KEY".to_owned());
 
         let error = config
@@ -2189,7 +2043,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_braced_dollar_prefixed_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("${OPENAI_API_KEY}".to_owned());
 
         let error = config
@@ -2202,7 +2056,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_percent_wrapped_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("%OPENAI_API_KEY%".to_owned());
 
         let error = config
@@ -2215,7 +2069,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_bare_dollar_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("$".to_owned());
 
         let error = config
@@ -2228,7 +2082,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_invalid_env_pointer_name() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("OPENAI API KEY".to_owned());
 
         let error = config
@@ -2240,7 +2094,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_bearer_prefixed_secret_in_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("Bearer sk-live-token-value".to_owned());
 
         let error = config
@@ -2252,7 +2106,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_uuid_shaped_secret_in_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("9f479837-0a12-4b56-89ab-cdef01234567".to_owned());
 
         let error = config
@@ -2264,7 +2118,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_invalid_typed_secret_ref_env_names() {
-        let config: LoongConfig = serde_json::from_value(serde_json::json!({
+        let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "provider": {
                 "api_key": {
                     "env": "$OPENAI_API_KEY"
@@ -2308,7 +2162,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_rejects_telegram_like_token_in_env_pointer() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.telegram.bot_token_env = Some("123456789:AAEZZ_exampleTokenValue".to_owned());
 
         let error = config
@@ -2320,7 +2174,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn config_validation_reports_multiple_env_pointer_issues_in_one_pass() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("OPENAI_API_KEY=sk-inline".to_owned());
         config.telegram.bot_token_env = Some("123456789:telegram-inline-secret-literal".to_owned());
 
@@ -2387,7 +2241,7 @@ bot_token = { file = "/run/secrets/telegram" }
 
     #[test]
     fn turn_loop_policy_defaults_are_stable() {
-        let config = LoongConfig::default();
+        let config = LoongClawConfig::default();
         assert_eq!(config.conversation.turn_loop.max_rounds, 4);
         assert_eq!(config.conversation.turn_loop.max_tool_steps_per_round, 1);
         assert_eq!(
@@ -2429,7 +2283,7 @@ max_followup_tool_payload_chars = 1200
 max_followup_tool_payload_chars_total = 3200
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse turn-loop config should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse turn-loop config should pass");
         assert_eq!(parsed.conversation.turn_loop.max_rounds, 6);
         assert_eq!(parsed.conversation.turn_loop.max_tool_steps_per_round, 3);
         assert_eq!(
@@ -2465,7 +2319,7 @@ max_followup_tool_payload_chars_total = 3200
 tool_result_payload_summary_limit_chars = 4096
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse conversation config should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
         assert_eq!(
             parsed.conversation.tool_result_payload_summary_limit_chars,
             4096
@@ -2487,7 +2341,7 @@ fast_lane_parallel_tool_execution_enabled = true
 fast_lane_parallel_tool_execution_max_in_flight = 7
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse conversation config should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
         assert!(
             parsed
                 .conversation
@@ -2518,7 +2372,7 @@ safe_lane_health_verify_failure_warn_threshold = 0.45
 safe_lane_health_replan_warn_threshold = 0.55
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse conversation config should pass");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation config should pass");
         assert_eq!(
             parsed
                 .conversation
@@ -2703,7 +2557,8 @@ safe_lane_health_replan_warn_threshold = 0.55
 [conversation]
 context_engine = " Legacy "
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse conversation context_engine");
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation context_engine");
         assert_eq!(
             parsed.conversation.context_engine_id().as_deref(),
             Some("legacy")
@@ -2718,7 +2573,7 @@ context_engine = " Legacy "
 turn_middlewares = [" Alpha ", "beta", "", "alpha"]
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse conversation turn_middlewares");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation turn_middlewares");
         assert_eq!(
             parsed.conversation.turn_middleware_ids(),
             vec!["alpha".to_owned(), "beta".to_owned()]
@@ -2732,7 +2587,7 @@ turn_middlewares = [" Alpha ", "beta", "", "alpha"]
 [memory]
 system = " Builtin "
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse memory.system");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse memory.system");
         assert_eq!(parsed.memory.resolved_system().as_str(), "builtin");
     }
 
@@ -2743,7 +2598,7 @@ system = " Builtin "
 [memory]
 system_id = " LuCid "
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse memory.system_id");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse memory.system_id");
         assert_eq!(parsed.memory.system_id.as_deref(), Some("lucid"));
         assert_eq!(parsed.memory.resolved_system_id(), "lucid");
     }
@@ -2755,7 +2610,8 @@ system_id = " LuCid "
 [memory]
 system = " LuCid "
 "#;
-        let error = toml::from_str::<LoongConfig>(raw).expect_err("lucid should stay unsupported");
+        let error =
+            toml::from_str::<LoongClawConfig>(raw).expect_err("lucid should stay unsupported");
         assert!(
             error.to_string().contains("available: builtin"),
             "error should keep builtin-only surface: {error}"
@@ -2774,7 +2630,7 @@ compact_preserve_recent_turns = 4
 compact_fail_open = false
 "#;
         let parsed =
-            toml::from_str::<LoongConfig>(raw).expect("parse conversation compaction config");
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation compaction config");
         assert!(parsed.conversation.compact_enabled);
         assert_eq!(parsed.conversation.compact_min_messages(), Some(6));
         assert_eq!(
@@ -2879,7 +2735,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/workspace/project"]
 [acp.backends.acpx.mcp_servers.filesystem.env]
 MCP_LOG = "warn"
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse ACP config");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse ACP config");
         assert!(parsed.acp.enabled);
         assert_eq!(parsed.acp.backend_id().as_deref(), Some("acpx"));
         assert_eq!(parsed.acp.resolved_default_agent().as_deref(), Ok("claude"));
@@ -3006,7 +2862,7 @@ allowed_channels = [" Telegram ", "feishu"]
 allowed_account_ids = [" Work Bot ", "ops-bot"]
 thread_routing = "thread_only"
 "#;
-        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse ACP dispatch config");
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse ACP dispatch config");
         assert!(parsed.acp.enabled);
         assert!(!parsed.acp.dispatch.enabled);
         assert_eq!(

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::CliResult;
 use crate::mcp::McpConfig;
 use crate::secrets::DefaultSecretResolver;
-use loong_contracts::{SecretRef, SecretResolver};
+use loongclaw_contracts::{SecretRef, SecretResolver};
 
 use super::{
     OnebotChannelConfig, QqbotChannelConfig, WeixinChannelConfig,
@@ -33,7 +33,7 @@ use super::{
     provider::{ProviderConfig, ProviderKind, ProviderProfileConfig},
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
-        DEFAULT_CONFIG_FILE, default_loong_home as shared_default_loong_home, expand_path,
+        DEFAULT_CONFIG_FILE, default_loongclaw_home as shared_default_loongclaw_home, expand_path,
         format_config_validation_issues,
     },
     tools::{
@@ -106,7 +106,7 @@ impl ConfigValidationDiagnostic {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct LoongConfig {
+pub struct LoongClawConfig {
     #[serde(default, skip_serializing)]
     pub provider: ProviderConfig,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -185,10 +185,32 @@ pub struct LoongConfig {
     pub memory: MemoryConfig,
     #[serde(default)]
     pub audit: AuditConfig,
+    #[serde(default, skip_serializing_if = "GatewayConfig::is_default")]
+    pub gateway: GatewayConfig,
     #[serde(default, skip_serializing_if = "ControlPlaneConfig::is_default")]
     pub control_plane: ControlPlaneConfig,
     #[serde(default)]
     pub acp: AcpConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GatewayConfig {
+    #[serde(default = "default_gateway_port")]
+    pub port: u16,
+}
+
+impl GatewayConfig {
+    fn is_default(config: &Self) -> bool {
+        *config == Self::default()
+    }
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self {
+            port: default_gateway_port(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -616,6 +638,10 @@ const fn default_acp_max_concurrent_sessions() -> usize {
 
 const fn default_true() -> bool {
     true
+}
+
+const fn default_gateway_port() -> u16 {
+    26_306
 }
 
 const fn default_acp_session_idle_ttl_ms() -> u64 {
@@ -1098,7 +1124,7 @@ fn canonicalize_provider_profile_for_encoding(profile: &mut ProviderProfileConfi
     );
 }
 
-fn canonicalize_channel_configs_for_encoding(config: &mut LoongConfig) {
+fn canonicalize_channel_configs_for_encoding(config: &mut LoongClawConfig) {
     canonicalize_telegram_channel_for_encoding(&mut config.telegram);
     canonicalize_feishu_channel_for_encoding(&mut config.feishu);
     canonicalize_matrix_channel_for_encoding(&mut config.matrix);
@@ -1213,14 +1239,9 @@ fn canonicalize_onebot_channel_for_encoding(config: &mut OnebotChannelConfig) {
 
 fn canonicalize_discord_channel_for_encoding(config: &mut DiscordChannelConfig) {
     canonicalize_env_secret_reference(&mut config.bot_token, &mut config.bot_token_env);
-    canonicalize_env_string_reference(&mut config.application_id, &mut config.application_id_env);
 
     for account in config.accounts.values_mut() {
         canonicalize_env_secret_reference(&mut account.bot_token, &mut account.bot_token_env);
-        canonicalize_env_string_reference(
-            &mut account.application_id,
-            &mut account.application_id_env,
-        );
     }
 }
 
@@ -1422,11 +1443,11 @@ fn canonicalize_optional_env_name(env_name: &mut Option<String>) {
 }
 
 fn canonicalize_provider_secret_env_reference(
-    inline_secret: &mut Option<loong_contracts::SecretRef>,
+    inline_secret: &mut Option<loongclaw_contracts::SecretRef>,
     env_name: &mut Option<String>,
 ) {
     if let Some(explicit_env_name) = secret_ref_env_name(inline_secret.as_ref()) {
-        *inline_secret = Some(loong_contracts::SecretRef::Env {
+        *inline_secret = Some(loongclaw_contracts::SecretRef::Env {
             env: explicit_env_name,
         });
         *env_name = None;
@@ -1435,7 +1456,7 @@ fn canonicalize_provider_secret_env_reference(
 
     if inline_secret
         .as_ref()
-        .is_some_and(loong_contracts::SecretRef::is_configured)
+        .is_some_and(loongclaw_contracts::SecretRef::is_configured)
     {
         *env_name = None;
         return;
@@ -1447,7 +1468,7 @@ fn canonicalize_provider_secret_env_reference(
         .filter(|value| !value.is_empty())
         .map(str::to_owned);
     if let Some(normalized_env_name) = normalized_env_name {
-        *inline_secret = Some(loong_contracts::SecretRef::Env {
+        *inline_secret = Some(loongclaw_contracts::SecretRef::Env {
             env: normalized_env_name,
         });
     }
@@ -1460,7 +1481,7 @@ fn canonicalize_env_string_reference(value: &mut Option<String>, env_name: &mut 
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
         .and_then(|raw| {
-            let secret_ref = loong_contracts::SecretRef::Inline(raw.to_owned());
+            let secret_ref = loongclaw_contracts::SecretRef::Inline(raw.to_owned());
             secret_ref_env_name(Some(&secret_ref))
         });
     let Some(explicit_env_name) = explicit_env_name else {
@@ -1551,7 +1572,7 @@ pub(crate) fn normalize_dispatch_account_id(raw: &str) -> Option<String> {
     }
 }
 
-impl LoongConfig {
+impl LoongClawConfig {
     fn collect_validation_issues_with_report(
         &self,
         selection_report: Option<&ProviderSelectionNormalizationReport>,
@@ -1631,36 +1652,8 @@ impl LoongConfig {
         crate::channel::enabled_channel_ids(self, None)
     }
 
-    pub fn enabled_runtime_backed_channel_ids(&self) -> Vec<String> {
-        crate::channel::enabled_channel_ids(
-            self,
-            Some(crate::channel::ChannelRuntimeKind::RuntimeBacked),
-        )
-    }
-
     pub fn enabled_service_channel_ids(&self) -> Vec<String> {
-        self.enabled_runtime_backed_channel_ids()
-    }
-
-    pub fn enabled_plugin_backed_channel_ids(&self) -> Vec<String> {
-        crate::channel::enabled_channel_ids(
-            self,
-            Some(crate::channel::ChannelRuntimeKind::PluginBacked),
-        )
-    }
-
-    pub fn enabled_outbound_only_channel_ids(&self) -> Vec<String> {
-        crate::channel::enabled_channel_ids(
-            self,
-            Some(crate::channel::ChannelRuntimeKind::OutboundOnly),
-        )
-    }
-
-    pub fn enabled_catalog_only_channel_ids(&self) -> Vec<String> {
-        crate::channel::enabled_channel_ids(
-            self,
-            Some(crate::channel::ChannelRuntimeKind::CatalogOnly),
-        )
+        crate::channel::enabled_channel_ids(self, Some(crate::channel::ChannelRuntimeKind::Service))
     }
 
     pub fn active_provider_id(&self) -> Option<&str> {
@@ -1730,7 +1723,10 @@ impl LoongConfig {
         preferred_provider_selector(self.provider_selector_profiles(), target_profile_id)
     }
 
-    pub fn clone_with_provider_runtime_state(&self, provider_runtime_state: &LoongConfig) -> Self {
+    pub fn clone_with_provider_runtime_state(
+        &self,
+        provider_runtime_state: &LoongClawConfig,
+    ) -> Self {
         let mut merged = self.clone();
         merged.provider = provider_runtime_state.provider.clone();
         merged.providers = provider_runtime_state.providers.clone();
@@ -2037,8 +2033,8 @@ fn inspect_raw_provider_selection_intent(raw: &str) -> CliResult<RawProviderSele
 #[cfg(feature = "config-toml")]
 fn parse_toml_config_components(
     raw: &str,
-) -> CliResult<(LoongConfig, ProviderSelectionNormalizationReport)> {
-    let mut config = toml::from_str::<LoongConfig>(raw)
+) -> CliResult<(LoongClawConfig, ProviderSelectionNormalizationReport)> {
+    let mut config = toml::from_str::<LoongClawConfig>(raw)
         .map_err(|error| format!("failed to parse TOML config: {error}"))?;
     let selection_intent = inspect_raw_provider_selection_intent(raw)?;
     let had_saved_provider_profiles = !config.providers.is_empty();
@@ -2055,11 +2051,11 @@ fn parse_toml_config_components(
 #[cfg(not(feature = "config-toml"))]
 fn parse_toml_config_components(
     _raw: &str,
-) -> CliResult<(LoongConfig, ProviderSelectionNormalizationReport)> {
+) -> CliResult<(LoongClawConfig, ProviderSelectionNormalizationReport)> {
     Err("config-toml feature is disabled for this build".to_owned())
 }
 
-pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongConfig)> {
+pub fn load(path: Option<&str>) -> CliResult<(PathBuf, LoongClawConfig)> {
     let config_path = path.map(expand_path).unwrap_or_else(default_config_path);
     let raw = fs::read_to_string(&config_path).map_err(|error| {
         format!(
@@ -2125,7 +2121,7 @@ pub fn write_template(path: Option<&str>, force: bool) -> CliResult<PathBuf> {
         "{}{}{}",
         template_secret_usage_comment(),
         template_web_search_usage_comment(),
-        encode_toml_config(&LoongConfig::default())?
+        encode_toml_config(&LoongClawConfig::default())?
     );
     fs::write(&output_path, encoded).map_err(|error| {
         format!(
@@ -2136,7 +2132,7 @@ pub fn write_template(path: Option<&str>, force: bool) -> CliResult<PathBuf> {
     Ok(output_path)
 }
 
-pub fn write(path: Option<&str>, config: &LoongConfig, force: bool) -> CliResult<PathBuf> {
+pub fn write(path: Option<&str>, config: &LoongClawConfig, force: bool) -> CliResult<PathBuf> {
     let output_path = path.map(expand_path).unwrap_or_else(default_config_path);
     if output_path.exists() && !force {
         return Err(format!(
@@ -2169,16 +2165,16 @@ pub fn write(path: Option<&str>, config: &LoongConfig, force: bool) -> CliResult
     Ok(output_path)
 }
 
-pub fn render(config: &LoongConfig) -> CliResult<String> {
+pub fn render(config: &LoongClawConfig) -> CliResult<String> {
     encode_toml_config(config)
 }
 
 pub fn default_config_path() -> PathBuf {
-    default_loong_home().join(DEFAULT_CONFIG_FILE)
+    default_loongclaw_home().join(DEFAULT_CONFIG_FILE)
 }
 
-pub fn default_loong_home() -> PathBuf {
-    shared_default_loong_home()
+pub fn default_loongclaw_home() -> PathBuf {
+    shared_default_loongclaw_home()
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -2188,7 +2184,7 @@ fn config_write_failure_injected(output_path: &Path) -> bool {
         return true;
     }
 
-    let configured_path = std::env::var_os("LOONG_TEST_FAIL_CONFIG_WRITE_PATH");
+    let configured_path = std::env::var_os("LOONGCLAW_TEST_FAIL_CONFIG_WRITE_PATH");
     let Some(configured_path) = configured_path else {
         return false;
     };
@@ -2198,36 +2194,36 @@ fn config_write_failure_injected(output_path: &Path) -> bool {
 }
 
 #[cfg(feature = "config-toml")]
-fn parse_toml_config(raw: &str) -> CliResult<LoongConfig> {
+fn parse_toml_config(raw: &str) -> CliResult<LoongClawConfig> {
     let (config, selection_report) = parse_toml_config_components(raw)?;
     config.validate_with_report(Some(&selection_report))?;
     Ok(config)
 }
 
 #[cfg(feature = "config-toml")]
-fn parse_toml_config_without_validation(raw: &str) -> CliResult<LoongConfig> {
+fn parse_toml_config_without_validation(raw: &str) -> CliResult<LoongClawConfig> {
     parse_toml_config_components(raw).map(|(config, _selection_report)| config)
 }
 
 #[cfg(not(feature = "config-toml"))]
-fn parse_toml_config(_raw: &str) -> CliResult<LoongConfig> {
+fn parse_toml_config(_raw: &str) -> CliResult<LoongClawConfig> {
     Err("config-toml feature is disabled for this build".to_owned())
 }
 
 #[cfg(not(feature = "config-toml"))]
-fn parse_toml_config_without_validation(_raw: &str) -> CliResult<LoongConfig> {
+fn parse_toml_config_without_validation(_raw: &str) -> CliResult<LoongClawConfig> {
     Err("config-toml feature is disabled for this build".to_owned())
 }
 
 #[cfg(feature = "config-toml")]
-fn encode_toml_config(config: &LoongConfig) -> CliResult<String> {
+fn encode_toml_config(config: &LoongClawConfig) -> CliResult<String> {
     let encoded = config.clone_for_encoding();
     toml::to_string_pretty(&encoded)
         .map_err(|error| format!("failed to encode TOML config: {error}"))
 }
 
 #[cfg(not(feature = "config-toml"))]
-fn encode_toml_config(_config: &LoongConfig) -> CliResult<String> {
+fn encode_toml_config(_config: &LoongClawConfig) -> CliResult<String> {
     Err("config-toml feature is disabled for this build".to_owned())
 }
 
@@ -2235,7 +2231,7 @@ fn template_secret_usage_comment() -> &'static str {
     "# Secret configuration notes:\n\
 # - Preferred provider credential form: `providers.<profile_id>.api_key = { env = \"PROVIDER_API_KEY\" }`.\n\
 # - `providers.<profile_id>.api_key` still accepts direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
-# - Legacy `*_env` provider fields still load, but Loong now writes provider env refs back into the main secret field.\n\
+# - Legacy `*_env` provider fields still load, but LoongClaw now writes provider env refs back into the main secret field.\n\
 \n"
 }
 
@@ -2262,7 +2258,7 @@ mod tests {
         ONEBOT_ACCESS_TOKEN_ENV, ONEBOT_WEBSOCKET_URL_ENV, QQBOT_APP_ID_ENV,
         QQBOT_CLIENT_SECRET_ENV, WEIXIN_BRIDGE_ACCESS_TOKEN_ENV, WEIXIN_BRIDGE_URL_ENV,
     };
-    use loong_contracts::SecretRef;
+    use loongclaw_contracts::SecretRef;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_config_path(prefix: &str) -> PathBuf {
@@ -2280,7 +2276,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-validate-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-config-validate-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2308,7 +2304,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-template-comment-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-template-comment-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2330,7 +2326,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-template-api-key-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-template-api-key-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2353,7 +2349,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .expect("system clock before unix epoch")
             .as_nanos();
         let temp_dir =
-            std::env::temp_dir().join(format!("loong-template-web-search-notes-{unique}"));
+            std::env::temp_dir().join(format!("loongclaw-template-web-search-notes-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2383,7 +2379,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .expect("system clock before unix epoch")
             .as_nanos();
         let temp_dir =
-            std::env::temp_dir().join(format!("loong-template-tool-summary-limit-{unique}"));
+            std::env::temp_dir().join(format!("loongclaw-template-tool-summary-limit-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2410,7 +2406,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .expect("system clock before unix epoch")
             .as_nanos();
         let temp_dir = std::env::temp_dir().join(format!(
-            "loong-template-fast-lane-parallel-execution-{unique}"
+            "loongclaw-template-fast-lane-parallel-execution-{unique}"
         ));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
@@ -2434,7 +2430,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-template-matrix-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-template-matrix-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2458,7 +2454,8 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-template-plugin-bridges-{unique}"));
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-template-plugin-bridges-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
 
@@ -2496,7 +2493,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-diagnostics-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-config-diagnostics-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2512,7 +2509,7 @@ api_key_env = "$OPENAI_API_KEY"
         assert_eq!(diagnostics[0].code, "config.env_pointer.dollar_prefix");
         assert_eq!(
             diagnostics[0].problem_type,
-            "urn:loong:problem:config.env_pointer.dollar_prefix"
+            "urn:loongclaw:problem:config.env_pointer.dollar_prefix"
         );
         assert_eq!(
             diagnostics[0].title_key,
@@ -2547,7 +2544,7 @@ api_key_env = "$OPENAI_API_KEY"
             .expect("system clock before unix epoch")
             .as_nanos();
         let temp_dir =
-            std::env::temp_dir().join(format!("loong-config-typed-env-diagnostics-{unique}"));
+            std::env::temp_dir().join(format!("loongclaw-config-typed-env-diagnostics-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2578,7 +2575,8 @@ api_key = { env = "$OPENAI_API_KEY" }
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-channel-account-{unique}"));
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-config-channel-account-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2597,7 +2595,7 @@ bot_token_env = "WORK_TELEGRAM_TOKEN_DUP"
         assert_eq!(diagnostics[0].code, "config.channel_account.duplicate_id");
         assert_eq!(
             diagnostics[0].problem_type,
-            "urn:loong:problem:config.channel_account.duplicate_id"
+            "urn:loongclaw:problem:config.channel_account.duplicate_id"
         );
         assert_eq!(diagnostics[0].field_path, "telegram.accounts");
         assert_eq!(
@@ -2622,7 +2620,7 @@ bot_token_env = "WORK_TELEGRAM_TOKEN_DUP"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-locale-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-config-locale-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2654,8 +2652,8 @@ api_key_env = "$OPENAI_API_KEY"
     }
 
     #[test]
-    fn load_missing_config_guides_user_to_loong_onboard() {
-        let missing = unique_config_path("loong-config-missing");
+    fn load_missing_config_guides_user_to_loongclaw_onboard() {
+        let missing = unique_config_path("loongclaw-config-missing");
         let path_string = missing.display().to_string();
 
         let error = load(Some(&path_string)).expect_err("missing config should fail");
@@ -2669,7 +2667,7 @@ api_key_env = "$OPENAI_API_KEY"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-percent-{unique}"));
+        let temp_dir = std::env::temp_dir().join(format!("loongclaw-config-percent-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let raw = r#"
@@ -2684,7 +2682,7 @@ api_key_env = "%OPENAI_API_KEY%"
         assert_eq!(diagnostics[0].code, "config.env_pointer.percent_wrapped");
         assert_eq!(
             diagnostics[0].problem_type,
-            "urn:loong:problem:config.env_pointer.percent_wrapped"
+            "urn:loongclaw:problem:config.env_pointer.percent_wrapped"
         );
 
         std::fs::remove_file(&config_path).ok();
@@ -2698,7 +2696,8 @@ api_key_env = "%OPENAI_API_KEY%"
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("loong-config-no-secret-echo-{unique}"));
+        let temp_dir =
+            std::env::temp_dir().join(format!("loongclaw-config-no-secret-echo-{unique}"));
         std::fs::create_dir_all(&temp_dir).expect("create temp directory");
         let config_path = temp_dir.join("config.toml");
         let secret = "sk-inline-super-secret-token";
@@ -2725,9 +2724,9 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_persists_custom_model_and_prompt() {
-        let path = unique_config_path("loong-config-runtime");
+        let path = unique_config_path("loongclaw-config-runtime");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.model = "openai/gpt-5.1-codex".to_owned();
         config.cli.system_prompt = "You are an onboarding assistant.".to_owned();
 
@@ -2744,16 +2743,19 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_persists_prompt_pack_and_personality_metadata() {
-        let path = unique_config_path("loong-prompt-config");
+        let path = unique_config_path("loongclaw-prompt-config");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
-        config.cli.prompt_pack_id = Some("loong-core-v1".to_owned());
+        let mut config = LoongClawConfig::default();
+        config.cli.prompt_pack_id = Some("loongclaw-core-v1".to_owned());
         config.cli.personality = Some(crate::prompt::PromptPersonality::CyberRadical);
 
         write(Some(&path_string), &config, true).expect("config write should pass");
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
 
-        assert_eq!(loaded.cli.prompt_pack_id.as_deref(), Some("loong-core-v1"));
+        assert_eq!(
+            loaded.cli.prompt_pack_id.as_deref(),
+            Some("loongclaw-core-v1")
+        );
         assert_eq!(
             loaded.cli.personality,
             Some(crate::prompt::PromptPersonality::CyberRadical)
@@ -2765,10 +2767,10 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn load_accepts_legacy_prompt_personality_ids() {
-        let path = unique_config_path("loong-legacy-prompt-config");
+        let path = unique_config_path("loongclaw-legacy-prompt-config");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
-        config.cli.prompt_pack_id = Some("loong-core-v1".to_owned());
+        let mut config = LoongClawConfig::default();
+        config.cli.prompt_pack_id = Some("loongclaw-core-v1".to_owned());
         config.cli.personality = Some(crate::prompt::PromptPersonality::Hermit);
 
         write(Some(&path_string), &config, true).expect("config write should pass");
@@ -2811,9 +2813,9 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_persists_memory_profile_metadata() {
-        let path = unique_config_path("loong-memory-config");
+        let path = unique_config_path("loongclaw-memory-config");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
         config.memory.summary_max_chars = 900;
         config.memory.profile_note = Some("Imported NanoBot preferences".to_owned());
@@ -2837,9 +2839,9 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_persists_typed_personalization_metadata() {
-        let path = unique_config_path("loong-personalization-config");
+        let path = unique_config_path("loongclaw-personalization-config");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Thorough),
@@ -2898,7 +2900,7 @@ api_key_env = "{secret}"
     #[test]
     #[cfg(feature = "config-toml")]
     fn load_legacy_provider_table_populates_active_provider_profile_storage() {
-        let path = unique_config_path("loong-config-legacy-provider");
+        let path = unique_config_path("loongclaw-config-legacy-provider");
         let raw = r#"
 [provider]
 kind = "deepseek"
@@ -2960,7 +2962,7 @@ chat_completions_path = "/api/v1/chat/completions"
     #[test]
     #[cfg(feature = "config-toml")]
     fn validate_file_reports_warning_for_implicit_active_provider_recovery_in_mixed_config() {
-        let path = unique_config_path("loong-config-provider-selection-warning");
+        let path = unique_config_path("loongclaw-config-provider-selection-warning");
         let raw = r#"
 [provider]
 kind = "volcengine_coding"
@@ -3025,7 +3027,7 @@ chat_completions_path = "/api/v1/chat/completions"
     #[test]
     #[cfg(feature = "config-toml")]
     fn validate_file_reports_warning_for_unknown_active_provider_recovery_in_mixed_config() {
-        let path = unique_config_path("loong-config-provider-selection-unknown-active");
+        let path = unique_config_path("loongclaw-config-provider-selection-unknown-active");
         let raw = r#"
 active_provider = "missing-profile"
 
@@ -3063,7 +3065,7 @@ chat_completions_path = "/api/v1/chat/completions"
     #[test]
     #[cfg(feature = "config-toml")]
     fn validate_file_reports_legacy_provider_field_errors_even_when_provider_profiles_exist() {
-        let path = unique_config_path("loong-config-legacy-provider-validation");
+        let path = unique_config_path("loongclaw-config-legacy-provider-validation");
         let raw = r#"
 active_provider = "openrouter"
 
@@ -3145,10 +3147,10 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_default_config_does_not_eagerly_persist_provider_api_key_env_field() {
-        let path = unique_config_path("loong-config-runtime-default");
+        let path = unique_config_path("loongclaw-config-runtime-default");
         let path_string = path.display().to_string();
 
-        write(Some(&path_string), &LoongConfig::default(), true)
+        write(Some(&path_string), &LoongClawConfig::default(), true)
             .expect("default config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
@@ -3161,10 +3163,10 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_default_config_uses_provider_profiles_and_active_provider() {
-        let path = unique_config_path("loong-config-runtime-profiles");
+        let path = unique_config_path("loongclaw-config-runtime-profiles");
         let path_string = path.display().to_string();
 
-        write(Some(&path_string), &LoongConfig::default(), true)
+        write(Some(&path_string), &LoongClawConfig::default(), true)
             .expect("default config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
@@ -3178,10 +3180,10 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_default_config_includes_durable_audit_defaults() {
-        let path = unique_config_path("loong-config-runtime-audit");
+        let path = unique_config_path("loongclaw-config-runtime-audit");
         let path_string = path.display().to_string();
 
-        write(Some(&path_string), &LoongConfig::default(), true)
+        write(Some(&path_string), &LoongClawConfig::default(), true)
             .expect("default config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
@@ -3199,9 +3201,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_persists_provider_env_pointers_as_secret_refs() {
-        let path = unique_config_path("loong-config-runtime-canonical-provider-env");
+        let path = unique_config_path("loongclaw-config-runtime-canonical-provider-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
 
         write(Some(&path_string), &config, true).expect("config write should pass");
@@ -3217,9 +3219,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_migrates_inline_provider_env_references_to_secret_refs() {
-        let path = unique_config_path("loong-config-runtime-inline-provider-env");
+        let path = unique_config_path("loongclaw-config-runtime-inline-provider-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         let inline_references = [
             "${TEAM_OPENAI_KEY}",
             "$TEAM_OPENAI_KEY",
@@ -3249,9 +3251,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_canonicalizes_matching_provider_env_name_fields_into_secret_refs() {
-        let path = unique_config_path("loong-config-runtime-trimmed-provider-env");
+        let path = unique_config_path("loongclaw-config-runtime-trimmed-provider-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("${TEAM_OPENAI_KEY}".to_owned()));
         config.provider.api_key_env = Some(" TEAM_OPENAI_KEY ".to_owned());
 
@@ -3269,9 +3271,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_canonicalizes_matching_wecom_env_name_fields() {
-        let path = unique_config_path("loong-config-runtime-trimmed-wecom-env");
+        let path = unique_config_path("loongclaw-config-runtime-trimmed-wecom-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.wecom.bot_id = Some(SecretRef::Inline("${WECOM_BOT_ID}".to_owned()));
         config.wecom.bot_id_env = Some(" WECOM_BOT_ID ".to_owned());
         config.wecom.secret = Some(SecretRef::Inline("${WECOM_SECRET}".to_owned()));
@@ -3293,9 +3295,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_canonicalizes_matching_config_backed_channel_env_name_fields() {
-        let path = unique_config_path("loong-config-runtime-trimmed-config-backed-env");
+        let path = unique_config_path("loongclaw-config-runtime-trimmed-config-backed-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         let mut ops_nostr_account = crate::config::NostrAccountConfig::default();
 
         config.discord.bot_token = Some(SecretRef::Inline("${DISCORD_BOT_TOKEN}".to_owned()));
@@ -3355,9 +3357,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_canonicalizes_matching_plugin_backed_channel_env_name_fields() {
-        let path = unique_config_path("loong-config-runtime-trimmed-plugin-bridge-env");
+        let path = unique_config_path("loongclaw-config-runtime-trimmed-plugin-bridge-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
 
         config.weixin.bridge_url = Some("${WEIXIN_BRIDGE_URL}".to_owned());
         config.weixin.bridge_url_env = Some(" WEIXIN_BRIDGE_URL ".to_owned());
@@ -3406,9 +3408,9 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_preserves_provider_env_binding_when_inline_secret_is_blank() {
-        let path = unique_config_path("loong-config-runtime-blank-inline-provider-env");
+        let path = unique_config_path("loongclaw-config-runtime-blank-inline-provider-env");
         let path_string = path.display().to_string();
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("   ".to_owned()));
         config.provider.api_key_env = Some("TEAM_OPENAI_KEY".to_owned());
 
@@ -3425,7 +3427,7 @@ model = "gpt-5"
 
     #[test]
     fn resolve_provider_switch_target_prefers_profile_id_then_kind_default() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openai-main",
             ProviderProfileConfig {
@@ -3476,7 +3478,7 @@ model = "gpt-5"
 
     #[test]
     fn resolve_provider_switch_target_accepts_unique_model_selector() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openai-main",
             ProviderProfileConfig {
@@ -3512,7 +3514,7 @@ model = "gpt-5"
 
     #[test]
     fn resolve_provider_switch_target_accepts_unique_model_suffix_selector() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openrouter-main",
             ProviderProfileConfig {
@@ -3544,7 +3546,7 @@ model = "gpt-5"
 
     #[test]
     fn resolve_provider_switch_target_rejects_ambiguous_kind_without_default() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openai-main",
             ProviderProfileConfig {
@@ -3641,7 +3643,7 @@ model = "gpt-5"
 
     #[test]
     fn resolve_provider_switch_target_unknown_selector_lists_accepted_selectors() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openai-main",
             ProviderProfileConfig {
@@ -3680,7 +3682,7 @@ model = "gpt-5"
 
     #[test]
     fn switch_active_provider_updates_last_provider_and_kind_default() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.set_active_provider_profile(
             "openai-main",
             ProviderProfileConfig {
@@ -3747,10 +3749,10 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_default_config_keeps_external_skills_guardrails() {
-        let path = unique_config_path("loong-config-runtime-external-skills");
+        let path = unique_config_path("loongclaw-config-runtime-external-skills");
         let path_string = path.display().to_string();
 
-        write(Some(&path_string), &LoongConfig::default(), true)
+        write(Some(&path_string), &LoongClawConfig::default(), true)
             .expect("default config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
@@ -3776,12 +3778,12 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn write_rejects_overwrite_without_force() {
-        let path = unique_config_path("loong-config-runtime");
+        let path = unique_config_path("loongclaw-config-runtime");
         let path_string = path.display().to_string();
-        let first = LoongConfig::default();
+        let first = LoongClawConfig::default();
         write(Some(&path_string), &first, true).expect("initial config write should pass");
 
-        let mut updated = LoongConfig::default();
+        let mut updated = LoongClawConfig::default();
         updated.provider.model = "openai/gpt-5".to_owned();
         let error = write(Some(&path_string), &updated, false)
             .expect_err("overwrite without --force should fail");
@@ -3793,7 +3795,7 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn tool_config_round_trips_session_and_delegate_settings() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.tools.sessions.visibility = crate::config::tools::SessionVisibility::SelfOnly;
         config.tools.sessions.list_limit = 12;
         config.tools.sessions.history_limit = 34;
@@ -3806,7 +3808,7 @@ model = "gpt-5"
             vec!["file.read".to_owned(), "shell.exec".to_owned()];
 
         let encoded = encode_toml_config(&config).expect("encode config");
-        let parsed = toml::from_str::<LoongConfig>(&encoded).expect("parse encoded config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
 
         assert_eq!(parsed.tools.sessions, config.tools.sessions);
         assert_eq!(parsed.tools.messages, config.tools.messages);
@@ -3816,13 +3818,13 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn audit_config_round_trips_mode_and_path_settings() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.audit.mode = crate::config::AuditMode::Jsonl;
-        config.audit.path = "~/.loong/audit/custom-events.jsonl".to_owned();
+        config.audit.path = "~/.loongclaw/audit/custom-events.jsonl".to_owned();
         config.audit.retain_in_memory = false;
 
         let encoded = encode_toml_config(&config).expect("encode config");
-        let parsed = toml::from_str::<LoongConfig>(&encoded).expect("parse encoded config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
 
         assert_eq!(parsed.audit, config.audit);
     }
@@ -3830,11 +3832,11 @@ model = "gpt-5"
     #[test]
     #[cfg(feature = "config-toml")]
     fn outbound_http_config_round_trips_private_host_override() {
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         config.outbound_http.allow_private_hosts = true;
 
         let encoded = encode_toml_config(&config).expect("encode config");
-        let parsed = toml::from_str::<LoongConfig>(&encoded).expect("parse encoded config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
 
         assert!(parsed.outbound_http.allow_private_hosts);
     }

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -3,6 +3,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::sync::{Notify, broadcast};
@@ -14,9 +15,7 @@ use crate::acp::{
     shared_acp_session_manager,
 };
 #[cfg(feature = "memory-sqlite")]
-use crate::config::LoongConfig;
-#[cfg(feature = "memory-sqlite")]
-use crate::config::ToolConfig;
+use crate::config::LoongClawConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
@@ -24,15 +23,9 @@ use crate::session::repository::{
     ApprovalRequestRecord, ApprovalRequestStatus, ControlPlaneDeviceTokenRecord,
     ControlPlanePairingRequestRecord as PersistedControlPlanePairingRequestRecord,
     ControlPlanePairingRequestStatus as PersistedControlPlanePairingRequestStatus,
-    NewControlPlaneDeviceTokenRecord, NewControlPlanePairingRequestRecord, SessionEventRecord,
+    NewControlPlaneDeviceTokenRecord, NewControlPlanePairingRequestRecord,
     SessionObservationRecord, SessionRepository, SessionSummaryRecord,
-    SessionTerminalOutcomeRecord, TransitionControlPlanePairingRequestIfCurrentRequest,
-};
-#[cfg(feature = "memory-sqlite")]
-use crate::tools::session::{
-    SessionRuntimeSelfContinuityRecord, SessionWorkflowBindingRecord, SessionWorkflowRecord,
-    build_session_tool_policy_status_payload, load_session_workflow_record,
-    session_delegate_lifecycle_at,
+    TransitionControlPlanePairingRequestIfCurrentRequest,
 };
 
 const DEFAULT_RECENT_EVENT_LIMIT: usize = 256;
@@ -828,7 +821,7 @@ impl ControlPlaneManager {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlPlaneConnectionPrincipal {
     pub connection_id: String,
     pub client_id: String,
@@ -837,12 +830,13 @@ pub struct ControlPlaneConnectionPrincipal {
     pub device_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlPlaneConnectionLease {
     pub token: String,
     pub principal: ControlPlaneConnectionPrincipal,
     pub issued_at_ms: u64,
     pub expires_at_ms: u64,
+    pub acknowledged_seq: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -850,6 +844,7 @@ struct ControlPlaneConnectionRecord {
     principal: ControlPlaneConnectionPrincipal,
     issued_at_ms: u64,
     expires_at_ms: u64,
+    acknowledged_seq: Option<u64>,
 }
 
 #[derive(Debug, Default)]
@@ -885,7 +880,40 @@ impl ControlPlaneConnectionRegistry {
                 principal: record.principal.clone(),
                 issued_at_ms: record.issued_at_ms,
                 expires_at_ms: record.expires_at_ms,
+                acknowledged_seq: record.acknowledged_seq,
             }))
+    }
+
+    pub fn acknowledge_seq(
+        &self,
+        token: &str,
+        seq: u64,
+    ) -> Result<Option<ControlPlaneConnectionLease>, String> {
+        let token = token.trim();
+        if token.is_empty() {
+            return Ok(None);
+        }
+        let now_ms = current_time_ms();
+        let mut connections = self
+            .connections
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        connections.retain(|_, record| record.expires_at_ms > now_ms);
+        let Some(record) = connections.get_mut(token) else {
+            return Ok(None);
+        };
+        let next_acknowledged_seq = match record.acknowledged_seq {
+            Some(existing) => existing.max(seq),
+            None => seq,
+        };
+        record.acknowledged_seq = Some(next_acknowledged_seq);
+        Ok(Some(ControlPlaneConnectionLease {
+            token: token.to_owned(),
+            principal: record.principal.clone(),
+            issued_at_ms: record.issued_at_ms,
+            expires_at_ms: record.expires_at_ms,
+            acknowledged_seq: record.acknowledged_seq,
+        }))
     }
 
     pub fn revoke(&self, token: &str) -> bool {
@@ -898,6 +926,56 @@ impl ControlPlaneConnectionRegistry {
             .unwrap_or_else(|error| error.into_inner())
             .remove(token)
             .is_some()
+    }
+
+    pub fn snapshot_leases(&self) -> Vec<ControlPlaneConnectionLease> {
+        let now_ms = current_time_ms();
+        let mut connections = self
+            .connections
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        connections.retain(|_, record| record.expires_at_ms > now_ms);
+        let mut leases = connections
+            .iter()
+            .map(|(token, record)| ControlPlaneConnectionLease {
+                token: token.clone(),
+                principal: record.principal.clone(),
+                issued_at_ms: record.issued_at_ms,
+                expires_at_ms: record.expires_at_ms,
+                acknowledged_seq: record.acknowledged_seq,
+            })
+            .collect::<Vec<_>>();
+        leases.sort_by(|left, right| left.token.cmp(&right.token));
+        leases
+    }
+
+    pub fn restore_leases(
+        &self,
+        leases: &[ControlPlaneConnectionLease],
+    ) -> Result<usize, String> {
+        let now_ms = current_time_ms();
+        let mut connections = self
+            .connections
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        connections.clear();
+        let mut restored = 0usize;
+        for lease in leases {
+            if lease.expires_at_ms <= now_ms {
+                continue;
+            }
+            connections.insert(
+                lease.token.clone(),
+                ControlPlaneConnectionRecord {
+                    principal: lease.principal.clone(),
+                    issued_at_ms: lease.issued_at_ms,
+                    expires_at_ms: lease.expires_at_ms,
+                    acknowledged_seq: lease.acknowledged_seq,
+                },
+            );
+            restored = restored.saturating_add(1);
+        }
+        Ok(restored)
     }
 
     fn issue_with_ttl_ms(
@@ -914,6 +992,7 @@ impl ControlPlaneConnectionRegistry {
             principal: principal.clone(),
             issued_at_ms,
             expires_at_ms,
+            acknowledged_seq: None,
         };
         self.connections
             .write()
@@ -924,6 +1003,7 @@ impl ControlPlaneConnectionRegistry {
             principal,
             issued_at_ms,
             expires_at_ms,
+            acknowledged_seq: None,
         }
     }
 }
@@ -1012,6 +1092,15 @@ pub struct ControlPlanePairingRequestRecord {
     pub resolved_at_ms: Option<u64>,
     pub issued_token_id: Option<String>,
     pub device_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlaneApprovedDeviceSummary {
+    pub device_id: String,
+    pub public_key: String,
+    pub role: String,
+    pub approved_scopes: BTreeSet<String>,
+    pub issued_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1200,6 +1289,69 @@ impl ControlPlanePairingRegistry {
         });
         requests.truncate(limit.max(1));
         requests
+    }
+
+    pub fn pending_request_count(&self) -> usize {
+        self.requests
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .filter(|record| record.status == ControlPlanePairingStatus::Pending)
+            .count()
+    }
+
+    pub fn approved_device_count(&self) -> usize {
+        self.approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .len()
+    }
+
+    pub fn list_approved_devices(&self, limit: usize) -> Vec<ControlPlaneApprovedDeviceSummary> {
+        let mut approved_devices = self
+            .approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        approved_devices.sort_by(|left, right| {
+            right
+                .approved_at_ms
+                .cmp(&left.approved_at_ms)
+                .then_with(|| left.device_id.cmp(&right.device_id))
+        });
+        approved_devices.truncate(limit.max(1));
+
+        approved_devices
+            .iter()
+            .map(approved_device_summary_from_record)
+            .collect()
+    }
+
+    pub fn last_activity_ms(&self) -> Option<u64> {
+        let requests_last_activity = self
+            .requests
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .flat_map(|record| [Some(record.requested_at_ms), record.resolved_at_ms])
+            .flatten()
+            .max();
+        let devices_last_activity = self
+            .approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .map(|device| device.approved_at_ms)
+            .max();
+
+        match (requests_last_activity, devices_last_activity) {
+            (Some(left), Some(right)) => Some(left.max(right)),
+            (Some(left), None) => Some(left),
+            (None, Some(right)) => Some(right),
+            (None, None) => None,
+        }
     }
 
     pub fn resolve_request(
@@ -1474,6 +1626,18 @@ fn approved_device_requires_pairing(
     !scopes_within_approved
 }
 
+fn approved_device_summary_from_record(
+    approved: &ControlPlaneApprovedDeviceRecord,
+) -> ControlPlaneApprovedDeviceSummary {
+    ControlPlaneApprovedDeviceSummary {
+        device_id: approved.device_id.clone(),
+        public_key: approved.public_key.clone(),
+        role: approved.role.clone(),
+        approved_scopes: approved.approved_scopes.clone(),
+        issued_at_ms: approved.approved_at_ms,
+    }
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlPlaneRepositorySnapshotSummary {
@@ -1489,91 +1653,7 @@ pub struct ControlPlaneSessionListView {
     pub current_session_id: String,
     pub matched_count: usize,
     pub returned_count: usize,
-    pub sessions: Vec<ControlPlaneSessionSummaryView>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControlPlaneSessionSummaryView {
-    pub session: SessionSummaryRecord,
-    pub workflow: ControlPlaneSessionWorkflowView,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControlPlaneSessionWorkflowContinuityView {
-    pub present: bool,
-    pub resolved_identity_present: bool,
-    pub session_profile_projection_present: bool,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControlPlaneSessionWorkflowBindingWorktreeView {
-    pub worktree_id: String,
-    pub workspace_root: String,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControlPlaneSessionWorkflowBindingView {
-    pub session_id: String,
-    pub task_id: String,
-    pub mode: String,
-    pub execution_surface: String,
-    pub worktree: Option<ControlPlaneSessionWorkflowBindingWorktreeView>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControlPlaneSessionWorkflowView {
-    pub workflow_id: String,
-    pub task: Option<String>,
-    pub phase: Option<String>,
-    pub operation_kind: Option<String>,
-    pub operation_scope: Option<String>,
-    pub task_session_id: Option<String>,
-    pub lineage_root_session_id: Option<String>,
-    pub lineage_depth: Option<usize>,
-    pub runtime_self_continuity: Option<ControlPlaneSessionWorkflowContinuityView>,
-    pub binding: Option<ControlPlaneSessionWorkflowBindingView>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq)]
-pub struct ControlPlaneSessionObservationView {
-    pub session: ControlPlaneSessionSummaryView,
-    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
-    pub recent_events: Vec<SessionEventRecord>,
-    pub tail_events: Vec<SessionEventRecord>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq)]
-pub struct ControlPlaneTaskSummaryView {
-    pub task_id: String,
-    pub session_id: String,
-    pub scope_session_id: String,
-    pub label: Option<String>,
-    pub session_state: String,
-    pub delegate_phase: Option<String>,
-    pub delegate_mode: Option<String>,
-    pub timeout_seconds: Option<u64>,
-    pub workflow: ControlPlaneSessionWorkflowView,
-    pub approval_request_count: usize,
-    pub approval_attention_count: usize,
-    pub effective_tool_ids: Vec<String>,
-    pub effective_runtime_narrowing: Value,
-    pub last_error: Option<String>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq)]
-pub struct ControlPlaneTaskListView {
-    pub current_session_id: String,
-    pub matched_count: usize,
-    pub returned_count: usize,
-    pub tasks: Vec<ControlPlaneTaskSummaryView>,
+    pub sessions: Vec<SessionSummaryRecord>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1606,20 +1686,14 @@ pub struct ControlPlaneAcpSessionReadView {
 #[derive(Debug, Clone)]
 pub struct ControlPlaneRepositoryView {
     memory_config: MemoryRuntimeConfig,
-    tool_config: ToolConfig,
     current_session_id: String,
 }
 
 #[cfg(feature = "memory-sqlite")]
 impl ControlPlaneRepositoryView {
-    pub fn new(
-        memory_config: MemoryRuntimeConfig,
-        tool_config: ToolConfig,
-        current_session_id: impl Into<String>,
-    ) -> Self {
+    pub fn new(memory_config: MemoryRuntimeConfig, current_session_id: impl Into<String>) -> Self {
         Self {
             memory_config,
-            tool_config,
             current_session_id: normalize_control_plane_session_id(&current_session_id.into()),
         }
     }
@@ -1650,52 +1724,18 @@ impl ControlPlaneRepositoryView {
         limit: usize,
     ) -> Result<ControlPlaneSessionListView, String> {
         let repo = self.open_repo()?;
-        let mut visible_sessions = self.visible_sessions(&repo)?;
+        let mut sessions = self.visible_sessions(&repo)?;
         if !include_archived {
-            visible_sessions.retain(|session| session.archived_at.is_none());
+            sessions.retain(|session| session.archived_at.is_none());
         }
-        let matched_count = visible_sessions.len();
-        visible_sessions.truncate(limit.clamp(1, CONTROL_PLANE_MAX_LIST_LIMIT));
-        let session_views = self.load_session_summary_views(&repo, visible_sessions.as_slice())?;
-        let returned_count = session_views.len();
+        let matched_count = sessions.len();
+        sessions.truncate(limit.clamp(1, CONTROL_PLANE_MAX_LIST_LIMIT));
+        let returned_count = sessions.len();
         Ok(ControlPlaneSessionListView {
             current_session_id: self.current_session_id.clone(),
             matched_count,
             returned_count,
-            sessions: session_views,
-        })
-    }
-
-    pub fn list_background_tasks(
-        &self,
-        include_archived: bool,
-        limit: usize,
-    ) -> Result<ControlPlaneTaskListView, String> {
-        let repo = self.open_repo()?;
-        let mut visible_sessions = self.visible_sessions(&repo)?;
-        if !include_archived {
-            visible_sessions.retain(|session| session.archived_at.is_none());
-        }
-
-        let mut task_views = Vec::new();
-        for session in &visible_sessions {
-            let task_view = self.build_background_task_view(&repo, session)?;
-            let Some(task_view) = task_view else {
-                continue;
-            };
-            task_views.push(task_view);
-        }
-
-        let matched_count = task_views.len();
-        let bounded_limit = limit.clamp(1, CONTROL_PLANE_MAX_LIST_LIMIT);
-        task_views.truncate(bounded_limit);
-        let returned_count = task_views.len();
-
-        Ok(ControlPlaneTaskListView {
-            current_session_id: self.current_session_id.clone(),
-            matched_count,
-            returned_count,
-            tasks: task_views,
+            sessions,
         })
     }
 
@@ -1705,40 +1745,19 @@ impl ControlPlaneRepositoryView {
         recent_event_limit: usize,
         tail_after_id: Option<i64>,
         tail_page_limit: usize,
-    ) -> Result<Option<ControlPlaneSessionObservationView>, String> {
+    ) -> Result<Option<SessionObservationRecord>, String> {
         let target_session_id = target_session_id.trim();
         if target_session_id.is_empty() {
             return Err("control_plane_session_id_missing".to_owned());
         }
         let repo = self.open_repo()?;
         self.ensure_visible_session(&repo, target_session_id)?;
-        let observation = repo.load_session_observation(
+        repo.load_session_observation(
             target_session_id,
             recent_event_limit.clamp(1, CONTROL_PLANE_MAX_RECENT_EVENT_LIMIT),
             tail_after_id,
             tail_page_limit.clamp(1, CONTROL_PLANE_MAX_TAIL_EVENT_LIMIT),
-        )?;
-        self.build_session_observation_view(&repo, observation)
-    }
-
-    pub fn read_background_task(
-        &self,
-        target_session_id: &str,
-    ) -> Result<Option<ControlPlaneTaskSummaryView>, String> {
-        let trimmed_session_id = target_session_id.trim();
-        if trimmed_session_id.is_empty() {
-            return Err("control_plane_session_id_missing".to_owned());
-        }
-
-        let repo = self.open_repo()?;
-        self.ensure_visible_session(&repo, trimmed_session_id)?;
-
-        let session = repo.load_session_summary_with_legacy_fallback(trimmed_session_id)?;
-        let Some(session) = session else {
-            return Ok(None);
-        };
-
-        self.build_background_task_view(&repo, &session)
+        )
     }
 
     pub fn ensure_visible_session_id(&self, target_session_id: &str) -> Result<(), String> {
@@ -1824,108 +1843,6 @@ impl ControlPlaneRepositoryView {
         ))
     }
 
-    fn load_session_summary_views(
-        &self,
-        repo: &SessionRepository,
-        sessions: &[SessionSummaryRecord],
-    ) -> Result<Vec<ControlPlaneSessionSummaryView>, String> {
-        let mut session_views = Vec::new();
-        for session in sessions {
-            let session_clone = session.clone();
-            let workflow_record = load_session_workflow_record(repo, session, None)?;
-            let workflow = control_plane_session_workflow_view(workflow_record);
-            let session_view = ControlPlaneSessionSummaryView {
-                session: session_clone,
-                workflow,
-            };
-            session_views.push(session_view);
-        }
-        Ok(session_views)
-    }
-
-    fn build_session_observation_view(
-        &self,
-        repo: &SessionRepository,
-        observation: Option<SessionObservationRecord>,
-    ) -> Result<Option<ControlPlaneSessionObservationView>, String> {
-        let Some(observation) = observation else {
-            return Ok(None);
-        };
-
-        let workflow_record = load_session_workflow_record(repo, &observation.session, None)?;
-        let workflow = control_plane_session_workflow_view(workflow_record);
-        let session_view = ControlPlaneSessionSummaryView {
-            session: observation.session,
-            workflow,
-        };
-        let observation_view = ControlPlaneSessionObservationView {
-            session: session_view,
-            terminal_outcome: observation.terminal_outcome,
-            recent_events: observation.recent_events,
-            tail_events: observation.tail_events,
-        };
-        Ok(Some(observation_view))
-    }
-
-    fn build_background_task_view(
-        &self,
-        repo: &SessionRepository,
-        session: &SessionSummaryRecord,
-    ) -> Result<Option<ControlPlaneTaskSummaryView>, String> {
-        if session.kind != crate::session::repository::SessionKind::DelegateChild {
-            return Ok(None);
-        }
-
-        let delegate_events = repo.list_delegate_lifecycle_events(&session.session_id)?;
-        let current_timestamp = current_control_plane_unix_timestamp();
-        let delegate_lifecycle =
-            session_delegate_lifecycle_at(session, delegate_events.as_slice(), current_timestamp);
-        let Some(delegate_lifecycle) = delegate_lifecycle else {
-            return Ok(None);
-        };
-
-        let is_async_mode = delegate_lifecycle.mode == "async";
-        if !is_async_mode {
-            return Ok(None);
-        }
-
-        let workflow_record =
-            load_session_workflow_record(repo, session, Some(delegate_events.as_slice()))?;
-        let workflow = control_plane_session_workflow_view(workflow_record);
-        let tool_policy_payload =
-            build_session_tool_policy_status_payload(repo, &session.session_id, &self.tool_config)?;
-        let effective_tool_ids = control_plane_effective_tool_ids(&tool_policy_payload);
-        let effective_runtime_narrowing =
-            control_plane_effective_runtime_narrowing(&tool_policy_payload);
-        let approval_requests =
-            repo.list_approval_requests_for_session(&session.session_id, None)?;
-        let pending_approval_requests = repo.list_approval_requests_for_session(
-            &session.session_id,
-            Some(ApprovalRequestStatus::Pending),
-        )?;
-        let delegate_phase = delegate_lifecycle.phase.to_owned();
-        let delegate_mode = delegate_lifecycle.mode.to_owned();
-
-        let task_view = ControlPlaneTaskSummaryView {
-            task_id: session.session_id.clone(),
-            session_id: session.session_id.clone(),
-            scope_session_id: self.current_session_id.clone(),
-            label: session.label.clone(),
-            session_state: session.state.as_str().to_owned(),
-            delegate_phase: Some(delegate_phase),
-            delegate_mode: Some(delegate_mode),
-            timeout_seconds: delegate_lifecycle.timeout_seconds,
-            workflow,
-            approval_request_count: approval_requests.len(),
-            approval_attention_count: pending_approval_requests.len(),
-            effective_tool_ids,
-            effective_runtime_narrowing,
-            last_error: session.last_error.clone(),
-        };
-
-        Ok(Some(task_view))
-    }
-
     fn count_approvals(
         &self,
         repo: &SessionRepository,
@@ -1943,118 +1860,15 @@ impl ControlPlaneRepositoryView {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn control_plane_session_workflow_continuity_view(
-    continuity: SessionRuntimeSelfContinuityRecord,
-) -> ControlPlaneSessionWorkflowContinuityView {
-    ControlPlaneSessionWorkflowContinuityView {
-        present: continuity.present,
-        resolved_identity_present: continuity.resolved_identity_present,
-        session_profile_projection_present: continuity.session_profile_projection_present,
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn control_plane_session_workflow_view(
-    workflow: SessionWorkflowRecord,
-) -> ControlPlaneSessionWorkflowView {
-    let phase = workflow
-        .phase
-        .map(|value: loong_contracts::GovernedWorkflowPhase| value.as_str().to_owned());
-    let operation_kind = workflow
-        .operation_kind
-        .map(|value: loong_contracts::WorkflowOperationKind| value.as_str().to_owned());
-    let operation_scope = workflow
-        .operation_scope
-        .map(|value: loong_contracts::WorkflowOperationScope| value.as_str().to_owned());
-    let runtime_self_continuity = workflow
-        .runtime_self_continuity
-        .map(control_plane_session_workflow_continuity_view);
-    let binding = workflow
-        .binding
-        .map(control_plane_session_workflow_binding_view);
-
-    ControlPlaneSessionWorkflowView {
-        workflow_id: workflow.workflow_id,
-        task: workflow.task,
-        phase,
-        operation_kind,
-        operation_scope,
-        task_session_id: workflow.task_session_id,
-        lineage_root_session_id: workflow.lineage_root_session_id,
-        lineage_depth: workflow.lineage_depth,
-        runtime_self_continuity,
-        binding,
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn control_plane_session_workflow_binding_view(
-    binding: SessionWorkflowBindingRecord,
-) -> ControlPlaneSessionWorkflowBindingView {
-    let worktree =
-        binding
-            .worktree
-            .map(|worktree| ControlPlaneSessionWorkflowBindingWorktreeView {
-                worktree_id: worktree.worktree_id,
-                workspace_root: worktree.workspace_root,
-            });
-
-    ControlPlaneSessionWorkflowBindingView {
-        session_id: binding.session_id,
-        task_id: binding.task_id,
-        mode: binding.mode.as_str().to_owned(),
-        execution_surface: binding.execution_surface,
-        worktree,
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn current_control_plane_unix_timestamp() -> i64 {
-    let now = SystemTime::now();
-    let duration_since_epoch = now.duration_since(UNIX_EPOCH).unwrap_or_default();
-    let seconds_since_epoch = duration_since_epoch.as_secs();
-    let bounded_seconds = seconds_since_epoch.min(i64::MAX as u64);
-    bounded_seconds as i64
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn control_plane_effective_tool_ids(tool_policy_payload: &Value) -> Vec<String> {
-    let tool_id_values = tool_policy_payload
-        .get("effective_tool_ids")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-
-    let mut tool_ids = Vec::new();
-    for tool_id_value in tool_id_values {
-        let tool_id = tool_id_value.as_str();
-        let Some(tool_id) = tool_id else {
-            continue;
-        };
-        let owned_tool_id = tool_id.to_owned();
-        tool_ids.push(owned_tool_id);
-    }
-    tool_ids
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn control_plane_effective_runtime_narrowing(tool_policy_payload: &Value) -> Value {
-    tool_policy_payload
-        .get("effective_runtime_narrowing")
-        .cloned()
-        .unwrap_or(Value::Null)
-}
-
-#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone)]
 pub struct ControlPlaneAcpView {
-    config: LoongConfig,
+    config: LoongClawConfig,
     current_session_id: String,
 }
 
 #[cfg(feature = "memory-sqlite")]
 impl ControlPlaneAcpView {
-    pub fn new(config: LoongConfig, current_session_id: impl Into<String>) -> Self {
+    pub fn new(config: LoongClawConfig, current_session_id: impl Into<String>) -> Self {
         Self {
             config,
             current_session_id: normalize_control_plane_session_id(&current_session_id.into()),
@@ -2144,8 +1958,7 @@ impl ControlPlaneAcpView {
         if self.current_session_id == DEFAULT_CONTROL_PLANE_SESSION_ID {
             return Ok(None);
         }
-        let memory_config =
-            MemoryRuntimeConfig::from_memory_config_without_env_overrides(&self.config.memory);
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         SessionRepository::new(&memory_config).map(Some)
     }
 
@@ -2218,7 +2031,7 @@ mod tests {
             AcpRoutingOrigin, AcpSessionBindingScope, AcpSessionMetadata, AcpSessionMode,
             AcpSessionState, AcpSessionStore, AcpSqliteSessionStore,
         },
-        config::LoongConfig,
+        config::LoongClawConfig,
     };
 
     use super::*;
@@ -2535,6 +2348,86 @@ mod tests {
             registry
                 .resolve(&active.token)
                 .expect("resolve revoked")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn connection_registry_tracks_monotonic_acknowledged_seq() {
+        let registry = ControlPlaneConnectionRegistry::new();
+        let lease = registry.issue(ControlPlaneConnectionPrincipal {
+            connection_id: "cp-ack".to_owned(),
+            client_id: "cli".to_owned(),
+            role: "operator".to_owned(),
+            scopes: BTreeSet::from(["operator.read".to_owned()]),
+            device_id: Some("device-1".to_owned()),
+        });
+
+        let updated = registry
+            .acknowledge_seq(&lease.token, 7)
+            .expect("acknowledge seq")
+            .expect("lease should exist");
+        assert_eq!(updated.acknowledged_seq, Some(7));
+
+        let downgraded = registry
+            .acknowledge_seq(&lease.token, 3)
+            .expect("acknowledge smaller seq")
+            .expect("lease should still exist");
+        assert_eq!(downgraded.acknowledged_seq, Some(7));
+
+        let resolved = registry
+            .resolve(&lease.token)
+            .expect("resolve lease")
+            .expect("lease should exist");
+        assert_eq!(resolved.acknowledged_seq, Some(7));
+    }
+
+    #[test]
+    fn connection_registry_restores_non_expired_leases_from_snapshot() {
+        let registry = ControlPlaneConnectionRegistry::new();
+        let future_expiry = current_time_ms().saturating_add(30_000);
+        let leases = vec![
+            ControlPlaneConnectionLease {
+                token: "cpt-restore-active".to_owned(),
+                principal: ControlPlaneConnectionPrincipal {
+                    connection_id: "cp-restore".to_owned(),
+                    client_id: "cli".to_owned(),
+                    role: "operator".to_owned(),
+                    scopes: BTreeSet::from(["operator.read".to_owned()]),
+                    device_id: Some("device-1".to_owned()),
+                },
+                issued_at_ms: current_time_ms(),
+                expires_at_ms: future_expiry,
+                acknowledged_seq: Some(9),
+            },
+            ControlPlaneConnectionLease {
+                token: "cpt-restore-expired".to_owned(),
+                principal: ControlPlaneConnectionPrincipal {
+                    connection_id: "cp-expired".to_owned(),
+                    client_id: "cli".to_owned(),
+                    role: "operator".to_owned(),
+                    scopes: BTreeSet::new(),
+                    device_id: None,
+                },
+                issued_at_ms: current_time_ms().saturating_sub(60_000),
+                expires_at_ms: current_time_ms().saturating_sub(1),
+                acknowledged_seq: None,
+            },
+        ];
+
+        let restored = registry.restore_leases(&leases).expect("restore leases");
+        assert_eq!(restored, 1);
+
+        let resolved = registry
+            .resolve("cpt-restore-active")
+            .expect("resolve restored lease")
+            .expect("active lease should exist");
+        assert_eq!(resolved.acknowledged_seq, Some(9));
+        assert_eq!(resolved.principal.device_id.as_deref(), Some("device-1"));
+        assert!(
+            registry
+                .resolve("cpt-restore-expired")
+                .expect("resolve expired restored lease")
                 .is_none()
         );
     }
@@ -2943,7 +2836,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
         let base = std::env::temp_dir().join(format!(
-            "loong-control-plane-view-{test_name}-{}",
+            "loongclaw-control-plane-view-{test_name}-{}",
             std::process::id()
         ));
         let _ = fs::create_dir_all(&base);
@@ -2958,7 +2851,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     fn broken_memory_config(test_name: &str) -> MemoryRuntimeConfig {
         let base = std::env::temp_dir().join(format!(
-            "loong-control-plane-broken-{test_name}-{}",
+            "loongclaw-control-plane-broken-{test_name}-{}",
             std::process::id()
         ));
         let sqlite_path = base.join("sqlite-dir");
@@ -3019,21 +2912,7 @@ mod tests {
             event_kind: "delegate_started".to_owned(),
             actor_session_id: Some("root-session".to_owned()),
             payload_json: serde_json::json!({
-                "task": "research control plane parity",
-                "label": "Child",
-                "execution": {
-                    "mode": "async",
-                    "depth": 1,
-                    "max_depth": 3,
-                    "active_children": 0,
-                    "max_active_children": 2,
-                    "timeout_seconds": 90,
-                    "allow_shell_in_child": false,
-                    "child_tool_allowlist": ["file.read"],
-                    "workspace_root": "/tmp/loong/control-plane/child-session",
-                    "kernel_bound": false,
-                    "runtime_narrowing": {}
-                }
+                "status": "started",
             }),
         })
         .expect("append child session event");
@@ -3053,12 +2932,6 @@ mod tests {
             }),
         })
         .expect("create visible approval request");
-        repo.upsert_session_tool_policy(crate::session::repository::NewSessionToolPolicyRecord {
-            session_id: "child-session".to_owned(),
-            requested_tool_ids: vec!["file.read".to_owned()],
-            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
-        })
-        .expect("create visible tool policy");
 
         repo.create_session(NewSessionRecord {
             session_id: "hidden-root".to_owned(),
@@ -3085,7 +2958,7 @@ mod tests {
         })
         .expect("create hidden approval request");
 
-        ControlPlaneRepositoryView::new(config, ToolConfig::default(), "root-session")
+        ControlPlaneRepositoryView::new(config, "root-session")
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -3117,7 +2990,7 @@ mod tests {
         })
         .expect("create hidden root session");
 
-        let mut config = LoongConfig::default();
+        let mut config = LoongClawConfig::default();
         let sqlite_path = memory_config
             .sqlite_path
             .as_ref()
@@ -3137,7 +3010,6 @@ mod tests {
                     channel_id: Some("feishu".to_owned()),
                     account_id: Some("lark-prod".to_owned()),
                     conversation_id: Some("oc_visible".to_owned()),
-                    participant_id: None,
                     thread_id: Some("thread-visible".to_owned()),
                 }),
                 activation_origin: Some(AcpRoutingOrigin::ExplicitRequest),
@@ -3161,7 +3033,6 @@ mod tests {
                     channel_id: Some("telegram".to_owned()),
                     account_id: None,
                     conversation_id: Some("hidden".to_owned()),
-                    participant_id: None,
                     thread_id: None,
                 }),
                 activation_origin: Some(AcpRoutingOrigin::AutomaticDispatch),
@@ -3198,33 +3069,19 @@ mod tests {
             sessions
                 .sessions
                 .iter()
-                .any(|session| session.session.session_id == "root-session")
+                .any(|session| session.session_id == "root-session")
         );
-        let child = sessions
-            .sessions
-            .iter()
-            .find(|session| session.session.session_id == "child-session")
-            .expect("child session view");
-        assert_eq!(child.workflow.workflow_id, "root-session");
-        assert_eq!(
-            child.workflow.task.as_deref(),
-            Some("research control plane parity")
-        );
-        assert_eq!(child.workflow.phase.as_deref(), Some("execute"));
-        assert_eq!(
-            child
-                .workflow
-                .binding
-                .as_ref()
-                .expect("workflow binding")
-                .mode,
-            "advisory_only"
+        assert!(
+            sessions
+                .sessions
+                .iter()
+                .any(|session| session.session_id == "child-session")
         );
         assert!(
             !sessions
                 .sessions
                 .iter()
-                .any(|session| session.session.session_id == "hidden-root")
+                .any(|session| session.session_id == "hidden-root")
         );
     }
 
@@ -3236,26 +3093,7 @@ mod tests {
             .read_session("child-session", 20, None, 50)
             .expect("visible session read")
             .expect("visible session observation");
-        assert_eq!(observation.session.session.session_id, "child-session");
-        assert_eq!(observation.session.workflow.workflow_id, "root-session");
-        assert_eq!(
-            observation.session.workflow.task.as_deref(),
-            Some("research control plane parity")
-        );
-        assert_eq!(
-            observation.session.workflow.phase.as_deref(),
-            Some("execute")
-        );
-        assert_eq!(
-            observation
-                .session
-                .workflow
-                .binding
-                .as_ref()
-                .expect("workflow binding")
-                .execution_surface,
-            "delegate.async"
-        );
+        assert_eq!(observation.session.session_id, "child-session");
         assert_eq!(observation.recent_events.len(), 1);
         assert_eq!(observation.recent_events[0].event_kind, "delegate_started");
 
@@ -3271,69 +3109,6 @@ mod tests {
             .read_session("hidden-root", 20, None, 50)
             .expect_err("hidden session should be rejected");
         assert!(error.contains("visibility_denied"));
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[test]
-    fn repository_view_lists_visible_background_tasks_with_workflow_metadata() {
-        let view = seeded_repository_view("task-list");
-        let tasks = view
-            .list_background_tasks(false, 50)
-            .expect("background task list");
-
-        assert_eq!(tasks.current_session_id, "root-session");
-        assert_eq!(tasks.matched_count, 1);
-        assert_eq!(tasks.returned_count, 1);
-
-        let task = tasks.tasks.first().expect("first background task");
-        assert_eq!(task.task_id, "child-session");
-        assert_eq!(task.workflow.workflow_id, "root-session");
-        assert_eq!(
-            task.workflow.task.as_deref(),
-            Some("research control plane parity")
-        );
-        assert_eq!(task.workflow.phase.as_deref(), Some("execute"));
-        let binding = task.workflow.binding.as_ref().expect("workflow binding");
-        assert_eq!(binding.session_id, "child-session");
-        assert_eq!(binding.task_id, "child-session");
-        assert_eq!(binding.mode, "advisory_only");
-        assert_eq!(task.delegate_mode.as_deref(), Some("async"));
-        assert_eq!(task.delegate_phase.as_deref(), Some("running"));
-        assert_eq!(task.approval_request_count, 1);
-        assert_eq!(task.approval_attention_count, 1);
-        assert_eq!(task.effective_tool_ids, vec!["file.read".to_owned()]);
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[test]
-    fn repository_view_reads_visible_background_task_detail() {
-        let view = seeded_repository_view("task-read");
-        let task = view
-            .read_background_task("child-session")
-            .expect("background task read")
-            .expect("background task detail");
-
-        assert_eq!(task.task_id, "child-session");
-        assert_eq!(task.workflow.workflow_id, "root-session");
-        assert_eq!(
-            task.workflow
-                .binding
-                .as_ref()
-                .expect("workflow binding")
-                .worktree
-                .as_ref()
-                .expect("worktree binding")
-                .workspace_root,
-            "/tmp/loong/control-plane/child-session"
-        );
-        assert_eq!(task.delegate_mode.as_deref(), Some("async"));
-        assert_eq!(task.session_state, "running");
-        assert_eq!(task.approval_request_count, 1);
-
-        let hidden_error = view
-            .read_background_task("hidden-root")
-            .expect_err("hidden session should be rejected");
-        assert!(hidden_error.contains("visibility_denied"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/gateway/api_events.rs
+++ b/crates/daemon/src/gateway/api_events.rs
@@ -22,9 +22,9 @@ const MAX_GATEWAY_EVENT_LIMIT: usize = 256;
 #[derive(Debug, Deserialize)]
 pub(crate) struct GatewayEventsQuery {
     #[serde(default)]
-    after_seq: Option<u64>,
+    pub(crate) after_seq: Option<u64>,
     #[serde(default)]
-    limit: Option<usize>,
+    pub(crate) limit: Option<usize>,
 }
 
 struct GatewayEventStreamState {
@@ -35,7 +35,7 @@ struct GatewayEventStreamState {
     replay_limit: usize,
 }
 
-fn bounded_gateway_event_limit(raw_limit: Option<usize>) -> usize {
+pub(crate) fn bounded_gateway_event_limit(raw_limit: Option<usize>) -> usize {
     let requested_limit = raw_limit.unwrap_or(DEFAULT_GATEWAY_EVENT_LIMIT);
     requested_limit.clamp(1, MAX_GATEWAY_EVENT_LIMIT)
 }
@@ -122,7 +122,7 @@ async fn next_gateway_sse_item(
     }
 }
 
-fn gateway_event_stream(
+pub(crate) fn gateway_event_stream(
     bus: GatewayEventBus,
     after_seq: Option<u64>,
     limit: usize,

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -4,6 +4,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use loongclaw_protocol::{
+    ControlPlaneConnectRequest, ControlPlanePairingListResponse,
+    ControlPlanePairingResolveRequest, ControlPlanePairingResolveResponse,
+};
+use reqwest::blocking::Client as BlockingClient;
 use reqwest::{Client, Method, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -11,9 +16,22 @@ use serde_json::Value;
 use crate::CliResult;
 
 use super::{
-    read_models::GatewayOperatorSummaryReadModel,
-    state::{GatewayOwnerStatus, default_gateway_runtime_state_dir, load_gateway_owner_status},
+    read_models::{
+        GatewayNodeInventoryReadModel, GatewayOperatorSummaryReadModel,
+        GatewayPairingCompleteReadModel, GatewayPairingSessionReadModel,
+        GatewayPairingStartReadModel, GatewayPairingEventsReadModel,
+    },
+    state::{
+        GatewayOwnerStatus, default_gateway_runtime_state_dir, gateway_control_token_path,
+        load_gateway_owner_status,
+    },
 };
+
+const DEFAULT_GATEWAY_BOOTSTRAP_HOST: &str = "127.0.0.1";
+const DEFAULT_GATEWAY_BOOTSTRAP_CONNECT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_millis(500);
+const DEFAULT_GATEWAY_BOOTSTRAP_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(2);
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GatewayAcpSessionsRequest {
@@ -31,6 +49,14 @@ pub struct GatewayAcpStatusRequest<'a> {
     pub route_session_id: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GatewayPairingRequestsRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
 #[derive(Debug, Clone)]
 pub struct GatewayLocalDiscovery {
     runtime_dir: PathBuf,
@@ -38,12 +64,22 @@ pub struct GatewayLocalDiscovery {
     socket_address: SocketAddr,
     base_url: String,
     bearer_token: String,
+    source: GatewayLocalDiscoverySource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayLocalDiscoverySource {
+    OwnerState,
+    DefaultBootstrap,
+    OwnerStateFallback,
 }
 
 impl GatewayLocalDiscovery {
     pub fn discover_default() -> CliResult<Self> {
         let runtime_dir = default_gateway_runtime_state_dir();
-        Self::discover(runtime_dir.as_path())
+        let bootstrap_address = default_gateway_bootstrap_socket_address();
+        discover_prefer_bootstrap(runtime_dir.as_path(), bootstrap_address)
     }
 
     pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
@@ -66,6 +102,7 @@ impl GatewayLocalDiscovery {
             socket_address,
             base_url,
             bearer_token,
+            source: GatewayLocalDiscoverySource::OwnerState,
         })
     }
 
@@ -85,9 +122,104 @@ impl GatewayLocalDiscovery {
         self.base_url.as_str()
     }
 
+    pub fn source(&self) -> GatewayLocalDiscoverySource {
+        self.source
+    }
+
     fn bearer_token(&self) -> &str {
         self.bearer_token.as_str()
     }
+}
+
+fn discover_prefer_bootstrap(
+    runtime_dir: &Path,
+    bootstrap_address: SocketAddr,
+) -> CliResult<GatewayLocalDiscovery> {
+    let bootstrap_result = discover_with_bootstrap(runtime_dir, bootstrap_address);
+    if let Ok(discovery) = bootstrap_result {
+        return Ok(discovery);
+    }
+
+    let owner_state_result = GatewayLocalDiscovery::discover(runtime_dir);
+    match owner_state_result {
+        Ok(mut discovery) => {
+            discovery.source = GatewayLocalDiscoverySource::OwnerStateFallback;
+            Ok(discovery)
+        }
+        Err(owner_state_error) => {
+            let bootstrap_error = bootstrap_result.expect_err("bootstrap result should be err");
+            let runtime_dir_text = runtime_dir.display().to_string();
+            let error = format!(
+                "gateway bootstrap discovery failed in {runtime_dir_text}: {bootstrap_error}; owner-state fallback failed: {owner_state_error}"
+            );
+            Err(error)
+        }
+    }
+}
+
+fn discover_with_bootstrap(
+    runtime_dir: &Path,
+    bootstrap_address: SocketAddr,
+) -> CliResult<GatewayLocalDiscovery> {
+    let token_path = gateway_control_token_path(runtime_dir);
+    let bearer_token = load_gateway_bearer_token(token_path.as_path())?;
+    let owner_status =
+        request_gateway_owner_status_from_bootstrap(bootstrap_address, bearer_token.as_str())?;
+    let socket_address = validate_gateway_local_owner_status(&owner_status)?;
+    let base_url = format!("http://{socket_address}");
+    let runtime_dir = runtime_dir.to_path_buf();
+
+    Ok(GatewayLocalDiscovery {
+        runtime_dir,
+        owner_status,
+        socket_address,
+        base_url,
+        bearer_token,
+        source: GatewayLocalDiscoverySource::DefaultBootstrap,
+    })
+}
+
+fn default_gateway_bootstrap_socket_address() -> SocketAddr {
+    let gateway_config = crate::mvp::config::GatewayConfig::default();
+    let bootstrap_port = gateway_config.port;
+    let bootstrap_host = DEFAULT_GATEWAY_BOOTSTRAP_HOST
+        .parse::<IpAddr>()
+        .expect("default gateway bootstrap host should stay valid");
+    SocketAddr::new(bootstrap_host, bootstrap_port)
+}
+
+fn request_gateway_owner_status_from_bootstrap(
+    socket_address: SocketAddr,
+    bearer_token: &str,
+) -> CliResult<GatewayOwnerStatus> {
+    let bootstrap_url = format!("http://{socket_address}/v1/status");
+    let http_client = BlockingClient::builder()
+        .connect_timeout(DEFAULT_GATEWAY_BOOTSTRAP_CONNECT_TIMEOUT)
+        .timeout(DEFAULT_GATEWAY_BOOTSTRAP_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|error| format!("build gateway bootstrap client failed: {error}"))?;
+    let response = http_client
+        .get(bootstrap_url.as_str())
+        .bearer_auth(bearer_token)
+        .send()
+        .map_err(|error| {
+            format!("gateway bootstrap request failed for {bootstrap_url}: {error}")
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let response_text = response
+            .text()
+            .unwrap_or_else(|_| "unable to read gateway bootstrap error body".to_owned());
+        let error = format!(
+            "gateway bootstrap request failed for {bootstrap_url} with status {status}: {}",
+            response_text.trim()
+        );
+        return Err(error);
+    }
+
+    response.json::<GatewayOwnerStatus>().map_err(|error| {
+        format!("decode gateway bootstrap response failed for {bootstrap_url}: {error}")
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -141,6 +273,11 @@ impl GatewayLocalClient {
 
     pub async fn operator_summary(&self) -> CliResult<GatewayOperatorSummaryReadModel> {
         let path = "/api/gateway/operator-summary";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn nodes(&self) -> CliResult<GatewayNodeInventoryReadModel> {
+        let path = "/v1/nodes";
         self.request_json(Method::GET, path).await
     }
 
@@ -204,6 +341,100 @@ impl GatewayLocalClient {
     pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
         let path = "/api/gateway/stop";
         self.request_json(Method::POST, path).await
+    }
+
+    pub async fn pairing_requests(
+        &self,
+        request: &GatewayPairingRequestsRequest<'_>,
+    ) -> CliResult<ControlPlanePairingListResponse> {
+        let path = "/v1/pairing/requests";
+        self.request_json_with_query(Method::GET, path, request)
+            .await
+    }
+
+    pub async fn pairing_start(&self) -> CliResult<GatewayPairingStartReadModel> {
+        let path = "/v1/pairing/start";
+        self.request_json(Method::POST, path).await
+    }
+
+    pub async fn pairing_resolve(
+        &self,
+        request: &ControlPlanePairingResolveRequest,
+    ) -> CliResult<ControlPlanePairingResolveResponse> {
+        let path = "/v1/pairing/resolve";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.post(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let request_builder = request_builder.json(request);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
+            .await
+    }
+
+    pub async fn pairing_complete(
+        &self,
+        request: &ControlPlaneConnectRequest,
+    ) -> CliResult<GatewayPairingCompleteReadModel> {
+        let path = "/v1/pairing/complete";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.post(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let request_builder = request_builder.json(request);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
+            .await
+    }
+
+    pub async fn pairing_session(&self, session_token: &str) -> CliResult<GatewayPairingSessionReadModel> {
+        let path = "/v1/pairing/session";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(session_token);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+            .await
+    }
+
+    pub async fn pairing_events(
+        &self,
+        session_token: &str,
+        after_seq: Option<u64>,
+        limit: Option<usize>,
+        ack_seq: Option<u64>,
+    ) -> CliResult<GatewayPairingEventsReadModel> {
+        let path = "/v1/pairing/events";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(session_token);
+        let query = build_gateway_pairing_events_query(after_seq, limit, ack_seq);
+        let request_builder = request_builder.query(&query);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+            .await
+    }
+
+    pub async fn pairing_stream_response(
+        &self,
+        session_token: &str,
+        after_seq: Option<u64>,
+        limit: Option<usize>,
+        ack_seq: Option<u64>,
+    ) -> CliResult<Response> {
+        let path = "/v1/pairing/stream";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(session_token);
+        let query = build_gateway_pairing_events_query(after_seq, limit, ack_seq);
+        let request_builder = request_builder.query(&query);
+        self.send_gateway_request(request_builder, endpoint.as_str()).await
     }
 
     pub async fn health(&self) -> CliResult<Value> {
@@ -362,6 +593,24 @@ fn trimmed_non_empty(raw: Option<&str>) -> Option<String> {
     Some(trimmed.to_owned())
 }
 
+fn build_gateway_pairing_events_query(
+    after_seq: Option<u64>,
+    limit: Option<usize>,
+    ack_seq: Option<u64>,
+) -> Vec<(String, String)> {
+    let mut query = Vec::new();
+    if let Some(after_seq) = after_seq {
+        query.push(("after_seq".to_owned(), after_seq.to_string()));
+    }
+    if let Some(limit) = limit {
+        query.push(("limit".to_owned(), limit.to_string()));
+    }
+    if let Some(ack_seq) = ack_seq {
+        query.push(("ack_seq".to_owned(), ack_seq.to_string()));
+    }
+    query
+}
+
 async fn parse_json_response(response: Response) -> CliResult<Value> {
     let status = response.status();
     if !status.is_success() {
@@ -481,27 +730,35 @@ async fn decode_gateway_error_message(response: Response) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::gateway::state::GatewayPortSource;
     use std::{
         fs,
+        io::{Read, Write},
+        net::TcpListener,
         path::PathBuf,
+        thread,
         time::{SystemTime, UNIX_EPOCH},
     };
 
     use super::*;
 
     fn gateway_owner_status_fixture() -> GatewayOwnerStatus {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis() as u64;
         GatewayOwnerStatus {
-            runtime_dir: "/tmp/loong-gateway-runtime".to_owned(),
+            runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
             phase: "running".to_owned(),
             running: true,
             stale: false,
             pid: Some(42),
             mode: super::super::state::GatewayOwnerMode::GatewayHeadless,
             version: "0.1.0".to_owned(),
-            config_path: "/tmp/loong.toml".to_owned(),
+            config_path: "/tmp/loongclaw.toml".to_owned(),
             attached_cli_session: None,
-            started_at_ms: 100,
-            last_heartbeat_at: 200,
+            started_at_ms: now_ms.saturating_sub(100),
+            last_heartbeat_at: now_ms,
             stopped_at_ms: None,
             shutdown_reason: None,
             last_error: None,
@@ -509,7 +766,8 @@ mod tests {
             running_surface_count: 1,
             bind_address: Some("127.0.0.1".to_owned()),
             port: Some(7777),
-            token_path: Some("/tmp/loong-gateway-runtime/control-token".to_owned()),
+            port_source: Some(GatewayPortSource::Default),
+            token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
         }
     }
 
@@ -519,7 +777,63 @@ mod tests {
             .expect("system clock before unix epoch")
             .as_nanos();
         let temp_dir = std::env::temp_dir();
-        temp_dir.join(format!("loong-gateway-client-{label}-{suffix}"))
+        temp_dir.join(format!("loongclaw-gateway-client-{label}-{suffix}"))
+    }
+
+    fn write_gateway_token_for_test(runtime_dir: &Path, token: &str) -> PathBuf {
+        let token_path = gateway_control_token_path(runtime_dir);
+        if let Some(parent) = token_path.parent() {
+            fs::create_dir_all(parent).expect("create gateway runtime dir");
+        }
+        fs::write(token_path.as_path(), token).expect("write gateway token");
+        token_path
+    }
+
+    fn spawn_gateway_status_server_once(
+        mut status: GatewayOwnerStatus,
+        expected_token: &str,
+    ) -> (SocketAddr, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind bootstrap server");
+        let socket_address = listener.local_addr().expect("bootstrap server addr");
+        if status.bind_address.is_none() {
+            status.bind_address = Some("127.0.0.1".to_owned());
+        }
+        if status.port.is_none() {
+            status.port = Some(socket_address.port());
+        }
+        let expected_header = format!("Authorization: Bearer {expected_token}");
+        let server = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut request_buffer = [0_u8; 8192];
+                let read = stream
+                    .read(&mut request_buffer)
+                    .expect("read bootstrap request");
+                let request_text = String::from_utf8_lossy(&request_buffer[..read]).into_owned();
+                let request_text_lower = request_text.to_ascii_lowercase();
+                let expected_header_lower = expected_header.to_ascii_lowercase();
+                assert!(
+                    request_text_lower.contains(expected_header_lower.as_str()),
+                    "expected bearer token in bootstrap request: {request_text}"
+                );
+                let body = serde_json::to_string(&status).expect("serialize gateway status");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write bootstrap response");
+            }
+        });
+        (socket_address, server)
+    }
+
+    fn unused_loopback_socket_address() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral probe");
+        let socket_address = listener.local_addr().expect("ephemeral probe addr");
+        drop(listener);
+        socket_address
     }
 
     #[test]
@@ -579,5 +893,57 @@ mod tests {
         assert!(error.contains("empty"), "unexpected error: {error}");
 
         fs::remove_file(token_path).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_prefers_bootstrap_when_owner_status_is_missing() {
+        let runtime_dir = unique_temp_path("bootstrap-runtime");
+        fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
+        let token_path = write_gateway_token_for_test(runtime_dir.as_path(), "bootstrap-token");
+        let mut status = gateway_owner_status_fixture();
+        status.token_path = Some(token_path.display().to_string());
+        status.port = None;
+        let (socket_address, server) = spawn_gateway_status_server_once(status, "bootstrap-token");
+
+        let discovery =
+            discover_prefer_bootstrap(runtime_dir.as_path(), socket_address).expect("bootstrap");
+
+        assert_eq!(discovery.socket_address(), socket_address);
+        assert_eq!(discovery.owner_status().port, Some(socket_address.port()));
+        assert_eq!(
+            discovery.source(),
+            GatewayLocalDiscoverySource::DefaultBootstrap
+        );
+
+        server.join().expect("bootstrap server join");
+        fs::remove_dir_all(runtime_dir).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_falls_back_to_owner_status_when_bootstrap_is_unavailable() {
+        let runtime_dir = unique_temp_path("fallback-runtime");
+        fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
+        let token_path = write_gateway_token_for_test(runtime_dir.as_path(), "fallback-token");
+        let mut status = gateway_owner_status_fixture();
+        status.port = Some(7_777);
+        status.token_path = Some(token_path.display().to_string());
+        crate::gateway::state::write_gateway_owner_snapshot_for_test(
+            runtime_dir.as_path(),
+            &status,
+        )
+        .expect("write gateway owner snapshot");
+        let unused_bootstrap = unused_loopback_socket_address();
+
+        let discovery =
+            discover_prefer_bootstrap(runtime_dir.as_path(), unused_bootstrap).expect("fallback");
+
+        assert_eq!(discovery.socket_address().port(), 7_777);
+        assert_eq!(discovery.owner_status().port, Some(7_777));
+        assert_eq!(
+            discovery.source(),
+            GatewayLocalDiscoverySource::OwnerStateFallback
+        );
+
+        fs::remove_dir_all(runtime_dir).ok();
     }
 }

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -4,16 +4,26 @@ use std::{
     io::Write,
     net::{Ipv4Addr, SocketAddrV4},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Weak},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
     Json, Router,
     extract::{Query, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+    response::{IntoResponse, Response, sse::{KeepAlive, Sse}},
     routing::{get, post},
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use loongclaw_protocol::{
+    CONTROL_PLANE_PROTOCOL_VERSION, ControlPlaneChallengeResponse, ControlPlaneConnectErrorCode,
+    ControlPlaneConnectErrorResponse, ControlPlaneConnectRequest, ControlPlanePrincipal,
+    ControlPlanePairingListResponse, ControlPlanePairingRequestSummary,
+    ControlPlanePairingResolveRequest, ControlPlanePairingResolveResponse,
+    ControlPlanePairingStatus, ControlPlaneRole, ControlPlaneScope,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::{
@@ -23,35 +33,49 @@ use tokio::{
 };
 
 use crate::mvp::acp::AcpSessionManager;
-use crate::mvp::config::LoongConfig;
+use crate::mvp::config::LoongClawConfig;
 use crate::{
     CliResult, build_channels_cli_json_payload,
     collect_runtime_snapshot_cli_state_from_loaded_config, mvp, supervisor::LoadedSupervisorConfig,
 };
 
 use super::api_acp::{handle_acp_dispatch, handle_acp_observability, handle_acp_status};
+use super::api_events::{GatewayEventsQuery, bounded_gateway_event_limit, gateway_event_stream};
 use super::api_events::handle_events;
 use super::api_health::handle_health;
 use super::api_turn::handle_turn;
 use super::event_bus::GatewayEventBus;
-use super::openai_compat::{handle_chat_completions, handle_models};
 use super::read_models::{
-    GatewayChannelInventoryReadModel, GatewayOperatorSummaryReadModel,
-    GatewayRuntimeSnapshotReadModel, build_acp_observability_read_model,
-    build_acp_session_list_read_model, build_acp_status_read_model,
-    build_operator_summary_read_model, build_runtime_snapshot_read_model,
+    GatewayChannelInventoryReadModel, GatewayOperatorPairingSummaryReadModel,
+    GatewayOperatorSummaryReadModel, GatewayRuntimeSnapshotReadModel,
+    build_acp_observability_read_model, build_acp_session_list_read_model,
+    build_acp_status_read_model, build_gateway_pairing_complete_read_model,
+    build_gateway_pairing_events_read_model, build_gateway_pairing_session_read_model,
+    build_gateway_pairing_start_read_model, build_node_inventory_read_model,
+    build_operator_nodes_summary_read_model, build_operator_summary_read_model,
+    build_runtime_snapshot_read_model,
 };
 use super::state::{
-    GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
-    load_gateway_owner_status, request_gateway_stop,
+    GatewayControlSurfaceBinding, GatewayPairingRuntimeState, GatewayPortSource,
+    GatewayStopRequestOutcome, gateway_control_token_path,
+    load_gateway_owner_status, load_gateway_pairing_runtime_state,
+    request_gateway_stop, write_gateway_pairing_runtime_state,
 };
 
 const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
 const GATEWAY_CONTROL_RUNTIME_DIR_MODE: u32 = 0o700;
 const GATEWAY_ACP_SESSION_LIST_DEFAULT_LIMIT: usize = 50;
 const GATEWAY_ACP_SESSION_LIST_MAX_LIMIT: usize = 200;
+const GATEWAY_CONTROL_PORT_ENV: &str = "LOONGCLAW_GATEWAY_PORT";
+const GATEWAY_PAIRING_CHALLENGE_MAX_FUTURE_SKEW_MS: u64 = 10_000;
 
 type GatewayControlJsonResponse = (StatusCode, Json<Value>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GatewayPortResolution {
+    port: u16,
+    source: GatewayPortSource,
+}
 
 #[derive(Debug, Default, Deserialize)]
 struct GatewayAcpSessionsQuery {
@@ -65,6 +89,19 @@ struct GatewayAcpStatusQuery {
     route_session_id: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct GatewayPairingListQuery {
+    status: Option<String>,
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayPairingEventsQuery {
+    after_seq: Option<u64>,
+    limit: Option<usize>,
+    ack_seq: Option<u64>,
+}
+
 #[derive(Clone)]
 pub(crate) struct GatewayControlAppState {
     pub(crate) runtime_dir: PathBuf,
@@ -74,7 +111,9 @@ pub(crate) struct GatewayControlAppState {
     pub(crate) runtime_snapshot: Arc<GatewayRuntimeSnapshotReadModel>,
     pub(crate) event_bus: Option<GatewayEventBus>,
     pub(crate) acp_manager: Option<Arc<AcpSessionManager>>,
-    pub(crate) config: Option<LoongConfig>,
+    pub(crate) challenge_registry: Arc<mvp::control_plane::ControlPlaneChallengeRegistry>,
+    pub(crate) connection_registry: Arc<mvp::control_plane::ControlPlaneConnectionRegistry>,
+    pub(crate) config: Option<LoongClawConfig>,
 }
 
 impl GatewayControlAppState {
@@ -91,18 +130,10 @@ impl GatewayControlAppState {
                 catalog_view: "channel_catalog",
                 legacy_channel_views: &[],
             },
-            summary: GatewayChannelInventorySummaryReadModel {
-                total_surface_count: 0,
-                runtime_backed_surface_count: 0,
-                config_backed_surface_count: 0,
-                plugin_backed_surface_count: 0,
-                catalog_only_surface_count: 0,
-            },
             channels: vec![],
             catalog_only_channels: vec![],
             channel_catalog: vec![],
             channel_surfaces: vec![],
-            channel_access_policies: vec![],
         };
         let runtime_snapshot = GatewayRuntimeSnapshotReadModel {
             config: String::new(),
@@ -117,10 +148,7 @@ impl GatewayControlAppState {
             acp: json!({}),
             channels: GatewayRuntimeSnapshotChannelsReadModel {
                 enabled_channel_ids: vec![],
-                enabled_runtime_backed_channel_ids: vec![],
                 enabled_service_channel_ids: vec![],
-                enabled_plugin_backed_channel_ids: vec![],
-                enabled_outbound_only_channel_ids: vec![],
                 inventory: channel_inventory.clone(),
             },
             tool_runtime: json!({}),
@@ -148,6 +176,8 @@ impl GatewayControlAppState {
             runtime_snapshot: Arc::new(runtime_snapshot),
             event_bus: None,
             acp_manager: None,
+            challenge_registry: Arc::new(mvp::control_plane::ControlPlaneChallengeRegistry::new()),
+            connection_registry: Arc::new(mvp::control_plane::ControlPlaneConnectionRegistry::new()),
             config: None,
         }
     }
@@ -227,20 +257,27 @@ pub async fn start_gateway_control_surface(
     runtime_dir: &Path,
     loaded_config: &LoadedSupervisorConfig,
     acp_manager: Option<Arc<AcpSessionManager>>,
+    port_override: Option<u16>,
 ) -> CliResult<GatewayControlSurface> {
     let channel_inventory = build_gateway_channel_inventory_read_model(loaded_config)?;
     let runtime_snapshot = build_gateway_runtime_snapshot_read_model(loaded_config)?;
     let bearer_token = new_gateway_control_bearer_token();
     let token_path = gateway_control_token_path(runtime_dir);
+    let persisted_pairing_runtime = load_gateway_pairing_runtime_state(runtime_dir);
 
     write_gateway_control_token_file(token_path.as_path(), bearer_token.as_str())?;
 
-    let listener_address = gateway_control_listener_address();
+    let port_resolution =
+        resolve_gateway_control_listener_port(&loaded_config.config, port_override)?;
+    let listener_address = gateway_control_listener_address_from_port_resolution(port_resolution);
     let listener_result = TcpListener::bind(listener_address).await;
     let listener = match listener_result {
         Ok(listener) => listener,
         Err(error) => {
-            let bind_error = format!("bind gateway control surface failed: {error}");
+            let bind_error = format!(
+                "bind gateway control surface failed on {}: {error}",
+                listener_address
+            );
             let cleanup_result = remove_gateway_control_token_file(token_path.as_path());
             let final_error = merge_gateway_control_errors(bind_error, cleanup_result.err());
             return Err(final_error);
@@ -264,13 +301,23 @@ pub async fn start_gateway_control_surface(
     let binding = GatewayControlSurfaceBinding {
         bind_address,
         port,
+        port_source: port_resolution.source,
         token_path: token_path.clone(),
     };
 
-    let event_bus = if acp_manager.is_some() {
-        Some(GatewayEventBus::new(256))
-    } else {
-        None
+    let connection_registry = Arc::new(mvp::control_plane::ControlPlaneConnectionRegistry::new());
+    if let Some(persisted_pairing_runtime) = persisted_pairing_runtime.as_ref() {
+        connection_registry
+            .restore_leases(&persisted_pairing_runtime.sessions)
+            .map_err(|error| format!("restore gateway pairing sessions failed: {error}"))?;
+    }
+    let event_bus = match (persisted_pairing_runtime.as_ref(), acp_manager.is_some()) {
+        (Some(persisted_pairing_runtime), _) => Some(GatewayEventBus::from_snapshot(
+            256,
+            persisted_pairing_runtime.event_bus.clone(),
+        )),
+        (None, true) => Some(GatewayEventBus::new(256)),
+        (None, false) => None,
     };
 
     let app_state = GatewayControlAppState {
@@ -281,15 +328,19 @@ pub async fn start_gateway_control_surface(
         runtime_snapshot: Arc::new(runtime_snapshot),
         event_bus,
         acp_manager,
+        challenge_registry: Arc::new(mvp::control_plane::ControlPlaneChallengeRegistry::new()),
+        connection_registry,
         config: Some(loaded_config.config.clone()),
     };
     let app_state = Arc::new(app_state);
-    let router = build_gateway_control_router(app_state);
+    attach_gateway_pairing_runtime_persist_hook(app_state.clone());
+    let router = build_gateway_control_router(app_state.clone());
 
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (exit_sender, _) = watch::channel::<Option<CliResult<()>>>(None);
     let exit_sender_for_task = exit_sender.clone();
     let token_path_for_task = token_path;
+    let app_state_for_task = app_state;
     let join_handle = tokio::spawn(async move {
         let server = axum::serve(listener, router);
         let server = server.with_graceful_shutdown(async move {
@@ -298,6 +349,8 @@ pub async fn start_gateway_control_surface(
         let server_result = server
             .await
             .map_err(|error| format!("gateway control surface server failed: {error}"));
+        let persist_result = persist_gateway_pairing_runtime_state(app_state_for_task.as_ref());
+        let server_result = combine_gateway_control_task_results(server_result, persist_result);
         let cleanup_result = remove_gateway_control_token_file(token_path_for_task.as_path());
         let final_result = combine_gateway_control_task_results(server_result, cleanup_result);
         let _ = exit_sender_for_task.send(Some(final_result.clone()));
@@ -335,6 +388,23 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
             "/api/gateway/acp/observability",
             get(handle_gateway_acp_observability),
         )
+        .route(
+            "/api/gateway/pairing/requests",
+            get(handle_gateway_pairing_requests),
+        )
+        .route("/api/gateway/pairing/start", post(handle_gateway_pairing_start))
+        .route("/api/gateway/nodes", get(handle_gateway_nodes))
+        .route(
+            "/api/gateway/pairing/resolve",
+            post(handle_gateway_pairing_resolve),
+        )
+        .route(
+            "/api/gateway/pairing/complete",
+            post(handle_gateway_pairing_complete),
+        )
+        .route("/api/gateway/pairing/session", get(handle_gateway_pairing_session))
+        .route("/api/gateway/pairing/events", get(handle_gateway_pairing_events))
+        .route("/api/gateway/pairing/stream", get(handle_gateway_pairing_stream))
         .route("/api/gateway/stop", post(handle_gateway_stop))
         .route("/v1/status", get(handle_gateway_status))
         .route("/v1/channels", get(handle_gateway_channels))
@@ -342,10 +412,16 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route("/v1/acp/status", get(handle_acp_status))
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
+        .route("/v1/nodes", get(handle_gateway_nodes))
+        .route("/v1/pairing/start", post(handle_gateway_pairing_start))
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
+        .route("/v1/pairing/complete", post(handle_gateway_pairing_complete))
+        .route("/v1/pairing/session", get(handle_gateway_pairing_session))
+        .route("/v1/pairing/events", get(handle_gateway_pairing_events))
+        .route("/v1/pairing/stream", get(handle_gateway_pairing_stream))
         .route("/v1/events", get(handle_events))
         .route("/v1/turn", post(handle_turn))
-        .route("/v1/models", get(handle_models))
-        .route("/v1/chat/completions", post(handle_chat_completions))
         .route("/health", get(handle_health))
         .with_state(app_state)
 }
@@ -443,6 +519,7 @@ async fn handle_gateway_operator_summary(
         &status,
         app_state.channel_inventory.as_ref(),
         app_state.runtime_snapshot.as_ref(),
+        app_state.as_ref(),
     );
     let payload = serialize_json_value(&summary, "gateway operator summary payload");
     match payload {
@@ -652,6 +729,502 @@ async fn handle_gateway_acp_observability(
     json_response(StatusCode::OK, payload)
 }
 
+async fn handle_gateway_pairing_requests(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Query(query): Query<GatewayPairingListQuery>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let parsed_status = match query.status.as_deref() {
+        Some(raw_status) => match parse_gateway_pairing_status(raw_status) {
+            Ok(status) => Some(status),
+            Err(error) => {
+                return json_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_pairing_status",
+                    error.as_str(),
+                );
+            }
+        },
+        None => None,
+    };
+    let limit = query.limit.unwrap_or(50);
+    let requests = pairing_registry.list_requests(parsed_status, limit);
+    let matched_count = requests.len();
+    let returned_count = matched_count;
+    let payload = ControlPlanePairingListResponse {
+        matched_count,
+        returned_count,
+        requests: requests
+            .into_iter()
+            .map(map_gateway_pairing_request)
+            .collect::<Vec<_>>(),
+    };
+    let payload = match serialize_json_value(&payload, "gateway pairing list payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_pairing_start(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let challenge = app_state.challenge_registry.issue();
+    let challenge = ControlPlaneChallengeResponse {
+        nonce: challenge.nonce,
+        issued_at_ms: challenge.issued_at_ms,
+        expires_at_ms: challenge.expires_at_ms,
+    };
+    let payload = build_gateway_pairing_start_read_model(challenge);
+    let payload = match serialize_json_value(&payload, "gateway pairing start payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_nodes(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let paired_devices = pairing_registry.list_approved_devices(256);
+    let payload = build_node_inventory_read_model(
+        app_state.config_path.as_str(),
+        app_state.channel_inventory.as_ref(),
+        paired_devices.as_slice(),
+    );
+    let payload = match serialize_json_value(&payload, "gateway node inventory payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_pairing_complete(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Json(request): Json<ControlPlaneConnectRequest>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    if request.max_protocol < CONTROL_PLANE_PROTOCOL_VERSION
+        || request.min_protocol > CONTROL_PLANE_PROTOCOL_VERSION
+    {
+        return json_connect_error(
+            StatusCode::BAD_REQUEST,
+            ControlPlaneConnectErrorCode::ProtocolMismatch,
+            format!("protocol mismatch: expected protocol {CONTROL_PLANE_PROTOCOL_VERSION}"),
+        );
+    }
+
+    let device = match request.device.as_ref() {
+        Some(device) => device,
+        None => {
+            return json_connect_error(
+                StatusCode::BAD_REQUEST,
+                ControlPlaneConnectErrorCode::ChallengeRequired,
+                "gateway pairing complete requires device identity",
+            );
+        }
+    };
+
+    if let Err(response) = verify_gateway_pairing_device_challenge(app_state.as_ref(), &request) {
+        return response;
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    let requested_scopes = request
+        .scopes
+        .iter()
+        .map(|scope| scope.as_str().to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    let device_token = request
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.device_token.as_deref());
+
+    match pairing_registry.evaluate_connect(
+        device.device_id.as_str(),
+        request.client.id.as_str(),
+        device.public_key.as_str(),
+        request.role.as_str(),
+        &requested_scopes,
+        device_token,
+    ) {
+        Ok(mvp::control_plane::ControlPlanePairingConnectDecision::Authorized) => {
+            let requested_scopes = request.scopes.iter().copied().collect::<Vec<_>>();
+            let lease = issue_gateway_pairing_session_lease(app_state.as_ref(), &request);
+            let _ = persist_gateway_pairing_runtime_state(app_state.as_ref());
+            let payload = build_gateway_pairing_complete_read_model(
+                device.device_id.as_str(),
+                request.client.id.as_str(),
+                request.role,
+                requested_scopes,
+                lease,
+            );
+            let payload = match serialize_json_value(&payload, "gateway pairing complete payload") {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return json_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "serialize_failed",
+                        error.as_str(),
+                    );
+                }
+            };
+            json_response(StatusCode::OK, payload)
+        }
+        Ok(mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request: pairing_request,
+            ..
+        }) => json_connect_error_with_request(
+            StatusCode::FORBIDDEN,
+            ControlPlaneConnectErrorCode::PairingRequired,
+            format!(
+                "device `{}` requires operator pairing approval before connect can complete",
+                pairing_request.device_id
+            ),
+            Some(pairing_request.pairing_request_id.clone()),
+        ),
+        Ok(mvp::control_plane::ControlPlanePairingConnectDecision::DeviceTokenRequired) => {
+            json_connect_error(
+                StatusCode::UNAUTHORIZED,
+                ControlPlaneConnectErrorCode::DeviceTokenRequired,
+                format!(
+                    "device `{}` is paired but must present auth.device_token on connect",
+                    device.device_id
+                ),
+            )
+        }
+        Ok(mvp::control_plane::ControlPlanePairingConnectDecision::DeviceTokenInvalid) => {
+            json_connect_error(
+                StatusCode::UNAUTHORIZED,
+                ControlPlaneConnectErrorCode::DeviceTokenInvalid,
+                format!(
+                    "device `{}` presented an invalid auth.device_token",
+                    device.device_id
+                ),
+            )
+        }
+        Err(error) => json_error(
+            StatusCode::BAD_REQUEST,
+            "pairing_complete_failed",
+            error.as_str(),
+        ),
+    }
+}
+
+async fn handle_gateway_pairing_session(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    let lease = match authorize_gateway_pairing_session_scope_request(
+        &headers,
+        app_state.as_ref(),
+        ControlPlaneScope::OperatorRead,
+    ) {
+        Ok(lease) => lease,
+        Err(response) => return response,
+    };
+
+    let principal = gateway_pairing_protocol_principal(&lease);
+    let replay_window = app_state
+        .event_bus
+        .as_ref()
+        .map(GatewayEventBus::replay_window)
+        .unwrap_or(super::event_bus::GatewayEventReplayWindow {
+            oldest_retained_seq: None,
+            latest_seq: None,
+        });
+    let payload = build_gateway_pairing_session_read_model(
+        super::read_models::GatewayPairingSessionLeaseReadModel {
+            connection_token: lease.token,
+            connection_token_expires_at_ms: lease.expires_at_ms,
+            principal,
+            last_acknowledged_seq: lease.acknowledged_seq,
+        },
+        replay_window,
+    );
+    let payload = match serialize_json_value(&payload, "gateway pairing session payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_pairing_events(
+    headers: HeaderMap,
+    Query(query): Query<GatewayPairingEventsQuery>,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    let session_token = match extract_gateway_pairing_session_token(&headers) {
+        Some(token) => token,
+        None => {
+            return json_error(
+                StatusCode::UNAUTHORIZED,
+                "missing_session_token",
+                "missing gateway pairing session token",
+            );
+        }
+    };
+
+    let lease = match authorize_gateway_pairing_session_scope_request(
+        &headers,
+        app_state.as_ref(),
+        ControlPlaneScope::OperatorRead,
+    ) {
+        Ok(lease) => lease,
+        Err(response) => return response,
+    };
+
+    let Some(event_bus) = app_state.event_bus.as_ref() else {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "event_stream_unavailable",
+            "gateway event streaming is not available",
+        );
+    };
+
+    let after_seq = query.after_seq.unwrap_or(0);
+    let limit = query.limit.unwrap_or(50).clamp(1, 256);
+    let lease = if let Some(ack_seq) = query.ack_seq {
+        match app_state
+            .connection_registry
+            .acknowledge_seq(session_token.as_str(), ack_seq)
+        {
+            Ok(Some(updated)) => updated,
+            Ok(None) => {
+                return json_error(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_session_token",
+                    "invalid or expired gateway pairing session token",
+                );
+            }
+            Err(error) => {
+                return json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "session_registry_failed",
+                    error.as_str(),
+                );
+            }
+        }
+    } else {
+        lease
+    };
+    if query.ack_seq.is_some() {
+        let _ = persist_gateway_pairing_runtime_state(app_state.as_ref());
+    }
+    let replay_window = event_bus.replay_window();
+    if gateway_pairing_after_seq_is_stale(query.after_seq.unwrap_or(0), replay_window) {
+        let message = match (replay_window.oldest_retained_seq, replay_window.latest_seq) {
+            (Some(oldest), Some(latest)) => format!(
+                "requested after_seq={} is older than retained replay window {}..{}",
+                after_seq, oldest, latest
+            ),
+            _ => format!("requested after_seq={after_seq} is outside the retained replay window"),
+        };
+        return json_stale_cursor_error(
+            message.as_str(),
+            lease.acknowledged_seq,
+            replay_window,
+        );
+    }
+    let events = event_bus.recent_events_after(after_seq, limit);
+    let payload = build_gateway_pairing_events_read_model(
+        after_seq,
+        lease.acknowledged_seq,
+        replay_window,
+        events,
+    );
+    let payload = match serialize_json_value(&payload, "gateway pairing events payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_pairing_stream(
+    headers: HeaderMap,
+    Query(query): Query<GatewayEventsQuery>,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> Response {
+    let lease = match authorize_gateway_pairing_session_scope_request(
+        &headers,
+        app_state.as_ref(),
+        ControlPlaneScope::OperatorRead,
+    ) {
+        Ok(lease) => lease,
+        Err(response) => return response.into_response(),
+    };
+
+    let Some(event_bus) = app_state.event_bus.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(serde_json::json!({"error": "gateway event streaming is not available"})),
+        )
+            .into_response();
+    };
+
+    let after_seq = query.after_seq.unwrap_or(0);
+    let replay_window = event_bus.replay_window();
+    if gateway_pairing_after_seq_is_stale(after_seq, replay_window) {
+        let message = match (replay_window.oldest_retained_seq, replay_window.latest_seq) {
+            (Some(oldest), Some(latest)) => format!(
+                "requested after_seq={} is older than retained replay window {}..{}",
+                after_seq, oldest, latest
+            ),
+            _ => format!("requested after_seq={after_seq} is outside the retained replay window"),
+        };
+        return json_stale_cursor_error(
+            message.as_str(),
+            lease.acknowledged_seq,
+            replay_window,
+        )
+        .into_response();
+    }
+
+    let limit = bounded_gateway_event_limit(query.limit);
+    let event_stream = gateway_event_stream(event_bus.clone(), query.after_seq, limit);
+    Sse::new(event_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+async fn handle_gateway_pairing_resolve(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+    Json(request): Json<ControlPlanePairingResolveRequest>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+        Ok(pairing_registry) => pairing_registry,
+        Err(error) => {
+            return json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            );
+        }
+    };
+
+    match pairing_registry.resolve_request(request.pairing_request_id.as_str(), request.approve) {
+        Ok(Some(record)) => {
+            let payload = ControlPlanePairingResolveResponse {
+                request: map_gateway_pairing_request(record.clone()),
+                device_token: record.device_token,
+            };
+            let payload = match serialize_json_value(&payload, "gateway pairing resolve payload") {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return json_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "serialize_failed",
+                        error.as_str(),
+                    );
+                }
+            };
+            json_response(StatusCode::OK, payload)
+        }
+        Ok(None) => {
+            let message = format!(
+                "pairing request `{}` not found",
+                request.pairing_request_id.trim()
+            );
+            json_error(StatusCode::NOT_FOUND, "pairing_not_found", message.as_str())
+        }
+        Err(error) => json_error(
+            StatusCode::BAD_REQUEST,
+            "pairing_resolve_failed",
+            error.as_str(),
+        ),
+    }
+}
+
 async fn handle_gateway_stop(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
@@ -751,11 +1324,94 @@ fn build_gateway_operator_summary_read_model(
     status: &super::state::GatewayOwnerStatus,
     channel_inventory: &GatewayChannelInventoryReadModel,
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+    app_state: &GatewayControlAppState,
 ) -> GatewayOperatorSummaryReadModel {
-    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot)
+    let pairing_summary = build_gateway_pairing_summary_read_model(app_state);
+    let node_inventory = build_gateway_node_inventory_read_model(app_state);
+    let nodes = build_operator_nodes_summary_read_model(&node_inventory);
+    build_operator_summary_read_model(
+        status,
+        channel_inventory,
+        runtime_snapshot,
+        pairing_summary,
+        nodes,
+    )
 }
 
-fn gateway_control_config(app_state: &GatewayControlAppState) -> CliResult<&LoongConfig> {
+fn build_gateway_pairing_summary_read_model(
+    app_state: &GatewayControlAppState,
+) -> GatewayOperatorPairingSummaryReadModel {
+    let pairing_registry_result = gateway_pairing_registry(app_state);
+    match pairing_registry_result {
+        Ok(pairing_registry) => GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: pairing_registry.pending_request_count(),
+            approved_device_count: pairing_registry.approved_device_count(),
+            last_activity_ms: pairing_registry.last_activity_ms(),
+        },
+        Err(_error) => GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 0,
+            approved_device_count: 0,
+            last_activity_ms: None,
+        },
+    }
+}
+
+fn build_gateway_node_inventory_read_model(
+    app_state: &GatewayControlAppState,
+) -> super::read_models::GatewayNodeInventoryReadModel {
+    match gateway_pairing_registry(app_state) {
+        Ok(pairing_registry) => {
+            let paired_devices = pairing_registry.list_approved_devices(256);
+            build_node_inventory_read_model(
+                app_state.config_path.as_str(),
+                app_state.channel_inventory.as_ref(),
+                paired_devices.as_slice(),
+            )
+        }
+        Err(_error) => build_node_inventory_read_model(
+            app_state.config_path.as_str(),
+            app_state.channel_inventory.as_ref(),
+            &[],
+        ),
+    }
+}
+
+fn attach_gateway_pairing_runtime_persist_hook(app_state: Arc<GatewayControlAppState>) {
+    let Some(event_bus) = app_state.event_bus.as_ref() else {
+        return;
+    };
+    let weak_app_state: Weak<GatewayControlAppState> = Arc::downgrade(&app_state);
+    event_bus.set_publish_hook(Arc::new(move || {
+        if let Some(app_state) = weak_app_state.upgrade() {
+            let _ = persist_gateway_pairing_runtime_state(app_state.as_ref());
+        }
+    }));
+}
+
+fn persist_gateway_pairing_runtime_state(app_state: &GatewayControlAppState) -> CliResult<()> {
+    let sessions = app_state.connection_registry.snapshot_leases();
+    let max_acknowledged_seq = sessions
+        .iter()
+        .filter_map(|lease| lease.acknowledged_seq)
+        .max()
+        .unwrap_or(0);
+    let event_bus_snapshot = app_state
+        .event_bus
+        .as_ref()
+        .map(GatewayEventBus::snapshot)
+        .unwrap_or(super::event_bus::GatewayEventBusSnapshot {
+            next_seq: 0,
+            recent_events: Vec::new(),
+        });
+    let event_bus = super::event_bus::GatewayEventBusSnapshot {
+        next_seq: event_bus_snapshot.next_seq.max(max_acknowledged_seq),
+        recent_events: event_bus_snapshot.recent_events,
+    };
+    let state = GatewayPairingRuntimeState { sessions, event_bus };
+    write_gateway_pairing_runtime_state(app_state.runtime_dir.as_path(), &state)
+}
+
+fn gateway_control_config(app_state: &GatewayControlAppState) -> CliResult<&LoongClawConfig> {
     let config = app_state
         .config
         .as_ref()
@@ -771,6 +1427,336 @@ fn gateway_control_acp_manager(
         .as_deref()
         .ok_or_else(|| "gateway ACP session manager is unavailable".to_owned())?;
     Ok(manager)
+}
+
+fn gateway_pairing_registry(
+    app_state: &GatewayControlAppState,
+) -> CliResult<mvp::control_plane::ControlPlanePairingRegistry> {
+    let config = gateway_control_config(app_state)?;
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+    }
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = config;
+        Err("gateway pairing requires sqlite memory support".to_owned())
+    }
+}
+
+fn issue_gateway_pairing_session_lease(
+    app_state: &GatewayControlAppState,
+    request: &ControlPlaneConnectRequest,
+) -> super::read_models::GatewayPairingSessionLeaseReadModel {
+    let connection_id = format!(
+        "gwp-{:016x}",
+        gateway_current_time_ms().saturating_add(rand::random::<u32>() as u64)
+    );
+    let principal = mvp::control_plane::ControlPlaneConnectionPrincipal {
+        connection_id,
+        client_id: request.client.id.clone(),
+        role: request.role.as_str().to_owned(),
+        scopes: request
+            .scopes
+            .iter()
+            .map(|scope| scope.as_str().to_owned())
+            .collect(),
+        device_id: request.device.as_ref().map(|device| device.device_id.clone()),
+    };
+    let lease = app_state.connection_registry.issue(principal);
+    let principal = gateway_pairing_protocol_principal(&lease);
+    super::read_models::GatewayPairingSessionLeaseReadModel {
+        connection_token: lease.token,
+        connection_token_expires_at_ms: lease.expires_at_ms,
+        principal,
+        last_acknowledged_seq: lease.acknowledged_seq,
+    }
+}
+
+fn gateway_pairing_protocol_principal(
+    lease: &mvp::control_plane::ControlPlaneConnectionLease,
+) -> ControlPlanePrincipal {
+    let role = match lease.principal.role.as_str() {
+        "operator" => ControlPlaneRole::Operator,
+        _ => ControlPlaneRole::Node,
+    };
+    let scopes = lease
+        .principal
+        .scopes
+        .iter()
+        .filter_map(|scope| ControlPlaneScope::parse(scope.as_str()))
+        .collect();
+    ControlPlanePrincipal {
+        connection_id: lease.principal.connection_id.clone(),
+        client_id: lease.principal.client_id.clone(),
+        role,
+        scopes,
+        device_id: lease.principal.device_id.clone(),
+    }
+}
+
+fn authorize_gateway_pairing_session_request(
+    headers: &HeaderMap,
+    app_state: &GatewayControlAppState,
+) -> Result<mvp::control_plane::ControlPlaneConnectionLease, GatewayControlJsonResponse> {
+    let Some(token) = extract_gateway_pairing_session_token(headers) else {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "missing_session_token",
+            "missing gateway pairing session token",
+        ));
+    };
+    let lease = app_state
+        .connection_registry
+        .resolve(token.as_str())
+        .map_err(|error| {
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "session_registry_failed",
+                error.as_str(),
+            )
+        })?;
+    let Some(lease) = lease else {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_session_token",
+            "invalid or expired gateway pairing session token",
+        ));
+    };
+    Ok(lease)
+}
+
+fn authorize_gateway_pairing_session_scope_request(
+    headers: &HeaderMap,
+    app_state: &GatewayControlAppState,
+    required_scope: ControlPlaneScope,
+) -> Result<mvp::control_plane::ControlPlaneConnectionLease, GatewayControlJsonResponse> {
+    let lease = authorize_gateway_pairing_session_request(headers, app_state)?;
+    let has_required_scope = lease
+        .principal
+        .scopes
+        .iter()
+        .any(|scope| scope == required_scope.as_str() || scope == ControlPlaneScope::OperatorAdmin.as_str());
+    if !has_required_scope {
+        return Err(json_error(
+            StatusCode::FORBIDDEN,
+            "insufficient_scope",
+            "gateway pairing session token does not grant the required scope",
+        ));
+    }
+    Ok(lease)
+}
+
+fn extract_gateway_pairing_session_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            headers
+                .get("x-loongclaw-pairing-session-token")
+                .and_then(|value| value.to_str().ok())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn gateway_pairing_after_seq_is_stale(
+    after_seq: u64,
+    replay_window: super::event_bus::GatewayEventReplayWindow,
+) -> bool {
+    let Some(oldest_retained_seq) = replay_window.oldest_retained_seq else {
+        return false;
+    };
+    after_seq < oldest_retained_seq.saturating_sub(1)
+}
+
+fn verify_gateway_pairing_device_challenge(
+    app_state: &GatewayControlAppState,
+    request: &ControlPlaneConnectRequest,
+) -> Result<(), GatewayControlJsonResponse> {
+    let device = request
+        .device
+        .as_ref()
+        .ok_or_else(|| {
+            json_connect_error(
+                StatusCode::BAD_REQUEST,
+                ControlPlaneConnectErrorCode::ChallengeRequired,
+                "gateway pairing complete requires device identity",
+            )
+        })?;
+
+    let challenge = app_state
+        .challenge_registry
+        .consume(device.nonce.as_str())
+        .map_err(|error| {
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "challenge_registry_failed",
+                error.as_str(),
+            )
+        })?
+        .ok_or_else(|| {
+            json_connect_error(
+                StatusCode::UNAUTHORIZED,
+                ControlPlaneConnectErrorCode::ChallengeExpired,
+                format!(
+                    "unknown or expired control-plane challenge `{}`",
+                    device.nonce
+                ),
+            )
+        })?;
+
+    let now_ms = gateway_current_time_ms();
+    if device.signed_at_ms < challenge.issued_at_ms
+        || device.signed_at_ms
+            > challenge
+                .expires_at_ms
+                .saturating_add(GATEWAY_PAIRING_CHALLENGE_MAX_FUTURE_SKEW_MS)
+        || device.signed_at_ms
+            > now_ms.saturating_add(GATEWAY_PAIRING_CHALLENGE_MAX_FUTURE_SKEW_MS)
+    {
+        return Err(json_connect_error(
+            StatusCode::UNAUTHORIZED,
+            ControlPlaneConnectErrorCode::ChallengeExpired,
+            format!(
+                "control-plane device signature timestamp is outside the challenge window for `{}`",
+                device.device_id
+            ),
+        ));
+    }
+
+    let public_key_bytes = base64::engine::general_purpose::STANDARD
+        .decode(device.public_key.as_bytes())
+        .map_err(|error| {
+            json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_device_public_key_encoding",
+                format!("invalid control-plane device public_key encoding: {error}").as_str(),
+            )
+        })?;
+    let signature_bytes = base64::engine::general_purpose::STANDARD
+        .decode(device.signature.as_bytes())
+        .map_err(|error| {
+            json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_device_signature_encoding",
+                format!("invalid control-plane device signature encoding: {error}").as_str(),
+            )
+        })?;
+
+    let public_key_array: [u8; 32] = public_key_bytes.try_into().map_err(|_error| {
+        json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_device_public_key_length",
+            "control-plane device public_key must decode to 32 bytes",
+        )
+    })?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_array).map_err(|error| {
+        json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_device_public_key",
+            format!("invalid control-plane device public_key: {error}").as_str(),
+        )
+    })?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|error| {
+        json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_device_signature",
+            format!("invalid control-plane device signature bytes: {error}").as_str(),
+        )
+    })?;
+    let message = gateway_pairing_device_signature_message(request, device);
+    verifying_key.verify(&message, &signature).map_err(|error| {
+        json_connect_error(
+            StatusCode::UNAUTHORIZED,
+            ControlPlaneConnectErrorCode::DeviceSignatureInvalid,
+            format!("control-plane device signature verification failed: {error}"),
+        )
+    })?;
+
+    Ok(())
+}
+
+fn gateway_pairing_device_signature_message(
+    request: &ControlPlaneConnectRequest,
+    device: &loongclaw_protocol::ControlPlaneDeviceIdentity,
+) -> Vec<u8> {
+    let scopes = request
+        .scopes
+        .iter()
+        .map(|scope| scope.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "loongclaw-control-plane-connect-v1\nnonce={}\ndevice_id={}\nclient_id={}\nrole={}\nscopes={}\nsigned_at_ms={}",
+        device.nonce,
+        device.device_id,
+        request.client.id,
+        request.role.as_str(),
+        scopes,
+        device.signed_at_ms
+    )
+    .into_bytes()
+}
+
+fn map_gateway_pairing_status(
+    status: mvp::control_plane::ControlPlanePairingStatus,
+) -> ControlPlanePairingStatus {
+    match status {
+        mvp::control_plane::ControlPlanePairingStatus::Pending => {
+            ControlPlanePairingStatus::Pending
+        }
+        mvp::control_plane::ControlPlanePairingStatus::Approved => {
+            ControlPlanePairingStatus::Approved
+        }
+        mvp::control_plane::ControlPlanePairingStatus::Rejected => {
+            ControlPlanePairingStatus::Rejected
+        }
+    }
+}
+
+fn map_gateway_pairing_request(
+    request: mvp::control_plane::ControlPlanePairingRequestRecord,
+) -> ControlPlanePairingRequestSummary {
+    let requested_scopes = request
+        .requested_scopes
+        .into_iter()
+        .filter_map(|scope| ControlPlaneScope::parse(scope.as_str()))
+        .collect::<std::collections::BTreeSet<_>>();
+    let role = match request.role.as_str() {
+        "operator" => ControlPlaneRole::Operator,
+        _ => ControlPlaneRole::Node,
+    };
+
+    ControlPlanePairingRequestSummary {
+        pairing_request_id: request.pairing_request_id,
+        device_id: request.device_id,
+        client_id: request.client_id,
+        public_key: request.public_key,
+        role,
+        requested_scopes,
+        status: map_gateway_pairing_status(request.status),
+        requested_at_ms: request.requested_at_ms,
+        resolved_at_ms: request.resolved_at_ms,
+    }
+}
+
+fn parse_gateway_pairing_status(
+    raw: &str,
+) -> Result<mvp::control_plane::ControlPlanePairingStatus, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "pending" => Ok(mvp::control_plane::ControlPlanePairingStatus::Pending),
+        "approved" => Ok(mvp::control_plane::ControlPlanePairingStatus::Approved),
+        "rejected" => Ok(mvp::control_plane::ControlPlanePairingStatus::Rejected),
+        _ => Err(format!("unknown pairing status `{raw}`")),
+    }
 }
 
 fn gateway_acp_session_list_limit(requested_limit: Option<usize>) -> usize {
@@ -792,10 +1778,89 @@ fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Val
     serde_json::to_value(value).map_err(|error| format!("serialize {context} failed: {error}"))
 }
 
-fn gateway_control_listener_address() -> SocketAddrV4 {
+fn gateway_current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn default_gateway_control_listener_address(config: &LoongClawConfig) -> SocketAddrV4 {
     let bind_address = Ipv4Addr::LOCALHOST;
-    let bind_port = 0_u16;
+    let bind_port = config.gateway.port;
     SocketAddrV4::new(bind_address, bind_port)
+}
+
+fn gateway_control_listener_address_from_port_resolution(
+    resolution: GatewayPortResolution,
+) -> SocketAddrV4 {
+    let bind_address = Ipv4Addr::LOCALHOST;
+    let bind_port = resolution.port;
+    SocketAddrV4::new(bind_address, bind_port)
+}
+
+fn resolve_gateway_control_listener_port(
+    config: &LoongClawConfig,
+    port_override: Option<u16>,
+) -> CliResult<GatewayPortResolution> {
+    if let Some(port_override) = port_override {
+        let source = if port_override == 0 {
+            GatewayPortSource::EphemeralCli
+        } else {
+            GatewayPortSource::Cli
+        };
+        let resolution = GatewayPortResolution {
+            port: port_override,
+            source,
+        };
+        return Ok(resolution);
+    }
+
+    let env_port = resolve_gateway_control_listener_port_from_env()?;
+    if let Some(port) = env_port {
+        let resolution = GatewayPortResolution {
+            port,
+            source: GatewayPortSource::Env,
+        };
+        return Ok(resolution);
+    }
+
+    let configured_port = config.gateway.port;
+    if configured_port != 26_306 {
+        let resolution = GatewayPortResolution {
+            port: configured_port,
+            source: GatewayPortSource::Config,
+        };
+        return Ok(resolution);
+    }
+
+    let default_address = default_gateway_control_listener_address(config);
+    let default_port = default_address.port();
+    let resolution = GatewayPortResolution {
+        port: default_port,
+        source: GatewayPortSource::Default,
+    };
+    Ok(resolution)
+}
+
+fn resolve_gateway_control_listener_port_from_env() -> CliResult<Option<u16>> {
+    let raw_value = std::env::var_os(GATEWAY_CONTROL_PORT_ENV);
+    let Some(raw_value) = raw_value else {
+        return Ok(None);
+    };
+
+    let raw_value = raw_value.to_string_lossy();
+    let trimmed_value = raw_value.trim();
+    if trimmed_value.is_empty() {
+        return Ok(None);
+    }
+
+    let parsed_port = trimmed_value.parse::<u16>().map_err(|error| {
+        format!("parse {GATEWAY_CONTROL_PORT_ENV}=`{trimmed_value}` failed: {error}")
+    })?;
+    Ok(Some(parsed_port))
 }
 
 fn new_gateway_control_bearer_token() -> String {
@@ -987,6 +2052,60 @@ fn json_error(status_code: StatusCode, code: &str, message: &str) -> GatewayCont
     json_response(status_code, payload)
 }
 
+fn json_stale_cursor_error(
+    message: &str,
+    last_acknowledged_seq: Option<u64>,
+    replay_window: super::event_bus::GatewayEventReplayWindow,
+) -> GatewayControlJsonResponse {
+    let earliest_resumable_after_seq = replay_window
+        .oldest_retained_seq
+        .map(|seq| seq.saturating_sub(1))
+        .unwrap_or(0);
+    let payload = json!({
+        "error": {
+            "code": "stale_cursor",
+            "message": message,
+            "last_acknowledged_seq": last_acknowledged_seq,
+            "earliest_resumable_after_seq": earliest_resumable_after_seq,
+            "replay_window": {
+                "oldest_retained_seq": replay_window.oldest_retained_seq,
+                "latest_seq": replay_window.latest_seq,
+            }
+        }
+    });
+    json_response(StatusCode::CONFLICT, payload)
+}
+
+fn json_connect_error(
+    status_code: StatusCode,
+    code: ControlPlaneConnectErrorCode,
+    error: impl Into<String>,
+) -> GatewayControlJsonResponse {
+    json_connect_error_with_request(status_code, code, error, None)
+}
+
+fn json_connect_error_with_request(
+    status_code: StatusCode,
+    code: ControlPlaneConnectErrorCode,
+    error: impl Into<String>,
+    pairing_request_id: Option<String>,
+) -> GatewayControlJsonResponse {
+    let payload = ControlPlaneConnectErrorResponse {
+        code,
+        error: error.into(),
+        pairing_request_id,
+    };
+    let payload = serde_json::to_value(&payload).unwrap_or_else(|serialize_error| {
+        json!({
+            "error": {
+                "code": "serialize_failed",
+                "message": format!("serialize control-plane connect error failed: {serialize_error}"),
+            }
+        })
+    });
+    json_response(status_code, payload)
+}
+
 /// Minimal router for health endpoint integration tests.
 #[doc(hidden)]
 pub fn build_gateway_health_test_router() -> Router {
@@ -1011,7 +2130,7 @@ pub fn build_gateway_events_test_router(
 #[doc(hidden)]
 pub fn build_gateway_acp_test_router(
     bearer_token: String,
-    config: LoongConfig,
+    config: LoongClawConfig,
     acp_manager: Arc<AcpSessionManager>,
 ) -> Router {
     let mut state = GatewayControlAppState::test_minimal(bearer_token);
@@ -1023,4 +2142,153 @@ pub fn build_gateway_acp_test_router(
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
         .with_state(app_state)
+}
+
+/// Minimal router for gateway pairing endpoint integration tests.
+#[doc(hidden)]
+pub fn build_gateway_pairing_test_router(bearer_token: String, config: LoongClawConfig) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    state.event_bus = Some(GatewayEventBus::new(64));
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/pairing/start", post(handle_gateway_pairing_start))
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
+        .route("/v1/pairing/complete", post(handle_gateway_pairing_complete))
+        .route("/v1/pairing/session", get(handle_gateway_pairing_session))
+        .route("/v1/pairing/events", get(handle_gateway_pairing_events))
+        .route("/v1/pairing/stream", get(handle_gateway_pairing_stream))
+        .with_state(app_state)
+}
+
+#[doc(hidden)]
+pub fn build_gateway_pairing_test_router_with_event_bus(
+    bearer_token: String,
+    config: LoongClawConfig,
+    event_bus: GatewayEventBus,
+) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    state.event_bus = Some(event_bus);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/pairing/start", post(handle_gateway_pairing_start))
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
+        .route("/v1/pairing/complete", post(handle_gateway_pairing_complete))
+        .route("/v1/pairing/session", get(handle_gateway_pairing_session))
+        .route("/v1/pairing/events", get(handle_gateway_pairing_events))
+        .route("/v1/pairing/stream", get(handle_gateway_pairing_stream))
+        .with_state(app_state)
+}
+
+/// Minimal router for gateway node inventory integration tests.
+#[doc(hidden)]
+pub fn build_gateway_nodes_test_router(
+    bearer_token: String,
+    config: LoongClawConfig,
+    channel_inventory: GatewayChannelInventoryReadModel,
+) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    state.channel_inventory = Arc::new(channel_inventory);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/nodes", get(handle_gateway_nodes))
+        .with_state(app_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GATEWAY_CONTROL_PORT_ENV, gateway_control_listener_address_from_port_resolution,
+        resolve_gateway_control_listener_port,
+    };
+    use crate::gateway::state::GatewayPortSource;
+    use crate::mvp::config::LoongClawConfig;
+    use crate::test_support::ScopedEnv;
+
+    #[test]
+    fn gateway_control_listener_port_defaults_to_26306() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let config = LoongClawConfig::default();
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let listener_address = gateway_control_listener_address_from_port_resolution(resolution);
+        let actual_ip = *listener_address.ip();
+        let actual_port = listener_address.port();
+
+        assert_eq!(actual_ip, std::net::Ipv4Addr::LOCALHOST);
+        assert_eq!(actual_port, 26_306);
+        assert_eq!(resolution.source, GatewayPortSource::Default);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_uses_env_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
+
+        let config = LoongClawConfig::default();
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let resolved_port = resolution.port;
+
+        assert_eq!(resolved_port, 26_316);
+        assert_eq!(resolution.source, GatewayPortSource::Env);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_uses_config_default_when_no_override_is_present() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let mut config = LoongClawConfig::default();
+        config.gateway.port = 26_346;
+
+        let resolution = resolve_gateway_control_listener_port(&config, None).expect("resolution");
+        let resolved_port = resolution.port;
+
+        assert_eq!(resolved_port, 26_346);
+        assert_eq!(resolution.source, GatewayPortSource::Config);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_prefers_explicit_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "26316");
+
+        let config = LoongClawConfig::default();
+        let resolution =
+            resolve_gateway_control_listener_port(&config, Some(26_326)).expect("resolution");
+        let resolved_port = resolution.port;
+
+        assert_eq!(resolved_port, 26_326);
+        assert_eq!(resolution.source, GatewayPortSource::Cli);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_accepts_ephemeral_zero() {
+        let mut env = ScopedEnv::new();
+        env.remove(GATEWAY_CONTROL_PORT_ENV);
+
+        let config = LoongClawConfig::default();
+        let resolution =
+            resolve_gateway_control_listener_port(&config, Some(0)).expect("resolution");
+        let resolved_port = resolution.port;
+
+        assert_eq!(resolved_port, 0);
+        assert_eq!(resolution.source, GatewayPortSource::EphemeralCli);
+    }
+
+    #[test]
+    fn gateway_control_listener_port_rejects_invalid_env_override() {
+        let mut env = ScopedEnv::new();
+        env.set(GATEWAY_CONTROL_PORT_ENV, "invalid");
+
+        let config = LoongClawConfig::default();
+        let error = resolve_gateway_control_listener_port(&config, None).expect_err("invalid env");
+
+        assert!(error.contains(GATEWAY_CONTROL_PORT_ENV));
+    }
 }

--- a/crates/daemon/src/gateway/event_bus.rs
+++ b/crates/daemon/src/gateway/event_bus.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -16,10 +17,24 @@ pub struct GatewayEventRecord {
     pub payload: Value,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayEventReplayWindow {
+    pub oldest_retained_seq: Option<u64>,
+    pub latest_seq: Option<u64>,
+}
+
 #[derive(Debug, Default)]
 struct GatewayEventRetentionState {
     recent_events: VecDeque<GatewayEventRecord>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GatewayEventBusSnapshot {
+    pub next_seq: u64,
+    pub recent_events: Vec<GatewayEventRecord>,
+}
+
+type GatewayEventPublishHook = Arc<dyn Fn() + Send + Sync + 'static>;
 
 /// Broadcast channel for streaming gateway events to SSE subscribers.
 #[derive(Clone)]
@@ -28,6 +43,7 @@ pub struct GatewayEventBus {
     next_seq: Arc<AtomicU64>,
     retention_limit: usize,
     retention_state: Arc<RwLock<GatewayEventRetentionState>>,
+    publish_hook: Arc<Mutex<Option<GatewayEventPublishHook>>>,
 }
 
 impl GatewayEventBus {
@@ -43,7 +59,37 @@ impl GatewayEventBus {
             next_seq,
             retention_limit,
             retention_state,
+            publish_hook: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub fn from_snapshot(capacity: usize, snapshot: GatewayEventBusSnapshot) -> Self {
+        let mut recent_events = snapshot.recent_events;
+        let capacity = capacity.max(1);
+        if recent_events.len() > capacity {
+            let drop_count = recent_events.len() - capacity;
+            recent_events.drain(0..drop_count);
+        }
+        let latest_recent_seq = recent_events.last().map(|record| record.seq).unwrap_or(0);
+        let next_seq = snapshot.next_seq.max(latest_recent_seq);
+        let (sender, _) = broadcast::channel(capacity);
+        Self {
+            sender,
+            next_seq: Arc::new(AtomicU64::new(next_seq)),
+            retention_limit: capacity,
+            retention_state: Arc::new(RwLock::new(GatewayEventRetentionState {
+                recent_events: VecDeque::from(recent_events),
+            })),
+            publish_hook: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn set_publish_hook(&self, hook: GatewayEventPublishHook) {
+        let mut hook_guard = self
+            .publish_hook
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *hook_guard = Some(hook);
     }
 
     /// Create a new subscriber receiver.
@@ -69,6 +115,31 @@ impl GatewayEventBus {
         matching_events
     }
 
+    pub fn replay_window(&self) -> GatewayEventReplayWindow {
+        let retention_guard = self
+            .retention_state
+            .read()
+            .unwrap_or_else(|error| error.into_inner());
+        let oldest_retained_seq = retention_guard.recent_events.front().map(|record| record.seq);
+        let latest_seq = retention_guard.recent_events.back().map(|record| record.seq);
+        GatewayEventReplayWindow {
+            oldest_retained_seq,
+            latest_seq,
+        }
+    }
+
+    pub fn snapshot(&self) -> GatewayEventBusSnapshot {
+        let next_seq = self.next_seq.load(Ordering::Relaxed);
+        let retention_guard = self
+            .retention_state
+            .read()
+            .unwrap_or_else(|error| error.into_inner());
+        GatewayEventBusSnapshot {
+            next_seq,
+            recent_events: retention_guard.recent_events.iter().cloned().collect(),
+        }
+    }
+
     pub fn publish(&self, payload: Value) -> GatewayEventRecord {
         let retention_guard = self.retention_state.write();
         let mut retention_guard = retention_guard.unwrap_or_else(|error| error.into_inner());
@@ -78,7 +149,16 @@ impl GatewayEventBus {
         while retention_guard.recent_events.len() > self.retention_limit {
             retention_guard.recent_events.pop_front();
         }
+        drop(retention_guard);
         let _ = self.sender.send(record.clone());
+        let publish_hook = self
+            .publish_hook
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        if let Some(publish_hook) = publish_hook {
+            publish_hook();
+        }
         record
     }
 
@@ -112,6 +192,7 @@ impl AcpTurnEventSink for BroadcastEventSink {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn broadcast_sink_delivers_to_subscriber() {
@@ -182,5 +263,36 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(bounded_seqs, vec![3, 4]);
+    }
+
+    #[test]
+    fn event_bus_snapshot_restores_recent_events_and_monotonic_seq() {
+        let bus = GatewayEventBus::new(4);
+        bus.publish(json!({"event_type": "first"}));
+        bus.publish(json!({"event_type": "second"}));
+        let snapshot = bus.snapshot();
+
+        let restored = GatewayEventBus::from_snapshot(4, snapshot);
+        let replay = restored.recent_events_after(0, 10);
+        let replay_seqs = replay.iter().map(|record| record.seq).collect::<Vec<_>>();
+        assert_eq!(replay_seqs, vec![1, 2]);
+
+        let published = restored.publish(json!({"event_type": "third"}));
+        assert_eq!(published.seq, 3);
+    }
+
+    #[test]
+    fn event_bus_publish_invokes_registered_hook() {
+        let bus = GatewayEventBus::new(4);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let invocations_for_hook = invocations.clone();
+        bus.set_publish_hook(Arc::new(move || {
+            invocations_for_hook.fetch_add(1, Ordering::Relaxed);
+        }));
+
+        bus.publish(json!({"event_type": "first"}));
+        bus.publish(json!({"event_type": "second"}));
+
+        assert_eq!(invocations.load(Ordering::Relaxed), 2);
     }
 }

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 
+use loongclaw_protocol::{
+    CONTROL_PLANE_PROTOCOL_VERSION, ControlPlaneChallengeResponse, ControlPlanePrincipal,
+    ControlPlaneRole, ControlPlaneScope,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -12,6 +16,7 @@ use crate::mvp;
 use crate::plugin_bridge_account_summary::plugin_bridge_account_summary;
 
 use super::state::GatewayOwnerStatus;
+use super::event_bus::{GatewayEventRecord, GatewayEventReplayWindow};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GatewayChannelInventorySchema {
@@ -27,12 +32,10 @@ pub type ChannelsCliJsonSchema = GatewayChannelInventorySchema;
 pub struct GatewayChannelInventoryReadModel {
     pub config: String,
     pub schema: GatewayChannelInventorySchema,
-    pub summary: GatewayChannelInventorySummaryReadModel,
     pub channels: Vec<mvp::channel::ChannelStatusSnapshot>,
     pub catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
     pub channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
     pub channel_surfaces: Vec<GatewayChannelSurfaceReadModel>,
-    pub channel_access_policies: Vec<mvp::channel::ChannelConfiguredAccountAccessPolicy>,
 }
 
 pub type ChannelsCliJsonPayload = GatewayChannelInventoryReadModel;
@@ -45,22 +48,12 @@ pub struct GatewayChannelSurfaceReadModel {
     pub plugin_bridge_account_summary: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GatewayChannelInventorySummaryReadModel {
-    pub total_surface_count: usize,
-    pub runtime_backed_surface_count: usize,
-    pub config_backed_surface_count: usize,
-    pub plugin_backed_surface_count: usize,
-    pub catalog_only_surface_count: usize,
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct GatewayAcpBindingScopeReadModel {
     pub route_session_id: String,
     pub channel_id: Option<String>,
     pub account_id: Option<String>,
     pub conversation_id: Option<String>,
-    pub participant_id: Option<String>,
     pub thread_id: Option<String>,
 }
 
@@ -183,7 +176,6 @@ pub struct GatewayConversationAddressReadModel {
     pub channel_id: Option<String>,
     pub account_id: Option<String>,
     pub conversation_id: Option<String>,
-    pub participant_id: Option<String>,
     pub thread_id: Option<String>,
 }
 
@@ -201,7 +193,6 @@ pub struct GatewayAcpDispatchTargetReadModel {
     pub channel_id: Option<String>,
     pub account_id: Option<String>,
     pub conversation_id: Option<String>,
-    pub participant_id: Option<String>,
     pub thread_id: Option<String>,
     pub channel_path: Vec<String>,
 }
@@ -238,10 +229,7 @@ pub struct GatewayRuntimeSnapshotSchema {
 #[derive(Debug, Clone, Serialize)]
 pub struct GatewayRuntimeSnapshotChannelsReadModel {
     pub enabled_channel_ids: Vec<String>,
-    pub enabled_runtime_backed_channel_ids: Vec<String>,
     pub enabled_service_channel_ids: Vec<String>,
-    pub enabled_plugin_backed_channel_ids: Vec<String>,
-    pub enabled_outbound_only_channel_ids: Vec<String>,
     pub inventory: GatewayChannelInventoryReadModel,
 }
 
@@ -285,9 +273,6 @@ pub struct GatewayOperatorChannelSurfaceReadModel {
     pub misconfigured_account_count: usize,
     pub ready_send_account_count: usize,
     pub ready_serve_account_count: usize,
-    pub conversation_gated_account_count: usize,
-    pub sender_gated_account_count: usize,
-    pub mention_gated_account_count: usize,
     pub default_configured_account_id: Option<String>,
     pub plugin_bridge_account_summary: Option<String>,
     pub service_enabled: bool,
@@ -302,12 +287,6 @@ pub struct GatewayOperatorChannelsSummaryReadModel {
     pub enabled_account_count: usize,
     pub misconfigured_account_count: usize,
     pub runtime_backed_channel_count: usize,
-    pub config_backed_channel_count: usize,
-    pub plugin_backed_channel_count: usize,
-    pub catalog_only_channel_count: usize,
-    pub enabled_runtime_backed_channel_count: usize,
-    pub enabled_plugin_backed_channel_count: usize,
-    pub enabled_outbound_only_channel_count: usize,
     pub enabled_service_channel_count: usize,
     pub ready_service_channel_count: usize,
     pub surfaces: Vec<GatewayOperatorChannelSurfaceReadModel>,
@@ -316,15 +295,131 @@ pub struct GatewayOperatorChannelsSummaryReadModel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayOperatorRuntimeSummaryReadModel {
     pub enabled_channel_ids: Vec<String>,
-    pub enabled_runtime_backed_channel_ids: Vec<String>,
     pub enabled_service_channel_ids: Vec<String>,
-    pub enabled_plugin_backed_channel_ids: Vec<String>,
-    pub enabled_outbound_only_channel_ids: Vec<String>,
     pub visible_tool_count: usize,
     pub capability_snapshot_sha256: String,
     pub active_provider_profile_id: Option<String>,
     pub active_provider_label: Option<String>,
     pub tool_calling: GatewayToolCallingReadModel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorPairingSummaryReadModel {
+    pub pending_request_count: usize,
+    pub approved_device_count: usize,
+    pub last_activity_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayNodeInventorySummaryReadModel {
+    pub paired_device_count: usize,
+    pub managed_bridge_count: usize,
+    pub total_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorNodesSummaryReadModel {
+    pub paired_device_count: usize,
+    pub managed_bridge_count: usize,
+    pub total_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairedDeviceNodeReadModel {
+    pub node_id: String,
+    pub node_kind: String,
+    pub trust_state: String,
+    pub role: String,
+    pub public_key: String,
+    pub approved_scopes: Vec<String>,
+    pub issued_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayManagedBridgeNodeReadModel {
+    pub node_id: String,
+    pub node_kind: String,
+    pub trust_state: String,
+    pub channel_id: String,
+    pub implementation_status: String,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub configured_plugin_id: Option<String>,
+    pub selected_plugin_id: Option<String>,
+    pub discovery_status: Option<String>,
+    pub selection_status: Option<String>,
+    pub compatible_plugins: usize,
+    pub incomplete_plugins: usize,
+    pub incompatible_plugins: usize,
+    pub account_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayNodeInventoryReadModel {
+    pub config: String,
+    pub summary: GatewayNodeInventorySummaryReadModel,
+    pub paired_devices: Vec<GatewayPairedDeviceNodeReadModel>,
+    pub managed_bridges: Vec<GatewayManagedBridgeNodeReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingStartReadModel {
+    pub protocol: u32,
+    pub challenge: ControlPlaneChallengeResponse,
+    pub connect_path: String,
+    pub pairing_requests_path: String,
+    pub pairing_resolve_path: String,
+    pub recommended_role: ControlPlaneRole,
+    pub recommended_scopes: Vec<ControlPlaneScope>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingCompleteReadModel {
+    pub status: String,
+    pub device_id: String,
+    pub client_id: String,
+    pub role: ControlPlaneRole,
+    pub requested_scopes: Vec<ControlPlaneScope>,
+    pub lease: GatewayPairingSessionLeaseReadModel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingSessionLeaseReadModel {
+    pub connection_token: String,
+    pub connection_token_expires_at_ms: u64,
+    pub principal: ControlPlanePrincipal,
+    pub last_acknowledged_seq: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingSessionReadModel {
+    pub status: String,
+    pub connection_token_expires_at_ms: u64,
+    pub principal: ControlPlanePrincipal,
+    pub last_acknowledged_seq: Option<u64>,
+    pub resume_status: String,
+    pub resume_from_after_seq: u64,
+    pub earliest_resumable_after_seq: u64,
+    pub replay_window: GatewayPairingReplayWindowReadModel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingReplayWindowReadModel {
+    pub oldest_retained_seq: Option<u64>,
+    pub latest_seq: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairingEventsReadModel {
+    pub after_seq: u64,
+    pub effective_after_seq: u64,
+    pub returned_count: usize,
+    pub last_acknowledged_seq: Option<u64>,
+    pub resume_status: String,
+    pub next_after_seq: u64,
+    pub earliest_resumable_after_seq: u64,
+    pub replay_window: GatewayPairingReplayWindowReadModel,
+    pub events: Vec<GatewayEventRecord>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -342,6 +437,8 @@ pub struct GatewayOperatorSummaryReadModel {
     pub control_surface: GatewayOperatorControlSurfaceReadModel,
     pub channels: GatewayOperatorChannelsSummaryReadModel,
     pub runtime: GatewayOperatorRuntimeSummaryReadModel,
+    pub pairing: GatewayOperatorPairingSummaryReadModel,
+    pub nodes: GatewayOperatorNodesSummaryReadModel,
 }
 
 pub fn build_channel_inventory_read_model(
@@ -358,24 +455,20 @@ pub fn build_channel_inventory_read_model(
     let channels = inventory.channels.clone();
     let catalog_only_channels = inventory.catalog_only_channels.clone();
     let channel_catalog = inventory.channel_catalog.clone();
-    let summary = build_channel_inventory_summary_read_model(&inventory.channel_surfaces);
     let channel_surfaces = inventory
         .channel_surfaces
         .iter()
         .cloned()
         .map(build_channel_surface_read_model)
         .collect();
-    let channel_access_policies = inventory.channel_access_policies.clone();
 
     GatewayChannelInventoryReadModel {
         config,
         schema,
-        summary,
         channels,
         catalog_only_channels,
         channel_catalog,
         channel_surfaces,
-        channel_access_policies,
     }
 }
 
@@ -387,48 +480,6 @@ fn build_channel_surface_read_model(
     GatewayChannelSurfaceReadModel {
         surface,
         plugin_bridge_account_summary,
-    }
-}
-
-fn build_channel_inventory_summary_read_model(
-    channel_surfaces: &[mvp::channel::ChannelSurface],
-) -> GatewayChannelInventorySummaryReadModel {
-    let total_surface_count = channel_surfaces.len();
-    let runtime_backed_surface_count = channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
-        })
-        .count();
-    let config_backed_surface_count = channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::ConfigBacked
-        })
-        .count();
-    let plugin_backed_surface_count = channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-        })
-        .count();
-    let catalog_only_surface_count = channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::Stub
-        })
-        .count();
-
-    GatewayChannelInventorySummaryReadModel {
-        total_surface_count,
-        runtime_backed_surface_count,
-        config_backed_surface_count,
-        plugin_backed_surface_count,
-        catalog_only_surface_count,
     }
 }
 
@@ -519,16 +570,10 @@ pub fn build_runtime_snapshot_read_model(
     let acp = crate::runtime_snapshot_acp_json(&snapshot.acp);
     let inventory = build_channel_inventory_read_model(config.as_str(), &snapshot.channels);
     let enabled_channel_ids = snapshot.enabled_channel_ids.clone();
-    let enabled_runtime_backed_channel_ids = snapshot.enabled_runtime_backed_channel_ids.clone();
     let enabled_service_channel_ids = snapshot.enabled_service_channel_ids.clone();
-    let enabled_plugin_backed_channel_ids = snapshot.enabled_plugin_backed_channel_ids.clone();
-    let enabled_outbound_only_channel_ids = snapshot.enabled_outbound_only_channel_ids.clone();
     let channels = GatewayRuntimeSnapshotChannelsReadModel {
         enabled_channel_ids,
-        enabled_runtime_backed_channel_ids,
         enabled_service_channel_ids,
-        enabled_plugin_backed_channel_ids,
-        enabled_outbound_only_channel_ids,
         inventory,
     };
     let tool_runtime = crate::runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime);
@@ -566,6 +611,8 @@ pub fn build_operator_summary_read_model(
     owner_status: &GatewayOwnerStatus,
     channel_inventory: &GatewayChannelInventoryReadModel,
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+    pairing: GatewayOperatorPairingSummaryReadModel,
+    nodes: GatewayOperatorNodesSummaryReadModel,
 ) -> GatewayOperatorSummaryReadModel {
     let owner = owner_status.clone();
     let control_surface = build_operator_control_surface_read_model(owner_status);
@@ -577,7 +624,151 @@ pub fn build_operator_summary_read_model(
         control_surface,
         channels,
         runtime,
+        pairing,
+        nodes,
     }
+}
+
+pub fn build_node_inventory_read_model(
+    config_path: &str,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    paired_devices: &[mvp::control_plane::ControlPlaneApprovedDeviceSummary],
+) -> GatewayNodeInventoryReadModel {
+    let config = config_path.to_owned();
+    let paired_devices = build_paired_device_nodes_read_model(paired_devices);
+    let managed_bridges = build_managed_bridge_nodes_read_model(channel_inventory);
+    let summary = GatewayNodeInventorySummaryReadModel {
+        paired_device_count: paired_devices.len(),
+        managed_bridge_count: managed_bridges.len(),
+        total_count: paired_devices.len() + managed_bridges.len(),
+    };
+
+    GatewayNodeInventoryReadModel {
+        config,
+        summary,
+        paired_devices,
+        managed_bridges,
+    }
+}
+
+pub fn build_operator_nodes_summary_read_model(
+    inventory: &GatewayNodeInventoryReadModel,
+) -> GatewayOperatorNodesSummaryReadModel {
+    GatewayOperatorNodesSummaryReadModel {
+        paired_device_count: inventory.summary.paired_device_count,
+        managed_bridge_count: inventory.summary.managed_bridge_count,
+        total_count: inventory.summary.total_count,
+    }
+}
+
+pub fn build_gateway_pairing_start_read_model(
+    challenge: ControlPlaneChallengeResponse,
+) -> GatewayPairingStartReadModel {
+    GatewayPairingStartReadModel {
+        protocol: CONTROL_PLANE_PROTOCOL_VERSION,
+        challenge,
+        connect_path: "/v1/pairing/complete".to_owned(),
+        pairing_requests_path: "/v1/pairing/requests".to_owned(),
+        pairing_resolve_path: "/v1/pairing/resolve".to_owned(),
+        recommended_role: ControlPlaneRole::Operator,
+        recommended_scopes: vec![
+            ControlPlaneScope::OperatorRead,
+            ControlPlaneScope::OperatorPairing,
+        ],
+    }
+}
+
+pub fn build_gateway_pairing_complete_read_model(
+    device_id: &str,
+    client_id: &str,
+    role: ControlPlaneRole,
+    requested_scopes: Vec<ControlPlaneScope>,
+    lease: GatewayPairingSessionLeaseReadModel,
+) -> GatewayPairingCompleteReadModel {
+    GatewayPairingCompleteReadModel {
+        status: "authorized".to_owned(),
+        device_id: device_id.to_owned(),
+        client_id: client_id.to_owned(),
+        role,
+        requested_scopes,
+        lease,
+    }
+}
+
+pub fn build_gateway_pairing_session_read_model(
+    lease: GatewayPairingSessionLeaseReadModel,
+    replay_window: GatewayEventReplayWindow,
+) -> GatewayPairingSessionReadModel {
+    let earliest_resumable_after_seq =
+        replay_window.oldest_retained_seq.map(|seq| seq.saturating_sub(1)).unwrap_or(0);
+    let (resume_status, resume_from_after_seq) =
+        gateway_pairing_resume_contract(lease.last_acknowledged_seq, replay_window);
+    GatewayPairingSessionReadModel {
+        status: "active".to_owned(),
+        connection_token_expires_at_ms: lease.connection_token_expires_at_ms,
+        principal: lease.principal,
+        last_acknowledged_seq: lease.last_acknowledged_seq,
+        resume_status: resume_status.to_owned(),
+        resume_from_after_seq,
+        earliest_resumable_after_seq,
+        replay_window: build_gateway_pairing_replay_window_read_model(replay_window),
+    }
+}
+
+pub fn build_gateway_pairing_events_read_model(
+    after_seq: u64,
+    last_acknowledged_seq: Option<u64>,
+    replay_window: GatewayEventReplayWindow,
+    events: Vec<GatewayEventRecord>,
+) -> GatewayPairingEventsReadModel {
+    let returned_count = events.len();
+    let next_after_seq = events.last().map(|event| event.seq).unwrap_or(after_seq);
+    let earliest_resumable_after_seq =
+        replay_window.oldest_retained_seq.map(|seq| seq.saturating_sub(1)).unwrap_or(0);
+    let resume_status = if after_seq == 0 {
+        "fresh"
+    } else {
+        "resumed"
+    };
+    GatewayPairingEventsReadModel {
+        after_seq,
+        effective_after_seq: after_seq,
+        returned_count,
+        last_acknowledged_seq,
+        resume_status: resume_status.to_owned(),
+        next_after_seq,
+        earliest_resumable_after_seq,
+        replay_window: build_gateway_pairing_replay_window_read_model(replay_window),
+        events,
+    }
+}
+
+pub fn build_gateway_pairing_replay_window_read_model(
+    replay_window: GatewayEventReplayWindow,
+) -> GatewayPairingReplayWindowReadModel {
+    GatewayPairingReplayWindowReadModel {
+        oldest_retained_seq: replay_window.oldest_retained_seq,
+        latest_seq: replay_window.latest_seq,
+    }
+}
+
+fn gateway_pairing_resume_contract(
+    last_acknowledged_seq: Option<u64>,
+    replay_window: GatewayEventReplayWindow,
+) -> (&'static str, u64) {
+    let earliest_resumable_after_seq =
+        replay_window.oldest_retained_seq.map(|seq| seq.saturating_sub(1)).unwrap_or(0);
+    let Some(last_acknowledged_seq) = last_acknowledged_seq else {
+        return ("fresh", 0);
+    };
+
+    if replay_window.oldest_retained_seq.is_some()
+        && last_acknowledged_seq < earliest_resumable_after_seq
+    {
+        return ("stale", earliest_resumable_after_seq);
+    }
+
+    ("resumed", last_acknowledged_seq)
 }
 
 fn build_acp_binding_scope_read_model(
@@ -587,7 +778,6 @@ fn build_acp_binding_scope_read_model(
     let channel_id = binding.channel_id.clone();
     let account_id = binding.account_id.clone();
     let conversation_id = binding.conversation_id.clone();
-    let participant_id = binding.participant_id.clone();
     let thread_id = binding.thread_id.clone();
 
     GatewayAcpBindingScopeReadModel {
@@ -595,7 +785,6 @@ fn build_acp_binding_scope_read_model(
         channel_id,
         account_id,
         conversation_id,
-        participant_id,
         thread_id,
     }
 }
@@ -766,7 +955,6 @@ fn build_conversation_address_read_model(
     let channel_id = address.channel_id.clone();
     let account_id = address.account_id.clone();
     let conversation_id = address.conversation_id.clone();
-    let participant_id = address.participant_id.clone();
     let thread_id = address.thread_id.clone();
 
     GatewayConversationAddressReadModel {
@@ -774,7 +962,6 @@ fn build_conversation_address_read_model(
         channel_id,
         account_id,
         conversation_id,
-        participant_id,
         thread_id,
     }
 }
@@ -802,7 +989,6 @@ fn build_acp_dispatch_target_read_model(
     let channel_id = target.channel_id.clone();
     let account_id = target.account_id.clone();
     let conversation_id = target.conversation_id.clone();
-    let participant_id = target.participant_id.clone();
     let thread_id = target.thread_id.clone();
     let channel_path = target.channel_path.clone();
 
@@ -813,7 +999,6 @@ fn build_acp_dispatch_target_read_model(
         channel_id,
         account_id,
         conversation_id,
-        participant_id,
         thread_id,
         channel_path,
     }
@@ -883,43 +1068,10 @@ fn build_operator_channels_summary_read_model(
                 == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
         })
         .count();
-    let config_backed_channel_count = channel_inventory
-        .channel_catalog
-        .iter()
-        .filter(|channel| {
-            channel.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::ConfigBacked
-        })
-        .count();
-    let plugin_backed_channel_count = channel_inventory
-        .channel_catalog
-        .iter()
-        .filter(|channel| {
-            channel.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-        })
-        .count();
-    let catalog_only_channel_count = channel_inventory
-        .channel_catalog
-        .iter()
-        .filter(|channel| {
-            channel.implementation_status == mvp::channel::ChannelCatalogImplementationStatus::Stub
-        })
-        .count();
-    let enabled_runtime_backed_channel_ids =
-        &runtime_snapshot.channels.enabled_runtime_backed_channel_ids;
-    let enabled_plugin_backed_channel_ids =
-        &runtime_snapshot.channels.enabled_plugin_backed_channel_ids;
-    let enabled_outbound_only_channel_ids =
-        &runtime_snapshot.channels.enabled_outbound_only_channel_ids;
     let enabled_service_channel_ids = &runtime_snapshot.channels.enabled_service_channel_ids;
-    let enabled_runtime_backed_channel_count = enabled_runtime_backed_channel_ids.len();
-    let enabled_plugin_backed_channel_count = enabled_plugin_backed_channel_ids.len();
-    let enabled_outbound_only_channel_count = enabled_outbound_only_channel_ids.len();
     let enabled_service_channel_count = enabled_service_channel_ids.len();
     let surfaces = build_operator_channel_surface_read_models(
         &channel_inventory.channel_surfaces,
-        &channel_inventory.channel_access_policies,
         enabled_service_channel_ids,
     );
     let ready_service_channel_count = surfaces
@@ -934,12 +1086,6 @@ fn build_operator_channels_summary_read_model(
         enabled_account_count,
         misconfigured_account_count,
         runtime_backed_channel_count,
-        config_backed_channel_count,
-        plugin_backed_channel_count,
-        catalog_only_channel_count,
-        enabled_runtime_backed_channel_count,
-        enabled_plugin_backed_channel_count,
-        enabled_outbound_only_channel_count,
         enabled_service_channel_count,
         ready_service_channel_count,
         surfaces,
@@ -948,17 +1094,13 @@ fn build_operator_channels_summary_read_model(
 
 fn build_operator_channel_surface_read_models(
     channel_surfaces: &[GatewayChannelSurfaceReadModel],
-    channel_access_policies: &[mvp::channel::ChannelConfiguredAccountAccessPolicy],
     enabled_service_channel_ids: &[String],
 ) -> Vec<GatewayOperatorChannelSurfaceReadModel> {
     let mut surfaces = Vec::with_capacity(channel_surfaces.len());
 
     for channel_surface in channel_surfaces {
-        let surface = build_operator_channel_surface_read_model(
-            channel_surface,
-            channel_access_policies,
-            enabled_service_channel_ids,
-        );
+        let surface =
+            build_operator_channel_surface_read_model(channel_surface, enabled_service_channel_ids);
         surfaces.push(surface);
     }
 
@@ -967,7 +1109,6 @@ fn build_operator_channel_surface_read_models(
 
 fn build_operator_channel_surface_read_model(
     channel_surface: &GatewayChannelSurfaceReadModel,
-    channel_access_policies: &[mvp::channel::ChannelConfiguredAccountAccessPolicy],
     enabled_service_channel_ids: &[String],
 ) -> GatewayOperatorChannelSurfaceReadModel {
     let surface = &channel_surface.surface;
@@ -999,25 +1140,6 @@ fn build_operator_channel_surface_read_model(
             channel_account_operation_is_ready(account, mvp::channel::CHANNEL_OPERATION_SERVE_ID)
         })
         .count();
-    let conversation_gated_account_count = channel_access_policies
-        .iter()
-        .filter(|policy| policy.channel_id == surface.catalog.id)
-        .filter(|policy| {
-            policy.summary.conversation_mode != mvp::channel::ChannelAccessRestrictionMode::Open
-        })
-        .count();
-    let sender_gated_account_count = channel_access_policies
-        .iter()
-        .filter(|policy| policy.channel_id == surface.catalog.id)
-        .filter(|policy| {
-            policy.summary.sender_mode != mvp::channel::ChannelAccessRestrictionMode::Open
-        })
-        .count();
-    let mention_gated_account_count = channel_access_policies
-        .iter()
-        .filter(|policy| policy.channel_id == surface.catalog.id)
-        .filter(|policy| policy.summary.mention_required)
-        .count();
     let default_configured_account_id = surface.default_configured_account_id.clone();
     let plugin_bridge_account_summary = channel_surface.plugin_bridge_account_summary.clone();
     let service_enabled = enabled_service_channel_ids.contains(&channel_id);
@@ -1032,9 +1154,6 @@ fn build_operator_channel_surface_read_model(
         misconfigured_account_count,
         ready_send_account_count,
         ready_serve_account_count,
-        conversation_gated_account_count,
-        sender_gated_account_count,
-        mention_gated_account_count,
         default_configured_account_id,
         plugin_bridge_account_summary,
         service_enabled,
@@ -1046,21 +1165,9 @@ fn build_operator_runtime_summary_read_model(
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
 ) -> GatewayOperatorRuntimeSummaryReadModel {
     let enabled_channel_ids = runtime_snapshot.channels.enabled_channel_ids.clone();
-    let enabled_runtime_backed_channel_ids = runtime_snapshot
-        .channels
-        .enabled_runtime_backed_channel_ids
-        .clone();
     let enabled_service_channel_ids = runtime_snapshot
         .channels
         .enabled_service_channel_ids
-        .clone();
-    let enabled_plugin_backed_channel_ids = runtime_snapshot
-        .channels
-        .enabled_plugin_backed_channel_ids
-        .clone();
-    let enabled_outbound_only_channel_ids = runtime_snapshot
-        .channels
-        .enabled_outbound_only_channel_ids
         .clone();
     let visible_tool_count = runtime_snapshot.tools.visible_tool_count;
     let capability_snapshot_sha256 = runtime_snapshot.tools.capability_snapshot_sha256.clone();
@@ -1071,15 +1178,111 @@ fn build_operator_runtime_summary_read_model(
 
     GatewayOperatorRuntimeSummaryReadModel {
         enabled_channel_ids,
-        enabled_runtime_backed_channel_ids,
         enabled_service_channel_ids,
-        enabled_plugin_backed_channel_ids,
-        enabled_outbound_only_channel_ids,
         visible_tool_count,
         capability_snapshot_sha256,
         active_provider_profile_id,
         active_provider_label,
         tool_calling,
+    }
+}
+
+fn build_paired_device_nodes_read_model(
+    paired_devices: &[mvp::control_plane::ControlPlaneApprovedDeviceSummary],
+) -> Vec<GatewayPairedDeviceNodeReadModel> {
+    paired_devices
+        .iter()
+        .map(|device| GatewayPairedDeviceNodeReadModel {
+            node_id: device.device_id.clone(),
+            node_kind: paired_device_node_kind(device.role.as_str()).to_owned(),
+            trust_state: "paired".to_owned(),
+            role: device.role.clone(),
+            public_key: device.public_key.clone(),
+            approved_scopes: device.approved_scopes.iter().cloned().collect(),
+            issued_at_ms: device.issued_at_ms,
+        })
+        .collect()
+}
+
+fn build_managed_bridge_nodes_read_model(
+    channel_inventory: &GatewayChannelInventoryReadModel,
+) -> Vec<GatewayManagedBridgeNodeReadModel> {
+    let mut nodes = channel_inventory
+        .channel_surfaces
+        .iter()
+        .filter_map(|surface| {
+            let discovery = surface.surface.plugin_bridge_discovery.as_ref()?;
+            let enabled_account_count = surface
+                .surface
+                .configured_accounts
+                .iter()
+                .filter(|snapshot| snapshot.enabled)
+                .count();
+            let has_operator_relevant_surface = enabled_account_count > 0
+                || discovery.selected_plugin_id.is_some()
+                || discovery.configured_plugin_id.is_some()
+                || discovery.compatible_plugins > 0;
+            if !has_operator_relevant_surface {
+                return None;
+            }
+            Some(GatewayManagedBridgeNodeReadModel {
+                node_id: format!("managed_bridge:{}", surface.surface.catalog.id),
+                node_kind: "managed_bridge".to_owned(),
+                trust_state: managed_bridge_trust_state(discovery).to_owned(),
+                channel_id: surface.surface.catalog.id.to_owned(),
+                implementation_status: surface
+                    .surface
+                    .catalog
+                    .implementation_status
+                    .as_str()
+                    .to_owned(),
+                configured_account_count: surface.surface.configured_accounts.len(),
+                enabled_account_count,
+                configured_plugin_id: discovery.configured_plugin_id.clone(),
+                selected_plugin_id: discovery.selected_plugin_id.clone(),
+                discovery_status: Some(discovery.status.as_str().to_owned()),
+                selection_status: discovery.selection_status.map(
+                    |status: mvp::channel::ChannelPluginBridgeSelectionStatus| {
+                        status.as_str().to_owned()
+                    },
+                ),
+                compatible_plugins: discovery.compatible_plugins,
+                incomplete_plugins: discovery.incomplete_plugins,
+                incompatible_plugins: discovery.incompatible_plugins,
+                account_summary: surface.plugin_bridge_account_summary.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    nodes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+    nodes
+}
+
+fn paired_device_node_kind(role: &str) -> &'static str {
+    match role {
+        "operator" => "operator_ui",
+        _ => "node_client",
+    }
+}
+
+fn managed_bridge_trust_state(
+    discovery: &mvp::channel::ChannelPluginBridgeDiscovery,
+) -> &'static str {
+    use mvp::channel::ChannelPluginBridgeDiscoveryStatus as DiscoveryStatus;
+
+    match discovery.status {
+        DiscoveryStatus::NotConfigured => "not_configured",
+        DiscoveryStatus::ScanFailed => "scan_failed",
+        DiscoveryStatus::NoMatches => "unresolved",
+        DiscoveryStatus::MatchesFound => {
+            if discovery
+                .selection_status
+                .is_some_and(|status| status.selects_ready_plugin())
+            {
+                "ready"
+            } else {
+                "review_required"
+            }
+        }
     }
 }
 
@@ -1150,7 +1353,7 @@ mod tests {
 
     #[test]
     fn operator_channel_surface_read_model_keeps_plugin_backed_summary_context() {
-        let config: mvp::config::LoongConfig = serde_json::from_value(serde_json::json!({
+        let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
             "weixin": {
                 "enabled": true,
                 "default_account": "ops",
@@ -1173,20 +1376,14 @@ mod tests {
         let inventory = mvp::channel::channel_inventory(&config);
         let surface = inventory
             .channel_surfaces
-            .iter()
+            .into_iter()
             .find(|surface| surface.catalog.id == "weixin")
             .expect("weixin surface");
-        let read_model = build_channel_surface_read_model(surface.clone());
-        let operator_surface = build_operator_channel_surface_read_model(
-            &read_model,
-            &inventory.channel_access_policies,
-            &Vec::new(),
-        );
+        let read_model = build_channel_surface_read_model(surface);
+        let operator_surface = build_operator_channel_surface_read_model(&read_model, &Vec::new());
 
         assert_eq!(operator_surface.channel_id, "weixin");
         assert_eq!(operator_surface.implementation_status, "plugin_backed");
-        assert_eq!(operator_surface.conversation_gated_account_count, 0);
-        assert_eq!(operator_surface.sender_gated_account_count, 0);
         assert_eq!(
             operator_surface.plugin_bridge_account_summary.as_deref(),
             Some(
@@ -1197,62 +1394,23 @@ mod tests {
 
     #[test]
     fn operator_channel_surface_read_model_keeps_non_plugin_backed_summary_empty() {
-        let mut config = mvp::config::LoongConfig::default();
+        let mut config = mvp::config::LoongClawConfig::default();
         config.telegram.enabled = true;
-        config.telegram.bot_token = Some(loong_contracts::SecretRef::Inline(
+        config.telegram.bot_token = Some(loongclaw_contracts::SecretRef::Inline(
             "123456:test-token".to_owned(),
         ));
         config.telegram.allowed_chat_ids = vec![1];
         let inventory = mvp::channel::channel_inventory(&config);
         let surface = inventory
             .channel_surfaces
-            .iter()
+            .into_iter()
             .find(|surface| surface.catalog.id == "telegram")
             .expect("telegram surface");
-        let read_model = build_channel_surface_read_model(surface.clone());
-        let operator_surface = build_operator_channel_surface_read_model(
-            &read_model,
-            &inventory.channel_access_policies,
-            &Vec::new(),
-        );
+        let read_model = build_channel_surface_read_model(surface);
+        let operator_surface = build_operator_channel_surface_read_model(&read_model, &Vec::new());
 
         assert_eq!(operator_surface.channel_id, "telegram");
         assert_eq!(operator_surface.implementation_status, "runtime_backed");
-        assert_eq!(operator_surface.conversation_gated_account_count, 1);
-        assert_eq!(operator_surface.sender_gated_account_count, 0);
         assert_eq!(operator_surface.plugin_bridge_account_summary, None);
-    }
-
-    #[test]
-    fn channel_inventory_read_model_includes_structured_channel_access_policies() {
-        let mut config = mvp::config::LoongConfig::default();
-        config.feishu.enabled = true;
-        config.feishu.app_id = Some(loong_contracts::SecretRef::Inline("cli_a1b2c3".to_owned()));
-        config.feishu.app_secret = Some(loong_contracts::SecretRef::Inline("secret".to_owned()));
-        config.feishu.allowed_chat_ids = vec!["*".to_owned()];
-        config.feishu.allowed_sender_ids = vec!["ou_admin".to_owned()];
-
-        let inventory = mvp::channel::channel_inventory(&config);
-        let read_model = build_channel_inventory_read_model("/tmp/loong.toml", &inventory);
-        let access_policy = read_model
-            .channel_access_policies
-            .iter()
-            .find(|policy| policy.channel_id == "feishu")
-            .expect("feishu access policy");
-
-        assert_eq!(access_policy.conversation_config_key, "allowed_chat_ids");
-        assert_eq!(access_policy.sender_config_key, "allowed_sender_ids");
-        assert_eq!(
-            access_policy.summary.conversation_mode,
-            mvp::channel::ChannelAccessRestrictionMode::WildcardAllowlist
-        );
-        assert_eq!(
-            access_policy.summary.allowed_conversations,
-            vec!["*".to_owned()]
-        );
-        assert_eq!(
-            access_policy.summary.allowed_senders,
-            vec!["ou_admin".to_owned()]
-        );
     }
 }

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -14,9 +14,9 @@ use crate::mvp::acp::AcpSessionManager;
 
 use super::control::start_gateway_control_surface;
 use super::state::{
-    GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayStopRequestOutcome,
-    default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
-    wait_for_gateway_stop_request,
+    GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayPortSource,
+    GatewayStopRequestOutcome, default_gateway_runtime_state_dir, load_gateway_owner_status,
+    request_gateway_stop, wait_for_gateway_stop_request,
 };
 
 #[derive(Subcommand, Debug)]
@@ -25,6 +25,11 @@ pub enum GatewayCommand {
     Run {
         #[arg(long)]
         config: Option<String>,
+        #[arg(
+            long,
+            help = "Gateway control-surface port (default 26306; use 0 for an ephemeral OS-assigned port)"
+        )]
+        port: Option<u16>,
         #[arg(long)]
         session: Option<String>,
         #[arg(long = "channel-account", value_name = "CHANNEL=ACCOUNT")]
@@ -45,22 +50,16 @@ enum GatewayRuntimeEntryPoint {
     MultiChannelServeCompatibility,
 }
 
-impl GatewayRuntimeEntryPoint {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::GatewayRun => "gateway_run",
-            Self::MultiChannelServeCompatibility => "multi_channel_compat",
-        }
-    }
-}
-
 pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
     match command {
         GatewayCommand::Run {
             config,
+            port,
             session,
             channel_account,
-        } => run_gateway_run_cli(config.as_deref(), session.as_deref(), channel_account).await,
+        } => {
+            run_gateway_run_cli(config.as_deref(), port, session.as_deref(), channel_account).await
+        }
         GatewayCommand::Status { json } => run_gateway_status_cli(json),
         GatewayCommand::Stop => run_gateway_stop_cli(),
     }
@@ -68,12 +67,14 @@ pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
 
 pub async fn run_gateway_run_cli(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
 ) -> CliResult<()> {
     let runtime_dir = default_gateway_runtime_state_dir();
     let supervisor = run_gateway_runtime_with_hooks_for_test(
         config_path,
+        port,
         session,
         channel_accounts,
         runtime_dir.as_path(),
@@ -92,6 +93,7 @@ pub async fn run_multi_channel_serve_gateway_compat_cli(
     let runtime_dir = default_gateway_runtime_state_dir();
     let supervisor = run_gateway_runtime_with_hooks_for_test(
         config_path,
+        None,
         Some(session),
         channel_accounts,
         runtime_dir.as_path(),
@@ -104,6 +106,7 @@ pub async fn run_multi_channel_serve_gateway_compat_cli(
 
 async fn run_gateway_runtime_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -115,22 +118,6 @@ async fn run_gateway_runtime_with_hooks_for_test(
     let spec =
         build_gateway_supervisor_spec(&loaded_config, session, &channel_accounts, entry_point)?;
     let owner_mode = gateway_owner_mode(entry_point, session);
-    let configured_surface_count = spec.surfaces.len();
-    let resolved_config_path = loaded_config.resolved_path.display().to_string();
-    let runtime_dir_display = runtime_dir.display().to_string();
-    let attached_cli_session = session.unwrap_or("-");
-
-    tracing::info!(
-        target: "loong.gateway",
-        entry_point = entry_point.as_str(),
-        owner_mode = owner_mode.as_str(),
-        config_path = %resolved_config_path,
-        runtime_dir = %runtime_dir_display,
-        attached_cli_session = %attached_cli_session,
-        configured_surface_count,
-        "starting gateway runtime"
-    );
-
     let tracker = Arc::new(GatewayOwnerTracker::acquire(
         runtime_dir,
         owner_mode,
@@ -145,7 +132,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
         build_gateway_acp_session_manager,
     )?;
     let control_surface_result =
-        start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager)).await;
+        start_gateway_control_surface(runtime_dir, &loaded_config, Some(acp_manager), port).await;
     let control_surface = match control_surface_result {
         Ok(control_surface) => control_surface,
         Err(error) => {
@@ -160,22 +147,6 @@ async fn run_gateway_runtime_with_hooks_for_test(
         tracker.finalize_with_error(final_error.as_str())?;
         return Err(final_error);
     }
-
-    let control_binding = control_surface.binding();
-    let bind_address = control_binding.bind_address.as_str();
-    let port = control_binding.port;
-    let token_path = control_binding.token_path.display().to_string();
-
-    tracing::info!(
-        target: "loong.gateway",
-        entry_point = entry_point.as_str(),
-        owner_mode = owner_mode.as_str(),
-        configured_surface_count,
-        bind_address = %bind_address,
-        port,
-        token_path = %token_path,
-        "gateway control surface is ready"
-    );
 
     let mut runtime_hooks = hooks.clone();
     let original_wait_for_shutdown = hooks.wait_for_shutdown.clone();
@@ -226,6 +197,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
 #[doc(hidden)]
 pub async fn run_gateway_run_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: Option<&str>,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -233,6 +205,7 @@ pub async fn run_gateway_run_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
+        port,
         session,
         channel_accounts,
         runtime_dir,
@@ -245,6 +218,7 @@ pub async fn run_gateway_run_with_hooks_for_test(
 #[doc(hidden)]
 pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
     config_path: Option<&str>,
+    port: Option<u16>,
     session: &str,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
     runtime_dir: &Path,
@@ -252,6 +226,7 @@ pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
 ) -> CliResult<crate::supervisor::SupervisorState> {
     run_gateway_runtime_with_hooks_for_test(
         config_path,
+        port,
         Some(session),
         channel_accounts,
         runtime_dir,
@@ -365,12 +340,13 @@ pub(crate) fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerSt
         running_surface_count: 0,
         bind_address: None,
         port: None,
+        port_source: None,
         token_path: None,
     }
 }
 
 fn build_gateway_acp_session_manager(
-    config: &crate::mvp::config::LoongConfig,
+    config: &crate::mvp::config::LoongClawConfig,
 ) -> CliResult<Arc<AcpSessionManager>> {
     let manager = crate::mvp::acp::shared_acp_session_manager(config)?;
     Ok(manager)
@@ -378,8 +354,8 @@ fn build_gateway_acp_session_manager(
 
 fn acquire_gateway_acp_session_manager(
     tracker: &GatewayOwnerTracker,
-    config: &crate::mvp::config::LoongConfig,
-    builder: impl FnOnce(&crate::mvp::config::LoongConfig) -> CliResult<Arc<AcpSessionManager>>,
+    config: &crate::mvp::config::LoongClawConfig,
+    builder: impl FnOnce(&crate::mvp::config::LoongClawConfig) -> CliResult<Arc<AcpSessionManager>>,
 ) -> CliResult<Arc<AcpSessionManager>> {
     let manager_result = builder(config);
     let manager = match manager_result {
@@ -409,10 +385,14 @@ fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
         .port
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_owned());
+    let port_source = status
+        .port_source
+        .map(GatewayPortSource::as_str)
+        .unwrap_or("-");
     let token_path = status.token_path.as_deref().unwrap_or("-");
 
     format!(
-        "runtime_dir={}\nphase={} running={} stale={} pid={} mode={} config={} session={} version={}\nstarted_at_ms={} last_heartbeat_at_ms={} stopped_at_ms={}\nsurfaces configured={} running={}\nshutdown_reason={}\nlast_error={}\nbind_address={} port={} token_path={}",
+        "runtime_dir={}\nphase={} running={} stale={} pid={} mode={} config={} session={} version={}\nstarted_at_ms={} last_heartbeat_at_ms={} stopped_at_ms={}\nsurfaces configured={} running={}\nshutdown_reason={}\nlast_error={}\nbind_address={} port={} port_source={} token_path={}",
         status.runtime_dir,
         status.phase,
         status.running,
@@ -431,6 +411,7 @@ fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
         last_error,
         bind_address,
         port,
+        port_source,
         token_path,
     )
 }
@@ -467,7 +448,7 @@ mod tests {
             .as_nanos();
         let process_id = std::process::id();
         let runtime_dir = std::env::temp_dir().join(format!(
-            "loong-gateway-service-{label}-{process_id}-{timestamp}"
+            "loongclaw-gateway-service-{label}-{process_id}-{timestamp}"
         ));
         fs::create_dir_all(runtime_dir.as_path()).expect("create runtime dir");
         runtime_dir
@@ -485,9 +466,9 @@ mod tests {
             1,
         )
         .expect("acquire gateway owner tracker");
-        let config = crate::mvp::config::LoongConfig::default();
+        let config = crate::mvp::config::LoongClawConfig::default();
         let expected_error = "simulated ACP manager init failure".to_owned();
-        let builder = |_config: &crate::mvp::config::LoongConfig| Err(expected_error.clone());
+        let builder = |_config: &crate::mvp::config::LoongClawConfig| Err(expected_error.clone());
 
         let manager_result = acquire_gateway_acp_session_manager(&tracker, &config, builder);
         let error = match manager_result {
@@ -513,5 +494,36 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(runtime_dir.as_path());
+    }
+
+    #[test]
+    fn render_gateway_status_text_surfaces_port_source() {
+        let status = GatewayOwnerStatus {
+            runtime_dir: "/tmp/runtime".to_owned(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: "0.0.0-test".to_owned(),
+            config_path: "/tmp/config.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1,
+            last_heartbeat_at: 2,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 0,
+            running_surface_count: 0,
+            bind_address: Some("127.0.0.1".to_owned()),
+            port: Some(26_306),
+            port_source: Some(GatewayPortSource::Default),
+            token_path: Some("/tmp/token".to_owned()),
+        };
+
+        let rendered = render_gateway_status_text(&status);
+
+        assert!(rendered.contains("port=26306"));
+        assert!(rendered.contains("port_source=default"));
     }
 }

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -60,6 +60,7 @@ pub struct GatewayOwnerStatus {
     pub running_surface_count: usize,
     pub bind_address: Option<String>,
     pub port: Option<u16>,
+    pub port_source: Option<GatewayPortSource>,
     pub token_path: Option<String>,
 }
 
@@ -67,7 +68,36 @@ pub struct GatewayOwnerStatus {
 pub struct GatewayControlSurfaceBinding {
     pub bind_address: String,
     pub port: u16,
+    pub port_source: GatewayPortSource,
     pub token_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GatewayPairingRuntimeState {
+    pub sessions: Vec<mvp::control_plane::ControlPlaneConnectionLease>,
+    pub event_bus: super::event_bus::GatewayEventBusSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayPortSource {
+    Default,
+    Config,
+    Env,
+    Cli,
+    EphemeralCli,
+}
+
+impl GatewayPortSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Config => "config",
+            Self::Env => "env",
+            Self::Cli => "cli",
+            Self::EphemeralCli => "ephemeral_cli",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,6 +125,7 @@ struct PersistedGatewayOwnerState {
     running_surface_count: usize,
     bind_address: Option<String>,
     port: Option<u16>,
+    port_source: Option<GatewayPortSource>,
     token_path: Option<String>,
     owner_token: String,
 }
@@ -149,6 +180,7 @@ impl GatewayOwnerTracker {
             running_surface_count: 0,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
             owner_token: owner_token.clone(),
         };
@@ -240,6 +272,7 @@ impl GatewayOwnerTracker {
                 .map_err(|error| format!("gateway owner state lock poisoned: {error}"))?;
             state_guard.bind_address = Some(binding.bind_address.clone());
             state_guard.port = Some(binding.port);
+            state_guard.port_source = Some(binding.port_source);
             state_guard.token_path = Some(binding.token_path.display().to_string());
             state_guard.last_heartbeat_at = now_ms();
             state_guard.clone()
@@ -333,6 +366,7 @@ impl GatewayOwnerTracker {
             if !running {
                 state_guard.bind_address = None;
                 state_guard.port = None;
+                state_guard.port_source = None;
                 state_guard.token_path = None;
             }
             state_guard.clone()
@@ -358,7 +392,7 @@ impl Drop for GatewayOwnerTracker {
 }
 
 pub fn default_gateway_runtime_state_dir() -> PathBuf {
-    mvp::config::default_loong_home().join("gateway-runtime")
+    mvp::config::default_loongclaw_home().join("gateway-runtime")
 }
 
 pub fn load_gateway_owner_status(runtime_dir: &Path) -> Option<GatewayOwnerStatus> {
@@ -448,6 +482,7 @@ pub(crate) fn write_gateway_owner_snapshot_for_test(
         running_surface_count: persisted_state.running_surface_count,
         bind_address: persisted_state.bind_address.clone(),
         port: persisted_state.port,
+        port_source: persisted_state.port_source,
         token_path: persisted_state.token_path.clone(),
         owner_token,
     };
@@ -498,6 +533,7 @@ fn build_gateway_owner_status(
         running_surface_count: persisted_state.running_surface_count,
         bind_address: persisted_state.bind_address.clone(),
         port: persisted_state.port,
+        port_source: persisted_state.port_source,
         token_path: persisted_state.token_path.clone(),
     }
 }
@@ -532,6 +568,25 @@ pub fn gateway_control_token_path(runtime_dir: &Path) -> PathBuf {
     runtime_dir.join("control-token")
 }
 
+pub fn gateway_pairing_runtime_state_path(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("pairing-runtime.json")
+}
+
+pub fn load_gateway_pairing_runtime_state(
+    runtime_dir: &Path,
+) -> Option<GatewayPairingRuntimeState> {
+    let path = gateway_pairing_runtime_state_path(runtime_dir);
+    read_json_path(path.as_path())
+}
+
+pub fn write_gateway_pairing_runtime_state(
+    runtime_dir: &Path,
+    state: &GatewayPairingRuntimeState,
+) -> CliResult<()> {
+    let path = gateway_pairing_runtime_state_path(runtime_dir);
+    write_json_path(path.as_path(), state, "gateway pairing runtime state")
+}
+
 fn read_persisted_gateway_owner_state(path: &Path) -> Option<PersistedGatewayOwnerState> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str::<PersistedGatewayOwnerState>(&raw).ok()
@@ -540,6 +595,11 @@ fn read_persisted_gateway_owner_state(path: &Path) -> Option<PersistedGatewayOwn
 fn read_persisted_gateway_stop_request(path: &Path) -> Option<PersistedGatewayStopRequest> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str::<PersistedGatewayStopRequest>(&raw).ok()
+}
+
+fn read_json_path<T: for<'de> Deserialize<'de>>(path: &Path) -> Option<T> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<T>(&raw).ok()
 }
 
 fn persisted_gateway_owner_is_stale(
@@ -673,17 +733,29 @@ fn write_status_snapshot(
 fn write_json_path<T: Serialize>(path: &Path, value: &T, context: &str) -> CliResult<()> {
     ensure_parent_dir(path, context)?;
     let encoded = serialize_json_pretty(value, context)?;
+    let temp_path = atomic_temp_path(path);
     let open_result = OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
-        .open(path);
+        .open(temp_path.as_path());
     let mut file = open_result
-        .map_err(|error| format!("open {context} failed for {}: {error}", path.display()))?;
+        .map_err(|error| format!("open {context} failed for {}: {error}", temp_path.display()))?;
     file.write_all(encoded.as_bytes())
-        .map_err(|error| format!("write {context} failed for {}: {error}", path.display()))?;
+        .map_err(|error| format!("write {context} failed for {}: {error}", temp_path.display()))?;
     file.sync_all()
-        .map_err(|error| format!("sync {context} failed for {}: {error}", path.display()))
+        .map_err(|error| format!("sync {context} failed for {}: {error}", temp_path.display()))?;
+    drop(file);
+
+    fs::rename(temp_path.as_path(), path).map_err(|error| {
+        let _ = fs::remove_file(temp_path.as_path());
+        format!(
+            "replace {context} failed for {} with {}: {error}",
+            path.display(),
+            temp_path.display()
+        )
+    })?;
+    sync_parent_dir(path, context)
 }
 
 fn serialize_json_pretty<T: Serialize>(value: &T, context: &str) -> CliResult<String> {
@@ -701,6 +773,39 @@ fn ensure_parent_dir(path: &Path, context: &str) -> CliResult<()> {
     }
     fs::create_dir_all(parent)
         .map_err(|error| format!("create {context} parent directory failed: {error}"))
+}
+
+fn atomic_temp_path(path: &Path) -> PathBuf {
+    let process_id = std::process::id();
+    let suffix = now_ms();
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("gateway-state");
+    let temp_file_name = format!(".{file_name}.{process_id}.{suffix}.tmp");
+    path.with_file_name(temp_file_name)
+}
+
+fn sync_parent_dir(path: &Path, context: &str) -> CliResult<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    let dir = fs::File::open(parent).map_err(|error| {
+        format!(
+            "open {context} parent directory failed for {}: {error}",
+            parent.display()
+        )
+    })?;
+    dir.sync_all().map_err(|error| {
+        format!(
+            "sync {context} parent directory failed for {}: {error}",
+            parent.display()
+        )
+    })
 }
 
 fn remove_active_owner_if_owned(path: &Path, owner_token: &str) -> CliResult<()> {
@@ -773,14 +878,14 @@ mod tests {
             .expect("system clock before unix epoch")
             .as_nanos();
         let runtime_dir =
-            std::env::temp_dir().join(format!("loong-gateway-runtime-{label}-{suffix}"));
+            std::env::temp_dir().join(format!("loongclaw-gateway-runtime-{label}-{suffix}"));
         fs::create_dir_all(&runtime_dir).expect("create gateway runtime dir");
         runtime_dir
     }
 
     fn sample_status(running: bool, last_heartbeat_at: u64) -> GatewayOwnerStatus {
         GatewayOwnerStatus {
-            runtime_dir: "/tmp/loong-gateway-runtime".to_owned(),
+            runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
             phase: if running {
                 "running".to_owned()
             } else {
@@ -791,7 +896,7 @@ mod tests {
             pid: Some(4242),
             mode: GatewayOwnerMode::GatewayHeadless,
             version: env!("CARGO_PKG_VERSION").to_owned(),
-            config_path: "/tmp/loong.toml".to_owned(),
+            config_path: "/tmp/loongclaw.toml".to_owned(),
             attached_cli_session: None,
             started_at_ms: 1_710_000_000_000,
             last_heartbeat_at,
@@ -806,6 +911,7 @@ mod tests {
             running_surface_count: if running { 2 } else { 0 },
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         }
     }
@@ -832,7 +938,7 @@ mod tests {
         let tracker = GatewayOwnerTracker::acquire(
             runtime_dir.as_path(),
             GatewayOwnerMode::GatewayHeadless,
-            Path::new("/tmp/loong.toml"),
+            Path::new("/tmp/loongclaw.toml"),
             None,
             0,
         )
@@ -887,6 +993,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
             owner_token: "stale-owner".to_owned(),
         };
@@ -928,7 +1035,7 @@ mod tests {
         let tracker = GatewayOwnerTracker::acquire(
             runtime_dir.as_path(),
             GatewayOwnerMode::GatewayHeadless,
-            Path::new("/tmp/loong.toml"),
+            Path::new("/tmp/loongclaw.toml"),
             None,
             0,
         )
@@ -940,5 +1047,63 @@ mod tests {
         let stop_request_path = gateway_stop_request_path(runtime_dir.as_path());
         assert!(stop_request_path.exists());
         drop(tracker);
+    }
+
+    #[test]
+    fn gateway_pairing_runtime_state_roundtrips_after_rewrite() {
+        let runtime_dir = temp_gateway_runtime_dir("pairing-runtime-state");
+        let first = GatewayPairingRuntimeState {
+            sessions: vec![mvp::control_plane::ControlPlaneConnectionLease {
+                token: "cpt-one".to_owned(),
+                principal: mvp::control_plane::ControlPlaneConnectionPrincipal {
+                    connection_id: "cp-1".to_owned(),
+                    client_id: "cli".to_owned(),
+                    role: "operator".to_owned(),
+                    scopes: std::collections::BTreeSet::from(["operator.read".to_owned()]),
+                    device_id: Some("device-1".to_owned()),
+                },
+                issued_at_ms: 10,
+                expires_at_ms: now_ms().saturating_add(60_000),
+                acknowledged_seq: Some(7),
+            }],
+            event_bus: super::super::event_bus::GatewayEventBusSnapshot {
+                next_seq: 7,
+                recent_events: vec![super::super::event_bus::GatewayEventRecord {
+                    seq: 7,
+                    payload: serde_json::json!({"event_type": "first"}),
+                }],
+            },
+        };
+        write_gateway_pairing_runtime_state(runtime_dir.as_path(), &first)
+            .expect("write first pairing runtime state");
+
+        let second = GatewayPairingRuntimeState {
+            sessions: vec![mvp::control_plane::ControlPlaneConnectionLease {
+                token: "cpt-two".to_owned(),
+                principal: mvp::control_plane::ControlPlaneConnectionPrincipal {
+                    connection_id: "cp-2".to_owned(),
+                    client_id: "cli".to_owned(),
+                    role: "operator".to_owned(),
+                    scopes: std::collections::BTreeSet::from(["operator.read".to_owned()]),
+                    device_id: Some("device-2".to_owned()),
+                },
+                issued_at_ms: 20,
+                expires_at_ms: now_ms().saturating_add(60_000),
+                acknowledged_seq: Some(11),
+            }],
+            event_bus: super::super::event_bus::GatewayEventBusSnapshot {
+                next_seq: 11,
+                recent_events: vec![super::super::event_bus::GatewayEventRecord {
+                    seq: 11,
+                    payload: serde_json::json!({"event_type": "second"}),
+                }],
+            },
+        };
+        write_gateway_pairing_runtime_state(runtime_dir.as_path(), &second)
+            .expect("rewrite pairing runtime state");
+
+        let loaded = load_gateway_pairing_runtime_state(runtime_dir.as_path())
+            .expect("load pairing runtime state");
+        assert_eq!(loaded, second);
     }
 }

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -1,11 +1,13 @@
-use loong_contracts::WorkRuntimeHealthSnapshot;
-use loong_spec::CliResult;
+use loongclaw_contracts::WorkRuntimeHealthSnapshot;
+use loongclaw_spec::CliResult;
 use serde::Serialize;
 use std::path::Path;
 
 use crate::gateway::read_models::{
-    GatewayAcpObservabilityReadModel, GatewayOperatorSummaryReadModel,
-    build_acp_observability_read_model, build_operator_summary_read_model,
+    GatewayAcpObservabilityReadModel, GatewayOperatorNodesSummaryReadModel,
+    GatewayOperatorPairingSummaryReadModel, GatewayOperatorSummaryReadModel,
+    build_acp_observability_read_model, build_node_inventory_read_model,
+    build_operator_nodes_summary_read_model, build_operator_summary_read_model,
     build_runtime_snapshot_read_model,
 };
 use crate::gateway::service::default_gateway_owner_status;
@@ -13,7 +15,7 @@ use crate::gateway::state::{default_gateway_runtime_state_dir, load_gateway_owne
 use crate::mvp;
 use crate::supervisor::LoadedSupervisorConfig;
 
-const STATUS_CLI_JSON_SCHEMA_VERSION: u32 = 2;
+const STATUS_CLI_JSON_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct StatusCliJsonSchema {
@@ -39,22 +41,12 @@ pub struct StatusCliWorkUnitReadModel {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct StatusCliAction {
-    pub label: String,
-    pub command: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
 pub struct StatusCliReadModel {
     pub config: String,
     pub schema: StatusCliJsonSchema,
-    pub active_provider: String,
-    pub active_model: String,
-    pub memory_profile: String,
     pub gateway: GatewayOperatorSummaryReadModel,
     pub acp: StatusCliAcpReadModel,
     pub work_units: StatusCliWorkUnitReadModel,
-    pub next_actions: Vec<StatusCliAction>,
     pub recipes: Vec<String>,
 }
 
@@ -101,17 +93,23 @@ pub async fn collect_status_cli_read_model(
         config_path_text,
         owner_status_option,
     );
-    let gateway =
-        build_operator_summary_read_model(&owner_status, &channel_inventory, &runtime_snapshot);
+    let gateway_pairing_summary = collect_status_cli_gateway_pairing_summary(&config);
+    let pairing = GatewayOperatorPairingSummaryReadModel {
+        pending_request_count: gateway_pairing_summary.pending_request_count,
+        approved_device_count: gateway_pairing_summary.approved_device_count,
+        last_activity_ms: gateway_pairing_summary.last_activity_ms,
+    };
+    let nodes =
+        collect_status_cli_gateway_nodes_summary(config_path_text, &config, &channel_inventory);
+    let gateway = build_operator_summary_read_model(
+        &owner_status,
+        &channel_inventory,
+        &runtime_snapshot,
+        pairing,
+        nodes,
+    );
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
-    let next_actions = crate::next_actions::collect_setup_next_actions(&config, config_path_text)
-        .into_iter()
-        .map(|action| StatusCliAction {
-            label: action.label,
-            command: action.command,
-        })
-        .collect();
     let recipes = build_status_cli_recipes(config_path_text);
     let schema = StatusCliJsonSchema {
         version: STATUS_CLI_JSON_SCHEMA_VERSION,
@@ -122,13 +120,9 @@ pub async fn collect_status_cli_read_model(
     Ok(StatusCliReadModel {
         config: config_path_display,
         schema,
-        active_provider: crate::provider_presentation::active_provider_detail_label(&config),
-        active_model: config.provider.model.clone(),
-        memory_profile: config.memory.profile.as_str().to_owned(),
         gateway,
         acp,
         work_units,
-        next_actions,
         recipes,
     })
 }
@@ -155,7 +149,7 @@ fn select_gateway_owner_status_for_config(
 
 async fn collect_status_cli_acp_read_model(
     config_path: &str,
-    config: &mvp::config::LoongConfig,
+    config: &mvp::config::LoongClawConfig,
 ) -> StatusCliAcpReadModel {
     let enabled = config.acp.enabled;
     let persisted_session_count = load_persisted_acp_session_count(config);
@@ -211,8 +205,76 @@ fn build_unavailable_acp_read_model(
     }
 }
 
+fn collect_status_cli_gateway_pairing_summary(
+    config: &mvp::config::LoongClawConfig,
+) -> GatewayOperatorPairingSummaryReadModel {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        match mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config) {
+            Ok(registry) => GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: registry.pending_request_count(),
+                approved_device_count: registry.approved_device_count(),
+                last_activity_ms: registry.last_activity_ms(),
+            },
+            Err(_error) => GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: 0,
+                approved_device_count: 0,
+                last_activity_ms: None,
+            },
+        }
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = config;
+        GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 0,
+            approved_device_count: 0,
+            last_activity_ms: None,
+        }
+    }
+}
+
+fn collect_status_cli_gateway_nodes_summary(
+    config_path: &str,
+    config: &mvp::config::LoongClawConfig,
+    channel_inventory: &crate::ChannelsCliJsonPayload,
+) -> GatewayOperatorNodesSummaryReadModel {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let paired_devices =
+            match mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+            {
+                Ok(registry) => registry.list_approved_devices(256),
+                Err(_error) => Vec::new(),
+            };
+        let node_inventory = build_node_inventory_read_model(
+            config_path,
+            channel_inventory,
+            paired_devices.as_slice(),
+        );
+        build_operator_nodes_summary_read_model(&node_inventory)
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = config_path;
+        let _ = config;
+        let _ = channel_inventory;
+        GatewayOperatorNodesSummaryReadModel {
+            paired_device_count: 0,
+            managed_bridge_count: 0,
+            total_count: 0,
+        }
+    }
+}
+
 fn collect_status_cli_work_unit_read_model(
-    config: &mvp::config::LoongConfig,
+    config: &mvp::config::LoongClawConfig,
 ) -> StatusCliWorkUnitReadModel {
     #[cfg(not(feature = "memory-sqlite"))]
     {
@@ -260,7 +322,7 @@ fn collect_status_cli_work_unit_read_model(
     }
 }
 
-fn load_persisted_acp_session_count(config: &mvp::config::LoongConfig) -> Option<usize> {
+fn load_persisted_acp_session_count(config: &mvp::config::LoongClawConfig) -> Option<usize> {
     #[cfg(not(any(feature = "memory-sqlite", feature = "mvp")))]
     {
         let _ = config;
@@ -308,6 +370,7 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
     let control_surface = &gateway.control_surface;
     let channels = &gateway.channels;
     let runtime = &gateway.runtime;
+    let pairing = &gateway.pairing;
     let base_url_option = control_surface.base_url.as_deref();
     let base_url = base_url_option.unwrap_or("-");
     let owner_pid = render_optional_u32(owner.pid);
@@ -323,297 +386,78 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
     let active_provider_label = active_provider_label_option.unwrap_or("-");
     let capability_snapshot_sha256 = runtime.capability_snapshot_sha256.as_str();
     let tool_calling = &runtime.tool_calling;
-    let mut sections = Vec::new();
 
-    if let Some(primary_action) = status.next_actions.first() {
-        sections.push(loong_app::tui_surface::TuiSectionSpec::ActionGroup {
-            title: Some("start here".to_owned()),
-            inline_title_when_wide: false,
-            items: vec![loong_app::tui_surface::TuiActionSpec {
-                label: primary_action.label.clone(),
-                command: primary_action.command.clone(),
-            }],
-        });
-    }
-    if status.next_actions.len() > 1 {
-        sections.push(loong_app::tui_surface::TuiSectionSpec::ActionGroup {
-            title: Some("also useful".to_owned()),
-            inline_title_when_wide: false,
-            items: status
-                .next_actions
-                .iter()
-                .skip(1)
-                .map(|action| loong_app::tui_surface::TuiActionSpec {
-                    label: action.label.clone(),
-                    command: action.command.clone(),
-                })
-                .collect(),
-        });
-    }
-
-    sections.push(loong_app::tui_surface::TuiSectionSpec::Checklist {
-        title: Some("runtime posture".to_owned()),
-        items: vec![
-            loong_app::tui_surface::TuiChecklistItemSpec {
-                status: if tool_calling.availability == "ready" {
-                    loong_app::tui_surface::TuiChecklistStatus::Pass
-                } else {
-                    loong_app::tui_surface::TuiChecklistStatus::Warn
-                },
-                label: "tool calling".to_owned(),
-                detail: format!(
-                    "{} · structured schema={} · mode={}",
-                    tool_calling.availability,
-                    tool_calling.structured_tool_schema_enabled,
-                    tool_calling.effective_tool_schema_mode
-                ),
-            },
-            loong_app::tui_surface::TuiChecklistItemSpec {
-                status: if status.acp.availability == "available"
-                    || status.acp.availability == "disabled"
-                {
-                    loong_app::tui_surface::TuiChecklistStatus::Pass
-                } else {
-                    loong_app::tui_surface::TuiChecklistStatus::Warn
-                },
-                label: "ACP".to_owned(),
-                detail: format!(
-                    "enabled={} · availability={}",
-                    status.acp.enabled, status.acp.availability
-                ),
-            },
-            loong_app::tui_surface::TuiChecklistItemSpec {
-                status: if status.work_units.availability == "available" {
-                    loong_app::tui_surface::TuiChecklistStatus::Pass
-                } else {
-                    loong_app::tui_surface::TuiChecklistStatus::Warn
-                },
-                label: "work units".to_owned(),
-                detail: format!("availability={}", status.work_units.availability),
-            },
-        ],
-    });
-
-    sections.push(loong_app::tui_surface::TuiSectionSpec::KeyValues {
-        title: Some("saved runtime".to_owned()),
-        items: vec![
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "config".to_owned(),
-                value: status.config.clone(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "provider".to_owned(),
-                value: status.active_provider.clone(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "model".to_owned(),
-                value: status.active_model.clone(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "memory profile".to_owned(),
-                value: status.memory_profile.clone(),
-            },
-        ],
-    });
-    sections.push(loong_app::tui_surface::TuiSectionSpec::KeyValues {
-        title: Some("gateway summary".to_owned()),
-        items: vec![
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "phase".to_owned(),
-                value: owner.phase.clone(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "mode".to_owned(),
-                value: owner.mode.as_str().to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "pid".to_owned(),
-                value: owner_pid,
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "attached session".to_owned(),
-                value: owner_session.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "control base url".to_owned(),
-                value: base_url.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "visible tools".to_owned(),
-                value: runtime.visible_tool_count.to_string(),
-            },
-        ],
-    });
-    sections.push(loong_app::tui_surface::TuiSectionSpec::KeyValues {
-        title: Some("channel and recovery detail".to_owned()),
-        items: vec![
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "owner config".to_owned(),
-                value: owner.config_path.clone(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "loopback only".to_owned(),
-                value: control_surface.loopback_only.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "configured surfaces".to_owned(),
-                value: owner.configured_surface_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "running surfaces".to_owned(),
-                value: owner.running_surface_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "channel catalog".to_owned(),
-                value: channels.catalog_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "configured accounts".to_owned(),
-                value: channels.configured_account_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "configured channels".to_owned(),
-                value: channels.configured_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled accounts".to_owned(),
-                value: channels.enabled_account_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "misconfigured accounts".to_owned(),
-                value: channels.misconfigured_account_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "runtime-backed channels".to_owned(),
-                value: channels.runtime_backed_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "config-backed channels".to_owned(),
-                value: channels.config_backed_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "plugin-backed channels".to_owned(),
-                value: channels.plugin_backed_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "catalog-only channels".to_owned(),
-                value: channels.catalog_only_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled runtime-backed".to_owned(),
-                value: channels.enabled_runtime_backed_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled service channels".to_owned(),
-                value: channels.enabled_service_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled plugin-backed".to_owned(),
-                value: channels.enabled_plugin_backed_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled outbound-only".to_owned(),
-                value: channels.enabled_outbound_only_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "ready service channels".to_owned(),
-                value: channels.ready_service_channel_count.to_string(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "enabled channels".to_owned(),
-                value: render_status_channel_ids(&runtime.enabled_channel_ids),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "runtime-backed enabled ids".to_owned(),
-                value: render_status_channel_ids(&runtime.enabled_runtime_backed_channel_ids),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "service enabled ids".to_owned(),
-                value: render_status_channel_ids(&runtime.enabled_service_channel_ids),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "plugin-backed enabled ids".to_owned(),
-                value: render_status_channel_ids(&runtime.enabled_plugin_backed_channel_ids),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "outbound-only enabled ids".to_owned(),
-                value: render_status_channel_ids(&runtime.enabled_outbound_only_channel_ids),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "shutdown reason".to_owned(),
-                value: owner_shutdown_reason.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "last error".to_owned(),
-                value: owner_error.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "provider profile".to_owned(),
-                value: active_provider_profile_id.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "provider label".to_owned(),
-                value: active_provider_label.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "capability snapshot".to_owned(),
-                value: capability_snapshot_sha256.to_owned(),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "ACP".to_owned(),
-                value: render_status_cli_acp_text(&status.acp),
-            },
-            loong_app::tui_surface::TuiKeyValueSpec::Plain {
-                key: "work units".to_owned(),
-                value: render_status_cli_work_units_text(&status.work_units),
-            },
-        ],
-    });
+    let mut lines = Vec::new();
+    lines.push(format!("config={}", status.config));
+    lines.push(format!(
+        "gateway phase={} running={} stale={} mode={} pid={} session={} control_base_url={} owner_config={} loopback_only={} surfaces_configured={} surfaces_running={}",
+        owner.phase,
+        owner.running,
+        owner.stale,
+        owner.mode.as_str(),
+        owner_pid,
+        owner_session,
+        base_url,
+        owner.config_path,
+        control_surface.loopback_only,
+        owner.configured_surface_count,
+        owner.running_surface_count,
+    ));
+    lines.push(format!(
+        "gateway_shutdown_reason={} gateway_last_error={}",
+        owner_shutdown_reason, owner_error,
+    ));
+    lines.push(format!(
+        "channels catalog={} configured={} enabled_accounts={} misconfigured_accounts={} runtime_backed={} enabled_service_channels={} ready_service_channels={}",
+        channels.catalog_channel_count,
+        channels.configured_account_count,
+        channels.enabled_account_count,
+        channels.misconfigured_account_count,
+        channels.runtime_backed_channel_count,
+        channels.enabled_service_channel_count,
+        channels.ready_service_channel_count,
+    ));
+    lines.push(format!(
+        "runtime provider_profile={} provider_label={} visible_tool_count={} capability_snapshot_sha256={}",
+        active_provider_profile_id,
+        active_provider_label,
+        runtime.visible_tool_count,
+        capability_snapshot_sha256,
+    ));
+    lines.push(format!(
+        "tool_calling availability={} structured_tool_schema_enabled={} mode={} active_model={} reason={}",
+        tool_calling.availability,
+        tool_calling.structured_tool_schema_enabled,
+        tool_calling.effective_tool_schema_mode,
+        tool_calling.active_model,
+        tool_calling.reason,
+    ));
+    lines.push(format!(
+        "pairing pending={} approved_devices={} last_activity_ms={}",
+        pairing.pending_request_count,
+        pairing.approved_device_count,
+        pairing
+            .last_activity_ms
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+    ));
+    lines.push(format!(
+        "nodes total={} paired_devices={} managed_bridges={}",
+        gateway.nodes.total_count,
+        gateway.nodes.paired_device_count,
+        gateway.nodes.managed_bridge_count,
+    ));
+    lines.push(render_status_cli_acp_text(&status.acp));
+    lines.push(render_status_cli_work_units_text(&status.work_units));
 
     if !status.recipes.is_empty() {
-        sections.push(loong_app::tui_surface::TuiSectionSpec::ActionGroup {
-            title: Some("deep dives".to_owned()),
-            inline_title_when_wide: false,
-            items: status
-                .recipes
-                .iter()
-                .map(|recipe| loong_app::tui_surface::TuiActionSpec {
-                    label: "recipe".to_owned(),
-                    command: recipe.clone(),
-                })
-                .collect(),
-        });
+        lines.push("recipes:".to_owned());
+        for recipe in &status.recipes {
+            lines.push(format!("- {recipe}"));
+        }
     }
 
-    let screen = loong_app::tui_surface::TuiScreenSpec {
-        header_style: loong_app::tui_surface::TuiHeaderStyle::Compact,
-        subtitle: Some("operator runtime summary".to_owned()),
-        title: Some("status".to_owned()),
-        progress_line: None,
-        intro_lines: vec![
-            "Use this summary to decide the next operator action before drilling into raw runtime detail.".to_owned(),
-        ],
-        sections,
-        choices: Vec::new(),
-        footer_lines: vec![
-            "Use loong status --json for machine-readable automation.".to_owned(),
-        ],
-    };
-
-    loong_app::tui_surface::render_tui_screen_spec_ratatui(
-        &screen,
-        loong_app::presentation::detect_render_width(),
-        false,
-    )
-    .join("\n")
-}
-
-fn render_status_channel_ids(channel_ids: &[String]) -> String {
-    if channel_ids.is_empty() {
-        return "-".to_owned();
-    }
-
-    channel_ids.join(",")
+    lines.join("\n")
 }
 
 fn render_status_cli_acp_text(acp: &StatusCliAcpReadModel) -> String {
@@ -689,9 +533,10 @@ mod tests {
     use super::*;
     use crate::gateway::read_models::{
         GatewayOperatorChannelsSummaryReadModel, GatewayOperatorControlSurfaceReadModel,
+        GatewayOperatorNodesSummaryReadModel, GatewayOperatorPairingSummaryReadModel,
         GatewayOperatorRuntimeSummaryReadModel,
     };
-    use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus};
+    use crate::gateway::state::{GatewayOwnerMode, GatewayOwnerStatus, GatewayPortSource};
 
     #[test]
     fn render_status_cli_text_surfaces_drill_down_recipes() {
@@ -715,6 +560,7 @@ mod tests {
                 running_surface_count: 1,
                 bind_address: Some("127.0.0.1".to_owned()),
                 port: Some(7777),
+                port_source: Some(GatewayPortSource::Default),
                 token_path: Some("/tmp/token".to_owned()),
             },
             control_surface: GatewayOperatorControlSurfaceReadModel {
@@ -728,22 +574,13 @@ mod tests {
                 enabled_account_count: 1,
                 misconfigured_account_count: 0,
                 runtime_backed_channel_count: 1,
-                config_backed_channel_count: 0,
-                plugin_backed_channel_count: 0,
-                catalog_only_channel_count: 0,
-                enabled_runtime_backed_channel_count: 1,
-                enabled_plugin_backed_channel_count: 0,
-                enabled_outbound_only_channel_count: 0,
                 enabled_service_channel_count: 1,
                 ready_service_channel_count: 1,
                 surfaces: Vec::new(),
             },
             runtime: GatewayOperatorRuntimeSummaryReadModel {
                 enabled_channel_ids: vec!["telegram".to_owned()],
-                enabled_runtime_backed_channel_ids: vec!["telegram".to_owned()],
                 enabled_service_channel_ids: vec!["telegram".to_owned()],
-                enabled_plugin_backed_channel_ids: Vec::new(),
-                enabled_outbound_only_channel_ids: Vec::new(),
                 visible_tool_count: 4,
                 capability_snapshot_sha256: "abc123".to_owned(),
                 active_provider_profile_id: Some("demo".to_owned()),
@@ -758,6 +595,16 @@ mod tests {
                             .to_owned(),
                 },
             },
+            pairing: GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: 1,
+                approved_device_count: 2,
+                last_activity_ms: Some(3),
+            },
+            nodes: GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 2,
+                managed_bridge_count: 1,
+                total_count: 3,
+            },
         };
         let status = StatusCliReadModel {
             config: "/tmp/config.toml".to_owned(),
@@ -766,9 +613,6 @@ mod tests {
                 surface: "status",
                 purpose: "operator_runtime_summary",
             },
-            active_provider: "Demo [demo]".to_owned(),
-            active_model: "gpt-4.1-mini".to_owned(),
-            memory_profile: "window_only".to_owned(),
             gateway,
             acp: StatusCliAcpReadModel {
                 enabled: false,
@@ -792,29 +636,18 @@ mod tests {
                     expired_lease_count: 0,
                 }),
             },
-            next_actions: vec![StatusCliAction {
-                label: "first answer".to_owned(),
-                command: "loong ask --config '/tmp/config.toml' --message 'hello'".to_owned(),
-            }],
             recipes: vec!["loong gateway status".to_owned()],
         };
 
         let rendered = render_status_cli_text(&status);
 
-        assert!(rendered.contains("start here"));
-        assert!(
-            rendered.contains(
-                "- first answer: loong ask --config '/tmp/config.toml' --message 'hello'"
-            )
-        );
-        assert!(rendered.contains("runtime posture"));
-        assert!(rendered.contains("[OK] tool calling"));
-        assert!(rendered.contains("configured channels"));
-        assert!(rendered.contains("enabled channels"));
-        assert!(rendered.contains("service enabled ids"));
-        assert!(rendered.contains("saved runtime"));
-        assert!(rendered.contains("deep dives"));
-        assert!(rendered.contains("- recipe: loong gateway status"));
+        assert!(rendered.contains("gateway phase=running"));
+        assert!(rendered.contains("tool_calling availability=ready"));
+        assert!(rendered.contains("pairing pending=1 approved_devices=2"));
+        assert!(rendered.contains("nodes total=3 paired_devices=2 managed_bridges=1"));
+        assert!(rendered.contains("acp enabled=false availability=disabled"));
+        assert!(rendered.contains("work_units availability=available total_count=0"));
+        assert!(rendered.contains("recipes:\n- loong gateway status"));
     }
 
     #[test]
@@ -839,6 +672,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         };
 
@@ -875,6 +709,7 @@ mod tests {
             running_surface_count: 1,
             bind_address: None,
             port: None,
+            port_source: None,
             token_path: None,
         };
 

--- a/crates/daemon/tests/integration/gateway_api_pairing.rs
+++ b/crates/daemon/tests/integration/gateway_api_pairing.rs
@@ -1,0 +1,660 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use loongclaw_protocol::{
+    CONTROL_PLANE_PROTOCOL_VERSION, ControlPlaneClientIdentity, ControlPlaneConnectRequest,
+    ControlPlaneDeviceIdentity, ControlPlanePairingListResponse,
+    ControlPlanePairingResolveRequest, ControlPlanePairingResolveResponse, ControlPlanePairingStatus,
+    ControlPlaneRole, ControlPlaneScope,
+};
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use tower::ServiceExt;
+
+use super::*;
+
+fn gateway_pairing_test_config(label: &str) -> (mvp::config::LoongClawConfig, PathBuf) {
+    let root_dir = unique_temp_dir(label);
+    std::fs::create_dir_all(root_dir.as_path()).expect("create gateway pairing test dir");
+
+    let sqlite_path = root_dir.join("memory.sqlite3");
+    let sqlite_path_text = sqlite_path.display().to_string();
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.sqlite_path = sqlite_path_text;
+
+    (config, root_dir)
+}
+
+fn seed_pending_pairing_request(config: &mvp::config::LoongClawConfig) -> String {
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let registry =
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+            .expect("pairing registry");
+    let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "device-1",
+            "cli",
+            "public-key-1",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    match decision {
+        mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request, ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    }
+}
+
+async fn json_body(response: axum::response::Response) -> serde_json::Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("decode json")
+}
+
+fn pairing_complete_signature_message(
+    request: &ControlPlaneConnectRequest,
+    device: &ControlPlaneDeviceIdentity,
+) -> Vec<u8> {
+    let scopes = request
+        .scopes
+        .iter()
+        .map(|scope| scope.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "loongclaw-control-plane-connect-v1\nnonce={}\ndevice_id={}\nclient_id={}\nrole={}\nscopes={}\nsigned_at_ms={}",
+        device.nonce,
+        device.device_id,
+        request.client.id,
+        request.role.as_str(),
+        scopes,
+        device.signed_at_ms
+    )
+    .into_bytes()
+}
+
+fn build_signed_pairing_complete_request(
+    signing_key: &SigningKey,
+    nonce: &str,
+    issued_at_ms: u64,
+    device_token: Option<String>,
+) -> ControlPlaneConnectRequest {
+    let public_key = signing_key.verifying_key();
+    let device_id = "device-1".to_owned();
+    let client_id = "cli".to_owned();
+    let scopes = BTreeSet::from([ControlPlaneScope::OperatorRead]);
+    let signed_at_ms = issued_at_ms.saturating_add(1);
+
+    let mut request = ControlPlaneConnectRequest {
+        min_protocol: CONTROL_PLANE_PROTOCOL_VERSION,
+        max_protocol: CONTROL_PLANE_PROTOCOL_VERSION,
+        client: ControlPlaneClientIdentity {
+            id: client_id,
+            version: "1.0.0".to_owned(),
+            mode: "operator_ui".to_owned(),
+            platform: "macos".to_owned(),
+            display_name: Some("LoongClaw CLI".to_owned()),
+        },
+        role: ControlPlaneRole::Operator,
+        scopes,
+        caps: BTreeSet::new(),
+        commands: BTreeSet::new(),
+        permissions: std::collections::BTreeMap::new(),
+        auth: Some(loongclaw_protocol::ControlPlaneAuthClaims {
+            token: None,
+            device_token,
+            bootstrap_token: None,
+            password: None,
+        }),
+        device: Some(ControlPlaneDeviceIdentity {
+            device_id,
+            public_key: base64::engine::general_purpose::STANDARD
+                .encode(public_key.as_bytes()),
+            signature: String::new(),
+            signed_at_ms,
+            nonce: nonce.to_owned(),
+        }),
+    };
+
+    let message = pairing_complete_signature_message(
+        &request,
+        request.device.as_ref().expect("device"),
+    );
+    let signature = signing_key.sign(&message);
+    request
+        .device
+        .as_mut()
+        .expect("device")
+        .signature = base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
+    request
+}
+
+#[tokio::test]
+async fn gateway_pairing_requests_reject_missing_auth() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-auth");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/requests")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_requests_return_pending_request_records() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-list");
+    let pairing_request_id = seed_pending_pairing_request(&config);
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/requests?status=pending&limit=10")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let list: ControlPlanePairingListResponse =
+        serde_json::from_slice(&body).expect("pairing list json");
+
+    assert_eq!(list.matched_count, 1);
+    assert_eq!(list.returned_count, 1);
+    assert_eq!(list.requests[0].pairing_request_id, pairing_request_id);
+    assert_eq!(list.requests[0].status, ControlPlanePairingStatus::Pending);
+    assert_eq!(list.requests[0].device_id, "device-1");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_resolve_approves_request_and_returns_device_token() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-resolve");
+    let pairing_request_id = seed_pending_pairing_request(&config);
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/resolve")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&ControlPlanePairingResolveRequest {
+                        pairing_request_id,
+                        approve: true,
+                    })
+                    .expect("encode pairing resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let resolved: ControlPlanePairingResolveResponse =
+        serde_json::from_slice(&body).expect("pairing resolve json");
+
+    assert_eq!(resolved.request.status, ControlPlanePairingStatus::Approved);
+    assert!(resolved.device_token.is_some());
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_resolve_returns_not_found_for_unknown_request() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-missing");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/resolve")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&ControlPlanePairingResolveRequest {
+                        pairing_request_id: "missing-request".to_owned(),
+                        approve: true,
+                    })
+                    .expect("encode pairing resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = json_body(response).await;
+    assert_eq!(body["error"]["code"], "pairing_not_found");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_start_rejects_missing_auth() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-start-auth");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/start")
+                .method("POST")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_start_returns_bootstrap_bundle() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-start");
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router(
+        "test-token".to_owned(),
+        config,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/start")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_body(response).await;
+    assert_eq!(body["protocol"], CONTROL_PLANE_PROTOCOL_VERSION);
+    assert_eq!(body["connect_path"], "/v1/pairing/complete");
+    assert_eq!(body["pairing_requests_path"], "/v1/pairing/requests");
+    assert_eq!(body["pairing_resolve_path"], "/v1/pairing/resolve");
+    assert_eq!(body["recommended_role"], "operator");
+    assert!(body["challenge"]["nonce"].as_str().is_some());
+    assert!(body["challenge"]["expires_at_ms"].as_u64().unwrap_or(0)
+        >= body["challenge"]["issued_at_ms"].as_u64().unwrap_or(0));
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_complete_requires_pairing_then_authorizes_after_resolution() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-complete");
+    let event_bus = loongclaw_daemon::gateway::event_bus::GatewayEventBus::new(64);
+    let app = loongclaw_daemon::gateway::control::build_gateway_pairing_test_router_with_event_bus(
+        "test-token".to_owned(),
+        config,
+        event_bus.clone(),
+    );
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/start")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start_response.status(), StatusCode::OK);
+    let start_body = json_body(start_response).await;
+    let nonce = start_body["challenge"]["nonce"]
+        .as_str()
+        .expect("challenge nonce");
+    let issued_at_ms = start_body["challenge"]["issued_at_ms"]
+        .as_u64()
+        .expect("challenge issued_at_ms");
+    let signing_key = SigningKey::from_bytes(&rand::random::<[u8; 32]>());
+
+    let initial_request =
+        build_signed_pairing_complete_request(&signing_key, nonce, issued_at_ms, None);
+    let initial_complete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/complete")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&initial_request).expect("encode pairing complete request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(initial_complete_response.status(), StatusCode::FORBIDDEN);
+    let initial_complete_body = to_bytes(initial_complete_response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let initial_error: loongclaw_protocol::ControlPlaneConnectErrorResponse =
+        serde_json::from_slice(&initial_complete_body).expect("pairing complete error json");
+    assert_eq!(
+        initial_error.code,
+        loongclaw_protocol::ControlPlaneConnectErrorCode::PairingRequired
+    );
+    let pairing_request_id = initial_error
+        .pairing_request_id
+        .expect("pairing request id");
+
+    let resolve_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/resolve")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&ControlPlanePairingResolveRequest {
+                        pairing_request_id,
+                        approve: true,
+                    })
+                    .expect("encode resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolve_response.status(), StatusCode::OK);
+    let resolve_body = to_bytes(resolve_response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let resolved: ControlPlanePairingResolveResponse =
+        serde_json::from_slice(&resolve_body).expect("resolve json");
+    let device_token = resolved.device_token.expect("device token");
+
+    let second_start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/start")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let second_start_body = json_body(second_start_response).await;
+    let second_nonce = second_start_body["challenge"]["nonce"]
+        .as_str()
+        .expect("second challenge nonce");
+    let second_issued_at_ms = second_start_body["challenge"]["issued_at_ms"]
+        .as_u64()
+        .expect("second challenge issued_at_ms");
+
+    let authorized_request = build_signed_pairing_complete_request(
+        &signing_key,
+        second_nonce,
+        second_issued_at_ms,
+        Some(device_token),
+    );
+    let authorized_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/complete")
+                .method("POST")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&authorized_request)
+                        .expect("encode authorized pairing complete request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(authorized_response.status(), StatusCode::OK);
+    let authorized_body = json_body(authorized_response).await;
+    assert_eq!(authorized_body["status"], "authorized");
+    assert_eq!(authorized_body["device_id"], "device-1");
+    assert_eq!(authorized_body["role"], "operator");
+    let session_token = authorized_body["lease"]["connection_token"]
+        .as_str()
+        .expect("lease token")
+        .to_owned();
+    assert!(
+        authorized_body["lease"]["connection_token_expires_at_ms"]
+            .as_u64()
+            .unwrap_or(0)
+            > 0
+    );
+    assert_eq!(
+        authorized_body["lease"]["principal"]["device_id"],
+        "device-1"
+    );
+
+    let session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/session")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(session_response.status(), StatusCode::OK);
+    let session_body = json_body(session_response).await;
+    assert_eq!(session_body["status"], "active");
+    assert_eq!(session_body["principal"]["device_id"], "device-1");
+    assert_eq!(session_body["principal"]["role"], "operator");
+    assert_eq!(session_body["last_acknowledged_seq"], serde_json::Value::Null);
+    assert_eq!(session_body["resume_status"], "fresh");
+    assert_eq!(session_body["resume_from_after_seq"], 0);
+    assert_eq!(session_body["earliest_resumable_after_seq"], 0);
+    assert_eq!(session_body["replay_window"]["oldest_retained_seq"], serde_json::Value::Null);
+    assert_eq!(session_body["replay_window"]["latest_seq"], serde_json::Value::Null);
+
+    event_bus.publish(serde_json::json!({
+        "event_type": "pairing.test",
+        "message": "hello"
+    }));
+    event_bus.publish(serde_json::json!({
+        "event_type": "pairing.test",
+        "message": "world"
+    }));
+
+    let pairing_events_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/events?after_seq=0&limit=10&ack_seq=2")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(pairing_events_response.status(), StatusCode::OK);
+    let pairing_events_body = json_body(pairing_events_response).await;
+    assert_eq!(pairing_events_body["after_seq"], 0);
+    assert_eq!(pairing_events_body["effective_after_seq"], 0);
+    assert_eq!(pairing_events_body["returned_count"], 2);
+    assert_eq!(pairing_events_body["last_acknowledged_seq"], 2);
+    assert_eq!(pairing_events_body["resume_status"], "fresh");
+    assert_eq!(pairing_events_body["next_after_seq"], 2);
+    assert_eq!(pairing_events_body["earliest_resumable_after_seq"], 0);
+    assert_eq!(pairing_events_body["replay_window"]["oldest_retained_seq"], 1);
+    assert_eq!(pairing_events_body["replay_window"]["latest_seq"], 2);
+    assert_eq!(pairing_events_body["events"][0]["payload"]["message"], "hello");
+    assert_eq!(pairing_events_body["events"][1]["payload"]["message"], "world");
+
+    let pairing_stream_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/stream?after_seq=2&limit=10")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(pairing_stream_response.status(), StatusCode::OK);
+    let pairing_stream_content_type = pairing_stream_response
+        .headers()
+        .get("content-type")
+        .expect("pairing stream content type")
+        .to_str()
+        .expect("pairing stream content type text");
+    assert!(pairing_stream_content_type.starts_with("text/event-stream"));
+
+    let resumed_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/session")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resumed_session_response.status(), StatusCode::OK);
+    let resumed_session_body = json_body(resumed_session_response).await;
+    assert_eq!(resumed_session_body["last_acknowledged_seq"], 2);
+    assert_eq!(resumed_session_body["resume_status"], "resumed");
+    assert_eq!(resumed_session_body["resume_from_after_seq"], 2);
+    assert_eq!(resumed_session_body["earliest_resumable_after_seq"], 0);
+
+    let stale_events_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/events?after_seq=0&limit=10")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale_events_response.status(), StatusCode::OK);
+
+    for index in 0..70 {
+        event_bus.publish(serde_json::json!({
+            "event_type": "pairing.rollover",
+            "index": index,
+        }));
+    }
+
+    let stale_cursor_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/events?after_seq=1&limit=10")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale_cursor_response.status(), StatusCode::CONFLICT);
+    let stale_cursor_body = json_body(stale_cursor_response).await;
+    assert_eq!(stale_cursor_body["error"]["code"], "stale_cursor");
+    assert_eq!(stale_cursor_body["error"]["last_acknowledged_seq"], 2);
+    assert!(
+        stale_cursor_body["error"]["earliest_resumable_after_seq"]
+            .as_u64()
+            .unwrap_or(0)
+            > 1
+    );
+
+    let stale_stream_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/stream?after_seq=1&limit=10")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale_stream_response.status(), StatusCode::CONFLICT);
+    let stale_stream_body = json_body(stale_stream_response).await;
+    assert_eq!(stale_stream_body["error"]["code"], "stale_cursor");
+
+    let stale_session_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/session")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale_session_response.status(), StatusCode::OK);
+    let stale_session_body = json_body(stale_session_response).await;
+    assert_eq!(stale_session_body["last_acknowledged_seq"], 2);
+    assert_eq!(stale_session_body["resume_status"], "stale");
+    assert!(
+        stale_session_body["resume_from_after_seq"]
+            .as_u64()
+            .unwrap_or(0)
+            > 1
+    );
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -17,7 +17,7 @@ use axum::{
         header::{AUTHORIZATION, CONTENT_TYPE},
     },
 };
-use loong_daemon::{
+use loongclaw_daemon::{
     CliResult,
     gateway::{
         client::{GatewayAcpSessionsRequest, GatewayAcpStatusRequest, GatewayLocalClient},
@@ -30,7 +30,7 @@ use loong_daemon::{
             AcpSessionHandle, AcpSessionState, AcpSessionStore, AcpSqliteSessionStore,
             AcpTurnRequest, AcpTurnResult, AcpTurnStopReason, register_acp_backend,
         },
-        config::{AcpConfig, LoongConfig},
+        config::{AcpConfig, LoongClawConfig},
     },
     supervisor::{LoadedSupervisorConfig, SupervisorRuntimeHooks},
 };
@@ -65,7 +65,7 @@ impl AcpRuntimeBackend for GatewayEchoBackend {
 
     async fn ensure_session(
         &self,
-        _config: &LoongConfig,
+        _config: &LoongClawConfig,
         request: &AcpSessionBootstrap,
     ) -> CliResult<AcpSessionHandle> {
         let session_key = request.session_key.clone();
@@ -89,7 +89,7 @@ impl AcpRuntimeBackend for GatewayEchoBackend {
 
     async fn run_turn(
         &self,
-        _config: &LoongConfig,
+        _config: &LoongClawConfig,
         _session: &AcpSessionHandle,
         request: &AcpTurnRequest,
     ) -> CliResult<AcpTurnResult> {
@@ -108,11 +108,15 @@ impl AcpRuntimeBackend for GatewayEchoBackend {
         })
     }
 
-    async fn cancel(&self, _config: &LoongConfig, _session: &AcpSessionHandle) -> CliResult<()> {
+    async fn cancel(
+        &self,
+        _config: &LoongClawConfig,
+        _session: &AcpSessionHandle,
+    ) -> CliResult<()> {
         Ok(())
     }
 
-    async fn close(&self, _config: &LoongConfig, _session: &AcpSessionHandle) -> CliResult<()> {
+    async fn close(&self, _config: &LoongClawConfig, _session: &AcpSessionHandle) -> CliResult<()> {
         Ok(())
     }
 }
@@ -158,17 +162,17 @@ fn gateway_config_path(sqlite_path: &Path) -> PathBuf {
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(std::env::temp_dir);
-    parent_directory.join("loong-gateway-acp.toml")
+    parent_directory.join("loongclaw-gateway-acp.toml")
 }
 
 fn gateway_turn_loaded_config_fixture(
     sqlite_path: &Path,
     backend_id: &str,
 ) -> LoadedSupervisorConfig {
-    let mut config = LoongConfig::default();
+    let mut config = LoongClawConfig::default();
+    config.gateway.port = 0;
     let sqlite_path_text = sqlite_path.display().to_string();
     config.memory.sqlite_path = sqlite_path_text;
-    config.audit.mode = loong_app::config::AuditMode::InMemory;
     config.acp = AcpConfig {
         enabled: true,
         backend: Some(backend_id.to_owned()),
@@ -212,7 +216,7 @@ async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
 
 #[tokio::test]
 async fn gateway_turn_rejects_missing_auth() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({"session_id": "s1", "input": "hello"});
     let response = app
         .oneshot(
@@ -230,7 +234,7 @@ async fn gateway_turn_rejects_missing_auth() {
 
 #[tokio::test]
 async fn gateway_turn_rejects_missing_session_id() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({"input": "hello"});
     let response = app
         .oneshot(
@@ -249,7 +253,7 @@ async fn gateway_turn_rejects_missing_session_id() {
 
 #[tokio::test]
 async fn gateway_turn_rejects_empty_input() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({"session_id": "s1", "input": ""});
     let response = app
         .oneshot(
@@ -268,7 +272,7 @@ async fn gateway_turn_rejects_empty_input() {
 
 #[tokio::test]
 async fn gateway_turn_returns_503_when_no_acp_backend() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({"session_id": "s1", "input": "hello"});
     let response = app
         .oneshot(
@@ -287,7 +291,7 @@ async fn gateway_turn_returns_503_when_no_acp_backend() {
 
 #[tokio::test]
 async fn gateway_turn_rejects_channel_scope_without_conversation_id() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({
         "session_id": "opaque-session",
         "channel_id": "telegram",
@@ -310,7 +314,7 @@ async fn gateway_turn_rejects_channel_scope_without_conversation_id() {
 
 #[tokio::test]
 async fn gateway_turn_accepts_structured_session_scope_before_backend_check() {
-    let app = loong_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
+    let app = loongclaw_daemon::gateway::api_turn::build_turn_test_router_no_backend("tok".into());
     let body = json!({
         "session_id": "opaque-session",
         "channel_id": "telegram",
@@ -362,6 +366,7 @@ async fn gateway_run_turn_persists_acp_session_metadata_into_configured_sqlite_s
 
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -435,6 +440,7 @@ async fn gateway_acp_operator_endpoints_surface_shared_session_truth() {
 
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),

--- a/crates/daemon/tests/integration/gateway_nodes.rs
+++ b/crates/daemon/tests/integration/gateway_nodes.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeSet;
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use tower::ServiceExt;
+
+use super::*;
+
+fn gateway_nodes_test_config(label: &str) -> (mvp::config::LoongClawConfig, std::path::PathBuf) {
+    let root_dir = unique_temp_dir(label);
+    std::fs::create_dir_all(root_dir.as_path()).expect("create gateway nodes test dir");
+
+    let sqlite_path = root_dir.join("memory.sqlite3");
+    let sqlite_path_text = sqlite_path.display().to_string();
+    let install_root = root_dir.join("managed-bridges");
+    let mut config = mixed_account_weixin_plugin_bridge_config();
+    config.memory.sqlite_path = sqlite_path_text;
+    config.external_skills.install_root = Some(install_root.display().to_string());
+
+    (config, root_dir)
+}
+
+fn seed_approved_pairing_device(config: &mvp::config::LoongClawConfig) {
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let registry =
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+            .expect("pairing registry");
+    let requested_scopes =
+        BTreeSet::from(["operator.read".to_owned(), "operator.pairing".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "device-1",
+            "cli",
+            "public-key-1",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    let pairing_request_id = match decision {
+        mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request, ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    };
+    let resolved = registry
+        .resolve_request(pairing_request_id.as_str(), true)
+        .expect("resolve request")
+        .expect("resolved record");
+    assert!(resolved.device_token.is_some());
+}
+
+async fn decode_json(response: axum::response::Response) -> serde_json::Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("decode json")
+}
+
+#[tokio::test]
+async fn gateway_nodes_reject_missing_auth() {
+    let (config, root_dir) = gateway_nodes_test_config("gateway-nodes-auth");
+    install_ready_weixin_managed_bridge(root_dir.join("managed-bridges").as_path());
+    let inventory = mvp::channel::channel_inventory(&config);
+    let channels_payload =
+        loongclaw_daemon::build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
+    let app = loongclaw_daemon::gateway::control::build_gateway_nodes_test_router(
+        "test-token".to_owned(),
+        config,
+        channels_payload,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/nodes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_nodes_return_paired_devices_and_managed_bridges() {
+    let (config, root_dir) = gateway_nodes_test_config("gateway-nodes-inventory");
+    install_ready_weixin_managed_bridge(root_dir.join("managed-bridges").as_path());
+    seed_approved_pairing_device(&config);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let channels_payload =
+        loongclaw_daemon::build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
+    let app = loongclaw_daemon::gateway::control::build_gateway_nodes_test_router(
+        "test-token".to_owned(),
+        config,
+        channels_payload,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/nodes")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = decode_json(response).await;
+
+    assert_eq!(body["summary"]["paired_device_count"], 1);
+    assert_eq!(body["summary"]["managed_bridge_count"], 1);
+    assert_eq!(body["summary"]["total_count"], 2);
+
+    assert_eq!(body["paired_devices"][0]["node_id"], "device-1");
+    assert_eq!(body["paired_devices"][0]["node_kind"], "operator_ui");
+    assert_eq!(body["paired_devices"][0]["trust_state"], "paired");
+
+    assert_eq!(
+        body["managed_bridges"][0]["node_id"],
+        "managed_bridge:weixin"
+    );
+    assert_eq!(body["managed_bridges"][0]["node_kind"], "managed_bridge");
+    assert_eq!(body["managed_bridges"][0]["trust_state"], "ready");
+    assert_eq!(body["managed_bridges"][0]["channel_id"], "weixin");
+    assert_eq!(
+        body["managed_bridges"][0]["implementation_status"],
+        "plugin_backed"
+    );
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -10,7 +10,9 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use loong_daemon::{
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use loongclaw_daemon::{
     gateway::{
         client::{GatewayLocalClient, GatewayStopResponseOutcome},
         service::{
@@ -18,11 +20,15 @@ use loong_daemon::{
             run_multi_channel_serve_gateway_compat_with_hooks_for_test,
         },
         state::{
-            GatewayOwnerMode, GatewayStopRequestOutcome, load_gateway_owner_status,
-            request_gateway_stop,
+            GatewayOwnerMode, GatewayStopRequestOutcome, gateway_pairing_runtime_state_path,
+            load_gateway_owner_status, request_gateway_stop,
         },
     },
     supervisor::{BackgroundChannelRunnerRequest, LoadedSupervisorConfig, SupervisorRuntimeHooks},
+};
+use loongclaw_protocol::{
+    CONTROL_PLANE_PROTOCOL_VERSION, ControlPlaneClientIdentity, ControlPlaneConnectRequest,
+    ControlPlaneDeviceIdentity, ControlPlanePairingResolveRequest, ControlPlaneScope,
 };
 use serde_json::Value;
 use tokio::time::{sleep, timeout};
@@ -50,41 +56,66 @@ fn unique_runtime_dir(label: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("system clock before unix epoch")
         .as_nanos();
-    let runtime_dir =
-        std::env::temp_dir().join(format!("loong-daemon-gateway-owner-state-{label}-{suffix}"));
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "loongclaw-daemon-gateway-owner-state-{label}-{suffix}"
+    ));
     std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
     runtime_dir
 }
 
-fn headless_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
-    let mut config = mvp::config::LoongConfig::default();
-    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
+fn unique_gateway_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port probe");
+    let local_address = listener.local_addr().expect("read ephemeral port probe");
+    local_address.port()
+}
+
+fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let runtime_root = unique_runtime_dir("headless-config");
+    let config_path = runtime_root.join("loongclaw.toml");
+    let sqlite_path = runtime_root.join("memory.sqlite3");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.gateway.port = 0;
     config.memory.sqlite_path = sqlite_path.display().to_string();
 
     LoadedSupervisorConfig {
-        resolved_path: runtime_dir.join("loong.toml"),
+        resolved_path: config_path,
         config,
     }
 }
 
-fn telegram_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
-    let mut config = mvp::config::LoongConfig::default();
+fn headless_loaded_config_fixture_for_root(runtime_root: &std::path::Path) -> LoadedSupervisorConfig {
+    let config_path = runtime_root.join("loongclaw.toml");
+    let sqlite_path = runtime_root.join("memory.sqlite3");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.gateway.port = 0;
+    config.memory.sqlite_path = sqlite_path.display().to_string();
+
+    LoadedSupervisorConfig {
+        resolved_path: config_path,
+        config,
+    }
+}
+
+fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let runtime_root = unique_runtime_dir("telegram-config");
+    let config_path = runtime_root.join("loongclaw.toml");
+    let sqlite_path = runtime_root.join("memory.sqlite3");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.gateway.port = 0;
     config.telegram.enabled = true;
-    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
     LoadedSupervisorConfig {
-        resolved_path: runtime_dir.join("loong.toml"),
+        resolved_path: config_path,
         config,
     }
 }
 
-fn plugin_backed_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
+fn plugin_backed_loaded_config_fixture() -> LoadedSupervisorConfig {
     let mut config = super::mixed_account_weixin_plugin_bridge_config();
-    let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
-    config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.gateway.port = 0;
 
     LoadedSupervisorConfig {
-        resolved_path: runtime_dir.join("loong.toml"),
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
         config,
     }
 }
@@ -126,7 +157,7 @@ async fn wait_until(description: &str, predicate: impl Fn() -> bool) {
 
 async fn wait_for_gateway_control_surface(
     runtime_dir: &std::path::Path,
-) -> loong_daemon::gateway::state::GatewayOwnerStatus {
+) -> loongclaw_daemon::gateway::state::GatewayOwnerStatus {
     wait_until("gateway control surface binding", || {
         let status = load_gateway_owner_status(runtime_dir);
         let Some(status) = status else {
@@ -144,14 +175,81 @@ async fn wait_for_gateway_control_surface(
         .expect("gateway control surface status should be present")
 }
 
+fn pairing_complete_signature_message(
+    request: &ControlPlaneConnectRequest,
+    device: &ControlPlaneDeviceIdentity,
+) -> Vec<u8> {
+    let scopes = request
+        .scopes
+        .iter()
+        .map(|scope| scope.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "loongclaw-control-plane-connect-v1\nnonce={}\ndevice_id={}\nclient_id={}\nrole={}\nscopes={}\nsigned_at_ms={}",
+        device.nonce,
+        device.device_id,
+        request.client.id,
+        request.role.as_str(),
+        scopes,
+        device.signed_at_ms
+    )
+    .into_bytes()
+}
+
+fn build_signed_pairing_complete_request(
+    signing_key: &SigningKey,
+    nonce: &str,
+    issued_at_ms: u64,
+    device_token: Option<String>,
+) -> ControlPlaneConnectRequest {
+    let public_key = signing_key.verifying_key();
+    let mut request = ControlPlaneConnectRequest {
+        min_protocol: CONTROL_PLANE_PROTOCOL_VERSION,
+        max_protocol: CONTROL_PLANE_PROTOCOL_VERSION,
+        client: ControlPlaneClientIdentity {
+            id: "cli".to_owned(),
+            version: "1.0.0".to_owned(),
+            mode: "operator_ui".to_owned(),
+            platform: "macos".to_owned(),
+            display_name: Some("LoongClaw CLI".to_owned()),
+        },
+        role: loongclaw_protocol::ControlPlaneRole::Operator,
+        scopes: std::collections::BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        caps: std::collections::BTreeSet::new(),
+        commands: std::collections::BTreeSet::new(),
+        permissions: std::collections::BTreeMap::new(),
+        auth: Some(loongclaw_protocol::ControlPlaneAuthClaims {
+            token: None,
+            device_token,
+            bootstrap_token: None,
+            password: None,
+        }),
+        device: Some(ControlPlaneDeviceIdentity {
+            device_id: "device-1".to_owned(),
+            public_key: base64::engine::general_purpose::STANDARD
+                .encode(public_key.as_bytes()),
+            signature: String::new(),
+            signed_at_ms: issued_at_ms.saturating_add(1),
+            nonce: nonce.to_owned(),
+        }),
+    };
+
+    let message = pairing_complete_signature_message(
+        &request,
+        request.device.as_ref().expect("device"),
+    );
+    let signature = signing_key.sign(&message);
+    request.device.as_mut().expect("device").signature =
+        base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
+    request
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request() {
     let runtime_dir = unique_runtime_dir("headless-stop");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -164,6 +262,7 @@ async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -208,12 +307,16 @@ async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn gateway_owner_state_rejects_second_active_owner_slot() {
-    let runtime_dir = unique_runtime_dir("exclusive-slot");
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_uses_configured_gateway_port_when_no_override_is_present() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("config-port");
+    let configured_port = unique_gateway_port();
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
         }),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
@@ -227,6 +330,164 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
+
+    assert_eq!(actual_port, configured_port);
+    assert_eq!(running_status.bind_address.as_deref(), Some("127.0.0.1"));
+    assert_eq!(port_source.as_str(), "config");
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_uses_cli_gateway_port_override_when_present() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("cli-port");
+    let configured_port = unique_gateway_port();
+    let cli_port = unique_gateway_port();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            Some(cli_port),
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
+
+    assert_eq!(actual_port, cli_port);
+    assert_eq!(port_source.as_str(), "cli");
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn gateway_owner_state_marks_explicit_ephemeral_cli_port_source() {
+    let _lock = lock_daemon_test_environment();
+    let runtime_dir = unique_runtime_dir("ephemeral-cli-port");
+    let configured_port = unique_gateway_port();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(move |_| {
+            let mut loaded = headless_loaded_config_fixture();
+            loaded.config.gateway.port = configured_port;
+            Ok(loaded)
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            Some(0),
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let actual_port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let port_source = running_status
+        .port_source
+        .expect("port source should be persisted");
+
+    assert!(actual_port > 0);
+    assert_eq!(port_source.as_str(), "ephemeral_cli");
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_rejects_second_active_owner_slot() {
+    let runtime_dir = unique_runtime_dir("exclusive-slot");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -244,10 +505,7 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
     .await;
 
     let second_hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -257,6 +515,7 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
         observe_state: Arc::new(|_| Ok(())),
     };
     let second_result = run_gateway_run_with_hooks_for_test(
+        None,
         None,
         None,
         Vec::new(),
@@ -282,10 +541,7 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
 async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request() {
     let runtime_dir = unique_runtime_dir("duplicate-start-pending-stop");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -298,6 +554,7 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -318,10 +575,7 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
     assert_eq!(stop_result, GatewayStopRequestOutcome::Requested);
 
     let second_hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -331,6 +585,7 @@ async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request
         observe_state: Arc::new(|_| Ok(())),
     };
     let second_result = run_gateway_run_with_hooks_for_test(
+        None,
         None,
         None,
         Vec::new(),
@@ -361,10 +616,7 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
         telegram_runner,
     )]);
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(telegram_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(telegram_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|options| {
             boxed_cli_result(async move {
@@ -380,6 +632,7 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_multi_channel_serve_gateway_compat_with_hooks_for_test(
+            None,
             None,
             "cli-supervisor",
             Vec::new(),
@@ -421,10 +674,7 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     let _lock = lock_daemon_test_environment();
     let runtime_dir = unique_runtime_dir("localhost-control");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -437,6 +687,7 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -699,10 +950,7 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
 async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy() {
     let runtime_dir = unique_runtime_dir("turn-policy-disabled");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -715,6 +963,7 @@ async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy()
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -770,10 +1019,7 @@ async fn gateway_owner_state_turn_endpoint_rejects_when_acp_disabled_by_policy()
 async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stops_runtime() {
     let runtime_dir = unique_runtime_dir("local-client");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(headless_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -786,6 +1032,7 @@ async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stop
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -877,10 +1124,7 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
 {
     let runtime_dir = unique_runtime_dir("plugin-backed-parity");
     let hooks = SupervisorRuntimeHooks {
-        load_config: Arc::new({
-            let runtime_dir = runtime_dir.clone();
-            move |_| Ok(plugin_backed_loaded_config_fixture(runtime_dir.as_path()))
-        }),
+        load_config: Arc::new(|_| Ok(plugin_backed_loaded_config_fixture())),
         initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(|_| {
             panic!("headless gateway run should not start the concurrent CLI host")
@@ -893,6 +1137,7 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
     let runtime_dir_for_run = runtime_dir.clone();
     let run = tokio::spawn(async move {
         run_gateway_run_with_hooks_for_test(
+            None,
             None,
             None,
             Vec::new(),
@@ -952,6 +1197,9 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
             .as_deref(),
         Some(expected_summary)
     );
+    assert_eq!(operator_summary.nodes.managed_bridge_count, 1);
+    assert_eq!(operator_summary.nodes.paired_device_count, 0);
+    assert_eq!(operator_summary.nodes.total_count, 1);
 
     let stop = client.stop().await.expect("request gateway stop");
     assert_eq!(stop.outcome, GatewayStopResponseOutcome::Requested);
@@ -962,4 +1210,258 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
         .expect("join gateway run after local client stop")
         .expect("gateway run should return supervisor state");
     assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_restores_pairing_session_continuity_after_restart() {
+    let runtime_dir = unique_runtime_dir("pairing-continuity");
+    let config_root = unique_runtime_dir("pairing-continuity-config");
+    let first_loaded = headless_loaded_config_fixture_for_root(config_root.as_path());
+    let first_hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new({
+            let loaded = first_loaded.clone();
+            move |_| Ok(loaded.clone())
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_first_run = runtime_dir.clone();
+    let first_run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_first_run.as_path(),
+            first_hooks,
+        )
+        .await
+    });
+
+    let first_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let base_url = format!(
+        "http://{}:{}",
+        first_status
+            .bind_address
+            .as_deref()
+            .expect("bind address should exist"),
+        first_status.port.expect("port should exist")
+    );
+    let gateway_token = fs::read_to_string(
+        first_status
+            .token_path
+            .as_deref()
+            .expect("gateway token path should exist"),
+    )
+    .expect("read gateway token");
+    let gateway_token = gateway_token.trim().to_owned();
+    let http_client = reqwest::Client::new();
+
+    let start_response = http_client
+        .post(format!("{base_url}/v1/pairing/start"))
+        .bearer_auth(gateway_token.as_str())
+        .send()
+        .await
+        .expect("send pairing start");
+    assert_eq!(start_response.status(), reqwest::StatusCode::OK);
+    let start_json: Value = start_response.json().await.expect("decode pairing start");
+    let nonce = start_json["challenge"]["nonce"]
+        .as_str()
+        .expect("challenge nonce");
+    let issued_at_ms = start_json["challenge"]["issued_at_ms"]
+        .as_u64()
+        .expect("challenge issued_at_ms");
+    let signing_key = SigningKey::from_bytes(&rand::random::<[u8; 32]>());
+
+    let initial_request =
+        build_signed_pairing_complete_request(&signing_key, nonce, issued_at_ms, None);
+    let initial_complete_response = http_client
+        .post(format!("{base_url}/v1/pairing/complete"))
+        .bearer_auth(gateway_token.as_str())
+        .json(&initial_request)
+        .send()
+        .await
+        .expect("send pairing complete");
+    assert_eq!(initial_complete_response.status(), reqwest::StatusCode::FORBIDDEN);
+    let initial_complete_json: Value = initial_complete_response
+        .json()
+        .await
+        .expect("decode pairing complete error");
+    let pairing_request_id = initial_complete_json["pairing_request_id"]
+        .as_str()
+        .or_else(|| initial_complete_json["error"]["pairing_request_id"].as_str())
+        .expect("pairing request id")
+        .to_owned();
+
+    let resolve_response = http_client
+        .post(format!("{base_url}/v1/pairing/resolve"))
+        .bearer_auth(gateway_token.as_str())
+        .json(&ControlPlanePairingResolveRequest {
+            pairing_request_id,
+            approve: true,
+        })
+        .send()
+        .await
+        .expect("send pairing resolve");
+    assert_eq!(resolve_response.status(), reqwest::StatusCode::OK);
+    let resolve_json: Value = resolve_response.json().await.expect("decode pairing resolve");
+    let device_token = resolve_json["device_token"]
+        .as_str()
+        .expect("device token")
+        .to_owned();
+
+    let second_start_response = http_client
+        .post(format!("{base_url}/v1/pairing/start"))
+        .bearer_auth(gateway_token.as_str())
+        .send()
+        .await
+        .expect("send second pairing start");
+    assert_eq!(second_start_response.status(), reqwest::StatusCode::OK);
+    let second_start_json: Value = second_start_response
+        .json()
+        .await
+        .expect("decode second pairing start");
+    let second_nonce = second_start_json["challenge"]["nonce"]
+        .as_str()
+        .expect("second challenge nonce");
+    let second_issued_at_ms = second_start_json["challenge"]["issued_at_ms"]
+        .as_u64()
+        .expect("second challenge issued_at_ms");
+
+    let authorized_request = build_signed_pairing_complete_request(
+        &signing_key,
+        second_nonce,
+        second_issued_at_ms,
+        Some(device_token),
+    );
+    let authorized_response = http_client
+        .post(format!("{base_url}/v1/pairing/complete"))
+        .bearer_auth(gateway_token.as_str())
+        .json(&authorized_request)
+        .send()
+        .await
+        .expect("send authorized pairing complete");
+    assert_eq!(authorized_response.status(), reqwest::StatusCode::OK);
+    let authorized_json: Value = authorized_response
+        .json()
+        .await
+        .expect("decode authorized pairing complete");
+    let session_token = authorized_json["lease"]["connection_token"]
+        .as_str()
+        .expect("session token")
+        .to_owned();
+
+    let acknowledged_response = http_client
+        .get(format!("{base_url}/v1/pairing/events"))
+        .bearer_auth(session_token.as_str())
+        .query(&[("after_seq", "0"), ("limit", "1"), ("ack_seq", "9")])
+        .send()
+        .await
+        .expect("send pairing events acknowledge");
+    assert_eq!(acknowledged_response.status(), reqwest::StatusCode::OK);
+
+    let pairing_runtime_path = gateway_pairing_runtime_state_path(runtime_dir.as_path());
+    wait_until("gateway pairing runtime snapshot", || pairing_runtime_path.exists()).await;
+    let pairing_runtime_json = fs::read_to_string(pairing_runtime_path.as_path())
+        .expect("read pairing runtime snapshot");
+    let pairing_runtime_value: Value =
+        serde_json::from_str(&pairing_runtime_json).expect("decode pairing runtime snapshot");
+    assert_eq!(pairing_runtime_value["sessions"][0]["token"], session_token);
+    assert_eq!(pairing_runtime_value["sessions"][0]["acknowledged_seq"], 9);
+
+    let stop_result = request_gateway_stop(runtime_dir.as_path()).expect("request stop");
+    assert_eq!(stop_result, GatewayStopRequestOutcome::Requested);
+
+    let first_supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, first_run)
+        .await
+        .expect("first gateway run should stop")
+        .expect("join first gateway run")
+        .expect("first gateway run should return supervisor state");
+    assert!(first_supervisor.final_exit_result().is_ok());
+
+    let second_loaded = headless_loaded_config_fixture_for_root(config_root.as_path());
+    let second_hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new({
+            let loaded = second_loaded.clone();
+            move |_| Ok(loaded.clone())
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_second_run = runtime_dir.clone();
+    let second_run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_second_run.as_path(),
+            second_hooks,
+        )
+        .await
+    });
+
+    let second_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let second_base_url = format!(
+        "http://{}:{}",
+        second_status
+            .bind_address
+            .as_deref()
+            .expect("second bind address should exist"),
+        second_status.port.expect("second port should exist")
+    );
+    let second_http_client = reqwest::Client::new();
+
+    let resumed_session_response = second_http_client
+        .get(format!("{second_base_url}/v1/pairing/session"))
+        .bearer_auth(session_token.as_str())
+        .send()
+        .await
+        .expect("send resumed pairing session");
+    assert_eq!(resumed_session_response.status(), reqwest::StatusCode::OK);
+    let resumed_session_json: Value = resumed_session_response
+        .json()
+        .await
+        .expect("decode resumed pairing session");
+    assert_eq!(resumed_session_json["last_acknowledged_seq"], 9);
+    assert_eq!(resumed_session_json["resume_status"], "resumed");
+    assert_eq!(resumed_session_json["resume_from_after_seq"], 9);
+
+    let resumed_events_response = second_http_client
+        .get(format!("{second_base_url}/v1/pairing/events"))
+        .bearer_auth(session_token.as_str())
+        .query(&[("after_seq", "9"), ("limit", "1")])
+        .send()
+        .await
+        .expect("send resumed pairing events");
+    assert_eq!(resumed_events_response.status(), reqwest::StatusCode::OK);
+    let resumed_events_json: Value = resumed_events_response
+        .json()
+        .await
+        .expect("decode resumed pairing events");
+    assert_eq!(resumed_events_json["last_acknowledged_seq"], 9);
+    assert_eq!(resumed_events_json["resume_status"], "resumed");
+    assert_eq!(resumed_events_json["next_after_seq"], 9);
+
+    let second_stop = request_gateway_stop(runtime_dir.as_path()).expect("request second stop");
+    assert_eq!(second_stop, GatewayStopRequestOutcome::Requested);
+
+    let second_supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, second_run)
+        .await
+        .expect("second gateway run should stop")
+        .expect("join second gateway run")
+        .expect("second gateway run should return supervisor state");
+    assert!(second_supervisor.final_exit_result().is_ok());
 }

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -14,8 +14,8 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
 fn write_gateway_test_config(root: &std::path::Path) -> PathBuf {
     fs::create_dir_all(root).expect("create gateway test root");
 
-    let config = mvp::config::LoongConfig::default();
-    let config_path = root.join("loong.toml");
+    let config = mvp::config::LoongClawConfig::default();
+    let config_path = root.join("loongclaw.toml");
     let config_path_text = config_path
         .to_str()
         .expect("config path should be valid utf-8");
@@ -29,40 +29,6 @@ fn legacy_channel_inventory_json(
     config_path: &str,
     inventory: &mvp::channel::ChannelInventory,
 ) -> Value {
-    let total_surface_count = inventory.channel_surfaces.len();
-    let runtime_backed_surface_count = inventory
-        .channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
-        })
-        .count();
-    let config_backed_surface_count = inventory
-        .channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::ConfigBacked
-        })
-        .count();
-    let plugin_backed_surface_count = inventory
-        .channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-        })
-        .count();
-    let catalog_only_surface_count = inventory
-        .channel_surfaces
-        .iter()
-        .filter(|surface| {
-            surface.catalog.implementation_status
-                == mvp::channel::ChannelCatalogImplementationStatus::Stub
-        })
-        .count();
-
     serde_json::json!({
         "config": config_path,
         "schema": {
@@ -71,18 +37,10 @@ fn legacy_channel_inventory_json(
             "catalog_view": "channel_catalog",
             "legacy_channel_views": CHANNELS_CLI_JSON_LEGACY_VIEWS,
         },
-        "summary": {
-            "total_surface_count": total_surface_count,
-            "runtime_backed_surface_count": runtime_backed_surface_count,
-            "config_backed_surface_count": config_backed_surface_count,
-            "plugin_backed_surface_count": plugin_backed_surface_count,
-            "catalog_only_surface_count": catalog_only_surface_count,
-        },
         "channels": inventory.channels,
         "catalog_only_channels": inventory.catalog_only_channels,
         "channel_catalog": inventory.channel_catalog,
         "channel_surfaces": inventory.channel_surfaces,
-        "channel_access_policies": inventory.channel_access_policies,
     })
 }
 
@@ -146,7 +104,6 @@ fn legacy_acp_dispatch_payload_json(
             "channel_id": address.channel_id,
             "account_id": address.account_id,
             "conversation_id": address.conversation_id,
-            "participant_id": address.participant_id,
             "thread_id": address.thread_id,
         },
         "dispatch": acp_dispatch_decision_json(session_id, decision),
@@ -154,35 +111,20 @@ fn legacy_acp_dispatch_payload_json(
 }
 #[test]
 fn gateway_read_model_channel_inventory_matches_channel_cli_contract() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
     let payload =
-        gateway::read_models::build_channel_inventory_read_model("/tmp/loong.toml", &inventory);
+        gateway::read_models::build_channel_inventory_read_model("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize channel inventory read model");
-    let legacy = legacy_channel_inventory_json("/tmp/loong.toml", &inventory);
+    let legacy = legacy_channel_inventory_json("/tmp/loongclaw.toml", &inventory);
 
-    assert_eq!(payload.config, "/tmp/loong.toml");
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.schema.version, CHANNELS_CLI_JSON_SCHEMA_VERSION);
     assert_eq!(payload.schema.primary_channel_view, "channel_surfaces");
     assert_eq!(payload.schema.catalog_view, "channel_catalog");
     assert_eq!(
         payload.schema.legacy_channel_views,
         CHANNELS_CLI_JSON_LEGACY_VIEWS
-    );
-    assert_eq!(
-        payload.summary.total_surface_count,
-        inventory.channel_surfaces.len()
-    );
-    assert_eq!(
-        payload.summary.runtime_backed_surface_count,
-        inventory
-            .channel_surfaces
-            .iter()
-            .filter(|surface| {
-                surface.catalog.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
-            })
-            .count()
     );
     assert_eq!(encoded, legacy);
     assert_eq!(
@@ -213,7 +155,6 @@ fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
             channel_id: Some("telegram".to_owned()),
             account_id: Some("bot_123456".to_owned()),
             conversation_id: Some("42".to_owned()),
-            participant_id: None,
             thread_id: None,
         }),
         activation_origin: Some(mvp::acp::AcpRoutingOrigin::AutomaticDispatch),
@@ -226,7 +167,7 @@ fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
     };
 
     let payload = gateway::read_models::build_acp_status_read_model(
-        "/tmp/loong.toml",
+        "/tmp/loongclaw.toml",
         Some("agent:codex:telegram:42"),
         Some("telegram:42"),
         Some("telegram:bot_123456:42"),
@@ -235,7 +176,7 @@ fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
     );
     let encoded = serde_json::to_value(&payload).expect("serialize ACP status read model");
     let legacy = legacy_acp_status_payload_json(
-        "/tmp/loong.toml",
+        "/tmp/loongclaw.toml",
         Some("agent:codex:telegram:42"),
         Some("telegram:42"),
         Some("telegram:bot_123456:42"),
@@ -243,7 +184,7 @@ fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
         &status,
     );
 
-    assert_eq!(payload.config, "/tmp/loong.toml");
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.resolved_session_key, "agent:codex:telegram:42");
     assert_eq!(payload.status.state, "busy");
     assert_eq!(payload.status.mode, Some("interactive"));
@@ -270,7 +211,6 @@ fn gateway_read_model_acp_session_list_keeps_metadata_and_counts() {
                 channel_id: Some("telegram".to_owned()),
                 account_id: Some("bot_123456".to_owned()),
                 conversation_id: Some("42".to_owned()),
-                participant_id: None,
                 thread_id: None,
             }),
             activation_origin: Some(mvp::acp::AcpRoutingOrigin::AutomaticDispatch),
@@ -301,12 +241,15 @@ fn gateway_read_model_acp_session_list_keeps_metadata_and_counts() {
         },
     ];
 
-    let payload =
-        gateway::read_models::build_acp_session_list_read_model("/tmp/loong.toml", 9, &sessions);
+    let payload = gateway::read_models::build_acp_session_list_read_model(
+        "/tmp/loongclaw.toml",
+        9,
+        &sessions,
+    );
     let encoded = serde_json::to_value(&payload).expect("serialize ACP session list read model");
-    let legacy = legacy_acp_session_list_payload_json("/tmp/loong.toml", 9, &sessions);
+    let legacy = legacy_acp_session_list_payload_json("/tmp/loongclaw.toml", 9, &sessions);
 
-    assert_eq!(payload.config, "/tmp/loong.toml");
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.matched_count, 9);
     assert_eq!(payload.returned_count, sessions.len());
     assert_eq!(encoded, legacy);
@@ -358,11 +301,11 @@ fn gateway_read_model_acp_observability_keeps_rollups_and_provenance() {
     };
 
     let payload =
-        gateway::read_models::build_acp_observability_read_model("/tmp/loong.toml", &snapshot);
+        gateway::read_models::build_acp_observability_read_model("/tmp/loongclaw.toml", &snapshot);
     let encoded = serde_json::to_value(&payload).expect("serialize ACP observability read model");
-    let legacy = legacy_acp_observability_payload_json("/tmp/loong.toml", &snapshot);
+    let legacy = legacy_acp_observability_payload_json("/tmp/loongclaw.toml", &snapshot);
 
-    assert_eq!(payload.config, "/tmp/loong.toml");
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.snapshot.runtime_cache.active_sessions, 2);
     assert_eq!(payload.snapshot.sessions.bound, 1);
     assert_eq!(payload.snapshot.turns.completed, 8);
@@ -381,7 +324,6 @@ fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
         Some("feishu"),
         Some("oc_123"),
         Some("lark-prod"),
-        Some("ou_sender_1"),
         Some("om_thread_1"),
     )
     .expect("build ACP dispatch address");
@@ -396,7 +338,6 @@ fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
             channel_id: Some("feishu".to_owned()),
             account_id: Some("lark-prod".to_owned()),
             conversation_id: Some("oc_123".to_owned()),
-            participant_id: None,
             thread_id: Some("om_thread_1".to_owned()),
             channel_path: vec![
                 "lark-prod".to_owned(),
@@ -407,16 +348,20 @@ fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
     };
 
     let payload = gateway::read_models::build_acp_dispatch_read_model(
-        "/tmp/loong.toml",
+        "/tmp/loongclaw.toml",
         &address,
         "opaque-session",
         &decision,
     );
     let encoded = serde_json::to_value(&payload).expect("serialize ACP dispatch read model");
-    let legacy =
-        legacy_acp_dispatch_payload_json("/tmp/loong.toml", &address, "opaque-session", &decision);
+    let legacy = legacy_acp_dispatch_payload_json(
+        "/tmp/loongclaw.toml",
+        &address,
+        "opaque-session",
+        &decision,
+    );
 
-    assert_eq!(payload.config, "/tmp/loong.toml");
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.address.channel_id.as_deref(), Some("feishu"));
     assert_eq!(payload.dispatch.session, "opaque-session");
     assert_eq!(payload.dispatch.decision.reason, "allowed");
@@ -433,7 +378,7 @@ fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
 
 #[test]
 fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
-    let root = unique_temp_dir("loong-gateway-runtime-snapshot");
+    let root = unique_temp_dir("loongclaw-gateway-runtime-snapshot");
     let config_path = write_gateway_test_config(&root);
     let config_path_text = config_path
         .to_str()
@@ -458,18 +403,6 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
         payload.tools.visible_tool_names.len()
     );
     assert_eq!(
-        payload.channels.enabled_runtime_backed_channel_ids,
-        snapshot.enabled_runtime_backed_channel_ids
-    );
-    assert_eq!(
-        payload.channels.enabled_plugin_backed_channel_ids,
-        snapshot.enabled_plugin_backed_channel_ids
-    );
-    assert_eq!(
-        payload.channels.enabled_outbound_only_channel_ids,
-        snapshot.enabled_outbound_only_channel_ids
-    );
-    assert_eq!(
         encoded["channels"]["inventory"]["schema"]["catalog_view"],
         "channel_catalog"
     );
@@ -490,7 +423,7 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
 
 #[test]
 fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups() {
-    let root = unique_temp_dir("loong-gateway-operator-summary");
+    let root = unique_temp_dir("loongclaw-gateway-operator-summary");
     let config_path = write_gateway_test_config(&root);
     let config_path_text = config_path
         .to_str()
@@ -504,7 +437,7 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
     );
     let runtime_snapshot = gateway::read_models::build_runtime_snapshot_read_model(&snapshot);
     let owner_status = gateway::state::GatewayOwnerStatus {
-        runtime_dir: "/tmp/loong-gateway-runtime".to_owned(),
+        runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
         phase: "running".to_owned(),
         running: true,
         stale: false,
@@ -522,17 +455,33 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         running_surface_count: 0,
         bind_address: Some("127.0.0.1".to_owned()),
         port: Some(7777),
-        token_path: Some("/tmp/loong-gateway-runtime/control-token".to_owned()),
+        port_source: Some(gateway::state::GatewayPortSource::Default),
+        token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
     };
 
     let summary = gateway::read_models::build_operator_summary_read_model(
         &owner_status,
         &inventory,
         &runtime_snapshot,
+        gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 1,
+            approved_device_count: 2,
+            last_activity_ms: Some(300),
+        },
+        gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+            paired_device_count: 2,
+            managed_bridge_count: 1,
+            total_count: 3,
+        },
     );
     let encoded = serde_json::to_value(&summary).expect("serialize operator summary read model");
 
     assert_eq!(summary.owner.phase, "running");
+    assert_eq!(summary.pairing.pending_request_count, 1);
+    assert_eq!(summary.pairing.approved_device_count, 2);
+    assert_eq!(summary.nodes.paired_device_count, 2);
+    assert_eq!(summary.nodes.managed_bridge_count, 1);
+    assert_eq!(summary.nodes.total_count, 3);
     assert_eq!(
         summary.control_surface.base_url.as_deref(),
         Some("http://127.0.0.1:7777")
@@ -543,17 +492,6 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         inventory.channel_catalog.len()
     );
     assert_eq!(
-        summary.channels.plugin_backed_channel_count,
-        inventory
-            .channel_catalog
-            .iter()
-            .filter(|channel| {
-                channel.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-            })
-            .count()
-    );
-    assert_eq!(
         summary.channels.configured_account_count,
         inventory.channels.len()
     );
@@ -562,45 +500,12 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         runtime_snapshot.channels.enabled_service_channel_ids.len()
     );
     assert_eq!(
-        summary.channels.enabled_runtime_backed_channel_count,
-        runtime_snapshot
-            .channels
-            .enabled_runtime_backed_channel_ids
-            .len()
-    );
-    assert_eq!(
-        summary.channels.enabled_plugin_backed_channel_count,
-        runtime_snapshot
-            .channels
-            .enabled_plugin_backed_channel_ids
-            .len()
-    );
-    assert_eq!(
-        summary.channels.enabled_outbound_only_channel_count,
-        runtime_snapshot
-            .channels
-            .enabled_outbound_only_channel_ids
-            .len()
-    );
-    assert_eq!(
         summary.channels.surfaces.len(),
         inventory.channel_surfaces.len()
     );
     assert_eq!(
         summary.runtime.visible_tool_count,
         runtime_snapshot.tools.visible_tool_count
-    );
-    assert_eq!(
-        summary.runtime.enabled_runtime_backed_channel_ids,
-        runtime_snapshot.channels.enabled_runtime_backed_channel_ids
-    );
-    assert_eq!(
-        summary.runtime.enabled_plugin_backed_channel_ids,
-        runtime_snapshot.channels.enabled_plugin_backed_channel_ids
-    );
-    assert_eq!(
-        summary.runtime.enabled_outbound_only_channel_ids,
-        runtime_snapshot.channels.enabled_outbound_only_channel_ids
     );
     assert_eq!(
         summary.runtime.active_provider_profile_id.as_deref(),

--- a/crates/daemon/tests/integration/managed_bridge_parity.rs
+++ b/crates/daemon/tests/integration/managed_bridge_parity.rs
@@ -5,16 +5,16 @@ fn render_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
 }
 
-fn gateway_owner_status_fixture() -> loong_daemon::gateway::state::GatewayOwnerStatus {
-    loong_daemon::gateway::state::GatewayOwnerStatus {
-        runtime_dir: "/tmp/loong-runtime".to_owned(),
+fn gateway_owner_status_fixture() -> loongclaw_daemon::gateway::state::GatewayOwnerStatus {
+    loongclaw_daemon::gateway::state::GatewayOwnerStatus {
+        runtime_dir: "/tmp/loongclaw-runtime".to_owned(),
         phase: "running".to_owned(),
         running: true,
         stale: false,
         pid: Some(12345),
-        mode: loong_daemon::gateway::state::GatewayOwnerMode::GatewayHeadless,
+        mode: loongclaw_daemon::gateway::state::GatewayOwnerMode::GatewayHeadless,
         version: env!("CARGO_PKG_VERSION").to_owned(),
-        config_path: "/tmp/loong.toml".to_owned(),
+        config_path: "/tmp/loongclaw.toml".to_owned(),
         attached_cli_session: None,
         started_at_ms: 1,
         last_heartbeat_at: 1,
@@ -25,16 +25,17 @@ fn gateway_owner_status_fixture() -> loong_daemon::gateway::state::GatewayOwnerS
         running_surface_count: 0,
         bind_address: Some("127.0.0.1".to_owned()),
         port: Some(31337),
-        token_path: Some("/tmp/loong.token".to_owned()),
+        port_source: Some(loongclaw_daemon::gateway::state::GatewayPortSource::Default),
+        token_path: Some("/tmp/loongclaw.token".to_owned()),
     }
 }
 
 fn runtime_snapshot_fixture(
-    inventory: &loong_daemon::ChannelsCliJsonPayload,
-) -> loong_daemon::gateway::read_models::GatewayRuntimeSnapshotReadModel {
-    loong_daemon::gateway::read_models::GatewayRuntimeSnapshotReadModel {
-        config: "/tmp/loong.toml".to_owned(),
-        schema: loong_daemon::gateway::read_models::GatewayRuntimeSnapshotSchema {
+    inventory: &loongclaw_daemon::ChannelsCliJsonPayload,
+) -> loongclaw_daemon::gateway::read_models::GatewayRuntimeSnapshotReadModel {
+    loongclaw_daemon::gateway::read_models::GatewayRuntimeSnapshotReadModel {
+        config: "/tmp/loongclaw.toml".to_owned(),
+        schema: loongclaw_daemon::gateway::read_models::GatewayRuntimeSnapshotSchema {
             version: 1,
             surface: "runtime_snapshot",
             purpose: "test",
@@ -43,21 +44,18 @@ fn runtime_snapshot_fixture(
         context_engine: serde_json::json!({}),
         memory_system: serde_json::json!({}),
         acp: serde_json::json!({}),
-        channels: loong_daemon::gateway::read_models::GatewayRuntimeSnapshotChannelsReadModel {
+        channels: loongclaw_daemon::gateway::read_models::GatewayRuntimeSnapshotChannelsReadModel {
             enabled_channel_ids: vec!["weixin".to_owned()],
-            enabled_runtime_backed_channel_ids: Vec::new(),
             enabled_service_channel_ids: Vec::new(),
-            enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
-            enabled_outbound_only_channel_ids: Vec::new(),
             inventory: inventory.clone(),
         },
         tool_runtime: serde_json::json!({}),
-        tools: loong_daemon::gateway::read_models::GatewayRuntimeSnapshotToolsReadModel {
+        tools: loongclaw_daemon::gateway::read_models::GatewayRuntimeSnapshotToolsReadModel {
             visible_tool_count: 0,
             visible_tool_names: Vec::new(),
             capability_snapshot_sha256: String::new(),
             capability_snapshot: String::new(),
-            tool_calling: loong_daemon::gateway::read_models::GatewayToolCallingReadModel {
+            tool_calling: loongclaw_daemon::gateway::read_models::GatewayToolCallingReadModel {
                 availability: "inactive".to_owned(),
                 structured_tool_schema_enabled: true,
                 effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
@@ -79,16 +77,28 @@ fn managed_bridge_parity_keeps_summary_aligned_across_text_json_and_operator_vie
     config.external_skills.install_root = Some(install_root.display().to_string());
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = loong_daemon::render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered =
+        loongclaw_daemon::render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
     let channels_payload =
-        loong_daemon::build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+        loongclaw_daemon::build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let owner_status = gateway_owner_status_fixture();
     let runtime_snapshot = runtime_snapshot_fixture(&channels_payload);
-    let operator_summary = loong_daemon::gateway::read_models::build_operator_summary_read_model(
-        &owner_status,
-        &channels_payload,
-        &runtime_snapshot,
-    );
+    let operator_summary =
+        loongclaw_daemon::gateway::read_models::build_operator_summary_read_model(
+            &owner_status,
+            &channels_payload,
+            &runtime_snapshot,
+            loongclaw_daemon::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+                pending_request_count: 0,
+                approved_device_count: 0,
+                last_activity_ms: None,
+            },
+            loongclaw_daemon::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 0,
+                managed_bridge_count: 1,
+                total_count: 1,
+            },
+        );
     let weixin_channels_surface = channels_payload
         .channel_surfaces
         .iter()
@@ -123,7 +133,7 @@ fn managed_bridge_parity_keeps_summary_aligned_across_text_json_and_operator_vie
 fn managed_bridge_parity_keeps_doctor_json_and_channels_json_account_summary_in_sync() {
     let root = unique_temp_dir("managed-bridge-parity-cli-json");
     let install_root = root.join("managed-skills");
-    let config_path = root.join("loong.toml");
+    let config_path = root.join("loongclaw.toml");
     let mut config = mixed_account_weixin_plugin_bridge_config();
 
     install_ready_weixin_managed_bridge(install_root.as_path());
@@ -135,7 +145,7 @@ fn managed_bridge_parity_keeps_doctor_json_and_channels_json_account_summary_in_
     )
     .expect("write config");
 
-    let doctor_output = Command::new(env!("CARGO_BIN_EXE_loong"))
+    let doctor_output = Command::new(env!("CARGO_BIN_EXE_loongclaw"))
         .arg("doctor")
         .arg("--config")
         .arg(&config_path)
@@ -157,7 +167,7 @@ fn managed_bridge_parity_keeps_doctor_json_and_channels_json_account_summary_in_
         .find(|value| value["name"].as_str() == Some("weixin managed bridge discovery"))
         .expect("weixin doctor check");
 
-    let channels_output = Command::new(env!("CARGO_BIN_EXE_loong"))
+    let channels_output = Command::new(env!("CARGO_BIN_EXE_loongclaw"))
         .arg("channels")
         .arg("--config")
         .arg(&config_path)

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -57,7 +57,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     let temp_dir = std::env::temp_dir();
     let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
     let process_id = std::process::id();
-    let directory_name = format!("loong-integration-{label}-{process_id}-{nanos}-{counter}");
+    let directory_name = format!("loongclaw-integration-{label}-{process_id}-{nanos}-{counter}");
 
     canonical_temp_dir.join(directory_name)
 }
@@ -108,7 +108,7 @@ fn validation_diagnostic_with_severity(
     mvp::config::ConfigValidationDiagnostic {
         severity: severity.to_owned(),
         code: code.to_owned(),
-        problem_type: format!("urn:loong:problem:{code}"),
+        problem_type: format!("urn:loongclaw:problem:{code}"),
         title_key: format!("{code}.title"),
         title: code.to_owned(),
         message_key: code.to_owned(),
@@ -132,7 +132,9 @@ mod feishu_cli;
 mod gateway_api_acp;
 mod gateway_api_events;
 mod gateway_api_health;
+mod gateway_api_pairing;
 mod gateway_api_turn;
+mod gateway_nodes;
 mod gateway_owner_state;
 mod gateway_read_models;
 mod import_cli;
@@ -281,7 +283,7 @@ fn cli_runtime_restore_help_mentions_dry_run_default() {
 #[test]
 fn ask_cli_accepts_message_session_and_acp_flags() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "ask",
         "--message",
         "Summarize this repository",
@@ -320,7 +322,7 @@ fn ask_cli_accepts_message_session_and_acp_flags() {
 #[test]
 fn ask_cli_accepts_latest_session_selector() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "ask",
         "--message",
         "Summarize this repository",
@@ -343,7 +345,7 @@ fn ask_cli_accepts_latest_session_selector() {
 #[test]
 fn init_spec_cli_accepts_plugin_trust_guard_preset() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "init-spec",
         "--output",
         "/tmp/plugin-trust-guard.json",
@@ -364,7 +366,7 @@ fn init_spec_cli_accepts_plugin_trust_guard_preset() {
 #[test]
 fn run_spec_cli_accepts_render_summary_flag() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "run-spec",
         "--spec",
         "/tmp/tool-search-trusted.json",
@@ -389,7 +391,7 @@ fn run_spec_cli_accepts_render_summary_flag() {
 
 #[test]
 fn ask_cli_requires_message_flag() {
-    let error = try_parse_cli(["loong", "ask"]).expect_err("ask without --message should fail");
+    let error = try_parse_cli(["loongclaw", "ask"]).expect_err("ask without --message should fail");
     let rendered = error.to_string();
 
     assert!(
@@ -401,11 +403,11 @@ fn ask_cli_requires_message_flag() {
 #[test]
 fn audit_cli_recent_parses_global_flags_after_subcommand() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "recent",
         "--config",
-        "/tmp/loong.toml",
+        "/tmp/loongclaw.toml",
         "--limit",
         "25",
         "--json",
@@ -418,10 +420,10 @@ fn audit_cli_recent_parses_global_flags_after_subcommand() {
             json,
             command,
         }) => {
-            assert_eq!(config.as_deref(), Some("/tmp/loong.toml"));
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
             assert!(json);
             match command {
-                loong_daemon::audit_cli::AuditCommands::Recent {
+                loongclaw_daemon::audit_cli::AuditCommands::Recent {
                     limit,
                     since_epoch_s,
                     until_epoch_s,
@@ -455,7 +457,7 @@ fn audit_cli_recent_parses_global_flags_after_subcommand() {
 
 #[test]
 fn audit_cli_summary_parses_limit_without_json() {
-    let cli = try_parse_cli(["loong", "audit", "summary", "--limit", "10"])
+    let cli = try_parse_cli(["loongclaw", "audit", "summary", "--limit", "10"])
         .expect("audit summary CLI should parse");
 
     match cli.command {
@@ -467,7 +469,7 @@ fn audit_cli_summary_parses_limit_without_json() {
             assert_eq!(config, None);
             assert!(!json);
             match command {
-                loong_daemon::audit_cli::AuditCommands::Summary {
+                loongclaw_daemon::audit_cli::AuditCommands::Summary {
                     limit,
                     since_epoch_s,
                     until_epoch_s,
@@ -500,7 +502,7 @@ fn audit_cli_summary_parses_limit_without_json() {
 #[test]
 fn audit_cli_recent_parses_kind_and_triage_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "recent",
         "--limit",
@@ -514,7 +516,7 @@ fn audit_cli_recent_parses_kind_and_triage_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Recent {
+            loongclaw_daemon::audit_cli::AuditCommands::Recent {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -548,7 +550,7 @@ fn audit_cli_recent_parses_kind_and_triage_filters() {
 #[test]
 fn audit_cli_recent_parses_tool_search_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "recent",
         "--query-contains",
@@ -562,7 +564,7 @@ fn audit_cli_recent_parses_tool_search_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Recent {
+            loongclaw_daemon::audit_cli::AuditCommands::Recent {
                 kind,
                 query_contains,
                 trust_tier,
@@ -580,12 +582,18 @@ fn audit_cli_recent_parses_tool_search_filters() {
 
 #[test]
 fn audit_cli_summary_parses_kind_filter_in_canonical_form() {
-    let cli = try_parse_cli(["loong", "audit", "summary", "--kind", "ToolSearchEvaluated"])
-        .expect("audit summary CLI should parse canonical event kind filter");
+    let cli = try_parse_cli([
+        "loongclaw",
+        "audit",
+        "summary",
+        "--kind",
+        "ToolSearchEvaluated",
+    ])
+    .expect("audit summary CLI should parse canonical event kind filter");
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Summary {
+            loongclaw_daemon::audit_cli::AuditCommands::Summary {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -616,12 +624,12 @@ fn audit_cli_summary_parses_kind_filter_in_canonical_form() {
 
 #[test]
 fn audit_cli_summary_parses_group_by_alias() {
-    let cli = try_parse_cli(["loong", "audit", "summary", "--group-by", "token-id"])
+    let cli = try_parse_cli(["loongclaw", "audit", "summary", "--group-by", "token-id"])
         .expect("audit summary CLI should parse group-by alias");
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Summary { group_by, .. } => {
+            loongclaw_daemon::audit_cli::AuditCommands::Summary { group_by, .. } => {
                 assert_eq!(group_by.as_deref(), Some("token"));
             }
             other => panic!("unexpected audit subcommand parsed: {other:?}"),
@@ -633,7 +641,7 @@ fn audit_cli_summary_parses_group_by_alias() {
 #[test]
 fn audit_cli_discovery_parses_trust_filters_and_aliases() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "discovery",
         "--limit",
@@ -649,7 +657,7 @@ fn audit_cli_discovery_parses_trust_filters_and_aliases() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Discovery {
+            loongclaw_daemon::audit_cli::AuditCommands::Discovery {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -682,12 +690,12 @@ fn audit_cli_discovery_parses_trust_filters_and_aliases() {
 
 #[test]
 fn audit_cli_discovery_parses_group_by_alias() {
-    let cli = try_parse_cli(["loong", "audit", "discovery", "--group-by", "agent-id"])
+    let cli = try_parse_cli(["loongclaw", "audit", "discovery", "--group-by", "agent-id"])
         .expect("audit discovery CLI should parse group-by alias");
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Discovery { group_by, .. } => {
+            loongclaw_daemon::audit_cli::AuditCommands::Discovery { group_by, .. } => {
                 assert_eq!(group_by.as_deref(), Some("agent"));
             }
             other => panic!("unexpected audit subcommand parsed: {other:?}"),
@@ -699,7 +707,7 @@ fn audit_cli_discovery_parses_group_by_alias() {
 #[test]
 fn audit_cli_recent_parses_time_window_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "recent",
         "--since-epoch-s",
@@ -713,7 +721,7 @@ fn audit_cli_recent_parses_time_window_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Recent {
+            loongclaw_daemon::audit_cli::AuditCommands::Recent {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -747,7 +755,7 @@ fn audit_cli_recent_parses_time_window_filters() {
 #[test]
 fn audit_cli_discovery_parses_pack_and_agent_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "discovery",
         "--pack-id",
@@ -761,7 +769,7 @@ fn audit_cli_discovery_parses_pack_and_agent_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Discovery {
+            loongclaw_daemon::audit_cli::AuditCommands::Discovery {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -795,7 +803,7 @@ fn audit_cli_discovery_parses_pack_and_agent_filters() {
 #[test]
 fn audit_cli_recent_parses_event_and_token_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "recent",
         "--event-id",
@@ -807,7 +815,7 @@ fn audit_cli_recent_parses_event_and_token_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::Recent {
+            loongclaw_daemon::audit_cli::AuditCommands::Recent {
                 limit,
                 since_epoch_s,
                 until_epoch_s,
@@ -841,7 +849,7 @@ fn audit_cli_recent_parses_event_and_token_filters() {
 #[test]
 fn audit_cli_token_trail_parses_required_token_and_identity_filters() {
     let cli = try_parse_cli([
-        "loong",
+        "loongclaw",
         "audit",
         "token-trail",
         "--token-id",
@@ -861,7 +869,7 @@ fn audit_cli_token_trail_parses_required_token_and_identity_filters() {
 
     match cli.command {
         Some(Commands::Audit { command, .. }) => match command {
-            loong_daemon::audit_cli::AuditCommands::TokenTrail {
+            loongclaw_daemon::audit_cli::AuditCommands::TokenTrail {
                 token_id,
                 limit,
                 since_epoch_s,
@@ -934,32 +942,32 @@ fn validation_summary_counts_error_and_warning_diagnostics_separately() {
 
 #[test]
 fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
-    let mut config = mvp::config::LoongConfig::default();
+    let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
-    config.telegram.bot_token = Some(loong_contracts::SecretRef::Inline(
+    config.telegram.bot_token = Some(loongclaw_contracts::SecretRef::Inline(
         "123456:telegram-token".to_owned(),
     ));
     config.telegram.allowed_chat_ids = vec![1001];
     config.feishu.enabled = true;
-    config.feishu.app_id = Some(loong_contracts::SecretRef::Inline("cli_a1b2c3".to_owned()));
-    config.feishu.app_secret = Some(loong_contracts::SecretRef::Inline("app-secret".to_owned()));
+    config.feishu.app_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "cli_a1b2c3".to_owned(),
+    ));
+    config.feishu.app_secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "app-secret".to_owned(),
+    ));
     config.wecom.enabled = true;
-    config.wecom.bot_id = Some(loong_contracts::SecretRef::Inline("bot_test".to_owned()));
-    config.wecom.secret = Some(loong_contracts::SecretRef::Inline("secret_test".to_owned()));
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "bot_test".to_owned(),
+    ));
+    config.wecom.secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "secret_test".to_owned(),
+    ));
     config.wecom.allowed_conversation_ids = vec!["group_demo".to_owned()];
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
-    assert!(
-        rendered
-            .lines()
-            .next()
-            .is_some_and(|line| line.starts_with("LOONG")),
-        "channel surface text should now use the shared compact header: {rendered}"
-    );
-    assert!(rendered.contains("channels"));
-    assert!(rendered.contains("config=/tmp/loong.toml"));
+    assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains("Telegram [telegram]"));
     assert!(
         rendered.contains("capabilities=runtime_backed,multi_account,send,serve,runtime_tracking")
@@ -981,33 +989,22 @@ fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
     assert!(rendered.contains("configured_accounts=1"));
     assert!(rendered.contains("aliases=lark"));
     assert!(rendered.contains("account=feishu:cli_a1b2c3"));
-    let feishu_section = rendered
-        .split("Feishu/Lark [feishu]")
-        .nth(1)
-        .expect("feishu section should render");
-    assert!(feishu_section.contains("policy conversation_key=allowed_chat_ids"));
-    assert!(feishu_section.contains("sender_key=allowed_sender_ids"));
-    assert!(feishu_section.contains("mention_required=false"));
-    assert!(feishu_section.contains("senders=-"));
     assert!(rendered.contains(&format!(
         "op send ({}) ready: ready target_kinds=receive_id,message_reply requirements=enabled,app_id,app_secret",
         channel_send_command("feishu")
     )));
     assert!(rendered.contains(&format!(
-        "op serve ({}) misconfigured: allowed_chat_ids is empty target_kinds=message_reply requirements=enabled,app_id,app_secret,mode,allowed_chat_ids,allowed_sender_ids,verification_token,encrypt_key",
+        "op serve ({}) misconfigured: allowed_chat_ids is empty target_kinds=message_reply requirements=enabled,app_id,app_secret,mode,allowed_chat_ids,verification_token,encrypt_key",
         channel_serve_command("feishu")
     )));
     assert!(rendered.contains("WeCom [wecom]"));
     assert!(rendered.contains("account=wecom:bot_test"));
-    assert!(rendered.contains(
-        "policy conversation_key=allowed_conversation_ids conversation_mode=exact_allowlist sender_key=allowed_sender_ids sender_mode=open mention_required=false conversations=group_demo senders=-"
-    ));
     assert!(rendered.contains(&format!(
         "op send ({}) ready: ready target_kinds=conversation requirements=enabled,bot_id,secret,websocket_url",
         channel_send_command("wecom")
     )));
     assert!(rendered.contains(&format!(
-        "op serve ({}) ready: ready target_kinds=conversation requirements=enabled,bot_id,secret,allowed_conversation_ids,allowed_sender_ids,websocket_url,ping_interval_s",
+        "op serve ({}) ready: ready target_kinds=conversation requirements=enabled,bot_id,secret,allowed_conversation_ids,websocket_url,ping_interval_s",
         channel_serve_command("wecom")
     )));
     assert!(rendered.contains("running=false"));
@@ -1015,7 +1012,7 @@ fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
 
 #[test]
 fn render_channel_surfaces_text_reports_configured_accounts_for_multi_account_channels() {
-    let config: mvp::config::LoongConfig = serde_json::from_value(serde_json::json!({
+    let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
         "telegram": {
             "enabled": true,
             "default_account": "Work Bot",
@@ -1036,7 +1033,7 @@ fn render_channel_surfaces_text_reports_configured_accounts_for_multi_account_ch
     .expect("deserialize multi-account config");
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("configured_accounts=2"));
     assert!(rendered.contains("default_configured_account=work-bot"));
@@ -1046,7 +1043,7 @@ fn render_channel_surfaces_text_reports_configured_accounts_for_multi_account_ch
 
 #[test]
 fn render_channel_surfaces_text_reports_default_account_marker() {
-    let config: mvp::config::LoongConfig = serde_json::from_value(serde_json::json!({
+    let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
         "telegram": {
             "enabled": true,
             "default_account": "Work Bot",
@@ -1067,7 +1064,7 @@ fn render_channel_surfaces_text_reports_default_account_marker() {
     .expect("deserialize multi-account config");
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(rendered.contains("configured_account=work-bot"));
     assert!(rendered.contains("default_account=true"));
@@ -1076,50 +1073,10 @@ fn render_channel_surfaces_text_reports_default_account_marker() {
 
 #[test]
 fn render_channel_surfaces_text_reports_catalog_only_channels() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
-    let expected_summary = format!(
-        "summary total_surfaces={} runtime_backed={} config_backed={} plugin_backed={} catalog_only={}",
-        inventory.channel_surfaces.len(),
-        inventory
-            .channel_surfaces
-            .iter()
-            .filter(|surface| {
-                surface.catalog.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
-            })
-            .count(),
-        inventory
-            .channel_surfaces
-            .iter()
-            .filter(|surface| {
-                surface.catalog.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::ConfigBacked
-            })
-            .count(),
-        inventory
-            .channel_surfaces
-            .iter()
-            .filter(|surface| {
-                surface.catalog.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-            })
-            .count(),
-        inventory
-            .channel_surfaces
-            .iter()
-            .filter(|surface| {
-                surface.catalog.implementation_status
-                    == mvp::channel::ChannelCatalogImplementationStatus::Stub
-            })
-            .count()
-    );
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
-    assert!(rendered.contains(expected_summary.as_str()));
-    assert!(rendered.contains("runtime-backed channels:"));
-    assert!(rendered.contains("config-backed channels:"));
-    assert!(rendered.contains("plugin-backed channels:"));
     assert!(rendered.contains("catalog-only channels:"));
     assert!(rendered.contains(
         "Discord [discord] implementation_status=config_backed selection_order=40 selection_label=\"community server bot\" capabilities=multi_account,send aliases=discord-bot transport=discord_http_api target_kinds=conversation configured_accounts=1 default_configured_account=default"
@@ -1158,7 +1115,7 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
         channel_serve_command("whatsapp")
     )));
     assert!(rendered.contains(
-        "LINE [line] implementation_status=runtime_backed selection_order=60 selection_label=\"consumer messaging bot\" capabilities=runtime_backed,multi_account,send,serve,runtime_tracking aliases=line-bot transport=line_messaging_api target_kinds=address configured_accounts=1 default_configured_account=default"
+        "LINE [line] implementation_status=config_backed selection_order=60 selection_label=\"consumer messaging bot\" capabilities=multi_account,send aliases=line-bot transport=line_messaging_api target_kinds=address configured_accounts=1 default_configured_account=default"
     ));
     assert!(rendered.contains(
         "DingTalk [dingtalk] implementation_status=config_backed selection_order=80 selection_label=\"group webhook bot\" capabilities=multi_account,send aliases=ding,ding-bot transport=dingtalk_custom_robot_webhook target_kinds=endpoint configured_accounts=1 default_configured_account=default"
@@ -1221,7 +1178,7 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
         "op serve (imessage-serve) unsupported: imessage bridge sync runtime is not implemented yet target_kinds=conversation requirements=enabled,bridge_url,bridge_token,allowed_chat_ids"
     ));
     assert!(rendered.contains(
-        "Webhook [webhook] implementation_status=runtime_backed selection_order=110 selection_label=\"generic http integration\" capabilities=runtime_backed,multi_account,send,serve,runtime_tracking aliases=http-webhook transport=generic_webhook target_kinds=endpoint configured_accounts=1 default_configured_account=default"
+        "Webhook [webhook] implementation_status=config_backed selection_order=110 selection_label=\"generic http integration\" capabilities=multi_account,send aliases=http-webhook transport=generic_webhook target_kinds=endpoint configured_accounts=1 default_configured_account=default"
     ));
     assert!(rendered.contains(
         "WebChat [webchat] implementation_status=stub selection_order=230 selection_label=\"embedded web inbox\""
@@ -1230,50 +1187,21 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
         "op send (webhook-send) disabled: disabled by webhook account configuration target_kinds=endpoint requirements=enabled,endpoint_url"
     ));
     assert!(rendered.contains(
-        "op serve (webhook-serve) disabled: disabled by webhook account configuration target_kinds=endpoint requirements=enabled,signing_secret"
+        "op serve (webhook-serve) unsupported: generic webhook serve runtime is not implemented yet target_kinds=endpoint requirements=enabled,public_base_url,signing_secret"
     ));
     assert!(rendered.contains(
         "onboarding strategy=manual_config status_command=\"loong doctor\" repair_command=\"loong doctor --fix\""
     ));
     assert!(rendered.contains(
-        "setup_hint=\"configure discord bot credentials in loong.toml under discord or discord.accounts.<account>; outbound direct send is shipped, while gateway-based serve support remains planned\""
+        "setup_hint=\"configure discord bot credentials in loongclaw.toml under discord or discord.accounts.<account>; outbound direct send is shipped, while gateway-based serve support remains planned\""
     ));
 }
 
 #[test]
-fn render_channel_surfaces_text_groups_plugin_backed_channels_into_their_own_section() {
-    let config = mvp::config::LoongConfig::default();
-    let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
-
-    let plugin_section = rendered
-        .split("plugin-backed channels:")
-        .nth(1)
-        .expect("plugin-backed channels section should exist");
-    let plugin_section = plugin_section
-        .split("catalog-only channels:")
-        .next()
-        .expect("plugin-backed section should precede catalog-only section");
-
-    assert!(
-        plugin_section.contains("Weixin [weixin]"),
-        "plugin-backed section should include weixin: {plugin_section}"
-    );
-    assert!(
-        plugin_section.contains("QQ Bot [qqbot]"),
-        "plugin-backed section should include qqbot: {plugin_section}"
-    );
-    assert!(
-        plugin_section.contains("OneBot [onebot]"),
-        "plugin-backed section should include onebot: {plugin_section}"
-    );
-}
-
-#[test]
 fn render_channel_surfaces_text_reports_managed_plugin_bridge_discovery() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(
         rendered.contains("Weixin [weixin]"),
@@ -1289,9 +1217,9 @@ fn render_channel_surfaces_text_reports_managed_plugin_bridge_discovery() {
 
 #[test]
 fn render_channel_surfaces_text_reports_plugin_backed_stable_targets() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(
         rendered.contains(
@@ -1314,7 +1242,7 @@ fn render_channel_surfaces_text_reports_plugin_backed_stable_targets() {
 
 #[test]
 fn render_channel_surfaces_text_reports_managed_plugin_bridge_ambiguity_and_setup_guidance() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let mut inventory = mvp::channel::channel_inventory(&config);
     let weixin_surface = inventory
         .channel_surfaces
@@ -1340,19 +1268,14 @@ fn render_channel_surfaces_text_reports_managed_plugin_bridge_ambiguity_and_setu
     discovery.incompatible_plugins = 0;
     discovery.plugins = vec![mvp::channel::ChannelDiscoveredPluginBridge {
         plugin_id: "weixin-bridge-a".to_owned(),
-        source_path: "/tmp/weixin-bridge-a/loong.plugin.json".to_owned(),
+        source_path: "/tmp/weixin-bridge-a/loongclaw.plugin.json".to_owned(),
         package_root: "/tmp/weixin-bridge-a".to_owned(),
-        package_manifest_path: Some("/tmp/weixin-bridge-a/loong.plugin.json".to_owned()),
+        package_manifest_path: Some("/tmp/weixin-bridge-a/loongclaw.plugin.json".to_owned()),
         bridge_kind: "managed_connector".to_owned(),
         adapter_family: "channel-bridge".to_owned(),
         transport_family: Some("wechat_clawbot_ilink_bridge".to_owned()),
         target_contract: Some("weixin_reply_loop".to_owned()),
         account_scope: Some("shared".to_owned()),
-        runtime_contract: Some("loong_channel_bridge_v1".to_owned()),
-        runtime_operations: vec![
-            "send_message".to_owned(),
-            "receive_batch".to_owned(),
-        ],
         status: mvp::channel::ChannelDiscoveredPluginBridgeStatus::CompatibleIncompleteContract,
         issues: vec!["example issue".to_owned()],
         missing_fields: vec!["metadata.transport_family".to_owned()],
@@ -1366,7 +1289,7 @@ fn render_channel_surfaces_text_reports_managed_plugin_bridge_ambiguity_and_setu
         ),
     }];
 
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(
         rendered.contains("ambiguity_status=multiple_compatible_plugins"),
@@ -1402,7 +1325,7 @@ fn render_channel_surfaces_text_reports_plugin_bridge_account_summary_for_mixed_
     config.external_skills.install_root = Some(install_root.display().to_string());
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let rendered = render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered = render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(
         rendered.contains("selected_plugin_id=weixin-managed-bridge"),
@@ -1432,7 +1355,7 @@ fn render_channel_surfaces_text_reports_plugin_bridge_account_summary_for_mixed_
 
 #[test]
 fn render_channel_surfaces_text_escapes_untrusted_managed_bridge_values() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let mut inventory = mvp::channel::channel_inventory(&config);
     let weixin_surface = inventory
         .channel_surfaces
@@ -1458,8 +1381,6 @@ fn render_channel_surfaces_text_escapes_untrusted_managed_bridge_values() {
         transport_family: Some("wechat clawbot".to_owned()),
         target_contract: Some("weixin\nreply".to_owned()),
         account_scope: Some("shared scope".to_owned()),
-        runtime_contract: Some("loong_channel_bridge_v1".to_owned()),
-        runtime_operations: vec!["send_message".to_owned(), "receive_batch".to_owned()],
         status: mvp::channel::ChannelDiscoveredPluginBridgeStatus::CompatibleIncompleteContract,
         issues: vec!["missing\nfield".to_owned()],
         missing_fields: vec!["metadata.transport family".to_owned()],
@@ -1471,7 +1392,8 @@ fn render_channel_surfaces_text_escapes_untrusted_managed_bridge_values() {
         setup_remediation: Some("fix bridge\nthen retry".to_owned()),
     }];
 
-    let rendered = loong_daemon::render_channel_surfaces_text("/tmp/loong.toml", &inventory);
+    let rendered =
+        loongclaw_daemon::render_channel_surfaces_text("/tmp/loongclaw.toml", &inventory);
 
     assert!(
         rendered.contains("managed_install_root=\"/tmp/managed bridge\""),
@@ -1539,21 +1461,21 @@ fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
 
 #[test]
 fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
-    let config = mvp::config::LoongConfig {
+    let config = mvp::config::LoongClawConfig {
         memory: mvp::config::MemoryConfig {
             profile: mvp::config::MemoryProfile::WindowPlusSummary,
             fail_open: false,
             ingest_mode: mvp::config::MemoryIngestMode::AsyncBackground,
             ..mvp::config::MemoryConfig::default()
         },
-        ..mvp::config::LoongConfig::default()
+        ..mvp::config::LoongClawConfig::default()
     };
     let snapshot =
         mvp::memory::collect_memory_system_runtime_snapshot(&config).expect("runtime snapshot");
 
-    let payload = build_memory_systems_cli_json_payload("/tmp/loong.toml", &snapshot);
+    let payload = build_memory_systems_cli_json_payload("/tmp/loongclaw.toml", &snapshot);
 
-    assert_eq!(payload["config"], "/tmp/loong.toml");
+    assert_eq!(payload["config"], "/tmp/loongclaw.toml");
     assert_eq!(payload["selected"]["id"], "builtin");
     assert_eq!(payload["selected"]["source"], "default");
     assert_eq!(
@@ -1595,35 +1517,21 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
 
 #[test]
 fn render_memory_system_snapshot_text_reports_fail_open_policy() {
-    let mut env = loong_daemon::test_support::ScopedEnv::new();
-    for key in [
-        "LOONG_MEMORY_BACKEND",
-        "LOONG_MEMORY_SYSTEM",
-        "LOONG_MEMORY_PROFILE",
-        "LOONG_MEMORY_FAIL_OPEN",
-        "LOONG_MEMORY_INGEST_MODE",
-        "LOONG_SQLITE_PATH",
-        "LOONG_SLIDING_WINDOW",
-        "LOONG_MEMORY_SUMMARY_MAX_CHARS",
-        "LOONG_MEMORY_PROFILE_NOTE",
-    ] {
-        env.remove(key);
-    }
-    let config = mvp::config::LoongConfig {
+    let config = mvp::config::LoongClawConfig {
         memory: mvp::config::MemoryConfig {
             profile: mvp::config::MemoryProfile::WindowPlusSummary,
             fail_open: false,
             ingest_mode: mvp::config::MemoryIngestMode::AsyncBackground,
             ..mvp::config::MemoryConfig::default()
         },
-        ..mvp::config::LoongConfig::default()
+        ..mvp::config::LoongClawConfig::default()
     };
     let snapshot =
         mvp::memory::collect_memory_system_runtime_snapshot(&config).expect("runtime snapshot");
 
-    let rendered = render_memory_system_snapshot_text("/tmp/loong.toml", &snapshot);
+    let rendered = render_memory_system_snapshot_text("/tmp/loongclaw.toml", &snapshot);
 
-    assert!(rendered.contains("config=/tmp/loong.toml"));
+    assert!(rendered.contains("config=/tmp/loongclaw.toml"));
     assert!(rendered.contains(
         "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration,retrieval_provenance runtime_fallback_kind=metadata_only stages=derive,retrieve,rank,compact pre_assembly_stages=derive,retrieve,rank recall_modes=prompt_assembly,operator_inspection core_operations=append_turn,window,clear_session,replace_turns,read_context,read_stage_envelope"
     ));
@@ -1638,9 +1546,9 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
     let surfaces = encoded["channel_surfaces"]
         .as_array()
@@ -1696,7 +1604,6 @@ fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
                     "app_secret",
                     "mode",
                     "allowed_chat_ids",
-                    "allowed_sender_ids",
                     "verification_token",
                     "encrypt_key",
                 ])
@@ -1704,49 +1611,10 @@ fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
 }
 
 #[test]
-fn build_channels_cli_json_payload_includes_structured_channel_access_policy_summaries() {
-    let mut config = mvp::config::LoongConfig::default();
-    config.matrix.enabled = true;
-    config.matrix.access_token = Some(loong_contracts::SecretRef::Inline(
-        "matrix-token".to_owned(),
-    ));
-    config.matrix.base_url = Some("https://matrix.example.org".to_owned());
-    config.matrix.allowed_room_ids = vec!["!ops:example.org".to_owned()];
-    config.matrix.allowed_sender_ids = vec!["@alice:example.org".to_owned()];
-
-    let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
-    let encoded = serde_json::to_value(&payload).expect("serialize payload");
-    let access_policies = encoded["channel_access_policies"]
-        .as_array()
-        .expect("channel access policies array");
-
-    assert!(access_policies.iter().any(|policy| {
-        policy.get("channel_id").and_then(serde_json::Value::as_str) == Some("matrix")
-            && policy
-                .get("conversation_config_key")
-                .and_then(serde_json::Value::as_str)
-                == Some("allowed_room_ids")
-            && policy
-                .get("sender_config_key")
-                .and_then(serde_json::Value::as_str)
-                == Some("allowed_sender_ids")
-            && policy
-                .get("conversation_mode")
-                .and_then(serde_json::Value::as_str)
-                == Some("exact_allowlist")
-            && policy
-                .get("sender_mode")
-                .and_then(serde_json::Value::as_str)
-                == Some("exact_allowlist")
-    }));
-}
-
-#[test]
 fn build_channels_cli_json_payload_includes_onboarding_metadata() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert!(
@@ -1809,9 +1677,9 @@ fn build_channels_cli_json_payload_includes_onboarding_metadata() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_plugin_bridge_contracts() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert!(
@@ -1868,9 +1736,9 @@ fn build_channels_cli_json_payload_includes_plugin_bridge_contracts() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_plugin_bridge_stable_targets() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert!(
@@ -1945,9 +1813,9 @@ fn build_channels_cli_json_payload_includes_plugin_bridge_stable_targets() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_managed_plugin_bridge_discovery() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert!(
@@ -1977,7 +1845,7 @@ fn build_channels_cli_json_payload_includes_managed_plugin_bridge_discovery() {
 
 #[test]
 fn build_channels_cli_json_payload_includes_managed_plugin_bridge_guidance_fields() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let mut inventory = mvp::channel::channel_inventory(&config);
     let weixin_surface = inventory
         .channel_surfaces
@@ -2001,16 +1869,14 @@ fn build_channels_cli_json_payload_includes_managed_plugin_bridge_guidance_field
         vec!["weixin-bridge-a".to_owned(), "weixin-bridge-b".to_owned()];
     discovery.plugins = vec![mvp::channel::ChannelDiscoveredPluginBridge {
         plugin_id: "weixin-bridge-a".to_owned(),
-        source_path: "/tmp/weixin-bridge-a/loong.plugin.json".to_owned(),
+        source_path: "/tmp/weixin-bridge-a/loongclaw.plugin.json".to_owned(),
         package_root: "/tmp/weixin-bridge-a".to_owned(),
-        package_manifest_path: Some("/tmp/weixin-bridge-a/loong.plugin.json".to_owned()),
+        package_manifest_path: Some("/tmp/weixin-bridge-a/loongclaw.plugin.json".to_owned()),
         bridge_kind: "managed_connector".to_owned(),
         adapter_family: "channel-bridge".to_owned(),
         transport_family: Some("wechat_clawbot_ilink_bridge".to_owned()),
         target_contract: Some("weixin_reply_loop".to_owned()),
         account_scope: Some("shared".to_owned()),
-        runtime_contract: Some("loong_channel_bridge_v1".to_owned()),
-        runtime_operations: vec!["send_message".to_owned(), "receive_batch".to_owned()],
         status: mvp::channel::ChannelDiscoveredPluginBridgeStatus::CompatibleReady,
         issues: Vec::new(),
         missing_fields: Vec::new(),
@@ -2024,7 +1890,7 @@ fn build_channels_cli_json_payload_includes_managed_plugin_bridge_guidance_field
         ),
     }];
 
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
     let surfaces = encoded["channel_surfaces"]
         .as_array()
@@ -2069,7 +1935,7 @@ fn build_channels_cli_json_payload_includes_managed_plugin_bridge_guidance_field
 
 #[test]
 fn build_channels_cli_json_payload_includes_duplicate_managed_bridge_selection_fields() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let mut inventory = mvp::channel::channel_inventory(&config);
     let weixin_surface = inventory
         .channel_surfaces
@@ -2095,7 +1961,7 @@ fn build_channels_cli_json_payload_includes_duplicate_managed_bridge_selection_f
         "weixin-bridge-shared".to_owned(),
     ];
 
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
     let surfaces = encoded["channel_surfaces"]
         .as_array()
@@ -2141,7 +2007,7 @@ fn build_channels_cli_json_payload_includes_plugin_bridge_account_summary_for_mi
     config.external_skills.install_root = Some(install_root.display().to_string());
 
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
     let surfaces = encoded["channel_surfaces"]
         .as_array()
@@ -2187,21 +2053,21 @@ fn build_channels_cli_json_payload_includes_plugin_bridge_account_summary_for_mi
 
 #[test]
 fn build_channels_cli_json_payload_includes_full_channel_catalog() {
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert_eq!(
         encoded.get("config").and_then(serde_json::Value::as_str),
-        Some("/tmp/loong.toml")
+        Some("/tmp/loongclaw.toml")
     );
     assert_eq!(
         encoded
             .get("schema")
             .and_then(|schema| schema.get("version"))
             .and_then(serde_json::Value::as_u64),
-        Some(u64::from(CHANNELS_CLI_JSON_SCHEMA_VERSION))
+        Some(1)
     );
     assert_eq!(
         encoded
@@ -2229,29 +2095,6 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
                     .collect::<Vec<_>>()
             }),
         Some(vec!["channels", "catalog_only_channels"])
-    );
-    assert_eq!(
-        encoded
-            .get("summary")
-            .and_then(|summary| summary.get("total_surface_count"))
-            .and_then(serde_json::Value::as_u64),
-        Some(inventory.channel_surfaces.len() as u64)
-    );
-    assert_eq!(
-        encoded
-            .get("summary")
-            .and_then(|summary| summary.get("plugin_backed_surface_count"))
-            .and_then(serde_json::Value::as_u64),
-        Some(
-            inventory
-                .channel_surfaces
-                .iter()
-                .filter(|surface| {
-                    surface.catalog.implementation_status
-                        == mvp::channel::ChannelCatalogImplementationStatus::PluginBacked
-                })
-                .count() as u64
-        )
     );
     assert_eq!(
         encoded
@@ -2619,9 +2462,9 @@ fn build_channels_cli_json_payload_includes_full_channel_catalog() {
 fn build_channels_cli_json_payload_includes_grouped_channel_surfaces() {
     let _env = super::MigrationEnvironmentGuard::set(&[("TELEGRAM_BOT_TOKEN", None)]);
 
-    let config = mvp::config::LoongConfig::default();
+    let config = mvp::config::LoongClawConfig::default();
     let inventory = mvp::channel::channel_inventory(&config);
-    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let payload = build_channels_cli_json_payload("/tmp/loongclaw.toml", &inventory);
     let encoded = serde_json::to_value(&payload).expect("serialize payload");
 
     assert_eq!(

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -1,5 +1,5 @@
 use super::*;
-use loong_contracts::SecretRef;
+use loongclaw_contracts::SecretRef;
 use serde_json::Value;
 use std::{
     fs,
@@ -28,7 +28,7 @@ fn write_status_config(
     fs::create_dir_all(root).expect("create fixture root");
 
     let sqlite_path = root.join("memory.sqlite3");
-    let mut config = mvp::config::LoongConfig::default();
+    let mut config = mvp::config::LoongClawConfig::default();
     config.memory.sqlite_path = sqlite_path.display().to_string();
     config.tools.file_root = Some(root.display().to_string());
     config.set_active_provider_profile(
@@ -52,7 +52,7 @@ fn write_status_config(
         config.acp.allowed_agents = vec!["codex".to_owned()];
     }
 
-    let config_path = root.join("loong.toml");
+    let config_path = root.join("loongclaw.toml");
     let config_path_text = config_path
         .to_str()
         .expect("config path should be valid utf-8");
@@ -75,7 +75,7 @@ fn run_status_cli_process(
         .to_str()
         .expect("config path should be valid utf-8");
 
-    Command::new(env!("CARGO_BIN_EXE_loong"))
+    Command::new(env!("CARGO_BIN_EXE_loongclaw"))
         .arg("status")
         .arg("--config")
         .arg(config_path_text)
@@ -101,21 +101,27 @@ fn cli_status_help_mentions_operator_runtime_summary() {
 
 #[test]
 fn cli_status_parse_accepts_config_and_json_flags() {
-    let cli = try_parse_cli(["loong", "status", "--config", "/tmp/loong.toml", "--json"])
-        .expect("status CLI should parse");
+    let cli = try_parse_cli([
+        "loongclaw",
+        "status",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--json",
+    ])
+    .expect("status CLI should parse");
 
     let command = cli.command.expect("CLI should parse a subcommand");
     let Commands::Status { config, json } = command else {
         panic!("unexpected CLI parse result: {command:?}");
     };
 
-    assert_eq!(config.as_deref(), Some("/tmp/loong.toml"));
+    assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
     assert!(json);
 }
 
 #[test]
 fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
-    let root = unique_temp_dir("loong-status-cli-json");
+    let root = unique_temp_dir("loongclaw-status-cli-json");
     let home_root = root.join("home");
     fs::create_dir_all(&home_root).expect("create home root");
     let config_path = write_status_config(
@@ -148,6 +154,9 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
         payload["gateway"]["runtime"]["tool_calling"]["structured_tool_schema_enabled"],
         true
     );
+    assert_eq!(payload["gateway"]["nodes"]["paired_device_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["managed_bridge_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["total_count"], 0);
     assert_eq!(payload["acp"]["enabled"], true);
     let acp_availability = payload["acp"]["availability"]
         .as_str()
@@ -187,7 +196,7 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
 
 #[test]
 fn status_cli_text_surfaces_section_summaries_and_recipes() {
-    let root = unique_temp_dir("loong-status-cli-text");
+    let root = unique_temp_dir("loongclaw-status-cli-text");
     let home_root = root.join("home");
     fs::create_dir_all(&home_root).expect("create home root");
     let config_path = write_status_config(
@@ -208,12 +217,12 @@ fn status_cli_text_surfaces_section_summaries_and_recipes() {
 
     let stdout = render_output(&output.stdout);
 
-    assert!(stdout.contains("operator runtime summary"));
-    assert!(stdout.contains("start here"));
-    assert!(stdout.contains("runtime posture"));
-    assert!(stdout.contains("[WARN] tool calling"));
-    assert!(stdout.contains("enabled=false · availability=disabled"));
-    assert!(stdout.contains("deep dives"));
+    assert!(stdout.contains("gateway phase=stopped"));
+    assert!(stdout.contains("tool_calling availability=degraded"));
+    assert!(stdout.contains("structured_tool_schema_enabled=false"));
+    assert!(stdout.contains("acp enabled=false availability=disabled"));
+    assert!(stdout.contains("work_units availability="));
+    assert!(stdout.contains("recipes:"));
 
     fs::remove_dir_all(&root).ok();
 }

--- a/scripts/check_public_repo_hygiene.sh
+++ b/scripts/check_public_repo_hygiene.sh
@@ -22,6 +22,22 @@ check_forbidden_path() {
     found_issue=1
 }
 
+check_staged_diff_pattern() {
+    local pattern="$1"
+    local description="$2"
+    local matches
+
+    matches=$(git diff --cached --no-ext-diff --unified=0 -- . | grep -nE "$pattern" || true)
+
+    if [[ -z "$matches" ]]; then
+        return
+    fi
+
+    echo "[public-hygiene] $description" >&2
+    echo "$matches" >&2
+    found_issue=1
+}
+
 check_secret_pattern() {
     local pattern="$1"
     local description="$2"
@@ -44,6 +60,16 @@ check_secret_pattern '"OPENAI_API_KEY"[[:space:]]*:[[:space:]]*"sk-[A-Za-z0-9_-]
     "inline OpenAI key material detected in tracked JSON-like content"
 check_secret_pattern 'OPENAI_API_KEY=sk-[A-Za-z0-9_-]{20,}' \
     "inline OpenAI key assignment detected in tracked content"
+check_staged_diff_pattern '^(\+).*/Users/[^[:space:]"'"'"'<>]+' \
+    "local absolute macOS path detected in staged diff"
+check_staged_diff_pattern '^(\+).*/home/[^[:space:]"'"'"'<>]+' \
+    "local absolute Linux path detected in staged diff"
+check_staged_diff_pattern '^(\+).*([A-Za-z]:\\\\Users\\\\[^[:space:]"'"'"'<>]+)' \
+    "local absolute Windows path detected in staged diff"
+check_staged_diff_pattern '^(\+).*-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----' \
+    "private key material detected in staged diff"
+check_staged_diff_pattern '^(\+).*(ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|sk-[A-Za-z0-9_-]{20,})' \
+    "high-risk credential literal detected in staged diff"
 
 if [[ "$found_issue" -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
## Summary

- Problem:
  - the localhost gateway had a stable front door and a local pairing inbox, but paired-session continuity was still too shallow and too easy to lose across lifecycle changes
- Why it matters:
  - local paired clients need a single durable gateway noun that can bootstrap pairing, issue a paired-session lease, surface replay state, and survive restart without silently degrading continuity
- What changed:
  - kept the stable localhost gateway front door and extended it through pairing bootstrap, pairing completion, lease issuance, JSON replay, SSE stream reuse, and explicit stale-cursor recovery
  - exposed paired-session contract surfaces on the gateway for `pairing/start`, `pairing/complete`, `pairing/session`, `pairing/events`, and `pairing/stream`
  - added paired-session node inventory and operator summary rollups so pairing and managed-bridge state remain visible from the same gateway surface
  - reused the existing control-plane pairing and connection primitives instead of adding a second policy plane
  - persisted runtime-owned paired-session continuity state, including leases, acknowledged cursors, and retained gateway event windows, and restored that state on gateway restart
  - upgraded gateway runtime JSON persistence to atomic replace writes and added live persistence hooks for lease issuance, ack updates, and event publication
- What did not change (scope boundary):
  - no remote bind or public exposure expansion
  - no relay transport or internet-facing pairing flow
  - no second durable business database outside the existing runtime-owned gateway state and current control-plane/session stores

## Linked Issues

- Closes #1299
- Related #1232

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - widens the localhost gateway from a stable front door into a real paired-session contract surface
  - introduces runtime-owned continuity persistence for paired-session leases, acknowledged cursors, and retained event windows
  - makes stale replay an explicit contract instead of a silent best-effort truncation path
- Rollout / guardrails:
  - all new surfaces stay localhost-only behind the existing gateway bearer boundary
  - relay and remote exposure remain out of scope
  - pairing, session, JSON replay, and SSE stream semantics all reuse one paired-session contract instead of splitting into separate flows
  - workspace `cargo test --workspace --locked` and `cargo test --workspace --all-features --locked` were run after the slice landed
- Rollback path:
  - revert the paired-session gateway routes and runtime snapshot persistence while keeping the existing stable localhost gateway owner contract intact

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
CARGO_TARGET_DIR=<shared-target> cargo test -p loongclaw gateway_ -- --test-threads=1
CARGO_TARGET_DIR=<shared-target> cargo test -p loongclaw-app connection_registry_ -- --test-threads=1
CARGO_TARGET_DIR=<shared-target> cargo test --workspace --locked --quiet
CARGO_TARGET_DIR=<shared-target> cargo test --workspace --all-features --locked --quiet
CARGO_TARGET_DIR=<shared-target> cargo clippy -p loongclaw -p loongclaw-app --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<shared-target> LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh
```

Validation notes:
- gateway targeted and integration suites passed, including paired-session bootstrap, lease issuance, replay, SSE stream, stale-cursor handling, and clean-restart continuity
- `loongclaw-app` connection-registry tests passed after adding acknowledged cursor snapshot/restore support
- `cargo test --workspace --locked --quiet` passed in full
- `cargo test --workspace --all-features --locked --quiet` passed in full
- `cargo clippy -p loongclaw -p loongclaw-app --all-targets --all-features -- -D warnings` passed
- `LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh` still fails on pre-existing missing `.docs` release debug/trace artifacts unrelated to this slice

## User-visible / Operator-visible Changes

- `loongclaw gateway run` continues to provide the stable local front door on localhost, but the gateway can now also:
  - bootstrap local pairing
  - complete paired-session lease issuance
  - surface paired-session replay state through JSON and SSE
  - preserve paired-session continuity across clean restart
- paired clients now get explicit `fresh`, `resumed`, and `stale` replay semantics instead of silent stale-cursor truncation
- operators can inspect paired-device and managed-bridge rollups through the gateway summary and node inventory surfaces

## Failure Recovery

- Fast rollback or disable path:
  - revert the paired-session routes and continuity persistence changes, returning the gateway to the earlier stable-front-door + local-pairing-inbox shape
- Observable failure symptoms reviewers should watch for:
  - paired-session tokens stop working after clean restart
  - replay cursors silently rewind or truncate instead of surfacing `stale_cursor`
  - SSE stream and JSON replay drift from each other on cursor semantics
  - gateway runtime snapshot files become malformed or continuity state disappears between live updates and restart

## Reviewer Focus

- `crates/app/src/control_plane.rs`
- `crates/daemon/src/gateway/control.rs`
- `crates/daemon/src/gateway/event_bus.rs`
- `crates/daemon/src/gateway/state.rs`
- `crates/daemon/src/gateway/read_models.rs`
- `crates/daemon/src/gateway/client.rs`
- `crates/daemon/tests/integration/gateway_api_pairing.rs`
- `crates/daemon/tests/integration/gateway_owner_state.rs`
