### PR TITLE
Refactor session-core durability away from memory augmentation surfaces

### DIFF
--- a/crates/app/src/acp/store.rs
+++ b/crates/app/src/acp/store.rs
@@ -122,10 +122,11 @@ impl AcpSqliteSessionStore {
     }
 
     fn resolved_path(&self) -> CliResult<PathBuf> {
-        let runtime_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: self.path.clone(),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let runtime_config = self
+            .path
+            .clone()
+            .map(crate::memory::runtime_config::MemoryRuntimeConfig::for_sqlite_path)
+            .unwrap_or_default();
         crate::memory::ensure_memory_db_ready(self.path.clone(), &runtime_config)
             .map_err(|error| format!("resolve ACP sqlite store path failed: {error}"))
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -95,14 +95,12 @@ use super::conversation::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::conversation::{load_fast_lane_tool_batch_event_summary, load_safe_lane_event_summary};
-#[cfg(any(test, feature = "memory-sqlite"))]
-use super::memory;
-#[cfg(feature = "memory-sqlite")]
-use super::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use super::session::LATEST_SESSION_SELECTOR;
 #[cfg(feature = "memory-sqlite")]
 use super::session::latest_resumable_root_session_id;
+#[cfg(feature = "memory-sqlite")]
+use super::session::store::{self, SessionStoreConfig};
 use super::tui_surface::{
     TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec, TuiHeaderStyle,
     TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec, render_tui_message_body_spec,
@@ -264,7 +262,7 @@ pub(crate) struct CliTurnRuntime {
     pub(crate) effective_working_directory: Option<PathBuf>,
     pub(crate) memory_label: String,
     #[cfg(feature = "memory-sqlite")]
-    pub(crate) memory_config: MemoryRuntimeConfig,
+    pub(crate) memory_config: SessionStoreConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -582,12 +580,12 @@ pub(crate) fn initialize_cli_turn_runtime_with_loaded_config_and_kernel_ctx(
         .or_else(|| config.acp.dispatch.resolved_working_directory());
 
     #[cfg(feature = "memory-sqlite")]
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
 
     #[cfg(feature = "memory-sqlite")]
     let memory_label = {
         let sqlite_path = config.memory.resolved_sqlite_path();
-        let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
+        let initialized = store::ensure_session_store_ready(Some(sqlite_path), &memory_config)
             .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
         initialized.display().to_string()
     };
@@ -642,7 +640,7 @@ fn resolve_cli_session_id(
 fn resolve_cli_runtime_session_id(
     session_hint: Option<&str>,
     session_requirement: CliSessionRequirement,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<String> {
     let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
     let should_resolve_latest = session_requirement == CliSessionRequirement::AllowImplicitDefault
@@ -1664,7 +1662,7 @@ async fn print_fast_lane_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -1700,7 +1698,7 @@ async fn print_safe_lane_summary(
     limit: usize,
     conversation_config: &ConversationConfig,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -1741,7 +1739,7 @@ async fn print_turn_checkpoint_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] _memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] _memory_config: &SessionStoreConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -2183,7 +2181,7 @@ async fn load_fast_lane_summary_output(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<String> {
     let summary =
         load_fast_lane_tool_batch_event_summary(session_id, limit, binding, memory_config).await?;
@@ -2520,7 +2518,7 @@ async fn load_safe_lane_summary_output(
     limit: usize,
     conversation_config: &ConversationConfig,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<String> {
     let summary = load_safe_lane_event_summary(session_id, limit, binding, memory_config).await?;
 
@@ -3527,7 +3525,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     fn test_kernel_context_with_memory(
         agent_id: &str,
-        memory_config: &MemoryRuntimeConfig,
+        memory_config: &SessionStoreConfig,
     ) -> crate::KernelContext {
         let clock = Arc::new(FixedClock::new(1_700_000_000));
         let audit = Arc::new(InMemoryAuditSink::default());
@@ -3675,17 +3673,15 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    pub(super) fn init_chat_test_memory(
-        label: &str,
-    ) -> (LoongConfig, MemoryRuntimeConfig, PathBuf) {
+    pub(super) fn init_chat_test_memory(label: &str) -> (LoongConfig, SessionStoreConfig, PathBuf) {
         let sqlite_path = unique_chat_sqlite_path(label);
         cleanup_chat_test_memory(&sqlite_path);
 
         let mut config = LoongConfig::default();
         config.audit.mode = crate::config::AuditMode::InMemory;
         config.memory.sqlite_path = sqlite_path.display().to_string();
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::ensure_memory_db_ready(
+        let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
+        store::ensure_session_store_ready(
             Some(config.memory.resolved_sqlite_path()),
             &memory_config,
         )
@@ -3795,10 +3791,10 @@ mod tests {
     fn append_assistant_payloads(
         session_id: &str,
         payloads: &[String],
-        memory_config: &MemoryRuntimeConfig,
+        memory_config: &SessionStoreConfig,
     ) {
         for payload in payloads {
-            crate::memory::append_turn_direct(session_id, "assistant", payload, memory_config)
+            store::append_session_turn_direct(session_id, "assistant", payload, memory_config)
                 .expect("persist assistant payload");
         }
     }
@@ -4045,9 +4041,9 @@ mod tests {
         let (config, memory_config, sqlite_path) = init_chat_test_memory("diagnostics");
 
         let session_id = "chat-binding-history-direct";
-        crate::memory::append_turn_direct(session_id, "user", "hello", &memory_config)
+        store::append_session_turn_direct(session_id, "user", "hello", &memory_config)
             .expect("persist user turn");
-        crate::memory::append_turn_direct(session_id, "assistant", "world", &memory_config)
+        store::append_session_turn_direct(session_id, "assistant", "world", &memory_config)
             .expect("persist assistant turn");
 
         let direct_lines = load_history_lines(
@@ -6124,7 +6120,7 @@ allowed_decisions: yes / auto / full / esc";
         config.conversation.compact_enabled = false;
         config.conversation.compact_preserve_recent_turns = 2;
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
         let kernel_ctx = test_kernel_context_with_memory("chat-manual-compaction", &memory_config);
         let session_id = "chat-manual-compaction";
 
@@ -6138,7 +6134,7 @@ allowed_decisions: yes / auto / full / esc";
             ("user", "recent ask"),
             ("assistant", "recent reply"),
         ] {
-            crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            store::append_session_turn_direct(session_id, role, content, &memory_config)
                 .expect("seed turns should succeed");
         }
 
@@ -6170,7 +6166,7 @@ allowed_decisions: yes / auto / full / esc";
             "manual compaction detail should reuse the continuity boundary note"
         );
 
-        let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+        let turns = store::window_session_turns(session_id, 32, &memory_config)
             .expect("window load should succeed");
         assert!(
             turns[0]

--- a/crates/app/src/chat/control_plane.rs
+++ b/crates/app/src/chat/control_plane.rs
@@ -1,8 +1,8 @@
 use crate::CliResult;
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{ApprovalRequestRecord, SessionRepository};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::store::SessionStoreConfig;
 
 pub(crate) const CHAT_SESSION_KIND_DELEGATE_CHILD: &str = "delegate_child";
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -106,7 +106,7 @@ impl ChatControlPlaneSessionSummary {
 
 impl ChatControlPlaneStore {
     #[cfg(feature = "memory-sqlite")]
-    pub(crate) fn new(memory_config: &MemoryRuntimeConfig) -> CliResult<Self> {
+    pub(crate) fn new(memory_config: &SessionStoreConfig) -> CliResult<Self> {
         let repo = SessionRepository::new(memory_config)?;
         Ok(Self { repo })
     }

--- a/crates/app/src/chat/latest_session_selector_tests.rs
+++ b/crates/app/src/chat/latest_session_selector_tests.rs
@@ -2,6 +2,7 @@ use super::tests::{cleanup_chat_test_memory, init_chat_test_memory};
 use super::*;
 use crate::conversation::ConversationRuntimeBinding;
 use crate::session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState};
+use crate::session::store;
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
@@ -35,9 +36,9 @@ fn append_session_turn(
     session_id: &str,
     role: &str,
     content: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) {
-    crate::memory::append_turn_direct(session_id, role, content, memory_config)
+    store::append_session_turn_direct(session_id, role, content, memory_config)
         .expect("append session turn");
 }
 

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -18,10 +18,10 @@ use crate::conversation::collect_context_engine_runtime_snapshot;
 use crate::conversation::resolve_context_engine_selection;
 #[cfg(any(test, feature = "memory-sqlite"))]
 use crate::memory;
-#[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(any(test, feature = "memory-sqlite"))]
 use crate::runtime_self_continuity;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::store::SessionStoreConfig;
 use crate::tui_surface::TuiActionSpec;
 use crate::tui_surface::TuiCalloutTone;
 use crate::tui_surface::TuiChoiceSpec;
@@ -823,7 +823,7 @@ pub(super) async fn print_history(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<()> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -1055,7 +1055,7 @@ pub(super) async fn load_history_lines(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<Vec<String>> {
     if let Some(ctx) = binding.kernel_context() {
         let request = memory::build_window_request(session_id, limit);

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -18,8 +18,6 @@ use crate::config::LoongConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::config::ToolConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalRequestRecord, ApprovalRequestStatus, ControlPlaneDeviceTokenRecord,
     ControlPlanePairingRequestRecord as PersistedControlPlanePairingRequestRecord,
@@ -28,6 +26,8 @@ use crate::session::repository::{
     SessionObservationRecord, SessionRepository, SessionSummaryRecord,
     SessionTerminalOutcomeRecord, TransitionControlPlanePairingRequestIfCurrentRequest,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::session::store::{self, SessionStoreConfig};
 #[cfg(feature = "memory-sqlite")]
 use crate::tools::session::{
     SessionRuntimeSelfContinuityRecord, SessionWorkflowBindingRecord, SessionWorkflowRecord,
@@ -1041,7 +1041,7 @@ pub struct ControlPlanePairingRegistry {
     requests: RwLock<BTreeMap<String, ControlPlanePairingRequestRecord>>,
     approved_devices: RwLock<BTreeMap<String, ControlPlaneApprovedDeviceRecord>>,
     #[cfg(feature = "memory-sqlite")]
-    memory_config: Option<MemoryRuntimeConfig>,
+    memory_config: Option<SessionStoreConfig>,
 }
 
 impl Default for ControlPlanePairingRegistry {
@@ -1062,7 +1062,7 @@ impl ControlPlanePairingRegistry {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    pub fn with_memory_config(memory_config: MemoryRuntimeConfig) -> Result<Self, String> {
+    pub fn with_memory_config(memory_config: SessionStoreConfig) -> Result<Self, String> {
         let repo = SessionRepository::new(&memory_config)?;
         let persisted_requests = repo.list_control_plane_pairing_requests(None)?;
         let persisted_devices = repo.list_control_plane_device_tokens()?;
@@ -1605,7 +1605,7 @@ pub struct ControlPlaneAcpSessionReadView {
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone)]
 pub struct ControlPlaneRepositoryView {
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     tool_config: ToolConfig,
     current_session_id: String,
 }
@@ -1613,7 +1613,7 @@ pub struct ControlPlaneRepositoryView {
 #[cfg(feature = "memory-sqlite")]
 impl ControlPlaneRepositoryView {
     pub fn new(
-        memory_config: MemoryRuntimeConfig,
+        memory_config: SessionStoreConfig,
         tool_config: ToolConfig,
         current_session_id: impl Into<String>,
     ) -> Self {
@@ -2144,8 +2144,9 @@ impl ControlPlaneAcpView {
         if self.current_session_id == DEFAULT_CONTROL_PLANE_SESSION_ID {
             return Ok(None);
         }
-        let memory_config =
-            MemoryRuntimeConfig::from_memory_config_without_env_overrides(&self.config.memory);
+        let memory_config = store::session_store_config_from_memory_config_without_env_overrides(
+            &self.config.memory,
+        );
         SessionRepository::new(&memory_config).map(Some)
     }
 
@@ -2206,12 +2207,12 @@ mod tests {
     use std::fs;
 
     #[cfg(feature = "memory-sqlite")]
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
-    #[cfg(feature = "memory-sqlite")]
     use crate::session::repository::{
         ApprovalRequestStatus, NewApprovalRequestRecord, NewSessionEvent, NewSessionRecord,
         SessionKind, SessionRepository, SessionState,
     };
+    #[cfg(feature = "memory-sqlite")]
+    use crate::session::store::SessionStoreConfig;
     #[cfg(feature = "memory-sqlite")]
     use crate::{
         acp::{
@@ -2941,7 +2942,7 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-control-plane-view-{test_name}-{}",
             std::process::id()
@@ -2949,23 +2950,23 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn broken_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn broken_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-control-plane-broken-{test_name}-{}",
             std::process::id()
         ));
         let sqlite_path = base.join("sqlite-dir");
         let _ = fs::create_dir_all(&sqlite_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -7,9 +7,9 @@ use tokio::runtime::Handle;
 use tokio::time::{Duration, sleep};
 
 use crate::config::LoongConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::session::frozen_result::FrozenResult;
 use crate::session::repository::{NewSessionEvent, SessionRepository};
+use crate::session::store::SessionStoreConfig;
 
 pub(crate) const DELEGATE_RESULTS_ANNOUNCED_EVENT_KIND: &str = "delegate_results_announced";
 
@@ -61,7 +61,7 @@ struct DelegateAnnounceBatch {
 }
 
 pub(crate) fn enqueue_delegate_result_announce(
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     parent_session_id: String,
     child_session_id: String,
     settings: DelegateAnnounceSettings,
@@ -76,7 +76,7 @@ pub(crate) fn enqueue_delegate_result_announce(
 }
 
 fn enqueue_delegate_result_announce_internal(
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     parent_session_id: String,
     child_session_id: String,
     settings: DelegateAnnounceSettings,
@@ -178,7 +178,7 @@ fn enqueue_delegate_result_announce_internal(
 }
 
 async fn drain_delegate_announce_queue(
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     queue_key: String,
     parent_session_id: String,
 ) {
@@ -216,7 +216,7 @@ async fn drain_delegate_announce_queue(
 }
 
 fn flush_delegate_announce_batch(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     parent_session_id: &str,
     batch: &DelegateAnnounceBatch,
 ) -> Result<(), String> {
@@ -436,7 +436,7 @@ fn pause_delegate_announce_queue(parent_session_id: &str) {
 }
 
 fn delegate_announce_queue_key(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     parent_session_id: &str,
 ) -> String {
     let sqlite_path = memory_config.sqlite_path.clone();
@@ -471,7 +471,7 @@ pub(crate) fn delegate_announce_test_lock_for_tests() -> &'static tokio::sync::M
 
 #[cfg(test)]
 pub(crate) fn enqueue_delegate_result_announce_without_spawn_for_tests(
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     parent_session_id: String,
     child_session_id: String,
     settings: DelegateAnnounceSettings,
@@ -500,25 +500,25 @@ mod tests {
         flush_delegate_announce_batch, reset_delegate_announce_queues_for_tests,
         restore_delegate_announce_batch,
     };
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::frozen_result::{FrozenContent, FrozenResult};
     use crate::session::repository::{
         FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind, SessionRepository,
         SessionState,
     };
+    use crate::session::store::SessionStoreConfig;
 
     const DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT: Duration = Duration::from_secs(20);
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base =
             std::env::temp_dir().join(format!("loong-announce-{test_name}-{}", std::process::id()));
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
@@ -576,7 +576,7 @@ mod tests {
     }
 
     async fn wait_for_parent_announce_event(
-        memory_config: &MemoryRuntimeConfig,
+        memory_config: &SessionStoreConfig,
         parent_session_id: &str,
     ) -> serde_json::Value {
         let deadline = tokio::time::Instant::now() + DELEGATE_ANNOUNCE_EVENT_WAIT_TIMEOUT;
@@ -619,7 +619,7 @@ mod tests {
     }
 
     async fn flush_delegate_announce_queue_for_tests(
-        memory_config: &MemoryRuntimeConfig,
+        memory_config: &SessionStoreConfig,
         parent_session_id: &str,
     ) {
         let queue_key = delegate_announce_queue_key(memory_config, parent_session_id);

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -595,17 +595,15 @@ async fn load_stage_envelope(
     binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<memory::StageEnvelope> {
     if let Some(ctx) = binding.kernel_context() {
-        let runtime_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         let tool_runtime_config =
             crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
         let workspace_root = tool_runtime_config
             .effective_workspace_root()
             .map(Path::to_path_buf);
-        let request = memory::build_read_stage_envelope_request_with_workspace_root(
+        let request = memory::build_read_stage_envelope_request_for_memory_config(
             session_id,
             workspace_root.as_deref(),
-            &runtime_config,
+            &config.memory,
         );
         let caps = BTreeSet::from([Capability::MemoryRead]);
         let outcome = ctx
@@ -625,9 +623,7 @@ async fn load_stage_envelope(
             .ok_or_else(|| "decode staged memory envelope via kernel failed".to_owned());
     }
 
-    let runtime_config =
-        memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    memory::hydrate_stage_envelope(session_id, &runtime_config)
+    memory::hydrate_stage_envelope_for_memory_config(session_id, None, &config.memory)
         .map_err(|error| format!("load staged memory envelope failed: {error}"))
 }
 
@@ -788,16 +784,36 @@ mod tests {
         config.memory.sqlite_path = sqlite_path_text.clone();
 
         let memory_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
 
-        memory::append_turn_direct(session_id, "user", "turn 1", &memory_config)
-            .expect("append turn 1 should succeed");
-        memory::append_turn_direct(session_id, "assistant", "turn 2", &memory_config)
-            .expect("append turn 2 should succeed");
-        memory::append_turn_direct(session_id, "user", "turn 3", &memory_config)
-            .expect("append turn 3 should succeed");
-        memory::append_turn_direct(session_id, "assistant", "turn 4", &memory_config)
-            .expect("append turn 4 should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "user",
+            "turn 1",
+            &memory_config,
+        )
+        .expect("append turn 1 should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "assistant",
+            "turn 2",
+            &memory_config,
+        )
+        .expect("append turn 2 should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "user",
+            "turn 3",
+            &memory_config,
+        )
+        .expect("append turn 3 should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "assistant",
+            "turn 4",
+            &memory_config,
+        )
+        .expect("append turn 4 should succeed");
 
         let binding =
             ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
@@ -846,10 +862,15 @@ mod tests {
         config.memory.sqlite_path = sqlite_path_text.clone();
 
         let memory_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
 
-        memory::append_turn_direct(session_id, "assistant", "turn 1", &memory_config)
-            .expect("append turn should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "assistant",
+            "turn 1",
+            &memory_config,
+        )
+        .expect("append turn should succeed");
 
         let binding =
             ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
@@ -952,11 +973,21 @@ mod tests {
         config.memory.system_id = Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
 
         let memory_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        memory::append_turn_direct(session_id, "user", "turn 1", &memory_config)
-            .expect("append turn 1 should succeed");
-        memory::append_turn_direct(session_id, "assistant", "turn 2", &memory_config)
-            .expect("append turn 2 should succeed");
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "user",
+            "turn 1",
+            &memory_config,
+        )
+        .expect("append turn 1 should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "assistant",
+            "turn 2",
+            &memory_config,
+        )
+        .expect("append turn 2 should succeed");
 
         let binding =
             ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
@@ -1019,10 +1050,15 @@ mod tests {
         config.memory.sqlite_path = sqlite_path_text.clone();
 
         let memory_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
 
-        memory::append_turn_direct(session_id, "assistant", "turn 1", &memory_config)
-            .expect("append turn should succeed");
+        crate::session::store::append_session_turn_direct(
+            session_id,
+            "assistant",
+            "turn 1",
+            &memory_config,
+        )
+        .expect("append turn should succeed");
 
         let binding =
             ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));

--- a/crates/app/src/conversation/delegate_support.rs
+++ b/crates/app/src/conversation/delegate_support.rs
@@ -15,13 +15,13 @@ use serde_json::Value;
 use tokio::runtime::Handle;
 
 use crate::config::LoongConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::delegate_runtime::next_delegate_child_depth;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::frozen_result::capture_frozen_result;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{FinalizeSessionTerminalRequest, SessionRepository, SessionState};
+use crate::session::store::SessionStoreConfig;
 
 #[cfg(feature = "memory-sqlite")]
 use super::announce::{DelegateAnnounceSettings, enqueue_delegate_result_announce};
@@ -39,7 +39,7 @@ use super::turn_coordinator::emit_async_delegate_child_terminal_event;
 
 #[cfg(all(feature = "memory-sqlite", test))]
 pub(crate) fn finalize_async_delegate_spawn_failure(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
@@ -62,7 +62,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
 
 #[cfg(feature = "memory-sqlite")]
 pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
@@ -100,7 +100,7 @@ pub(crate) fn format_async_delegate_spawn_panic(panic_payload: Box<dyn Any + Sen
 pub(crate) fn spawn_async_delegate_detached(
     runtime_handle: Handle,
     config: Arc<LoongConfig>,
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     spawner: Arc<dyn AsyncDelegateSpawner>,
     request: AsyncDelegateSpawnRequest,
     max_frozen_bytes: usize,
@@ -194,7 +194,7 @@ pub(crate) fn enqueue_delegate_result_announce_for_parent(
     parent_session_id: &str,
     child_session_id: &str,
 ) {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
     let announce_settings = DelegateAnnounceSettings::from_config(config);
 
     enqueue_delegate_result_announce_with_memory_config(
@@ -207,7 +207,7 @@ pub(crate) fn enqueue_delegate_result_announce_for_parent(
 
 #[cfg(feature = "memory-sqlite")]
 pub(crate) fn enqueue_delegate_result_announce_with_memory_config(
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     parent_session_id: String,
     child_session_id: String,
     announce_settings: DelegateAnnounceSettings,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -45,12 +45,12 @@ use super::turn_middleware_registry::{
 use super::{PromptFragment, PromptFrameAuthority, PromptLane};
 
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     SessionKind, SessionRepository, SessionState, SessionToolPolicyRecord,
     TransitionSessionWithEventIfCurrentRequest,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::session::store;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionContext {
@@ -459,7 +459,7 @@ struct PersistedSessionSnapshot {
 
 #[cfg(feature = "memory-sqlite")]
 fn open_session_repository(config: &LoongConfig) -> CliResult<SessionRepository> {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     SessionRepository::new(&memory_config)
         .map_err(|error| format!("open session repository failed: {error}"))
 }
@@ -789,7 +789,7 @@ pub async fn execute_async_delegate_spawn_request(
         ));
     }
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
     let runtime = load_default_conversation_runtime(config)?;
     let runtime_ref = &runtime;
@@ -1894,11 +1894,11 @@ where
 
         #[cfg(feature = "memory-sqlite")]
         {
-            memory::append_turn_direct(
+            store::append_session_turn_direct(
                 session_id,
                 role,
                 content,
-                memory::runtime_config::get_memory_runtime_config(),
+                store::current_session_store_config(),
             )
             .map_err(|error| format!("persist {role} turn failed: {error}"))?;
         }

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -11,7 +11,7 @@ use crate::KernelContext;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory;
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::session::store::{self, SessionStoreConfig};
 
 use super::analytics::{
     DiscoveryFirstEventSummary, FastLaneToolBatchEventSummary, PromptFrameEventSummary,
@@ -141,7 +141,7 @@ pub async fn load_turn_checkpoint_event_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<TurnCheckpointEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -163,7 +163,7 @@ pub async fn load_safe_lane_event_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<SafeLaneEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -184,7 +184,7 @@ pub async fn load_fast_lane_tool_batch_event_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<FastLaneToolBatchEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -205,7 +205,7 @@ pub async fn load_prompt_frame_event_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<PromptFrameEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -226,7 +226,7 @@ pub async fn load_discovery_first_event_summary(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     load_discovery_first_event_summary_with_binding(
         session_id,
@@ -242,7 +242,7 @@ pub async fn load_discovery_first_event_summary_with_kernel_context(
     session_id: &str,
     limit: usize,
     kernel_ctx: Option<&KernelContext>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     let binding = kernel_ctx.map_or_else(
         ConversationRuntimeBinding::direct,
@@ -262,7 +262,7 @@ pub(crate) async fn load_discovery_first_event_summary_with_binding(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -283,7 +283,7 @@ pub(crate) async fn load_latest_turn_checkpoint_entry(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+    #[cfg(feature = "memory-sqlite")] memory_config: &SessionStoreConfig,
 ) -> CliResult<Option<TurnCheckpointLatestEntry>> {
     #[cfg(feature = "memory-sqlite")]
     {
@@ -306,7 +306,7 @@ pub(crate) async fn load_turn_checkpoint_history_snapshot(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<TurnCheckpointHistorySnapshot> {
     let assistant_contents =
         load_assistant_contents_from_session_window(session_id, limit, binding, memory_config)
@@ -319,7 +319,7 @@ pub(crate) async fn load_assistant_contents_from_session_window(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> CliResult<Vec<String>> {
     load_assistant_contents_from_session_window_detailed(session_id, limit, binding, memory_config)
         .await
@@ -331,7 +331,7 @@ async fn load_assistant_history_summary<T, F>(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     summarize: F,
 ) -> CliResult<T>
 where
@@ -348,7 +348,7 @@ pub(crate) async fn load_assistant_contents_from_session_window_detailed(
     session_id: &str,
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> Result<Vec<String>, AssistantHistoryLoadError> {
     if let Some(ctx) = binding.kernel_context() {
         let request = MemoryCoreRequest {
@@ -375,7 +375,7 @@ pub(crate) async fn load_assistant_contents_from_session_window_detailed(
         return collect_assistant_contents_from_memory_window_payload(outcome.payload.get("turns"));
     }
 
-    let turns = memory::window_direct(session_id, limit, memory_config)
+    let turns = store::window_session_turns(session_id, limit, memory_config)
         .map_err(AssistantHistoryLoadError::direct_read_failed)?;
     Ok(turns
         .iter()

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -43,7 +43,7 @@ use crate::session::repository::{
     TransitionApprovalRequestIfCurrentRequest,
 };
 #[cfg(feature = "memory-sqlite")]
-use crate::session::store::SessionStoreConfig as MemoryRuntimeConfig;
+use crate::session::store::SessionStoreConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::test_support::unique_temp_dir;
 
@@ -51,7 +51,7 @@ use crate::test_support::unique_temp_dir;
 const DEEP_DELEGATE_REENTRY_TEST_STACK_SIZE_BYTES: usize = 32 * 1024 * 1024;
 
 #[cfg(feature = "memory-sqlite")]
-fn session_store_config_from_config(config: &LoongConfig) -> MemoryRuntimeConfig {
+fn session_store_config_from_config(config: &LoongConfig) -> SessionStoreConfig {
     crate::session::store::session_store_config_from_memory_config(&config.memory)
 }
 
@@ -60,7 +60,7 @@ fn append_session_turn_direct(
     session_id: &str,
     role: &str,
     content: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
 ) -> Result<(), String> {
     crate::session::store::append_session_turn_direct(session_id, role, content, config)
 }
@@ -69,7 +69,7 @@ fn append_session_turn_direct(
 fn window_session_turns(
     session_id: &str,
     limit: usize,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
 ) -> Result<Vec<crate::session::store::SessionTranscriptTurn>, String> {
     crate::session::store::window_session_turns(session_id, limit, config)
 }
@@ -158,7 +158,7 @@ struct FakeRuntime {
     after_turn_result: Result<(), String>,
     compact_result: Result<(), String>,
     #[cfg(feature = "memory-sqlite")]
-    durable_memory_config: Option<MemoryRuntimeConfig>,
+    durable_memory_config: Option<SessionStoreConfig>,
     #[cfg(feature = "memory-sqlite")]
     async_delegate_spawner_override: Option<Arc<dyn crate::conversation::AsyncDelegateSpawner>>,
     persisted: Mutex<Vec<(String, String, String)>>,
@@ -369,7 +369,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             timeout_seconds,
             binding,
         } = request;
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+        let memory_config = SessionStoreConfig::from_memory_config(&self.config.memory);
         let repo = crate::session::repository::SessionRepository::new(&memory_config)?;
         let runtime = self
             .runtime
@@ -428,7 +428,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
 #[cfg(feature = "memory-sqlite")]
 struct ApprovalFinalizationConflictRuntime {
     inner: FakeRuntime,
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     approval_request_id: String,
     replay_error: String,
 }
@@ -437,7 +437,7 @@ struct ApprovalFinalizationConflictRuntime {
 impl ApprovalFinalizationConflictRuntime {
     fn new(
         inner: FakeRuntime,
-        memory_config: MemoryRuntimeConfig,
+        memory_config: SessionStoreConfig,
         approval_request_id: &str,
         replay_error: &str,
     ) -> Self {
@@ -1141,7 +1141,7 @@ impl FakeRuntime {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn with_durable_memory_config(mut self, config: MemoryRuntimeConfig) -> Self {
+    fn with_durable_memory_config(mut self, config: SessionStoreConfig) -> Self {
         self.durable_memory_config = Some(config);
         self
     }
@@ -1886,7 +1886,7 @@ fn collect_markdown_file_paths(root: &std::path::Path) -> Vec<PathBuf> {
 #[cfg(feature = "memory-sqlite")]
 fn test_kernel_context_with_memory(
     agent_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
 ) -> KernelContext {
     let clock = Arc::new(FixedClock::new(1_700_000_000));
     let audit = Arc::new(InMemoryAuditSink::default());
@@ -17091,7 +17091,7 @@ fn prepare_discovery_first_summary_test(
     db_scope: &str,
     direct_session_id: &str,
     payloads: &[String],
-) -> (PathBuf, MemoryRuntimeConfig) {
+) -> (PathBuf, SessionStoreConfig) {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id(db_scope, "binding")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -32,8 +32,6 @@ use crate::acp::{
 };
 use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
 use crate::memory::{
     MemorySystem, MemorySystemCapability, MemorySystemMetadata, RECALL_FIRST_MEMORY_SYSTEM_ID,
     register_memory_system,
@@ -45,10 +43,36 @@ use crate::session::repository::{
     TransitionApprovalRequestIfCurrentRequest,
 };
 #[cfg(feature = "memory-sqlite")]
+use crate::session::store::SessionStoreConfig as MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
 use crate::test_support::unique_temp_dir;
 
 #[cfg(feature = "memory-sqlite")]
 const DEEP_DELEGATE_REENTRY_TEST_STACK_SIZE_BYTES: usize = 32 * 1024 * 1024;
+
+#[cfg(feature = "memory-sqlite")]
+fn session_store_config_from_config(config: &LoongConfig) -> MemoryRuntimeConfig {
+    crate::session::store::session_store_config_from_memory_config(&config.memory)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_session_turn_direct(
+    session_id: &str,
+    role: &str,
+    content: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<(), String> {
+    crate::session::store::append_session_turn_direct(session_id, role, content, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn window_session_turns(
+    session_id: &str,
+    limit: usize,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<crate::session::store::SessionTranscriptTurn>, String> {
+    crate::session::store::window_session_turns(session_id, limit, config)
+}
 
 #[cfg(feature = "memory-sqlite")]
 async fn wait_for_delegate_announce_event(
@@ -1690,7 +1714,7 @@ impl ConversationRuntime for FakeRuntime {
         }
         #[cfg(feature = "memory-sqlite")]
         if let Some(config) = self.durable_memory_config.as_ref() {
-            crate::memory::append_turn_direct(session_id, role, content, config)
+            append_session_turn_direct(session_id, role, content, config)
                 .map_err(|error| format!("persist {role} turn failed: {error}"))?;
         }
         self.persisted.lock().expect("persist lock").push((
@@ -1810,7 +1834,7 @@ async fn provider_messages_with_kernel_binding(
     session_id: &str,
     kernel_ctx: &KernelContext,
 ) -> Vec<Value> {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(config);
     let workspace_root = config
         .tools
         .file_root
@@ -1938,7 +1962,7 @@ fn seed_delegate_child_session_with_contract(
 ) -> String {
     let sqlite_path = unique_memory_sqlite_path(&format!("delegate-runtime-contract-{suffix}"));
     config.memory.sqlite_path = sqlite_path;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session_id = format!("root-session-{suffix}");
     let child_session_id = format!("child-session-{suffix}");
@@ -2553,8 +2577,7 @@ fn default_runtime_tool_view_uses_persisted_delegate_child_restrictions() {
     ));
     let _ = std::fs::remove_file(&db_path);
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -2600,7 +2623,7 @@ fn default_runtime_tool_view_intersects_root_session_with_persisted_tool_policy(
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -2677,8 +2700,7 @@ fn default_runtime_tool_view_denies_delegate_for_broken_lineage_child() {
     ));
     let _ = std::fs::remove_file(&db_path);
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -2716,8 +2738,7 @@ fn default_runtime_session_context_uses_persisted_parent_session_id() {
     ));
     let _ = std::fs::remove_file(&db_path);
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -2790,8 +2811,7 @@ fn default_runtime_session_context_errors_when_session_repository_is_unavailable
 fn default_runtime_session_context_uses_persisted_subagent_profile() {
     let mut config = test_config();
     config.memory.sqlite_path = unique_memory_sqlite_path("persisted-profile");
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -2887,8 +2907,7 @@ fn default_runtime_session_context_derives_subagent_profile_for_legacy_child_wit
     let mut config = test_config();
     config.tools.delegate.max_depth = 3;
     config.memory.sqlite_path = unique_memory_sqlite_path("legacy-derived-profile");
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -2948,8 +2967,7 @@ fn default_runtime_tool_view_respects_persisted_leaf_subagent_profile() {
     let mut config = test_config();
     config.tools.delegate.max_depth = 3;
     config.memory.sqlite_path = unique_memory_sqlite_path("persisted-leaf-profile");
-    let memory_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -3422,15 +3440,14 @@ async fn default_runtime_kernel_stage_hydration_still_applies_system_prompt_addi
         "kernel-stage-hydration-tool-view",
         sample_delegate_runtime_narrowing(),
     );
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&child_session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&child_session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&child_session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&child_session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&child_session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&child_session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
-    crate::memory::append_turn_direct(&child_session_id, "assistant", "turn 4", &runtime_config)
+    append_session_turn_direct(&child_session_id, "assistant", "turn 4", &runtime_config)
         .expect("append turn 4 should succeed");
 
     let runtime = DefaultConversationRuntime::default();
@@ -3523,7 +3540,7 @@ async fn default_runtime_build_context_does_not_add_delegate_runtime_contract_fo
     let mut config = test_config();
     let sqlite_path = unique_memory_sqlite_path("persisted-root-session-no-contract");
     config.memory.sqlite_path = sqlite_path;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session-no-contract".to_owned(),
@@ -3664,15 +3681,14 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
         .expect("append turn 4 should succeed");
 
     let assembled = runtime
@@ -3734,7 +3750,7 @@ async fn default_runtime_build_context_rehydrates_runtime_self_continuity_when_l
     config.memory.sqlite_path = sqlite_path.clone();
     config.tools.file_root = Some(empty_workspace_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&session_id);
 
@@ -3799,7 +3815,7 @@ async fn default_runtime_build_context_rehydrates_delegate_child_runtime_self_co
     config.memory.sqlite_path = sqlite_path.clone();
     config.tools.file_root = Some(empty_workspace_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&root_session_id);
     let child_session = create_child_session_record(&child_session_id, &root_session_id);
@@ -3858,7 +3874,7 @@ async fn default_runtime_build_context_prefers_live_identity_over_stored_runtime
     config.memory.sqlite_path = sqlite_path.clone();
     config.tools.file_root = Some(workspace_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&session_id);
     let stored_identity_text = "# Identity\n\n- Name: Stored continuity identity";
@@ -3915,7 +3931,7 @@ async fn default_runtime_build_context_rehydrates_missing_session_profile_from_s
     config.memory.sqlite_path = sqlite_path.clone();
     config.tools.file_root = Some(workspace_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&session_id);
     let stored_identity_text = "# Identity\n\n- Name: Stored continuity identity";
@@ -3969,9 +3985,8 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
         .expect("append turn should succeed");
 
     let assembled = runtime
@@ -4033,7 +4048,7 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
     config.conversation.compact_min_messages = Some(999);
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&session_id);
     let session_id_for_hook = session_id.clone();
@@ -4130,13 +4145,12 @@ async fn default_runtime_build_context_fail_open_memory_derivation_preserves_rec
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
 
     let assembled = runtime
@@ -4182,15 +4196,14 @@ async fn default_runtime_kernel_build_context_matches_builtin_summary_projection
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
         .expect("append turn 4 should succeed");
 
     let kernel_ctx =
@@ -4228,9 +4241,8 @@ async fn default_runtime_kernel_build_context_preserves_profile_projection() {
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
         .expect("append turn should succeed");
 
     let kernel_ctx =
@@ -4280,13 +4292,12 @@ async fn default_runtime_build_context_with_registry_selected_system_keeps_runti
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
 
     let assembled = runtime
@@ -4354,13 +4365,12 @@ async fn default_runtime_build_context_with_recall_first_system_prioritizes_reca
     )
     .expect("write workspace memory file");
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
 
     let assembled = runtime
@@ -4424,13 +4434,12 @@ async fn default_runtime_kernel_build_context_emits_context_artifact_annotations
     config.memory.sliding_window = 2;
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let runtime_config =
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+    let runtime_config = session_store_config_from_config(&config);
+    append_session_turn_direct(&session_id, "user", "turn 1", &runtime_config)
         .expect("append turn 1 should succeed");
-    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+    append_session_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
         .expect("append turn 2 should succeed");
-    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+    append_session_turn_direct(&session_id, "user", "turn 3", &runtime_config)
         .expect("append turn 3 should succeed");
 
     let kernel_ctx = test_kernel_context_with_memory(
@@ -6382,7 +6391,7 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
     config.conversation.compact_min_messages = Some(999);
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let exported_capture = Arc::new(Mutex::new(None::<String>));
     let workspace_root_for_hook = workspace_root.clone();
     let exported_capture_for_hook = Arc::clone(&exported_capture);
@@ -6426,14 +6435,14 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
     .with_durable_memory_config(memory_config.clone())
     .with_compact_hook(compact_hook);
 
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         "session-pre-compaction-flush",
         "user",
         "earlier ask",
         &memory_config,
     )
     .expect("seed earlier user turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         "session-pre-compaction-flush",
         "assistant",
         "earlier reply",
@@ -6485,7 +6494,7 @@ async fn handle_turn_with_runtime_does_not_flush_durable_memory_when_compaction_
     config.memory.sliding_window = 1;
     config.conversation.compact_enabled = false;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
@@ -7135,7 +7144,7 @@ async fn default_runtime_build_context_includes_tool_discovery_delta_from_persis
     let mut config = test_config();
     let sqlite_path = unique_memory_sqlite_path("tool-discovery-delta");
     config.memory.sqlite_path = sqlite_path;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let session_id = "session-tool-discovery-delta";
     let discovery_event = crate::memory::build_conversation_event_content(
         "tool_discovery_refreshed",
@@ -7154,7 +7163,7 @@ async fn default_runtime_build_context_includes_tool_discovery_delta_from_persis
         }),
     );
 
-    crate::memory::append_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
+    append_session_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
         .expect("persist discovery event");
 
     let runtime = DefaultConversationRuntime::default();
@@ -7200,7 +7209,7 @@ async fn default_runtime_build_context_sanitizes_tool_discovery_delta_advisory_t
     let mut config = test_config();
     let sqlite_path = unique_memory_sqlite_path("tool-discovery-delta-sanitized-advisory");
     config.memory.sqlite_path = sqlite_path;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let session_id = "session-tool-discovery-delta-sanitized-advisory";
     let discovery_event = crate::memory::build_conversation_event_content(
         "tool_discovery_refreshed",
@@ -7223,7 +7232,7 @@ async fn default_runtime_build_context_sanitizes_tool_discovery_delta_advisory_t
         }),
     );
 
-    crate::memory::append_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
+    append_session_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
         .expect("persist discovery event");
 
     let runtime = DefaultConversationRuntime::default();
@@ -7291,7 +7300,7 @@ async fn default_runtime_build_messages_filters_tool_discovery_delta_to_requeste
     let mut config = test_config();
     let sqlite_path = unique_memory_sqlite_path("tool-discovery-delta-filtered-view");
     config.memory.sqlite_path = sqlite_path;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let session_id = "session-tool-discovery-delta-filtered-view";
     let discovery_event = crate::memory::build_conversation_event_content(
         "tool_discovery_refreshed",
@@ -7311,7 +7320,7 @@ async fn default_runtime_build_messages_filters_tool_discovery_delta_to_requeste
         }),
     );
 
-    crate::memory::append_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
+    append_session_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
         .expect("persist discovery event");
 
     let runtime = DefaultConversationRuntime::default();
@@ -7354,7 +7363,7 @@ async fn default_runtime_build_context_uses_configured_runtime_tool_view_for_too
     config.external_skills.enabled = true;
     config.tools.web_search.enabled = false;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let session_id = "session-tool-discovery-delta-configured-runtime-view";
     let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(&config);
     let discovery_event = crate::memory::build_conversation_event_content(
@@ -7390,7 +7399,7 @@ async fn default_runtime_build_context_uses_configured_runtime_tool_view_for_too
         "configured runtime tool view should hide web.search when disabled"
     );
 
-    crate::memory::append_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
+    append_session_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
         .expect("persist discovery event");
 
     let runtime = DefaultConversationRuntime::default();
@@ -7451,7 +7460,7 @@ async fn default_runtime_kernel_build_context_uses_configured_runtime_tool_view_
     config.external_skills.enabled = true;
     config.tools.web_search.enabled = false;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let session_id = "session-tool-discovery-delta-configured-runtime-view-kernel";
     let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(&config);
     let discovery_event = crate::memory::build_conversation_event_content(
@@ -7487,7 +7496,7 @@ async fn default_runtime_kernel_build_context_uses_configured_runtime_tool_view_
         "configured runtime tool view should hide web.search when disabled"
     );
 
-    crate::memory::append_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
+    append_session_turn_direct(session_id, "assistant", &discovery_event, &memory_config)
         .expect("persist discovery event");
 
     let kernel_ctx = test_kernel_context_with_memory(
@@ -8901,7 +8910,7 @@ async fn handle_turn_with_runtime_provider_switch_tool_updates_provider_for_foll
     config.memory.sqlite_path = unique_acp_sqlite_path("provider-switch-followup-round");
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "session-provider-switch".to_owned(),
@@ -9066,15 +9075,15 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     let sqlite_path = unique_memory_sqlite_path("fast-lane-batch-event");
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(
+    let memory_config = session_store_config_from_config(&config);
+    append_session_turn_direct(
         "session-fast-lane-batch-event",
         "user",
         "hello",
         &memory_config,
     )
     .expect("append user turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         "session-fast-lane-batch-event",
         "assistant",
         "done",
@@ -9234,15 +9243,15 @@ async fn handle_turn_with_runtime_fast_lane_batch_persist_failure_surfaces_runti
     let sqlite_path = unique_memory_sqlite_path("fast-lane-batch-persist-failure");
     config.memory.sqlite_path = sqlite_path.clone();
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(
+    let memory_config = session_store_config_from_config(&config);
+    append_session_turn_direct(
         "session-fast-lane-batch-persist-failure",
         "user",
         "hello",
         &memory_config,
     )
     .expect("append user turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         "session-fast-lane-batch-persist-failure",
         "assistant",
         "done",
@@ -11105,8 +11114,8 @@ async fn handle_turn_with_runtime_safe_lane_session_governor_does_not_reuse_sqli
         .conversation
         .safe_lane_session_governor_force_node_max_attempts = 1;
 
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    crate::memory::append_turn_direct(
+    let mem_config = session_store_config_from_config(&config);
+    append_session_turn_direct(
         "session-safe-governor-fallback",
         "assistant",
         r#"{"type":"conversation_event","event":"final_status","payload":{"status":"failed","failure_code":"safe_lane_plan_node_retryable_error","route_decision":"terminal"}} "#.trim(),
@@ -13476,7 +13485,7 @@ async fn default_app_tool_dispatcher_executes_session_wait_for_visible_terminal_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13543,7 +13552,7 @@ async fn child_session_hidden_session_wait_is_rejected_by_default_dispatcher() {
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13603,7 +13612,7 @@ async fn child_session_hidden_sessions_send_is_rejected_by_default_dispatcher() 
     let mut config = test_config();
     config.tools.messages.enabled = true;
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13658,7 +13667,7 @@ async fn sessions_send_rejects_unknown_target_session() {
     config.tools.messages.enabled = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("sessions-send-unknown-target");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13705,7 +13714,7 @@ async fn sessions_send_rejects_delegate_child_target() {
     config.tools.messages.enabled = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("sessions-send-child-target");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13761,7 +13770,7 @@ async fn continue_session_with_runtime_reopens_completed_delegate_child_and_refr
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-completed-child");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13884,7 +13893,7 @@ async fn continue_session_with_runtime_preserves_prior_terminal_outcome_when_res
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-preserve-outcome");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -13980,7 +13989,7 @@ async fn continue_session_with_runtime_backfills_profile_from_older_delegate_anc
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-profile-backfill");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14070,7 +14079,7 @@ async fn continue_session_with_runtime_rejects_running_delegate_child() {
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-running-child");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14119,7 +14128,7 @@ async fn continue_session_with_runtime_rejects_failed_delegate_child() {
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-failed-child");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14192,7 +14201,7 @@ async fn continue_session_with_runtime_rejects_archived_delegate_child() {
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-archived-child");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14274,7 +14283,7 @@ async fn continue_session_with_runtime_rejects_invalid_timeout_override() {
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-invalid-timeout");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14349,7 +14358,7 @@ async fn continue_session_with_runtime_caps_timeout_override_and_persists_contra
     config.tools.delegate.timeout_seconds = 30;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-timeout-cap");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -14449,7 +14458,7 @@ async fn default_app_tool_dispatcher_rejects_session_continue_without_runtime_co
     config.tools.sessions.allow_mutation = true;
     config.memory.sqlite_path = unique_acp_sqlite_path("session-continue-not-configured");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -15226,7 +15235,7 @@ async fn autonomy_policy_turn_engine_discovery_only_denies_capability_install() 
     config.external_skills.enabled = true;
     config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-discovery-install-denied",
@@ -15309,7 +15318,7 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_ca
     config.external_skills.enabled = true;
     config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
@@ -15432,7 +15441,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_allows_capability_instal
     config.external_skills.enabled = true;
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
@@ -15528,7 +15537,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_enforces_capability_budg
     config.external_skills.enabled = true;
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-bounded-install-budget",
@@ -15667,7 +15676,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_pr
     let canonical_config_path =
         std::fs::canonicalize(&config_path).expect("canonicalize config path");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
@@ -15765,7 +15774,7 @@ async fn autonomy_policy_turn_engine_discovery_only_denies_topology_expand() {
     config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-discovery-delegate-denied");
     config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-discovery-delegate-denied",
@@ -15825,7 +15834,7 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_po
     config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-guided-policy-mutation-denied");
     config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-guided-policy-mutation-denied",
@@ -15918,7 +15927,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_se
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
     config.tools.sessions.allow_mutation = true;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-bounded-session-mutation-denied",
@@ -16006,7 +16015,7 @@ async fn autonomy_policy_turn_engine_advisory_binding_denies_session_mutation_be
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
     config.tools.sessions.allow_mutation = true;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let session_id = "session-autonomy-advisory-session-mutation";
@@ -16396,7 +16405,7 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
     config.external_skills.enabled = true;
     config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
     let dispatcher = crate::conversation::turn_engine::DefaultAppToolDispatcher::with_config(
-        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory),
+        session_store_config_from_config(&config),
         config.clone(),
     );
     let session_context = crate::conversation::SessionContext::root_with_tool_view(
@@ -17091,10 +17100,10 @@ fn prepare_discovery_first_summary_test(
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     for payload in payloads {
-        crate::memory::append_turn_direct(direct_session_id, "assistant", payload, &mem_config)
+        append_session_turn_direct(direct_session_id, "assistant", payload, &mem_config)
             .expect("persist discovery-first payload");
     }
 
@@ -17634,7 +17643,7 @@ async fn load_turn_checkpoint_event_summary_prefers_kernel_memory_window_when_co
     let audit = Arc::new(InMemoryAuditSink::default());
     let (ctx, invocations) = build_kernel_context_with_window_turns(audit, checkpoint_turns);
     let config = test_config();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     let summary = load_turn_checkpoint_event_summary(
         "session-k-turn-checkpoint",
@@ -17682,9 +17691,9 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_erro
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.memory.sliding_window = 8;
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         "session-kernel-window-error",
         "assistant",
         r#"{"type":"conversation_event","event":"turn_checkpoint","payload":{"schema_version":1,"stage":"finalized","checkpoint":{"lane":{"lane":"safe","result_kind":"tool_call"},"finalization":{"persistence_mode":"success"}},"finalization_progress":{"after_turn":"completed","compaction":"skipped"},"failure":null}}"#,
@@ -17723,7 +17732,7 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_payl
     let (ctx, invocations) =
         build_kernel_context_with_raw_window_payload(audit, json!({"unexpected": "shape"}));
     let config = test_config();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     let error = load_turn_checkpoint_event_summary(
         "session-kernel-window-malformed",
@@ -17759,7 +17768,7 @@ async fn load_turn_checkpoint_event_summary_fails_closed_when_kernel_window_assi
         }),
     );
     let config = test_config();
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     let error = load_turn_checkpoint_event_summary(
         "session-kernel-window-malformed-assistant-content",
@@ -17790,7 +17799,7 @@ async fn load_turn_checkpoint_event_summary_direct_read_failure_uses_neutral_err
     let mut config = test_config();
     config.memory.sqlite_path = sqlite_dir.display().to_string();
     config.memory.sliding_window = 8;
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     let error = load_turn_checkpoint_event_summary(
         "session-direct-read-error",
@@ -18303,13 +18312,13 @@ async fn persisted_turn_checkpoint_events_survive_reload_without_polluting_promp
 
     let runtime = DefaultConversationRuntime::default();
     let session_id = "session-turn-checkpoint-reload";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18339,7 +18348,7 @@ async fn persisted_turn_checkpoint_events_survive_reload_without_polluting_promp
         &mem_config,
     )
     .expect("persist post_persist checkpoint");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18395,8 +18404,8 @@ async fn persisted_turn_checkpoint_events_survive_reload_without_polluting_promp
         "checkpoint events must not pollute provider prompt history: {messages:?}"
     );
 
-    let turns = crate::memory::window_direct(session_id, 16, &mem_config)
-        .expect("load raw turns from sqlite");
+    let turns =
+        window_session_turns(session_id, 16, &mem_config).expect("load raw turns from sqlite");
     let assistant_contents = turns
         .iter()
         .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
@@ -18435,13 +18444,13 @@ async fn load_turn_checkpoint_event_summary_reads_recovery_state_from_sqlite_his
     config.memory.sliding_window = 8;
 
     let session_id = "session-turn-checkpoint-reader";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18470,7 +18479,7 @@ async fn load_turn_checkpoint_event_summary_reads_recovery_state_from_sqlite_his
         &mem_config,
     )
     .expect("persist post_persist checkpoint");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18565,13 +18574,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_finalizes_pending_checkpoint()
     config.conversation.compact_fail_open = false;
 
     let session_id = "session-turn-checkpoint-repair-pending";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18676,13 +18685,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_without
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-missing-identity";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18782,13 +18791,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_preserves_safe_lane_override_r
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-repair-safe-lane-override-manual-reason";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18888,13 +18897,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_requires_manual_repair_on_iden
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-identity-mismatch";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -18990,13 +18999,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_retries_failed_compaction_only
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-compaction";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19100,13 +19109,13 @@ async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_
     config.conversation.compact_trigger_estimated_tokens = None;
 
     let session_id = "session-turn-checkpoint-repair-compaction-context";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19223,13 +19232,13 @@ async fn repair_turn_checkpoint_tail_prefers_checkpoint_estimate_for_compaction_
     config.conversation.compact_trigger_estimated_tokens = Some(50);
 
     let session_id = "session-turn-checkpoint-repair-compaction-estimate";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19332,13 +19341,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_reports_preparation_content_mis
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-probe-context-fingerprint-mismatch";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19448,13 +19457,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_when_repair_not_ne
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-probe-not-needed";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19544,13 +19553,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_summary_manual
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-probe-summary-manual";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19640,13 +19649,13 @@ async fn probe_turn_checkpoint_tail_runtime_gate_returns_none_for_runnable_repai
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-probe-runnable";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19738,13 +19747,13 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_manual_
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-diagnostics-summary-manual";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19845,13 +19854,13 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_assessm
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-diagnostics-runtime-drift";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -19973,13 +19982,13 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_degrades_build_context_fa
     config.memory.sliding_window = 12;
 
     let session_id = "session-turn-checkpoint-diagnostics-build-context-failure";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -20258,7 +20267,7 @@ async fn handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_k
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.delegate.child_tool_allowlist = vec!["web.fetch".to_owned()];
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -20425,7 +20434,7 @@ async fn session_context_uses_persisted_child_tool_view_constraints() {
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.delegate.child_tool_allowlist = vec!["file.read".to_owned()];
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -20510,7 +20519,7 @@ async fn session_context_preserves_child_workspace_root_from_delegate_execution_
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.file_root = Some(empty_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -20633,7 +20642,7 @@ async fn trait_default_session_context_preserves_delegate_execution_contract() {
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.file_root = Some(empty_root.display().to_string());
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -20713,7 +20722,7 @@ async fn session_context_preserves_child_runtime_narrowing_after_many_later_even
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.create_session(NewSessionRecord {
         session_id: "root-session".to_owned(),
@@ -20803,7 +20812,7 @@ async fn session_context_merges_persisted_session_policy_runtime_narrowing() {
         sample_delegate_runtime_narrowing(),
     );
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     repo.upsert_session_tool_policy(NewSessionToolPolicyRecord {
         session_id: child_session_id.clone(),
@@ -20865,7 +20874,7 @@ async fn handle_turn_with_runtime_executes_session_tools_via_default_dispatcher(
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -20946,7 +20955,7 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
     config.telegram.base_url = base_url;
     config.telegram.allowed_chat_ids = vec![123];
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -20965,10 +20974,10 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
         state: crate::session::repository::SessionState::Ready,
     })
     .expect("create telegram root");
-    crate::memory::append_turn_direct("telegram:123", "user", "previous inbound", &memory_config)
+    append_session_turn_direct("telegram:123", "user", "previous inbound", &memory_config)
         .expect("append prior transcript turn");
     let before_turns =
-        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+        window_session_turns("telegram:123", 10, &memory_config).expect("window turns");
 
     let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
@@ -21029,7 +21038,7 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
     assert!(request.contains("\"text\":\"hello root channel\""));
 
     let after_turns =
-        crate::memory::window_direct("telegram:123", 10, &memory_config).expect("window turns");
+        window_session_turns("telegram:123", 10, &memory_config).expect("window turns");
     assert_eq!(after_turns.len(), before_turns.len());
     assert_eq!(after_turns[0].role, before_turns[0].role);
     assert_eq!(after_turns[0].content, before_turns[0].content);
@@ -21059,7 +21068,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
 
     let mut config = make_delegate_announce_test_config(&db_path);
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21176,7 +21185,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
 
     let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21333,7 +21342,7 @@ async fn handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks
 
     let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21460,7 +21469,7 @@ async fn handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_s
 
     let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21541,7 +21550,7 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
     let mut config = make_delegate_announce_test_config(&db_path);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21663,7 +21672,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_once_preserve
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21797,7 +21806,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_core_replay_f
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -21912,7 +21921,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_kernel_replays_previo
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22084,7 +22093,7 @@ async fn handle_turn_with_runtime_requires_approval_before_shell_exec_execution(
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22195,7 +22204,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_shell_exec_fo
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22328,7 +22337,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22507,7 +22516,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22639,7 +22648,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -22819,7 +22828,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_persis
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
 
@@ -22957,7 +22966,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_kernel_replay_surface
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23067,7 +23076,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23221,7 +23230,7 @@ async fn spawn_background_delegate_with_runtime_creates_missing_root_session_sco
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
 
@@ -23310,7 +23319,7 @@ async fn spawn_background_delegate_with_runtime_uses_default_timeout_when_omitte
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.tools.delegate.timeout_seconds = 77;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23364,7 +23373,7 @@ async fn handle_turn_with_runtime_delegate_async_direct_binding_fails_before_per
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23452,7 +23461,7 @@ async fn handle_turn_with_runtime_delegate_async_direct_binding_still_fails_when
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23538,7 +23547,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_keeps_delegate_async_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23664,7 +23673,7 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23756,7 +23765,7 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
     config.tools.delegate.max_active_children = 1;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -23848,7 +23857,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24010,7 +24019,7 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24120,7 +24129,7 @@ async fn handle_turn_with_runtime_delegate_async_profile_shapes_child_execution_
     config.tools.delegate.allow_shell_in_child = true;
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24241,7 +24250,7 @@ async fn handle_turn_with_runtime_delegate_async_projects_queued_event_to_parent
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24332,7 +24341,7 @@ async fn handle_turn_with_runtime_delegate_async_projects_terminal_event_to_pare
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24458,7 +24467,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24591,7 +24600,7 @@ async fn handle_turn_with_runtime_kernel_delegate_async_spawn_failure_closes_lif
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24698,7 +24707,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24812,7 +24821,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -24933,7 +24942,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25021,7 +25030,7 @@ async fn handle_turn_with_runtime_delegate_supports_worktree_isolation_for_clean
     config.tools.file_root = Some(repo_root.display().to_string());
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25149,7 +25158,7 @@ async fn handle_turn_with_runtime_delegate_async_worktree_isolation_retains_dirt
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25334,7 +25343,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
     config.memory.sqlite_path = db_path.display().to_string();
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate_async");
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25489,7 +25498,7 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
     enable_guided_autonomy(&mut config);
     preapprove_tool_call(&mut config, "delegate");
     config.tools.delegate.max_depth = 2;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25599,7 +25608,7 @@ async fn handle_turn_with_runtime_executes_session_wait_via_default_dispatcher()
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25691,7 +25700,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_tools_via_default_d
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.conversation.safe_lane_plan_execution_enabled = true;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25777,7 +25786,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
     config.telegram.base_url = base_url;
     config.telegram.allowed_chat_ids = vec![123];
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25873,7 +25882,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_session_wait_via_default_di
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
     config.conversation.safe_lane_plan_execution_enabled = true;
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
     repo.create_session(crate::session::repository::NewSessionRecord {
@@ -25965,13 +25974,13 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-context-mismatch";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26082,13 +26091,13 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-context-fingerprint-mismatch";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26206,13 +26215,13 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_malformed_prepara
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-preparation-malformed";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26319,13 +26328,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_after_turn_rep
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let session_id = "session-turn-checkpoint-repair-after-turn-fail";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26431,13 +26440,13 @@ async fn repair_turn_checkpoint_tail_with_runtime_persists_failed_compaction_rep
     config.conversation.compact_fail_open = false;
 
     let session_id = "session-turn-checkpoint-repair-compaction-fail";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26547,13 +26556,13 @@ async fn durable_turn_checkpoint_repair_persists_finalized_checkpoint_and_repeat
     config.conversation.compact_fail_open = false;
 
     let session_id = "session-turn-checkpoint-durable-repair-idempotent";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -26715,7 +26724,7 @@ async fn repair_turn_checkpoint_tail_with_runtime_recovers_discovery_followup_ch
     let session_id = "session-turn-checkpoint-discovery-followup-repair";
     let user_input = "search for the right tool, then read and summarize note.md";
     let final_reply = "Summary: the note says hello from discovery followup repair.";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     let harness = TurnTestHarness::new();
     std::fs::write(
@@ -26860,13 +26869,13 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
     config.conversation.compact_fail_open = false;
 
     let session_id = "session-turn-checkpoint-durable-repair-retry";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
-    crate::memory::append_turn_direct(
+    append_session_turn_direct(
         session_id,
         "assistant",
         &json!({
@@ -27470,7 +27479,7 @@ async fn default_context_engine_compact_context_rewrites_persisted_window() {
     config.memory.sqlite_path = db_path.clone();
     config.memory.sliding_window = 32;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx =
         test_kernel_context_with_memory("test-default-context-engine-compaction", &memory_config);
     let session_id = "default-context-engine-compaction";
@@ -27485,7 +27494,7 @@ async fn default_context_engine_compact_context_rewrites_persisted_window() {
         ("user", "recent ask"),
         ("assistant", "recent reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed turns should succeed");
     }
 
@@ -27495,8 +27504,8 @@ async fn default_context_engine_compact_context_rewrites_persisted_window() {
         .await
         .expect("default engine compaction should succeed");
 
-    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
-        .expect("window load should succeed");
+    let turns =
+        window_session_turns(session_id, 32, &memory_config).expect("window load should succeed");
 
     assert_eq!(turns.len(), 7);
     assert_eq!(turns[0].role, "user");
@@ -27521,7 +27530,7 @@ async fn default_context_engine_compact_context_compacts_full_session_but_assemb
     config.memory.sqlite_path = db_path.clone();
     config.memory.sliding_window = 4;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx = test_kernel_context_with_memory(
         "test-default-context-engine-compaction-clamp",
         &memory_config,
@@ -27536,7 +27545,7 @@ async fn default_context_engine_compact_context_compacts_full_session_but_assemb
         ("user", "recent ask"),
         ("assistant", "recent reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed turns should succeed");
     }
 
@@ -27546,8 +27555,8 @@ async fn default_context_engine_compact_context_compacts_full_session_but_assemb
         .await
         .expect("default engine compaction should succeed");
 
-    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
-        .expect("window load should succeed");
+    let turns =
+        window_session_turns(session_id, 32, &memory_config).expect("window load should succeed");
     assert_eq!(turns.len(), 4);
     assert_eq!(turns[0].role, "user");
     assert!(turns[0].content.contains("Compacted 3 earlier turns"));
@@ -27594,7 +27603,7 @@ async fn default_context_engine_compact_context_rewrites_from_full_session_snaps
     config.memory.sliding_window = 4;
     config.conversation.compact_preserve_recent_turns = 2;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx = test_kernel_context_with_memory(
         "test-default-context-engine-compaction-full-session-snapshot",
         &memory_config,
@@ -27613,7 +27622,7 @@ async fn default_context_engine_compact_context_rewrites_from_full_session_snaps
         ("user", "turn 9"),
         ("assistant", "turn 10"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed turns should succeed");
     }
 
@@ -27623,8 +27632,8 @@ async fn default_context_engine_compact_context_rewrites_from_full_session_snaps
         .await
         .expect("default engine compaction should succeed");
 
-    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
-        .expect("window load should succeed");
+    let turns =
+        window_session_turns(session_id, 32, &memory_config).expect("window load should succeed");
     assert_eq!(turns.len(), 3);
     assert_eq!(turns[0].role, "user");
     assert!(turns[0].content.contains("Compacted 8 earlier turns"));
@@ -27647,7 +27656,7 @@ async fn default_context_engine_compact_context_summarizes_visible_history_not_c
     config.memory.sliding_window = 32;
     config.conversation.compact_preserve_recent_turns = 2;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx = test_kernel_context_with_memory(
         "test-default-context-engine-compaction-visible-history",
         &memory_config,
@@ -27682,7 +27691,7 @@ async fn default_context_engine_compact_context_summarizes_visible_history_not_c
         ("user", "recent ask"),
         ("assistant", "recent reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed turns should succeed");
     }
 
@@ -27849,7 +27858,7 @@ async fn default_context_engine_compact_context_preserves_existing_summarized_hi
     config.memory.sliding_window = 2;
     config.conversation.compact_preserve_recent_turns = 1;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx = test_kernel_context_with_memory(
         "test-default-context-engine-preserve-summary-history",
         &memory_config,
@@ -27862,7 +27871,7 @@ async fn default_context_engine_compact_context_preserves_existing_summarized_hi
         ("user", "turn 3"),
         ("assistant", "turn 4"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed turns should succeed");
     }
 
@@ -27909,7 +27918,7 @@ async fn default_context_engine_compact_context_can_run_again_after_a_prior_chec
     config.memory.sliding_window = 32;
     config.conversation.compact_preserve_recent_turns = 2;
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = session_store_config_from_config(&config);
     let kernel_ctx = test_kernel_context_with_memory(
         "test-default-context-engine-repeated-compaction",
         &memory_config,
@@ -27926,7 +27935,7 @@ async fn default_context_engine_compact_context_can_run_again_after_a_prior_chec
         ("user", "recent ask"),
         ("assistant", "recent reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("seed initial turns should succeed");
     }
 
@@ -27942,7 +27951,7 @@ async fn default_context_engine_compact_context_can_run_again_after_a_prior_chec
         ("user", "newest ask"),
         ("assistant", "newest reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+        append_session_turn_direct(session_id, role, content, &memory_config)
             .expect("append follow-up turns should succeed");
     }
 
@@ -27951,8 +27960,8 @@ async fn default_context_engine_compact_context_can_run_again_after_a_prior_chec
         .await
         .expect("second compaction should succeed");
 
-    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
-        .expect("window load should succeed");
+    let turns =
+        window_session_turns(session_id, 32, &memory_config).expect("window load should succeed");
     let summary = &turns[0].content;
 
     assert_eq!(turns.len(), 3);
@@ -28109,7 +28118,7 @@ async fn handle_turn_with_runtime_persists_completed_compaction_checkpoint_when_
     config.conversation.compact_fail_open = false;
 
     let session_id = "session-turn-checkpoint-default-engine-compaction";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
     for (role, content) in [
         ("user", "ask 1"),
@@ -28121,7 +28130,7 @@ async fn handle_turn_with_runtime_persists_completed_compaction_checkpoint_when_
         ("user", "recent ask"),
         ("assistant", "recent reply"),
     ] {
-        crate::memory::append_turn_direct(session_id, role, content, &mem_config)
+        append_session_turn_direct(session_id, role, content, &mem_config)
             .expect("seed turn should succeed");
     }
 
@@ -28156,8 +28165,7 @@ async fn handle_turn_with_runtime_persists_completed_compaction_checkpoint_when_
         .expect("turn should succeed with durable compaction");
     assert_eq!(reply, "fresh reply");
 
-    let turns =
-        crate::memory::window_direct(session_id, 32, &mem_config).expect("load compacted turns");
+    let turns = window_session_turns(session_id, 32, &mem_config).expect("load compacted turns");
     let assistant_contents = turns
         .iter()
         .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
@@ -28211,11 +28219,11 @@ async fn handle_turn_with_runtime_persists_failed_open_compaction_checkpoint_whe
     config.conversation.compact_fail_open = true;
 
     let session_id = "session-turn-checkpoint-compaction-failed-open";
-    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let mem_config = session_store_config_from_config(&config);
 
-    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+    append_session_turn_direct(session_id, "user", "hello", &mem_config)
         .expect("persist user turn");
-    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+    append_session_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
         .expect("persist assistant turn");
 
     let runtime = FakeRuntime::with_turns_and_completions(
@@ -28251,8 +28259,7 @@ async fn handle_turn_with_runtime_persists_failed_open_compaction_checkpoint_whe
     assert_eq!(reply, "assistant-reply-2");
     assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
 
-    let turns =
-        crate::memory::window_direct(session_id, 16, &mem_config).expect("load fail-open turns");
+    let turns = window_session_turns(session_id, 16, &mem_config).expect("load fail-open turns");
     let assistant_contents = turns
         .iter()
         .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -31,12 +31,12 @@ use crate::acp::{
     AcpConversationTurnOptions, AcpTurnEventSink, evaluate_acp_conversation_turn_entry_for_address,
     execute_acp_conversation_turn_for_address,
 };
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::delegate_runtime::{
     DelegateChildExecutionPolicy, build_delegate_child_lifecycle_seed,
 };
 use crate::runtime_self_continuity;
+use crate::session::store::{self, SessionStoreConfig};
 
 use self::safe_lane_events::*;
 use self::safe_lane_execution::*;
@@ -1680,7 +1680,7 @@ impl ConversationTurnCoordinator {
     ) -> CliResult<TurnCheckpointTailRepairOutcome> {
         #[cfg(feature = "memory-sqlite")]
         {
-            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+            let memory_config = store::session_store_config_from_memory_config(&config.memory);
             let Some(entry) = load_latest_turn_checkpoint_entry(
                 session_id,
                 config.memory.sliding_window,
@@ -1714,7 +1714,7 @@ impl ConversationTurnCoordinator {
     ) -> CliResult<TurnCheckpointDiagnostics> {
         #[cfg(feature = "memory-sqlite")]
         {
-            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+            let memory_config = store::session_store_config_from_memory_config(&config.memory);
             let (summary, latest_entry) =
                 load_turn_checkpoint_history_snapshot(session_id, limit, binding, &memory_config)
                     .await?
@@ -2149,7 +2149,7 @@ impl ConversationTurnCoordinator {
             runtime.bootstrap(config, session_id, kernel_ctx).await?;
         }
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
         let repo = SessionRepository::new(&memory_config)?;
         let Some(pending_request) = repo
             .list_approval_requests_for_session(session_id, Some(ApprovalRequestStatus::Pending))?
@@ -2463,7 +2463,7 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
             .filter(|value| !value.is_empty())
             .map(|_| config.tools.resolved_file_root());
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
         let compact_stage_result =
             crate::memory::run_compact_stage(session_id, workspace_root.as_deref(), &memory_config)
                 .await;
@@ -2512,7 +2512,7 @@ fn persist_runtime_self_continuity_for_compaction(
     config: &LoongConfig,
     session_id: &str,
 ) -> Result<(), String> {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
 
     ensure_session_exists_for_runtime_self_continuity(&repo, session_id)?;
@@ -3799,7 +3799,7 @@ async fn probe_turn_checkpoint_tail_runtime_gate_entry_with_limit<
     limit: usize,
     binding: ConversationRuntimeBinding<'_>,
 ) -> CliResult<Option<TurnCheckpointTailRepairRuntimeProbe>> {
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     let Some(entry) =
         load_latest_turn_checkpoint_entry(session_id, limit, binding, &memory_config).await?
     else {
@@ -4094,8 +4094,7 @@ where
 
                 #[cfg(feature = "memory-sqlite")]
                 {
-                    let memory_config =
-                        MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+                    let memory_config = SessionStoreConfig::from_memory_config(&self.config.memory);
                     let effective_tool_config =
                         effective_tool_config_for_session(&self.config.tools, session_context);
                     let approval_runtime = CoordinatorApprovalResolutionRuntime::new(
@@ -4271,7 +4270,9 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     let child_label = delegate_policy.label.clone();
     let subagent_identity =
         crate::tools::delegate::subagent_identity_for_delegate_request(&delegate_request);
-    let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
+    let repo = SessionRepository::new(&store::session_store_config_from_memory_config(
+        &config.memory,
+    ))?;
     let next_child_depth = next_delegate_child_depth_for_delegate(config, &repo, session_context)?;
     let runtime_self_continuity =
         effective_runtime_self_continuity_for_session(config, session_context);
@@ -4463,7 +4464,7 @@ async fn enqueue_background_task_with_runtime<R: ConversationRuntime + ?Sized>(
 
 #[cfg(feature = "memory-sqlite")]
 struct PreparedAsyncDelegateEnqueue {
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     request: AsyncDelegateSpawnRequest,
     outcome: loong_contracts::ToolCoreOutcome,
 }
@@ -4483,7 +4484,7 @@ async fn build_delegate_async_enqueue_request<R: ConversationRuntime + ?Sized>(
     let child_label = delegate_policy.label.clone();
     let subagent_identity =
         crate::tools::delegate::subagent_identity_for_delegate_request(&delegate_request);
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
 
     ensure_session_exists_for_runtime_self_continuity(&repo, &session_context.session_id)?;
@@ -4689,7 +4690,9 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
     // been created. The remaining job is to run the child turn with the shared
     // runtime/binding, enforce timeout + unwind containment, and then finalize
     // the persisted delegate session/announcement state from the outcome.
-    let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
+    let repo = SessionRepository::new(&store::session_store_config_from_memory_config(
+        &config.memory,
+    ))?;
     let start = Instant::now();
     let child_coordinator = ConversationTurnCoordinator::new();
     let child_turn_future = child_coordinator.handle_turn_with_runtime(
@@ -4987,7 +4990,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         }
     };
     let base_app_dispatcher = DefaultAppToolDispatcher::with_config(
-        MemoryRuntimeConfig::from_memory_config(&config.memory),
+        store::session_store_config_from_memory_config(&config.memory),
         config.clone(),
     );
     let app_dispatcher = CoordinatorAppToolDispatcher {
@@ -5962,7 +5965,7 @@ async fn load_safe_lane_history_signals_for_governor(
         .safe_lane_session_governor_window_turns();
     #[cfg(feature = "memory-sqlite")]
     {
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
         return match load_assistant_contents_from_session_window_detailed(
             session_id,
             window_turns,
@@ -6371,12 +6374,12 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn sqlite_memory_config(label: &str) -> MemoryRuntimeConfig {
+    fn sqlite_memory_config(label: &str) -> SessionStoreConfig {
         let path = unique_sqlite_path(label);
         let _ = std::fs::remove_file(&path);
         let mut config = LoongConfig::default();
         config.memory.sqlite_path = path.display().to_string();
-        MemoryRuntimeConfig::from_memory_config(&config.memory)
+        store::session_store_config_from_memory_config(&config.memory)
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -8142,15 +8145,15 @@ mod tests {
         config.conversation.compact_trigger_estimated_tokens = Some(1);
         config.conversation.compact_fail_open = true;
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::append_turn_direct(
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
+        crate::session::store::append_session_turn_direct(
             "session-durable-flush-fail-open",
             "user",
             "remember the deployment cutoff",
             &memory_config,
         )
         .expect("append user turn");
-        crate::memory::append_turn_direct(
+        crate::session::store::append_session_turn_direct(
             "session-durable-flush-fail-open",
             "assistant",
             "deployment cutoff is tonight",
@@ -8198,8 +8201,8 @@ mod tests {
         let _ = std::fs::remove_file(&sqlite_path);
         config.memory.sqlite_path = sqlite_path.display().to_string();
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::append_turn_direct(
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
+        crate::session::store::append_session_turn_direct(
             "compact-session-build-messages",
             "user",
             "remember this detail",
@@ -8255,8 +8258,8 @@ mod tests {
         let _ = std::fs::remove_file(&sqlite_path);
         config.memory.sqlite_path = sqlite_path.display().to_string();
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        crate::memory::append_turn_direct(
+        let memory_config = store::session_store_config_from_memory_config(&config.memory);
+        crate::session::store::append_session_turn_direct(
             "compact-session-readback-fail",
             "user",
             "keep the context intact",

--- a/crates/app/src/conversation/turn_coordinator/provider_turn_apply.rs
+++ b/crates/app/src/conversation/turn_coordinator/provider_turn_apply.rs
@@ -279,7 +279,7 @@ where
                 #[cfg(feature = "memory-sqlite")]
                 {
                     let memory_config =
-                        MemoryRuntimeConfig::from_memory_config(&self.config.memory);
+                        store::session_store_config_from_memory_config(&self.config.memory);
                     let effective_tool_config =
                         effective_tool_config_for_session(&self.config.tools, session_context);
                     let approval_runtime = CoordinatorApprovalResolutionRuntime::new(

--- a/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
+++ b/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
@@ -44,7 +44,7 @@ pub(super) async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         }
     };
     let base_app_dispatcher = DefaultAppToolDispatcher::with_config(
-        MemoryRuntimeConfig::from_memory_config(&config.memory),
+        store::session_store_config_from_memory_config(&config.memory),
         config.clone(),
     );
     let app_dispatcher = CoordinatorAppToolDispatcher {

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -16,7 +16,6 @@ use crate::config::{
     GovernedToolApprovalMode, LoongConfig, SessionVisibility, ToolConfig, ToolConsentMode,
 };
 use crate::context::KernelContext;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::approval_runtime::{GovernedToolApprovalRequest, OperatorApprovalRuntime};
 #[cfg(feature = "memory-sqlite")]
@@ -27,6 +26,7 @@ use crate::operator::session_graph::OperatorSessionGraph;
 use crate::session::repository::{
     NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
 };
+use crate::session::store::{self, SessionStoreConfig};
 use crate::tools::runtime_events::{
     ToolRuntimeEvent, ToolRuntimeEventSink, with_tool_runtime_event_sink,
 };
@@ -568,13 +568,13 @@ impl ToolExecutionPreflight {
 
 #[derive(Clone)]
 pub struct DefaultAppToolDispatcher {
-    memory_config: MemoryRuntimeConfig,
+    memory_config: SessionStoreConfig,
     tool_config: ToolConfig,
     app_config: Option<Arc<LoongConfig>>,
 }
 
 impl DefaultAppToolDispatcher {
-    pub fn new(memory_config: MemoryRuntimeConfig, tool_config: ToolConfig) -> Self {
+    pub fn new(memory_config: SessionStoreConfig, tool_config: ToolConfig) -> Self {
         Self {
             memory_config,
             tool_config,
@@ -582,7 +582,7 @@ impl DefaultAppToolDispatcher {
         }
     }
 
-    pub fn with_config(memory_config: MemoryRuntimeConfig, app_config: LoongConfig) -> Self {
+    pub fn with_config(memory_config: SessionStoreConfig, app_config: LoongConfig) -> Self {
         Self {
             memory_config,
             tool_config: app_config.tools.clone(),
@@ -592,7 +592,7 @@ impl DefaultAppToolDispatcher {
 
     pub fn runtime() -> Self {
         Self::new(
-            crate::memory::runtime_config::get_memory_runtime_config().clone(),
+            store::current_session_store_config().clone(),
             ToolConfig::default(),
         )
     }
@@ -3969,7 +3969,7 @@ mod tests {
         SessionRepository, SessionState,
     };
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-turn-engine-approval-{test_name}-{}",
             std::process::id()
@@ -3977,9 +3977,9 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::acp::{AcpTurnEventSink, JsonlAcpTurnEventSink};
-use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::session::store;
 
 use super::super::config::LoongConfig;
 use super::ProviderErrorMode;
@@ -120,7 +120,7 @@ impl ConversationTurnLoop {
         let session_context = runtime.session_context(config, session_id, binding)?;
         let tool_view = session_context.tool_view.clone();
         let app_dispatcher = DefaultAppToolDispatcher::with_config(
-            MemoryRuntimeConfig::from_memory_config(&config.memory),
+            store::session_store_config_from_memory_config(&config.memory),
             config.clone(),
         );
         let turn_id = super::turn_shared::next_conversation_turn_id();

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "memory-sqlite")]
+use std::path::Path;
+#[cfg(feature = "memory-sqlite")]
 use std::path::PathBuf;
 #[cfg(test)]
 use std::{
@@ -250,6 +252,18 @@ pub fn append_turn_direct(
     sqlite::append_turn_direct(session_id, role, content, config)
 }
 
+#[cfg(all(test, feature = "memory-sqlite"))]
+#[allow(dead_code)]
+pub(crate) fn append_turn_direct_with_sqlite_path(
+    session_id: &str,
+    role: &str,
+    content: &str,
+    sqlite_path: &Path,
+) -> Result<(), String> {
+    let config = runtime_config::MemoryRuntimeConfig::for_sqlite_path(sqlite_path.to_path_buf());
+    append_turn_direct(session_id, role, content, &config)
+}
+
 #[cfg(feature = "memory-sqlite")]
 #[cfg(test)]
 pub fn replace_session_turns_direct(
@@ -336,6 +350,45 @@ pub(crate) fn search_canonical_memory(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<Vec<CanonicalMemorySearchHit>, String> {
     sqlite::search_canonical_records_for_recall(query, limit, exclude_session_id, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn search_canonical_memory_with_sqlite_path(
+    query: &str,
+    limit: usize,
+    exclude_session_id: Option<&str>,
+    sqlite_path: &Path,
+) -> Result<Vec<CanonicalMemorySearchHit>, String> {
+    let config = runtime_config::MemoryRuntimeConfig::for_sqlite_path(sqlite_path.to_path_buf());
+    search_canonical_memory(query, limit, exclude_session_id, &config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn build_read_stage_envelope_request_for_memory_config(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &crate::config::MemoryConfig,
+) -> MemoryCoreRequest {
+    let runtime_config = runtime_config::MemoryRuntimeConfig::from_memory_config(config);
+    build_read_stage_envelope_request_with_workspace_root(
+        session_id,
+        workspace_root,
+        &runtime_config,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn hydrate_stage_envelope_for_memory_config(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &crate::config::MemoryConfig,
+) -> Result<StageEnvelope, String> {
+    let runtime_config = runtime_config::MemoryRuntimeConfig::from_memory_config(config);
+    orchestrator::hydrate_stage_envelope_with_workspace_root(
+        session_id,
+        workspace_root,
+        &runtime_config,
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -614,7 +614,7 @@ fn recent_window_records(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{MemoryMode, MemoryProfile};
+    use crate::config::MemoryProfile;
     use crate::memory::{
         DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, MemoryContextKind, MemoryRecallMode,
         MemoryScope, MemoryStageFamily, MemorySystem, MemorySystemCapability, MemorySystemMetadata,
@@ -649,6 +649,26 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
+    fn sqlite_memory_config(
+        db_path: std::path::PathBuf,
+    ) -> crate::memory::runtime_config::MemoryRuntimeConfig {
+        crate::memory::runtime_config::MemoryRuntimeConfig::for_sqlite_path(db_path)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn sqlite_memory_config_with_profile(
+        db_path: std::path::PathBuf,
+        profile: MemoryProfile,
+        sliding_window: usize,
+    ) -> crate::memory::runtime_config::MemoryRuntimeConfig {
+        let mut config = sqlite_memory_config(db_path);
+        config.profile = profile;
+        config.mode = profile.mode();
+        config.sliding_window = sliding_window;
+        config
+    }
+
+    #[cfg(feature = "memory-sqlite")]
     #[test]
     fn hydrated_memory_builtin_orchestrator_returns_recent_window_records() {
         let tmp = hydrated_memory_temp_dir("loong-hydrated-window");
@@ -656,13 +676,8 @@ mod tests {
         let db_path = tmp.join("window.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct("hydrated-window", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -690,10 +705,7 @@ mod tests {
         let db_path = tmp.join("diagnostics.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_memory_config(db_path.clone());
 
         let hydrated = hydrate_memory_context("hydrated-diagnostics", &config)
             .expect("hydrate memory context");
@@ -721,13 +733,8 @@ mod tests {
         let db_path = tmp.join("summary.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("hydrated-summary", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -768,13 +775,8 @@ mod tests {
         let db_path = tmp.join("cross-session-recall.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 8,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 8);
 
         append_turn_direct(
             "prior-session",
@@ -829,14 +831,9 @@ mod tests {
         let db_path = tmp.join("profile.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::ProfilePlusWindow,
-            mode: MemoryMode::ProfilePlusWindow,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            profile_note: Some("Imported ZeroClaw preferences".to_owned()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::ProfilePlusWindow, 2);
+        config.profile_note = Some("Imported ZeroClaw preferences".to_owned());
 
         let hydrated =
             hydrate_memory_context("hydrated-profile", &config).expect("hydrate memory context");
@@ -868,13 +865,8 @@ mod tests {
         let db_path = tmp.join("stage-order.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("stage-order", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -924,13 +916,8 @@ mod tests {
         let db_path = tmp.join("stage-fallback.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -974,13 +961,8 @@ mod tests {
             .display()
             .to_string();
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 4);
 
         let envelope = hydrate_stage_envelope_with_workspace_root(
             "stage-window-plus-summary",
@@ -1088,13 +1070,8 @@ mod tests {
         let db_path = tmp.join("retrieval-query.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 4);
 
         append_turn_direct(
             "stage-retrieval-query",
@@ -1151,13 +1128,8 @@ mod tests {
         let db_path = tmp.join("window-only.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
 
         let envelope =
             hydrate_stage_envelope("stage-window-only", &config).expect("hydrate staged envelope");
@@ -1185,14 +1157,9 @@ mod tests {
             .display()
             .to_string();
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::ProfilePlusWindow,
-            mode: MemoryMode::ProfilePlusWindow,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            profile_note: Some("Imported ZeroClaw preferences".to_owned()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::ProfilePlusWindow, 4);
+        config.profile_note = Some("Imported ZeroClaw preferences".to_owned());
 
         let envelope = hydrate_stage_envelope_with_workspace_root(
             "stage-profile-plus-window",
@@ -1250,13 +1217,8 @@ mod tests {
         let db_path = tmp.join("registry-selected.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
         config.resolved_system_id = Some(REGISTRY_RETRIEVE_ONLY_SYSTEM_ID.to_owned());
 
         append_turn_direct("registry-selected", "user", "turn 1", &config)
@@ -1332,13 +1294,8 @@ mod tests {
         let db_path = tmp.join("workspace-recall.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
         config.resolved_system_id = Some(WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
 
         append_turn_direct("workspace-recall", "user", "turn 1", &config)
@@ -1441,13 +1398,8 @@ mod tests {
         let memory_file_path = tmp.join("MEMORY.md");
         std::fs::write(&memory_file_path, "curated workspace fact").expect("write memory file");
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
         config.resolved_system_id =
             Some(crate::memory::WORKSPACE_RECALL_MEMORY_SYSTEM_ID.to_owned());
 
@@ -1494,13 +1446,8 @@ mod tests {
         let db_path = tmp.join("unknown-selected.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
         config.resolved_system_id = Some("lucid".to_owned());
 
         append_turn_direct("unknown-selected", "user", "turn 1", &config)
@@ -1538,13 +1485,8 @@ mod tests {
         let db_path = tmp.join("compact-stage.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("compact-stage-succeeded", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1574,13 +1516,8 @@ mod tests {
         let db_path = tmp.join("compact-stage-skipped.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("compact-stage-skipped", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1607,13 +1544,8 @@ mod tests {
         let db_path = tmp.join("compact-stage-duplicate.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("compact-stage-duplicate", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1654,13 +1586,8 @@ mod tests {
         let db_path = tmp.join("compact-stage-registry-selected.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
         config.resolved_system_id = Some(REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID.to_owned());
 
         append_turn_direct("compact-stage-registry-selected", "user", "turn 1", &config)
@@ -1705,13 +1632,8 @@ mod tests {
         let db_path = tmp.join("derivation.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1756,13 +1678,8 @@ mod tests {
         let db_path = tmp.join("retrieval.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1807,13 +1724,8 @@ mod tests {
         let db_path = tmp.join("rank.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct(session_id, "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -1858,13 +1770,8 @@ mod tests {
         let db_path = tmp.join("strict-reserved.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
         config.fail_open = false;
 
         append_turn_direct(session_id, "assistant", "turn 1", &config)

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -147,6 +147,18 @@ impl MemoryRuntimeConfig {
         Self::from_memory_config_base(config)
     }
 
+    /// Build a minimal runtime config bound to one explicit SQLite path.
+    ///
+    /// This is intended for tooling and tests that need to inspect canonical
+    /// memory records through the same runtime surface without constructing a
+    /// full `MemoryConfig`.
+    pub fn for_sqlite_path(sqlite_path: impl Into<PathBuf>) -> Self {
+        Self {
+            sqlite_path: Some(sqlite_path.into()),
+            ..Self::default()
+        }
+    }
+
     pub const fn strict_mode_requested(&self) -> bool {
         !self.fail_open
     }
@@ -282,6 +294,17 @@ mod tests {
             config.sqlite_path,
             Some(PathBuf::from("/tmp/test-memory.sqlite3"))
         );
+    }
+
+    #[test]
+    fn runtime_config_for_sqlite_path_sets_only_explicit_sqlite_override() {
+        let config = MemoryRuntimeConfig::for_sqlite_path("/tmp/helper-memory.sqlite3");
+
+        assert_eq!(
+            config.sqlite_path,
+            Some(PathBuf::from("/tmp/helper-memory.sqlite3"))
+        );
+        assert_eq!(config.backend, MemoryBackendKind::Sqlite);
     }
 
     #[test]

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -289,13 +289,13 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
         ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionRecord,
         SessionKind, SessionRepository, SessionState,
     };
+    use crate::session::store::SessionStoreConfig;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let process_id = std::process::id();
         let temp_dir = std::env::temp_dir();
         let directory_name = format!("loong-operator-approval-runtime-{test_name}-{process_id}");
@@ -305,9 +305,9 @@ mod tests {
         let db_path = base_dir.join("memory.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
@@ -328,7 +328,7 @@ mod tests {
         repo.create_session(session_record).expect("create session");
     }
 
-    fn delete_session_row(memory_config: &MemoryRuntimeConfig, session_id: &str) {
+    fn delete_session_row(memory_config: &SessionStoreConfig, session_id: &str) {
         let db_path = memory_config
             .sqlite_path
             .as_ref()

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -9,7 +9,6 @@ use crate::conversation::{
     ConstrainedSubagentProfile, ConstrainedSubagentTerminalReason, ConversationRuntimeBinding,
     DelegateBuiltinProfile,
 };
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity::RuntimeSelfContinuity;
 use crate::session::frozen_result::capture_frozen_result;
 use crate::session::recovery::{
@@ -20,6 +19,7 @@ use crate::session::repository::{
     CreateSessionWithEventRequest, FinalizeSessionTerminalRequest, NewSessionRecord, SessionKind,
     SessionRepository, SessionState,
 };
+use crate::session::store::SessionStoreConfig;
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::trust::{
     delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
@@ -276,7 +276,7 @@ fn build_delegate_child_event_payload(
 
 #[cfg(test)]
 pub(crate) fn finalize_async_delegate_spawn_failure(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
@@ -306,7 +306,7 @@ pub(crate) fn finalize_async_delegate_spawn_failure(
 }
 
 pub(crate) fn finalize_async_delegate_spawn_failure_with_recovery(
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
@@ -597,8 +597,8 @@ mod tests {
 
     use super::*;
     use crate::config::LoongConfig;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{NewSessionEvent, NewSessionRecord};
+    use crate::session::store::SessionStoreConfig;
     use crate::trust::extract_trust_event_payload;
 
     fn isolated_repo(test_name: &str) -> SessionRepository {
@@ -612,9 +612,9 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_file(&sqlite_path);
-        let config = MemoryRuntimeConfig {
+        let config = SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         };
         let repo = SessionRepository::new(&config).expect("session repository");
         let sqlite_path = config.sqlite_path.expect("sqlite path");
@@ -919,9 +919,9 @@ mod tests {
         drop(conn);
 
         finalize_async_delegate_spawn_failure_with_recovery(
-            &MemoryRuntimeConfig {
+            &SessionStoreConfig {
                 sqlite_path: Some(sqlite_path),
-                ..MemoryRuntimeConfig::default()
+                ..SessionStoreConfig::default()
             },
             "child-session",
             "root-session",

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -81,12 +81,12 @@ mod tests {
 
     use rusqlite::params;
 
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
         NewSessionRecord, SessionKind, SessionRepository, SessionState,
     };
+    use crate::session::store::SessionStoreConfig;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let process_id = std::process::id();
         let temp_dir = std::env::temp_dir();
         let directory_name = format!("loong-operator-session-graph-{test_name}-{process_id}");
@@ -96,13 +96,13 @@ mod tests {
         let db_path = base_dir.join("memory.sqlite3");
         let _ = std::fs::remove_file(&db_path);
 
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
-    fn delete_session_row(memory_config: &MemoryRuntimeConfig, session_id: &str) {
+    fn delete_session_row(memory_config: &SessionStoreConfig, session_id: &str) {
         let sqlite_path = memory_config
             .sqlite_path
             .as_ref()

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -5,6 +5,9 @@ pub mod recovery;
 pub mod repository;
 
 #[cfg(feature = "memory-sqlite")]
+pub mod store;
+
+#[cfg(feature = "memory-sqlite")]
 pub mod trajectory;
 
 #[cfg(feature = "memory-sqlite")]
@@ -15,9 +18,9 @@ pub const LATEST_SESSION_SELECTOR: &str = "latest";
 
 #[cfg(feature = "memory-sqlite")]
 pub fn latest_resumable_root_session_id(
-    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+    store_config: &store::SessionStoreConfig,
 ) -> crate::CliResult<Option<String>> {
-    let repo = repository::SessionRepository::new(memory_config)?;
+    let repo = repository::SessionRepository::new(store_config)?;
     let latest_session = repo.latest_resumable_root_session_summary()?;
     let latest_session_id = latest_session.map(|summary| summary.session_id);
     Ok(latest_session_id)
@@ -73,29 +76,28 @@ mod delegate_cancelled_reason_tests {
 mod latest_cli_session_selector_tests {
     use super::LATEST_SESSION_SELECTOR;
     use super::latest_resumable_root_session_id;
-    use crate::memory;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::NewSessionRecord;
     use crate::session::repository::SessionKind;
     use crate::session::repository::SessionRepository;
     use crate::session::repository::SessionState;
+    use crate::session::store;
     use crate::test_support::unique_temp_dir;
     use rusqlite::Connection;
     use rusqlite::params;
     use std::path::Path;
     use std::path::PathBuf;
 
-    fn init_selector_test_memory(label: &str) -> (PathBuf, MemoryRuntimeConfig) {
+    fn init_selector_test_memory(label: &str) -> (PathBuf, store::SessionStoreConfig) {
         let root = unique_temp_dir(label);
         std::fs::create_dir_all(&root).expect("create selector test workspace");
 
         let sqlite_path = root.join("memory.sqlite3");
-        let config = MemoryRuntimeConfig {
+        let config = store::SessionStoreConfig {
             sqlite_path: Some(sqlite_path.clone()),
-            ..MemoryRuntimeConfig::default()
+            ..store::SessionStoreConfig::default()
         };
 
-        memory::ensure_memory_db_ready(Some(sqlite_path), &config)
+        store::ensure_session_store_ready(Some(sqlite_path), &config)
             .expect("initialize selector test memory");
 
         (root, config)
@@ -117,12 +119,12 @@ mod latest_cli_session_selector_tests {
     }
 
     fn append_session_turn(
-        memory_config: &MemoryRuntimeConfig,
+        store_config: &store::SessionStoreConfig,
         session_id: &str,
         role: &str,
         content: &str,
     ) {
-        memory::append_turn_direct(session_id, role, content, memory_config)
+        store::append_session_turn_direct(session_id, role, content, store_config)
             .expect("append selector test turn");
     }
 

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -8,10 +8,8 @@ use rusqlite::{
 use serde_json::Value;
 
 use super::frozen_result::FrozenResult;
+use super::store::{self, SessionStoreConfig, SessionTranscriptTurn};
 use crate::config::ToolConsentMode;
-use crate::memory;
-use crate::memory::ConversationTurn;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
 pub(crate) const SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE: usize = 200;
@@ -370,7 +368,7 @@ pub struct SessionTrajectoryReadSnapshot {
     pub summary: SessionSummaryRecord,
     pub lineage_root_session_id: Option<String>,
     pub lineage_depth: usize,
-    pub turns: Vec<ConversationTurn>,
+    pub turns: Vec<SessionTranscriptTurn>,
     pub events: Vec<SessionEventRecord>,
     pub approval_requests: Vec<ApprovalRequestRecord>,
     pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
@@ -474,8 +472,8 @@ pub struct SessionRepository {
 }
 
 impl SessionRepository {
-    pub fn new(config: &MemoryRuntimeConfig) -> Result<Self, String> {
-        let db_path = memory::ensure_memory_db_ready(config.sqlite_path.clone(), config)?;
+    pub fn new(config: &SessionStoreConfig) -> Result<Self, String> {
+        let db_path = store::ensure_session_store_ready(config.sqlite_path.clone(), config)?;
         Ok(Self { db_path })
     }
 
@@ -1220,7 +1218,7 @@ impl SessionRepository {
             let lineage_root_session_id =
                 Self::lineage_root_session_id_with_conn(conn, &session_id)?;
             let lineage_depth = Self::session_lineage_depth_with_conn(conn, &session_id)?;
-            let turns = memory::transcript_direct_paged_with_conn(
+            let turns = store::transcript_session_turns_paged_with_conn(
                 conn,
                 &session_id,
                 SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE,
@@ -3932,13 +3930,12 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::memory::append_turn_direct;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::store::{SessionStoreConfig, append_session_turn_direct};
     use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
     use super::*;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-session-repository-{test_name}-{}",
             std::process::id()
@@ -3946,9 +3943,9 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
@@ -3979,12 +3976,12 @@ mod tests {
     }
 
     fn append_session_turn(
-        config: &MemoryRuntimeConfig,
+        config: &SessionStoreConfig,
         session_id: &str,
         role: &str,
         content: &str,
     ) {
-        append_turn_direct(session_id, role, content, config).expect("append session turn");
+        append_session_turn_direct(session_id, role, content, config).expect("append session turn");
     }
 
     fn set_session_updated_at(repo: &SessionRepository, session_id: &str, updated_at: i64) {
@@ -4504,8 +4501,9 @@ mod tests {
     #[test]
     fn list_visible_sessions_infers_legacy_rows_from_turn_history_without_backfill() {
         let config = isolated_memory_config("legacy-visible-sessions");
-        append_turn_direct("telegram:123", "user", "hello", &config).expect("append user turn");
-        append_turn_direct("telegram:123", "assistant", "world", &config)
+        append_session_turn_direct("telegram:123", "user", "hello", &config)
+            .expect("append user turn");
+        append_session_turn_direct("telegram:123", "assistant", "world", &config)
             .expect("append assistant turn");
 
         let repo = SessionRepository::new(&config).expect("repository");
@@ -4536,9 +4534,10 @@ mod tests {
     #[test]
     fn inferred_legacy_session_kind_uses_known_prefixes() {
         let config = isolated_memory_config("legacy-kind-prefixes");
-        append_turn_direct("delegate:legacy-child", "assistant", "done", &config)
+        append_session_turn_direct("delegate:legacy-child", "assistant", "done", &config)
             .expect("append delegate turn");
-        append_turn_direct("telegram:456", "user", "ping", &config).expect("append telegram turn");
+        append_session_turn_direct("telegram:456", "user", "ping", &config)
+            .expect("append telegram turn");
 
         let repo = SessionRepository::new(&config).expect("repository");
         let delegate_session = repo
@@ -4819,7 +4818,7 @@ mod tests {
         })
         .expect("create child");
 
-        append_turn_direct(
+        append_session_turn_direct(
             "child-session",
             "assistant",
             "Deploy freeze window is Friday and migration starts Saturday.",

--- a/crates/app/src/session/store.rs
+++ b/crates/app/src/session/store.rs
@@ -1,0 +1,123 @@
+#[cfg(feature = "memory-sqlite")]
+use std::path::PathBuf;
+
+#[cfg(feature = "memory-sqlite")]
+use rusqlite::Connection;
+
+#[cfg(feature = "memory-sqlite")]
+use crate::config::MemoryConfig;
+
+#[cfg(feature = "memory-sqlite")]
+/// Transitional session-store adapter over the existing memory SQLite substrate.
+///
+/// This layer intentionally gives session-core callers one stable namespace for
+/// transcript and session durability while the underlying persistence backend
+/// still lives in `memory::*`.
+pub type SessionStoreConfig = crate::memory::runtime_config::MemoryRuntimeConfig;
+
+#[cfg(feature = "memory-sqlite")]
+pub type SessionTranscriptTurn = crate::memory::ConversationTurn;
+
+#[cfg(feature = "memory-sqlite")]
+pub type SessionWindowTurn = crate::memory::WindowTurn;
+
+#[cfg(feature = "memory-sqlite")]
+pub fn session_store_config_from_memory_config(config: &MemoryConfig) -> SessionStoreConfig {
+    SessionStoreConfig::from_memory_config(config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn session_store_config_from_memory_config_without_env_overrides(
+    config: &MemoryConfig,
+) -> SessionStoreConfig {
+    SessionStoreConfig::from_memory_config_without_env_overrides(config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn current_session_store_config() -> &'static SessionStoreConfig {
+    crate::memory::runtime_config::get_memory_runtime_config()
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn ensure_session_store_ready(
+    path: Option<PathBuf>,
+    config: &SessionStoreConfig,
+) -> Result<PathBuf, String> {
+    crate::memory::ensure_memory_db_ready(path, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn append_session_turn_direct(
+    session_id: &str,
+    role: &str,
+    content: &str,
+    config: &SessionStoreConfig,
+) -> Result<(), String> {
+    crate::memory::append_turn_direct(session_id, role, content, config)
+}
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+pub fn replace_session_turns_direct(
+    session_id: &str,
+    turns: &[SessionWindowTurn],
+    config: &SessionStoreConfig,
+) -> Result<(), String> {
+    crate::memory::replace_session_turns_direct(session_id, turns, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn window_session_turns(
+    session_id: &str,
+    limit: usize,
+    config: &SessionStoreConfig,
+) -> Result<Vec<SessionTranscriptTurn>, String> {
+    crate::memory::window_direct(session_id, limit, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn window_session_turns_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<SessionTranscriptTurn>, String> {
+    crate::memory::window_direct_with_conn(conn, session_id, limit)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn transcript_session_turns_paged_with_conn(
+    conn: &Connection,
+    session_id: &str,
+    page_size: usize,
+) -> Result<Vec<SessionTranscriptTurn>, String> {
+    crate::memory::transcript_direct_paged_with_conn(conn, session_id, page_size)
+}
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+mod tests {
+    use crate::session::store::{
+        SessionStoreConfig, append_session_turn_direct, ensure_session_store_ready,
+        window_session_turns,
+    };
+    use crate::test_support::unique_temp_dir;
+
+    #[test]
+    fn session_store_facade_round_trips_transcript_turns() {
+        let root = unique_temp_dir("session-store-facade");
+        std::fs::create_dir_all(&root).expect("create session store test root");
+        let sqlite_path = root.join("memory.sqlite3");
+        let config = SessionStoreConfig {
+            sqlite_path: Some(sqlite_path.clone()),
+            ..SessionStoreConfig::default()
+        };
+
+        ensure_session_store_ready(Some(sqlite_path), &config).expect("initialize session store");
+        append_session_turn_direct("session-store-test", "user", "hello", &config)
+            .expect("append turn");
+        let turns =
+            window_session_turns("session-store-test", 8, &config).expect("load session turns");
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].role, "user");
+        assert_eq!(turns[0].content, "hello");
+    }
+}

--- a/crates/app/src/session/trajectory.rs
+++ b/crates/app/src/session/trajectory.rs
@@ -4,10 +4,7 @@ use serde_json::Value;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-use crate::memory;
-use crate::memory::ConversationTurn;
 use crate::memory::canonical_memory_record_from_persisted_turn;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::repository::ApprovalDecision;
 use super::repository::ApprovalRequestRecord;
@@ -16,6 +13,7 @@ use super::repository::SessionEventRecord;
 use super::repository::SessionRepository;
 use super::repository::SessionSummaryRecord;
 use super::repository::SessionTerminalOutcomeRecord;
+use super::store::{self, SessionStoreConfig, SessionTranscriptTurn};
 
 pub const SESSION_TRAJECTORY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
 pub const SESSION_TRAJECTORY_ARTIFACT_SURFACE: &str = "runtime_trajectory";
@@ -140,7 +138,7 @@ pub struct SessionTrajectoryArtifact {
 
 pub fn export_session_trajectory(
     session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     options: &SessionTrajectoryExportOptions,
 ) -> Result<SessionTrajectoryArtifact, String> {
     validate_export_options(options)?;
@@ -213,17 +211,17 @@ fn load_export_turns_with_conn(
     conn: &rusqlite::Connection,
     session_id: &str,
     turn_limit: usize,
-) -> Result<Vec<ConversationTurn>, String> {
+) -> Result<Vec<SessionTranscriptTurn>, String> {
     if turn_limit == 0 {
         return Ok(Vec::new());
     }
 
-    let recent_turns = memory::window_direct_with_conn(conn, session_id, turn_limit)?;
+    let recent_turns = store::window_session_turns_with_conn(conn, session_id, turn_limit)?;
     if recent_turns.len() == turn_limit {
         return Ok(recent_turns);
     }
 
-    let transcript = memory::transcript_direct_paged_with_conn(
+    let transcript = store::transcript_session_turns_paged_with_conn(
         conn,
         session_id,
         SESSION_TRAJECTORY_TRANSCRIPT_PAGE_SIZE,
@@ -233,7 +231,10 @@ fn load_export_turns_with_conn(
     Ok(trimmed_transcript)
 }
 
-fn trim_turns_to_limit(turns: Vec<ConversationTurn>, turn_limit: usize) -> Vec<ConversationTurn> {
+fn trim_turns_to_limit(
+    turns: Vec<SessionTranscriptTurn>,
+    turn_limit: usize,
+) -> Vec<SessionTranscriptTurn> {
     let turn_count = turns.len();
     if turn_count <= turn_limit {
         return turns;
@@ -285,7 +286,7 @@ fn resolve_first_sequence(total_turn_count: usize, exported_turn_count: usize) -
 }
 
 fn build_trajectory_turns(
-    turns: &[ConversationTurn],
+    turns: &[SessionTranscriptTurn],
     first_sequence: usize,
 ) -> Vec<SessionTrajectoryTurn> {
     let mut trajectory_turns = Vec::with_capacity(turns.len());
@@ -313,7 +314,7 @@ fn build_trajectory_events(events: &[SessionEventRecord]) -> Vec<SessionTrajecto
 
 fn build_canonical_records(
     session_id: &str,
-    turns: &[ConversationTurn],
+    turns: &[SessionTranscriptTurn],
 ) -> Vec<SessionTrajectoryCanonicalRecord> {
     let mut canonical_records = Vec::with_capacity(turns.len());
 
@@ -383,7 +384,7 @@ impl SessionTrajectorySession {
 }
 
 impl SessionTrajectoryTurn {
-    fn from_turn(sequence: usize, turn: &ConversationTurn) -> Self {
+    fn from_turn(sequence: usize, turn: &SessionTranscriptTurn) -> Self {
         Self {
             sequence,
             role: turn.role.clone(),
@@ -464,12 +465,10 @@ impl SessionTrajectoryApprovalRequest {
 mod tests {
     use serde_json::json;
 
-    use super::ConversationTurn;
     use super::SessionTrajectoryExportOptions;
+    use super::SessionTranscriptTurn;
     use super::export_session_trajectory;
     use super::trim_turns_to_limit;
-    use crate::memory;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::FinalizeSessionTerminalRequest;
     use crate::session::repository::NewApprovalRequestRecord;
     use crate::session::repository::NewSessionEvent;
@@ -478,24 +477,25 @@ mod tests {
     use crate::session::repository::SessionRecord;
     use crate::session::repository::SessionRepository;
     use crate::session::repository::SessionState;
+    use crate::session::store::{SessionStoreConfig, append_session_turn_direct};
     use crate::test_support::unique_temp_dir;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let root = unique_temp_dir(test_name);
         let sqlite_path = root.join("memory.sqlite3");
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
     fn append_turns(
         session_id: &str,
-        config: &MemoryRuntimeConfig,
+        config: &SessionStoreConfig,
         contents: &[&str],
     ) -> Result<(), String> {
         for content in contents {
-            memory::append_turn_direct(session_id, "assistant", content, config)?;
+            append_session_turn_direct(session_id, "assistant", content, config)?;
         }
 
         Ok(())
@@ -653,17 +653,17 @@ mod tests {
     #[test]
     fn trim_turns_to_limit_keeps_only_the_most_recent_turns() {
         let turns = vec![
-            ConversationTurn {
+            SessionTranscriptTurn {
                 role: "assistant".to_owned(),
                 content: "one".to_owned(),
                 ts: 1,
             },
-            ConversationTurn {
+            SessionTranscriptTurn {
                 role: "assistant".to_owned(),
                 content: "two".to_owned(),
                 ts: 2,
             },
-            ConversationTurn {
+            SessionTranscriptTurn {
                 role: "assistant".to_owned(),
                 content: "three".to_owned(),
                 ts: 3,

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -9,7 +9,6 @@ use super::payload::{optional_payload_limit, optional_payload_string, required_p
 use crate::config::ToolConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::config::{SessionVisibility, ToolConsentMode};
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::approval_runtime::OperatorApprovalRuntime;
 #[cfg(feature = "memory-sqlite")]
@@ -18,6 +17,7 @@ use crate::session::repository::{
     NewApprovalGrantRecord, NewSessionToolConsentRecord, SessionRepository,
     TransitionApprovalRequestIfCurrentRequest,
 };
+use crate::session::store::SessionStoreConfig;
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -346,7 +346,7 @@ struct ApprovalRequestView {
 pub fn execute_approval_tool_with_policies(
     request: ToolCoreRequest,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     #[cfg(not(feature = "memory-sqlite"))]
@@ -389,7 +389,7 @@ pub fn execute_approval_tool_with_policies(
 pub async fn execute_approval_tool_with_runtime_support(
     request: ToolCoreRequest,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     runtime: Option<&(dyn ApprovalResolutionRuntime + '_)>,
 ) -> Result<ToolCoreOutcome, String> {
@@ -434,7 +434,7 @@ pub async fn execute_approval_tool_with_runtime_support(
 fn execute_approval_requests_list(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
@@ -512,7 +512,7 @@ fn execute_approval_requests_list(
 fn execute_approval_request_status(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let approval_request_id =
@@ -542,7 +542,7 @@ fn execute_approval_request_status(
 async fn execute_approval_request_resolve(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     runtime: &(dyn ApprovalResolutionRuntime + '_),
 ) -> Result<ToolCoreOutcome, String> {
@@ -571,7 +571,7 @@ async fn execute_approval_request_resolve(
 
 #[cfg(feature = "memory-sqlite")]
 async fn resolve_approval_request_with_runtime(
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     runtime: &(dyn ApprovalResolutionRuntime + '_),
     request: ApprovalResolutionRequest,
 ) -> Result<ApprovalResolutionOutcome, String> {
@@ -1348,14 +1348,14 @@ mod tests {
 
     use super::*;
     use crate::config::ToolConfig;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
         ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewApprovalRequestRecord,
         NewSessionRecord, SessionKind, SessionRepository, SessionState,
         TransitionApprovalRequestIfCurrentRequest,
     };
+    use crate::session::store::SessionStoreConfig;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-approval-tools-{test_name}-{}",
             std::process::id()
@@ -1363,9 +1363,9 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
@@ -1471,7 +1471,7 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     fn age_runtime_grant(
-        config: &MemoryRuntimeConfig,
+        config: &SessionStoreConfig,
         scope_session_id: &str,
         approval_key: &str,
         updated_at: i64,
@@ -1492,7 +1492,7 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn delete_session_row(config: &MemoryRuntimeConfig, session_id: &str) {
+    fn delete_session_row(config: &SessionStoreConfig, session_id: &str) {
         let db_path = config
             .sqlite_path
             .as_ref()

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -4980,15 +4980,11 @@ mod tests {
     fn memory_search_corpus_visibility_gate_allows_canonical_memory_without_workspace_files() {
         let runtime_dir = tempdir().expect("tempdir");
         let db_path = runtime_dir.path().join("memory.sqlite3");
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
-        crate::memory::append_turn_direct(
+        crate::memory::append_turn_direct_with_sqlite_path(
             "canonical-search-gate-session",
             "assistant",
             "Rollback checklist includes smoke tests and release notes.",
-            &memory_config,
+            &db_path,
         )
         .expect("append canonical turn");
 
@@ -5012,15 +5008,11 @@ mod tests {
     fn runtime_tool_view_includes_memory_search_for_canonical_memory_without_workspace_files() {
         let runtime_dir = tempdir().expect("tempdir");
         let db_path = runtime_dir.path().join("memory.sqlite3");
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
-        crate::memory::append_turn_direct(
+        crate::memory::append_turn_direct_with_sqlite_path(
             "canonical-view-session",
             "assistant",
             "Rollback checklist includes smoke tests and release notes.",
-            &memory_config,
+            &db_path,
         )
         .expect("append canonical turn");
 

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -519,11 +519,12 @@ fn search_canonical_memory_results(
         return Ok(Vec::new());
     }
 
-    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-        sqlite_path: Some(sqlite_path.clone()),
-        ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-    };
-    let hits = crate::memory::search_canonical_memory(query, max_results, None, &memory_config)?;
+    let hits = crate::memory::search_canonical_memory_with_sqlite_path(
+        query,
+        max_results,
+        None,
+        sqlite_path,
+    )?;
 
     Ok(hits
         .into_iter()
@@ -663,15 +664,11 @@ mod tests {
 
         std::fs::create_dir_all(&root).expect("create root dir");
 
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
-        crate::memory::append_turn_direct(
+        crate::memory::append_turn_direct_with_sqlite_path(
             "release-session",
             "assistant",
             "Deployment cutoff is 17:00 Beijing time and requires a release note.",
-            &memory_config,
+            &db_path,
         )
         .expect("append canonical assistant turn");
 
@@ -733,10 +730,6 @@ mod tests {
 
         std::fs::create_dir_all(&root).expect("create root dir");
 
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
         let payload = json!({
             "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
             "_loong_internal": true,
@@ -748,11 +741,11 @@ mod tests {
             },
         })
         .to_string();
-        crate::memory::append_turn_direct(
+        crate::memory::append_turn_direct_with_sqlite_path(
             "metadata-session",
             "assistant",
             &payload,
-            &memory_config,
+            &db_path,
         )
         .expect("append structured canonical turn");
 

--- a/crates/app/src/tools/messaging.rs
+++ b/crates/app/src/tools/messaging.rs
@@ -4,19 +4,18 @@ use serde_json::{Value, json};
 use super::payload::required_payload_string;
 
 use crate::config::{LoongConfig, ToolConfig};
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository,
 };
+use crate::session::store::SessionStoreConfig;
 
 const SESSION_MESSAGE_SENT_EVENT_KIND: &str = "session_message_sent";
 
 pub(crate) async fn execute_sessions_send_with_config(
     payload: Value,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     app_config: &LoongConfig,
 ) -> Result<ToolCoreOutcome, String> {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -20,7 +20,7 @@ use tool_search::{
 
 use crate::KernelContext;
 use crate::config::ToolConfig;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::session::store::SessionStoreConfig;
 
 pub(crate) mod approval;
 mod bash;
@@ -340,7 +340,7 @@ pub fn execute_tool_core(request: ToolCoreRequest) -> Result<ToolCoreOutcome, St
 pub fn execute_app_tool_with_config(
     request: ToolCoreRequest,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     execute_app_tool_with_browser_companion_readiness(
@@ -355,7 +355,7 @@ pub fn execute_app_tool_with_config(
 pub(crate) fn execute_app_tool_with_visibility_checked_config(
     request: ToolCoreRequest,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     execute_app_tool_with_browser_companion_readiness(
@@ -370,7 +370,7 @@ pub(crate) fn execute_app_tool_with_visibility_checked_config(
 fn execute_app_tool_with_browser_companion_readiness(
     request: ToolCoreRequest,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     assume_browser_companion_ready: bool,
 ) -> Result<ToolCoreOutcome, String> {
@@ -432,7 +432,7 @@ fn execute_app_tool_with_browser_companion_readiness(
 pub async fn wait_for_session_with_config(
     payload: Value,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     #[cfg(not(feature = "memory-sqlite"))]
@@ -465,7 +465,7 @@ pub(crate) async fn continue_session_with_runtime<
 >(
     payload: Value,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     app_config: &crate::config::LoongConfig,
     runtime: &R,
@@ -3303,7 +3303,7 @@ mod tests {
                 }),
             },
             "root-session",
-            &crate::memory::runtime_config::MemoryRuntimeConfig::default(),
+            &crate::session::store::SessionStoreConfig::default(),
             &tool_config,
         )
         .expect("browser companion click should succeed");

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -24,8 +24,6 @@ use crate::conversation::{
     ConstrainedSubagentIdentity, ConstrainedSubagentProfile, DelegateBuiltinProfile,
     coordination_actions_for_subagent_handle, subagent_surface_fields,
 };
-use crate::memory;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::runtime_self_continuity;
 #[cfg(feature = "memory-sqlite")]
@@ -37,6 +35,7 @@ use crate::session::recovery::{
     build_queued_async_overdue_recovery_payload, build_running_async_overdue_recovery_payload,
     observe_missing_recovery, recovery_json,
 };
+use crate::session::store::{self, SessionStoreConfig};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::{
     DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
@@ -312,7 +311,7 @@ fn collect_session_batch_results(
 pub fn execute_session_tool_with_config(
     request: ToolCoreRequest,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
 ) -> Result<ToolCoreOutcome, String> {
     execute_session_tool_with_policies(request, current_session_id, config, &ToolConfig::default())
 }
@@ -320,7 +319,7 @@ pub fn execute_session_tool_with_config(
 pub fn execute_session_tool_with_policies(
     request: ToolCoreRequest,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     #[cfg(not(feature = "memory-sqlite"))]
@@ -411,7 +410,7 @@ struct SessionContinueRequest {
 pub(crate) async fn continue_session_with_runtime<R: ConversationRuntime + ?Sized>(
     payload: Value,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     app_config: &LoongConfig,
     runtime: &R,
@@ -588,7 +587,7 @@ fn inject_session_continue_payload(
 fn parse_session_continue_request(
     payload: &Value,
     current_session_id: &str,
-    memory_config: &MemoryRuntimeConfig,
+    memory_config: &SessionStoreConfig,
     default_timeout_seconds: u64,
 ) -> Result<SessionContinueRequest, String> {
     let session_id = required_payload_string(payload, "session_id", "session_continue")?;
@@ -673,7 +672,7 @@ fn load_delegate_execution_contract(
 pub(super) async fn wait_for_session_tool_with_policies(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_target_request(&payload)?;
@@ -715,7 +714,7 @@ pub(super) async fn wait_for_session_tool_with_policies(
 fn execute_sessions_list(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
@@ -813,7 +812,7 @@ fn execute_sessions_list(
 fn execute_session_events(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let target_session_id = required_payload_string(&payload, "session_id", "session tool")?;
@@ -857,7 +856,7 @@ fn execute_session_events(
 fn execute_sessions_history(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let target_session_id = required_payload_string(&payload, "session_id", "session tool")?;
@@ -875,7 +874,7 @@ fn execute_sessions_history(
         &target_session_id,
         tool_config.sessions.visibility,
     )?;
-    let turns = memory::window_direct(&target_session_id, limit, config)
+    let turns = store::window_session_turns(&target_session_id, limit, config)
         .map_err(|error| format!("load session transcript failed: {error}"))?;
 
     Ok(ToolCoreOutcome {
@@ -892,7 +891,7 @@ fn execute_sessions_history(
 fn execute_session_tool_policy_status(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
@@ -921,7 +920,7 @@ fn execute_session_tool_policy_status(
 fn execute_session_tool_policy_set(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
@@ -1003,7 +1002,7 @@ fn execute_session_tool_policy_set(
 fn execute_session_tool_policy_clear(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let repo = SessionRepository::new(config)?;
@@ -1035,7 +1034,7 @@ fn execute_session_tool_policy_clear(
 fn execute_session_status(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_target_request(&payload)?;
@@ -1080,7 +1079,7 @@ fn execute_session_status(
 fn execute_session_recover(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
@@ -1147,7 +1146,7 @@ fn execute_session_recover(
 fn execute_session_cancel(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
@@ -1214,7 +1213,7 @@ fn execute_session_cancel(
 fn execute_session_archive(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_session_mutation_request(&payload)?;
@@ -1304,7 +1303,7 @@ fn apply_session_archive_plan(
     repo: &SessionRepository,
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     snapshot: &SessionInspectionSnapshot,
     archive_plan: &SessionArchivePlan,
@@ -1350,7 +1349,7 @@ fn apply_session_archive_plan(
 fn execute_session_archive_batch_result(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     dry_run: bool,
 ) -> Result<SessionBatchResultRecord, String> {
@@ -1476,7 +1475,7 @@ fn session_archive_action_json(plan: &SessionArchivePlan) -> Value {
 pub(super) fn inspect_visible_session_with_policies(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     recent_event_limit: usize,
 ) -> Result<SessionInspectionSnapshot, String> {
@@ -1497,7 +1496,7 @@ pub(super) fn inspect_visible_session_with_policies(
 async fn wait_for_single_session_with_policies(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     after_id: Option<i64>,
     timeout_ms: u64,
@@ -1566,7 +1565,7 @@ async fn wait_for_single_session_with_policies(
 async fn wait_for_session_batch_with_policies(
     target_session_ids: Vec<String>,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     after_id: Option<i64>,
     timeout_ms: u64,
@@ -1737,7 +1736,7 @@ async fn wait_for_session_batch_with_policies(
 pub(super) fn observe_visible_session_with_policies(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     recent_event_limit: usize,
     tail_after_id: Option<i64>,
@@ -2221,7 +2220,7 @@ fn session_terminal_outcome_missing_reason(
 fn execute_session_status_batch_result(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<SessionBatchResultRecord, String> {
     let repo = SessionRepository::new(config)?;
@@ -2273,7 +2272,7 @@ fn execute_session_status_batch_result(
 fn execute_session_recover_batch_result(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     dry_run: bool,
 ) -> Result<SessionBatchResultRecord, String> {
@@ -2380,7 +2379,7 @@ fn apply_session_recover_plan(
     repo: &SessionRepository,
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     snapshot: &SessionInspectionSnapshot,
     recover_plan: &SessionRecoverPlan,
@@ -2588,7 +2587,7 @@ fn session_recovery_error(plan: &SessionRecoverPlan) -> String {
 fn execute_session_cancel_batch_result(
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     dry_run: bool,
 ) -> Result<SessionBatchResultRecord, String> {
@@ -2695,7 +2694,7 @@ fn apply_session_cancel_plan(
     repo: &SessionRepository,
     target_session_id: &str,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
     snapshot: &SessionInspectionSnapshot,
     cancel_plan: SessionCancelPlan,
@@ -3967,16 +3966,15 @@ mod tests {
     use serde_json::{Value, json};
 
     use crate::config::{SessionVisibility, ToolConfig};
-    use crate::memory::append_turn_direct;
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
         FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionEventRecord,
         SessionKind, SessionRepository, SessionState, SessionSummaryRecord,
     };
+    use crate::session::store::{SessionStoreConfig, append_session_turn_direct};
 
     use super::{execute_session_tool_with_config, execute_session_tool_with_policies};
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-session-tools-{test_name}-{}",
             std::process::id()
@@ -3984,16 +3982,16 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
     fn execute_session_mutation_tool_with_config(
         request: ToolCoreRequest,
         current_session_id: &str,
-        config: &MemoryRuntimeConfig,
+        config: &SessionStoreConfig,
     ) -> Result<ToolCoreOutcome, String> {
         let mut tool_config = ToolConfig::default();
         tool_config.sessions.allow_mutation = true;
@@ -4001,7 +3999,7 @@ mod tests {
     }
 
     fn overwrite_session_event_ts(
-        config: &MemoryRuntimeConfig,
+        config: &SessionStoreConfig,
         session_id: &str,
         event_kind: &str,
         ts: i64,
@@ -4022,7 +4020,7 @@ mod tests {
         assert!(updated > 0, "expected at least one updated event row");
     }
 
-    fn overwrite_session_updated_at(config: &MemoryRuntimeConfig, session_id: &str, ts: i64) {
+    fn overwrite_session_updated_at(config: &SessionStoreConfig, session_id: &str, ts: i64) {
         let db_path = config
             .sqlite_path
             .as_ref()
@@ -4104,10 +4102,11 @@ mod tests {
         })
         .expect("create other");
 
-        append_turn_direct("root-session", "user", "root turn", &config).expect("append root turn");
-        append_turn_direct("child-session", "assistant", "child turn", &config)
+        append_session_turn_direct("root-session", "user", "root turn", &config)
+            .expect("append root turn");
+        append_session_turn_direct("child-session", "assistant", "child turn", &config)
             .expect("append child turn");
-        append_turn_direct("other-session", "user", "other turn", &config)
+        append_session_turn_direct("other-session", "user", "other turn", &config)
             .expect("append other turn");
 
         let outcome = execute_session_tool_with_config(
@@ -4709,8 +4708,9 @@ mod tests {
         })
         .expect("append event");
 
-        append_turn_direct("child-session", "user", "hello", &config).expect("append user turn");
-        append_turn_direct("child-session", "assistant", "world", &config)
+        append_session_turn_direct("child-session", "user", "hello", &config)
+            .expect("append user turn");
+        append_session_turn_direct("child-session", "assistant", "world", &config)
             .expect("append assistant turn");
 
         let outcome = execute_session_tool_with_config(
@@ -4864,8 +4864,9 @@ mod tests {
             }),
         })
         .expect("append delegate_started");
-        append_turn_direct("child-session", "user", "hello", &config).expect("append user turn");
-        append_turn_direct("child-session", "assistant", "world", &config)
+        append_session_turn_direct("child-session", "user", "hello", &config)
+            .expect("append user turn");
+        append_session_turn_direct("child-session", "assistant", "world", &config)
             .expect("append assistant turn");
 
         let outcome = execute_session_tool_with_config(
@@ -6940,9 +6941,9 @@ mod tests {
     #[test]
     fn session_status_returns_inferred_legacy_current_session_without_backfill() {
         let config = isolated_memory_config("legacy-session-status");
-        append_turn_direct("delegate:legacy-child", "user", "hello", &config)
+        append_session_turn_direct("delegate:legacy-child", "user", "hello", &config)
             .expect("append user turn");
-        append_turn_direct("delegate:legacy-child", "assistant", "done", &config)
+        append_session_turn_direct("delegate:legacy-child", "assistant", "done", &config)
             .expect("append assistant turn");
 
         let outcome = execute_session_tool_with_config(

--- a/crates/app/src/tools/session_search.rs
+++ b/crates/app/src/tools/session_search.rs
@@ -7,8 +7,8 @@ use serde_json::{Value, json};
 use super::payload::{optional_payload_limit, optional_payload_string, required_payload_string};
 
 use crate::config::{SessionVisibility, ToolConfig};
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::session::repository::{SessionRepository, SessionSearchSourceKind};
+use crate::session::store::SessionStoreConfig;
 
 const DEFAULT_SESSION_SEARCH_MAX_RESULTS: usize = 5;
 const MAX_SESSION_SEARCH_MAX_RESULTS: usize = 20;
@@ -34,7 +34,7 @@ struct SessionSearchHit {
 pub(super) fn execute_session_search_with_policies(
     payload: Value,
     current_session_id: &str,
-    config: &MemoryRuntimeConfig,
+    config: &SessionStoreConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let query = required_payload_string(&payload, "query", "session_search")?;
@@ -308,13 +308,13 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::memory::append_turn_direct;
     use crate::session::repository::{
         FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
         SessionRepository, SessionState,
     };
+    use crate::session::store::append_session_turn_direct;
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-session-search-{test_name}-{}",
             std::process::id()
@@ -322,9 +322,9 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 
@@ -361,14 +361,14 @@ mod tests {
         let repo = SessionRepository::new(&config).expect("repository");
         create_root_and_child(&repo);
 
-        append_turn_direct(
+        append_session_turn_direct(
             "child-session",
             "assistant",
             "Deploy freeze window is Friday and customer migration starts Saturday.",
             &config,
         )
         .expect("append child turn");
-        append_turn_direct(
+        append_session_turn_direct(
             "other-session",
             "assistant",
             "Deploy freeze for hidden session.",
@@ -422,7 +422,7 @@ mod tests {
         let repo = SessionRepository::new(&config).expect("repository");
         create_root_and_child(&repo);
 
-        append_turn_direct(
+        append_session_turn_direct(
             "child-session",
             "assistant",
             "Deploy freeze window is Friday.",
@@ -453,7 +453,7 @@ mod tests {
         let repo = SessionRepository::new(&config).expect("repository");
         create_root_and_child(&repo);
 
-        append_turn_direct(
+        append_session_turn_direct(
             "child-session",
             "assistant",
             "Deploy freeze window is Friday.",

--- a/crates/app/src/work/repository.rs
+++ b/crates/app/src/work/repository.rs
@@ -10,8 +10,7 @@ use rand::random;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde_json::{Value, json};
 
-use crate::memory;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::session::store::{self, SessionStoreConfig};
 
 const WORK_UNIT_CREATED_EVENT_KIND: &str = "work_unit_created";
 const WORK_UNIT_LEASED_EVENT_KIND: &str = "work_unit_leased";
@@ -193,8 +192,8 @@ struct RawWorkUnitRecord {
 }
 
 impl WorkUnitRepository {
-    pub fn new(config: &MemoryRuntimeConfig) -> Result<Self, String> {
-        let db_path = memory::ensure_memory_db_ready(config.sqlite_path.clone(), config)?;
+    pub fn new(config: &SessionStoreConfig) -> Result<Self, String> {
+        let db_path = store::ensure_session_store_ready(config.sqlite_path.clone(), config)?;
         let repository = Self { db_path };
         repository.ensure_schema()?;
         Ok(repository)
@@ -2300,7 +2299,7 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::store::SessionStoreConfig;
 
     use super::{
         AcquireWorkUnitLeaseRequest, AddWorkUnitDependencyRequest, AppendWorkUnitNoteRequest,
@@ -2316,7 +2315,7 @@ mod tests {
         WorkUnitStatus,
     };
 
-    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> SessionStoreConfig {
         let base = std::env::temp_dir().join(format!(
             "loong-work-unit-repository-{test_name}-{}",
             std::process::id()
@@ -2324,9 +2323,9 @@ mod tests {
         let _ = fs::create_dir_all(&base);
         let db_path = base.join("memory.sqlite3");
         let _ = fs::remove_file(&db_path);
-        MemoryRuntimeConfig {
+        SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
+            ..SessionStoreConfig::default()
         }
     }
 

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -34,6 +34,7 @@ design backlog artifacts are intentionally out of the public docs flow.
 | [Core Beliefs](core-beliefs.md) | you need the engineering principles that should survive refactors |
 | [Layered Kernel Design](layered-kernel-design.md) | you need the crate and layer boundary model before changing runtime shape |
 | [Runtime Entrypoint and Bootstrap Map](runtime-entrypoint-map.md) | you need the shortest source-facing map of how CLI, channel, gateway, control-plane, and daemon task turns enter the shared runtime |
+| [Single-Entry Runtime Convergence](single-entry-runtime-convergence.md) | you are working on session-vs-memory ownership or converging host turn seams without breaking the current crate contract |
 | [Harness Engineering](harness-engineering.md) | you are working on the agent-driven development environment itself |
 
 ## Boundary Rules

--- a/docs/design-docs/single-entry-runtime-convergence.md
+++ b/docs/design-docs/single-entry-runtime-convergence.md
@@ -1,0 +1,178 @@
+# Single-Entry Runtime Convergence
+
+## Status
+
+Active
+
+## Summary
+
+LoongClaw should continue to present one product entrypoint, `loong`, while making its
+runtime boundaries more explicit inside the existing 7-crate workspace.
+
+This document defines the first refactor lane:
+
+- keep the current 7-crate DAG intact
+- separate **session core** from **memory augmentation** semantically before any crate split
+- converge turn-bearing hosts on shared runtime seams before introducing new crates
+- avoid speculative surface crates such as a shared UI core until real reuse exists
+
+## Why This Exists
+
+The current repository already has a strong lower-layer shape:
+
+- kernel governance remains explicit in [ARCHITECTURE.md](../../ARCHITECTURE.md)
+- the 7-crate DAG is a stated non-negotiable in
+  [Core Beliefs](core-beliefs.md) and
+  [ARCHITECTURE.md](../../ARCHITECTURE.md)
+
+The pressure is above that layer:
+
+- [crates/app/src/lib.rs](../../crates/app/src/lib.rs) exposes provider, conversation, memory,
+  session, chat, presentation, and TUI concerns from one crate
+- [crates/app/src/chat.rs](../../crates/app/src/chat.rs) mixes CLI interaction, session
+  selection, runtime initialization, and presentation
+- [crates/app/src/memory/mod.rs](../../crates/app/src/memory/mod.rs) currently mixes transcript
+  CRUD with durable recall / memory-system orchestration
+- [crates/app/src/session/mod.rs](../../crates/app/src/session/mod.rs) depends on
+  memory runtime config, which makes session durability look like a memory add-on
+- [crates/daemon/src/gateway/api_turn.rs](../../crates/daemon/src/gateway/api_turn.rs) and
+  [crates/daemon/src/control_plane_server.rs](../../crates/daemon/src/control_plane_server.rs)
+  both need to stay aligned with the shared
+  [AgentRuntime](../../crates/app/src/agent_runtime.rs) turn entry seam
+
+The result is not that the kernel is unclear. The result is that product/runtime seams are still
+too implicit.
+
+## Constraints
+
+The first refactor phase must preserve all of the following:
+
+1. The 7-crate DAG remains the repository contract for now.
+2. No new public product split. The user-facing entry remains `loong`.
+3. No breaking changes to existing external CLI or protocol behavior.
+4. Kernel-first routing and policy boundaries remain intact.
+5. No new dependency is introduced solely for refactor convenience.
+
+## Core Decisions
+
+### 1. Single entry is a product decision, not a layering constraint
+
+`loong` remains the only product entrypoint.
+
+That does not imply that chat, runtime, session durability, ACP dispatch, TUI rendering, and
+future Web/App surfaces should continue to share one internal ownership boundary.
+
+### 2. Session durability is core runtime state
+
+LoongClaw must treat the following as runtime/session core, not optional memory:
+
+- thread/session/transcript persistence
+- recent window reads
+- history replay and recovery
+- compaction inputs and session lineage
+
+The following remain memory augmentation:
+
+- durable recall
+- cross-session/project memory
+- workspace memory documents
+- recall systems and memory orchestration policies
+
+The current repository does not yet enforce that split cleanly, so the first job is semantic
+ownership, not immediate crate extraction.
+
+### 3. Host turn convergence comes before crate extraction
+
+Turn-bearing hosts should stop re-implementing runtime preparation logic independently.
+
+In practice, the first convergence target is host-submitted agent turns:
+
+- gateway `/v1/turn`
+- control-plane `/turn/submit`
+- future host/runtime surfaces that submit ACP-backed turns
+
+Phase 0 should converge those hosts on one runtime-facing entry seam rather than letting each
+daemon surface hand-roll turn bootstrap rules.
+
+### 4. Physical crate extraction is a later step
+
+Potential future crates such as `sessions`, `runtime`, `gateway`, or `tui` are architectural
+directions, not immediate refactor obligations.
+
+The repository should only split crates after:
+
+- ownership boundaries are stable inside the current crates
+- host call sites already converge on shared seams
+- tests prove the seams are behavior-preserving
+
+### 5. Not every remaining `memory::*` call is refactor debt
+
+After the session-store convergence work, the remaining `memory::*` references
+fall into three buckets:
+
+- the thin [session::store](../../crates/app/src/session/store.rs) adapter itself
+- true memory-augmentation paths such as staged envelope hydration / recall
+- memory-facing tools and their tests
+
+Those should not be collapsed into `session::store` just to reduce grep hits.
+The goal is semantic clarity, not zero textual mentions of `memory`.
+
+## Phase Plan
+
+### Phase 0: Runtime convergence inside the existing DAG
+
+Goal:
+
+- remove duplicated host turn bootstrap logic
+- keep daemon hosts thin and behaviorally identical
+- document the intended seam in-repo
+
+Implementation shape:
+
+- shared host turn entry through [agent_runtime.rs](../../crates/app/src/agent_runtime.rs)
+- gateway and control-plane consume that seam instead of bespoke bootstrap code
+- no new crate introduced
+
+### Phase 1: Session vs memory semantic split inside `app`
+
+Goal:
+
+- make transcript/window/session durability read as session runtime state
+- make durable recall read as augmentation
+
+This phase may still live inside `crates/app` while module ownership changes.
+
+### Phase 2: Host/runtime seam hardening
+
+Goal:
+
+- make host call sites depend on shared runtime entry helpers rather than bespoke assembly
+- keep CLI/TUI behavior intact while reducing cross-module knowledge in daemon surfaces
+
+### Phase 3: Re-evaluate physical crate extraction
+
+Only after phases 0-2 are stable should the repository decide whether new crates are justified.
+
+## Non-Goals
+
+The first refactor phase does **not** do the following:
+
+- split the workspace beyond the current 7 crates
+- create a generic shared UI core
+- rename the product into separate `code` and `agent` surfaces
+- redesign protocol contracts for speculative future clients
+
+It also does **not** rebrand true memory-augmentation surfaces as session-core
+surfaces. Session transcript durability and memory recall should become clearer
+by moving apart, not by forcing them through one namespace.
+
+## Acceptance Criteria
+
+The convergence plan is successful when all of the following are true:
+
+1. Gateway and control-plane turn submission reuse the same runtime-facing entry seam.
+2. Host bootstrap logic lives in the runtime-facing `app` layer rather than daemon-only helpers.
+3. Existing external request/response behavior remains unchanged.
+4. Tests cover the shared seam and prevent host-specific duplicate bootstrap logic from drifting.
+5. Repository docs clearly state that session durability and memory augmentation are distinct
+   concerns even before any crate split.


### PR DESCRIPTION
## Summary

This PR gives session transcript and durability paths one explicit home under `session::store` while keeping true memory augmentation logic on the memory side.

## What changed

- added `crates/app/src/session/store.rs` as the session-core front door for transcript and durability primitives
- migrated session-facing callers across chat, conversation runtime, session tools, repositories, and operator paths to that surface
- clarified the intended boundary in `docs/design-docs/single-entry-runtime-convergence.md`
- removed the last session-facing naming leaks where `SessionStoreConfig` still read as `MemoryRuntimeConfig`

## Why

Before this change, session durability and transcript operations were semantically mixed into `memory::*`, which made product-core session behavior look like an optional memory feature.

After this change:

- session transcript/store code reads as session-core
- true augmentation code stays on the memory side
- the current crate contract stays intact

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

Closes #1303
