### PR TITLE
Normalize direct exec aliases and keep browser failures on the public surface

### DIFF
--- a/crates/app/src/tools/download_guard.rs
+++ b/crates/app/src/tools/download_guard.rs
@@ -26,8 +26,9 @@ impl ByteBudget {
         }
 
         Err(format!(
-            "{surface_name} Content-Length ({content_length}) exceeds max_bytes limit ({} bytes)",
-            self.max_bytes
+            "{surface_name} Content-Length ({content_length}) exceeds max_bytes limit ({} bytes){}",
+            self.max_bytes,
+            byte_budget_retry_hint(surface_name)
         ))
     }
 
@@ -36,8 +37,9 @@ impl ByteBudget {
 
         if next_consumed > self.max_bytes {
             return Err(format!(
-                "{surface_name} exceeded max_bytes limit ({} bytes)",
-                self.max_bytes
+                "{surface_name} exceeded max_bytes limit ({} bytes){}",
+                self.max_bytes,
+                byte_budget_retry_hint(surface_name)
             ));
         }
 
@@ -47,5 +49,44 @@ impl ByteBudget {
 
     pub(crate) fn consumed(&self) -> usize {
         self.consumed
+    }
+}
+
+fn byte_budget_retry_hint(surface_name: &str) -> &'static str {
+    if surface_name.contains("browser") {
+        return "; retry with a smaller `max_bytes` or a more focused browser extract";
+    }
+
+    if surface_name.contains("web") {
+        return "; retry with a smaller `max_bytes` or a narrower web request";
+    }
+
+    "; retry with a smaller `max_bytes` or a narrower read"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByteBudget;
+
+    #[test]
+    fn content_length_exceed_error_includes_retry_hint() {
+        let budget = ByteBudget::new(16);
+        let error = budget
+            .reject_if_content_length_exceeds(Some(32), "web.fetch response")
+            .expect_err("content length over limit should fail");
+
+        assert!(error.contains("max_bytes limit"));
+        assert!(error.contains("narrower web request"));
+    }
+
+    #[test]
+    fn streaming_overflow_error_includes_retry_hint() {
+        let mut budget = ByteBudget::new(16);
+        let error = budget
+            .try_consume(32, "browser response")
+            .expect_err("stream overrun should fail");
+
+        assert!(error.contains("max_bytes limit"));
+        assert!(error.contains("focused browser extract"));
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -935,6 +935,21 @@ fn is_expected_tool_request_error(error: &str) -> bool {
     if error.starts_with("invalid_internal_runtime_narrowing:") {
         return true;
     }
+    if error.starts_with("tool_surface_unavailable:") {
+        return true;
+    }
+    if error.starts_with("direct_") {
+        return true;
+    }
+    if error.contains("max_bytes limit") {
+        return true;
+    }
+    if error.contains("browser tools are disabled by config.tools.browser.enabled=false") {
+        return true;
+    }
+    if error.contains("web.fetch is disabled by config.tools.web.enabled=false") {
+        return true;
+    }
     error.contains("reserved for trusted internal tool context")
 }
 

--- a/crates/app/src/tools/routing.rs
+++ b/crates/app/src/tools/routing.rs
@@ -16,6 +16,7 @@ pub(super) fn resolved_inner_tool_name_for_logs(canonical_name: &str, payload: &
             .and_then(|tool_id| route_hidden_discoverable_tool_name(tool_id, inner_arguments).ok());
         let inner_tool_name = resolved_hidden_tool_name
             .or_else(|| inner_tool_id.map(canonical_tool_name))
+            .map(display_inner_tool_name_for_logs)
             .unwrap_or("-");
         return inner_tool_name.to_owned();
     }
@@ -30,7 +31,9 @@ pub(super) fn resolved_inner_tool_name_for_logs(canonical_name: &str, payload: &
 
     let direct_tool_name = canonical_name;
     let resolved_tool_name = route_direct_tool_name(direct_tool_name, payload).ok();
-    let resolved_tool_name = resolved_tool_name.unwrap_or("-");
+    let resolved_tool_name = resolved_tool_name
+        .map(display_inner_tool_name_for_logs)
+        .unwrap_or("-");
     resolved_tool_name.to_owned()
 }
 
@@ -53,9 +56,11 @@ fn route_direct_tool_request(
         route_direct_tool_name_for_view(tool_name.as_str(), &payload, &runtime_view)?;
     let tool_visible = runtime_view.contains(routed_tool_name);
     if !tool_visible {
+        let routed_tool_display = routed_tool_display_name(routed_tool_name);
+        let unavailable_hint = unavailable_runtime_hint(routed_tool_name, &runtime_view);
         return Err(format!(
-            "tool_surface_unavailable: `{}` cannot route to `{}` in this runtime",
-            tool_name, routed_tool_name
+            "tool_surface_unavailable: `{}` cannot route to `{}` in this runtime{}",
+            tool_name, routed_tool_display, unavailable_hint
         ));
     }
 
@@ -92,10 +97,18 @@ pub(crate) fn route_direct_tool_name(
 }
 
 fn route_direct_exec_tool_name(payload: &Value) -> Result<&'static str, String> {
-    let has_command = payload_has_non_null_field(payload, "command");
+    let command = payload
+        .get("command")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let script = payload
+        .get("script")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     let has_args = payload_has_non_null_field(payload, "args");
-    let has_script = payload_has_non_null_field(payload, "script");
-    let mode_count = count_true([has_command, has_script]);
+    let mode_count = count_true([command.is_some(), script.is_some()]);
 
     if mode_count == 0 {
         return Err(
@@ -105,25 +118,40 @@ fn route_direct_exec_tool_name(payload: &Value) -> Result<&'static str, String> 
     }
 
     if mode_count > 1 {
+        if command == script
+            && let Some(value) = command
+        {
+            return Ok(if !has_args && command_uses_shell_syntax(value) {
+                BASH_EXEC_TOOL_NAME
+            } else {
+                SHELL_EXEC_TOOL_NAME
+            });
+        }
+
         return Err(
             "direct_exec_ambiguous: provide either `command` or `script`, not both".to_owned(),
         );
     }
 
-    if has_script {
+    if script.is_some() {
         return Ok(BASH_EXEC_TOOL_NAME);
     }
 
-    let command = payload
-        .get("command")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            "direct_exec_requires_command_or_script: expected `command` for argv mode, or `script` for raw shell mode"
-                .to_owned()
-        })?;
-    let uses_shell_syntax = command.contains('\n')
+    let command = command.ok_or_else(|| {
+        "direct_exec_requires_command_or_script: expected `command` for argv mode, or `script` for raw shell mode"
+            .to_owned()
+    })?;
+    let uses_shell_syntax = command_uses_shell_syntax(command);
+
+    if !has_args && uses_shell_syntax {
+        return Ok(BASH_EXEC_TOOL_NAME);
+    }
+
+    Ok(SHELL_EXEC_TOOL_NAME)
+}
+
+fn command_uses_shell_syntax(command: &str) -> bool {
+    command.contains('\n')
         || command.contains("&&")
         || command.contains("||")
         || command.contains('|')
@@ -131,13 +159,7 @@ fn route_direct_exec_tool_name(payload: &Value) -> Result<&'static str, String> 
         || command.contains('>')
         || command.contains('<')
         || command.contains("$(")
-        || command.contains('`');
-
-    if !has_args && uses_shell_syntax {
-        return Ok(BASH_EXEC_TOOL_NAME);
-    }
-
-    Ok(SHELL_EXEC_TOOL_NAME)
+        || command.contains('`')
 }
 
 fn route_direct_read_tool_name(payload: &Value) -> Result<&'static str, String> {
@@ -857,4 +879,101 @@ pub(super) fn count_true<const N: usize>(values: [bool; N]) -> usize {
     }
 
     count
+}
+
+fn unavailable_runtime_hint(routed_tool_name: &str, runtime_view: &ToolView) -> &'static str {
+    if !routed_tool_name.starts_with("browser.companion.") {
+        return "";
+    }
+
+    if runtime_view.contains("browser.open") || runtime_view.contains("browser.extract") {
+        return "; read-only browser inspection is still available";
+    }
+
+    "; browser interaction is unavailable in this runtime"
+}
+
+fn routed_tool_display_name(routed_tool_name: &str) -> &str {
+    if routed_tool_name.starts_with("browser.companion.") {
+        return "managed browser actions";
+    }
+
+    routed_tool_name
+}
+
+fn display_inner_tool_name_for_logs(tool_name: &str) -> &str {
+    if tool_name.starts_with("browser.companion.") {
+        return "browser";
+    }
+
+    tool_name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn direct_exec_normalizes_duplicate_command_and_script_sources() {
+        let routed = route_direct_exec_tool_name(&json!({
+            "command": "echo hello",
+            "script": "echo hello"
+        }))
+        .expect("equivalent exec sources should normalize");
+
+        assert_eq!(routed, SHELL_EXEC_TOOL_NAME);
+    }
+
+    #[test]
+    fn direct_exec_ignores_blank_aliases() {
+        let routed = route_direct_exec_tool_name(&json!({
+            "command": "   ",
+            "script": "echo hello"
+        }))
+        .expect("blank command alias should be ignored");
+
+        assert_eq!(routed, BASH_EXEC_TOOL_NAME);
+    }
+
+    #[test]
+    fn browser_surface_unavailable_hint_mentions_read_only_fallbacks() {
+        let runtime_view = ToolView::from_tool_names(["browser.open", "browser.extract"]);
+        let payload = json!({
+            "session_id": "browser-companion-1",
+            "selector": "#submit",
+            "text": "hello"
+        });
+        let request = loong_contracts::ToolCoreRequest {
+            tool_name: "browser".to_owned(),
+            payload: payload.clone(),
+        };
+        let managed_browser_route =
+            route_direct_browser_tool_name(&payload).expect("managed browser payload should route");
+
+        let error =
+            route_direct_tool_request(request, &runtime_config::ToolRuntimeConfig::default())
+                .expect_err("managed browser type should be unavailable in default runtime");
+
+        assert!(error.contains("managed browser actions"));
+        assert!(error.contains("read-only browser inspection"));
+        assert!(
+            unavailable_runtime_hint(managed_browser_route, &runtime_view)
+                .contains("read-only browser inspection")
+        );
+    }
+
+    #[test]
+    fn browser_companion_routes_collapse_to_browser_in_logs() {
+        let logged_tool_name = resolved_inner_tool_name_for_logs(
+            "browser",
+            &json!({
+                "session_id": "browser-companion-1",
+                "selector": "#submit",
+                "text": "hello"
+            }),
+        );
+
+        assert_eq!(logged_tool_name, "browser");
+    }
 }

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -118,6 +118,15 @@ fn expected_tool_request_error_classifies_validation_failures() {
     assert!(super::is_expected_tool_request_error(
         "tool `tool.invoke` payload._loong is reserved for trusted internal tool context; retry without that field"
     ));
+    assert!(super::is_expected_tool_request_error(
+        "direct_exec_ambiguous: provide either `command` or `script`, not both"
+    ));
+    assert!(super::is_expected_tool_request_error(
+        "tool_surface_unavailable: `browser` cannot route to `managed browser actions` in this runtime; read-only browser inspection is still available"
+    ));
+    assert!(super::is_expected_tool_request_error(
+        "web.fetch response exceeded max_bytes limit (120000 bytes); retry with a smaller `max_bytes` or a narrower web request"
+    ));
 }
 
 #[test]

--- a/docs/releases/support/architecture-drift-2026-04.md
+++ b/docs/releases/support/architecture-drift-2026-04.md
@@ -20,7 +20,7 @@ release review. It is not part of the primary public release trail.
   repository's current architecture boundaries
 
 ## Summary
-- Generated at: 2026-04-19T11:38:12Z
+- Generated at: 2026-04-20T03:23:27Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/support/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -42,7 +42,7 @@ release review. It is not part of the primary public release trail.
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6145 | 7300 | 1155 | 58 | 160 | 102 | 84.2% | HEALTHY | 6936 | -11.4% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 2111 | 6400 | 4289 | 0 | 110 | 110 | 33.0% | HEALTHY | 1779 | 18.7% | BREACH | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9592 | 11200 | 1608 | 50 | 120 | 70 | 85.6% | WATCH | 10831 | -11.4% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 1556 | 15000 | 13444 | 45 | 70 | 25 | 64.3% | HEALTHY | 14472 | -89.2% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 1571 | 15000 | 13429 | 45 | 70 | 25 | 64.3% | HEALTHY | 14472 | -89.1% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 4877 | 6500 | 1623 | 162 | 210 | 48 | 77.1% | HEALTHY | 6324 | -22.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 5783 | 9800 | 4017 | 209 | 250 | 41 | 83.6% | HEALTHY | 9519 | -39.2% | PASS | 228 |
 
@@ -96,7 +96,7 @@ release review. It is not part of the primary public release trail.
 <!-- arch-hotspot key=chat_runtime lines=6145 functions=58 -->
 <!-- arch-hotspot key=channel_mod lines=2111 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=9592 functions=50 -->
-<!-- arch-hotspot key=tools_mod lines=1556 functions=45 -->
+<!-- arch-hotspot key=tools_mod lines=1571 functions=45 -->
 <!-- arch-hotspot key=daemon_lib lines=4877 functions=162 -->
 <!-- arch-hotspot key=onboard_cli lines=5783 functions=209 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  - direct `exec` calls rejected semantically duplicate `command` + `script` payloads before normalization
  - browser runtime-denial copy leaked internal managed-browser route naming
  - known routing and byte-budget denials were logged as warning-grade failures instead of expected request rejections
- Why it matters:
  - callers can hit avoidable tool failures on valid compatibility payloads
  - user-facing / operator-facing diagnostics become noisy and expose internal naming that the direct `browser` surface is supposed to hide
  - browser/web recovery guidance is weaker than it should be when requests hit byte-budget limits
- What changed:
  - normalized duplicate or blank `command` / `script` aliases in direct exec routing
  - collapsed managed browser internal route names back to the public `browser` surface for logs and runtime-unavailable copy
  - added concise retry hints to byte-budget failures
  - classified direct routing / surface / byte-budget denials as expected tool request errors so they do not warn like unexpected runtime faults
  - added regression coverage for exec normalization, browser-surface unavailability copy, log-name collapsing, byte-budget hinting, and expected-error classification
- What did not change (scope boundary):
  - canonical hidden browser companion tool ids remain unchanged
  - provider-facing direct tool architecture remains unchanged
  - no new browser/runtime execution lane was added

## Linked Issues

- Closes #1319
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh check -p loong-app --all-targets --all-features --locked
./scripts/cargo-local-toolchain.sh test -p loong-app --lib --locked
./scripts/cargo-local-toolchain.sh test --workspace --locked
./scripts/cargo-local-toolchain.sh test --workspace --all-features --locked
./scripts/cargo-local-toolchain.sh clippy -p loong-app --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings

Results:
- app lib tests passed with 3526 tests after the final routing/logging refinement
- workspace tests passed in both locked and all-features lanes
- workspace clippy passed with -D warnings
```

## User-visible / Operator-visible Changes

- direct exec compatibility callers no longer fail on duplicate `command` / `script` aliases when the values agree
- managed browser runtime-unavailable copy now stays on the public `browser` surface instead of exposing internal companion route names
- byte-budget failures now include concise retry guidance
- expected routing / surface / byte-budget denials stop appearing as warning-grade runtime failures in `loong.tools`

## Failure Recovery

- Fast rollback or disable path:
  - revert commit `baa58fce`
- Observable failure symptoms reviewers should watch for:
  - direct exec calls still failing on duplicate aliases
  - browser runtime-denial copy surfacing `browser.companion.*` names again
  - `loong.tools` warning on `direct_*`, `tool_surface_unavailable`, or `max_bytes limit` request failures

## Reviewer Focus

- `crates/app/src/tools/routing.rs`
  - exec alias normalization and browser-surface copy/log collapsing
- `crates/app/src/tools/mod.rs`
  - expected-request error classification boundaries
- `crates/app/src/tools/download_guard.rs`
  - byte-budget hint wording and generic reuse across download surfaces
- `crates/app/src/tools/tools_mod_tests.rs`
  - regression coverage for the new error-classification expectations
