### PR TITLE
Add stable-only loong update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,10 @@ loong onboard                # Interactive setup — configure provider and mode
 loong ask --message "Summarize this repo in one sentence."  # Single-turn query to verify config
 loong chat                   # Start a multi-turn conversation
 loong doctor --fix           # Check environment and auto-fix common issues
+loong update                 # Replace this install with the latest stable GitHub release
 ```
+
+`loong update` always targets the latest stable GitHub release and never installs a pre-release.
 
 Running `onboard` is enough for the golden path — it writes a working config to `~/.loong/config.toml` without asking you to hand-edit TOML. The snippets below show what that file looks like on `dev` today, when you want to add another provider or wire up a channel.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,7 +146,10 @@ loong onboard                # 交互式初始化，配置 provider 和 model
 loong ask --message "用一句话总结这个仓库"  # 单轮提问，验证配置是否生效
 loong chat                   # 进入多轮对话
 loong doctor --fix           # 检查环境并自动修复常见问题
+loong update                 # 把当前安装升级到最新稳定版 GitHub Release
 ```
+
+`loong update` 只会安装最新稳定版 GitHub Release，绝不会切到 pre-release。
 
 走完 `onboard` 就够了 —— 它会把一份能跑的配置写到 `~/.loong/config.toml`，不需要你手写 TOML。如果你想再加一个 provider 或接入频道，下面几段是 dev 分支当前的实际形态。
 

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -5,6 +5,7 @@ impl Commands {
         match self {
             Self::Welcome => "welcome",
             Self::Demo => "demo",
+            Self::Update => "update",
             Self::RunTask { .. } => "run_task",
             Self::Turn { command } => match command {
                 crate::TurnCommands::Run { .. } => "turn_run",
@@ -114,6 +115,7 @@ mod tests {
     fn command_kind_for_logging_uses_stable_variant_names() {
         assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
         assert_eq!(Commands::AuditDemo.command_kind_for_logging(), "audit_demo");
+        assert_eq!(Commands::Update.command_kind_for_logging(), "update");
         assert_eq!(
             Commands::ValidateConfig {
                 config: None,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -182,6 +182,7 @@ mod tlon_cli;
 mod tool_calling_readiness;
 pub mod trajectory_cli;
 mod turn_cli;
+pub mod update_cli;
 pub mod work_unit_cli;
 pub use self::acp_cli::{
     acp_backend_metadata_json, acp_binding_scope_json, acp_control_plane_json,
@@ -230,6 +231,7 @@ pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
 pub use turn_cli::{TurnCommands, build_cli_chat_options, run_ask_cli, run_chat_cli};
+pub use update_cli::run_update_cli;
 #[rustfmt::skip]
 use tool_calling_readiness::{RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state};
 pub use trajectory_cli::{
@@ -471,6 +473,11 @@ pub enum Commands {
     Welcome,
     /// Run the original end-to-end bootstrap demo
     Demo,
+    #[command(
+        long_about = "Download and apply the latest stable GitHub release for the current Loong binary.\n\nThis command intentionally follows the latest stable release channel only. GitHub prereleases are excluded."
+    )]
+    /// Update this Loong install to the latest stable GitHub release
+    Update,
     #[command(hide = true)]
     /// Deprecated compatibility alias for the generic task runner
     RunTask {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -209,6 +209,7 @@ async fn run_command(command: Commands) -> CliResult<()> {
     match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
+        Commands::Update => run_update_cli().await,
         Commands::RunTask { objective, payload } => run_task_cli(&objective, &payload).await,
         Commands::Turn { command } => match command {
             loong_daemon::TurnCommands::Run {

--- a/crates/daemon/src/update_cli.rs
+++ b/crates/daemon/src/update_cli.rs
@@ -1,0 +1,579 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::Deserialize;
+
+use crate::{CLI_COMMAND_NAME, CliResult};
+
+const DEFAULT_RELEASE_REPO: &str = "eastreams/loong";
+const GITHUB_RELEASE_API_BASE: &str = "https://api.github.com";
+const GITHUB_RELEASE_DOWNLOAD_BASE: &str = "https://github.com";
+const UPDATE_USER_AGENT: &str = "Loong-Update";
+const UPDATE_RELEASE_REPO_ENV: &str = "LOONG_UPDATE_REPO";
+const UPDATE_RELEASE_API_URL_ENV: &str = "LOONG_UPDATE_RELEASE_API_URL";
+const UPDATE_RELEASE_BASE_URL_ENV: &str = "LOONG_UPDATE_RELEASE_BASE_URL";
+const INSTALL_RELEASE_REPO_ENV: &str = "LOONG_INSTALL_REPO";
+const INSTALL_RELEASE_BASE_URL_ENV: &str = "LOONG_INSTALL_RELEASE_BASE_URL";
+const TEST_EXECUTABLE_ENV: &str = "LOONG_UPDATE_TEST_EXECUTABLE";
+
+#[derive(Debug, Deserialize)]
+struct GitHubReleaseMetadata {
+    tag_name: String,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    draft: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdatePlatform {
+    Unix,
+    Windows,
+}
+
+impl UpdatePlatform {
+    fn current() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Unix
+        }
+    }
+
+    fn script_name(self) -> &'static str {
+        match self {
+            Self::Unix => "install.sh",
+            Self::Windows => "install.ps1",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UpdateRuntimeConfig {
+    release_repo: String,
+    latest_release_api_url: String,
+    release_base_url: String,
+}
+
+impl UpdateRuntimeConfig {
+    fn from_env() -> Self {
+        let release_repo = env::var(UPDATE_RELEASE_REPO_ENV)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                env::var(INSTALL_RELEASE_REPO_ENV)
+                    .ok()
+                    .map(|value| value.trim().to_owned())
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or_else(|| DEFAULT_RELEASE_REPO.to_owned());
+
+        let latest_release_api_url = env::var(UPDATE_RELEASE_API_URL_ENV)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| latest_release_api_url(release_repo.as_str()));
+
+        let release_base_url = env::var(UPDATE_RELEASE_BASE_URL_ENV)
+            .ok()
+            .map(|value| value.trim().trim_end_matches('/').to_owned())
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                env::var(INSTALL_RELEASE_BASE_URL_ENV)
+                    .ok()
+                    .map(|value| value.trim().trim_end_matches('/').to_owned())
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or_else(|| format!("{GITHUB_RELEASE_DOWNLOAD_BASE}/{release_repo}/releases"));
+
+        Self {
+            release_repo,
+            latest_release_api_url,
+            release_base_url,
+        }
+    }
+}
+
+pub async fn run_update_cli() -> CliResult<()> {
+    let runtime = UpdateRuntimeConfig::from_env();
+    let executable_override = env::var_os(TEST_EXECUTABLE_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    run_update_cli_with_runtime(runtime, executable_override).await
+}
+
+async fn run_update_cli_with_runtime(
+    runtime: UpdateRuntimeConfig,
+    current_executable_override: Option<PathBuf>,
+) -> CliResult<()> {
+    let platform = UpdatePlatform::current();
+    let current_executable = resolve_current_executable_path(current_executable_override)?;
+    let install_prefix = install_prefix_for_current_executable(current_executable.as_path())?;
+    let latest_release = fetch_latest_stable_release(&runtime).await?;
+    let script_name = platform.script_name();
+    let script_url = stable_release_script_url(
+        runtime.release_base_url.as_str(),
+        latest_release.tag_name.as_str(),
+        script_name,
+    );
+    let script_path = download_update_script(script_url.as_str(), script_name).await?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "==> Updating {CLI_COMMAND_NAME} to stable release {}",
+            latest_release.tag_name
+        );
+    }
+
+    let command_result = run_update_script(
+        platform,
+        script_path.as_path(),
+        install_prefix.as_path(),
+        latest_release.tag_name.as_str(),
+    );
+
+    let cleanup_result = fs::remove_file(&script_path);
+    if let Err(error) = cleanup_result
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            target: "loong.daemon",
+            path = %script_path.display(),
+            error = %error,
+            "failed to remove temporary update script"
+        );
+    }
+
+    command_result
+}
+
+fn resolve_current_executable_path(
+    current_executable_override: Option<PathBuf>,
+) -> CliResult<PathBuf> {
+    if let Some(override_path) = current_executable_override {
+        return Ok(override_path);
+    }
+
+    env::current_exe()
+        .map_err(|error| format!("failed to resolve current executable path: {error}"))
+}
+
+fn install_prefix_for_current_executable(current_executable: &Path) -> CliResult<PathBuf> {
+    current_executable
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "failed to determine install prefix from current executable {}",
+                current_executable.display()
+            )
+        })
+}
+
+async fn fetch_latest_stable_release(
+    runtime: &UpdateRuntimeConfig,
+) -> CliResult<GitHubReleaseMetadata> {
+    let response = reqwest::Client::new()
+        .get(runtime.latest_release_api_url.as_str())
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header(reqwest::header::USER_AGENT, UPDATE_USER_AGENT)
+        .send()
+        .await
+        .map_err(|error| {
+            format!(
+                "failed to contact GitHub release API for {}: {error}",
+                runtime.release_repo
+            )
+        })?;
+    let response = response.error_for_status().map_err(|error| {
+        format!(
+            "failed to resolve latest stable GitHub release for {}: {error}",
+            runtime.release_repo
+        )
+    })?;
+    let body = response.text().await.map_err(|error| {
+        format!(
+            "failed to read latest stable GitHub release response for {}: {error}",
+            runtime.release_repo
+        )
+    })?;
+    parse_latest_stable_release_response(body.as_str())
+}
+
+fn parse_latest_stable_release_response(response_body: &str) -> CliResult<GitHubReleaseMetadata> {
+    let release =
+        serde_json::from_str::<GitHubReleaseMetadata>(response_body).map_err(|error| {
+            format!("failed to parse latest stable GitHub release response: {error}")
+        })?;
+    let tag_name = release.tag_name.trim();
+    if tag_name.is_empty() {
+        return Err("latest stable GitHub release response did not include tag_name".to_owned());
+    }
+    if release.draft {
+        return Err(format!(
+            "latest stable GitHub release `{tag_name}` is still marked as a draft"
+        ));
+    }
+    if release.prerelease {
+        return Err(format!(
+            "latest stable GitHub release `{tag_name}` unexpectedly resolved to a pre-release"
+        ));
+    }
+    Ok(release)
+}
+
+async fn download_update_script(script_url: &str, script_name: &str) -> CliResult<PathBuf> {
+    let response = reqwest::Client::new()
+        .get(script_url)
+        .header(reqwest::header::USER_AGENT, UPDATE_USER_AGENT)
+        .send()
+        .await
+        .map_err(|error| {
+            format!("failed to download update installer from {script_url}: {error}")
+        })?;
+    let response = response
+        .error_for_status()
+        .map_err(|error| format!("update installer download failed for {script_url}: {error}"))?;
+    let script_bytes = response
+        .bytes()
+        .await
+        .map_err(|error| format!("failed to read update installer from {script_url}: {error}"))?;
+    write_temp_update_script(script_name, script_bytes.as_ref())
+}
+
+fn write_temp_update_script(script_name: &str, script_bytes: &[u8]) -> CliResult<PathBuf> {
+    let process_id = std::process::id();
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("failed to derive temporary update path timestamp: {error}"))?
+        .as_nanos();
+    let path = env::temp_dir().join(format!(
+        "loong-update-{process_id}-{unix_nanos}-{script_name}"
+    ));
+
+    fs::write(&path, script_bytes).map_err(|error| {
+        format!(
+            "failed to write temporary update installer to {}: {error}",
+            path.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&path)
+            .map_err(|error| {
+                format!(
+                    "failed to inspect temporary update installer {}: {error}",
+                    path.display()
+                )
+            })?
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).map_err(|error| {
+            format!(
+                "failed to mark temporary update installer {} executable: {error}",
+                path.display()
+            )
+        })?;
+    }
+
+    Ok(path)
+}
+
+fn run_update_script(
+    platform: UpdatePlatform,
+    script_path: &Path,
+    install_prefix: &Path,
+    release_tag: &str,
+) -> CliResult<()> {
+    let mut command =
+        build_update_script_command(platform, script_path, install_prefix, release_tag)?;
+    let rendered_command = render_update_command(&command);
+    let status = command.status().map_err(|error| {
+        format!("failed to launch update installer `{rendered_command}`: {error}")
+    })?;
+
+    if status.success() {
+        return Ok(());
+    }
+
+    match status.code() {
+        Some(code) => Err(format!(
+            "update installer `{rendered_command}` exited with status code {code}"
+        )),
+        None => Err(format!(
+            "update installer `{rendered_command}` terminated without an exit code"
+        )),
+    }
+}
+
+fn build_update_script_command(
+    platform: UpdatePlatform,
+    script_path: &Path,
+    install_prefix: &Path,
+    release_tag: &str,
+) -> CliResult<Command> {
+    match platform {
+        UpdatePlatform::Windows => {
+            let shell = ["pwsh", "powershell"]
+                .into_iter()
+                .find(|candidate| command_exists(candidate))
+                .ok_or_else(|| {
+                    "failed to find PowerShell (`pwsh` or `powershell`) for `loong update`"
+                        .to_owned()
+                })?;
+            let mut command = Command::new(shell);
+            command
+                .arg("-NoLogo")
+                .arg("-NoProfile")
+                .arg("-ExecutionPolicy")
+                .arg("Bypass")
+                .arg("-File")
+                .arg(script_path)
+                .arg("-Prefix")
+                .arg(install_prefix)
+                .arg("-Version")
+                .arg(release_tag);
+            Ok(command)
+        }
+        UpdatePlatform::Unix => {
+            if !command_exists("bash") {
+                return Err("failed to find `bash` for `loong update`".to_owned());
+            }
+
+            let mut command = Command::new("bash");
+            command
+                .arg(script_path)
+                .arg("--prefix")
+                .arg(install_prefix)
+                .arg("--version")
+                .arg(release_tag);
+            Ok(command)
+        }
+    }
+}
+
+fn render_update_command(command: &Command) -> String {
+    let program = command.get_program().to_string_lossy();
+    let args = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    if args.is_empty() {
+        return program.into_owned();
+    }
+    format!("{program} {}", args.join(" "))
+}
+
+fn command_exists(program: &str) -> bool {
+    env::var_os("PATH").is_some_and(|path| {
+        env::split_paths(&path).any(|directory| {
+            let candidate = directory.join(program);
+            if candidate.is_file() {
+                return true;
+            }
+
+            #[cfg(windows)]
+            {
+                return ["exe", "cmd", "bat"]
+                    .iter()
+                    .any(|extension| directory.join(format!("{program}.{extension}")).is_file());
+            }
+
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        })
+    })
+}
+
+fn latest_release_api_url(release_repo: &str) -> String {
+    format!("{GITHUB_RELEASE_API_BASE}/repos/{release_repo}/releases/latest")
+}
+
+fn stable_release_script_url(release_base_url: &str, tag_name: &str, script_name: &str) -> String {
+    format!(
+        "{}/download/{tag_name}/{script_name}",
+        release_base_url.trim_end_matches('/')
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::Mutex,
+        thread,
+    };
+
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn parse_latest_stable_release_response_accepts_stable_release() {
+        let release = parse_latest_stable_release_response(
+            r#"{"tag_name":"v0.4.2","draft":false,"prerelease":false}"#,
+        )
+        .expect("stable release response should parse");
+
+        assert_eq!(release.tag_name, "v0.4.2");
+        assert!(!release.draft);
+        assert!(!release.prerelease);
+    }
+
+    #[test]
+    fn parse_latest_stable_release_response_rejects_prerelease() {
+        let error = parse_latest_stable_release_response(
+            r#"{"tag_name":"v0.4.2-alpha.1","draft":false,"prerelease":true}"#,
+        )
+        .expect_err("pre-release response must be rejected");
+
+        assert!(error.contains("pre-release"));
+    }
+
+    #[test]
+    fn parse_latest_stable_release_response_rejects_draft_release() {
+        let error = parse_latest_stable_release_response(r#"{"tag_name":"v0.4.2","draft":true}"#)
+            .expect_err("draft release must be rejected");
+
+        assert!(error.contains("draft"));
+    }
+
+    #[test]
+    fn parse_latest_stable_release_response_requires_tag_name() {
+        let error = parse_latest_stable_release_response(r#"{"tag_name":"   "}"#)
+            .expect_err("blank tag name must be rejected");
+
+        assert!(error.contains("tag_name"));
+    }
+
+    #[test]
+    fn stable_release_script_url_points_at_release_download_asset() {
+        let url = stable_release_script_url(
+            "https://github.com/eastreams/loong/releases/",
+            "v1.2.3",
+            "install.sh",
+        );
+
+        assert_eq!(
+            url,
+            "https://github.com/eastreams/loong/releases/download/v1.2.3/install.sh"
+        );
+    }
+
+    #[test]
+    fn install_prefix_for_current_executable_uses_parent_directory() {
+        let prefix = install_prefix_for_current_executable(Path::new("/tmp/bin/loong"))
+            .expect("parent directory should resolve");
+
+        assert_eq!(prefix, PathBuf::from("/tmp/bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_update_cli_downloads_latest_stable_installer_and_preserves_prefix() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let temp_dir = TempDir::new().expect("temp dir");
+        let prefix_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&prefix_dir).expect("prefix dir");
+        let capture_file = temp_dir.path().join("installer-args.txt");
+        let (release_api_url, release_base_url, server_handle) =
+            spawn_release_test_server("v9.9.9".to_owned(), capture_file.clone());
+        let runtime = UpdateRuntimeConfig {
+            release_repo: DEFAULT_RELEASE_REPO.to_owned(),
+            latest_release_api_url: release_api_url,
+            release_base_url,
+        };
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let result = tokio_runtime.block_on(run_update_cli_with_runtime(
+            runtime,
+            Some(prefix_dir.join("loong")),
+        ));
+        server_handle.join().expect("server should exit cleanly");
+
+        result.expect("update command should execute the downloaded installer");
+        let captured = fs::read_to_string(&capture_file).expect("captured installer args");
+        let expected_prefix = prefix_dir.display().to_string();
+        assert_eq!(
+            captured,
+            format!("--prefix\n{expected_prefix}\n--version\nv9.9.9\n")
+        );
+    }
+
+    #[cfg(unix)]
+    fn spawn_release_test_server(
+        stable_tag: String,
+        capture_file: PathBuf,
+    ) -> (String, String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("local test server addr");
+        let handle = thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let mut request_buffer = [0_u8; 4096];
+                let read_len = stream.read(&mut request_buffer).expect("read request");
+                let request = String::from_utf8_lossy(&request_buffer[..read_len]).into_owned();
+                let request_line = request.lines().next().unwrap_or_default();
+
+                let (status_line, response_body, content_type) = if request_line
+                    .starts_with("GET /repos/eastreams/loong/releases/latest ")
+                {
+                    (
+                        "HTTP/1.1 200 OK",
+                        format!(
+                            r#"{{"tag_name":"{stable_tag}","draft":false,"prerelease":false}}"#
+                        ),
+                        "application/json",
+                    )
+                } else if request_line
+                    .starts_with(&format!("GET /releases/download/{stable_tag}/install.sh "))
+                {
+                    (
+                        "HTTP/1.1 200 OK",
+                        format!(
+                            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$@\" > \"{}\"\n",
+                            capture_file.display()
+                        ),
+                        "text/plain",
+                    )
+                } else {
+                    (
+                        "HTTP/1.1 404 Not Found",
+                        "not found".to_owned(),
+                        "text/plain",
+                    )
+                };
+
+                let response = format!(
+                    "{status_line}\r\nContent-Length: {}\r\nContent-Type: {content_type}\r\nConnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+
+        (
+            format!("http://{address}/repos/eastreams/loong/releases/latest"),
+            format!("http://{address}/releases"),
+            handle,
+        )
+    }
+}

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -56,6 +56,30 @@ fn welcome_subcommand_help_advertises_first_run_shortcuts() {
 }
 
 #[test]
+fn update_subcommand_help_mentions_latest_stable_release_only() {
+    let help = render_cli_help(["update"]);
+
+    assert!(
+        help.contains("latest stable GitHub release"),
+        "update help should describe the stable release channel: {help}"
+    );
+    assert!(
+        help.contains("prereleases are excluded"),
+        "update help should explicitly say prereleases are not used: {help}"
+    );
+}
+
+#[test]
+fn update_subcommand_parses_without_flags() {
+    let cli = try_parse_cli(["loong", "update"]).expect("`loong update` should parse");
+
+    match cli.command {
+        Some(Commands::Update) => {}
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn setup_subcommand_is_removed() {
     let error = try_parse_cli(["loong", "setup"])
         .expect_err("`setup` should no longer parse as a valid subcommand");

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-19T11:38:12Z
+- Generated at: 2026-04-19T16:46:41Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -43,7 +43,7 @@ release review. It is not part of the primary public release trail.
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2111 | 6400 | 4289 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.7% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9592 | 11200 | 1608 | 50 | 120 | 70 | 85.6% | WATCH | 10831 | -11.4% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 1556 | 15000 | 13444 | 45 | 70 | 25 | 64.3% | HEALTHY | 14472 | -89.2% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 4877 | 6500 | 1623 | 162 | 210 | 48 | 77.1% | HEALTHY | 6324 | -22.9% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 4884 | 6500 | 1616 | 162 | 210 | 48 | 77.1% | HEALTHY | 6324 | -22.8% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 5783 | 9800 | 4017 | 209 | 250 | 41 | 83.6% | HEALTHY | 9519 | -39.2% | PASS | 228 |
 
 ## Prioritization Signals
@@ -97,7 +97,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=channel_mod lines=2111 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9592 functions=50 -->
 <!-- arch-hotspot key=tools_mod lines=1556 functions=45 -->
-<!-- arch-hotspot key=daemon_lib lines=4877 functions=162 -->
+<!-- arch-hotspot key=daemon_lib lines=4884 functions=162 -->
 <!-- arch-hotspot key=onboard_cli lines=5783 functions=209 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary
- add a top-level `loong update` command that reuses the published GitHub installer assets
- keep self-update pinned to the latest stable release and explicitly reject prereleases
- cover the new command with focused CLI/help/runtime tests while keeping testability compatible with the repo's no-unsafe policy

## Testing
- `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- `env RUSTC=<redacted-rustc> RUSTDOC=<redacted-rustdoc> CARGO_TARGET_DIR=/tmp/loong-verify-rustc <redacted-cargo> test -p loong update -- --nocapture`
- `env RUSTC=<redacted-rustc> RUSTDOC=<redacted-rustdoc> CARGO_TARGET_DIR=/tmp/loong-verify-rustc <redacted-cargo> check -p loong`
- `env RUSTC=<redacted-rustc> RUSTDOC=<redacted-rustdoc> CARGO_TARGET_DIR=/tmp/loong-verify-rustc <redacted-cargo> clippy -p loong --lib --tests -- -D warnings`
