### PR TITLE
Make hidden skill recovery explain the lease-based invoke step

### DIFF
--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2442,7 +2442,7 @@ fn concealed_provider_tool_denial() -> TurnFailure {
 }
 
 fn tool_search_recovery_hint() -> &'static str {
-    " If you need a non-core capability, call tool.search with a short natural-language description of the task."
+    " If you need a non-core capability, call tool.search with a short natural-language description of the task. If tool.search returns a grouped hidden surface such as `skills`, `agent`, or `channel`, do not call that surface name directly; use tool.invoke with the fresh lease and put the requested operation inside payload.arguments."
 }
 
 fn provider_tool_denial_reason(reason: &str, source: &str) -> String {
@@ -4039,6 +4039,65 @@ mod tests {
         assert!(
             failure.reason.contains("tool.search"),
             "concealed denial should advertise discovery recovery: {}",
+            failure.reason
+        );
+        assert!(failure.supports_discovery_recovery);
+        assert!(
+            failure.reason.contains("tool.invoke"),
+            "concealed denial should advertise tool.invoke recovery: {}",
+            failure.reason
+        );
+        assert!(
+            failure.reason.contains("lease"),
+            "concealed denial should mention the lease requirement: {}",
+            failure.reason
+        );
+    }
+
+    #[test]
+    fn validate_turn_in_context_conceals_direct_hidden_skills_surface_and_advertises_lease_flow() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "skills".to_owned(),
+                args_json: json!({
+                    "operation": "list"
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-provider-direct-skills".to_owned(),
+                turn_id: "turn-provider-direct-skills".to_owned(),
+                tool_call_id: "call-provider-direct-skills".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "session-provider-direct-skills",
+            crate::tools::ToolView::from_tool_names(std::iter::empty::<&str>()),
+        );
+
+        let failure = TurnEngine::new(4)
+            .validate_turn_in_context(&turn, &session_context)
+            .expect_err("provider direct hidden skills surface should be concealed");
+
+        assert_eq!(failure.code, "tool_not_found");
+        assert!(
+            failure
+                .reason
+                .contains("tool_not_found: requested tool is not available")
+        );
+        assert!(
+            failure.reason.contains("tool.search"),
+            "concealed denial should advertise discovery recovery: {}",
+            failure.reason
+        );
+        assert!(
+            failure.reason.contains("tool.invoke"),
+            "concealed denial should explain the grouped-surface invoke flow: {}",
+            failure.reason
+        );
+        assert!(
+            failure.reason.contains("skills"),
+            "concealed denial should mention grouped hidden surfaces: {}",
             failure.reason
         );
         assert!(failure.supports_discovery_recovery);

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -26,7 +26,7 @@ pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the 
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
-pub const DISCOVERY_RECOVERY_FOLLOWUP_PROMPT: &str = "The previous tool call could not be executed as requested. If you still need a hidden or discoverable capability, call tool.search with a short natural-language description of the missing capability. Otherwise, provide the best possible answer with the currently available evidence.";
+pub const DISCOVERY_RECOVERY_FOLLOWUP_PROMPT: &str = "The previous tool call could not be executed as requested. If you still need a hidden or discoverable capability, call tool.search with a short natural-language description of the missing capability. If tool.search returns a grouped hidden surface such as `skills`, `agent`, or `channel`, do not call that surface name directly; reuse its fresh lease through tool.invoke and place the requested operation inside payload.arguments. Otherwise, provide the best possible answer with the currently available evidence.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
@@ -3043,6 +3043,14 @@ mod tests {
         assert!(user_prompt.contains(DISCOVERY_RECOVERY_FOLLOWUP_PROMPT));
         assert!(user_prompt.contains("Recovery reason:\nbounded-recovery"));
         assert!(!user_prompt.contains("tool_not_found"));
+        assert!(
+            user_prompt.contains("tool.invoke"),
+            "discovery recovery prompt should explain the invoke step: {user_prompt}"
+        );
+        assert!(
+            user_prompt.contains("lease"),
+            "discovery recovery prompt should mention the lease requirement: {user_prompt}"
+        );
         assert!(user_prompt.contains("Loop warning:\nwarning"));
     }
 

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -369,6 +369,7 @@ fn render_deferred_tool_text_workflow_section() -> String {
         "For `web`, distinguish search-provider mode from ordinary network mode: `web { query }` uses web-search providers, while `web { url }` or low-level request fields are still normal network access.".to_owned(),
         "Use `tool_search` only when the task needs a hidden surface such as `agent`, `skills`, or `channel`, and keep the query short and capability-focused.".to_owned(),
         "Use `tool_invoke` only with a fresh lease returned by `tool_search`; do not route normal direct-tool work through leases.".to_owned(),
+        "Grouped hidden surfaces such as `agent`, `skills`, and `channel` are not direct tool calls. If `tool_search` returns one of them, pass it back through `tool_invoke` with the returned lease instead of emitting that grouped name directly.".to_owned(),
         "When you need a tool, emit the raw JSON call instead of only describing the missing capability.".to_owned(),
         "Direct tool example:".to_owned(),
         direct_call_example,


### PR DESCRIPTION
## Summary

- Problem: Discovery-recovery copy for hidden surfaces could still be read as telling the model to call `skills` directly, which produced a misleading loop instead of a lease-based `tool.invoke`.
- Why it matters: Users hitting the hidden-surface path need truthful guidance, otherwise the model retries the wrong surface and hides the actual next step.
- What changed: Tightened provider-facing recovery hints and discovery-recovery prompt text to explicitly say grouped hidden surfaces (`skills`, `agent`, `channel`) are not direct tool calls and must go back through `tool.invoke` with the lease from `tool.search`; added regression coverage for direct hidden-surface denial and the prompt text.
- What did not change (scope boundary): Tool-search / lease / invoke routing semantics remain unchanged; this only clarifies recovery messaging.

## Linked Issues

- Closes #1313
- Related: none

## Change Type

- [x] Bug fix

## Touched Areas

- [x] Conversation / session runtime
- [x] Tools
- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- [x] `./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `./scripts/cargo-local-toolchain.sh test --workspace --all-features`
- [x] `./scripts/check_architecture_boundaries.sh`

Commands and evidence:

```text
All validation passed on <redacted-path> using CARGO_TARGET_DIR=<redacted-target-dir>
Focused regression tests passed:
- validate_turn_in_context_conceals_direct_hidden_skills_surface_and_advertises_lease_flow
- tool_driven_followup_tail_dispatches_discovery_recovery_payload
```

## User-visible / Operator-visible Changes

- Hidden-surface recovery now explicitly names the lease + invoke step for grouped surfaces.

## Failure Recovery

- Fast rollback or disable path: revert the prompt-copy edits in `crates/app/src/conversation/turn_engine.rs`, `crates/app/src/conversation/turn_shared.rs`, and `crates/app/src/provider/request_message_runtime.rs`.
- Observable failure symptoms reviewers should watch for: direct `skills` calls still being suggested after a `tool.search` lease is returned.

## Reviewer Focus

- The hidden-surface lease contract itself is unchanged; only the recovery text and test coverage moved.
