### PR TITLE
Stabilize process-global test state for cwd and subprocess-heavy tool tests

### DIFF
--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -5613,23 +5613,8 @@ pub(super) fn format_summary_block(summary_body: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::config::MemoryProfile;
+    use crate::test_support::ScopedCurrentDir;
     use serde_json::json;
-
-    struct CurrentDirGuard {
-        original: PathBuf,
-    }
-
-    impl Drop for CurrentDirGuard {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.original).expect("restore current dir");
-        }
-    }
-
-    fn set_current_dir_for_test(path: &Path) -> CurrentDirGuard {
-        let original = std::env::current_dir().expect("read current dir");
-        std::env::set_current_dir(path).expect("set current dir");
-        CurrentDirGuard { original }
-    }
 
     fn sqlite_test_config(db_path: impl Into<PathBuf>) -> MemoryRuntimeConfig {
         MemoryRuntimeConfig::for_sqlite_path(db_path)
@@ -6157,7 +6142,7 @@ mod tests {
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).expect("create temp dir");
         let db_path = tmp.join("data").join("alias.sqlite3");
-        let _cwd_guard = set_current_dir_for_test(&tmp);
+        let _cwd_guard = ScopedCurrentDir::new(&tmp);
 
         let relative_config =
             sqlite_test_config_with_profile("data/alias.sqlite3", MemoryProfile::WindowOnly, 2);
@@ -6202,7 +6187,7 @@ mod tests {
         let cwd = tmp.join("workspace").join("nested");
         fs::create_dir_all(&cwd).expect("create nested cwd dir");
         let db_path = tmp.join("workspace").join("data").join("alias.sqlite3");
-        let _cwd_guard = set_current_dir_for_test(&cwd);
+        let _cwd_guard = ScopedCurrentDir::new(&cwd);
 
         let alias_a =
             sqlite_test_config_with_profile("../data/alias.sqlite3", MemoryProfile::WindowOnly, 2);
@@ -6522,7 +6507,7 @@ mod tests {
             .join("workspace")
             .join("data")
             .join("alias-cache.sqlite3");
-        let _cwd_guard = set_current_dir_for_test(&cwd);
+        let _cwd_guard = ScopedCurrentDir::new(&cwd);
 
         let config = sqlite_test_config_with_profile(
             PathBuf::from("../data/alias-cache.sqlite3"),

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -300,38 +300,9 @@ pub(crate) const fn runtime_durable_recall_intro() -> &'static str {
 mod tests {
     use super::*;
     use crate::config::LoongConfig;
+    use crate::test_support::ScopedCurrentDir;
     use serde_json::json;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
-
-    struct ScopedCurrentDir {
-        _guard: MutexGuard<'static, ()>,
-        original: std::path::PathBuf,
-    }
-
-    impl ScopedCurrentDir {
-        fn lock() -> &'static Mutex<()> {
-            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            LOCK.get_or_init(|| Mutex::new(()))
-        }
-
-        fn enter(path: &std::path::Path) -> Self {
-            let guard = Self::lock().lock().expect("lock current dir test");
-            let original = std::env::current_dir().expect("read current dir");
-            std::env::set_current_dir(path).expect("set current dir");
-
-            Self {
-                _guard: guard,
-                original,
-            }
-        }
-    }
-
-    impl Drop for ScopedCurrentDir {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.original).expect("restore current dir");
-        }
-    }
 
     #[test]
     fn runtime_self_continuity_from_event_payload_defaults_missing_tool_usage_policy_lane() {
@@ -460,7 +431,7 @@ mod tests {
         let workspace_root = temp_dir.path();
         let agents_path = workspace_root.join("AGENTS.md");
         let mut config = LoongConfig::default();
-        let _guard = ScopedCurrentDir::enter(workspace_root);
+        let _guard = ScopedCurrentDir::new(workspace_root);
 
         std::fs::write(&agents_path, "cwd runtime self should stay advisory-only")
             .expect("write AGENTS");

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -183,6 +183,40 @@ pub(crate) fn acquire_subprocess_test_guard() -> MutexGuard<'static, ()> {
 }
 
 #[cfg(test)]
+fn current_dir_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
+pub(crate) struct ScopedCurrentDir {
+    original: PathBuf,
+    _lock: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl ScopedCurrentDir {
+    pub(crate) fn new(path: &Path) -> Self {
+        let lock = current_dir_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let original = std::env::current_dir().expect("read current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self {
+            original,
+            _lock: lock,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScopedCurrentDir {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).expect("restore current dir");
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn durable_memory_flush_test_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -152,7 +152,7 @@ async fn run_shell_command_with_timeout(
 #[cfg(all(test, feature = "tool-shell", unix))]
 mod tests {
     use super::*;
-    use crate::test_support::unique_temp_dir;
+    use crate::test_support::{acquire_subprocess_test_guard, unique_temp_dir};
     use crate::tools::runtime_config::ToolRuntimeConfig;
     use crate::tools::runtime_events::{
         ToolRuntimeEvent, ToolRuntimeEventSink, ToolRuntimeStream, with_tool_runtime_event_sink,
@@ -190,6 +190,14 @@ mod tests {
         }
     }
 
+    fn execute_shell_tool_for_subprocess_test(
+        request: ToolCoreRequest,
+        config: &ToolRuntimeConfig,
+    ) -> Result<ToolCoreOutcome, String> {
+        let _guard = acquire_subprocess_test_guard();
+        execute_shell_tool_with_config(request, config)
+    }
+
     #[test]
     fn shell_exec_defaults_cwd_to_configured_file_root() {
         let root = unique_temp_dir("loong-shell-default-cwd");
@@ -202,8 +210,8 @@ mod tests {
             }),
         };
 
-        let outcome =
-            execute_shell_tool_with_config(request, &config).expect("shell.exec should succeed");
+        let outcome = execute_shell_tool_for_subprocess_test(request, &config)
+            .expect("shell.exec should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["cwd"], root.display().to_string());
@@ -304,7 +312,7 @@ mod tests {
             .expect("current-thread runtime");
 
         let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
-            execute_shell_tool_with_config(request, &config)
+            execute_shell_tool_for_subprocess_test(request, &config)
         }));
         let outcome = outcome.expect("shell.exec should succeed under runtime sink");
         let events = lock_runtime_events(&sink);
@@ -359,7 +367,7 @@ mod tests {
             .expect("current-thread runtime");
 
         let outcome = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
-            execute_shell_tool_with_config(request, &config)
+            execute_shell_tool_for_subprocess_test(request, &config)
         }));
         let outcome = outcome.expect("shell.exec should succeed");
         let events = lock_runtime_events(&sink);
@@ -404,7 +412,7 @@ mod tests {
             .expect("current-thread runtime");
 
         let error = runtime.block_on(with_tool_runtime_event_sink(runtime_sink, async {
-            execute_shell_tool_with_config(request, &config)
+            execute_shell_tool_for_subprocess_test(request, &config)
         }));
         let error = error.expect_err("shell.exec should time out");
         let events = lock_runtime_events(&sink);

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -1,4 +1,21 @@
 use super::*;
+use crate::test_support::ScopedCurrentDir;
+
+fn execute_tool_core_for_subprocess_test(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let _guard = crate::test_support::acquire_subprocess_test_guard();
+    execute_tool_core_with_config(request, config)
+}
+
+fn execute_tool_core_with_trusted_subprocess_test_context(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let _guard = crate::test_support::acquire_subprocess_test_guard();
+    execute_tool_core_with_test_context(request, config)
+}
 
 #[cfg(feature = "tool-shell")]
 #[test]
@@ -79,7 +96,7 @@ fn tool_search_hides_bash_exec_when_governance_rules_failed_to_load() {
 #[cfg(feature = "tool-shell")]
 #[test]
 fn tool_search_routes_bash_capabilities_to_exec_when_runtime_is_available() {
-    let root = unique_tool_temp_dir("loongclaw-bash-tool-search-visible");
+    let root = unique_tool_temp_dir("loong-bash-tool-search-visible");
     std::fs::create_dir_all(&root).expect("create root dir");
 
     let mut config = test_tool_runtime_config(root);
@@ -108,7 +125,7 @@ fn tool_search_routes_bash_capabilities_to_exec_when_runtime_is_available() {
 #[cfg(feature = "tool-shell")]
 #[test]
 fn tool_search_exact_bash_query_surfaces_exec() {
-    let root = unique_tool_temp_dir("loongclaw-bash-tool-search-exact-query");
+    let root = unique_tool_temp_dir("loong-bash-tool-search-exact-query");
     std::fs::create_dir_all(&root).expect("create root dir");
 
     let mut config = test_tool_runtime_config(root);
@@ -247,7 +264,7 @@ fn bash_exec_reports_failed_status_for_non_zero_exit() {
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = ready_bash_exec_runtime_policy();
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "printf 'hello'; exit 7"}),
@@ -301,7 +318,7 @@ fn bash_exec_runs_command_string_via_bash_runtime() {
         ..runtime_config::BashExecRuntimePolicy::default()
     };
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "printf 'hello-from-bash'"}),
@@ -348,7 +365,7 @@ fn bash_exec_falls_back_to_file_root_when_current_dir_is_unavailable() {
     let cwd_guard = ScopedCurrentDir::new(&deleted_cwd);
     fs::remove_dir_all(&deleted_cwd).expect("remove deleted cwd");
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "printf fallback-from-file-root"}),
@@ -388,7 +405,7 @@ fn bash_exec_defaults_cwd_to_configured_file_root() {
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = ready_bash_exec_runtime_policy();
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({
@@ -430,7 +447,7 @@ fn bash_exec_allows_plain_command_when_prefix_rule_allows() {
     let (bash_exec, _log_path) = configured_test_bash_runtime_with_rules(&root);
     config.bash_exec = bash_exec;
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "printf ok"}),
@@ -477,7 +494,7 @@ fn bash_exec_uses_loong_home_rules_dir_even_when_runtime_is_built_without_config
     runtime.bash_exec.available = true;
     runtime.bash_exec.command = Some(runtime_path);
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "printf ok"}),
@@ -627,7 +644,7 @@ fn bash_exec_allows_parse_unreliable_command_when_shell_default_mode_is_allow() 
     let (bash_exec, _log_path) = configured_test_bash_runtime_with_rules(&root);
     config.bash_exec = bash_exec;
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({"command": "if then"}),
@@ -645,7 +662,7 @@ fn bash_exec_allows_parse_unreliable_command_when_shell_default_mode_is_allow() 
 #[test]
 fn bash_exec_keeps_shell_exec_unchanged() {
     let config = test_tool_runtime_config(std::env::temp_dir());
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "shell.exec".to_owned(),
             payload: json!({"command": "echo", "args": ["hi"]}),
@@ -673,7 +690,7 @@ fn bash_exec_honors_cwd() {
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = ready_bash_exec_runtime_policy();
 
-    let outcome = execute_tool_core_with_config(
+    let outcome = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({
@@ -739,7 +756,7 @@ fn bash_exec_times_out_when_timeout_ms_is_small() {
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = ready_bash_exec_runtime_policy();
 
-    let error = execute_tool_core_with_config(
+    let error = execute_tool_core_for_subprocess_test(
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({
@@ -777,14 +794,14 @@ fn direct_exec_routes_script_mode_to_bash_exec() {
 fn direct_exec_can_run_bash_through_the_collapsed_exec_surface() {
     use std::fs;
 
-    let root = unique_tool_temp_dir("loongclaw-direct-exec-bash");
+    let root = unique_tool_temp_dir("loong-direct-exec-bash");
     fs::create_dir_all(&root).expect("create fixture root");
 
     let mut config = test_tool_runtime_config(root.clone());
     config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
     config.bash_exec = ready_bash_exec_runtime_policy();
 
-    let outcome = execute_tool_core_with_test_context(
+    let outcome = execute_tool_core_with_trusted_subprocess_test_context(
         ToolCoreRequest {
             tool_name: "exec".to_owned(),
             payload: json!({

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -4,7 +4,6 @@ use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::sync::{MutexGuard, OnceLock};
 
 struct ToolTestRuntimeConfig {
     config: runtime_config::ToolRuntimeConfig,
@@ -32,7 +31,7 @@ impl ToolTestRuntimeConfig {
 }
 
 fn test_tool_runtime_config(root: impl AsRef<Path>) -> ToolTestRuntimeConfig {
-    let runtime_home = ScopedLoongHome::new("loongclaw-tool-runtime-home");
+    let runtime_home = ScopedLoongHome::new("loong-tool-runtime-home");
     let config = runtime_config::ToolRuntimeConfig {
         shell_allow: BTreeSet::from(["echo".to_owned(), "cat".to_owned(), "ls".to_owned()]),
         file_root: Some(root.as_ref().to_path_buf()),
@@ -58,36 +57,6 @@ fn ready_bash_exec_runtime_policy() -> runtime_config::BashExecRuntimePolicy {
         available: true,
         command: Some(PathBuf::from("bash")),
         ..runtime_config::BashExecRuntimePolicy::default()
-    }
-}
-
-struct ScopedCurrentDir {
-    original: PathBuf,
-    _lock: MutexGuard<'static, ()>,
-}
-
-fn current_dir_test_lock() -> &'static std::sync::Mutex<()> {
-    static CURRENT_DIR_TEST_LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-    CURRENT_DIR_TEST_LOCK.get_or_init(|| std::sync::Mutex::new(()))
-}
-
-impl ScopedCurrentDir {
-    fn new(path: &Path) -> Self {
-        let lock = current_dir_test_lock()
-            .lock()
-            .expect("lock current dir test");
-        let original = std::env::current_dir().expect("read current dir");
-        std::env::set_current_dir(path).expect("set current dir");
-        Self {
-            original,
-            _lock: lock,
-        }
-    }
-}
-
-impl Drop for ScopedCurrentDir {
-    fn drop(&mut self) {
-        std::env::set_current_dir(&self.original).expect("restore current dir");
     }
 }
 
@@ -2208,7 +2177,8 @@ fn browser_companion_protocol_surfaces_invalid_json_from_command() {
 #[cfg(feature = "tool-browser")]
 #[test]
 fn browser_companion_protocol_times_out_stalled_command() {
-    let root = unique_tool_temp_dir("loongclaw-browser-companion-timeout");
+    let _subprocess_guard = crate::test_support::acquire_subprocess_test_guard();
+    let root = unique_tool_temp_dir("loong-browser-companion-timeout");
     std::fs::create_dir_all(&root).expect("create fixture root");
     let script_path = write_browser_companion_sleep_script(&root, "browser-companion-timeout", 2);
     let mut config = browser_companion_runtime_config(&root, script_path.display().to_string());

--- a/crates/daemon/src/task_execution.rs
+++ b/crates/daemon/src/task_execution.rs
@@ -397,6 +397,17 @@ mod tests {
 
     #[tokio::test]
     async fn daemon_runtime_kernel_overrides_pi_local_stub_harness() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        let home = std::env::temp_dir().join(format!(
+            "loong-daemon-runtime-harness-home-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create isolated daemon home");
+        env.set("HOME", &home);
+        env.remove("LOONG_HOME");
+        env.remove("LOONG_CONFIG_PATH");
+        env.remove("LOONGCLAW_CONFIG_PATH");
+
         let kernel = build_daemon_runtime_kernel();
         let token = kernel
             .issue_token(DEFAULT_PACK_ID, DEFAULT_AGENT_ID, 120)


### PR DESCRIPTION
## Summary

This PR hardens the test suite around process-global cwd and subprocess-heavy tool paths.

## What changed

- serialized process cwd mutation behind a shared guard in `crate::test_support`
- serialized subprocess-heavy shell, bash, and browser-companion test paths behind the shared subprocess guard
- made the daemon runtime harness test hermetic with respect to local `HOME` / `LOONG_*` config state

## Why

These tests were correct in isolation but still relied on scheduler luck around process-global state. That made full-suite stability worse than it needed to be.

After this change, the affected tests coordinate shared state explicitly instead of racing each other.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`

Closes #1305
