### PR TITLE
Simplify sqlite-backed memory test setup around local helper configs

### DIFF
--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -5647,6 +5647,20 @@ mod tests {
         config
     }
 
+    fn sqlite_test_summary_config(
+        db_path: impl Into<PathBuf>,
+        sliding_window: usize,
+        summary_max_chars: usize,
+    ) -> MemoryRuntimeConfig {
+        let mut config = sqlite_test_config_with_profile(
+            db_path,
+            MemoryProfile::WindowPlusSummary,
+            sliding_window,
+        );
+        config.summary_max_chars = summary_max_chars;
+        config
+    }
+
     fn read_summary_checkpoint(
         config: &MemoryRuntimeConfig,
         session_id: &str,
@@ -6257,8 +6271,6 @@ mod tests {
 
     #[test]
     fn ensure_memory_db_ready_repairs_session_terminal_outcome_frozen_result_column() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6296,13 +6308,7 @@ mod tests {
         .expect("create legacy terminal outcome schema");
         drop(conn);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config).expect("repair sqlite db");
 
@@ -6318,8 +6324,6 @@ mod tests {
 
     #[test]
     fn ensure_memory_db_ready_repairs_session_event_search_storage() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6362,13 +6366,7 @@ mod tests {
         .expect("create legacy session event schema");
         drop(conn);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config).expect("repair sqlite db");
 
@@ -6404,8 +6402,6 @@ mod tests {
 
     #[test]
     fn ensure_memory_db_ready_repairs_session_tool_consent_mode_check_constraint() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6462,13 +6458,7 @@ mod tests {
         .expect("insert legacy session tool consent");
         drop(conn);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config)
             .expect("migrate legacy sqlite memory db");
@@ -6516,8 +6506,6 @@ mod tests {
 
     #[test]
     fn repeated_same_path_runtime_lookup_reuses_normalized_path_alias_cache() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6536,13 +6524,11 @@ mod tests {
             .join("alias-cache.sqlite3");
         let _cwd_guard = set_current_dir_for_test(&cwd);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(PathBuf::from("../data/alias-cache.sqlite3")),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(
+            PathBuf::from("../data/alias-cache.sqlite3"),
+            MemoryProfile::WindowOnly,
+            2,
+        );
 
         ensure_memory_db_ready(None, &config).expect("ensure alias-cache db ready");
 
@@ -6574,8 +6560,6 @@ mod tests {
 
     #[test]
     fn reopening_current_schema_db_skips_metadata_repairs() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6590,13 +6574,7 @@ mod tests {
         let db_path = tmp.join("schema-repair-skip.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config)
             .expect("bootstrap current schema db");
@@ -6622,8 +6600,6 @@ mod tests {
 
     #[test]
     fn reopening_current_schema_db_skips_schema_init_batch() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6638,13 +6614,7 @@ mod tests {
         let db_path = tmp.join("schema-init-skip.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config)
             .expect("bootstrap current schema db");
@@ -6669,8 +6639,6 @@ mod tests {
 
     #[test]
     fn ensure_memory_db_ready_diagnostics_distinguish_cache_miss_and_hit() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6685,13 +6653,7 @@ mod tests {
         let db_path = tmp.join("runtime-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         let (_, cold_bootstrap) =
             ensure_memory_db_ready_with_diagnostics(Some(db_path.clone()), &config)
@@ -6714,8 +6676,6 @@ mod tests {
 
     #[test]
     fn window_reads_route_through_cached_statement_preparation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6732,13 +6692,7 @@ mod tests {
         let db_path = tmp.join("prepared-window.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         window_direct_with_options("prepared-window-session", 2, true, &config)
             .expect("window query should succeed");
@@ -6757,8 +6711,6 @@ mod tests {
 
     #[test]
     fn window_only_context_snapshot_avoids_indexed_recent_turn_query() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6775,13 +6727,7 @@ mod tests {
         let db_path = tmp.join("window-only-snapshot.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct("window-only-snapshot-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -6825,8 +6771,6 @@ mod tests {
 
     #[test]
     fn summary_context_snapshot_avoids_indexed_window_materialization_query_shape() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6843,14 +6787,7 @@ mod tests {
         let db_path = tmp.join("summary-snapshot-window.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-snapshot-query-shape-session",
@@ -6929,8 +6866,6 @@ mod tests {
 
     #[test]
     fn summary_append_path_routes_multiple_sqls_through_cached_preparation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -6947,14 +6882,7 @@ mod tests {
         let db_path = tmp.join("prepared-summary.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct("prepared-summary-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -7002,8 +6930,6 @@ mod tests {
 
     #[test]
     fn summary_append_path_avoids_empty_checkpoint_delete_before_window_overflow() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7020,14 +6946,7 @@ mod tests {
         let db_path = tmp.join("summary-append-empty-delete.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 4, 256);
 
         append_turn_direct(
             "summary-append-empty-delete-session",
@@ -7058,8 +6977,6 @@ mod tests {
 
     #[test]
     fn summary_append_path_skips_summary_maintenance_queries_before_window_overflow() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7076,14 +6993,7 @@ mod tests {
         let db_path = tmp.join("summary-append-pre-overflow-maintenance-skip.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 4, 256);
 
         append_turn_direct(
             "summary-append-pre-overflow-maintenance-skip-session",
@@ -7119,8 +7029,6 @@ mod tests {
 
     #[test]
     fn summary_append_hot_path_advances_boundary_without_window_offset_probe() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7135,14 +7043,7 @@ mod tests {
         let db_path = tmp.join("summary-append-hot-boundary.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-append-hot-boundary-session",
@@ -7222,8 +7123,6 @@ mod tests {
 
     #[test]
     fn summary_append_cold_path_uses_dedicated_initial_checkpoint_query() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7239,14 +7138,7 @@ mod tests {
         let db_path = tmp.join("summary-append-cold-boundary.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-append-cold-boundary-session",
@@ -7322,8 +7214,6 @@ mod tests {
 
     #[test]
     fn summary_rebuild_routes_through_streaming_row_accumulation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7340,14 +7230,7 @@ mod tests {
         let db_path = tmp.join("summary-streaming-rebuild.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-streaming-rebuild-session",
@@ -7404,8 +7287,6 @@ mod tests {
 
     #[test]
     fn summary_catch_up_routes_through_streaming_row_accumulation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7422,14 +7303,7 @@ mod tests {
         let db_path = tmp.join("summary-streaming-catch-up.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-streaming-catch-up-session",
@@ -7479,8 +7353,6 @@ mod tests {
 
     #[test]
     fn summary_rebuild_skips_summary_formatting_after_budget_saturation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7500,14 +7372,7 @@ mod tests {
         let first_turn = "FIRST-MARKER ".repeat(40);
         let second_turn = "SECOND-MARKER ".repeat(20);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-saturation-rebuild-session",
@@ -7579,8 +7444,6 @@ mod tests {
 
     #[test]
     fn summary_rebuild_fast_forwards_frontier_after_budget_saturation() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7598,14 +7461,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
 
         let first_turn = "FIRST-MARKER ".repeat(40);
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-frontier-fast-forward-rebuild-session",
@@ -7672,8 +7528,6 @@ mod tests {
 
     #[test]
     fn summary_rebuild_load_diagnostics_split_stream_and_checkpoint_upsert_costs() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7688,14 +7542,7 @@ mod tests {
         let db_path = tmp.join("summary-rebuild-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         for (role, content) in [
             ("user", "turn 1"),
@@ -7766,8 +7613,6 @@ mod tests {
 
     #[test]
     fn summary_catch_up_advances_frontier_after_budget_saturation_without_reformatting() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7787,14 +7632,7 @@ mod tests {
         let first_turn = "FIRST-MARKER ".repeat(40);
         let second_turn = "SECOND-MARKER ".repeat(20);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-saturation-catch-up-session",
@@ -7869,8 +7707,6 @@ mod tests {
 
     #[test]
     fn summary_window_shrink_catch_up_avoids_scratch_normalization_buffer() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7887,14 +7723,7 @@ mod tests {
         let db_path = tmp.join("summary-fused-append-rebuild.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-fused-append-rebuild-session",
@@ -7949,8 +7778,6 @@ mod tests {
 
     #[test]
     fn summary_catch_up_avoids_scratch_normalization_buffer() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -7967,14 +7794,7 @@ mod tests {
         let db_path = tmp.join("summary-fused-append-catch-up.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "summary-fused-append-catch-up-session",
@@ -8034,21 +7854,14 @@ mod tests {
 
     #[test]
     fn context_snapshot_separates_materialized_summary_from_active_window() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp =
             std::env::temp_dir().join(format!("loong-context-snapshot-{}", std::process::id()));
         let _ = fs::create_dir_all(&tmp);
         let db_path = tmp.join("context-snapshot.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("snapshot-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -8087,8 +7900,6 @@ mod tests {
 
     #[test]
     fn append_turn_materializes_summary_checkpoint_once_window_overflows() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp = std::env::temp_dir().join(format!(
             "loong-summary-checkpoint-materialized-{}",
             std::process::id()
@@ -8097,14 +7908,7 @@ mod tests {
         let db_path = tmp.join("summary-checkpoint.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct("checkpoint-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -8131,8 +7935,6 @@ mod tests {
 
     #[test]
     fn initial_summary_checkpoint_waits_for_visible_overflow() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp = std::env::temp_dir().join(format!(
             "loong-initial-summary-visible-overflow-{}",
             std::process::id()
@@ -8141,14 +7943,7 @@ mod tests {
         let db_path = tmp.join("initial-summary-visible-overflow.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
         let hidden_turn = crate::memory::build_conversation_event_content(
             "provider_prompt_frame_snapshot",
             serde_json::json!({"phase": "initial"}),
@@ -8228,8 +8023,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_rebuilds_materialized_summary_when_window_size_changes() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp = std::env::temp_dir().join(format!(
             "loong-summary-checkpoint-window-rebuild-{}",
             std::process::id()
@@ -8238,14 +8031,7 @@ mod tests {
         let db_path = tmp.join("summary-window-rebuild.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "window-rebuild-session",
@@ -8301,8 +8087,6 @@ mod tests {
     #[test]
     fn load_context_snapshot_updates_checkpoint_metadata_without_rewriting_body_when_frontier_is_stable()
      {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8318,22 +8102,10 @@ mod tests {
         let db_path = tmp.join("summary-window-metadata-only.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_two = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
-        let config_window_only = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_two = sqlite_test_summary_config(db_path.clone(), 2, 256);
+        let mut config_window_only =
+            sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
+        config_window_only.summary_max_chars = 256;
         let config_window_three = MemoryRuntimeConfig {
             sliding_window: 3,
             ..config_window_two.clone()
@@ -8407,8 +8179,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_uses_compatible_checkpoint_body_fast_path() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8423,14 +8193,7 @@ mod tests {
         let db_path = tmp.join("summary-compatible-fast-path.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         for (role, content) in [
             ("user", "turn 1"),
@@ -8480,8 +8243,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_uses_catch_up_when_window_shrinks() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8498,14 +8259,7 @@ mod tests {
         let db_path = tmp.join("summary-window-shrink-catch-up.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_window_three = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 3,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_three = sqlite_test_summary_config(db_path.clone(), 3, 256);
 
         append_turn_direct(
             "window-shrink-catch-up-session",
@@ -8585,8 +8339,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_catch_up_probes_frontier_when_saturated() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8605,14 +8357,7 @@ mod tests {
 
         let first_turn = "FIRST-MARKER ".repeat(40);
         let second_turn = "SECOND-MARKER ".repeat(20);
-        let config_window_three = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 3,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_window_three = sqlite_test_summary_config(db_path.clone(), 3, 256);
 
         append_turn_direct(
             "window-shrink-saturated-catch-up-session",
@@ -8703,8 +8448,6 @@ mod tests {
 
     #[test]
     fn recent_turn_query_with_boundary_id_returns_oldest_active_window_turn() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8719,13 +8462,7 @@ mod tests {
         let db_path = tmp.join("window-boundary.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowOnly,
-            mode: MemoryMode::WindowOnly,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 2);
 
         append_turn_direct("window-boundary-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -8756,8 +8493,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_rebuilds_materialized_summary_when_budget_changes() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8774,14 +8509,7 @@ mod tests {
         let first_turn = "alpha ".repeat(40);
         let second_turn = "SECOND-MARKER ".repeat(8);
 
-        let config_small_budget = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_small_budget = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "budget-rebuild-session",
@@ -8862,8 +8590,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_skips_rebuild_when_budget_changes_but_summary_is_unsaturated() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8878,14 +8604,7 @@ mod tests {
         let db_path = tmp.join("summary-budget-metadata-only.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_small_budget = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_small_budget = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "budget-metadata-only-session",
@@ -8965,8 +8684,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_diagnostics_identify_metadata_only_budget_change_fast_path() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -8980,14 +8697,7 @@ mod tests {
         let db_path = tmp.join("summary-budget-load-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config_small_budget = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config_small_budget = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "budget-load-diagnostics-session",
@@ -9065,8 +8775,6 @@ mod tests {
     #[test]
     fn load_context_snapshot_skips_redundant_meta_query_when_window_probe_already_proves_checkpoint_absent()
      {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9081,14 +8789,7 @@ mod tests {
         let db_path = tmp.join("known-absent-checkpoint-meta-query.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         for (role, content) in [
             ("user", "turn 1"),
@@ -9154,8 +8855,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_diagnostics_split_exact_window_query_costs() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9170,14 +8869,7 @@ mod tests {
         let db_path = tmp.join("exact-window-query-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "exact-window-query-diagnostics-session",
@@ -9218,8 +8910,6 @@ mod tests {
 
     #[test]
     fn load_context_snapshot_diagnostics_split_known_overflow_window_query_costs() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9234,14 +8924,7 @@ mod tests {
         let db_path = tmp.join("known-overflow-window-query-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "known-overflow-window-query-diagnostics-session",
@@ -9292,8 +8975,6 @@ mod tests {
     #[test]
     fn load_context_snapshot_diagnostics_split_fallback_window_query_costs_when_turn_count_is_missing()
      {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9308,14 +8989,7 @@ mod tests {
         let db_path = tmp.join("fallback-window-query-diagnostics.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "fallback-window-query-diagnostics-session",
@@ -9383,8 +9057,6 @@ mod tests {
 
     #[test]
     fn clear_session_removes_materialized_summary_checkpoint() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp = std::env::temp_dir().join(format!(
             "loong-summary-checkpoint-clear-session-{}",
             std::process::id()
@@ -9393,14 +9065,7 @@ mod tests {
         let db_path = tmp.join("summary-clear-session.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct("clear-checkpoint-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -9434,8 +9099,6 @@ mod tests {
 
     #[test]
     fn ensure_memory_db_ready_migrates_legacy_summary_checkpoint_body_bytes() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9515,14 +9178,7 @@ mod tests {
         .expect("insert legacy checkpoint");
         drop(conn);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 4, 256);
 
         ensure_memory_db_ready(Some(db_path.clone()), &config)
             .expect("migrate legacy sqlite memory db");
@@ -9609,8 +9265,6 @@ mod tests {
 
     #[test]
     fn context_snapshot_returns_no_materialized_summary_when_window_covers_session() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let tmp = std::env::temp_dir().join(format!(
             "loong-context-snapshot-short-{}",
             std::process::id()
@@ -9619,13 +9273,8 @@ mod tests {
         let db_path = tmp.join("context-snapshot-short.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 4);
 
         append_turn_direct("snapshot-short-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -9646,8 +9295,6 @@ mod tests {
 
     #[test]
     fn summary_context_snapshot_avoids_checkpoint_query_when_window_exactly_covers_session() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9664,13 +9311,8 @@ mod tests {
         let db_path = tmp.join("context-snapshot-exact-window.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config =
+            sqlite_test_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
 
         append_turn_direct("snapshot-exact-window-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -9732,8 +9374,6 @@ mod tests {
     #[test]
     fn summary_context_snapshot_falls_back_to_payload_overflow_probe_when_turn_count_metadata_is_missing()
      {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9750,14 +9390,7 @@ mod tests {
         let db_path = tmp.join("context-snapshot-missing-turn-count.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct(
             "snapshot-missing-turn-count-session",
@@ -9833,8 +9466,6 @@ mod tests {
 
     #[test]
     fn summary_context_snapshot_uses_turn_count_metadata_to_choose_known_overflow_query_shape() {
-        use crate::config::{MemoryMode, MemoryProfile};
-
         let _guard = sqlite_runtime_test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -9851,14 +9482,7 @@ mod tests {
         let db_path = tmp.join("context-snapshot-known-overflow.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            profile: MemoryProfile::WindowPlusSummary,
-            mode: MemoryMode::WindowPlusSummary,
-            sqlite_path: Some(db_path.clone()),
-            sliding_window: 2,
-            summary_max_chars: 256,
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_summary_config(db_path.clone(), 2, 256);
 
         append_turn_direct("snapshot-known-overflow-session", "user", "turn 1", &config)
             .expect("append turn 1 should succeed");
@@ -9934,10 +9558,7 @@ mod tests {
         let db_path = tmp.join("canonical-search.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
 
         append_turn_direct(
             "prior-session",
@@ -10016,10 +9637,7 @@ mod tests {
         let db_path = tmp.join("canonical-structured-search.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
 
         let payload = json!({
             "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
@@ -10059,10 +9677,7 @@ mod tests {
         let db_path = tmp.join("canonical-chinese-search.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
 
         append_turn_direct(
             "workspace-session",
@@ -10094,10 +9709,7 @@ mod tests {
         let db_path = tmp.join("canonical-metadata-only-search.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
 
         let payload = json!({
             "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
@@ -10137,10 +9749,7 @@ mod tests {
         let db_path = tmp.join("stale-canonical-fts.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
         ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
 
         let conn = Connection::open(&db_path).expect("open sqlite db");
@@ -10220,10 +9829,7 @@ mod tests {
         let db_path = tmp.join("cached-runtime-stale-fts.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
         ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
 
         let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
@@ -10316,10 +9922,7 @@ mod tests {
         let db_path = tmp.join("cached-runtime-pairing-schema.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
         ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
 
         let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
@@ -10391,10 +9994,7 @@ mod tests {
         let db_path = tmp.join("future-schema-version.sqlite3");
         let _ = fs::remove_file(&db_path);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
         ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
 
         let runtime = acquire_memory_runtime(&config).expect("cached sqlite runtime");
@@ -10532,10 +10132,7 @@ mod tests {
         .expect("insert session state");
         drop(conn);
 
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..MemoryRuntimeConfig::default()
-        };
+        let config = sqlite_test_config(db_path.clone());
         let _ = ensure_memory_db_ready(None, &config).expect("upgrade legacy sqlite db");
 
         let hits = search_canonical_records_for_recall("rollback smoke test", 4, None, &config)

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -48,6 +48,13 @@ fn sqlite_memory_config_with_profile(
     config
 }
 
+fn selected_memory_system_config(system_id: &str) -> runtime_config::MemoryRuntimeConfig {
+    runtime_config::MemoryRuntimeConfig {
+        resolved_system_id: Some(system_id.to_owned()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    }
+}
+
 #[cfg(feature = "memory-sqlite")]
 fn cleanup_memory_workspace(workspace_root: &std::path::Path, db_path: &std::path::Path) {
     let _ = drop_cached_sqlite_runtime(db_path);
@@ -753,10 +760,7 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
 
     ensure_registry_runtime_executing_system_registered();
 
-    let config = runtime_config::MemoryRuntimeConfig {
-        resolved_system_id: Some("registry-runtime-executing".to_owned()),
-        ..runtime_config::MemoryRuntimeConfig::default()
-    };
+    let config = selected_memory_system_config("registry-runtime-executing");
 
     let request = MemoryCoreRequest {
         operation: "noop".to_owned(),
@@ -856,10 +860,7 @@ async fn registry_selected_system_can_use_compact_stage_hook_without_custom_runt
         .set(workspace_root.clone())
         .ok();
 
-    let config = runtime_config::MemoryRuntimeConfig {
-        resolved_system_id: Some("registry-compact-hook".to_owned()),
-        ..runtime_config::MemoryRuntimeConfig::default()
-    };
+    let config = selected_memory_system_config("registry-compact-hook");
     let diagnostics = run_compact_stage(
         "compact-hook-session",
         Some(workspace_root.as_path()),


### PR DESCRIPTION
## Summary

This pr cleans up the sqlite-backed memory test surface so backend test scenarios describe only the knobs that matter instead of repeating full runtime config literals.

## What changed

- added one shared summary-config helper for sqlite-backed memory tests
- collapsed repeated `MemoryRuntimeConfig` setup across the sqlite backend test suite onto the local helper family
- reused the same selected-system helper in the core memory regression tests
- kept all changes confined to test/support code

## Why

The sqlite-backed memory test surface had accumulated a large amount of config boilerplate. That made test intent harder to review and raised the maintenance cost of changing backend fixtures.

After this change, test cases read more directly as scenario differences instead of setup repetition.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`

Closes #1304
