### PR TITLE
Mature bridge-backed channel runtimes and operator diagnostics

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -115,7 +115,12 @@ pub use registry::{
     resolve_channel_onboarding_descriptor, resolve_channel_operation_descriptor,
     resolve_channel_runtime_command_descriptor, validate_plugin_channel_bridge_manifest,
 };
-pub use runtime::state::{ChannelOperationRuntime, ChannelOperationRuntimeTracker};
+pub use runtime::state::{
+    ChannelOperationDuplicateCleanupOutcome, ChannelOperationDuplicateCleanupResult,
+    ChannelOperationRuntime, ChannelOperationRuntimeIncident, ChannelOperationRuntimeIncidentKind,
+    ChannelOperationRuntimeTracker, ChannelOperationStopRequestOutcome,
+    request_channel_operation_duplicate_cleanup, request_channel_operation_stop,
+};
 #[cfg(any(
     feature = "channel-plugin-bridge",
     feature = "channel-telegram",

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -98,8 +98,8 @@ use plugin_bridge::{
     channel_surface_plugin_bridge_discovery_by_id, plugin_bridge_contract_from_descriptor,
 };
 use status_support::{
-    attach_runtime, build_invalid_dingtalk_snapshot, build_invalid_discord_snapshot,
-    build_invalid_email_snapshot, build_invalid_feishu_snapshot,
+    apply_runtime_attention, attach_runtime, build_invalid_dingtalk_snapshot,
+    build_invalid_discord_snapshot, build_invalid_email_snapshot, build_invalid_feishu_snapshot,
     build_invalid_google_chat_snapshot, build_invalid_imessage_snapshot,
     build_invalid_irc_snapshot, build_invalid_line_snapshot, build_invalid_matrix_snapshot,
     build_invalid_mattermost_snapshot, build_invalid_nextcloud_talk_snapshot,

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -6124,10 +6124,16 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             qqbot_serve_checks,
-            vec![(
-                "qqbot bridge serve contract",
-                ChannelDoctorCheckTrigger::PluginBridgeHealth,
-            )]
+            vec![
+                (
+                    "qqbot bridge serve contract",
+                    ChannelDoctorCheckTrigger::PluginBridgeHealth,
+                ),
+                (
+                    "qqbot bridge serve runtime",
+                    ChannelDoctorCheckTrigger::ReadyRuntime,
+                ),
+            ]
         );
 
         let onebot_serve =
@@ -6139,10 +6145,16 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             onebot_serve_checks,
-            vec![(
-                "onebot bridge serve contract",
-                ChannelDoctorCheckTrigger::PluginBridgeHealth,
-            )]
+            vec![
+                (
+                    "onebot bridge serve contract",
+                    ChannelDoctorCheckTrigger::PluginBridgeHealth,
+                ),
+                (
+                    "onebot bridge serve runtime",
+                    ChannelDoctorCheckTrigger::ReadyRuntime,
+                ),
+            ]
         );
     }
 

--- a/crates/app/src/channel/registry_bridge.rs
+++ b/crates/app/src/channel/registry_bridge.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::channel::http;
+use crate::channel::runtime::state;
 #[cfg(feature = "channel-plugin-bridge")]
 use crate::channel::{
     ManagedPluginBridgeRuntimeBinding, resolve_managed_plugin_bridge_runtime_binding,
@@ -17,10 +18,11 @@ use super::{
     ChannelCatalogOperation, ChannelCatalogOperationAvailability,
     ChannelCatalogOperationRequirement, ChannelCatalogTargetKind, ChannelDoctorCheckSpec,
     ChannelDoctorCheckTrigger, ChannelOnboardingDescriptor, ChannelOnboardingStrategy,
-    ChannelOperationHealth, ChannelOperationStatus, ChannelPluginBridgeStableTarget,
-    ChannelRegistryDescriptor, ChannelRegistryOperationDescriptor, ChannelStatusSnapshot,
-    PLUGIN_BACKED_CHANNEL_CAPABILITIES, disabled_operation, misconfigured_operation,
-    unsupported_operation, validate_http_url, validate_websocket_url,
+    ChannelOperationHealth, ChannelOperationRuntime, ChannelOperationStatus,
+    ChannelPluginBridgeStableTarget, ChannelRegistryDescriptor, ChannelRegistryOperationDescriptor,
+    ChannelStatusSnapshot, PLUGIN_BACKED_CHANNEL_CAPABILITIES, apply_runtime_attention,
+    disabled_operation, misconfigured_operation, unsupported_operation, validate_http_url,
+    validate_websocket_url,
 };
 
 const WEIXIN_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =
@@ -120,10 +122,16 @@ const WEIXIN_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorChec
     trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
 }];
 
-const WEIXIN_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
-    name: "weixin bridge serve contract",
-    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
-}];
+const WEIXIN_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[
+    ChannelDoctorCheckSpec {
+        name: "weixin bridge serve contract",
+        trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+    },
+    ChannelDoctorCheckSpec {
+        name: "weixin bridge serve runtime",
+        trigger: ChannelDoctorCheckTrigger::ReadyRuntime,
+    },
+];
 
 const WEIXIN_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
@@ -237,10 +245,16 @@ const QQBOT_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheck
     trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
 }];
 
-const QQBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
-    name: "qqbot bridge serve contract",
-    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
-}];
+const QQBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[
+    ChannelDoctorCheckSpec {
+        name: "qqbot bridge serve contract",
+        trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+    },
+    ChannelDoctorCheckSpec {
+        name: "qqbot bridge serve runtime",
+        trigger: ChannelDoctorCheckTrigger::ReadyRuntime,
+    },
+];
 
 const QQBOT_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
@@ -360,10 +374,16 @@ const ONEBOT_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorChec
     trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
 }];
 
-const ONEBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
-    name: "onebot bridge serve contract",
-    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
-}];
+const ONEBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[
+    ChannelDoctorCheckSpec {
+        name: "onebot bridge serve contract",
+        trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+    },
+    ChannelDoctorCheckSpec {
+        name: "onebot bridge serve runtime",
+        trigger: ChannelDoctorCheckTrigger::ReadyRuntime,
+    },
+];
 
 const ONEBOT_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
@@ -459,6 +479,8 @@ fn managed_bridge_operation_status(
     configured_account_id: &str,
     operation: ChannelCatalogOperation,
     required_runtime_operations: &[&str],
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> ChannelOperationStatus {
     let binding_result = resolve_managed_plugin_bridge_runtime_binding(
         config,
@@ -490,7 +512,7 @@ fn managed_bridge_operation_status(
         binding.runtime_contract
     );
 
-    ChannelOperationStatus {
+    let mut status = ChannelOperationStatus {
         id: operation.id,
         label: operation.label,
         command: operation.command,
@@ -498,7 +520,51 @@ fn managed_bridge_operation_status(
         detail,
         issues: Vec::new(),
         runtime: None,
+    };
+
+    if operation.tracks_runtime {
+        status.runtime = state::load_channel_operation_runtime_for_account_from_dir(
+            runtime_dir,
+            binding.platform,
+            operation.id,
+            binding.account_id.as_str(),
+            now_ms,
+        )
+        .map(|mut runtime| {
+            if runtime.account_id.is_none() {
+                runtime.account_id = Some(binding.account_id.clone());
+            }
+            if runtime.account_label.is_none() {
+                runtime.account_label = Some(binding.account_label.clone());
+            }
+            runtime
+        })
+        .or(Some(ChannelOperationRuntime {
+            running: false,
+            stale: false,
+            busy: false,
+            active_runs: 0,
+            consecutive_failures: 0,
+            last_run_activity_at: None,
+            last_heartbeat_at: None,
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: None,
+            pid: None,
+            account_id: Some(binding.account_id.clone()),
+            account_label: Some(binding.account_label.clone()),
+            instance_count: 0,
+            running_instances: 0,
+            stale_instances: 0,
+            duplicate_owner_pids: Vec::new(),
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
+        }));
+        apply_runtime_attention(&mut status);
     }
+
+    status
 }
 
 #[cfg(feature = "channel-plugin-bridge")]
@@ -596,8 +662,8 @@ pub(super) fn plugin_bridge_account_scope_note_for_channel_id(
 fn build_weixin_snapshots(
     descriptor: &ChannelRegistryDescriptor,
     config: &LoongConfig,
-    _runtime_dir: &Path,
-    _now_ms: u64,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = true;
     let http_policy = http::outbound_http_policy_from_config(config);
@@ -625,6 +691,8 @@ fn build_weixin_snapshots(
                     is_default_account,
                     default_account_source,
                     http_policy,
+                    runtime_dir,
+                    now_ms,
                 ),
                 Err(error) => build_invalid_weixin_snapshot(
                     descriptor,
@@ -643,8 +711,8 @@ fn build_weixin_snapshots(
 fn build_qqbot_snapshots(
     descriptor: &ChannelRegistryDescriptor,
     config: &LoongConfig,
-    _runtime_dir: &Path,
-    _now_ms: u64,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = true;
     let default_selection = config.qqbot.default_configured_account_selection();
@@ -670,6 +738,8 @@ fn build_qqbot_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    runtime_dir,
+                    now_ms,
                 ),
                 Err(error) => build_invalid_qqbot_snapshot(
                     descriptor,
@@ -688,8 +758,8 @@ fn build_qqbot_snapshots(
 fn build_onebot_snapshots(
     descriptor: &ChannelRegistryDescriptor,
     config: &LoongConfig,
-    _runtime_dir: &Path,
-    _now_ms: u64,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = true;
     let default_selection = config.onebot.default_configured_account_selection();
@@ -715,6 +785,8 @@ fn build_onebot_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    runtime_dir,
+                    now_ms,
                 ),
                 Err(error) => build_invalid_onebot_snapshot(
                     descriptor,
@@ -738,6 +810,8 @@ fn build_weixin_snapshot_for_account(
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
     http_policy: http::ChannelOutboundHttpPolicy,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -782,6 +856,8 @@ fn build_weixin_snapshot_for_account(
             resolved.configured_account_id.as_str(),
             WEIXIN_SEND_OPERATION,
             &[MANAGED_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -809,6 +885,8 @@ fn build_weixin_snapshot_for_account(
                 MANAGED_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
                 MANAGED_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
             ],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -869,6 +947,8 @@ fn build_qqbot_snapshot_for_account(
     resolved: ResolvedQqbotChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -910,6 +990,8 @@ fn build_qqbot_snapshot_for_account(
             resolved.configured_account_id.as_str(),
             QQBOT_SEND_OPERATION,
             &[MANAGED_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -937,6 +1019,8 @@ fn build_qqbot_snapshot_for_account(
                 MANAGED_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
                 MANAGED_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
             ],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -995,6 +1079,8 @@ fn build_onebot_snapshot_for_account(
     resolved: ResolvedOnebotChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    runtime_dir: &Path,
+    now_ms: u64,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -1039,6 +1125,8 @@ fn build_onebot_snapshot_for_account(
             resolved.configured_account_id.as_str(),
             ONEBOT_SEND_OPERATION,
             &[MANAGED_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -1066,6 +1154,8 @@ fn build_onebot_snapshot_for_account(
                 MANAGED_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
                 MANAGED_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
             ],
+            runtime_dir,
+            now_ms,
         )
     };
 
@@ -1624,6 +1714,153 @@ mod tests {
             serve
                 .detail
                 .contains("managed bridge runtime ready via plugin")
+        );
+        assert!(serve.runtime.is_some());
+        let runtime = serve.runtime.as_ref().expect("serve runtime");
+        assert!(!runtime.running);
+        assert_eq!(runtime.account_id.as_deref(), Some("default"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn weixin_status_attaches_live_runtime_state_when_managed_bridge_serve_is_running() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        write_runtime_manifest(
+            runtime_root.path(),
+            "weixin-managed-runtime",
+            "weixin",
+            vec![
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_RECEIVE_BATCH_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
+            ],
+        );
+
+        let mut config: LoongConfig = serde_json::from_value(json!({
+            "weixin": {
+                "enabled": true,
+                "bridge_url": "https://bridge.example.test/api",
+                "bridge_access_token": "bridge-token",
+                "allowed_contact_ids": ["wxid_alice"]
+            }
+        }))
+        .expect("deserialize weixin config");
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+
+        let spec = crate::channel::runtime::serve::ChannelServeRuntimeSpec {
+            platform: crate::channel::ChannelPlatform::Weixin,
+            operation_id: crate::channel::CHANNEL_OPERATION_SERVE_ID,
+            account_id: "default",
+            account_label: "default",
+        };
+
+        let snapshots = crate::channel::runtime::serve::with_channel_serve_runtime_in_dir(
+            runtime_root.path(),
+            4242,
+            spec,
+            |_runtime| async {
+                Ok(super::super::channel_status_snapshots_with_now(
+                    &config,
+                    runtime_root.path(),
+                    crate::channel::runtime::serve::channel_runtime_now_ms(),
+                ))
+            },
+        )
+        .await
+        .expect("produce runtime-backed snapshots");
+        let weixin = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "weixin")
+            .expect("weixin snapshot");
+        let serve = weixin.operation("serve").expect("weixin serve operation");
+        let runtime = serve.runtime.as_ref().expect("serve runtime");
+
+        assert!(runtime.running);
+        assert!(!runtime.stale);
+        assert_eq!(runtime.account_id.as_deref(), Some("default"));
+        assert_eq!(runtime.account_label.as_deref(), Some("default"));
+        assert_eq!(runtime.running_instances, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn weixin_status_surfaces_retrying_runtime_attention_for_managed_bridge_serve() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        write_runtime_manifest(
+            runtime_root.path(),
+            "weixin-managed-runtime",
+            "weixin",
+            vec![
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_RECEIVE_BATCH_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
+                crate::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
+            ],
+        );
+
+        let mut config: LoongConfig = serde_json::from_value(json!({
+            "weixin": {
+                "enabled": true,
+                "bridge_url": "https://bridge.example.test/api",
+                "bridge_access_token": "bridge-token",
+                "allowed_contact_ids": ["wxid_alice"]
+            }
+        }))
+        .expect("deserialize weixin config");
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        let runtime_root_path = runtime_root.path().to_path_buf();
+        let runtime_root_path_for_snapshots = runtime_root_path.clone();
+
+        let spec = crate::channel::runtime::serve::ChannelServeRuntimeSpec {
+            platform: crate::channel::ChannelPlatform::Weixin,
+            operation_id: crate::channel::CHANNEL_OPERATION_SERVE_ID,
+            account_id: "default",
+            account_label: "default",
+        };
+
+        let snapshots = crate::channel::runtime::serve::with_channel_serve_runtime_in_dir(
+            runtime_root_path.as_path(),
+            4343,
+            spec,
+            |runtime| async move {
+                runtime
+                    .record_failure("temporary bridge timeout")
+                    .await
+                    .expect("record runtime failure");
+                Ok(super::super::channel_status_snapshots_with_now(
+                    &config,
+                    runtime_root_path_for_snapshots.as_path(),
+                    crate::channel::runtime::serve::channel_runtime_now_ms(),
+                ))
+            },
+        )
+        .await
+        .expect("produce retrying runtime snapshots");
+        let weixin = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "weixin")
+            .expect("weixin snapshot");
+        let serve = weixin.operation("serve").expect("weixin serve operation");
+        let runtime = serve.runtime.as_ref().expect("serve runtime");
+
+        assert!(
+            serve
+                .detail
+                .contains("runtime retrying after transient failures")
+        );
+        assert!(
+            serve
+                .issues
+                .iter()
+                .any(|issue| issue.contains("consecutive_failures=1"))
+        );
+        assert_eq!(runtime.consecutive_failures, 1);
+        assert_eq!(
+            runtime.last_error.as_deref(),
+            Some("temporary bridge timeout")
         );
     }
 

--- a/crates/app/src/channel/registry_plugin_bridge_tests.rs
+++ b/crates/app/src/channel/registry_plugin_bridge_tests.rs
@@ -198,6 +198,17 @@ fn resolve_channel_catalog_entry_exposes_plugin_bridge_contracts() {
         .plugin_bridge_contract
         .as_ref()
         .expect("weixin plugin bridge contract");
+    assert_eq!(
+        weixin
+            .operations
+            .iter()
+            .map(|operation| operation.availability)
+            .collect::<Vec<_>>(),
+        vec![
+            ChannelCatalogOperationAvailability::ManagedBridge,
+            ChannelCatalogOperationAvailability::ManagedBridge,
+        ]
+    );
     assert_eq!(weixin_contract.manifest_channel_id, "weixin");
     assert_eq!(weixin_contract.required_setup_surface, "channel");
     assert_eq!(weixin_contract.runtime_owner, "external_plugin");
@@ -220,12 +231,34 @@ fn resolve_channel_catalog_entry_exposes_plugin_bridge_contracts() {
         .plugin_bridge_contract
         .as_ref()
         .expect("qqbot plugin bridge contract");
+    assert_eq!(
+        qqbot
+            .operations
+            .iter()
+            .map(|operation| operation.availability)
+            .collect::<Vec<_>>(),
+        vec![
+            ChannelCatalogOperationAvailability::ManagedBridge,
+            ChannelCatalogOperationAvailability::ManagedBridge,
+        ]
+    );
     assert_eq!(qqbot_contract.manifest_channel_id, "qqbot");
 
     let onebot_contract = onebot
         .plugin_bridge_contract
         .as_ref()
         .expect("onebot plugin bridge contract");
+    assert_eq!(
+        onebot
+            .operations
+            .iter()
+            .map(|operation| operation.availability)
+            .collect::<Vec<_>>(),
+        vec![
+            ChannelCatalogOperationAvailability::ManagedBridge,
+            ChannelCatalogOperationAvailability::ManagedBridge,
+        ]
+    );
     assert_eq!(onebot_contract.manifest_channel_id, "onebot");
 }
 

--- a/crates/app/src/channel/registry_status.rs
+++ b/crates/app/src/channel/registry_status.rs
@@ -654,6 +654,67 @@ pub(super) fn ready_operation(operation: ChannelCatalogOperation) -> ChannelOper
     }
 }
 
+pub(super) fn apply_runtime_attention(status: &mut ChannelOperationStatus) {
+    let Some(runtime) = status.runtime.as_ref() else {
+        return;
+    };
+    if status.health != ChannelOperationHealth::Ready {
+        return;
+    }
+
+    let runtime_issue = if runtime.stale {
+        Some((
+            "runtime stale",
+            "runtime stale; the latest heartbeat is outside the expected freshness window"
+                .to_owned(),
+        ))
+    } else if runtime.running_instances > 1 {
+        let duplicate_owner_pids = if runtime.duplicate_owner_pids.is_empty() {
+            "-".to_owned()
+        } else {
+            runtime
+                .duplicate_owner_pids
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        let preferred_owner_pid = runtime
+            .pid
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned());
+        Some((
+            "multiple runtime instances detected",
+            format!(
+                "multiple runtime instances detected; running_instances={}; preferred_owner_pid={preferred_owner_pid}; duplicate_owner_pids={duplicate_owner_pids}",
+                runtime.running_instances
+            ),
+        ))
+    } else if runtime.running && runtime.consecutive_failures > 0 {
+        let last_error = runtime.last_error.as_deref().unwrap_or("-");
+        Some((
+            "runtime retrying after transient failures",
+            format!(
+                "runtime retrying after transient failures; consecutive_failures={}; last_error={last_error}",
+                runtime.consecutive_failures,
+            ),
+        ))
+    } else {
+        None
+    };
+
+    let Some((detail_marker, issue)) = runtime_issue else {
+        return;
+    };
+
+    if !status.detail.contains(detail_marker) {
+        status.detail = format!("{}; {detail_marker}", status.detail);
+    }
+    if !status.issues.iter().any(|existing| existing == &issue) {
+        status.issues.push(issue);
+    }
+}
+
 pub(super) fn disabled_operation(
     operation: ChannelCatalogOperation,
     detail: String,
@@ -730,15 +791,24 @@ pub(super) fn attach_runtime(
             stale: false,
             busy: false,
             active_runs: 0,
+            consecutive_failures: 0,
             last_run_activity_at: None,
             last_heartbeat_at: None,
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: None,
             pid: None,
             account_id: Some(account_id.to_owned()),
             account_label: Some(account_label.to_owned()),
             instance_count: 0,
             running_instances: 0,
             stale_instances: 0,
+            duplicate_owner_pids: Vec::new(),
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
         }));
+        apply_runtime_attention(&mut status);
     }
     status
 }

--- a/crates/app/src/channel/runtime/serve.rs
+++ b/crates/app/src/channel/runtime/serve.rs
@@ -43,6 +43,10 @@ pub struct ChannelServeStopHandle {
 const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_POLL_MS: u64 = 25;
 #[cfg(not(test))]
 const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_POLL_MS: u64 = 500;
+#[cfg(test)]
+const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_COOLDOWN_MS: u64 = 50;
+#[cfg(not(test))]
+const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_COOLDOWN_MS: u64 = 5_000;
 
 impl ChannelServeStopHandle {
     pub fn new() -> Self {
@@ -154,7 +158,8 @@ pub fn ensure_channel_operation_runtime_slot_available_in_dir(
 ///
 /// The helper prunes stale runtime state, rejects duplicate active serve loops
 /// for the same platform/operation/account triple, starts a tracker before
-/// invoking `run`, and always attempts shutdown bookkeeping afterward.
+/// invoking `run`, auto-reclaims duplicate owners conservatively, and always
+/// attempts shutdown bookkeeping afterward.
 #[cfg(any(
     feature = "channel-plugin-bridge",
     feature = "channel-telegram",
@@ -290,6 +295,14 @@ fn maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
         return Ok(None);
     };
     if runtime.running_instances <= 1 || runtime.pid != Some(current_pid) {
+        return Ok(None);
+    }
+    if runtime
+        .last_duplicate_reclaim_at
+        .is_some_and(|last_reclaim_at| {
+            now.saturating_sub(last_reclaim_at) < CHANNEL_RUNTIME_DUPLICATE_RECLAIM_COOLDOWN_MS
+        })
+    {
         return Ok(None);
     }
 
@@ -442,8 +455,9 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{
-        ChannelServeRuntimeSpec, channel_runtime_now_ms,
-        maybe_reclaim_duplicate_runtime_owners_for_preferred_owner, merge_runtime_result,
+        CHANNEL_RUNTIME_DUPLICATE_RECLAIM_COOLDOWN_MS, ChannelServeRuntimeSpec,
+        channel_runtime_now_ms, maybe_reclaim_duplicate_runtime_owners_for_preferred_owner,
+        merge_runtime_result,
     };
     use crate::channel::CHANNEL_OPERATION_SERVE_ID;
     use crate::channel::ChannelPlatform;
@@ -554,6 +568,84 @@ mod tests {
         assert_eq!(runtime.pid, Some(6262));
         assert!(runtime.last_duplicate_reclaim_cleanup_owner_pids.is_empty());
         assert!(runtime.last_duplicate_reclaim_at.is_none());
+
+        first.shutdown().await.expect("shutdown first runtime");
+        second.shutdown().await.expect("shutdown second runtime");
+    }
+
+    #[tokio::test]
+    async fn duplicate_auto_reclaim_respects_cooldown_before_retrying() {
+        let runtime_dir = temp_runtime_dir("duplicate-auto-reclaim-cooldown");
+        let spec = ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Weixin,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id: "default",
+            account_label: "default",
+        };
+        let first = state::start_channel_operation_runtime_tracker_for_test(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+            5151,
+        )
+        .await
+        .expect("start first runtime");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = state::start_channel_operation_runtime_tracker_for_test(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+            6262,
+        )
+        .await
+        .expect("start second runtime");
+
+        second
+            .record_duplicate_reclaim(&[5151])
+            .await
+            .expect("seed duplicate reclaim cooldown");
+
+        let within_cooldown = maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            second.pid(),
+        )
+        .expect("preferred runtime can inspect duplicate cleanup state");
+        assert!(
+            within_cooldown.is_none(),
+            "duplicate auto-reclaim should skip retries while the cooldown is active"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), first.wait_for_stop_request())
+                .await
+                .is_err(),
+            "cooldown should prevent a new duplicate cleanup stop request"
+        );
+
+        tokio::time::sleep(Duration::from_millis(
+            CHANNEL_RUNTIME_DUPLICATE_RECLAIM_COOLDOWN_MS + 20,
+        ))
+        .await;
+
+        let after_cooldown = maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            second.pid(),
+        )
+        .expect("preferred runtime can retry duplicate cleanup after cooldown");
+        assert!(after_cooldown.is_some());
+        tokio::time::timeout(Duration::from_millis(200), first.wait_for_stop_request())
+            .await
+            .expect("first stop request should become visible after cooldown")
+            .expect("wait for first stop request after cooldown");
 
         first.shutdown().await.expect("shutdown first runtime");
         second.shutdown().await.expect("shutdown second runtime");

--- a/crates/app/src/channel/runtime/serve.rs
+++ b/crates/app/src/channel/runtime/serve.rs
@@ -4,10 +4,11 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use tokio::sync::Notify;
+use tokio::time::sleep;
 
 use super::super::types::ChannelPlatform;
 use super::state;
@@ -37,6 +38,11 @@ pub struct ChannelServeStopHandle {
     requested: Arc<AtomicBool>,
     stop: Arc<Notify>,
 }
+
+#[cfg(test)]
+const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_POLL_MS: u64 = 25;
+#[cfg(not(test))]
+const CHANNEL_RUNTIME_DUPLICATE_RECLAIM_POLL_MS: u64 = 500;
 
 impl ChannelServeStopHandle {
     pub fn new() -> Self {
@@ -185,6 +191,144 @@ where
     merge_runtime_result(result, shutdown_result)
 }
 
+async fn with_channel_serve_runtime_stop_tasks<F, Fut>(
+    runtime_dir: &std::path::Path,
+    spec: ChannelServeRuntimeSpec<'_>,
+    runtime: Arc<ChannelOperationRuntimeTracker>,
+    stop: ChannelServeStopHandle,
+    run: F,
+) -> CliResult<()>
+where
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>, ChannelServeStopHandle) -> Fut,
+    Fut: Future<Output = CliResult<()>>,
+{
+    let duplicate_reclaim_platform = spec.platform;
+    let duplicate_reclaim_operation_id = spec.operation_id;
+    let duplicate_reclaim_account_id = spec.account_id.to_owned();
+    let runtime_for_stop_request = runtime.clone();
+    let stop_for_stop_request = stop.clone();
+    let stop_request_task = tokio::spawn(async move {
+        let wait_result = runtime_for_stop_request.wait_for_stop_request().await;
+        if wait_result.is_ok() {
+            stop_for_stop_request.request_stop();
+        }
+    });
+    let runtime_for_duplicate_reclaim = runtime.clone();
+    let stop_for_duplicate_reclaim = stop.clone();
+    let duplicate_reclaim_runtime_dir = runtime_dir.to_path_buf();
+    let duplicate_reclaim_task = tokio::spawn(async move {
+        loop {
+            if stop_for_duplicate_reclaim.is_requested() {
+                break;
+            }
+            sleep(Duration::from_millis(
+                CHANNEL_RUNTIME_DUPLICATE_RECLAIM_POLL_MS,
+            ))
+            .await;
+            if stop_for_duplicate_reclaim.is_requested() {
+                break;
+            }
+            let reclaim_result = maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
+                duplicate_reclaim_runtime_dir.as_path(),
+                duplicate_reclaim_platform,
+                duplicate_reclaim_operation_id,
+                duplicate_reclaim_account_id.as_str(),
+                runtime_for_duplicate_reclaim.pid(),
+            );
+            match reclaim_result {
+                Ok(Some(result)) => {
+                    let record_result = runtime_for_duplicate_reclaim
+                        .record_duplicate_reclaim(result.targeted_owner_pids.as_slice())
+                        .await;
+                    if let Err(error) = record_result {
+                        tracing::warn!(
+                            target: "loong.channel.runtime",
+                            platform = duplicate_reclaim_platform.as_str(),
+                            operation_id = duplicate_reclaim_operation_id,
+                            account_id = duplicate_reclaim_account_id.as_str(),
+                            "duplicate runtime auto-reclaim persisted cleanup request poorly: {error}"
+                        );
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        target: "loong.channel.runtime",
+                        platform = duplicate_reclaim_platform.as_str(),
+                        operation_id = duplicate_reclaim_operation_id,
+                        account_id = duplicate_reclaim_account_id.as_str(),
+                        "duplicate runtime auto-reclaim failed: {error}"
+                    );
+                }
+            }
+        }
+    });
+    let result = run(runtime, stop).await;
+    stop_request_task.abort();
+    duplicate_reclaim_task.abort();
+    result
+}
+
+fn maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
+    runtime_dir: &std::path::Path,
+    platform: ChannelPlatform,
+    operation_id: &'static str,
+    account_id: &str,
+    current_pid: Option<u32>,
+) -> CliResult<Option<state::ChannelOperationDuplicateCleanupResult>> {
+    let Some(current_pid) = current_pid else {
+        return Ok(None);
+    };
+    let now = channel_runtime_now_ms();
+    let Some(runtime) = state::load_channel_operation_runtime_for_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now,
+    ) else {
+        return Ok(None);
+    };
+    if runtime.running_instances <= 1 || runtime.pid != Some(current_pid) {
+        return Ok(None);
+    }
+
+    let result = state::request_channel_operation_duplicate_cleanup_in_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        Some(account_id),
+    )?;
+    if matches!(
+        result.outcome,
+        state::ChannelOperationDuplicateCleanupOutcome::Requested
+    ) {
+        tracing::info!(
+            target: "loong.channel.runtime",
+            platform = platform.as_str(),
+            operation_id = operation_id,
+            account_id = account_id,
+            preferred_owner_pid = result.preferred_owner_pid.unwrap_or_default(),
+            cleanup_owner_pids = %render_runtime_owner_pid_list(result.targeted_owner_pids.as_slice()),
+            "duplicate runtime auto-reclaim requested cooperative shutdown for non-preferred owners"
+        );
+        return Ok(Some(result));
+    }
+    Ok(None)
+}
+
+fn render_runtime_owner_pid_list(owner_pids: &[u32]) -> String {
+    if owner_pids.is_empty() {
+        return "-".to_owned();
+    }
+
+    owner_pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 /// Variant of `with_channel_serve_runtime` that forwards a cooperative stop
 /// handle into the serve loop.
 #[cfg(any(
@@ -206,7 +350,17 @@ where
     F: FnOnce(Arc<ChannelOperationRuntimeTracker>, ChannelServeStopHandle) -> Fut,
     Fut: Future<Output = CliResult<()>>,
 {
-    with_channel_serve_runtime(spec, move |runtime| run(runtime, stop)).await
+    with_channel_serve_runtime(spec, move |runtime| async move {
+        with_channel_serve_runtime_stop_tasks(
+            state::default_channel_runtime_state_dir().as_path(),
+            spec,
+            runtime,
+            stop,
+            run,
+        )
+        .await
+    })
+    .await
 }
 
 #[cfg(test)]
@@ -229,8 +383,8 @@ where
     F: FnOnce(Arc<ChannelOperationRuntimeTracker>, ChannelServeStopHandle) -> Fut,
     Fut: Future<Output = CliResult<()>>,
 {
-    with_channel_serve_runtime_in_dir(runtime_dir, process_id, spec, move |runtime| {
-        run(runtime, stop)
+    with_channel_serve_runtime_in_dir(runtime_dir, process_id, spec, move |runtime| async move {
+        with_channel_serve_runtime_stop_tasks(runtime_dir, spec, runtime, stop, run).await
     })
     .await
 }
@@ -284,7 +438,27 @@ fn merge_runtime_result<T>(result: CliResult<T>, shutdown_result: CliResult<()>)
 
 #[cfg(test)]
 mod tests {
-    use super::merge_runtime_result;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use super::{
+        ChannelServeRuntimeSpec, channel_runtime_now_ms,
+        maybe_reclaim_duplicate_runtime_owners_for_preferred_owner, merge_runtime_result,
+    };
+    use crate::channel::CHANNEL_OPERATION_SERVE_ID;
+    use crate::channel::ChannelPlatform;
+    use crate::channel::runtime::state;
+
+    fn temp_runtime_dir(suffix: &str) -> PathBuf {
+        let unique = format!(
+            "loong-channel-serve-{suffix}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        std::env::temp_dir().join(unique)
+    }
 
     #[test]
     fn merge_runtime_result_returns_value_when_both_steps_succeed() {
@@ -317,5 +491,71 @@ mod tests {
 
         assert!(error.contains("run failed"));
         assert!(error.contains("shutdown failed"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_auto_reclaim_requests_cleanup_only_for_preferred_owner() {
+        let runtime_dir = temp_runtime_dir("duplicate-auto-reclaim");
+        let spec = ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Weixin,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id: "default",
+            account_label: "default",
+        };
+        let first = state::start_channel_operation_runtime_tracker_for_test(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+            5151,
+        )
+        .await
+        .expect("start first runtime");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = state::start_channel_operation_runtime_tracker_for_test(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            spec.account_label,
+            6262,
+        )
+        .await
+        .expect("start second runtime");
+
+        let reclaim_result = maybe_reclaim_duplicate_runtime_owners_for_preferred_owner(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            second.pid(),
+        )
+        .expect("preferred runtime can trigger duplicate cleanup");
+        assert!(reclaim_result.is_some());
+        tokio::time::timeout(Duration::from_millis(200), first.wait_for_stop_request())
+            .await
+            .expect("first stop request should become visible")
+            .expect("wait for first stop request");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), second.wait_for_stop_request())
+                .await
+                .is_err(),
+            "preferred runtime owner should not receive duplicate cleanup stop request"
+        );
+        let runtime = state::load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            spec.platform,
+            spec.operation_id,
+            spec.account_id,
+            channel_runtime_now_ms(),
+        )
+        .expect("load preferred runtime state");
+        assert_eq!(runtime.pid, Some(6262));
+        assert!(runtime.last_duplicate_reclaim_cleanup_owner_pids.is_empty());
+        assert!(runtime.last_duplicate_reclaim_at.is_none());
+
+        first.shutdown().await.expect("shutdown first runtime");
+        second.shutdown().await.expect("shutdown second runtime");
     }
 }

--- a/crates/app/src/channel/runtime/state.rs
+++ b/crates/app/src/channel/runtime/state.rs
@@ -19,6 +19,11 @@ use super::super::ChannelPlatform;
 
 const CHANNEL_RUNTIME_HEARTBEAT_MS: u64 = 5_000;
 const CHANNEL_RUNTIME_STALE_MS: u64 = 15_000;
+const CHANNEL_RUNTIME_INCIDENT_HISTORY_LIMIT: usize = 5;
+#[cfg(test)]
+const CHANNEL_RUNTIME_STOP_REQUEST_POLL_MS: u64 = 25;
+#[cfg(not(test))]
+const CHANNEL_RUNTIME_STOP_REQUEST_POLL_MS: u64 = 250;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ChannelOperationRuntime {
@@ -26,14 +31,38 @@ pub struct ChannelOperationRuntime {
     pub stale: bool,
     pub busy: bool,
     pub active_runs: usize,
+    pub consecutive_failures: usize,
     pub last_run_activity_at: Option<u64>,
     pub last_heartbeat_at: Option<u64>,
+    pub last_failure_at: Option<u64>,
+    pub last_recovery_at: Option<u64>,
+    pub last_error: Option<String>,
+    pub last_duplicate_reclaim_at: Option<u64>,
     pub pid: Option<u32>,
     pub account_id: Option<String>,
     pub account_label: Option<String>,
     pub instance_count: usize,
     pub running_instances: usize,
     pub stale_instances: usize,
+    pub duplicate_owner_pids: Vec<u32>,
+    pub last_duplicate_reclaim_cleanup_owner_pids: Vec<u32>,
+    pub recent_incidents: Vec<ChannelOperationRuntimeIncident>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelOperationRuntimeIncident {
+    pub at_ms: u64,
+    pub kind: ChannelOperationRuntimeIncidentKind,
+    pub detail: Option<String>,
+    pub owner_pids: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelOperationRuntimeIncidentKind {
+    Failure,
+    Recovery,
+    DuplicateReclaim,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -41,12 +70,56 @@ struct PersistedChannelOperationRuntime {
     running: bool,
     busy: bool,
     active_runs: usize,
+    #[serde(default)]
+    consecutive_failures: usize,
     last_run_activity_at: Option<u64>,
     last_heartbeat_at: Option<u64>,
+    #[serde(default)]
+    last_failure_at: Option<u64>,
+    #[serde(default)]
+    last_recovery_at: Option<u64>,
+    #[serde(default)]
+    last_error: Option<String>,
+    #[serde(default)]
+    last_duplicate_reclaim_at: Option<u64>,
+    #[serde(default)]
+    last_duplicate_reclaim_cleanup_owner_pids: Vec<u32>,
+    #[serde(default)]
+    recent_incidents: Vec<ChannelOperationRuntimeIncident>,
     pid: Option<u32>,
     account_id: Option<String>,
     account_label: Option<String>,
     owner_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedChannelOperationStopRequest {
+    requested_at_ms: u64,
+    requested_by_pid: u32,
+    target_owner_token: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelOperationStopRequestOutcome {
+    Requested,
+    AlreadyRequested,
+    AlreadyStopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelOperationDuplicateCleanupOutcome {
+    Requested,
+    AlreadyRequested,
+    NoDuplicates,
+    AlreadyStopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelOperationDuplicateCleanupResult {
+    pub outcome: ChannelOperationDuplicateCleanupOutcome,
+    pub preferred_owner_pid: Option<u32>,
+    pub duplicate_owner_pids: Vec<u32>,
+    pub targeted_owner_pids: Vec<u32>,
 }
 
 impl PersistedChannelOperationRuntime {
@@ -61,20 +134,32 @@ impl PersistedChannelOperationRuntime {
             stale,
             busy: self.busy,
             active_runs: self.active_runs,
+            consecutive_failures: self.consecutive_failures,
             last_run_activity_at: self.last_run_activity_at,
             last_heartbeat_at: self.last_heartbeat_at,
+            last_failure_at: self.last_failure_at,
+            last_recovery_at: self.last_recovery_at,
+            last_error: self.last_error.clone(),
+            last_duplicate_reclaim_at: self.last_duplicate_reclaim_at,
             pid: self.pid,
             account_id: self.account_id.clone(),
             account_label: self.account_label.clone(),
             instance_count: 0,
             running_instances: 0,
             stale_instances: 0,
+            duplicate_owner_pids: Vec::new(),
+            last_duplicate_reclaim_cleanup_owner_pids: self
+                .last_duplicate_reclaim_cleanup_owner_pids
+                .clone(),
+            recent_incidents: self.recent_incidents.clone(),
         }
     }
 }
 
 pub struct ChannelOperationRuntimeTracker {
     path: PathBuf,
+    stop_request_path: PathBuf,
+    owner_token: String,
     state: Arc<Mutex<PersistedChannelOperationRuntime>>,
     stopped: Arc<AtomicBool>,
     heartbeat_task: Mutex<Option<JoinHandle<()>>>,
@@ -171,16 +256,31 @@ impl ChannelOperationRuntimeTracker {
             account_id,
             Some(process_id),
         );
+        let owner_token = new_runtime_owner_token(process_id);
+        let stop_request_path = channel_operation_stop_request_path(
+            runtime_dir,
+            platform,
+            operation_id,
+            account_id,
+            owner_token.as_str(),
+        );
         let initial = PersistedChannelOperationRuntime {
             running: true,
             busy: false,
             active_runs: 0,
+            consecutive_failures: 0,
             last_run_activity_at: None,
             last_heartbeat_at: Some(now),
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: None,
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
             pid: Some(process_id),
             account_id: normalize_optional_account_value(account_id),
             account_label: normalize_optional_account_value(account_label),
-            owner_token: None,
+            owner_token: Some(owner_token.clone()),
         };
         write_runtime_state(&path, &initial)?;
 
@@ -208,6 +308,8 @@ impl ChannelOperationRuntimeTracker {
 
         Ok(Self {
             path,
+            stop_request_path,
+            owner_token,
             state,
             stopped,
             heartbeat_task: Mutex::new(Some(task)),
@@ -236,6 +338,83 @@ impl ChannelOperationRuntimeTracker {
         .await
     }
 
+    pub async fn record_failure(&self, error: &str) -> CliResult<()> {
+        let normalized_error = normalize_runtime_error_message(error);
+        self.update_state(|state| {
+            state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+            let now = now_ms();
+            state.last_failure_at = Some(now);
+            state.last_run_activity_at = Some(now);
+            state.last_heartbeat_at = Some(now);
+            state.last_error = Some(normalized_error.clone());
+            push_runtime_incident(
+                state,
+                ChannelOperationRuntimeIncident {
+                    at_ms: now,
+                    kind: ChannelOperationRuntimeIncidentKind::Failure,
+                    detail: Some(normalized_error),
+                    owner_pids: Vec::new(),
+                },
+            );
+        })
+        .await
+    }
+
+    pub async fn clear_failure(&self) -> CliResult<()> {
+        self.update_state(|state| {
+            if state.consecutive_failures == 0 && state.last_error.is_none() {
+                return;
+            }
+            let cleared_failure_count = state.consecutive_failures;
+            state.consecutive_failures = 0;
+            let now = now_ms();
+            state.last_recovery_at = Some(now);
+            state.last_run_activity_at = Some(now);
+            state.last_heartbeat_at = Some(now);
+            state.last_error = None;
+            push_runtime_incident(
+                state,
+                ChannelOperationRuntimeIncident {
+                    at_ms: now,
+                    kind: ChannelOperationRuntimeIncidentKind::Recovery,
+                    detail: Some(format!(
+                        "cleared {cleared_failure_count} consecutive failure(s)"
+                    )),
+                    owner_pids: Vec::new(),
+                },
+            );
+        })
+        .await
+    }
+
+    pub async fn record_duplicate_reclaim(&self, cleanup_owner_pids: &[u32]) -> CliResult<()> {
+        if cleanup_owner_pids.is_empty() {
+            return Ok(());
+        }
+        let mut normalized_cleanup_owner_pids = cleanup_owner_pids.to_vec();
+        normalized_cleanup_owner_pids.sort_unstable();
+        normalized_cleanup_owner_pids.dedup();
+        self.update_state(|state| {
+            let now = now_ms();
+            state.last_duplicate_reclaim_at = Some(now);
+            state.last_run_activity_at = Some(now);
+            state.last_heartbeat_at = Some(now);
+            state.last_duplicate_reclaim_cleanup_owner_pids = normalized_cleanup_owner_pids.clone();
+            push_runtime_incident(
+                state,
+                ChannelOperationRuntimeIncident {
+                    at_ms: now,
+                    kind: ChannelOperationRuntimeIncidentKind::DuplicateReclaim,
+                    detail: Some(
+                        "requested cooperative shutdown for duplicate runtime owners".to_owned(),
+                    ),
+                    owner_pids: normalized_cleanup_owner_pids.clone(),
+                },
+            );
+        })
+        .await
+    }
+
     pub async fn shutdown(&self) -> CliResult<()> {
         self.stopped.store(true, Ordering::SeqCst);
         let task = self
@@ -252,7 +431,17 @@ impl ChannelOperationRuntimeTracker {
             state.active_runs = 0;
             state.last_heartbeat_at = Some(now_ms());
         })
-        .await
+        .await?;
+        remove_stop_request(self.stop_request_path.as_path())
+    }
+
+    pub async fn wait_for_stop_request(&self) -> CliResult<()> {
+        let _ = self.owner_token.as_str();
+        wait_for_channel_operation_stop_request_path(self.stop_request_path.as_path()).await
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.state.lock().ok().and_then(|state| state.pid)
     }
 
     async fn update_state(
@@ -312,8 +501,15 @@ impl ChannelOperationExclusiveGuard {
             running: true,
             busy: true,
             active_runs: 1,
+            consecutive_failures: 0,
             last_run_activity_at: Some(now),
             last_heartbeat_at: Some(now),
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: None,
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
             pid: Some(process_id),
             account_id: normalize_optional_account_value(Some(account_id)),
             account_label: normalize_optional_account_value(Some(account_label)),
@@ -582,6 +778,32 @@ pub(crate) fn default_channel_runtime_state_dir() -> PathBuf {
     default_loong_home().join("channel-runtime")
 }
 
+pub fn request_channel_operation_stop(
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<ChannelOperationStopRequestOutcome> {
+    request_channel_operation_stop_in_dir(
+        default_channel_runtime_state_dir().as_path(),
+        platform,
+        operation_id,
+        account_id,
+    )
+}
+
+pub fn request_channel_operation_duplicate_cleanup(
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<ChannelOperationDuplicateCleanupResult> {
+    request_channel_operation_duplicate_cleanup_in_dir(
+        default_channel_runtime_state_dir().as_path(),
+        platform,
+        operation_id,
+        account_id,
+    )
+}
+
 fn channel_operation_runtime_file_prefix(
     platform: ChannelPlatform,
     operation_id: &str,
@@ -607,6 +829,17 @@ fn channel_operation_runtime_path(
     }
 }
 
+fn channel_operation_stop_request_path(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    owner_token: &str,
+) -> PathBuf {
+    let prefix = channel_operation_runtime_file_prefix(platform, operation_id, account_id);
+    runtime_dir.join(format!("{prefix}-stop-request-{owner_token}.json"))
+}
+
 fn matches_channel_operation_runtime_file(file_name: &str, prefix: &str) -> bool {
     if file_name == format!("{prefix}.json") {
         return true;
@@ -628,6 +861,11 @@ fn read_runtime_state(path: &Path, now_ms: u64) -> Option<ChannelOperationRuntim
 fn read_persisted_runtime_state(path: &Path) -> Option<PersistedChannelOperationRuntime> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str::<PersistedChannelOperationRuntime>(&raw).ok()
+}
+
+fn read_persisted_stop_request(path: &Path) -> Option<PersistedChannelOperationStopRequest> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<PersistedChannelOperationStopRequest>(&raw).ok()
 }
 
 fn runtime_state_path_is_inactive(path: &Path, now_ms: u64) -> bool {
@@ -660,11 +898,325 @@ fn summarize_runtime_candidates(
     let instance_count = candidates.len();
     let running_instances = candidates.iter().filter(|runtime| runtime.running).count();
     let stale_instances = candidates.iter().filter(|runtime| runtime.stale).count();
+    let duplicate_owner_pids = if running_instances > 1 {
+        let mut owner_pids = candidates
+            .iter()
+            .filter(|runtime| runtime.running)
+            .filter_map(|runtime| runtime.pid)
+            .collect::<Vec<_>>();
+        owner_pids.sort_unstable();
+        owner_pids.dedup();
+        owner_pids
+    } else {
+        Vec::new()
+    };
     let mut preferred = select_preferred_runtime(candidates)?;
     preferred.instance_count = instance_count;
     preferred.running_instances = running_instances;
     preferred.stale_instances = stale_instances;
+    preferred.duplicate_owner_pids = duplicate_owner_pids;
     Some(preferred)
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeOwnerCandidate {
+    persisted: PersistedChannelOperationRuntime,
+    runtime: ChannelOperationRuntime,
+}
+
+fn select_preferred_runtime_owner_candidate(
+    candidates: Vec<RuntimeOwnerCandidate>,
+) -> Option<RuntimeOwnerCandidate> {
+    candidates.into_iter().max_by_key(|candidate| {
+        (
+            candidate.runtime.running,
+            !candidate.runtime.stale,
+            candidate.runtime.last_heartbeat_at.unwrap_or(0),
+            candidate.runtime.last_run_activity_at.unwrap_or(0),
+            candidate.runtime.pid.unwrap_or(0),
+        )
+    })
+}
+
+fn load_runtime_owners_for_optional_account_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    now_ms: u64,
+) -> Vec<RuntimeOwnerCandidate> {
+    let prefix = channel_operation_runtime_file_prefix(platform, operation_id, account_id);
+    let mut candidates = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(runtime_dir) {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if !matches_channel_operation_runtime_file(file_name.as_ref(), &prefix) {
+                continue;
+            }
+            let Some(persisted) = read_persisted_runtime_state(entry.path().as_path()) else {
+                continue;
+            };
+            let runtime = persisted.to_runtime_view(now_ms);
+            candidates.push(RuntimeOwnerCandidate { persisted, runtime });
+        }
+    }
+
+    if candidates.is_empty() && account_id.is_some() {
+        return load_runtime_owners_for_optional_account_from_dir(
+            runtime_dir,
+            platform,
+            operation_id,
+            None,
+            now_ms,
+        );
+    }
+
+    if candidates.is_empty() {
+        let legacy_path =
+            channel_operation_runtime_path(runtime_dir, platform, operation_id, None, None);
+        if let Some(persisted) = read_persisted_runtime_state(&legacy_path) {
+            let runtime = persisted.to_runtime_view(now_ms);
+            candidates.push(RuntimeOwnerCandidate { persisted, runtime });
+        }
+    }
+
+    candidates
+}
+
+fn request_channel_operation_stop_in_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<ChannelOperationStopRequestOutcome> {
+    let now = now_ms();
+    prune_inactive_channel_operation_runtime_files_for_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now,
+    )?;
+    let owners = load_runtime_owners_for_optional_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now,
+    );
+    if owners.is_empty() {
+        return Ok(ChannelOperationStopRequestOutcome::AlreadyStopped);
+    }
+    let live_owners = owners
+        .into_iter()
+        .filter(|owner| owner.runtime.running && !owner.runtime.stale)
+        .collect::<Vec<_>>();
+    if live_owners.is_empty() {
+        return Ok(ChannelOperationStopRequestOutcome::AlreadyStopped);
+    }
+    let owners_to_stop = if live_owners.len() > 1 {
+        live_owners
+    } else {
+        vec![select_preferred_runtime_owner_candidate(live_owners).ok_or_else(|| {
+            format!(
+                "channel runtime stop request could not resolve a live owner for {} {} account `{}`",
+                platform.as_str(),
+                operation_id,
+                account_id.unwrap_or("-"),
+            )
+        })?]
+    };
+
+    let mut wrote_request = false;
+    let mut all_already_requested = true;
+    for owner in owners_to_stop {
+        let Some(owner_token) = owner.persisted.owner_token else {
+            return Err(format!(
+                "channel runtime stop request is unavailable for {} {} account `{}` because the active runtime owner token is missing",
+                platform.as_str(),
+                operation_id,
+                account_id.unwrap_or("-"),
+            ));
+        };
+        let stop_request_path = channel_operation_stop_request_path(
+            runtime_dir,
+            platform,
+            operation_id,
+            account_id,
+            owner_token.as_str(),
+        );
+        if read_persisted_stop_request(stop_request_path.as_path()).is_some() {
+            continue;
+        }
+        let stop_request = PersistedChannelOperationStopRequest {
+            requested_at_ms: now,
+            requested_by_pid: std::process::id(),
+            target_owner_token: owner_token,
+        };
+        write_stop_request(stop_request_path.as_path(), &stop_request)?;
+        wrote_request = true;
+        all_already_requested = false;
+    }
+
+    if wrote_request {
+        Ok(ChannelOperationStopRequestOutcome::Requested)
+    } else if all_already_requested {
+        Ok(ChannelOperationStopRequestOutcome::AlreadyRequested)
+    } else {
+        Ok(ChannelOperationStopRequestOutcome::AlreadyStopped)
+    }
+}
+
+pub(crate) fn request_channel_operation_duplicate_cleanup_in_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<ChannelOperationDuplicateCleanupResult> {
+    let now = now_ms();
+    prune_inactive_channel_operation_runtime_files_for_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now,
+    )?;
+    let owners = load_runtime_owners_for_optional_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now,
+    );
+    if owners.is_empty() {
+        return Ok(ChannelOperationDuplicateCleanupResult {
+            outcome: ChannelOperationDuplicateCleanupOutcome::AlreadyStopped,
+            preferred_owner_pid: None,
+            duplicate_owner_pids: Vec::new(),
+            targeted_owner_pids: Vec::new(),
+        });
+    }
+
+    let live_owners = owners
+        .into_iter()
+        .filter(|owner| owner.runtime.running && !owner.runtime.stale)
+        .collect::<Vec<_>>();
+    if live_owners.is_empty() {
+        return Ok(ChannelOperationDuplicateCleanupResult {
+            outcome: ChannelOperationDuplicateCleanupOutcome::AlreadyStopped,
+            preferred_owner_pid: None,
+            duplicate_owner_pids: Vec::new(),
+            targeted_owner_pids: Vec::new(),
+        });
+    }
+
+    let preferred = select_preferred_runtime_owner_candidate(live_owners.clone()).ok_or_else(|| {
+        format!(
+            "channel runtime duplicate cleanup could not resolve a live owner for {} {} account `{}`",
+            platform.as_str(),
+            operation_id,
+            account_id.unwrap_or("-"),
+        )
+    })?;
+    let preferred_owner_pid = preferred.runtime.pid;
+    let mut duplicate_owner_pids = live_owners
+        .iter()
+        .filter_map(|owner| owner.runtime.pid)
+        .collect::<Vec<_>>();
+    duplicate_owner_pids.sort_unstable();
+    duplicate_owner_pids.dedup();
+    if duplicate_owner_pids.len() <= 1 {
+        return Ok(ChannelOperationDuplicateCleanupResult {
+            outcome: ChannelOperationDuplicateCleanupOutcome::NoDuplicates,
+            preferred_owner_pid,
+            duplicate_owner_pids,
+            targeted_owner_pids: Vec::new(),
+        });
+    }
+
+    let preferred_owner_token =
+        preferred
+            .persisted
+            .owner_token
+            .as_deref()
+            .ok_or_else(|| {
+                format!(
+                    "channel runtime duplicate cleanup is unavailable for {} {} account `{}` because the preferred runtime owner token is missing",
+                    platform.as_str(),
+                    operation_id,
+                    account_id.unwrap_or("-"),
+                )
+            })?;
+
+    let targeted_owners = live_owners
+        .into_iter()
+        .filter(|owner| owner.persisted.owner_token.as_deref() != Some(preferred_owner_token))
+        .collect::<Vec<_>>();
+    let mut targeted_owner_pids = targeted_owners
+        .iter()
+        .filter_map(|owner| owner.runtime.pid)
+        .collect::<Vec<_>>();
+    targeted_owner_pids.sort_unstable();
+    targeted_owner_pids.dedup();
+
+    let mut wrote_request = false;
+    for owner in targeted_owners {
+        let Some(owner_token) = owner.persisted.owner_token else {
+            return Err(format!(
+                "channel runtime duplicate cleanup is unavailable for {} {} account `{}` because one or more duplicate runtime owner tokens are missing",
+                platform.as_str(),
+                operation_id,
+                account_id.unwrap_or("-"),
+            ));
+        };
+        let stop_request_path = channel_operation_stop_request_path(
+            runtime_dir,
+            platform,
+            operation_id,
+            account_id,
+            owner_token.as_str(),
+        );
+        if read_persisted_stop_request(stop_request_path.as_path()).is_some() {
+            continue;
+        }
+        let stop_request = PersistedChannelOperationStopRequest {
+            requested_at_ms: now,
+            requested_by_pid: std::process::id(),
+            target_owner_token: owner_token,
+        };
+        write_stop_request(stop_request_path.as_path(), &stop_request)?;
+        wrote_request = true;
+    }
+
+    let outcome = if wrote_request {
+        ChannelOperationDuplicateCleanupOutcome::Requested
+    } else {
+        ChannelOperationDuplicateCleanupOutcome::AlreadyRequested
+    };
+
+    Ok(ChannelOperationDuplicateCleanupResult {
+        outcome,
+        preferred_owner_pid,
+        duplicate_owner_pids,
+        targeted_owner_pids,
+    })
+}
+
+async fn wait_for_channel_operation_stop_request_path(stop_request_path: &Path) -> CliResult<()> {
+    loop {
+        if read_persisted_stop_request(stop_request_path).is_some() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(CHANNEL_RUNTIME_STOP_REQUEST_POLL_MS)).await;
+    }
 }
 
 fn normalize_optional_account_value(value: Option<&str>) -> Option<String> {
@@ -672,6 +1224,36 @@ fn normalize_optional_account_value(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+fn normalize_runtime_error_message(error: &str) -> String {
+    let collapsed = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    let trimmed = collapsed.trim();
+    if trimmed.is_empty() {
+        return "runtime operation failed".to_owned();
+    }
+
+    const MAX_CHARS: usize = 240;
+    if trimmed.chars().count() <= MAX_CHARS {
+        return trimmed.to_owned();
+    }
+
+    let truncated = trimmed.chars().take(MAX_CHARS).collect::<String>();
+    format!("{truncated}...")
+}
+
+fn push_runtime_incident(
+    state: &mut PersistedChannelOperationRuntime,
+    incident: ChannelOperationRuntimeIncident,
+) {
+    state.recent_incidents.push(incident);
+    let overflow = state
+        .recent_incidents
+        .len()
+        .saturating_sub(CHANNEL_RUNTIME_INCIDENT_HISTORY_LIMIT);
+    if overflow > 0 {
+        state.recent_incidents.drain(0..overflow);
+    }
 }
 
 fn acquire_exclusive_runtime_state(
@@ -789,6 +1371,17 @@ fn remove_exclusive_runtime_state_if_owned(path: &Path, owner_token: &str) -> Cl
     }
 }
 
+fn remove_stop_request(path: &Path) -> CliResult<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove channel runtime stop request failed for {}: {error}",
+            path.display()
+        )),
+    }
+}
+
 fn write_runtime_state(path: &Path, state: &PersistedChannelOperationRuntime) -> CliResult<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -799,6 +1392,22 @@ fn write_runtime_state(path: &Path, state: &PersistedChannelOperationRuntime) ->
     let encoded = serde_json::to_string_pretty(state)
         .map_err(|error| format!("serialize channel runtime state failed: {error}"))?;
     fs::write(path, encoded).map_err(|error| format!("write channel runtime state failed: {error}"))
+}
+
+fn write_stop_request(
+    path: &Path,
+    stop_request: &PersistedChannelOperationStopRequest,
+) -> CliResult<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("create channel runtime state directory failed: {error}"))?;
+    }
+    let encoded = serde_json::to_string_pretty(stop_request)
+        .map_err(|error| format!("serialize channel runtime stop request failed: {error}"))?;
+    fs::write(path, encoded)
+        .map_err(|error| format!("write channel runtime stop request failed: {error}"))
 }
 
 fn new_runtime_owner_token(process_id: u32) -> String {
@@ -833,8 +1442,15 @@ pub(crate) fn write_runtime_state_for_test(
         running,
         busy,
         active_runs,
+        consecutive_failures: 0,
         last_run_activity_at,
         last_heartbeat_at,
+        last_failure_at: None,
+        last_recovery_at: None,
+        last_error: None,
+        last_duplicate_reclaim_at: None,
+        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+        recent_incidents: Vec::new(),
         pid,
         account_id: None,
         account_label: None,
@@ -862,8 +1478,15 @@ pub(crate) fn write_runtime_state_for_test_with_pid(
         running,
         busy,
         active_runs,
+        consecutive_failures: 0,
         last_run_activity_at,
         last_heartbeat_at,
+        last_failure_at: None,
+        last_recovery_at: None,
+        last_error: None,
+        last_duplicate_reclaim_at: None,
+        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+        recent_incidents: Vec::new(),
         pid,
         account_id: None,
         account_label: None,
@@ -897,8 +1520,15 @@ pub(crate) fn write_runtime_state_for_test_with_account_and_pid(
         running,
         busy,
         active_runs,
+        consecutive_failures: 0,
         last_run_activity_at,
         last_heartbeat_at,
+        last_failure_at: None,
+        last_recovery_at: None,
+        last_error: None,
+        last_duplicate_reclaim_at: None,
+        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+        recent_incidents: Vec::new(),
         pid,
         account_id: Some(account_id.to_owned()),
         account_label: Some(test_account_label(account_id)),
@@ -988,6 +1618,301 @@ mod tests {
         .to_string_lossy()
         .into_owned();
         assert!(entries.contains(&expected_entry));
+    }
+
+    #[tokio::test]
+    async fn runtime_tracker_persists_failure_and_recovery_metadata() {
+        let runtime_dir = temp_runtime_dir("tracker-failure-metadata");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            20,
+            4343,
+        )
+        .await
+        .expect("start runtime tracker");
+
+        tracker
+            .record_failure("temporary bridge receive timeout")
+            .await
+            .expect("record runtime failure");
+        tracker
+            .clear_failure()
+            .await
+            .expect("clear runtime failure");
+        tracker.shutdown().await.expect("shutdown tracker");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            now_ms(),
+        )
+        .expect("load runtime state");
+
+        assert_eq!(runtime.consecutive_failures, 0);
+        assert!(runtime.last_failure_at.is_some());
+        assert!(runtime.last_recovery_at.is_some());
+        assert!(runtime.last_error.is_none());
+        assert_eq!(runtime.recent_incidents.len(), 2);
+        assert_eq!(
+            runtime.recent_incidents[0].kind,
+            ChannelOperationRuntimeIncidentKind::Failure
+        );
+        assert_eq!(
+            runtime.recent_incidents[1].kind,
+            ChannelOperationRuntimeIncidentKind::Recovery
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_tracker_persists_duplicate_reclaim_metadata() {
+        let runtime_dir = temp_runtime_dir("tracker-duplicate-reclaim-metadata");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4444,
+        )
+        .await
+        .expect("start runtime tracker");
+
+        tracker
+            .record_duplicate_reclaim(&[5151, 6262, 5151])
+            .await
+            .expect("record duplicate reclaim");
+        tracker.shutdown().await.expect("shutdown tracker");
+
+        let runtime = load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            now_ms(),
+        )
+        .expect("load runtime state");
+
+        assert!(runtime.last_duplicate_reclaim_at.is_some());
+        assert_eq!(
+            runtime.last_duplicate_reclaim_cleanup_owner_pids,
+            vec![5151, 6262]
+        );
+        assert_eq!(runtime.recent_incidents.len(), 1);
+        assert_eq!(
+            runtime.recent_incidents[0].kind,
+            ChannelOperationRuntimeIncidentKind::DuplicateReclaim
+        );
+        assert_eq!(runtime.recent_incidents[0].owner_pids, vec![5151, 6262]);
+    }
+
+    #[tokio::test]
+    async fn request_channel_operation_stop_requests_live_runtime_owner() {
+        let runtime_dir = temp_runtime_dir("tracker-stop-request");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4343,
+        )
+        .await
+        .expect("start runtime tracker");
+
+        let outcome = request_channel_operation_stop_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("request stop");
+
+        assert_eq!(outcome, ChannelOperationStopRequestOutcome::Requested);
+        tokio::time::timeout(Duration::from_millis(200), tracker.wait_for_stop_request())
+            .await
+            .expect("stop request should become visible")
+            .expect("wait for stop request");
+        tracker.shutdown().await.expect("shutdown tracker");
+    }
+
+    #[tokio::test]
+    async fn request_channel_operation_stop_is_idempotent_for_same_owner() {
+        let runtime_dir = temp_runtime_dir("tracker-stop-request-idempotent");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4545,
+        )
+        .await
+        .expect("start runtime tracker");
+
+        let first = request_channel_operation_stop_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("first stop request");
+        let second = request_channel_operation_stop_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("second stop request");
+
+        assert_eq!(first, ChannelOperationStopRequestOutcome::Requested);
+        assert_eq!(second, ChannelOperationStopRequestOutcome::AlreadyRequested);
+        tracker.shutdown().await.expect("shutdown tracker");
+    }
+
+    #[tokio::test]
+    async fn request_channel_operation_stop_ignores_stopped_runtime() {
+        let runtime_dir = temp_runtime_dir("tracker-stop-request-stopped");
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4646,
+        )
+        .await
+        .expect("start runtime tracker");
+        tracker.shutdown().await.expect("shutdown tracker");
+
+        let outcome = request_channel_operation_stop_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("request stop after shutdown");
+
+        assert_eq!(outcome, ChannelOperationStopRequestOutcome::AlreadyStopped);
+    }
+
+    #[tokio::test]
+    async fn request_channel_operation_stop_targets_all_live_duplicate_owners() {
+        let runtime_dir = temp_runtime_dir("tracker-stop-request-duplicates");
+        let first = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4747,
+        )
+        .await
+        .expect("start first runtime tracker");
+        let second = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            20,
+            4848,
+        )
+        .await
+        .expect("start second runtime tracker");
+
+        let outcome = request_channel_operation_stop_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("request stop for duplicate owners");
+
+        assert_eq!(outcome, ChannelOperationStopRequestOutcome::Requested);
+        tokio::time::timeout(Duration::from_millis(200), first.wait_for_stop_request())
+            .await
+            .expect("first stop request should become visible")
+            .expect("wait for first stop request");
+        tokio::time::timeout(Duration::from_millis(200), second.wait_for_stop_request())
+            .await
+            .expect("second stop request should become visible")
+            .expect("wait for second stop request");
+
+        let stop_request_count = fs::read_dir(&runtime_dir)
+            .expect("list runtime dir")
+            .filter_map(Result::ok)
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name.contains("stop-request"))
+            .count();
+        assert_eq!(stop_request_count, 2);
+
+        first.shutdown().await.expect("shutdown first tracker");
+        second.shutdown().await.expect("shutdown second tracker");
+    }
+
+    #[tokio::test]
+    async fn request_channel_operation_duplicate_cleanup_keeps_preferred_live_owner() {
+        let runtime_dir = temp_runtime_dir("tracker-duplicate-cleanup");
+        let first = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            200,
+            4949,
+        )
+        .await
+        .expect("start first runtime tracker");
+        sleep(Duration::from_millis(10)).await;
+        let second = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            "default",
+            "default",
+            200,
+            5050,
+        )
+        .await
+        .expect("start second runtime tracker");
+
+        let result = request_channel_operation_duplicate_cleanup_in_dir(
+            &runtime_dir,
+            ChannelPlatform::Weixin,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("default"),
+        )
+        .expect("request duplicate cleanup");
+
+        assert_eq!(
+            result.outcome,
+            ChannelOperationDuplicateCleanupOutcome::Requested
+        );
+        assert_eq!(result.preferred_owner_pid, Some(5050));
+        assert_eq!(result.duplicate_owner_pids, vec![4949, 5050]);
+        assert_eq!(result.targeted_owner_pids, vec![4949]);
+        tokio::time::timeout(Duration::from_millis(200), first.wait_for_stop_request())
+            .await
+            .expect("first stop request should become visible")
+            .expect("wait for first stop request");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), second.wait_for_stop_request())
+                .await
+                .is_err(),
+            "preferred runtime owner should not receive duplicate cleanup stop request"
+        );
+
+        first.shutdown().await.expect("shutdown first tracker");
+        second.shutdown().await.expect("shutdown second tracker");
     }
 
     #[tokio::test]
@@ -1412,8 +2337,15 @@ mod tests {
             running: true,
             busy: true,
             active_runs: 1,
+            consecutive_failures: 0,
             last_run_activity_at: Some(stale_now.saturating_sub(30_000)),
             last_heartbeat_at: Some(stale_now.saturating_sub(30_000)),
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: None,
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
             pid: Some(8001),
             account_id: Some("wecom_ops".to_owned()),
             account_label: Some(test_account_label("wecom_ops")),

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -285,7 +285,6 @@ fn read_tool_lease_secret_after_competitor_publish(secret_path: &Path) -> Result
     Err(message)
 }
 
-
 fn ensure_tool_lease_secret_parent_dir(secret_path: &Path) -> Result<(), String> {
     let parent = secret_path.parent();
     let Some(parent) = parent else {
@@ -328,7 +327,7 @@ fn read_tool_lease_secret_file_detail(
     }
 
     let normalized_secret = trimmed_secret.to_owned();
-    Ok(normalized_secret)
+    Ok(Some(normalized_secret))
 }
 
 enum ReadToolLeaseSecretFileError {

--- a/crates/app/src/tools/tool_lease_authority.rs
+++ b/crates/app/src/tools/tool_lease_authority.rs
@@ -261,17 +261,11 @@ fn read_tool_lease_secret_after_competitor_publish(secret_path: &Path) -> Result
     let mut attempt_index = 0usize;
 
     while attempt_index < retry_attempts {
-        let existing_secret = match read_tool_lease_secret_file(secret_path) {
-            Ok(existing_secret) => existing_secret,
-            Err(error)
-                if transient_tool_lease_secret_publication_error(error.as_str(), secret_path) =>
-            {
-                None
-            }
-            Err(error) => return Err(error),
-        };
-        if let Some(existing_secret) = existing_secret {
-            return Ok(existing_secret);
+        match read_tool_lease_secret_file_detail(secret_path) {
+            Ok(Some(existing_secret)) => return Ok(existing_secret),
+            Ok(None) => {}
+            Err(error) if error.is_retryable_publication_state() => {}
+            Err(error) => return Err(error.render(secret_path)),
         }
 
         attempt_index += 1;
@@ -291,18 +285,6 @@ fn read_tool_lease_secret_after_competitor_publish(secret_path: &Path) -> Result
     Err(message)
 }
 
-fn transient_tool_lease_secret_publication_error(error: &str, secret_path: &Path) -> bool {
-    let secret_path = secret_path.display();
-    let empty_prefix =
-        format!("tool_lease_authority_unavailable: secret file {secret_path} is empty");
-    let invalid_hex_prefix =
-        format!("tool_lease_authority_unavailable: secret file {secret_path} is not valid hex:");
-    let wrong_length_prefix =
-        format!("tool_lease_authority_unavailable: secret file {secret_path} has ");
-    error == empty_prefix
-        || error.starts_with(invalid_hex_prefix.as_str())
-        || error.starts_with(wrong_length_prefix.as_str())
-}
 
 fn ensure_tool_lease_secret_parent_dir(secret_path: &Path) -> Result<(), String> {
     let parent = secret_path.parent();
@@ -319,56 +301,73 @@ fn ensure_tool_lease_secret_parent_dir(secret_path: &Path) -> Result<(), String>
 }
 
 fn read_tool_lease_secret_file(secret_path: &Path) -> Result<Option<String>, String> {
+    read_tool_lease_secret_file_detail(secret_path).map_err(|error| error.render(secret_path))
+}
+
+fn read_tool_lease_secret_file_detail(
+    secret_path: &Path,
+) -> Result<Option<String>, ReadToolLeaseSecretFileError> {
     let raw_secret = match fs::read_to_string(secret_path) {
         Ok(raw_secret) => raw_secret,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            let message = format!(
-                "tool_lease_authority_unavailable: failed to read secret file {}: {error}",
-                secret_path.display()
-            );
-            return Err(message);
-        }
+        Err(error) => return Err(ReadToolLeaseSecretFileError::Io(error)),
     };
 
     let trimmed_secret = raw_secret.trim();
     if trimmed_secret.is_empty() {
-        let message = format!(
-            "tool_lease_authority_unavailable: secret file {} is empty",
-            secret_path.display()
-        );
-        return Err(message);
+        return Err(ReadToolLeaseSecretFileError::Empty);
     }
 
-    let normalized_secret = parse_tool_lease_secret_text(trimmed_secret, secret_path)?;
-    Ok(Some(normalized_secret))
-}
-
-fn parse_tool_lease_secret_text(
-    trimmed_secret: &str,
-    secret_path: &Path,
-) -> Result<String, String> {
-    let decoded_secret = hex::decode(trimmed_secret).map_err(|error| {
-        format!(
-            "tool_lease_authority_unavailable: secret file {} is not valid hex: {error}",
-            secret_path.display()
-        )
-    })?;
+    let decoded_secret =
+        hex::decode(trimmed_secret).map_err(ReadToolLeaseSecretFileError::InvalidHex)?;
 
     let secret_length = decoded_secret.len();
     let has_expected_length = secret_length == TOOL_LEASE_SECRET_BYTES;
     if !has_expected_length {
-        let message = format!(
-            "tool_lease_authority_unavailable: secret file {} has {} bytes; expected {}",
-            secret_path.display(),
-            secret_length,
-            TOOL_LEASE_SECRET_BYTES
-        );
-        return Err(message);
+        return Err(ReadToolLeaseSecretFileError::WrongLength(secret_length));
     }
 
     let normalized_secret = trimmed_secret.to_owned();
     Ok(normalized_secret)
+}
+
+enum ReadToolLeaseSecretFileError {
+    Io(std::io::Error),
+    Empty,
+    InvalidHex(hex::FromHexError),
+    WrongLength(usize),
+}
+
+impl ReadToolLeaseSecretFileError {
+    fn is_retryable_publication_state(&self) -> bool {
+        matches!(
+            self,
+            Self::Empty | Self::InvalidHex(_) | Self::WrongLength(_)
+        )
+    }
+
+    fn render(&self, secret_path: &Path) -> String {
+        match self {
+            Self::Io(error) => format!(
+                "tool_lease_authority_unavailable: failed to read secret file {}: {error}",
+                secret_path.display()
+            ),
+            Self::Empty => format!(
+                "tool_lease_authority_unavailable: secret file {} is empty",
+                secret_path.display()
+            ),
+            Self::InvalidHex(error) => format!(
+                "tool_lease_authority_unavailable: secret file {} is not valid hex: {error}",
+                secret_path.display()
+            ),
+            Self::WrongLength(secret_length) => format!(
+                "tool_lease_authority_unavailable: secret file {} has {} bytes; expected {}",
+                secret_path.display(),
+                secret_length,
+                TOOL_LEASE_SECRET_BYTES
+            ),
+        }
+    }
 }
 
 fn generate_tool_lease_secret() -> String {
@@ -594,6 +593,36 @@ mod tests {
         let observed_secret =
             read_tool_lease_secret_after_competitor_publish(secret_path.as_path())
                 .expect("wait for visible secret");
+
+        publisher.join().expect("join publisher thread");
+
+        assert_eq!(observed_secret, expected_secret);
+    }
+
+    #[test]
+    fn read_tool_lease_secret_after_competitor_publish_retries_partial_secret_visibility() {
+        let _home = scoped_tool_lease_home("loong-tool-lease-partial-visibility-home");
+        let secret_path = default_tool_lease_secret_path();
+        let parent_dir = secret_path.parent().expect("secret parent").to_path_buf();
+        std::fs::create_dir_all(&parent_dir).expect("create secret parent");
+
+        let expected_secret = generate_tool_lease_secret();
+        let publisher_path = secret_path.clone();
+        let publisher_secret = expected_secret.clone();
+
+        let publisher = std::thread::spawn(move || {
+            std::fs::write(&publisher_path, "").expect("publish empty secret file");
+            std::thread::park_timeout(std::time::Duration::from_millis(10));
+            let partial_secret = &publisher_secret[..publisher_secret.len() / 2];
+            std::fs::write(&publisher_path, partial_secret).expect("publish partial secret file");
+            std::thread::park_timeout(std::time::Duration::from_millis(10));
+            let secret_body = format!("{publisher_secret}\n");
+            std::fs::write(&publisher_path, secret_body).expect("publish complete secret file");
+        });
+
+        let observed_secret =
+            read_tool_lease_secret_after_competitor_publish(secret_path.as_path())
+                .expect("wait for fully published secret");
 
         publisher.join().expect("join publisher thread");
 

--- a/crates/daemon/src/channel_bridge_render.rs
+++ b/crates/daemon/src/channel_bridge_render.rs
@@ -18,6 +18,18 @@ pub(crate) fn push_channel_surface_plugin_bridge_contract(
         lines.push(stable_targets_line);
     }
 
+    let supported_operations = if plugin_bridge_contract.supported_operations.is_empty() {
+        "-".to_owned()
+    } else {
+        plugin_bridge_contract.supported_operations.join(",")
+    };
+    lines.push(format!(
+        "  plugin_bridge_contract required_setup_surface={} runtime_owner={} supported_operations={}",
+        plugin_bridge_contract.required_setup_surface,
+        plugin_bridge_contract.runtime_owner,
+        render_line_safe_text_value(&supported_operations),
+    ));
+
     let account_scope_note = plugin_bridge_contract.account_scope_note;
     let Some(account_scope_note) = account_scope_note else {
         return;

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
@@ -1673,6 +1673,158 @@ fn snapshot_has_external_plugin_bridge_owner(
     bridge_runtime_owner == Some("external_plugin")
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedBridgeRuntimeAttention<'a> {
+    channel_id: &'static str,
+    channel_label: &'a str,
+    account_ids: BTreeSet<String>,
+    reasons: BTreeSet<&'static str>,
+    preferred_owner_pids: BTreeSet<u32>,
+    cleanup_owner_pids: BTreeSet<u32>,
+    last_duplicate_reclaim_at: Option<u64>,
+    last_duplicate_reclaim_cleanup_owner_pids: BTreeSet<u32>,
+    recent_incidents: Vec<DoctorRuntimeIncident>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorRuntimeIncident {
+    account_id: Option<String>,
+    account_label: Option<String>,
+    kind: &'static str,
+    at_ms: u64,
+    detail: Option<String>,
+    owner_pids: Vec<u32>,
+}
+
+fn managed_bridge_runtime_attention_surfaces<'a>(
+    channel_surfaces: &'a [mvp::channel::ChannelSurface],
+) -> Vec<ManagedBridgeRuntimeAttention<'a>> {
+    let mut surfaces = Vec::new();
+
+    for surface in channel_surfaces {
+        let mut reasons = BTreeSet::new();
+        let mut account_ids = BTreeSet::new();
+        let mut preferred_owner_pids = BTreeSet::new();
+        let mut cleanup_owner_pids = BTreeSet::new();
+        let mut last_duplicate_reclaim_at = None;
+        let mut last_duplicate_reclaim_cleanup_owner_pids = BTreeSet::new();
+        let mut recent_incidents = Vec::new();
+
+        for snapshot in surface
+            .configured_accounts
+            .iter()
+            .filter(|snapshot| snapshot.enabled)
+            .filter(|snapshot| snapshot_has_external_plugin_bridge_owner(snapshot))
+        {
+            let Some(runtime) = snapshot
+                .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+                .and_then(|operation| operation.runtime.as_ref())
+            else {
+                continue;
+            };
+
+            if runtime.consecutive_failures > 0 {
+                reasons.insert("retrying");
+            }
+            if runtime.stale {
+                reasons.insert("stale");
+            }
+            if runtime.running_instances > 1 {
+                reasons.insert("duplicate_runtime_instances");
+                if let Some(pid) = runtime.pid {
+                    preferred_owner_pids.insert(pid);
+                }
+                for owner_pid in &runtime.duplicate_owner_pids {
+                    if Some(*owner_pid) == runtime.pid {
+                        continue;
+                    }
+                    cleanup_owner_pids.insert(*owner_pid);
+                }
+            }
+            if runtime.last_duplicate_reclaim_at.is_some_and(|value| {
+                last_duplicate_reclaim_at
+                    .map(|current| value > current)
+                    .unwrap_or(true)
+            }) {
+                last_duplicate_reclaim_at = runtime.last_duplicate_reclaim_at;
+                last_duplicate_reclaim_cleanup_owner_pids.clear();
+                for owner_pid in &runtime.last_duplicate_reclaim_cleanup_owner_pids {
+                    last_duplicate_reclaim_cleanup_owner_pids.insert(*owner_pid);
+                }
+            }
+            recent_incidents.extend(runtime.recent_incidents.iter().map(|incident| {
+                DoctorRuntimeIncident {
+                    account_id: runtime.account_id.clone(),
+                    account_label: runtime.account_label.clone(),
+                    kind: match incident.kind {
+                        mvp::channel::ChannelOperationRuntimeIncidentKind::Failure => "failure",
+                        mvp::channel::ChannelOperationRuntimeIncidentKind::Recovery => "recovery",
+                        mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim => {
+                            "duplicate_reclaim"
+                        }
+                    },
+                    at_ms: incident.at_ms,
+                    detail: incident.detail.clone(),
+                    owner_pids: incident.owner_pids.clone(),
+                }
+            }));
+            if runtime.stale || runtime.running_instances > 1 || runtime.consecutive_failures > 0 {
+                account_ids.insert(snapshot.configured_account_id.clone());
+            }
+        }
+
+        if reasons.is_empty() {
+            continue;
+        }
+
+        recent_incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+        recent_incidents.truncate(5);
+        surfaces.push(ManagedBridgeRuntimeAttention {
+            channel_id: surface.catalog.id,
+            channel_label: surface.catalog.label,
+            account_ids,
+            reasons,
+            preferred_owner_pids,
+            cleanup_owner_pids,
+            last_duplicate_reclaim_at,
+            last_duplicate_reclaim_cleanup_owner_pids,
+            recent_incidents,
+        });
+    }
+
+    surfaces
+}
+
+fn managed_bridge_runtime_serve_control_command(
+    attention: &ManagedBridgeRuntimeAttention<'_>,
+    config_path_display: &str,
+    duplicate_cleanup: bool,
+) -> Option<String> {
+    let family =
+        mvp::channel::resolve_channel_catalog_command_family_descriptor(attention.channel_id)?;
+    let command = crate::cli_handoff::format_subcommand_with_config(
+        family.serve.command,
+        config_path_display,
+    );
+    let control_flag = if duplicate_cleanup {
+        "--stop-duplicates"
+    } else {
+        "--stop"
+    };
+    let account_id = attention.account_ids.iter().next().cloned();
+    let needs_explicit_account = attention.account_ids.len() == 1;
+
+    if !needs_explicit_account {
+        return Some(format!("{command} {control_flag}"));
+    }
+
+    let account_id = account_id?;
+    Some(format!(
+        "{command} {control_flag} --account {}",
+        crate::cli_handoff::shell_quote_argument(&account_id)
+    ))
+}
+
 fn build_channel_runtime_check(
     name: &str,
     operation: &mvp::channel::ChannelOperationStatus,
@@ -1686,7 +1838,7 @@ fn build_channel_runtime_check(
     };
 
     let detail_tail = format!(
-        "account={} account_id={} pid={} busy={} active_runs={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={}",
+        "account={} account_id={} pid={} busy={} active_runs={} consecutive_failures={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={} last_failure_at={} last_recovery_at={} last_error={} duplicate_owner_pids={} last_duplicate_reclaim_at={} last_duplicate_reclaim_cleanup_owner_pids={} recent_incidents={}",
         runtime.account_label.as_deref().unwrap_or("-"),
         runtime.account_id.as_deref().unwrap_or("-"),
         runtime
@@ -1695,6 +1847,7 @@ fn build_channel_runtime_check(
             .unwrap_or_else(|| "-".to_owned()),
         runtime.busy,
         runtime.active_runs,
+        runtime.consecutive_failures,
         runtime.instance_count,
         runtime.running_instances,
         runtime.stale_instances,
@@ -1706,6 +1859,22 @@ fn build_channel_runtime_check(
             .last_heartbeat_at
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_owned()),
+        runtime
+            .last_failure_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        runtime
+            .last_recovery_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        runtime.last_error.as_deref().unwrap_or("-"),
+        render_u32_list(&runtime.duplicate_owner_pids),
+        runtime
+            .last_duplicate_reclaim_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned()),
+        render_u32_list(&runtime.last_duplicate_reclaim_cleanup_owner_pids),
+        render_runtime_incident_summary(runtime.recent_incidents.as_slice()),
     );
 
     if runtime.stale {
@@ -1722,6 +1891,14 @@ fn build_channel_runtime_check(
                 name: name.to_owned(),
                 level: DoctorCheckLevel::Warn,
                 detail: format!("multiple runtime instances detected ({detail_tail})"),
+            };
+        }
+
+        if runtime.consecutive_failures > 0 {
+            return DoctorCheck {
+                name: name.to_owned(),
+                level: DoctorCheckLevel::Warn,
+                detail: format!("runtime is retrying after transient failures ({detail_tail})"),
             };
         }
 
@@ -2181,11 +2358,106 @@ fn check_level_json(level: DoctorCheckLevel) -> &'static str {
     }
 }
 
+fn render_u32_list(values: &[u32]) -> String {
+    if values.is_empty() {
+        return "-".to_owned();
+    }
+
+    values
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn render_runtime_incident_summary(
+    incidents: &[mvp::channel::ChannelOperationRuntimeIncident],
+) -> String {
+    if incidents.is_empty() {
+        return "-".to_owned();
+    }
+
+    incidents
+        .iter()
+        .map(|incident| {
+            let kind = match incident.kind {
+                mvp::channel::ChannelOperationRuntimeIncidentKind::Failure => "failure",
+                mvp::channel::ChannelOperationRuntimeIncidentKind::Recovery => "recovery",
+                mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim => {
+                    "duplicate_reclaim"
+                }
+            };
+            format!("{kind}@{}", incident.at_ms)
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoctorRuntimeAttentionReason {
+    Retrying,
+    Stale,
+    DuplicateRuntimeInstances,
+}
+
+impl DoctorRuntimeAttentionReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Retrying => "retrying",
+            Self::Stale => "stale",
+            Self::DuplicateRuntimeInstances => "duplicate_runtime_instances",
+        }
+    }
+
+    fn remediation(self) -> &'static str {
+        match self {
+            Self::Retrying => "inspect_bridge_connectivity",
+            Self::Stale => "restart_stale_runtime",
+            Self::DuplicateRuntimeInstances => "stop_duplicate_runtime_instances",
+        }
+    }
+}
+
+fn doctor_runtime_attention_reason(check: &DoctorCheck) -> Option<DoctorRuntimeAttentionReason> {
+    if check
+        .detail
+        .contains("runtime is retrying after transient failures")
+    {
+        return Some(DoctorRuntimeAttentionReason::Retrying);
+    }
+    if check.detail.contains("stale runtime detected") {
+        return Some(DoctorRuntimeAttentionReason::Stale);
+    }
+    if check.detail.contains("multiple runtime instances detected") {
+        return Some(DoctorRuntimeAttentionReason::DuplicateRuntimeInstances);
+    }
+
+    None
+}
+
+fn doctor_runtime_attention_channel_id(check: &DoctorCheck) -> Option<String> {
+    for suffix in [
+        " bridge serve runtime",
+        " serve runtime",
+        " channel runtime",
+    ] {
+        if let Some(channel_id) = check.name.strip_suffix(suffix) {
+            let trimmed = channel_id.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_owned());
+            }
+        }
+    }
+
+    None
+}
+
 fn doctor_checks_json_payload(
     checks: &[DoctorCheck],
     channel_surfaces: &[mvp::channel::ChannelSurface],
 ) -> Vec<serde_json::Value> {
     let account_summaries = doctor_plugin_bridge_account_summaries(channel_surfaces);
+    let runtime_attention_surfaces = managed_bridge_runtime_attention_surfaces(channel_surfaces);
     let mut payload = Vec::with_capacity(checks.len());
 
     for check in checks {
@@ -2207,6 +2479,78 @@ fn doctor_checks_json_payload(
             object.insert(
                 "plugin_bridge_account_summary".to_owned(),
                 serde_json::Value::String(account_summary.clone()),
+            );
+        }
+
+        if let Some(reason) = doctor_runtime_attention_reason(check) {
+            let mut runtime_attention = serde_json::Map::new();
+            runtime_attention.insert(
+                "reason".to_owned(),
+                serde_json::Value::String(reason.as_str().to_owned()),
+            );
+            runtime_attention.insert(
+                "remediation".to_owned(),
+                serde_json::Value::String(reason.remediation().to_owned()),
+            );
+            if let Some(channel_id) = doctor_runtime_attention_channel_id(check) {
+                runtime_attention.insert(
+                    "channel_id".to_owned(),
+                    serde_json::Value::String(channel_id.clone()),
+                );
+                if let Some(surface) = runtime_attention_surfaces
+                    .iter()
+                    .find(|surface| surface.channel_id == channel_id.as_str())
+                {
+                    if !surface.preferred_owner_pids.is_empty() {
+                        runtime_attention.insert(
+                            "preferred_owner_pids".to_owned(),
+                            serde_json::json!(surface.preferred_owner_pids),
+                        );
+                    }
+                    if !surface.cleanup_owner_pids.is_empty() {
+                        runtime_attention.insert(
+                            "cleanup_owner_pids".to_owned(),
+                            serde_json::json!(surface.cleanup_owner_pids),
+                        );
+                    }
+                    if let Some(last_duplicate_reclaim_at) = surface.last_duplicate_reclaim_at {
+                        runtime_attention.insert(
+                            "last_duplicate_reclaim_at".to_owned(),
+                            serde_json::json!(last_duplicate_reclaim_at),
+                        );
+                    }
+                    if !surface.last_duplicate_reclaim_cleanup_owner_pids.is_empty() {
+                        runtime_attention.insert(
+                            "last_duplicate_reclaim_cleanup_owner_pids".to_owned(),
+                            serde_json::json!(surface.last_duplicate_reclaim_cleanup_owner_pids),
+                        );
+                    }
+                    if !surface.recent_incidents.is_empty() {
+                        runtime_attention.insert(
+                            "recent_incidents".to_owned(),
+                            serde_json::Value::Array(
+                                surface
+                                    .recent_incidents
+                                    .iter()
+                                    .map(|incident| {
+                                        serde_json::json!({
+                                            "account_id": incident.account_id,
+                                            "account_label": incident.account_label,
+                                            "kind": incident.kind,
+                                            "at_ms": incident.at_ms,
+                                            "detail": incident.detail,
+                                            "owner_pids": incident.owner_pids,
+                                        })
+                                    })
+                                    .collect(),
+                            ),
+                        );
+                    }
+                }
+            }
+            object.insert(
+                "runtime_attention".to_owned(),
+                serde_json::Value::Object(runtime_attention),
             );
         }
 
@@ -2318,6 +2662,95 @@ fn build_doctor_next_steps_with_channel_surfaces_and_path_env(
             push_unique_step(
                 &mut steps,
                 format!("Set provider credentials in env: {}", hints.join(" or ")),
+            );
+        }
+    }
+
+    for surface in managed_bridge_runtime_attention_surfaces(channel_surfaces) {
+        if surface.reasons.contains("retrying") {
+            push_unique_step(
+                &mut steps,
+                format!(
+                    "Inspect {} bridge connectivity, upstream session health, and external bridge logs, then rerun diagnostics: {rerun_command}",
+                    surface.channel_label
+                ),
+            );
+        }
+        if surface.reasons.contains("stale") {
+            let stop_command = managed_bridge_runtime_serve_control_command(
+                &surface,
+                config_path_display.as_str(),
+                false,
+            );
+            push_unique_step(
+                &mut steps,
+                match stop_command {
+                    Some(stop_command) => format!(
+                        "Restart the stale {} runtime or external bridge owner: {stop_command}",
+                        surface.channel_label
+                    ),
+                    None => format!(
+                        "Restart the stale {} runtime or external bridge owner, then rerun diagnostics: {rerun_command}",
+                        surface.channel_label
+                    ),
+                },
+            );
+        }
+        if surface.reasons.contains("duplicate_runtime_instances") {
+            let stop_command = managed_bridge_runtime_serve_control_command(
+                &surface,
+                config_path_display.as_str(),
+                true,
+            );
+            let keep_pid_note = if surface.preferred_owner_pids.len() == 1 {
+                let pid = surface
+                    .preferred_owner_pids
+                    .first()
+                    .copied()
+                    .unwrap_or_default();
+                format!("keep pid={pid}; ")
+            } else {
+                String::new()
+            };
+            let cleanup_pid_note = if surface.cleanup_owner_pids.is_empty() {
+                String::new()
+            } else {
+                let rendered_cleanup = surface
+                    .cleanup_owner_pids
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("cleanup pids={rendered_cleanup}; ")
+            };
+            let auto_reclaim_note = if let Some(last_duplicate_reclaim_at) =
+                surface.last_duplicate_reclaim_at
+            {
+                let rendered_cleanup = render_u32_list(
+                    &surface
+                        .last_duplicate_reclaim_cleanup_owner_pids
+                        .iter()
+                        .copied()
+                        .collect::<Vec<_>>(),
+                );
+                format!(
+                    "last auto reclaim at={last_duplicate_reclaim_at}; last auto cleanup pids={rendered_cleanup}; "
+                )
+            } else {
+                String::new()
+            };
+            push_unique_step(
+                &mut steps,
+                match stop_command {
+                    Some(stop_command) => format!(
+                        "Stop duplicate {} runtime instances so only one serve owner remains ({auto_reclaim_note}{keep_pid_note}{cleanup_pid_note}run {stop_command})",
+                        surface.channel_label
+                    ),
+                    None => format!(
+                        "Stop duplicate {} runtime instances so only one serve owner remains ({auto_reclaim_note}{keep_pid_note}{cleanup_pid_note}then rerun diagnostics: {rerun_command})",
+                        surface.channel_label
+                    ),
+                },
             );
         }
     }
@@ -4734,14 +5167,22 @@ mod tests {
                     stale: false,
                     busy: false,
                     active_runs: 0,
+                    consecutive_failures: 0,
                     last_run_activity_at: None,
                     last_heartbeat_at: None,
+                    last_failure_at: None,
+                    last_recovery_at: None,
+                    last_error: None,
+                    last_duplicate_reclaim_at: None,
                     pid: None,
                     account_id: Some("bot_123456".to_owned()),
                     account_label: Some("bot:123456".to_owned()),
                     instance_count: 1,
                     running_instances: 0,
                     stale_instances: 0,
+                    duplicate_owner_pids: Vec::new(),
+                    last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                    recent_incidents: Vec::new(),
                 }),
             }],
         }];
@@ -4788,14 +5229,22 @@ mod tests {
                     stale: true,
                     busy: true,
                     active_runs: 1,
+                    consecutive_failures: 0,
                     last_run_activity_at: Some(1_700_000_000_000),
                     last_heartbeat_at: Some(1_700_000_005_000),
+                    last_failure_at: None,
+                    last_recovery_at: None,
+                    last_error: None,
+                    last_duplicate_reclaim_at: None,
                     pid: Some(4242),
                     account_id: Some("feishu_cli_a1b2c3".to_owned()),
                     account_label: Some("feishu:cli_a1b2c3".to_owned()),
                     instance_count: 1,
                     running_instances: 0,
                     stale_instances: 1,
+                    duplicate_owner_pids: Vec::new(),
+                    last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                    recent_incidents: Vec::new(),
                 }),
             }],
         }];
@@ -4843,14 +5292,22 @@ mod tests {
                     stale: false,
                     busy: true,
                     active_runs: 1,
+                    consecutive_failures: 0,
                     last_run_activity_at: Some(1_700_000_000_000),
                     last_heartbeat_at: Some(1_700_000_005_000),
+                    last_failure_at: None,
+                    last_recovery_at: None,
+                    last_error: None,
+                    last_duplicate_reclaim_at: Some(1_700_000_007_000),
                     pid: Some(3003),
                     account_id: Some("bot_123456".to_owned()),
                     account_label: Some("bot:123456".to_owned()),
                     instance_count: 2,
                     running_instances: 2,
                     stale_instances: 0,
+                    duplicate_owner_pids: vec![3003, 3004],
+                    last_duplicate_reclaim_cleanup_owner_pids: vec![3004],
+                    recent_incidents: Vec::new(),
                 }),
             }],
         }];
@@ -4865,6 +5322,69 @@ mod tests {
                     && check.detail.contains("running_instances=2")
             }),
             "duplicate running telegram runtimes should emit runtime warning"
+        );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_warns_when_runtime_is_retrying() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "weixin",
+            configured_account_id: "default".to_owned(),
+            configured_account_label: "default".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
+            label: "Weixin",
+            aliases: vec!["wechat", "wx"],
+            transport: "wechat_clawbot_ilink_bridge",
+            compiled: true,
+            enabled: true,
+            api_base_url: None,
+            notes: vec!["bridge_runtime_owner=external_plugin".to_owned()],
+            reserved_runtime_fields: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "managed bridge reply loop",
+                command: "weixin-serve",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: Some(ChannelOperationRuntime {
+                    running: true,
+                    stale: false,
+                    busy: false,
+                    active_runs: 0,
+                    consecutive_failures: 2,
+                    last_run_activity_at: Some(1_700_000_000_000),
+                    last_heartbeat_at: Some(1_700_000_005_000),
+                    last_failure_at: Some(1_700_000_006_000),
+                    last_recovery_at: None,
+                    last_error: Some("temporary bridge timeout".to_owned()),
+                    last_duplicate_reclaim_at: None,
+                    pid: Some(5151),
+                    account_id: Some("default".to_owned()),
+                    account_label: Some("default".to_owned()),
+                    instance_count: 1,
+                    running_instances: 1,
+                    stale_instances: 0,
+                    duplicate_owner_pids: Vec::new(),
+                    last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                    recent_incidents: Vec::new(),
+                }),
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "weixin bridge serve runtime"
+                    && check.level == DoctorCheckLevel::Warn
+                    && check.detail.contains("retrying after transient failures")
+                    && check.detail.contains("consecutive_failures=2")
+                    && check.detail.contains("last_error=temporary bridge timeout")
+            }),
+            "retrying runtime should surface failure metadata instead of passing silently: {checks:#?}"
         );
     }
 
@@ -4905,14 +5425,22 @@ mod tests {
                     stale: false,
                     busy: false,
                     active_runs: 1,
+                    consecutive_failures: 0,
                     last_run_activity_at: Some(1_700_000_000_000),
                     last_heartbeat_at: Some(1_700_000_005_000),
+                    last_failure_at: None,
+                    last_recovery_at: None,
+                    last_error: None,
+                    last_duplicate_reclaim_at: None,
                     pid: Some(4242),
                     account_id: Some("feishu_main".to_owned()),
                     account_label: Some("feishu:main".to_owned()),
                     instance_count: 1,
                     running_instances: 1,
                     stale_instances: 0,
+                    duplicate_owner_pids: Vec::new(),
+                    last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                    recent_incidents: Vec::new(),
                 }),
             }],
         }];
@@ -5028,14 +5556,22 @@ mod tests {
                         stale: false,
                         busy: false,
                         active_runs: 0,
+                        consecutive_failures: 0,
                         last_run_activity_at: None,
                         last_heartbeat_at: None,
+                        last_failure_at: None,
+                        last_recovery_at: None,
+                        last_error: None,
+                        last_duplicate_reclaim_at: None,
                         pid: Some(2001),
                         account_id: Some("bot_123456".to_owned()),
                         account_label: Some("bot:123456".to_owned()),
                         instance_count: 1,
                         running_instances: 1,
                         stale_instances: 0,
+                        duplicate_owner_pids: Vec::new(),
+                        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                        recent_incidents: Vec::new(),
                     }),
                 }],
             },
@@ -5066,14 +5602,22 @@ mod tests {
                         stale: false,
                         busy: false,
                         active_runs: 0,
+                        consecutive_failures: 0,
                         last_run_activity_at: None,
                         last_heartbeat_at: None,
+                        last_failure_at: None,
+                        last_recovery_at: None,
+                        last_error: None,
+                        last_duplicate_reclaim_at: None,
                         pid: None,
                         account_id: Some("bot_654321".to_owned()),
                         account_label: Some("bot:654321".to_owned()),
                         instance_count: 0,
                         running_instances: 0,
                         stale_instances: 0,
+                        duplicate_owner_pids: Vec::new(),
+                        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+                        recent_incidents: Vec::new(),
                     }),
                 }],
             },
@@ -5165,6 +5709,99 @@ mod tests {
         assert!(checks.is_empty());
     }
 
+    fn build_weixin_runtime_attention_surfaces(
+        stale: bool,
+        running_instances: usize,
+        consecutive_failures: usize,
+    ) -> (mvp::config::LoongConfig, Vec<mvp::channel::ChannelSurface>) {
+        let mut config = mvp::config::LoongConfig::default();
+        config.weixin.enabled = true;
+        config.weixin.bridge_url = Some("https://bridge.example.test/weixin".to_owned());
+        config.weixin.bridge_access_token = Some(loong_contracts::SecretRef::Inline(
+            "weixin-token".to_owned(),
+        ));
+        config.weixin.allowed_contact_ids = vec!["wxid_alice".to_owned()];
+
+        let mut inventory = mvp::channel::channel_inventory(&config);
+        let surface = inventory
+            .channel_surfaces
+            .iter_mut()
+            .find(|surface| surface.catalog.id == "weixin")
+            .expect("weixin surface");
+        let snapshot = surface
+            .configured_accounts
+            .iter_mut()
+            .find(|snapshot| snapshot.configured_account_id == "default")
+            .expect("weixin default account");
+        let serve = snapshot
+            .operations
+            .iter_mut()
+            .find(|operation| operation.id == mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+            .expect("weixin serve operation");
+        serve.runtime = Some(mvp::channel::ChannelOperationRuntime {
+            running: !stale,
+            stale,
+            busy: false,
+            active_runs: 0,
+            consecutive_failures,
+            last_run_activity_at: Some(1_700_000_000_000),
+            last_heartbeat_at: Some(1_700_000_005_000),
+            last_failure_at: if consecutive_failures > 0 {
+                Some(1_700_000_006_000)
+            } else {
+                None
+            },
+            last_recovery_at: None,
+            last_error: if consecutive_failures > 0 {
+                Some("temporary bridge timeout".to_owned())
+            } else {
+                None
+            },
+            last_duplicate_reclaim_at: if running_instances > 1 {
+                Some(1_700_000_007_000)
+            } else {
+                None
+            },
+            pid: Some(5151),
+            account_id: Some("default".to_owned()),
+            account_label: Some("default".to_owned()),
+            instance_count: running_instances.max(1),
+            running_instances,
+            stale_instances: usize::from(stale),
+            duplicate_owner_pids: if running_instances > 1 {
+                vec![5151, 6262]
+            } else {
+                Vec::new()
+            },
+            last_duplicate_reclaim_cleanup_owner_pids: if running_instances > 1 {
+                vec![6262]
+            } else {
+                Vec::new()
+            },
+            recent_incidents: if consecutive_failures > 0 {
+                vec![mvp::channel::ChannelOperationRuntimeIncident {
+                    at_ms: 1_700_000_006_000,
+                    kind: mvp::channel::ChannelOperationRuntimeIncidentKind::Failure,
+                    detail: Some("temporary bridge timeout".to_owned()),
+                    owner_pids: Vec::new(),
+                }]
+            } else if running_instances > 1 {
+                vec![mvp::channel::ChannelOperationRuntimeIncident {
+                    at_ms: 1_700_000_007_000,
+                    kind: mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim,
+                    detail: Some(
+                        "requested cooperative shutdown for duplicate runtime owners".to_owned(),
+                    ),
+                    owner_pids: vec![6262],
+                }]
+            } else {
+                Vec::new()
+            },
+        });
+
+        (config, inventory.channel_surfaces)
+    }
+
     #[test]
     fn build_doctor_next_steps_guides_fix_and_provider_credentials() {
         let checks = vec![
@@ -5204,6 +5841,84 @@ mod tests {
                 .iter()
                 .any(|step| step == "Re-run diagnostics: loong doctor --config '/tmp/loong.toml'"),
             "doctor should tell the operator how to confirm the repair path: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_runtime_retry_diagnostics() {
+        let checks = vec![DoctorCheck {
+            name: "weixin bridge serve runtime".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "runtime is retrying after transient failures (account=default account_id=default pid=5151 busy=false active_runs=0 consecutive_failures=2 instance_count=1 running_instances=1 stale_instances=0 last_run_activity_at=1700000000000 last_heartbeat_at=1700000005000 last_failure_at=1700000006000 last_recovery_at=- last_error=temporary bridge timeout)".to_owned(),
+        }];
+        let (config, channel_surfaces) = build_weixin_runtime_attention_surfaces(false, 1, 2);
+
+        let next_steps = build_doctor_next_steps_with_channel_surfaces_and_path_env(
+            &checks,
+            Path::new("/tmp/loong.toml"),
+            &config,
+            &channel_surfaces,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Inspect Weixin bridge connectivity, upstream session health, and external bridge logs, then rerun diagnostics: loong doctor --config '/tmp/loong.toml'"
+            }),
+            "retrying runtime should produce a concrete bridge diagnostics step: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_stale_runtime_recovery() {
+        let checks = vec![DoctorCheck {
+            name: "weixin bridge serve runtime".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: "stale runtime detected (account=default account_id=default pid=5151 busy=false active_runs=0 consecutive_failures=0 instance_count=1 running_instances=0 stale_instances=1 last_run_activity_at=1700000000000 last_heartbeat_at=1700000005000 last_failure_at=- last_recovery_at=- last_error=-)".to_owned(),
+        }];
+        let (config, channel_surfaces) = build_weixin_runtime_attention_surfaces(true, 0, 0);
+
+        let next_steps = build_doctor_next_steps_with_channel_surfaces_and_path_env(
+            &checks,
+            Path::new("/tmp/loong.toml"),
+            &config,
+            &channel_surfaces,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Restart the stale Weixin runtime or external bridge owner: loong weixin-serve --config '/tmp/loong.toml' --stop --account 'default'"
+            }),
+            "stale runtime should produce a restart-oriented recovery step: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_duplicate_runtime_cleanup() {
+        let checks = vec![DoctorCheck {
+            name: "weixin bridge serve runtime".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "multiple runtime instances detected (account=default account_id=default pid=5151 busy=false active_runs=0 consecutive_failures=0 instance_count=2 running_instances=2 stale_instances=0 last_run_activity_at=1700000000000 last_heartbeat_at=1700000005000 last_failure_at=- last_recovery_at=- last_error=-)".to_owned(),
+        }];
+        let (config, channel_surfaces) = build_weixin_runtime_attention_surfaces(false, 2, 0);
+
+        let next_steps = build_doctor_next_steps_with_channel_surfaces_and_path_env(
+            &checks,
+            Path::new("/tmp/loong.toml"),
+            &config,
+            &channel_surfaces,
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step == "Stop duplicate Weixin runtime instances so only one serve owner remains (last auto reclaim at=1700000007000; last auto cleanup pids=6262; keep pid=5151; cleanup pids=6262; run loong weixin-serve --config '/tmp/loong.toml' --stop-duplicates --account 'default')"
+            }),
+            "duplicate runtime attention should produce a cleanup-oriented recovery step: {next_steps:#?}"
         );
     }
 
@@ -5452,6 +6167,43 @@ mod tests {
                 .as_str()
                 .expect("plugin bridge account summary string"),
             "configured_account=ops (default): ready; configured_account=backup: bridge_url is missing"
+        );
+    }
+
+    #[test]
+    fn doctor_json_checks_include_runtime_attention_metadata() {
+        let checks = vec![DoctorCheck {
+            name: "weixin bridge serve runtime".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "runtime is retrying after transient failures (account=default account_id=default pid=5151 busy=false active_runs=0 consecutive_failures=2 instance_count=1 running_instances=1 stale_instances=0 last_run_activity_at=1700000000000 last_heartbeat_at=1700000005000 last_failure_at=1700000006000 last_recovery_at=- last_error=temporary bridge timeout)".to_owned(),
+        }];
+        let (_config, channel_surfaces) = build_weixin_runtime_attention_surfaces(false, 1, 2);
+        let payload = doctor_checks_json_payload(&checks, &channel_surfaces);
+        let runtime_check = payload.first().expect("runtime check payload");
+
+        assert_eq!(
+            runtime_check["runtime_attention"]["channel_id"]
+                .as_str()
+                .expect("runtime attention channel id"),
+            "weixin"
+        );
+        assert_eq!(
+            runtime_check["runtime_attention"]["reason"]
+                .as_str()
+                .expect("runtime attention reason"),
+            "retrying"
+        );
+        assert_eq!(
+            runtime_check["runtime_attention"]["remediation"]
+                .as_str()
+                .expect("runtime attention remediation"),
+            "inspect_bridge_connectivity"
+        );
+        assert_eq!(
+            runtime_check["runtime_attention"]["recent_incidents"][0]["kind"]
+                .as_str()
+                .expect("runtime attention incident kind"),
+            "failure"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -9,6 +9,7 @@ use kernel::{probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal
 use loong_app as mvp;
 use loong_contracts::SecretRef;
 use loong_spec::CliResult;
+use serde::Serialize;
 use serde_json::json;
 
 use crate::plugin_bridge_account_summary::plugin_bridge_account_summary;
@@ -42,6 +43,15 @@ pub struct DoctorCheck {
     pub name: String,
     pub level: DoctorCheckLevel,
     pub detail: String,
+}
+
+const DOCTOR_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+struct DoctorCliJsonSchema {
+    version: u32,
+    surface: &'static str,
+    purpose: &'static str,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -220,6 +230,7 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
     if options.json {
         let checks = doctor_checks_json_payload(&checks, &channel_inventory.channel_surfaces);
         let payload = json!({
+            "schema": doctor_cli_json_schema(),
             "ok": summary.fail == 0,
             "config": config_path.display().to_string(),
             "summary": {
@@ -254,6 +265,14 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
         return Err("doctor detected failing checks".to_owned());
     }
     Ok(())
+}
+
+fn doctor_cli_json_schema() -> DoctorCliJsonSchema {
+    DoctorCliJsonSchema {
+        version: DOCTOR_CLI_JSON_SCHEMA_VERSION,
+        surface: "doctor",
+        purpose: "runtime_health_diagnostics",
+    }
 }
 
 fn check_directory_ready(

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1856,6 +1856,20 @@ fn build_channel_runtime_check(
         };
     };
 
+    let recent_incidents = runtime
+        .recent_incidents
+        .iter()
+        .map(|incident| {
+            let kind = match incident.kind {
+                mvp::channel::ChannelOperationRuntimeIncidentKind::Failure => "failure",
+                mvp::channel::ChannelOperationRuntimeIncidentKind::Recovery => "recovery",
+                mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim => {
+                    "duplicate_reclaim"
+                }
+            };
+            format!("{kind}@{}", incident.at_ms)
+        })
+        .collect::<Vec<_>>();
     let detail_tail = format!(
         "account={} account_id={} pid={} busy={} active_runs={} consecutive_failures={} instance_count={} running_instances={} stale_instances={} last_run_activity_at={} last_heartbeat_at={} last_failure_at={} last_recovery_at={} last_error={} duplicate_owner_pids={} last_duplicate_reclaim_at={} last_duplicate_reclaim_cleanup_owner_pids={} recent_incidents={}",
         runtime.account_label.as_deref().unwrap_or("-"),
@@ -1893,7 +1907,7 @@ fn build_channel_runtime_check(
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_owned()),
         render_u32_list(&runtime.last_duplicate_reclaim_cleanup_owner_pids),
-        render_runtime_incident_summary(runtime.recent_incidents.as_slice()),
+        render_runtime_incident_summary(recent_incidents.as_slice()),
     );
 
     if runtime.stale {
@@ -2389,27 +2403,12 @@ fn render_u32_list(values: &[u32]) -> String {
         .join(",")
 }
 
-fn render_runtime_incident_summary(
-    incidents: &[mvp::channel::ChannelOperationRuntimeIncident],
-) -> String {
+fn render_runtime_incident_summary(incidents: &[String]) -> String {
     if incidents.is_empty() {
         return "-".to_owned();
     }
 
-    incidents
-        .iter()
-        .map(|incident| {
-            let kind = match incident.kind {
-                mvp::channel::ChannelOperationRuntimeIncidentKind::Failure => "failure",
-                mvp::channel::ChannelOperationRuntimeIncidentKind::Recovery => "recovery",
-                mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim => {
-                    "duplicate_reclaim"
-                }
-            };
-            format!("{kind}@{}", incident.at_ms)
-        })
-        .collect::<Vec<_>>()
-        .join(",")
+    incidents.join(",")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/daemon/src/doctor_security_cli.rs
+++ b/crates/daemon/src/doctor_security_cli.rs
@@ -11,6 +11,15 @@ use serde_json::json;
 
 use crate::doctor_cli::durable_audit_target_issue;
 
+const DOCTOR_SECURITY_CLI_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorSecurityCliJsonSchema {
+    pub version: u32,
+    pub surface: &'static str,
+    pub purpose: &'static str,
+}
+
 #[derive(Debug, Clone)]
 pub struct DoctorSecurityCommandOptions {
     pub config: Option<String>,
@@ -161,12 +170,21 @@ pub async fn execute_doctor_security_command(
 
 pub fn doctor_security_cli_json(execution: &DoctorSecurityAuditExecution) -> serde_json::Value {
     json!({
+        "schema": doctor_security_cli_schema(),
         "command": "security",
         "config": execution.resolved_config_path,
         "ok": execution.ok,
         "summary": execution.summary,
         "findings": execution.findings,
     })
+}
+
+fn doctor_security_cli_schema() -> DoctorSecurityCliJsonSchema {
+    DoctorSecurityCliJsonSchema {
+        version: DOCTOR_SECURITY_CLI_JSON_SCHEMA_VERSION,
+        surface: "doctor_security",
+        purpose: "operator_security_posture",
+    }
 }
 
 pub fn render_doctor_security_cli_text(execution: &DoctorSecurityAuditExecution) -> String {
@@ -1933,6 +1951,9 @@ mod tests {
 
         let payload = doctor_security_cli_json(&execution);
 
+        assert_eq!(payload["schema"]["version"], 1);
+        assert_eq!(payload["schema"]["surface"], "doctor_security");
+        assert_eq!(payload["schema"]["purpose"], "operator_security_posture");
         assert_eq!(payload["command"], "security");
         assert_eq!(payload["summary"]["covered"], 1);
         assert_eq!(payload["findings"][0]["id"], "audit_retention");

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, SocketAddr};
 
 use serde::{Deserialize, Serialize};
@@ -302,6 +302,16 @@ pub struct GatewayOperatorControlSurfaceReadModel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorRuntimeIncidentReadModel {
+    pub account_id: Option<String>,
+    pub account_label: Option<String>,
+    pub kind: String,
+    pub at_ms: u64,
+    pub detail: Option<String>,
+    pub owner_pids: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayOperatorChannelSurfaceReadModel {
     pub channel_id: String,
     pub label: String,
@@ -316,6 +326,17 @@ pub struct GatewayOperatorChannelSurfaceReadModel {
     pub mention_gated_account_count: usize,
     pub default_configured_account_id: Option<String>,
     pub plugin_bridge_account_summary: Option<String>,
+    pub runtime_attention_account_count: usize,
+    pub runtime_attention_reasons: Vec<String>,
+    pub runtime_attention_remediations: Vec<String>,
+    pub retrying_runtime_account_count: usize,
+    pub stale_runtime_account_count: usize,
+    pub duplicate_runtime_account_count: usize,
+    pub preferred_runtime_owner_pids: Vec<u32>,
+    pub duplicate_runtime_cleanup_owner_pids: Vec<u32>,
+    pub last_duplicate_runtime_auto_reclaim_at: Option<u64>,
+    pub last_duplicate_runtime_auto_cleanup_owner_pids: Vec<u32>,
+    pub recent_runtime_incidents: Vec<GatewayOperatorRuntimeIncidentReadModel>,
     pub service_enabled: bool,
     pub service_ready: bool,
 }
@@ -336,6 +357,14 @@ pub struct GatewayOperatorChannelsSummaryReadModel {
     pub enabled_outbound_only_channel_count: usize,
     pub enabled_service_channel_count: usize,
     pub ready_service_channel_count: usize,
+    pub runtime_attention_surface_count: usize,
+    pub retrying_runtime_surface_count: usize,
+    pub stale_runtime_surface_count: usize,
+    pub duplicate_runtime_surface_count: usize,
+    pub runtime_attention_surface_ids: Vec<String>,
+    pub retrying_runtime_surface_ids: Vec<String>,
+    pub stale_runtime_surface_ids: Vec<String>,
+    pub duplicate_runtime_surface_ids: Vec<String>,
     pub surfaces: Vec<GatewayOperatorChannelSurfaceReadModel>,
 }
 
@@ -973,6 +1002,42 @@ fn build_operator_channels_summary_read_model(
         .iter()
         .filter(|surface| surface.service_ready)
         .count();
+    let runtime_attention_surface_count = surfaces
+        .iter()
+        .filter(|surface| surface.runtime_attention_account_count > 0)
+        .count();
+    let retrying_runtime_surface_count = surfaces
+        .iter()
+        .filter(|surface| surface.retrying_runtime_account_count > 0)
+        .count();
+    let stale_runtime_surface_count = surfaces
+        .iter()
+        .filter(|surface| surface.stale_runtime_account_count > 0)
+        .count();
+    let duplicate_runtime_surface_count = surfaces
+        .iter()
+        .filter(|surface| surface.duplicate_runtime_account_count > 0)
+        .count();
+    let runtime_attention_surface_ids = surfaces
+        .iter()
+        .filter(|surface| surface.runtime_attention_account_count > 0)
+        .map(|surface| surface.channel_id.clone())
+        .collect::<Vec<_>>();
+    let retrying_runtime_surface_ids = surfaces
+        .iter()
+        .filter(|surface| surface.retrying_runtime_account_count > 0)
+        .map(|surface| surface.channel_id.clone())
+        .collect::<Vec<_>>();
+    let stale_runtime_surface_ids = surfaces
+        .iter()
+        .filter(|surface| surface.stale_runtime_account_count > 0)
+        .map(|surface| surface.channel_id.clone())
+        .collect::<Vec<_>>();
+    let duplicate_runtime_surface_ids = surfaces
+        .iter()
+        .filter(|surface| surface.duplicate_runtime_account_count > 0)
+        .map(|surface| surface.channel_id.clone())
+        .collect::<Vec<_>>();
 
     GatewayOperatorChannelsSummaryReadModel {
         catalog_channel_count,
@@ -989,6 +1054,14 @@ fn build_operator_channels_summary_read_model(
         enabled_outbound_only_channel_count,
         enabled_service_channel_count,
         ready_service_channel_count,
+        runtime_attention_surface_count,
+        retrying_runtime_surface_count,
+        stale_runtime_surface_count,
+        duplicate_runtime_surface_count,
+        runtime_attention_surface_ids,
+        retrying_runtime_surface_ids,
+        stale_runtime_surface_ids,
+        duplicate_runtime_surface_ids,
         surfaces,
     }
 }
@@ -1067,8 +1140,43 @@ fn build_operator_channel_surface_read_model(
         .count();
     let default_configured_account_id = surface.default_configured_account_id.clone();
     let plugin_bridge_account_summary = channel_surface.plugin_bridge_account_summary.clone();
+    let runtime_attention_account_count = surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_has_runtime_attention(account))
+        .count();
+    let runtime_attention_reasons = collect_channel_surface_runtime_attention_reasons(surface);
+    let runtime_attention_remediations = runtime_attention_reasons
+        .iter()
+        .map(|reason| runtime_attention_reason_remediation(reason.as_str()).to_owned())
+        .collect::<Vec<_>>();
+    let retrying_runtime_account_count = surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_has_retrying_runtime(account))
+        .count();
+    let stale_runtime_account_count = surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_has_stale_runtime(account))
+        .count();
+    let duplicate_runtime_account_count = surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_has_duplicate_runtime(account))
+        .count();
+    let preferred_runtime_owner_pids =
+        collect_channel_surface_preferred_runtime_owner_pids(surface);
+    let duplicate_runtime_cleanup_owner_pids =
+        collect_channel_surface_duplicate_runtime_cleanup_owner_pids(surface);
+    let last_duplicate_runtime_auto_reclaim_at =
+        collect_channel_surface_last_duplicate_runtime_auto_reclaim_at(surface);
+    let last_duplicate_runtime_auto_cleanup_owner_pids =
+        collect_channel_surface_last_duplicate_runtime_auto_cleanup_owner_pids(surface);
+    let recent_runtime_incidents = collect_channel_surface_recent_runtime_incidents(surface);
     let service_enabled = enabled_service_channel_ids.contains(&channel_id);
-    let service_ready = service_enabled && ready_serve_account_count > 0;
+    let service_ready =
+        service_enabled && ready_serve_account_count > 0 && runtime_attention_account_count == 0;
 
     GatewayOperatorChannelSurfaceReadModel {
         channel_id,
@@ -1084,6 +1192,17 @@ fn build_operator_channel_surface_read_model(
         mention_gated_account_count,
         default_configured_account_id,
         plugin_bridge_account_summary,
+        runtime_attention_account_count,
+        runtime_attention_reasons,
+        runtime_attention_remediations,
+        retrying_runtime_account_count,
+        stale_runtime_account_count,
+        duplicate_runtime_account_count,
+        preferred_runtime_owner_pids,
+        duplicate_runtime_cleanup_owner_pids,
+        last_duplicate_runtime_auto_reclaim_at,
+        last_duplicate_runtime_auto_cleanup_owner_pids,
+        recent_runtime_incidents,
         service_enabled,
         service_ready,
     }
@@ -1212,6 +1331,197 @@ fn channel_account_operation_is_ready(
     operation.health == mvp::channel::ChannelOperationHealth::Ready
 }
 
+fn channel_account_serve_runtime(
+    account: &mvp::channel::ChannelStatusSnapshot,
+) -> Option<&mvp::channel::ChannelOperationRuntime> {
+    account
+        .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+        .and_then(|operation| operation.runtime.as_ref())
+}
+
+fn channel_account_has_runtime_attention(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    channel_account_has_retrying_runtime(account)
+        || channel_account_has_stale_runtime(account)
+        || channel_account_has_duplicate_runtime(account)
+}
+
+fn collect_channel_surface_runtime_attention_reasons(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+
+    if surface
+        .configured_accounts
+        .iter()
+        .any(channel_account_has_retrying_runtime)
+    {
+        reasons.push("retrying".to_owned());
+    }
+    if surface
+        .configured_accounts
+        .iter()
+        .any(channel_account_has_stale_runtime)
+    {
+        reasons.push("stale".to_owned());
+    }
+    if surface
+        .configured_accounts
+        .iter()
+        .any(channel_account_has_duplicate_runtime)
+    {
+        reasons.push("duplicate_runtime_instances".to_owned());
+    }
+
+    reasons
+}
+
+fn runtime_attention_reason_remediation(reason: &str) -> &'static str {
+    match reason {
+        "retrying" => "inspect_bridge_connectivity",
+        "stale" => "restart_stale_runtime",
+        "duplicate_runtime_instances" => "stop_duplicate_runtime_instances",
+        _ => "inspect_runtime_attention",
+    }
+}
+
+fn channel_account_has_retrying_runtime(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    channel_account_serve_runtime(account)
+        .map(|runtime| runtime.running && runtime.consecutive_failures > 0)
+        .unwrap_or(false)
+}
+
+fn channel_account_has_stale_runtime(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    channel_account_serve_runtime(account)
+        .map(|runtime| runtime.stale)
+        .unwrap_or(false)
+}
+
+fn channel_account_has_duplicate_runtime(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    channel_account_serve_runtime(account)
+        .map(|runtime| runtime.running_instances > 1)
+        .unwrap_or(false)
+}
+
+fn collect_channel_surface_preferred_runtime_owner_pids(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<u32> {
+    let mut owner_pids = BTreeSet::new();
+
+    for account in &surface.configured_accounts {
+        let Some(runtime) = channel_account_serve_runtime(account) else {
+            continue;
+        };
+        if runtime.duplicate_owner_pids.is_empty() {
+            continue;
+        }
+        let Some(pid) = runtime.pid else {
+            continue;
+        };
+        owner_pids.insert(pid);
+    }
+
+    owner_pids.into_iter().collect()
+}
+
+fn collect_channel_surface_duplicate_runtime_cleanup_owner_pids(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<u32> {
+    let mut owner_pids = BTreeSet::new();
+
+    for account in &surface.configured_accounts {
+        let Some(runtime) = channel_account_serve_runtime(account) else {
+            continue;
+        };
+        if runtime.duplicate_owner_pids.is_empty() {
+            continue;
+        }
+        let preferred_pid = runtime.pid;
+        for owner_pid in &runtime.duplicate_owner_pids {
+            if Some(*owner_pid) == preferred_pid {
+                continue;
+            }
+            owner_pids.insert(*owner_pid);
+        }
+    }
+
+    owner_pids.into_iter().collect()
+}
+
+fn collect_channel_surface_last_duplicate_runtime_auto_reclaim_at(
+    surface: &mvp::channel::ChannelSurface,
+) -> Option<u64> {
+    surface
+        .configured_accounts
+        .iter()
+        .filter_map(channel_account_serve_runtime)
+        .filter_map(|runtime| runtime.last_duplicate_reclaim_at)
+        .max()
+}
+
+fn collect_channel_surface_last_duplicate_runtime_auto_cleanup_owner_pids(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<u32> {
+    let latest_reclaim_at = collect_channel_surface_last_duplicate_runtime_auto_reclaim_at(surface);
+    let Some(latest_reclaim_at) = latest_reclaim_at else {
+        return Vec::new();
+    };
+
+    let mut owner_pids = BTreeSet::new();
+    for runtime in surface
+        .configured_accounts
+        .iter()
+        .filter_map(channel_account_serve_runtime)
+        .filter(|runtime| runtime.last_duplicate_reclaim_at == Some(latest_reclaim_at))
+    {
+        for owner_pid in &runtime.last_duplicate_reclaim_cleanup_owner_pids {
+            owner_pids.insert(*owner_pid);
+        }
+    }
+
+    owner_pids.into_iter().collect()
+}
+
+fn collect_channel_surface_recent_runtime_incidents(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<GatewayOperatorRuntimeIncidentReadModel> {
+    let mut incidents = surface
+        .configured_accounts
+        .iter()
+        .filter_map(|account| {
+            let runtime = channel_account_serve_runtime(account)?;
+            Some(
+                runtime
+                    .recent_incidents
+                    .iter()
+                    .map(|incident| GatewayOperatorRuntimeIncidentReadModel {
+                        account_id: runtime.account_id.clone(),
+                        account_label: runtime.account_label.clone(),
+                        kind: match incident.kind {
+                            mvp::channel::ChannelOperationRuntimeIncidentKind::Failure => {
+                                "failure".to_owned()
+                            }
+                            mvp::channel::ChannelOperationRuntimeIncidentKind::Recovery => {
+                                "recovery".to_owned()
+                            }
+                            mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim => {
+                                "duplicate_reclaim".to_owned()
+                            }
+                        },
+                        at_ms: incident.at_ms,
+                        detail: incident.detail.clone(),
+                        owner_pids: incident.owner_pids.clone(),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+    incidents.truncate(5);
+    incidents
+}
+
 fn gateway_owner_base_url(owner_status: &GatewayOwnerStatus) -> Option<String> {
     let bind_address = owner_status.bind_address.as_deref()?;
     let port = owner_status.port?;
@@ -1285,6 +1595,10 @@ mod tests {
         assert_eq!(operator_surface.implementation_status, "plugin_backed");
         assert_eq!(operator_surface.conversation_gated_account_count, 0);
         assert_eq!(operator_surface.sender_gated_account_count, 0);
+        assert_eq!(operator_surface.runtime_attention_account_count, 0);
+        assert!(operator_surface.runtime_attention_reasons.is_empty());
+        assert!(operator_surface.runtime_attention_remediations.is_empty());
+        assert_eq!(operator_surface.retrying_runtime_account_count, 0);
         assert_eq!(
             operator_surface.plugin_bridge_account_summary.as_deref(),
             Some(
@@ -1318,7 +1632,277 @@ mod tests {
         assert_eq!(operator_surface.implementation_status, "runtime_backed");
         assert_eq!(operator_surface.conversation_gated_account_count, 1);
         assert_eq!(operator_surface.sender_gated_account_count, 0);
+        assert_eq!(operator_surface.runtime_attention_account_count, 0);
+        assert!(operator_surface.runtime_attention_reasons.is_empty());
+        assert!(operator_surface.runtime_attention_remediations.is_empty());
         assert_eq!(operator_surface.plugin_bridge_account_summary, None);
+    }
+
+    #[test]
+    fn operator_channel_surface_read_model_counts_retrying_runtime_attention() {
+        let config = mvp::config::LoongConfig::default();
+        let mut inventory = mvp::channel::channel_inventory(&config);
+        let surface = inventory
+            .channel_surfaces
+            .iter_mut()
+            .find(|surface| surface.catalog.id == "weixin")
+            .expect("weixin surface");
+        let account = surface
+            .configured_accounts
+            .iter_mut()
+            .find(|account| account.configured_account_id == "default")
+            .expect("default weixin account");
+        let serve = account
+            .operations
+            .iter_mut()
+            .find(|operation| operation.id == "serve")
+            .expect("weixin serve operation");
+        serve.runtime = Some(mvp::channel::ChannelOperationRuntime {
+            running: true,
+            stale: false,
+            busy: false,
+            active_runs: 0,
+            consecutive_failures: 2,
+            last_run_activity_at: Some(1_700_000_000_000),
+            last_heartbeat_at: Some(1_700_000_005_000),
+            last_failure_at: Some(1_700_000_006_000),
+            last_recovery_at: None,
+            last_error: Some("temporary bridge timeout".to_owned()),
+            last_duplicate_reclaim_at: None,
+            pid: Some(5151),
+            account_id: Some("default".to_owned()),
+            account_label: Some("default".to_owned()),
+            instance_count: 1,
+            running_instances: 1,
+            stale_instances: 0,
+            duplicate_owner_pids: Vec::new(),
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
+        });
+
+        let read_model = build_channel_surface_read_model(surface.clone());
+        let operator_surface = build_operator_channel_surface_read_model(
+            &read_model,
+            &inventory.channel_access_policies,
+            &["weixin".to_owned()],
+        );
+
+        assert_eq!(operator_surface.runtime_attention_account_count, 1);
+        assert_eq!(
+            operator_surface.runtime_attention_reasons,
+            vec!["retrying".to_owned()]
+        );
+        assert_eq!(
+            operator_surface.runtime_attention_remediations,
+            vec!["inspect_bridge_connectivity".to_owned()]
+        );
+        assert_eq!(operator_surface.retrying_runtime_account_count, 1);
+        assert_eq!(operator_surface.stale_runtime_account_count, 0);
+        assert_eq!(operator_surface.duplicate_runtime_account_count, 0);
+        assert!(operator_surface.preferred_runtime_owner_pids.is_empty());
+        assert!(
+            operator_surface
+                .duplicate_runtime_cleanup_owner_pids
+                .is_empty()
+        );
+        assert!(
+            operator_surface
+                .last_duplicate_runtime_auto_reclaim_at
+                .is_none()
+        );
+        assert!(
+            operator_surface
+                .last_duplicate_runtime_auto_cleanup_owner_pids
+                .is_empty()
+        );
+        assert!(operator_surface.service_enabled);
+        assert!(!operator_surface.service_ready);
+    }
+
+    #[test]
+    fn operator_channel_surface_read_model_collects_duplicate_runtime_owner_pids() {
+        let config = mvp::config::LoongConfig::default();
+        let mut inventory = mvp::channel::channel_inventory(&config);
+        let surface = inventory
+            .channel_surfaces
+            .iter_mut()
+            .find(|surface| surface.catalog.id == "weixin")
+            .expect("weixin surface");
+        let account = surface
+            .configured_accounts
+            .iter_mut()
+            .find(|account| account.configured_account_id == "default")
+            .expect("default weixin account");
+        let serve = account
+            .operations
+            .iter_mut()
+            .find(|operation| operation.id == "serve")
+            .expect("weixin serve operation");
+        serve.runtime = Some(mvp::channel::ChannelOperationRuntime {
+            running: true,
+            stale: false,
+            busy: false,
+            active_runs: 0,
+            consecutive_failures: 0,
+            last_run_activity_at: Some(1_700_000_000_000),
+            last_heartbeat_at: Some(1_700_000_005_000),
+            last_failure_at: None,
+            last_recovery_at: None,
+            last_error: None,
+            last_duplicate_reclaim_at: Some(1_700_000_007_000),
+            pid: Some(6262),
+            account_id: Some("default".to_owned()),
+            account_label: Some("default".to_owned()),
+            instance_count: 2,
+            running_instances: 2,
+            stale_instances: 0,
+            duplicate_owner_pids: vec![5151, 6262],
+            last_duplicate_reclaim_cleanup_owner_pids: vec![5151],
+            recent_incidents: vec![mvp::channel::ChannelOperationRuntimeIncident {
+                at_ms: 1_700_000_007_000,
+                kind: mvp::channel::ChannelOperationRuntimeIncidentKind::DuplicateReclaim,
+                detail: Some(
+                    "requested cooperative shutdown for duplicate runtime owners".to_owned(),
+                ),
+                owner_pids: vec![5151],
+            }],
+        });
+
+        let read_model = build_channel_surface_read_model(surface.clone());
+        let operator_surface = build_operator_channel_surface_read_model(
+            &read_model,
+            &inventory.channel_access_policies,
+            &["weixin".to_owned()],
+        );
+
+        assert_eq!(operator_surface.runtime_attention_account_count, 1);
+        assert_eq!(
+            operator_surface.runtime_attention_reasons,
+            vec!["duplicate_runtime_instances".to_owned()]
+        );
+        assert_eq!(
+            operator_surface.runtime_attention_remediations,
+            vec!["stop_duplicate_runtime_instances".to_owned()]
+        );
+        assert_eq!(operator_surface.duplicate_runtime_account_count, 1);
+        assert_eq!(operator_surface.preferred_runtime_owner_pids, vec![6262]);
+        assert_eq!(
+            operator_surface.duplicate_runtime_cleanup_owner_pids,
+            vec![5151]
+        );
+        assert_eq!(
+            operator_surface.last_duplicate_runtime_auto_reclaim_at,
+            Some(1_700_000_007_000)
+        );
+        assert_eq!(
+            operator_surface.last_duplicate_runtime_auto_cleanup_owner_pids,
+            vec![5151]
+        );
+        assert_eq!(operator_surface.recent_runtime_incidents.len(), 1);
+        assert_eq!(
+            operator_surface.recent_runtime_incidents[0].kind,
+            "duplicate_reclaim"
+        );
+        assert_eq!(
+            operator_surface.recent_runtime_incidents[0].owner_pids,
+            vec![5151]
+        );
+        assert!(!operator_surface.service_ready);
+    }
+
+    #[test]
+    fn operator_channels_summary_read_model_collects_runtime_attention_surface_ids() {
+        let config = mvp::config::LoongConfig::default();
+        let mut inventory = mvp::channel::channel_inventory(&config);
+        let surface = inventory
+            .channel_surfaces
+            .iter_mut()
+            .find(|surface| surface.catalog.id == "weixin")
+            .expect("weixin surface");
+        let account = surface
+            .configured_accounts
+            .iter_mut()
+            .find(|account| account.configured_account_id == "default")
+            .expect("default weixin account");
+        let serve = account
+            .operations
+            .iter_mut()
+            .find(|operation| operation.id == "serve")
+            .expect("weixin serve operation");
+        serve.runtime = Some(mvp::channel::ChannelOperationRuntime {
+            running: true,
+            stale: false,
+            busy: false,
+            active_runs: 0,
+            consecutive_failures: 2,
+            last_run_activity_at: Some(1_700_000_000_000),
+            last_heartbeat_at: Some(1_700_000_005_000),
+            last_failure_at: Some(1_700_000_006_000),
+            last_recovery_at: None,
+            last_error: Some("temporary bridge timeout".to_owned()),
+            last_duplicate_reclaim_at: None,
+            pid: Some(5151),
+            account_id: Some("default".to_owned()),
+            account_label: Some("default".to_owned()),
+            instance_count: 1,
+            running_instances: 1,
+            stale_instances: 0,
+            duplicate_owner_pids: Vec::new(),
+            last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+            recent_incidents: Vec::new(),
+        });
+
+        let channel_inventory = build_channel_inventory_read_model("/tmp/loong.toml", &inventory);
+        let runtime_snapshot = GatewayRuntimeSnapshotReadModel {
+            config: "/tmp/loong.toml".to_owned(),
+            schema: GatewayRuntimeSnapshotSchema {
+                version: 1,
+                surface: "runtime_snapshot",
+                purpose: "test",
+            },
+            provider: serde_json::json!({}),
+            context_engine: serde_json::json!({}),
+            memory_system: serde_json::json!({}),
+            acp: serde_json::json!({}),
+            channels: GatewayRuntimeSnapshotChannelsReadModel {
+                enabled_channel_ids: vec!["weixin".to_owned()],
+                enabled_runtime_backed_channel_ids: Vec::new(),
+                enabled_service_channel_ids: vec!["weixin".to_owned()],
+                enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
+                enabled_outbound_only_channel_ids: Vec::new(),
+                inventory: channel_inventory.clone(),
+            },
+            tool_runtime: serde_json::json!({}),
+            tools: GatewayRuntimeSnapshotToolsReadModel {
+                visible_tool_count: 0,
+                visible_tool_names: Vec::new(),
+                capability_snapshot_sha256: "abc123".to_owned(),
+                capability_snapshot: "{}".to_owned(),
+                tool_calling: GatewayToolCallingReadModel {
+                    availability: "ready".to_owned(),
+                    structured_tool_schema_enabled: true,
+                    effective_tool_schema_mode: "enabled".to_owned(),
+                    active_model: "gpt-4.1-mini".to_owned(),
+                    reason: "test".to_owned(),
+                },
+            },
+            runtime_plugins: serde_json::json!({}),
+            external_skills: serde_json::json!({}),
+        };
+
+        let summary =
+            build_operator_channels_summary_read_model(&channel_inventory, &runtime_snapshot);
+
+        assert_eq!(
+            summary.runtime_attention_surface_ids,
+            vec!["weixin".to_owned()]
+        );
+        assert_eq!(
+            summary.retrying_runtime_surface_ids,
+            vec!["weixin".to_owned()]
+        );
+        assert!(summary.stale_runtime_surface_ids.is_empty());
+        assert!(summary.duplicate_runtime_surface_ids.is_empty());
     }
 
     #[test]

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1876,6 +1876,10 @@ mod tests {
             tools: GatewayRuntimeSnapshotToolsReadModel {
                 visible_tool_count: 0,
                 visible_tool_names: Vec::new(),
+                visible_direct_tool_names: Vec::new(),
+                hidden_tool_count: 0,
+                hidden_tool_tags: Vec::new(),
+                hidden_tool_surfaces: Vec::new(),
                 capability_snapshot_sha256: "abc123".to_owned(),
                 capability_snapshot: "{}".to_owned(),
                 tool_calling: GatewayToolCallingReadModel {
@@ -1884,6 +1888,13 @@ mod tests {
                     effective_tool_schema_mode: "enabled".to_owned(),
                     active_model: "gpt-4.1-mini".to_owned(),
                     reason: "test".to_owned(),
+                },
+                web_access: GatewayWebAccessReadModel {
+                    ordinary_network_access_enabled: false,
+                    query_search_enabled: false,
+                    query_search_default_provider: "duckduckgo".to_owned(),
+                    query_search_credential_ready: false,
+                    separation_note: crate::RUNTIME_WEB_ACCESS_SEPARATION_NOTE.to_owned(),
                 },
             },
             runtime_plugins: serde_json::json!({}),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -416,6 +416,8 @@ pub struct ChannelServeCliArgs<'a> {
     pub config_path: Option<&'a str>,
     pub account: Option<&'a str>,
     pub once: bool,
+    pub stop_requested: bool,
+    pub stop_duplicates_requested: bool,
     pub bind_override: Option<&'a str>,
     pub path_override: Option<&'a str>,
 }
@@ -1128,6 +1130,10 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "once")]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with_all = ["once", "stop"])]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1170,6 +1176,10 @@ pub enum Commands {
     FeishuServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "stop")]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
         #[arg(long)]
@@ -1200,6 +1210,10 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "once")]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with_all = ["once", "stop"])]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1224,6 +1238,10 @@ pub enum Commands {
     WecomServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "stop")]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1250,6 +1268,10 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "once")]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with_all = ["once", "stop"])]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1276,6 +1298,10 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "once")]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with_all = ["once", "stop"])]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1302,6 +1328,10 @@ pub enum Commands {
         config: Option<String>,
         #[arg(long, default_value_t = false)]
         once: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "once")]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with_all = ["once", "stop"])]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
     },
@@ -1309,6 +1339,10 @@ pub enum Commands {
     WhatsappServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "stop")]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
         #[arg(long)]
@@ -1388,6 +1422,10 @@ pub enum Commands {
     LineServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "stop")]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
         #[arg(long)]
@@ -1450,6 +1488,10 @@ pub enum Commands {
     WebhookServe {
         #[arg(long)]
         config: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stop: bool,
+        #[arg(long, default_value_t = false, conflicts_with = "stop")]
+        stop_duplicates: bool,
         #[arg(long)]
         account: Option<String>,
         #[arg(long)]
@@ -3862,7 +3904,264 @@ pub async fn run_channel_serve_cli(
     spec: ChannelServeCliSpec,
     args: ChannelServeCliArgs<'_>,
 ) -> CliResult<()> {
-    let _ = spec.family;
+    if args.stop_requested {
+        let channel_id = spec.family.channel_id;
+        let stop_result = match channel_id {
+            "telegram" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Telegram,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.telegram.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "feishu" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Feishu,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.feishu.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "line" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Line,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.line.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "matrix" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Matrix,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.matrix.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "wecom" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Wecom,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.wecom.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "webhook" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Webhook,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.webhook.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "whatsapp" => {
+                request_runtime_backed_channel_serve_stop(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::WhatsApp,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.whatsapp.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            _ => Err(format!(
+                "{} does not support --stop on this serve surface",
+                spec.family.serve.command
+            )),
+        };
+        return stop_result;
+    }
+    if args.stop_duplicates_requested {
+        let channel_id = spec.family.channel_id;
+        let stop_result = match channel_id {
+            "telegram" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Telegram,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.telegram.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "feishu" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Feishu,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.feishu.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "line" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Line,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.line.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "matrix" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Matrix,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.matrix.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "wecom" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Wecom,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.wecom.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "webhook" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::Webhook,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.webhook.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            "whatsapp" => {
+                request_runtime_backed_channel_serve_duplicate_cleanup(
+                    args.config_path,
+                    channel_id,
+                    mvp::channel::ChannelPlatform::WhatsApp,
+                    args.account,
+                    |config, account| {
+                        let resolved = config.whatsapp.resolve_account(account)?;
+                        Ok((
+                            resolved.configured_account_id,
+                            resolved.account.id,
+                            resolved.account.label,
+                        ))
+                    },
+                )
+                .await
+            }
+            _ => Err(format!(
+                "{} does not support --stop-duplicates on this serve surface",
+                spec.family.serve.command
+            )),
+        };
+        return stop_result;
+    }
     (spec.run)(args).await
 }
 
@@ -4200,6 +4499,40 @@ pub fn run_twitch_send_cli_impl(args: ChannelSendCliArgs<'_>) -> ChannelCliComma
 pub fn run_telegram_serve_cli_impl(args: ChannelServeCliArgs<'_>) -> ChannelCliCommandFuture<'_> {
     Box::pin(async move {
         let _ = (args.bind_override, args.path_override);
+        if args.stop_requested {
+            return request_runtime_backed_channel_serve_stop(
+                args.config_path,
+                "telegram",
+                mvp::channel::ChannelPlatform::Telegram,
+                args.account,
+                |config, account| {
+                    let resolved = config.telegram.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
+        if args.stop_duplicates_requested {
+            return request_runtime_backed_channel_serve_duplicate_cleanup(
+                args.config_path,
+                "telegram",
+                mvp::channel::ChannelPlatform::Telegram,
+                args.account,
+                |config, account| {
+                    let resolved = config.telegram.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
         with_graceful_shutdown(mvp::channel::run_telegram_channel(
             args.config_path,
             args.once,
@@ -4441,6 +4774,40 @@ pub fn parse_nostr_send_target_kind(
 pub fn run_matrix_serve_cli_impl(args: ChannelServeCliArgs<'_>) -> ChannelCliCommandFuture<'_> {
     Box::pin(async move {
         let _ = (args.bind_override, args.path_override);
+        if args.stop_requested {
+            return request_runtime_backed_channel_serve_stop(
+                args.config_path,
+                "matrix",
+                mvp::channel::ChannelPlatform::Matrix,
+                args.account,
+                |config, account| {
+                    let resolved = config.matrix.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
+        if args.stop_duplicates_requested {
+            return request_runtime_backed_channel_serve_duplicate_cleanup(
+                args.config_path,
+                "matrix",
+                mvp::channel::ChannelPlatform::Matrix,
+                args.account,
+                |config, account| {
+                    let resolved = config.matrix.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
         with_graceful_shutdown(mvp::channel::run_matrix_channel(
             args.config_path,
             args.once,
@@ -4457,12 +4824,138 @@ pub fn run_wecom_serve_cli_impl(args: ChannelServeCliArgs<'_>) -> ChannelCliComm
         // discarded because single-run mode and HTTP bind/path overrides do not
         // apply to this transport.
         let _ = (args.once, args.bind_override, args.path_override);
+        if args.stop_requested {
+            return request_runtime_backed_channel_serve_stop(
+                args.config_path,
+                "wecom",
+                mvp::channel::ChannelPlatform::Wecom,
+                args.account,
+                |config, account| {
+                    let resolved = config.wecom.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
+        if args.stop_duplicates_requested {
+            return request_runtime_backed_channel_serve_duplicate_cleanup(
+                args.config_path,
+                "wecom",
+                mvp::channel::ChannelPlatform::Wecom,
+                args.account,
+                |config, account| {
+                    let resolved = config.wecom.resolve_account(account)?;
+                    Ok((
+                        resolved.configured_account_id,
+                        resolved.account.id,
+                        resolved.account.label,
+                    ))
+                },
+            )
+            .await;
+        }
         with_graceful_shutdown(mvp::channel::run_wecom_channel(
             args.config_path,
             args.account,
         ))
         .await
     })
+}
+
+async fn request_runtime_backed_channel_serve_stop<F>(
+    config_path: Option<&str>,
+    channel_id: &str,
+    platform: mvp::channel::ChannelPlatform,
+    account_id: Option<&str>,
+    resolve_account: F,
+) -> CliResult<()>
+where
+    F: FnOnce(&mvp::config::LoongConfig, Option<&str>) -> CliResult<(String, String, String)>,
+{
+    let (_resolved_path, config) = mvp::config::load(config_path)?;
+    let (configured_account_id, runtime_account_id, runtime_account_label) =
+        resolve_account(&config, account_id)?;
+    let outcome = mvp::channel::request_channel_operation_stop(
+        platform,
+        mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+        Some(runtime_account_id.as_str()),
+    )?;
+
+    let outcome_label = match outcome {
+        mvp::channel::ChannelOperationStopRequestOutcome::Requested => "requested",
+        mvp::channel::ChannelOperationStopRequestOutcome::AlreadyRequested => "already_requested",
+        mvp::channel::ChannelOperationStopRequestOutcome::AlreadyStopped => "already_stopped",
+    };
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} serve stop {} (configured_account={}, account={})",
+            channel_id, outcome_label, configured_account_id, runtime_account_label
+        );
+    }
+
+    Ok(())
+}
+
+async fn request_runtime_backed_channel_serve_duplicate_cleanup<F>(
+    config_path: Option<&str>,
+    channel_id: &str,
+    platform: mvp::channel::ChannelPlatform,
+    account_id: Option<&str>,
+    resolve_account: F,
+) -> CliResult<()>
+where
+    F: FnOnce(&mvp::config::LoongConfig, Option<&str>) -> CliResult<(String, String, String)>,
+{
+    let (_resolved_path, config) = mvp::config::load(config_path)?;
+    let (configured_account_id, runtime_account_id, runtime_account_label) =
+        resolve_account(&config, account_id)?;
+    let result = mvp::channel::request_channel_operation_duplicate_cleanup(
+        platform,
+        mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+        Some(runtime_account_id.as_str()),
+    )?;
+
+    let outcome_label = match result.outcome {
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::Requested => "requested",
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::AlreadyRequested => {
+            "already_requested"
+        }
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::NoDuplicates => "no_duplicates",
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::AlreadyStopped => "already_stopped",
+    };
+    let preferred_owner_pid = result
+        .preferred_owner_pid
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let cleanup_owner_pids = if result.targeted_owner_pids.is_empty() {
+        "-".to_owned()
+    } else {
+        result
+            .targeted_owner_pids
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} serve duplicate cleanup {} (configured_account={}, account={}, preferred_owner_pid={}, cleanup_owner_pids={})",
+            channel_id,
+            outcome_label,
+            configured_account_id,
+            runtime_account_label,
+            preferred_owner_pid,
+            cleanup_owner_pids,
+        );
+    }
+
+    Ok(())
 }
 
 pub async fn run_multi_channel_serve_cli(

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -713,6 +713,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::TelegramServe {
             config,
             once,
+            stop,
+            stop_duplicates,
             account,
         } => {
             run_channel_serve_cli(
@@ -721,6 +723,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: None,
                     path_override: None,
                 },
@@ -771,6 +775,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         }
         Commands::FeishuServe {
             config,
+            stop,
+            stop_duplicates,
             account,
             bind,
             path,
@@ -781,6 +787,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once: false,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: bind.as_deref(),
                     path_override: path.as_deref(),
                 },
@@ -810,6 +818,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::MatrixServe {
             config,
             once,
+            stop,
+            stop_duplicates,
             account,
         } => {
             run_channel_serve_cli(
@@ -818,6 +828,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: None,
                     path_override: None,
                 },
@@ -844,13 +856,20 @@ async fn run_command(command: Commands) -> CliResult<()> {
             )
             .await
         }
-        Commands::WecomServe { config, account } => {
+        Commands::WecomServe {
+            config,
+            stop,
+            stop_duplicates,
+            account,
+        } => {
             run_channel_serve_cli(
                 WECOM_SERVE_CLI_SPEC,
                 ChannelServeCliArgs {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once: false,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: None,
                     path_override: None,
                 },
@@ -877,12 +896,16 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::WeixinServe {
             config,
             once,
+            stop,
+            stop_duplicates,
             account,
         } => {
             run_weixin_serve_cli_impl(ChannelServeCliArgs {
                 config_path: config.as_deref(),
                 account: account.as_deref(),
                 once,
+                stop_requested: stop,
+                stop_duplicates_requested: stop_duplicates,
                 bind_override: None,
                 path_override: None,
             })
@@ -908,12 +931,16 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::QqbotServe {
             config,
             once,
+            stop,
+            stop_duplicates,
             account,
         } => {
             run_qqbot_serve_cli_impl(ChannelServeCliArgs {
                 config_path: config.as_deref(),
                 account: account.as_deref(),
                 once,
+                stop_requested: stop,
+                stop_duplicates_requested: stop_duplicates,
                 bind_override: None,
                 path_override: None,
             })
@@ -939,12 +966,16 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::OnebotServe {
             config,
             once,
+            stop,
+            stop_duplicates,
             account,
         } => {
             run_onebot_serve_cli_impl(ChannelServeCliArgs {
                 config_path: config.as_deref(),
                 account: account.as_deref(),
                 once,
+                stop_requested: stop,
+                stop_duplicates_requested: stop_duplicates,
                 bind_override: None,
                 path_override: None,
             })
@@ -952,6 +983,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         }
         Commands::WhatsappServe {
             config,
+            stop,
+            stop_duplicates,
             account,
             bind,
             path,
@@ -962,6 +995,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once: false,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: bind.as_deref(),
                     path_override: path.as_deref(),
                 },
@@ -1050,6 +1085,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         }
         Commands::LineServe {
             config,
+            stop,
+            stop_duplicates,
             account,
             bind,
             path,
@@ -1060,6 +1097,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once: false,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: bind.as_deref(),
                     path_override: path.as_deref(),
                 },
@@ -1128,6 +1167,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
         }
         Commands::WebhookServe {
             config,
+            stop,
+            stop_duplicates,
             account,
             bind,
             path,
@@ -1138,6 +1179,8 @@ async fn run_command(command: Commands) -> CliResult<()> {
                     config_path: config.as_deref(),
                     account: account.as_deref(),
                     once: false,
+                    stop_requested: stop,
+                    stop_duplicates_requested: stop_duplicates,
                     bind_override: bind.as_deref(),
                     path_override: path.as_deref(),
                 },

--- a/crates/daemon/src/managed_plugin_bridge_runtime.rs
+++ b/crates/daemon/src/managed_plugin_bridge_runtime.rs
@@ -21,6 +21,34 @@ struct ManagedBridgeInvocationSuccess {
     runtime_evidence: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedManagedBridgeTarget {
+    embedded_account_id: Option<String>,
+    route_kind: String,
+    route_id: String,
+}
+
+#[cfg(test)]
+const MANAGED_BRIDGE_IDLE_POLL_MS: u64 = 25;
+#[cfg(not(test))]
+const MANAGED_BRIDGE_IDLE_POLL_MS: u64 = 500;
+const MANAGED_BRIDGE_SERVE_MAX_CONSECUTIVE_FAILURES: usize = 3;
+#[cfg(test)]
+const MANAGED_BRIDGE_SERVE_INITIAL_BACKOFF_MS: u64 = 25;
+#[cfg(not(test))]
+const MANAGED_BRIDGE_SERVE_INITIAL_BACKOFF_MS: u64 = 1_000;
+#[cfg(test)]
+const MANAGED_BRIDGE_SERVE_MAX_BACKOFF_MS: u64 = 100;
+#[cfg(not(test))]
+const MANAGED_BRIDGE_SERVE_MAX_BACKOFF_MS: u64 = 5_000;
+
+#[derive(Debug, Clone, Copy)]
+struct ManagedBridgeServeContext<'a> {
+    channel_id: &'a str,
+    plugin_id: &'a str,
+    configured_account_id: &'a str,
+}
+
 pub async fn run_managed_plugin_bridge_send(
     config_path: Option<&str>,
     channel_id: &str,
@@ -30,8 +58,14 @@ pub async fn run_managed_plugin_bridge_send(
     text: &str,
 ) -> CliResult<()> {
     let (resolved_path, config) = load_managed_bridge_runtime_config(config_path)?;
+    let parsed_target = parse_managed_bridge_target(channel_id, target)?;
+    let resolved_account_id = account_id
+        .map(normalize_bridge_account_id)
+        .or_else(|| parsed_target.embedded_account_id.clone());
     let binding = mvp::channel::resolve_managed_plugin_bridge_runtime_binding(
-        &config, channel_id, account_id,
+        &config,
+        channel_id,
+        resolved_account_id.as_deref(),
     )?;
     let supports_send = binding
         .supports_operation(mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION);
@@ -45,8 +79,14 @@ pub async fn run_managed_plugin_bridge_send(
     mvp::runtime_env::initialize_runtime_environment(&config, Some(resolved_path.as_path()));
 
     let bridge_policy = bridge_execution_policy_from_config(&config)?;
-    let outbound_target =
-        mvp::channel::ChannelOutboundTarget::new(target_platform(channel_id)?, target_kind, target);
+    let canonical_target =
+        canonicalize_managed_bridge_target(channel_id, &binding, &parsed_target)?;
+    enforce_managed_bridge_outbound_policy(channel_id, &binding, &parsed_target)?;
+    let outbound_target = mvp::channel::ChannelOutboundTarget::new(
+        target_platform(channel_id)?,
+        target_kind,
+        canonical_target.as_str(),
+    );
     let outbound_message = mvp::channel::ChannelOutboundMessage::Text(text.to_owned());
     let payload = send_message_payload(&binding, &outbound_target, &outbound_message);
     let invocation =
@@ -59,6 +99,20 @@ pub async fn run_managed_plugin_bridge_send(
             plugin_id = %binding.plugin.plugin_id,
             bridge_kind = %binding.plugin.runtime.bridge_kind.as_str(),
             "managed bridge send completed with runtime evidence"
+        );
+    }
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} message sent via managed bridge runtime (plugin_id={}, configured_account={}, account={}, target_kind={}, target={}, route_kind={})",
+            channel_id,
+            binding.plugin.plugin_id,
+            binding.configured_account_id,
+            binding.account_label,
+            target_kind.as_str(),
+            canonical_target,
+            parsed_target.route_kind,
         );
     }
 
@@ -105,6 +159,24 @@ pub async fn run_managed_plugin_bridge_channel(
     let stop = mvp::channel::ChannelServeStopHandle::new();
     let runtime_account_id = binding.account_id.clone();
     let runtime_account_label = binding.account_label.clone();
+    let selected_plugin_id = binding.plugin.plugin_id.clone();
+    let selected_bridge_kind = binding.plugin.runtime.bridge_kind.as_str().to_owned();
+    let configured_account_id = binding.configured_account_id.clone();
+    let configured_account_label = binding.configured_account_label.clone();
+    let endpoint = binding.endpoint.clone();
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} bridge serve starting (plugin_id={}, bridge_kind={}, configured_account={}, account={}, once={}, endpoint={})",
+            channel_id,
+            selected_plugin_id,
+            selected_bridge_kind,
+            configured_account_id,
+            configured_account_label,
+            once,
+            endpoint,
+        );
+    }
     let config = Arc::new(config);
     let resolved_path = Some(resolved_path);
     let kernel_ctx = Arc::new(kernel_ctx);
@@ -120,19 +192,127 @@ pub async fn run_managed_plugin_bridge_channel(
         stop,
         move |runtime, stop| async move {
             let mut adapter = ManagedPluginBridgeChannelAdapter::new(binding, bridge_policy);
+            let serve_context = ManagedBridgeServeContext {
+                channel_id,
+                plugin_id: selected_plugin_id.as_str(),
+                configured_account_id: configured_account_id.as_str(),
+            };
             run_managed_plugin_bridge_loop(
-                config,
-                resolved_path,
-                kernel_ctx,
                 &stop,
                 &runtime,
                 &mut adapter,
                 once,
+                serve_context,
+                |message, feedback_policy| {
+                    let config = config.clone();
+                    let resolved_path = resolved_path.clone();
+                    let kernel_ctx = kernel_ctx.clone();
+                    Box::pin(async move {
+                        let resolved_path = resolved_path.as_deref();
+                        mvp::channel::process_inbound_with_provider(
+                            config.as_ref(),
+                            resolved_path,
+                            &message,
+                            kernel_ctx.as_ref(),
+                            feedback_policy,
+                        )
+                        .await
+                    })
+                },
             )
             .await
         },
     )
     .await
+}
+
+async fn request_managed_plugin_bridge_serve_stop(
+    config_path: Option<&str>,
+    channel_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<()> {
+    let (_resolved_path, config) = load_managed_bridge_runtime_config(config_path)?;
+    let binding = mvp::channel::resolve_managed_plugin_bridge_runtime_binding(
+        &config, channel_id, account_id,
+    )?;
+    let outcome = mvp::channel::request_channel_operation_stop(
+        binding.platform,
+        mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+        Some(binding.account_id.as_str()),
+    )?;
+
+    let outcome_label = match outcome {
+        mvp::channel::ChannelOperationStopRequestOutcome::Requested => "requested",
+        mvp::channel::ChannelOperationStopRequestOutcome::AlreadyRequested => "already_requested",
+        mvp::channel::ChannelOperationStopRequestOutcome::AlreadyStopped => "already_stopped",
+    };
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} bridge serve stop {} (plugin_id={}, configured_account={}, account={})",
+            channel_id,
+            outcome_label,
+            binding.plugin.plugin_id,
+            binding.configured_account_id,
+            binding.account_label,
+        );
+    }
+
+    Ok(())
+}
+
+async fn request_managed_plugin_bridge_serve_duplicate_cleanup(
+    config_path: Option<&str>,
+    channel_id: &str,
+    account_id: Option<&str>,
+) -> CliResult<()> {
+    let (_resolved_path, config) = load_managed_bridge_runtime_config(config_path)?;
+    let binding = mvp::channel::resolve_managed_plugin_bridge_runtime_binding(
+        &config, channel_id, account_id,
+    )?;
+    let result = mvp::channel::request_channel_operation_duplicate_cleanup(
+        binding.platform,
+        mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+        Some(binding.account_id.as_str()),
+    )?;
+
+    let outcome_label = match result.outcome {
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::Requested => "requested",
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::AlreadyRequested => {
+            "already_requested"
+        }
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::NoDuplicates => "no_duplicates",
+        mvp::channel::ChannelOperationDuplicateCleanupOutcome::AlreadyStopped => "already_stopped",
+    };
+    let preferred_owner_pid = result
+        .preferred_owner_pid
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let cleanup_owner_pids = if result.targeted_owner_pids.is_empty() {
+        "-".to_owned()
+    } else {
+        result
+            .targeted_owner_pids
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "{} bridge serve duplicate cleanup {} (plugin_id={}, configured_account={}, account={}, preferred_owner_pid={}, cleanup_owner_pids={})",
+            channel_id,
+            outcome_label,
+            binding.plugin.plugin_id,
+            binding.configured_account_id,
+            binding.account_label,
+            preferred_owner_pid,
+            cleanup_owner_pids,
+        );
+    }
+
+    Ok(())
 }
 
 fn load_managed_bridge_runtime_config(
@@ -191,6 +371,188 @@ fn send_message_payload(
     payload_map.insert("message".to_owned(), message_value);
 
     Value::Object(payload_map)
+}
+
+fn parse_managed_bridge_target(
+    channel_id: &str,
+    raw_target: &str,
+) -> CliResult<ParsedManagedBridgeTarget> {
+    let trimmed_target = raw_target.trim();
+    if trimmed_target.is_empty() {
+        return Err(format!("{channel_id}-send requires --target"));
+    }
+
+    let allowed_route_kinds = managed_bridge_route_kinds(channel_id);
+    let parts = trimmed_target.split(':').collect::<Vec<_>>();
+    let (embedded_account_id, route_kind, route_id) = match parts.as_slice() {
+        [route_kind, route_id] => (None, *route_kind, *route_id),
+        [account_id, route_kind, route_id] => (
+            Some(normalize_bridge_account_id(account_id)),
+            *route_kind,
+            *route_id,
+        ),
+        [raw_channel_id, account_id, route_kind, route_id] => {
+            let normalized_channel_id = mvp::channel::normalize_channel_catalog_id(raw_channel_id)
+                .ok_or_else(|| {
+                    format!(
+                        "{channel_id} target prefix `{raw_channel_id}` is not a recognized channel id"
+                    )
+                })?;
+            if normalized_channel_id != channel_id {
+                return Err(format!(
+                    "{channel_id} target uses channel prefix `{normalized_channel_id}`, expected `{channel_id}`"
+                ));
+            }
+            (
+                Some(normalize_bridge_account_id(account_id)),
+                *route_kind,
+                *route_id,
+            )
+        }
+        _ => {
+            return Err(format!(
+                "{channel_id} target must use `{channel_id}:<account>:<kind>:<id>`, `<account>:<kind>:<id>`, or `<kind>:<id>`"
+            ));
+        }
+    };
+
+    let route_kind = allowed_route_kinds
+        .iter()
+        .find(|candidate| **candidate == route_kind)
+        .copied()
+        .ok_or_else(|| {
+            format!(
+                "{channel_id} target kind `{route_kind}` is unsupported; use {}",
+                allowed_route_kinds
+                    .iter()
+                    .map(|value| format!("`{value}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+    let route_id = route_id.trim();
+    if route_id.is_empty() {
+        return Err(format!("{channel_id} target conversation id is empty"));
+    }
+
+    Ok(ParsedManagedBridgeTarget {
+        embedded_account_id,
+        route_kind: route_kind.to_owned(),
+        route_id: route_id.to_owned(),
+    })
+}
+
+fn canonicalize_managed_bridge_target(
+    channel_id: &str,
+    binding: &mvp::channel::ManagedPluginBridgeRuntimeBinding,
+    parsed_target: &ParsedManagedBridgeTarget,
+) -> CliResult<String> {
+    if let Some(embedded_account_id) = parsed_target.embedded_account_id.as_deref()
+        && embedded_account_id != binding.configured_account_id
+    {
+        return Err(format!(
+            "{channel_id} target resolved account `{embedded_account_id}`, but the selected configured account is `{}`",
+            binding.configured_account_id
+        ));
+    }
+
+    Ok(format!(
+        "{channel_id}:{}:{}:{}",
+        binding.configured_account_id, parsed_target.route_kind, parsed_target.route_id
+    ))
+}
+
+fn managed_bridge_route_kinds(channel_id: &str) -> &'static [&'static str] {
+    match channel_id {
+        "weixin" => &["contact", "room"],
+        "qqbot" => &["c2c", "group", "channel"],
+        "onebot" => &["private", "group"],
+        _ => &[],
+    }
+}
+
+fn enforce_managed_bridge_outbound_policy(
+    channel_id: &str,
+    binding: &mvp::channel::ManagedPluginBridgeRuntimeBinding,
+    parsed_target: &ParsedManagedBridgeTarget,
+) -> CliResult<()> {
+    match channel_id {
+        "weixin" => {
+            if parsed_target.route_kind != "contact" {
+                return Ok(());
+            }
+            let allowed_contact_ids =
+                runtime_context_string_list(&binding.runtime_context, "allowed_contact_ids");
+            if route_id_is_allowed(
+                allowed_contact_ids.as_slice(),
+                parsed_target.route_id.as_str(),
+            ) {
+                return Ok(());
+            }
+            Err(format!(
+                "weixin target `{}` is not allowed by configured allowed_contact_ids",
+                parsed_target.route_id
+            ))
+        }
+        "qqbot" => {
+            let allowed_peer_ids =
+                runtime_context_string_list(&binding.runtime_context, "allowed_peer_ids");
+            if route_id_is_allowed(allowed_peer_ids.as_slice(), parsed_target.route_id.as_str()) {
+                return Ok(());
+            }
+            Err(format!(
+                "qqbot target `{}` is not allowed by configured allowed_peer_ids",
+                parsed_target.route_id
+            ))
+        }
+        "onebot" => {
+            if parsed_target.route_kind != "group" {
+                return Ok(());
+            }
+            let allowed_group_ids =
+                runtime_context_string_list(&binding.runtime_context, "allowed_group_ids");
+            if route_id_is_allowed(
+                allowed_group_ids.as_slice(),
+                parsed_target.route_id.as_str(),
+            ) {
+                return Ok(());
+            }
+            Err(format!(
+                "onebot group target `{}` is not allowed by configured allowed_group_ids",
+                parsed_target.route_id
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn runtime_context_string_list(runtime_context: &Value, key: &str) -> Vec<String> {
+    runtime_context
+        .get("account")
+        .and_then(|value| value.get("config"))
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn route_id_is_allowed(allowed_values: &[String], route_id: &str) -> bool {
+    if allowed_values.is_empty() {
+        return true;
+    }
+
+    allowed_values.iter().any(|allowed| {
+        let trimmed_allowed = allowed.trim();
+        trimmed_allowed == "*" || trimmed_allowed == route_id
+    })
 }
 
 fn receive_batch_payload(binding: &mvp::channel::ManagedPluginBridgeRuntimeBinding) -> Value {
@@ -431,61 +793,175 @@ impl mvp::channel::ChannelAdapter for ManagedPluginBridgeChannelAdapter {
     }
 }
 
-async fn run_managed_plugin_bridge_loop(
-    config: Arc<mvp::config::LoongConfig>,
-    resolved_path: Option<PathBuf>,
-    kernel_ctx: Arc<mvp::KernelContext>,
+async fn run_managed_plugin_bridge_loop<A, F>(
     stop: &mvp::channel::ChannelServeStopHandle,
     runtime: &mvp::channel::ChannelOperationRuntimeTracker,
-    adapter: &mut ManagedPluginBridgeChannelAdapter,
+    adapter: &mut A,
     once: bool,
-) -> CliResult<()> {
+    context: ManagedBridgeServeContext<'_>,
+    mut process: F,
+) -> CliResult<()>
+where
+    A: ChannelAdapter + Send + ?Sized,
+    F: FnMut(
+        mvp::channel::ChannelInboundMessage,
+        mvp::channel::ChannelTurnFeedbackPolicy,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<String>> + Send>>,
+{
+    let mut consecutive_failures = 0usize;
     loop {
         if stop.is_requested() {
             return Ok(());
         }
 
-        let batch = tokio::select! {
+        let iteration = tokio::select! {
             _ = stop.wait() => return Ok(()),
-            batch = adapter.receive_batch() => batch?,
+            result = run_managed_plugin_bridge_iteration(runtime, adapter, &mut process) => result,
         };
-        let had_messages = mvp::channel::process_channel_batch(
-            adapter,
-            batch,
-            Some(runtime),
-            |message, feedback_policy| {
-                let config = config.clone();
-                let resolved_path = resolved_path.clone();
-                let kernel_ctx = kernel_ctx.clone();
-                Box::pin(async move {
-                    let resolved_path = resolved_path.as_deref();
-                    mvp::channel::process_inbound_with_provider(
-                        config.as_ref(),
-                        resolved_path,
-                        &message,
-                        kernel_ctx.as_ref(),
-                        feedback_policy,
-                    )
-                    .await
-                })
-            },
-        )
-        .await?;
+        match iteration {
+            Ok(had_messages) => {
+                if consecutive_failures > 0 {
+                    let recovered_failures = consecutive_failures;
+                    consecutive_failures = 0;
+                    runtime.clear_failure().await?;
+                    report_managed_bridge_serve_recovered(context, recovered_failures);
+                }
 
-        if once {
-            return Ok(());
-        }
+                if once {
+                    return Ok(());
+                }
 
-        if had_messages {
-            continue;
-        }
+                if had_messages {
+                    continue;
+                }
 
-        let sleep = tokio::time::sleep(Duration::from_millis(500));
-        tokio::pin!(sleep);
-        tokio::select! {
-            _ = stop.wait() => return Ok(()),
-            _ = &mut sleep => {}
+                let sleep = tokio::time::sleep(Duration::from_millis(MANAGED_BRIDGE_IDLE_POLL_MS));
+                tokio::pin!(sleep);
+                tokio::select! {
+                    _ = stop.wait() => return Ok(()),
+                    _ = &mut sleep => {}
+                }
+            }
+            Err(error) => {
+                runtime.record_failure(error.as_str()).await?;
+                if once {
+                    return Err(error);
+                }
+
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures >= MANAGED_BRIDGE_SERVE_MAX_CONSECUTIVE_FAILURES {
+                    return Err(format!(
+                        "{} bridge serve failed after {} consecutive managed bridge runtime errors (plugin_id={}, configured_account={}): {}",
+                        context.channel_id,
+                        consecutive_failures,
+                        context.plugin_id,
+                        context.configured_account_id,
+                        error,
+                    ));
+                }
+
+                let backoff_ms = managed_bridge_serve_backoff_ms(consecutive_failures)
+                    .min(MANAGED_BRIDGE_SERVE_MAX_BACKOFF_MS);
+                report_managed_bridge_serve_retry(
+                    context,
+                    consecutive_failures,
+                    backoff_ms,
+                    error.as_str(),
+                );
+                let sleep = tokio::time::sleep(Duration::from_millis(backoff_ms));
+                tokio::pin!(sleep);
+                tokio::select! {
+                    _ = stop.wait() => return Ok(()),
+                    _ = &mut sleep => {}
+                }
+            }
         }
+    }
+}
+
+async fn run_managed_plugin_bridge_iteration<A, F>(
+    runtime: &mvp::channel::ChannelOperationRuntimeTracker,
+    adapter: &mut A,
+    process: &mut F,
+) -> CliResult<bool>
+where
+    A: ChannelAdapter + Send + ?Sized,
+    F: FnMut(
+        mvp::channel::ChannelInboundMessage,
+        mvp::channel::ChannelTurnFeedbackPolicy,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<String>> + Send>>,
+{
+    let batch = adapter.receive_batch().await?;
+    mvp::channel::process_channel_batch(
+        adapter,
+        batch,
+        Some(runtime),
+        |message, feedback_policy| process(message, feedback_policy),
+    )
+    .await
+}
+
+fn managed_bridge_serve_backoff_ms(consecutive_failures: usize) -> u64 {
+    let exponent = consecutive_failures.saturating_sub(1);
+    let shift = u32::try_from(exponent).unwrap_or(u32::MAX).min(8);
+    let multiplier = 1_u64.checked_shl(shift).unwrap_or(u64::MAX);
+    MANAGED_BRIDGE_SERVE_INITIAL_BACKOFF_MS
+        .saturating_mul(multiplier)
+        .min(MANAGED_BRIDGE_SERVE_MAX_BACKOFF_MS)
+}
+
+fn report_managed_bridge_serve_retry(
+    context: ManagedBridgeServeContext<'_>,
+    consecutive_failures: usize,
+    backoff_ms: u64,
+    error: &str,
+) {
+    tracing::warn!(
+        target: "loong.managed_bridge",
+        channel_id = context.channel_id,
+        plugin_id = context.plugin_id,
+        configured_account = context.configured_account_id,
+        consecutive_failures,
+        backoff_ms,
+        error = error,
+        "managed bridge serve iteration failed; retrying after transient backoff"
+    );
+    #[allow(clippy::print_stderr)]
+    {
+        eprintln!(
+            "{} bridge serve transient failure {}/{} (plugin_id={}, configured_account={}); retrying in {}ms: {}",
+            context.channel_id,
+            consecutive_failures,
+            MANAGED_BRIDGE_SERVE_MAX_CONSECUTIVE_FAILURES,
+            context.plugin_id,
+            context.configured_account_id,
+            backoff_ms,
+            error,
+        );
+    }
+}
+
+fn report_managed_bridge_serve_recovered(
+    context: ManagedBridgeServeContext<'_>,
+    recovered_failures: usize,
+) {
+    tracing::info!(
+        target: "loong.managed_bridge",
+        channel_id = context.channel_id,
+        plugin_id = context.plugin_id,
+        configured_account = context.configured_account_id,
+        recovered_failures,
+        "managed bridge serve recovered after transient failure"
+    );
+    #[allow(clippy::print_stderr)]
+    {
+        eprintln!(
+            "{} bridge serve recovered after {} transient failure(s) (plugin_id={}, configured_account={})",
+            context.channel_id,
+            recovered_failures,
+            context.plugin_id,
+            context.configured_account_id,
+        );
     }
 }
 
@@ -579,14 +1055,7 @@ fn run_managed_plugin_bridge_send_cli_impl<'a>(
             args.target_kind,
             args.text,
         )
-        .await?;
-        println!(
-            "{} message sent via managed bridge runtime (target={}, target_kind={})",
-            channel_id,
-            target,
-            args.target_kind.as_str(),
-        );
-        Ok(())
+        .await
     })
 }
 
@@ -608,6 +1077,22 @@ fn run_managed_plugin_bridge_serve_cli_impl<'a>(
 ) -> ChannelCliCommandFuture<'a> {
     Box::pin(async move {
         let _ = (args.bind_override, args.path_override);
+        if args.stop_requested {
+            return request_managed_plugin_bridge_serve_stop(
+                args.config_path,
+                channel_id,
+                args.account,
+            )
+            .await;
+        }
+        if args.stop_duplicates_requested {
+            return request_managed_plugin_bridge_serve_duplicate_cleanup(
+                args.config_path,
+                channel_id,
+                args.account,
+            )
+            .await;
+        }
         crate::with_graceful_shutdown(run_managed_plugin_bridge_channel(
             args.config_path,
             channel_id,
@@ -634,10 +1119,49 @@ fn require_managed_bridge_target<'a>(
     Ok(target)
 }
 
+fn normalize_bridge_account_id(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "default".to_owned();
+    }
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut last_was_separator = false;
+    for value in trimmed.chars() {
+        if value.is_ascii_alphanumeric() {
+            normalized.push(value.to_ascii_lowercase());
+            last_was_separator = false;
+            continue;
+        }
+        if matches!(value, '_' | '-') {
+            if !normalized.is_empty() && !last_was_separator {
+                normalized.push(value);
+                last_was_separator = true;
+            }
+            continue;
+        }
+        if !normalized.is_empty() && !last_was_separator {
+            normalized.push('-');
+            last_was_separator = true;
+        }
+    }
+
+    while matches!(normalized.chars().last(), Some('-' | '_')) {
+        normalized.pop();
+    }
+
+    if normalized.is_empty() {
+        "default".to_owned()
+    } else {
+        normalized
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use axum::Json;
@@ -655,6 +1179,85 @@ mod tests {
         requests: Arc<Mutex<Vec<Value>>>,
     }
 
+    #[derive(Debug, Clone)]
+    enum ScriptedReceiveStep {
+        Batch(Vec<mvp::channel::ChannelInboundMessage>),
+        Error(String),
+    }
+
+    #[derive(Clone, Default)]
+    struct ScriptedAdapterState {
+        receive_calls: Arc<AtomicUsize>,
+        send_calls: Arc<AtomicUsize>,
+        ack_calls: Arc<AtomicUsize>,
+        complete_calls: Arc<AtomicUsize>,
+    }
+
+    struct ScriptedChannelAdapter {
+        name: String,
+        receive_steps: Mutex<Vec<ScriptedReceiveStep>>,
+        state: ScriptedAdapterState,
+    }
+
+    impl ScriptedChannelAdapter {
+        fn new(
+            name: impl Into<String>,
+            receive_steps: Vec<ScriptedReceiveStep>,
+            state: ScriptedAdapterState,
+        ) -> Self {
+            Self {
+                name: name.into(),
+                receive_steps: Mutex::new(receive_steps),
+                state,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl mvp::channel::ChannelAdapter for ScriptedChannelAdapter {
+        fn name(&self) -> &str {
+            self.name.as_str()
+        }
+
+        async fn receive_batch(&mut self) -> CliResult<Vec<mvp::channel::ChannelInboundMessage>> {
+            self.state.receive_calls.fetch_add(1, Ordering::Relaxed);
+            let mut steps = self
+                .receive_steps
+                .lock()
+                .expect("lock scripted receive steps");
+            if steps.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            match steps.remove(0) {
+                ScriptedReceiveStep::Batch(batch) => Ok(batch),
+                ScriptedReceiveStep::Error(error) => Err(error),
+            }
+        }
+
+        async fn send_message(
+            &self,
+            _target: &mvp::channel::ChannelOutboundTarget,
+            _message: &mvp::channel::ChannelOutboundMessage,
+        ) -> CliResult<()> {
+            self.state.send_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn ack_inbound(
+            &mut self,
+            _message: &mvp::channel::ChannelInboundMessage,
+        ) -> CliResult<()> {
+            self.state.ack_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn complete_batch(&mut self) -> CliResult<()> {
+            self.state.complete_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
     async fn capture_handler(
         State(state): State<CaptureState>,
         Json(body): Json<Value>,
@@ -666,6 +1269,30 @@ mod tests {
                 "ok": true
             }
         }))
+    }
+
+    fn scripted_inbound_message(
+        platform: mvp::channel::ChannelPlatform,
+        account_id: &str,
+        conversation_id: &str,
+        reply_target_id: &str,
+        text: &str,
+    ) -> mvp::channel::ChannelInboundMessage {
+        mvp::channel::ChannelInboundMessage {
+            session: mvp::channel::ChannelSession::with_account(
+                platform,
+                account_id,
+                conversation_id,
+            )
+            .with_configured_account_id(account_id),
+            reply_target: mvp::channel::ChannelOutboundTarget::new(
+                platform,
+                mvp::channel::ChannelOutboundTargetKind::Conversation,
+                reply_target_id,
+            ),
+            text: text.to_owned(),
+            delivery: mvp::channel::ChannelDelivery::default(),
+        }
     }
 
     fn write_runtime_manifest(root: &std::path::Path, endpoint: &str) {
@@ -769,7 +1396,7 @@ mod tests {
             Some(config_path_string.as_str()),
             "weixin",
             None,
-            "weixin:default:contact:wxid_alice",
+            "contact:wxid_alice",
             mvp::channel::ChannelOutboundTargetKind::Conversation,
             "hello bridge",
         )
@@ -810,5 +1437,409 @@ mod tests {
         );
 
         server_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_managed_plugin_bridge_send_rejects_conflicting_embedded_account() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        let config_root = TempDir::new().expect("create config root");
+        write_runtime_manifest(runtime_root.path(), "http://127.0.0.1:9/bridge");
+
+        let mut config = mvp::config::LoongConfig::default();
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        config.weixin.enabled = true;
+        config.weixin.default_account = Some("ops".to_owned());
+        config.weixin.accounts.insert(
+            "ops".to_owned(),
+            mvp::config::WeixinAccountConfig {
+                enabled: Some(true),
+                account_id: Some("ops".to_owned()),
+                bridge_url: Some("http://127.0.0.1:9/bridge".to_owned()),
+                bridge_url_env: None,
+                bridge_access_token: Some(loong_contracts::SecretRef::Inline(
+                    "bridge-token".to_owned(),
+                )),
+                bridge_access_token_env: None,
+                allowed_contact_ids: Some(vec!["wxid_alice".to_owned()]),
+            },
+        );
+
+        let config_path = config_root.path().join("loong.toml");
+        let encoded_config = toml::to_string(&config).expect("serialize config");
+        fs::write(&config_path, encoded_config).expect("write config");
+        let config_path_string = config_path.to_string_lossy().to_string();
+
+        let error = run_managed_plugin_bridge_send(
+            Some(config_path_string.as_str()),
+            "weixin",
+            Some("ops"),
+            "backup:contact:wxid_alice",
+            mvp::channel::ChannelOutboundTargetKind::Conversation,
+            "hello bridge",
+        )
+        .await
+        .expect_err("conflicting account should fail");
+
+        assert!(
+            error.contains("selected configured account is `ops`"),
+            "unexpected managed bridge target/account error: {error}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_managed_plugin_bridge_send_rejects_disallowed_weixin_contact() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        let config_root = TempDir::new().expect("create config root");
+        write_runtime_manifest(runtime_root.path(), "http://127.0.0.1:9/bridge");
+
+        let mut config = mvp::config::LoongConfig::default();
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        config.weixin.enabled = true;
+        config.weixin.bridge_url = Some("http://127.0.0.1:9/bridge".to_owned());
+        config.weixin.bridge_access_token = Some(loong_contracts::SecretRef::Inline(
+            "bridge-token".to_owned(),
+        ));
+        config.weixin.allowed_contact_ids = vec!["wxid_alice".to_owned()];
+
+        let config_path = config_root.path().join("loong.toml");
+        let encoded_config = toml::to_string(&config).expect("serialize config");
+        fs::write(&config_path, encoded_config).expect("write config");
+        let config_path_string = config_path.to_string_lossy().to_string();
+
+        let error = run_managed_plugin_bridge_send(
+            Some(config_path_string.as_str()),
+            "weixin",
+            None,
+            "contact:wxid_bob",
+            mvp::channel::ChannelOutboundTargetKind::Conversation,
+            "hello bridge",
+        )
+        .await
+        .expect_err("disallowed weixin contact should fail");
+
+        assert!(
+            error.contains("allowed_contact_ids"),
+            "unexpected weixin allowlist error: {error}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn request_managed_plugin_bridge_serve_stop_writes_stop_request() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        let config_root = TempDir::new().expect("create config root");
+        let temp_home = TempDir::new().expect("create temp loong home");
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONG_HOME", temp_home.path().as_os_str());
+        write_runtime_manifest(runtime_root.path(), "http://127.0.0.1:9/bridge");
+
+        let runtime_dir = mvp::config::default_loong_home().join("channel-runtime");
+        fs::create_dir_all(&runtime_dir).expect("create channel runtime dir");
+        let runtime_path = runtime_dir.join("weixin-serve-default-5151.json");
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_millis() as u64;
+        let runtime_state = serde_json::json!({
+            "running": true,
+            "busy": false,
+            "active_runs": 0,
+            "consecutive_failures": 0,
+            "last_run_activity_at": now_ms.saturating_sub(500),
+            "last_heartbeat_at": now_ms.saturating_sub(100),
+            "last_failure_at": serde_json::Value::Null,
+            "last_recovery_at": serde_json::Value::Null,
+            "last_error": serde_json::Value::Null,
+            "pid": 5151u32,
+            "account_id": "default",
+            "account_label": "default",
+            "owner_token": "owner-5151"
+        });
+        let encoded_runtime =
+            serde_json::to_string_pretty(&runtime_state).expect("serialize runtime state");
+        fs::write(&runtime_path, encoded_runtime).expect("write runtime state");
+
+        let mut config = mvp::config::LoongConfig::default();
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        config.weixin.enabled = true;
+        config.weixin.bridge_url = Some("http://127.0.0.1:9/bridge".to_owned());
+        config.weixin.bridge_access_token = Some(loong_contracts::SecretRef::Inline(
+            "bridge-token".to_owned(),
+        ));
+        config.weixin.allowed_contact_ids = vec!["wxid_alice".to_owned()];
+
+        let config_path = config_root.path().join("loong.toml");
+        let encoded_config = toml::to_string(&config).expect("serialize config");
+        fs::write(&config_path, encoded_config).expect("write config");
+        let config_path_string = config_path.to_string_lossy().to_string();
+
+        request_managed_plugin_bridge_serve_stop(Some(config_path_string.as_str()), "weixin", None)
+            .await
+            .expect("request managed bridge serve stop");
+
+        let stop_request_path =
+            runtime_dir.join("weixin-serve-default-stop-request-owner-5151.json");
+        let encoded_stop_request =
+            fs::read_to_string(&stop_request_path).expect("read stop request");
+        let stop_request: serde_json::Value =
+            serde_json::from_str(&encoded_stop_request).expect("decode stop request");
+
+        assert_eq!(
+            stop_request
+                .get("target_owner_token")
+                .and_then(serde_json::Value::as_str),
+            Some("owner-5151")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn request_managed_plugin_bridge_duplicate_cleanup_keeps_preferred_owner() {
+        let runtime_root = TempDir::new().expect("create runtime plugin root");
+        let config_root = TempDir::new().expect("create config root");
+        let temp_home = TempDir::new().expect("create temp loong home");
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONG_HOME", temp_home.path().as_os_str());
+        write_runtime_manifest(runtime_root.path(), "http://127.0.0.1:9/bridge");
+
+        let runtime_dir = mvp::config::default_loong_home().join("channel-runtime");
+        fs::create_dir_all(&runtime_dir).expect("create channel runtime dir");
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_millis() as u64;
+        let first_runtime_state = serde_json::json!({
+            "running": true,
+            "busy": false,
+            "active_runs": 0,
+            "consecutive_failures": 0,
+            "last_run_activity_at": now_ms.saturating_sub(2_000),
+            "last_heartbeat_at": now_ms.saturating_sub(1_000),
+            "last_failure_at": serde_json::Value::Null,
+            "last_recovery_at": serde_json::Value::Null,
+            "last_error": serde_json::Value::Null,
+            "pid": 5151u32,
+            "account_id": "default",
+            "account_label": "default",
+            "owner_token": "owner-5151"
+        });
+        fs::write(
+            runtime_dir.join("weixin-serve-default-5151.json"),
+            serde_json::to_string_pretty(&first_runtime_state).expect("serialize first runtime"),
+        )
+        .expect("write first runtime");
+        let second_runtime_state = serde_json::json!({
+            "running": true,
+            "busy": false,
+            "active_runs": 0,
+            "consecutive_failures": 0,
+            "last_run_activity_at": now_ms.saturating_sub(200),
+            "last_heartbeat_at": now_ms.saturating_sub(100),
+            "last_failure_at": serde_json::Value::Null,
+            "last_recovery_at": serde_json::Value::Null,
+            "last_error": serde_json::Value::Null,
+            "pid": 6262u32,
+            "account_id": "default",
+            "account_label": "default",
+            "owner_token": "owner-6262"
+        });
+        fs::write(
+            runtime_dir.join("weixin-serve-default-6262.json"),
+            serde_json::to_string_pretty(&second_runtime_state).expect("serialize second runtime"),
+        )
+        .expect("write second runtime");
+
+        let mut config = mvp::config::LoongConfig::default();
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![runtime_root.path().display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        config.weixin.enabled = true;
+        config.weixin.bridge_url = Some("http://127.0.0.1:9/bridge".to_owned());
+        config.weixin.bridge_access_token = Some(loong_contracts::SecretRef::Inline(
+            "bridge-token".to_owned(),
+        ));
+        config.weixin.allowed_contact_ids = vec!["wxid_alice".to_owned()];
+
+        let config_path = config_root.path().join("loong.toml");
+        let encoded_config = toml::to_string(&config).expect("serialize config");
+        fs::write(&config_path, encoded_config).expect("write config");
+        let config_path_string = config_path.to_string_lossy().to_string();
+
+        request_managed_plugin_bridge_serve_duplicate_cleanup(
+            Some(config_path_string.as_str()),
+            "weixin",
+            None,
+        )
+        .await
+        .expect("request managed bridge duplicate cleanup");
+
+        let first_stop_request_path =
+            runtime_dir.join("weixin-serve-default-stop-request-owner-5151.json");
+        assert!(
+            first_stop_request_path.exists(),
+            "older duplicate owner should be targeted"
+        );
+        let second_stop_request_path =
+            runtime_dir.join("weixin-serve-default-stop-request-owner-6262.json");
+        assert!(
+            !second_stop_request_path.exists(),
+            "preferred runtime owner should be kept running"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn managed_bridge_serve_loop_recovers_after_transient_receive_failure() {
+        let adapter_state = ScriptedAdapterState::default();
+        let processed_messages = Arc::new(AtomicUsize::new(0));
+        let processed_messages_for_run = processed_messages.clone();
+        let adapter_state_for_assert = adapter_state.clone();
+        let stop = mvp::channel::ChannelServeStopHandle::new();
+        let spec = mvp::channel::ChannelServeRuntimeSpec {
+            platform: mvp::channel::ChannelPlatform::Weixin,
+            operation_id: mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+            account_id: "managed-bridge-recovery",
+            account_label: "managed-bridge-recovery",
+        };
+
+        mvp::channel::with_channel_serve_runtime_with_stop(
+            spec,
+            stop.clone(),
+            move |runtime, stop| async move {
+                let inbound_message = scripted_inbound_message(
+                    mvp::channel::ChannelPlatform::Weixin,
+                    "default",
+                    "wxid_alice",
+                    "weixin:default:contact:wxid_alice",
+                    "hello bridge",
+                );
+                let mut adapter = ScriptedChannelAdapter::new(
+                    "scripted-bridge",
+                    vec![
+                        ScriptedReceiveStep::Error("temporary receive failure".to_owned()),
+                        ScriptedReceiveStep::Batch(vec![inbound_message]),
+                    ],
+                    adapter_state,
+                );
+                let stop_for_process = stop.clone();
+                run_managed_plugin_bridge_loop(
+                    &stop,
+                    runtime.as_ref(),
+                    &mut adapter,
+                    false,
+                    ManagedBridgeServeContext {
+                        channel_id: "weixin",
+                        plugin_id: "scripted-bridge",
+                        configured_account_id: "managed-bridge-recovery",
+                    },
+                    move |_message, _feedback_policy| {
+                        let processed_messages = processed_messages_for_run.clone();
+                        let stop = stop_for_process.clone();
+                        Box::pin(async move {
+                            processed_messages.fetch_add(1, Ordering::Relaxed);
+                            stop.request_stop();
+                            Ok("pong".to_owned())
+                        })
+                    },
+                )
+                .await
+            },
+        )
+        .await
+        .expect("serve loop should recover after a transient receive failure");
+
+        assert_eq!(processed_messages.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            adapter_state_for_assert
+                .receive_calls
+                .load(Ordering::Relaxed),
+            2
+        );
+        assert_eq!(
+            adapter_state_for_assert.send_calls.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            adapter_state_for_assert.ack_calls.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            adapter_state_for_assert
+                .complete_calls
+                .load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn managed_bridge_serve_loop_stops_after_retry_budget() {
+        let adapter_state = ScriptedAdapterState::default();
+        let adapter_state_for_assert = adapter_state.clone();
+        let stop = mvp::channel::ChannelServeStopHandle::new();
+        let spec = mvp::channel::ChannelServeRuntimeSpec {
+            platform: mvp::channel::ChannelPlatform::Weixin,
+            operation_id: mvp::channel::CHANNEL_OPERATION_SERVE_ID,
+            account_id: "managed-bridge-budget",
+            account_label: "managed-bridge-budget",
+        };
+
+        let error = mvp::channel::with_channel_serve_runtime_with_stop(
+            spec,
+            stop,
+            move |runtime, stop| async move {
+                let mut adapter = ScriptedChannelAdapter::new(
+                    "scripted-bridge",
+                    vec![
+                        ScriptedReceiveStep::Error("failure one".to_owned()),
+                        ScriptedReceiveStep::Error("failure two".to_owned()),
+                        ScriptedReceiveStep::Error("failure three".to_owned()),
+                    ],
+                    adapter_state,
+                );
+                run_managed_plugin_bridge_loop(
+                    &stop,
+                    runtime.as_ref(),
+                    &mut adapter,
+                    false,
+                    ManagedBridgeServeContext {
+                        channel_id: "weixin",
+                        plugin_id: "scripted-bridge",
+                        configured_account_id: "managed-bridge-budget",
+                    },
+                    |_message, _feedback_policy| Box::pin(async { Ok("unused".to_owned()) }),
+                )
+                .await
+            },
+        )
+        .await
+        .expect_err("serve loop should stop after exhausting the retry budget");
+
+        assert!(
+            error.contains("failed after 3 consecutive managed bridge runtime errors"),
+            "unexpected retry-budget error: {error}"
+        );
+        assert_eq!(
+            adapter_state_for_assert
+                .receive_calls
+                .load(Ordering::Relaxed),
+            3
+        );
+        assert_eq!(
+            adapter_state_for_assert.send_calls.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            adapter_state_for_assert.ack_calls.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            adapter_state_for_assert
+                .complete_calls
+                .load(Ordering::Relaxed),
+            0
+        );
     }
 }

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -32,6 +32,14 @@ pub struct SetupNextAction {
     pub command: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedBridgeRuntimeAttentionSurface {
+    id: &'static str,
+    reasons: Vec<&'static str>,
+    preferred_owner_pids: Vec<u32>,
+    cleanup_owner_pids: Vec<u32>,
+}
+
 pub fn collect_setup_next_actions(
     config: &mvp::config::LoongConfig,
     config_path: &str,
@@ -48,6 +56,8 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
     let mut actions = Vec::new();
     let channel_actions =
         crate::migration::channels::collect_channel_next_actions(config, config_path);
+    let runtime_attention_plugin_bridge_surfaces =
+        collect_runtime_attention_plugin_bridge_surfaces(config);
     let unresolved_plugin_bridge_surfaces =
         collect_unresolved_plugin_bridge_surface_ids(config, &channel_actions);
     let blocked_outbound_surfaces = collect_blocked_outbound_surface_ids(config);
@@ -83,6 +93,13 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
                 ),
             });
         }
+    }
+    if !runtime_attention_plugin_bridge_surfaces.is_empty() {
+        let doctor_action = build_managed_bridge_runtime_doctor_action(
+            config_path,
+            &runtime_attention_plugin_bridge_surfaces,
+        );
+        actions.push(doctor_action);
     }
     if !unresolved_plugin_bridge_surfaces.is_empty() {
         let doctor_action =
@@ -159,6 +176,30 @@ fn collect_unresolved_plugin_bridge_surface_ids(
     unresolved_plugin_bridge_surface_ids(config)
 }
 
+fn collect_runtime_attention_plugin_bridge_surfaces(
+    config: &mvp::config::LoongConfig,
+) -> Vec<ManagedBridgeRuntimeAttentionSurface> {
+    let inventory = mvp::channel::channel_inventory(config);
+
+    inventory
+        .channel_surfaces
+        .into_iter()
+        .filter(enabled_plugin_bridge_surface)
+        .filter_map(|surface| {
+            let reasons = plugin_bridge_surface_runtime_attention_reasons(&surface);
+            if reasons.is_empty() {
+                return None;
+            }
+            Some(ManagedBridgeRuntimeAttentionSurface {
+                id: surface.catalog.id,
+                reasons,
+                preferred_owner_pids: collect_surface_preferred_runtime_owner_pids(&surface),
+                cleanup_owner_pids: collect_surface_duplicate_runtime_cleanup_owner_pids(&surface),
+            })
+        })
+        .collect()
+}
+
 fn unresolved_plugin_bridge_surface_ids(config: &mvp::config::LoongConfig) -> Vec<&'static str> {
     let inventory = mvp::channel::channel_inventory(config);
     let channel_checks = crate::migration::channels::collect_channel_preflight_checks(config);
@@ -178,6 +219,99 @@ fn unresolved_plugin_bridge_surface_ids(config: &mvp::config::LoongConfig) -> Ve
         })
         .map(|surface| surface.catalog.id)
         .collect()
+}
+
+fn plugin_bridge_surface_runtime_attention_reasons(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<&'static str> {
+    let mut reasons = BTreeSet::new();
+
+    for snapshot in surface
+        .configured_accounts
+        .iter()
+        .filter(|snapshot| snapshot.enabled)
+    {
+        for reason in channel_snapshot_runtime_attention_reasons(snapshot) {
+            reasons.insert(reason);
+        }
+    }
+
+    reasons.into_iter().collect()
+}
+
+fn channel_snapshot_runtime_attention_reasons(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+) -> Vec<&'static str> {
+    let Some(runtime) = snapshot
+        .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+        .and_then(|operation| operation.runtime.as_ref())
+    else {
+        return Vec::new();
+    };
+
+    let mut reasons = Vec::new();
+    if runtime.consecutive_failures > 0 {
+        reasons.push("retrying");
+    }
+    if runtime.stale {
+        reasons.push("stale");
+    }
+    if runtime.running_instances > 1 {
+        reasons.push("duplicate_runtime_instances");
+    }
+
+    reasons
+}
+
+fn collect_surface_preferred_runtime_owner_pids(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<u32> {
+    let mut owner_pids = BTreeSet::new();
+
+    for snapshot in &surface.configured_accounts {
+        let Some(runtime) = snapshot
+            .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+            .and_then(|operation| operation.runtime.as_ref())
+        else {
+            continue;
+        };
+        if runtime.duplicate_owner_pids.is_empty() {
+            continue;
+        }
+        let Some(pid) = runtime.pid else {
+            continue;
+        };
+        owner_pids.insert(pid);
+    }
+
+    owner_pids.into_iter().collect()
+}
+
+fn collect_surface_duplicate_runtime_cleanup_owner_pids(
+    surface: &mvp::channel::ChannelSurface,
+) -> Vec<u32> {
+    let mut owner_pids = BTreeSet::new();
+
+    for snapshot in &surface.configured_accounts {
+        let Some(runtime) = snapshot
+            .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+            .and_then(|operation| operation.runtime.as_ref())
+        else {
+            continue;
+        };
+        if runtime.duplicate_owner_pids.is_empty() {
+            continue;
+        }
+        let preferred_pid = runtime.pid;
+        for owner_pid in &runtime.duplicate_owner_pids {
+            if Some(*owner_pid) == preferred_pid {
+                continue;
+            }
+            owner_pids.insert(*owner_pid);
+        }
+    }
+
+    owner_pids.into_iter().collect()
 }
 
 fn collect_blocked_outbound_surface_ids(config: &mvp::config::LoongConfig) -> Vec<&'static str> {
@@ -248,6 +382,22 @@ fn build_managed_bridge_doctor_action(
     }
 }
 
+fn build_managed_bridge_runtime_doctor_action(
+    config_path: &str,
+    runtime_attention_surfaces: &[ManagedBridgeRuntimeAttentionSurface],
+) -> SetupNextAction {
+    let command = crate::cli_handoff::format_subcommand_with_config("doctor", config_path);
+    let label = managed_bridge_runtime_doctor_action_label(runtime_attention_surfaces);
+
+    SetupNextAction {
+        kind: SetupNextActionKind::Doctor,
+        channel_action_id: None,
+        browser_preview_phase: None,
+        label,
+        command,
+    }
+}
+
 fn build_outbound_channel_doctor_action(
     config_path: &str,
     blocked_surface_ids: &[&'static str],
@@ -302,10 +452,65 @@ fn outbound_channel_doctor_action_label(blocked_surface_ids: &[&'static str]) ->
     "verify configured outbound channels".to_owned()
 }
 
+fn managed_bridge_runtime_doctor_action_label(
+    runtime_attention_surfaces: &[ManagedBridgeRuntimeAttentionSurface],
+) -> String {
+    if runtime_attention_surfaces.len() == 1 {
+        let surface = runtime_attention_surfaces.first().expect("one surface");
+        let rendered_reasons = if surface.reasons.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", surface.reasons.join(","))
+        };
+        let keep_suffix = if surface.reasons.contains(&"duplicate_runtime_instances") {
+            let keep = if surface.preferred_owner_pids.len() == 1 {
+                let pid = surface
+                    .preferred_owner_pids
+                    .first()
+                    .copied()
+                    .unwrap_or_default();
+                format!(" keep pid={pid}")
+            } else {
+                String::new()
+            };
+            let cleanup = if surface.cleanup_owner_pids.is_empty() {
+                String::new()
+            } else {
+                let rendered_cleanup = surface
+                    .cleanup_owner_pids
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(" cleanup pids={rendered_cleanup}")
+            };
+            format!("{keep}{cleanup}")
+        } else {
+            String::new()
+        };
+        return format!(
+            "inspect {} managed bridge runtime{}{}",
+            surface.id, rendered_reasons, keep_suffix
+        );
+    }
+
+    if runtime_attention_surfaces.is_empty() {
+        return "inspect managed bridge runtimes".to_owned();
+    }
+
+    let rendered_surface_ids = runtime_attention_surfaces
+        .iter()
+        .map(|surface| surface.id)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("inspect managed bridge runtimes: {rendered_surface_ids}")
+}
+
 pub(crate) fn is_managed_bridge_doctor_action(action: &SetupNextAction) -> bool {
     let is_doctor = action.kind == SetupNextActionKind::Doctor;
     let label = action.label.as_str();
-    let is_managed_bridge_label = label.starts_with("verify ") && label.contains("managed bridge");
+    let is_managed_bridge_label = (label.starts_with("verify ") || label.starts_with("inspect "))
+        && label.contains("managed bridge");
 
     is_doctor && is_managed_bridge_label
 }
@@ -397,11 +602,109 @@ fn should_suggest_personalization(config: &mvp::config::LoongConfig) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::{
         fs,
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    fn write_runtime_attention_fixture(
+        channel_id: &str,
+        account_id: &str,
+        process_id: u32,
+        consecutive_failures: usize,
+    ) {
+        let runtime_dir = mvp::config::default_loong_home().join("channel-runtime");
+        fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+        let runtime_path =
+            runtime_dir.join(format!("{channel_id}-serve-{account_id}-{process_id}.json"));
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_millis() as u64;
+        let payload = serde_json::json!({
+            "running": true,
+            "busy": false,
+            "active_runs": 0,
+            "consecutive_failures": consecutive_failures,
+            "last_run_activity_at": now_ms.saturating_sub(500),
+            "last_heartbeat_at": now_ms.saturating_sub(100),
+            "last_failure_at": now_ms,
+            "last_recovery_at": serde_json::Value::Null,
+            "last_error": "temporary bridge timeout",
+            "pid": process_id,
+            "account_id": account_id,
+            "account_label": account_id,
+            "owner_token": serde_json::Value::Null
+        });
+        let encoded = serde_json::to_string_pretty(&payload).expect("encode runtime state");
+        fs::write(runtime_path, encoded).expect("write runtime attention state");
+    }
+
+    fn write_managed_bridge_runtime_manifest(root: &Path, channel_id: &str) {
+        let runtime_operations_json = serde_json::to_string(&vec![
+            mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_SEND_MESSAGE_OPERATION,
+            mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_RECEIVE_BATCH_OPERATION,
+            mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_ACK_INBOUND_OPERATION,
+            mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_COMPLETE_BATCH_OPERATION,
+        ])
+        .expect("serialize runtime operations");
+        let metadata = BTreeMap::from([
+            ("bridge_kind".to_owned(), "http_json".to_owned()),
+            ("adapter_family".to_owned(), "channel-bridge".to_owned()),
+            (
+                "transport_family".to_owned(),
+                "wechat_clawbot_ilink_bridge".to_owned(),
+            ),
+            ("target_contract".to_owned(), "weixin_reply_loop".to_owned()),
+            (
+                "channel_runtime_contract".to_owned(),
+                mvp::channel::CHANNEL_PLUGIN_BRIDGE_RUNTIME_CONTRACT_V1.to_owned(),
+            ),
+            (
+                "channel_runtime_operations_json".to_owned(),
+                runtime_operations_json,
+            ),
+        ]);
+        let plugin_id = format!("{channel_id}-managed-runtime");
+        let manifest = crate::kernel::PluginManifest {
+            api_version: Some("v1alpha1".to_owned()),
+            version: Some("1.0.0".to_owned()),
+            plugin_id: plugin_id.clone(),
+            provider_id: format!("{channel_id}-managed-runtime-provider"),
+            connector_name: format!("{channel_id}-managed-runtime-connector"),
+            channel_id: Some(channel_id.to_owned()),
+            endpoint: Some("http://127.0.0.1:9999/invoke".to_owned()),
+            capabilities: BTreeSet::new(),
+            trust_tier: crate::kernel::PluginTrustTier::Unverified,
+            metadata,
+            summary: None,
+            tags: Vec::new(),
+            input_examples: Vec::new(),
+            output_examples: Vec::new(),
+            defer_loading: false,
+            setup: Some(crate::kernel::PluginSetup {
+                mode: crate::kernel::PluginSetupMode::MetadataOnly,
+                surface: Some("channel".to_owned()),
+                required_env_vars: Vec::new(),
+                recommended_env_vars: Vec::new(),
+                required_config_keys: Vec::new(),
+                default_env_var: None,
+                docs_urls: Vec::new(),
+                remediation: None,
+            }),
+            slot_claims: Vec::new(),
+            compatibility: None,
+        };
+        let plugin_directory = root.join(plugin_id);
+        let manifest_path = plugin_directory.join("loong.plugin.json");
+        let encoded_manifest =
+            serde_json::to_string_pretty(&manifest).expect("serialize runtime manifest");
+
+        fs::create_dir_all(&plugin_directory).expect("create runtime plugin directory");
+        fs::write(&manifest_path, encoded_manifest).expect("write runtime plugin manifest");
+    }
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -733,6 +1036,46 @@ mod tests {
     }
 
     #[test]
+    fn collect_setup_next_actions_labels_single_runtime_attention_plugin_bridge_surface() {
+        let home = unique_temp_dir("loong-next-actions-runtime-attention");
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("LOONG_HOME", home.as_os_str());
+        write_runtime_attention_fixture("weixin", "default", 5151, 2);
+        let plugin_root = unique_temp_dir("loong-next-actions-runtime-plugin-root");
+        write_managed_bridge_runtime_manifest(plugin_root.as_path(), "weixin");
+
+        let mut config = mvp::config::LoongConfig::default();
+        config.runtime_plugins.enabled = true;
+        config.runtime_plugins.roots = vec![plugin_root.display().to_string()];
+        config.runtime_plugins.supported_bridges = vec!["http_json".to_owned()];
+        config.weixin.enabled = true;
+        config.weixin.bridge_url = Some("https://bridge.example.test/weixin".to_owned());
+        config.weixin.bridge_access_token = Some(loong_contracts::SecretRef::Inline(
+            "weixin-token".to_owned(),
+        ));
+        config.weixin.allowed_contact_ids = vec!["wxid_alice".to_owned()];
+
+        let actions = collect_setup_next_actions_with_path_env(
+            &config,
+            "/tmp/loong.toml",
+            Some(std::ffi::OsStr::new("")),
+        );
+        let doctor_action = actions
+            .iter()
+            .find(|action| action.kind == SetupNextActionKind::Doctor)
+            .expect("managed bridge runtime doctor action");
+
+        assert_eq!(
+            doctor_action.label,
+            "inspect weixin managed bridge runtime (retrying)"
+        );
+        assert_eq!(
+            doctor_action.command,
+            "loong doctor --config '/tmp/loong.toml'"
+        );
+    }
+
+    #[test]
     fn collect_setup_next_actions_labels_multiple_unresolved_plugin_bridge_surfaces() {
         let mut config = mvp::config::LoongConfig::default();
         config.weixin.enabled = true;
@@ -852,6 +1195,19 @@ mod tests {
             channel_action_id: None,
             browser_preview_phase: None,
             label: "verify managed bridges: weixin, qqbot".to_owned(),
+            command: "loong doctor --config '/tmp/loong.toml'".to_owned(),
+        };
+
+        assert!(is_managed_bridge_doctor_action(&action));
+    }
+
+    #[test]
+    fn is_managed_bridge_doctor_action_matches_runtime_attention_label() {
+        let action = SetupNextAction {
+            kind: SetupNextActionKind::Doctor,
+            channel_action_id: None,
+            browser_preview_phase: None,
+            label: "inspect weixin managed bridge runtime (retrying)".to_owned(),
             command: "loong doctor --config '/tmp/loong.toml'".to_owned(),
         };
 

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -1249,6 +1249,8 @@ mod tests {
                 enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
                 enabled_outbound_only_channel_ids: Vec::new(),
                 visible_tool_count: 4,
+                visible_direct_tool_names: vec!["read".to_owned(), "exec".to_owned()],
+                hidden_tool_surface_ids: vec!["agent".to_owned(), "web".to_owned()],
                 capability_snapshot_sha256: "abc123".to_owned(),
                 active_provider_profile_id: Some("demo".to_owned()),
                 active_provider_label: Some("Demo".to_owned()),
@@ -1260,6 +1262,13 @@ mod tests {
                     reason:
                         "provider turns include structured tool definitions for the active model"
                             .to_owned(),
+                },
+                web_access: crate::gateway::read_models::GatewayWebAccessReadModel {
+                    ordinary_network_access_enabled: true,
+                    query_search_enabled: false,
+                    query_search_default_provider: "duckduckgo".to_owned(),
+                    query_search_credential_ready: true,
+                    separation_note: crate::RUNTIME_WEB_ACCESS_SEPARATION_NOTE.to_owned(),
                 },
             },
         };
@@ -1377,6 +1386,8 @@ mod tests {
                 enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
                 enabled_outbound_only_channel_ids: Vec::new(),
                 visible_tool_count: 4,
+                visible_direct_tool_names: vec!["read".to_owned(), "exec".to_owned()],
+                hidden_tool_surface_ids: vec!["agent".to_owned(), "web".to_owned()],
                 capability_snapshot_sha256: "abc123".to_owned(),
                 active_provider_profile_id: Some("demo".to_owned()),
                 active_provider_label: Some("Demo".to_owned()),
@@ -1388,6 +1399,13 @@ mod tests {
                     reason:
                         "provider turns include structured tool definitions for the active model"
                             .to_owned(),
+                },
+                web_access: crate::gateway::read_models::GatewayWebAccessReadModel {
+                    ordinary_network_access_enabled: true,
+                    query_search_enabled: false,
+                    query_search_default_provider: "duckduckgo".to_owned(),
+                    query_search_credential_ready: true,
+                    separation_note: crate::RUNTIME_WEB_ACCESS_SEPARATION_NOTE.to_owned(),
                 },
             },
         };
@@ -1493,6 +1511,8 @@ mod tests {
                 enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
                 enabled_outbound_only_channel_ids: Vec::new(),
                 visible_tool_count: 4,
+                visible_direct_tool_names: vec!["read".to_owned(), "exec".to_owned()],
+                hidden_tool_surface_ids: vec!["agent".to_owned(), "web".to_owned()],
                 capability_snapshot_sha256: "abc123".to_owned(),
                 active_provider_profile_id: Some("demo".to_owned()),
                 active_provider_label: Some("Demo".to_owned()),
@@ -1504,6 +1524,13 @@ mod tests {
                     reason:
                         "provider turns include structured tool definitions for the active model"
                             .to_owned(),
+                },
+                web_access: crate::gateway::read_models::GatewayWebAccessReadModel {
+                    ordinary_network_access_enabled: true,
+                    query_search_enabled: false,
+                    query_search_default_provider: "duckduckgo".to_owned(),
+                    query_search_credential_ready: true,
+                    separation_note: crate::RUNTIME_WEB_ACCESS_SEPARATION_NOTE.to_owned(),
                 },
             },
         };

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -4,9 +4,9 @@ use serde::Serialize;
 use std::path::Path;
 
 use crate::gateway::read_models::{
-    GatewayAcpObservabilityReadModel, GatewayOperatorSummaryReadModel,
-    build_acp_observability_read_model, build_operator_summary_read_model,
-    build_runtime_snapshot_read_model,
+    GatewayAcpObservabilityReadModel, GatewayOperatorChannelsSummaryReadModel,
+    GatewayOperatorSummaryReadModel, build_acp_observability_read_model,
+    build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use crate::gateway::service::default_gateway_owner_status;
 use crate::gateway::state::{default_gateway_runtime_state_dir, load_gateway_owner_status};
@@ -105,13 +105,15 @@ pub async fn collect_status_cli_read_model(
         build_operator_summary_read_model(&owner_status, &channel_inventory, &runtime_snapshot);
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
-    let next_actions = crate::next_actions::collect_setup_next_actions(&config, config_path_text)
-        .into_iter()
-        .map(|action| StatusCliAction {
-            label: action.label,
-            command: action.command,
-        })
-        .collect();
+    let mut next_actions = collect_status_runtime_attention_actions(config_path_text, &gateway);
+    next_actions.extend(
+        crate::next_actions::collect_setup_next_actions(&config, config_path_text)
+            .into_iter()
+            .map(|action| StatusCliAction {
+                label: action.label,
+                command: action.command,
+            }),
+    );
     let recipes = build_status_cli_recipes(config_path_text);
     let schema = StatusCliJsonSchema {
         version: STATUS_CLI_JSON_SCHEMA_VERSION,
@@ -568,6 +570,38 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
                 value: channels.ready_service_channel_count.to_string(),
             },
             loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "runtime attention surfaces".to_owned(),
+                value: channels.runtime_attention_surface_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "retrying runtime surfaces".to_owned(),
+                value: channels.retrying_runtime_surface_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "stale runtime surfaces".to_owned(),
+                value: channels.stale_runtime_surface_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "duplicate runtime surfaces".to_owned(),
+                value: channels.duplicate_runtime_surface_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "runtime attention ids".to_owned(),
+                value: render_status_channel_ids(&channels.runtime_attention_surface_ids),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "retrying runtime ids".to_owned(),
+                value: render_status_channel_ids(&channels.retrying_runtime_surface_ids),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "stale runtime ids".to_owned(),
+                value: render_status_channel_ids(&channels.stale_runtime_surface_ids),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "duplicate runtime ids".to_owned(),
+                value: render_status_channel_ids(&channels.duplicate_runtime_surface_ids),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
                 key: "enabled channels".to_owned(),
                 value: render_status_channel_ids(&runtime.enabled_channel_ids),
             },
@@ -617,6 +651,13 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
             },
         ],
     });
+    let runtime_attention_items = collect_status_runtime_attention_items(channels);
+    if !runtime_attention_items.is_empty() {
+        sections.push(loong_app::tui_surface::TuiSectionSpec::Checklist {
+            title: Some("channel runtime attention".to_owned()),
+            items: runtime_attention_items,
+        });
+    }
 
     if !status.recipes.is_empty() {
         sections.push(loong_app::tui_surface::TuiSectionSpec::ActionGroup {
@@ -654,6 +695,167 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
         false,
     )
     .join("\n")
+}
+
+fn collect_status_runtime_attention_actions(
+    config_path: &str,
+    gateway: &GatewayOperatorSummaryReadModel,
+) -> Vec<StatusCliAction> {
+    let attention_surfaces = gateway
+        .channels
+        .surfaces
+        .iter()
+        .filter(|surface| surface.implementation_status == "plugin_backed")
+        .filter(|surface| surface.runtime_attention_account_count > 0)
+        .collect::<Vec<_>>();
+
+    if attention_surfaces.is_empty() {
+        return Vec::new();
+    }
+
+    let command = crate::cli_handoff::format_subcommand_with_config("doctor", config_path);
+    let label = if attention_surfaces.len() == 1 {
+        let surface = attention_surfaces
+            .first()
+            .expect("one runtime attention surface should exist");
+        status_runtime_attention_action_label(surface)
+    } else {
+        format!(
+            "inspect managed bridge runtimes: {}",
+            attention_surfaces
+                .iter()
+                .map(|surface| format!(
+                    "{}({})",
+                    surface.channel_id,
+                    if surface.runtime_attention_reasons.is_empty() {
+                        "attention".to_owned()
+                    } else {
+                        surface.runtime_attention_reasons.join(",")
+                    }
+                ))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+
+    vec![StatusCliAction { label, command }]
+}
+
+fn status_runtime_attention_action_label(
+    surface: &crate::gateway::read_models::GatewayOperatorChannelSurfaceReadModel,
+) -> String {
+    match surface.runtime_attention_reasons.as_slice() {
+        [reason] if reason == "retrying" => {
+            format!(
+                "inspect {} managed bridge runtime (retrying)",
+                surface.channel_id
+            )
+        }
+        [reason] if reason == "stale" => {
+            format!(
+                "recover stale {} managed bridge runtime",
+                surface.channel_id
+            )
+        }
+        [reason] if reason == "duplicate_runtime_instances" => format!(
+            "clean up duplicate {} managed bridge runtimes{}",
+            surface.channel_id,
+            render_status_runtime_keep_pid_suffix(surface)
+        ),
+        _ => {
+            let reasons = if surface.runtime_attention_reasons.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", surface.runtime_attention_reasons.join(","))
+            };
+            format!(
+                "inspect {} managed bridge runtime{}",
+                surface.channel_id, reasons
+            )
+        }
+    }
+}
+
+fn collect_status_runtime_attention_items(
+    channels: &GatewayOperatorChannelsSummaryReadModel,
+) -> Vec<loong_app::tui_surface::TuiChecklistItemSpec> {
+    channels
+        .surfaces
+        .iter()
+        .filter(|surface| surface.runtime_attention_account_count > 0)
+        .map(|surface| loong_app::tui_surface::TuiChecklistItemSpec {
+            status: loong_app::tui_surface::TuiChecklistStatus::Warn,
+            label: surface.label.clone(),
+            detail: format!(
+                "channel_id={} reasons={} remediations={} retrying={} stale={} duplicate_instances={} affected_accounts={} keep_pids={} cleanup_pids={} last_auto_reclaim_at={} auto_cleanup_pids={} incidents={}",
+                surface.channel_id,
+                if surface.runtime_attention_reasons.is_empty() {
+                    "-".to_owned()
+                } else {
+                    surface.runtime_attention_reasons.join(",")
+                },
+                if surface.runtime_attention_remediations.is_empty() {
+                    "-".to_owned()
+                } else {
+                    surface.runtime_attention_remediations.join(",")
+                },
+                surface.retrying_runtime_account_count,
+                surface.stale_runtime_account_count,
+                surface.duplicate_runtime_account_count,
+                surface.runtime_attention_account_count,
+                render_status_runtime_owner_pids(&surface.preferred_runtime_owner_pids),
+                render_status_runtime_owner_pids(&surface.duplicate_runtime_cleanup_owner_pids),
+                render_status_optional_timestamp(surface.last_duplicate_runtime_auto_reclaim_at),
+                render_status_runtime_owner_pids(
+                    &surface.last_duplicate_runtime_auto_cleanup_owner_pids,
+                ),
+                render_status_runtime_incident_summary(&surface.recent_runtime_incidents),
+            ),
+        })
+        .collect()
+}
+
+fn render_status_runtime_keep_pid_suffix(
+    surface: &crate::gateway::read_models::GatewayOperatorChannelSurfaceReadModel,
+) -> String {
+    if surface.preferred_runtime_owner_pids.len() == 1 {
+        let pid = surface
+            .preferred_runtime_owner_pids
+            .first()
+            .copied()
+            .unwrap_or_default();
+        return format!(" (keep pid {pid})");
+    }
+
+    String::new()
+}
+
+fn render_status_runtime_owner_pids(owner_pids: &[u32]) -> String {
+    if owner_pids.is_empty() {
+        return "-".to_owned();
+    }
+
+    owner_pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn render_status_optional_timestamp(timestamp_ms: Option<u64>) -> String {
+    timestamp_ms
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned())
+}
+
+fn render_status_runtime_incident_summary(
+    incidents: &[crate::gateway::read_models::GatewayOperatorRuntimeIncidentReadModel],
+) -> String {
+    let Some(incident) = incidents.first() else {
+        return "-".to_owned();
+    };
+
+    format!("{}@{}", incident.kind, incident.at_ms)
 }
 
 fn render_status_channel_ids(channel_ids: &[String]) -> String {
@@ -838,6 +1040,14 @@ mod tests {
                 enabled_outbound_only_channel_count: 0,
                 enabled_service_channel_count: 1,
                 ready_service_channel_count: 1,
+                runtime_attention_surface_count: 0,
+                retrying_runtime_surface_count: 0,
+                stale_runtime_surface_count: 0,
+                duplicate_runtime_surface_count: 0,
+                runtime_attention_surface_ids: Vec::new(),
+                retrying_runtime_surface_ids: Vec::new(),
+                stale_runtime_surface_ids: Vec::new(),
+                duplicate_runtime_surface_ids: Vec::new(),
                 surfaces: Vec::new(),
             },
             runtime: GatewayOperatorRuntimeSummaryReadModel {
@@ -922,6 +1132,11 @@ mod tests {
         assert!(rendered.contains("[OK] tool calling"));
         assert!(rendered.contains("[OK] ordinary network"));
         assert!(rendered.contains("[OK] query search"));
+        assert!(rendered.contains("configured channels"));
+        assert!(rendered.contains("enabled channels"));
+        assert!(rendered.contains("service enabled ids"));
+        assert!(rendered.contains("runtime attention surfaces"));
+        assert!(rendered.contains("runtime attention ids"));
         assert!(rendered.contains("saved runtime"));
         assert!(rendered.contains("gateway summary"));
         assert!(rendered.contains("visible tools: 4"));
@@ -941,6 +1156,410 @@ mod tests {
         assert!(rendered.contains("ACP: acp enabled=false availability=disabled"));
         assert!(rendered.contains("deep dives"));
         assert!(rendered.contains("- recipe: loong gateway status"));
+    }
+
+    #[test]
+    fn collect_status_runtime_attention_actions_prefers_managed_bridge_runtime_diagnostics() {
+        let gateway = GatewayOperatorSummaryReadModel {
+            owner: GatewayOwnerStatus {
+                runtime_dir: "/tmp/runtime".to_owned(),
+                phase: "running".to_owned(),
+                running: true,
+                stale: false,
+                pid: Some(42),
+                mode: GatewayOwnerMode::GatewayHeadless,
+                version: "0.0.0-test".to_owned(),
+                config_path: "/tmp/config.toml".to_owned(),
+                attached_cli_session: None,
+                started_at_ms: 1,
+                last_heartbeat_at: 2,
+                stopped_at_ms: None,
+                shutdown_reason: None,
+                last_error: None,
+                configured_surface_count: 1,
+                running_surface_count: 1,
+                bind_address: Some("127.0.0.1".to_owned()),
+                port: Some(7777),
+                token_path: Some("/tmp/token".to_owned()),
+            },
+            control_surface: GatewayOperatorControlSurfaceReadModel {
+                base_url: Some("http://127.0.0.1:7777".to_owned()),
+                loopback_only: true,
+            },
+            channels: GatewayOperatorChannelsSummaryReadModel {
+                catalog_channel_count: 3,
+                configured_channel_count: 1,
+                configured_account_count: 1,
+                enabled_account_count: 1,
+                misconfigured_account_count: 0,
+                runtime_backed_channel_count: 0,
+                config_backed_channel_count: 0,
+                plugin_backed_channel_count: 3,
+                catalog_only_channel_count: 0,
+                enabled_runtime_backed_channel_count: 0,
+                enabled_plugin_backed_channel_count: 1,
+                enabled_outbound_only_channel_count: 0,
+                enabled_service_channel_count: 1,
+                ready_service_channel_count: 1,
+                runtime_attention_surface_count: 1,
+                retrying_runtime_surface_count: 1,
+                stale_runtime_surface_count: 0,
+                duplicate_runtime_surface_count: 0,
+                runtime_attention_surface_ids: vec!["weixin".to_owned()],
+                retrying_runtime_surface_ids: vec!["weixin".to_owned()],
+                stale_runtime_surface_ids: Vec::new(),
+                duplicate_runtime_surface_ids: Vec::new(),
+                surfaces: vec![
+                    crate::gateway::read_models::GatewayOperatorChannelSurfaceReadModel {
+                        channel_id: "weixin".to_owned(),
+                        label: "Weixin".to_owned(),
+                        implementation_status: "plugin_backed".to_owned(),
+                        configured_account_count: 1,
+                        enabled_account_count: 1,
+                        misconfigured_account_count: 0,
+                        ready_send_account_count: 1,
+                        ready_serve_account_count: 1,
+                        conversation_gated_account_count: 0,
+                        sender_gated_account_count: 0,
+                        mention_gated_account_count: 0,
+                        default_configured_account_id: Some("default".to_owned()),
+                        plugin_bridge_account_summary: None,
+                        runtime_attention_account_count: 1,
+                        runtime_attention_reasons: vec!["retrying".to_owned()],
+                        runtime_attention_remediations: vec![
+                            "inspect_bridge_connectivity".to_owned(),
+                        ],
+                        retrying_runtime_account_count: 1,
+                        stale_runtime_account_count: 0,
+                        duplicate_runtime_account_count: 0,
+                        preferred_runtime_owner_pids: Vec::new(),
+                        duplicate_runtime_cleanup_owner_pids: Vec::new(),
+                        last_duplicate_runtime_auto_reclaim_at: None,
+                        last_duplicate_runtime_auto_cleanup_owner_pids: Vec::new(),
+                        recent_runtime_incidents: Vec::new(),
+                        service_enabled: true,
+                        service_ready: false,
+                    },
+                ],
+            },
+            runtime: GatewayOperatorRuntimeSummaryReadModel {
+                enabled_channel_ids: vec!["weixin".to_owned()],
+                enabled_runtime_backed_channel_ids: Vec::new(),
+                enabled_service_channel_ids: vec!["weixin".to_owned()],
+                enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
+                enabled_outbound_only_channel_ids: Vec::new(),
+                visible_tool_count: 4,
+                capability_snapshot_sha256: "abc123".to_owned(),
+                active_provider_profile_id: Some("demo".to_owned()),
+                active_provider_label: Some("Demo".to_owned()),
+                tool_calling: crate::gateway::read_models::GatewayToolCallingReadModel {
+                    availability: "ready".to_owned(),
+                    structured_tool_schema_enabled: true,
+                    effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                    active_model: "gpt-4.1-mini".to_owned(),
+                    reason:
+                        "provider turns include structured tool definitions for the active model"
+                            .to_owned(),
+                },
+            },
+        };
+
+        let actions = collect_status_runtime_attention_actions("/tmp/config.toml", &gateway);
+        let action = actions.first().expect("runtime attention action");
+
+        assert_eq!(
+            action.label,
+            "inspect weixin managed bridge runtime (retrying)"
+        );
+        assert_eq!(action.command, "loong doctor --config '/tmp/config.toml'");
+    }
+
+    #[test]
+    fn collect_status_runtime_attention_actions_include_duplicate_runtime_winner() {
+        let gateway = GatewayOperatorSummaryReadModel {
+            owner: GatewayOwnerStatus {
+                runtime_dir: "/tmp/runtime".to_owned(),
+                phase: "running".to_owned(),
+                running: true,
+                stale: false,
+                pid: Some(42),
+                mode: GatewayOwnerMode::GatewayHeadless,
+                version: "0.0.0-test".to_owned(),
+                config_path: "/tmp/config.toml".to_owned(),
+                attached_cli_session: None,
+                started_at_ms: 1,
+                last_heartbeat_at: 2,
+                stopped_at_ms: None,
+                shutdown_reason: None,
+                last_error: None,
+                configured_surface_count: 1,
+                running_surface_count: 1,
+                bind_address: Some("127.0.0.1".to_owned()),
+                port: Some(7777),
+                token_path: Some("/tmp/token".to_owned()),
+            },
+            control_surface: GatewayOperatorControlSurfaceReadModel {
+                base_url: Some("http://127.0.0.1:7777".to_owned()),
+                loopback_only: true,
+            },
+            channels: GatewayOperatorChannelsSummaryReadModel {
+                catalog_channel_count: 3,
+                configured_channel_count: 1,
+                configured_account_count: 1,
+                enabled_account_count: 1,
+                misconfigured_account_count: 0,
+                runtime_backed_channel_count: 0,
+                config_backed_channel_count: 0,
+                plugin_backed_channel_count: 3,
+                catalog_only_channel_count: 0,
+                enabled_runtime_backed_channel_count: 0,
+                enabled_plugin_backed_channel_count: 1,
+                enabled_outbound_only_channel_count: 0,
+                enabled_service_channel_count: 1,
+                ready_service_channel_count: 0,
+                runtime_attention_surface_count: 1,
+                retrying_runtime_surface_count: 0,
+                stale_runtime_surface_count: 0,
+                duplicate_runtime_surface_count: 1,
+                runtime_attention_surface_ids: vec!["weixin".to_owned()],
+                retrying_runtime_surface_ids: Vec::new(),
+                stale_runtime_surface_ids: Vec::new(),
+                duplicate_runtime_surface_ids: vec!["weixin".to_owned()],
+                surfaces: vec![
+                    crate::gateway::read_models::GatewayOperatorChannelSurfaceReadModel {
+                        channel_id: "weixin".to_owned(),
+                        label: "Weixin".to_owned(),
+                        implementation_status: "plugin_backed".to_owned(),
+                        configured_account_count: 1,
+                        enabled_account_count: 1,
+                        misconfigured_account_count: 0,
+                        ready_send_account_count: 1,
+                        ready_serve_account_count: 1,
+                        conversation_gated_account_count: 0,
+                        sender_gated_account_count: 0,
+                        mention_gated_account_count: 0,
+                        default_configured_account_id: Some("default".to_owned()),
+                        plugin_bridge_account_summary: None,
+                        runtime_attention_account_count: 1,
+                        runtime_attention_reasons: vec!["duplicate_runtime_instances".to_owned()],
+                        runtime_attention_remediations: vec![
+                            "stop_duplicate_runtime_instances".to_owned(),
+                        ],
+                        retrying_runtime_account_count: 0,
+                        stale_runtime_account_count: 0,
+                        duplicate_runtime_account_count: 1,
+                        preferred_runtime_owner_pids: vec![6262],
+                        duplicate_runtime_cleanup_owner_pids: vec![5151],
+                        last_duplicate_runtime_auto_reclaim_at: Some(1_700_000_007_000),
+                        last_duplicate_runtime_auto_cleanup_owner_pids: vec![5151],
+                        recent_runtime_incidents: vec![
+                            crate::gateway::read_models::GatewayOperatorRuntimeIncidentReadModel {
+                                account_id: Some("default".to_owned()),
+                                account_label: Some("default".to_owned()),
+                                kind: "duplicate_reclaim".to_owned(),
+                                at_ms: 1_700_000_007_000,
+                                detail: Some(
+                                    "requested cooperative shutdown for duplicate runtime owners"
+                                        .to_owned(),
+                                ),
+                                owner_pids: vec![5151],
+                            },
+                        ],
+                        service_enabled: true,
+                        service_ready: false,
+                    },
+                ],
+            },
+            runtime: GatewayOperatorRuntimeSummaryReadModel {
+                enabled_channel_ids: vec!["weixin".to_owned()],
+                enabled_runtime_backed_channel_ids: Vec::new(),
+                enabled_service_channel_ids: vec!["weixin".to_owned()],
+                enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
+                enabled_outbound_only_channel_ids: Vec::new(),
+                visible_tool_count: 4,
+                capability_snapshot_sha256: "abc123".to_owned(),
+                active_provider_profile_id: Some("demo".to_owned()),
+                active_provider_label: Some("Demo".to_owned()),
+                tool_calling: crate::gateway::read_models::GatewayToolCallingReadModel {
+                    availability: "ready".to_owned(),
+                    structured_tool_schema_enabled: true,
+                    effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                    active_model: "gpt-4.1-mini".to_owned(),
+                    reason:
+                        "provider turns include structured tool definitions for the active model"
+                            .to_owned(),
+                },
+            },
+        };
+
+        let actions = collect_status_runtime_attention_actions("/tmp/config.toml", &gateway);
+        let action = actions.first().expect("runtime attention action");
+
+        assert_eq!(
+            action.label,
+            "clean up duplicate weixin managed bridge runtimes (keep pid 6262)"
+        );
+        assert_eq!(action.command, "loong doctor --config '/tmp/config.toml'");
+    }
+
+    #[test]
+    fn render_status_cli_text_lists_channel_runtime_attention_section() {
+        let gateway = GatewayOperatorSummaryReadModel {
+            owner: GatewayOwnerStatus {
+                runtime_dir: "/tmp/runtime".to_owned(),
+                phase: "running".to_owned(),
+                running: true,
+                stale: false,
+                pid: Some(42),
+                mode: GatewayOwnerMode::GatewayHeadless,
+                version: "0.0.0-test".to_owned(),
+                config_path: "/tmp/config.toml".to_owned(),
+                attached_cli_session: None,
+                started_at_ms: 1,
+                last_heartbeat_at: 2,
+                stopped_at_ms: None,
+                shutdown_reason: None,
+                last_error: None,
+                configured_surface_count: 1,
+                running_surface_count: 1,
+                bind_address: Some("127.0.0.1".to_owned()),
+                port: Some(7777),
+                token_path: Some("/tmp/token".to_owned()),
+            },
+            control_surface: GatewayOperatorControlSurfaceReadModel {
+                base_url: Some("http://127.0.0.1:7777".to_owned()),
+                loopback_only: true,
+            },
+            channels: GatewayOperatorChannelsSummaryReadModel {
+                catalog_channel_count: 3,
+                configured_channel_count: 1,
+                configured_account_count: 1,
+                enabled_account_count: 1,
+                misconfigured_account_count: 0,
+                runtime_backed_channel_count: 0,
+                config_backed_channel_count: 0,
+                plugin_backed_channel_count: 3,
+                catalog_only_channel_count: 0,
+                enabled_runtime_backed_channel_count: 0,
+                enabled_plugin_backed_channel_count: 1,
+                enabled_outbound_only_channel_count: 0,
+                enabled_service_channel_count: 1,
+                ready_service_channel_count: 0,
+                runtime_attention_surface_count: 1,
+                retrying_runtime_surface_count: 1,
+                stale_runtime_surface_count: 0,
+                duplicate_runtime_surface_count: 0,
+                runtime_attention_surface_ids: vec!["weixin".to_owned()],
+                retrying_runtime_surface_ids: vec!["weixin".to_owned()],
+                stale_runtime_surface_ids: Vec::new(),
+                duplicate_runtime_surface_ids: Vec::new(),
+                surfaces: vec![
+                    crate::gateway::read_models::GatewayOperatorChannelSurfaceReadModel {
+                        channel_id: "weixin".to_owned(),
+                        label: "Weixin".to_owned(),
+                        implementation_status: "plugin_backed".to_owned(),
+                        configured_account_count: 1,
+                        enabled_account_count: 1,
+                        misconfigured_account_count: 0,
+                        ready_send_account_count: 1,
+                        ready_serve_account_count: 1,
+                        conversation_gated_account_count: 0,
+                        sender_gated_account_count: 0,
+                        mention_gated_account_count: 0,
+                        default_configured_account_id: Some("default".to_owned()),
+                        plugin_bridge_account_summary: None,
+                        runtime_attention_account_count: 1,
+                        runtime_attention_reasons: vec!["retrying".to_owned()],
+                        runtime_attention_remediations: vec![
+                            "inspect_bridge_connectivity".to_owned(),
+                        ],
+                        retrying_runtime_account_count: 1,
+                        stale_runtime_account_count: 0,
+                        duplicate_runtime_account_count: 0,
+                        preferred_runtime_owner_pids: Vec::new(),
+                        duplicate_runtime_cleanup_owner_pids: Vec::new(),
+                        last_duplicate_runtime_auto_reclaim_at: None,
+                        last_duplicate_runtime_auto_cleanup_owner_pids: Vec::new(),
+                        recent_runtime_incidents: Vec::new(),
+                        service_enabled: true,
+                        service_ready: false,
+                    },
+                ],
+            },
+            runtime: GatewayOperatorRuntimeSummaryReadModel {
+                enabled_channel_ids: vec!["weixin".to_owned()],
+                enabled_runtime_backed_channel_ids: Vec::new(),
+                enabled_service_channel_ids: vec!["weixin".to_owned()],
+                enabled_plugin_backed_channel_ids: vec!["weixin".to_owned()],
+                enabled_outbound_only_channel_ids: Vec::new(),
+                visible_tool_count: 4,
+                capability_snapshot_sha256: "abc123".to_owned(),
+                active_provider_profile_id: Some("demo".to_owned()),
+                active_provider_label: Some("Demo".to_owned()),
+                tool_calling: crate::gateway::read_models::GatewayToolCallingReadModel {
+                    availability: "ready".to_owned(),
+                    structured_tool_schema_enabled: true,
+                    effective_tool_schema_mode: "enabled_with_downgrade".to_owned(),
+                    active_model: "gpt-4.1-mini".to_owned(),
+                    reason:
+                        "provider turns include structured tool definitions for the active model"
+                            .to_owned(),
+                },
+            },
+        };
+        let status = StatusCliReadModel {
+            config: "/tmp/config.toml".to_owned(),
+            schema: StatusCliJsonSchema {
+                version: STATUS_CLI_JSON_SCHEMA_VERSION,
+                surface: "status",
+                purpose: "operator_runtime_summary",
+            },
+            active_provider: "Demo [demo]".to_owned(),
+            active_model: "gpt-4.1-mini".to_owned(),
+            memory_profile: "window_only".to_owned(),
+            gateway,
+            acp: StatusCliAcpReadModel {
+                enabled: false,
+                availability: "disabled".to_owned(),
+                error: None,
+                persisted_session_count: Some(0),
+                observability: None,
+            },
+            work_units: StatusCliWorkUnitReadModel {
+                availability: "available".to_owned(),
+                error: None,
+                health: Some(WorkRuntimeHealthSnapshot {
+                    total_count: 0,
+                    ready_count: 0,
+                    leased_count: 0,
+                    running_count: 0,
+                    blocked_count: 0,
+                    retry_pending_count: 0,
+                    terminal_count: 0,
+                    archived_count: 0,
+                    expired_lease_count: 0,
+                }),
+            },
+            next_actions: vec![StatusCliAction {
+                label: "inspect weixin managed bridge runtime (retrying)".to_owned(),
+                command: "loong doctor --config '/tmp/config.toml'".to_owned(),
+            }],
+            recipes: vec!["loong gateway status".to_owned()],
+        };
+
+        let rendered = render_status_cli_text(&status);
+
+        assert!(rendered.contains("channel runtime attention"));
+        assert!(rendered.contains("[WARN] Weixin"));
+        assert!(rendered.contains("channel_id=weixin"));
+        assert!(rendered.contains("reasons=retrying"));
+        assert!(rendered.contains("remediations=inspect_bridge_connectivity"));
+        assert!(rendered.contains("retrying=1"));
+        assert!(rendered.contains("duplicate_instances=0"));
+        assert!(rendered.contains("affected_accounts=1"));
+        assert!(rendered.contains("runtime attention ids"));
+        assert!(rendered.contains("weixin"));
+        assert!(rendered.contains("ready service channels"));
     }
 
     #[test]

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -2129,6 +2129,44 @@ fn matrix_serve_cli_accepts_once_and_account_flags() {
 }
 
 #[test]
+fn matrix_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "matrix-serve", "--stop", "--account", "ops"])
+        .expect("matrix serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::MatrixServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn matrix_serve_cli_accepts_stop_duplicates_flag() {
+    let cli = try_parse_cli([
+        "loong",
+        "matrix-serve",
+        "--stop-duplicates",
+        "--account",
+        "ops",
+    ])
+    .expect("matrix serve CLI should parse stop-duplicates flag");
+
+    match cli.command {
+        Some(Commands::MatrixServe {
+            stop_duplicates,
+            account,
+            ..
+        }) => {
+            assert!(stop_duplicates);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
 fn wecom_serve_cli_accepts_account_flag() {
     let cli = try_parse_cli(["loong", "wecom-serve", "--account", "ops"])
         .expect("wecom serve CLI should parse");
@@ -2138,6 +2176,180 @@ fn wecom_serve_cli_accepts_account_flag() {
             assert_eq!(account.as_deref(), Some("ops"));
         }
         other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn feishu_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "feishu-serve", "--stop", "--account", "ops"])
+        .expect("feishu serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::FeishuServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn feishu_serve_cli_accepts_stop_duplicates_flag() {
+    let cli = try_parse_cli([
+        "loong",
+        "feishu-serve",
+        "--stop-duplicates",
+        "--account",
+        "ops",
+    ])
+    .expect("feishu serve CLI should parse stop-duplicates flag");
+
+    match cli.command {
+        Some(Commands::FeishuServe {
+            stop_duplicates,
+            account,
+            ..
+        }) => {
+            assert!(stop_duplicates);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn wecom_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "wecom-serve", "--stop", "--account", "ops"])
+        .expect("wecom serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::WecomServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn line_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "line-serve", "--stop", "--account", "ops"])
+        .expect("line serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::LineServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn telegram_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "telegram-serve", "--stop", "--account", "ops"])
+        .expect("telegram serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::TelegramServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn managed_bridge_serve_cli_accepts_stop_flag() {
+    let weixin_cli = try_parse_cli(["loong", "weixin-serve", "--stop", "--account", "ops"])
+        .expect("weixin serve CLI should parse stop flag");
+    let qqbot_cli = try_parse_cli(["loong", "qqbot-serve", "--stop"])
+        .expect("qqbot serve CLI should parse stop flag");
+    let onebot_cli = try_parse_cli(["loong", "onebot-serve", "--stop"])
+        .expect("onebot serve CLI should parse stop flag");
+
+    match weixin_cli.command {
+        Some(Commands::WeixinServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected weixin serve parse result: {other:?}"),
+    }
+    match qqbot_cli.command {
+        Some(Commands::QqbotServe { stop, .. }) => assert!(stop),
+        other => panic!("unexpected qqbot serve parse result: {other:?}"),
+    }
+    match onebot_cli.command {
+        Some(Commands::OnebotServe { stop, .. }) => assert!(stop),
+        other => panic!("unexpected onebot serve parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn managed_bridge_serve_cli_accepts_stop_duplicates_flag() {
+    let weixin_cli = try_parse_cli([
+        "loong",
+        "weixin-serve",
+        "--stop-duplicates",
+        "--account",
+        "ops",
+    ])
+    .expect("weixin serve CLI should parse stop-duplicates flag");
+    let qqbot_cli = try_parse_cli(["loong", "qqbot-serve", "--stop-duplicates"])
+        .expect("qqbot serve CLI should parse stop-duplicates flag");
+    let onebot_cli = try_parse_cli(["loong", "onebot-serve", "--stop-duplicates"])
+        .expect("onebot serve CLI should parse stop-duplicates flag");
+
+    match weixin_cli.command {
+        Some(Commands::WeixinServe {
+            stop_duplicates,
+            account,
+            ..
+        }) => {
+            assert!(stop_duplicates);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected weixin serve parse result: {other:?}"),
+    }
+    match qqbot_cli.command {
+        Some(Commands::QqbotServe {
+            stop_duplicates, ..
+        }) => assert!(stop_duplicates),
+        other => panic!("unexpected qqbot serve parse result: {other:?}"),
+    }
+    match onebot_cli.command {
+        Some(Commands::OnebotServe {
+            stop_duplicates, ..
+        }) => assert!(stop_duplicates),
+        other => panic!("unexpected onebot serve parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn webhook_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "webhook-serve", "--stop", "--account", "ops"])
+        .expect("webhook serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::WebhookServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected webhook serve parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn whatsapp_serve_cli_accepts_stop_flag() {
+    let cli = try_parse_cli(["loong", "whatsapp-serve", "--stop", "--account", "ops"])
+        .expect("whatsapp serve CLI should parse stop flag");
+
+    match cli.command {
+        Some(Commands::WhatsappServe { stop, account, .. }) => {
+            assert!(stop);
+            assert_eq!(account.as_deref(), Some("ops"));
+        }
+        other => panic!("unexpected whatsapp serve parse result: {other:?}"),
     }
 }
 
@@ -2159,10 +2371,12 @@ fn fake_send_cli_runner(args: ChannelSendCliArgs<'_>) -> ChannelCliCommandFuture
 fn fake_serve_cli_runner(args: ChannelServeCliArgs<'_>) -> ChannelCliCommandFuture<'_> {
     Box::pin(async move {
         Err(format!(
-            "config={}|account={}|once={}|bind={}|path={}",
+            "config={}|account={}|once={}|stop={}|stop_duplicates={}|bind={}|path={}",
             args.config_path.unwrap_or("-"),
             args.account.unwrap_or("-"),
             args.once,
+            args.stop_requested,
+            args.stop_duplicates_requested,
             args.bind_override.unwrap_or("-"),
             args.path_override.unwrap_or("-")
         ))
@@ -2214,6 +2428,8 @@ fn run_channel_serve_cli_forwards_optional_arguments_to_runner() {
                 config_path: Some("/tmp/loong.toml"),
                 account: Some("ops"),
                 once: true,
+                stop_requested: false,
+                stop_duplicates_requested: false,
                 bind_override: Some("127.0.0.1:8123"),
                 path_override: Some("/hooks/feishu"),
             },
@@ -2222,7 +2438,7 @@ fn run_channel_serve_cli_forwards_optional_arguments_to_runner() {
 
     assert_eq!(
         error,
-        "config=/tmp/loong.toml|account=ops|once=true|bind=127.0.0.1:8123|path=/hooks/feishu"
+        "config=/tmp/loong.toml|account=ops|once=true|stop=false|stop_duplicates=false|bind=127.0.0.1:8123|path=/hooks/feishu"
     );
 }
 

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1295,6 +1295,12 @@ fn render_channel_surfaces_text_reports_plugin_backed_stable_targets() {
 
     assert!(
         rendered.contains(
+            "plugin_bridge_contract required_setup_surface=channel runtime_owner=external_plugin supported_operations=\"send,serve\""
+        ),
+        "rendered channel surfaces should expose plugin bridge contract ownership: {rendered}"
+    );
+    assert!(
+        rendered.contains(
             "stable_targets=\"weixin:<account>:contact:<id>[conversation]:direct contact conversation,weixin:<account>:room:<id>[conversation]:group room conversation\""
         ),
         "rendered channel surfaces should expose weixin stable target templates: {rendered}"
@@ -1822,6 +1828,17 @@ fn build_channels_cli_json_payload_includes_plugin_bridge_contracts() {
             .any(|entry| {
                 entry.get("id").and_then(serde_json::Value::as_str) == Some("weixin")
                     && entry
+                        .get("operations")
+                        .and_then(serde_json::Value::as_array)
+                        .map(|operations| {
+                            operations
+                                .iter()
+                                .filter_map(|operation| operation.get("availability"))
+                                .filter_map(serde_json::Value::as_str)
+                                .collect::<Vec<_>>()
+                        })
+                        == Some(vec!["managed_bridge", "managed_bridge"])
+                    && entry
                         .get("plugin_bridge_contract")
                         .and_then(|contract| contract.get("manifest_channel_id"))
                         .and_then(serde_json::Value::as_str)
@@ -2064,6 +2081,103 @@ fn build_channels_cli_json_payload_includes_managed_plugin_bridge_guidance_field
             .as_str()
             .expect("setup remediation should be string"),
         "Run the ClawBot setup flow before enabling this bridge."
+    );
+}
+
+#[test]
+fn build_channels_cli_json_payload_includes_runtime_retry_metadata() {
+    let config = mvp::config::LoongConfig::default();
+    let mut inventory = mvp::channel::channel_inventory(&config);
+    let weixin = inventory
+        .channels
+        .iter_mut()
+        .find(|snapshot| snapshot.id == "weixin")
+        .expect("weixin snapshot");
+    let serve = weixin
+        .operations
+        .iter_mut()
+        .find(|operation| operation.id == "serve")
+        .expect("weixin serve operation");
+
+    serve.detail = "managed bridge runtime ready via plugin weixin-managed-runtime; runtime retrying after transient failures".to_owned();
+    serve.issues = vec![
+        "runtime retrying after transient failures; consecutive_failures=2; last_error=temporary bridge timeout".to_owned(),
+    ];
+    serve.runtime = Some(mvp::channel::ChannelOperationRuntime {
+        running: true,
+        stale: false,
+        busy: false,
+        active_runs: 0,
+        consecutive_failures: 2,
+        last_run_activity_at: Some(1_700_000_000_000),
+        last_heartbeat_at: Some(1_700_000_005_000),
+        last_failure_at: Some(1_700_000_006_000),
+        last_recovery_at: None,
+        last_error: Some("temporary bridge timeout".to_owned()),
+        last_duplicate_reclaim_at: None,
+        pid: Some(5151),
+        account_id: Some("default".to_owned()),
+        account_label: Some("default".to_owned()),
+        instance_count: 1,
+        running_instances: 1,
+        stale_instances: 0,
+        duplicate_owner_pids: Vec::new(),
+        last_duplicate_reclaim_cleanup_owner_pids: Vec::new(),
+        recent_incidents: Vec::new(),
+    });
+
+    let payload = build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let encoded = serde_json::to_value(&payload).expect("serialize payload");
+
+    assert!(
+        encoded["channels"]
+            .as_array()
+            .expect("channels array")
+            .iter()
+            .any(|snapshot| {
+                snapshot.get("id").and_then(serde_json::Value::as_str) == Some("weixin")
+                    && snapshot
+                        .get("operations")
+                        .and_then(serde_json::Value::as_array)
+                        .map(|operations| {
+                            operations.iter().any(|operation| {
+                                operation.get("id").and_then(serde_json::Value::as_str)
+                                    == Some("serve")
+                                    && operation
+                                        .get("detail")
+                                        .and_then(serde_json::Value::as_str)
+                                        .map(|detail| {
+                                            detail.contains(
+                                                "runtime retrying after transient failures",
+                                            )
+                                        })
+                                        == Some(true)
+                                    && operation
+                                        .get("issues")
+                                        .and_then(serde_json::Value::as_array)
+                                        .map(|issues| {
+                                            issues.iter().any(|issue| {
+                                                issue.as_str().map(|issue| {
+                                                    issue.contains("consecutive_failures=2")
+                                                }) == Some(true)
+                                            })
+                                        })
+                                        == Some(true)
+                                    && operation
+                                        .get("runtime")
+                                        .and_then(|runtime| runtime.get("consecutive_failures"))
+                                        .and_then(serde_json::Value::as_u64)
+                                        == Some(2)
+                                    && operation
+                                        .get("runtime")
+                                        .and_then(|runtime| runtime.get("last_error"))
+                                        .and_then(serde_json::Value::as_str)
+                                        == Some("temporary bridge timeout")
+                            })
+                        })
+                        == Some(true)
+            }),
+        "channels json should preserve runtime retry metadata: {encoded:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -85,6 +85,27 @@ fn run_status_cli_process(
         .expect(context)
 }
 
+fn run_doctor_cli_process(
+    config_path: &Path,
+    home_root: &Path,
+    args: &[&str],
+    context: &str,
+) -> std::process::Output {
+    let home_root_text = home_root.to_str().expect("home root should be valid utf-8");
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    Command::new(env!("CARGO_BIN_EXE_loong"))
+        .arg("doctor")
+        .arg("--config")
+        .arg(config_path_text)
+        .args(args)
+        .env("LOONG_HOME", home_root_text)
+        .output()
+        .expect(context)
+}
+
 #[test]
 fn cli_status_help_mentions_operator_runtime_summary() {
     let help = render_cli_help(["status"]);
@@ -138,7 +159,9 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
     let stdout = render_output(&output.stdout);
     let payload: Value = serde_json::from_str(&stdout).expect("decode status json");
 
+    assert_eq!(payload["schema"]["version"], 2);
     assert_eq!(payload["schema"]["surface"], "status");
+    assert_eq!(payload["schema"]["purpose"], "operator_runtime_summary");
     assert_eq!(payload["gateway"]["owner"]["phase"], "stopped");
     assert_eq!(
         payload["gateway"]["runtime"]["tool_calling"]["availability"],
@@ -180,6 +203,52 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
             .map(|recipes| recipes.len() >= 4)
             .unwrap_or(false),
         "status JSON should include drill-down recipes: {payload:#?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn doctor_cli_json_includes_schema_for_machine_readable_automation() {
+    let root = unique_temp_dir("loong-doctor-cli-json");
+    let home_root = root.join("home");
+    fs::create_dir_all(&home_root).expect("create home root");
+    let config_path = write_status_config(
+        &root,
+        false,
+        mvp::config::ProviderToolSchemaModeConfig::EnabledWithDowngrade,
+    );
+    let output = run_doctor_cli_process(
+        &config_path,
+        &home_root,
+        &["--json", "--skip-model-probe"],
+        "run doctor CLI json",
+    );
+
+    if !output.status.success() {
+        let stdout = render_output(&output.stdout);
+        let stderr = render_output(&output.stderr);
+        panic!(
+            "doctor CLI json should succeed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+            output.status.code()
+        );
+    }
+
+    let stdout = render_output(&output.stdout);
+    let payload: Value = serde_json::from_str(&stdout).expect("decode doctor json");
+
+    assert_eq!(payload["schema"]["version"], 1);
+    assert_eq!(payload["schema"]["surface"], "doctor");
+    assert_eq!(payload["schema"]["purpose"], "runtime_health_diagnostics");
+    assert!(
+        payload["checks"]
+            .as_array()
+            .is_some_and(|checks| !checks.is_empty()),
+        "doctor JSON should include machine-readable checks: {payload:#?}"
+    );
+    assert!(
+        payload["next_steps"].is_array(),
+        "doctor JSON should keep next steps machine-readable: {payload:#?}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/site/use-loong/channel-guides/onebot.mdx
+++ b/site/use-loong/channel-guides/onebot.mdx
@@ -60,8 +60,8 @@ What success looks like:
 | --- | --- | --- |
 | managed bridge contract check | `loong doctor` | current readiness and remediation surface |
 | inventory + discovery inspection | `loong channels` | current operator inventory surface |
-| native send | `onebot-send` | planned native command; not implemented in Loong today |
-| native serve | `onebot-serve` | planned native command; runtime stays in the external bridge today |
+| bridge-backed send | `onebot-send` | executes through the selected managed bridge runtime; target contract stays `onebot:<account>:private:<user_id>` or `onebot:<account>:group:<group_id>` |
+| bridge-backed serve | `onebot-serve` | starts the selected managed bridge reply loop; upstream event-loop ownership still stays in the external bridge |
 
 ## Required Fields For Bridge Send Contract
 
@@ -94,6 +94,7 @@ Keep `<account>` stable so personal-account bridge routes stay unambiguous acros
 ## Managed Bridge Discovery Notes
 
 - OneBot is the right Loong surface when the upstream bridge already speaks OneBot v11 and you want a stable protocol contract inside Loong.
+- Managed bridge execution also requires `[runtime_plugins].enabled = true` plus one or more `runtime_plugins.roots`.
 - Discovery ambiguity should be resolved explicitly with `managed_bridge_plugin_id` rather than by relying on whichever plugin happens to be found first.
 - Bridge setup docs and missing-field guidance flow through `loong doctor` when the compatible plugin advertises them.
 
@@ -104,6 +105,12 @@ This surface does **not** join `multi-channel-serve` or `gateway run` today. The
 ## Operator Notes
 
 - Keep `allowed_group_ids` explicit.
+- Loong validates `allowed_group_ids` locally before forwarding a managed bridge group send, so disallowed groups fail before the external bridge sees the request.
+- `onebot-serve` retries transient managed bridge runtime failures with bounded backoff; repeated failures still terminate loudly so the upstream bridge can be checked.
+- `onebot-serve --stop` requests a cooperative shutdown for the currently selected managed bridge runtime owner.
+- When duplicate runtime owners appear, Loong automatically keeps the preferred live runtime owner and requests cooperative shutdown for the older duplicates when the winner is clear.
+- `onebot-serve --stop-duplicates` remains the operator fallback when duplicate runtime owners persist and you want Loong to keep the preferred live runtime owner while draining the others.
+- While it is retrying, `loong doctor` and `loong channels` surface the current failure count and last bridge error.
 - Treat the OneBot websocket URL as part of the trust boundary; do not point it at a vague shared relay unless you intend to widen that boundary.
 - Prefer stable account ids before layering more than one bridge identity into the same config.
 

--- a/site/use-loong/channel-guides/qqbot.mdx
+++ b/site/use-loong/channel-guides/qqbot.mdx
@@ -60,8 +60,8 @@ What success looks like:
 | --- | --- | --- |
 | managed bridge contract check | `loong doctor` | current readiness and remediation surface |
 | inventory + discovery inspection | `loong channels` | current operator inventory surface |
-| native send | `qqbot-send` | planned native command; not implemented in Loong today |
-| native serve | `qqbot-serve` | planned native command; runtime stays in the external bridge today |
+| bridge-backed send | `qqbot-send` | executes through the selected managed bridge runtime; target contract stays `qqbot:<account>:c2c:<openid>`, `qqbot:<account>:group:<openid>`, or `qqbot:<account>:channel:<id>` |
+| bridge-backed serve | `qqbot-serve` | starts the selected managed bridge reply loop; upstream session ownership still stays in the external bridge |
 
 ## Required Fields For Bridge Send Contract
 
@@ -95,6 +95,7 @@ QQ Bot openids are scoped to the selected account. Keep account ids stable so ro
 ## Managed Bridge Discovery Notes
 
 - Compatible managed bridges can advertise required config keys and setup docs URLs that Loong then surfaces through `doctor`.
+- Managed bridge execution also requires `[runtime_plugins].enabled = true` plus one or more `runtime_plugins.roots`.
 - If discovery finds several compatible bridges, `managed_bridge_plugin_id` is the correct tie-breaker.
 - If bridge metadata is incomplete, Loong keeps the surface visible and reports the missing fields instead of flattening everything into one generic placeholder.
 
@@ -105,6 +106,12 @@ This surface does **not** join `multi-channel-serve` or `gateway run` today. The
 ## Operator Notes
 
 - Keep `allowed_peer_ids` explicit and narrow.
+- Loong validates `allowed_peer_ids` locally before forwarding a managed bridge send, so a mistyped openid is rejected before it reaches the external bridge.
+- `qqbot-serve` retries transient managed bridge runtime failures with bounded backoff; repeated failures still bubble up as a hard error for operator inspection.
+- `qqbot-serve --stop` requests a cooperative shutdown for the currently selected managed bridge runtime owner.
+- When duplicate runtime owners appear, Loong automatically keeps the preferred live runtime owner and requests cooperative shutdown for the older duplicates when the winner is clear.
+- `qqbot-serve --stop-duplicates` remains the operator fallback when duplicate runtime owners persist and you want Loong to keep the preferred live runtime owner while draining the others.
+- While it is retrying, `loong doctor` and `loong channels` surface the current failure count and last bridge error.
 - Treat QQ Bot as a multi-account surface from the start if you expect separate direct, group, or guild identities.
 - Prefer one selected managed bridge per environment rather than leaving ambiguity unresolved.
 

--- a/site/use-loong/channel-guides/weixin.mdx
+++ b/site/use-loong/channel-guides/weixin.mdx
@@ -60,8 +60,8 @@ What success looks like:
 | --- | --- | --- |
 | managed bridge contract check | `loong doctor` | current readiness and remediation surface |
 | inventory + discovery inspection | `loong channels` | current operator inventory surface |
-| native send | `weixin-send` | planned native command; not implemented in Loong today |
-| native serve | `weixin-serve` | planned native command; runtime stays in the external bridge today |
+| bridge-backed send | `weixin-send` | executes through the selected managed bridge runtime; target contract stays `weixin:<account>:contact:<id>` or `weixin:<account>:room:<id>` |
+| bridge-backed serve | `weixin-serve` | starts the selected managed bridge reply loop; upstream session ownership still stays in the external bridge |
 
 ## Required Fields For Bridge Send Contract
 
@@ -92,6 +92,7 @@ Use these templates when you need one bridge implementation and later tooling to
 ## Managed Bridge Discovery Notes
 
 - Loong scans the configured managed install root for compatible bridge manifests.
+- Managed bridge execution also requires `[runtime_plugins].enabled = true` plus one or more `runtime_plugins.roots`.
 - If exactly one compatible bridge is found, `loong doctor` and `loong channels` can surface it as the selected plugin.
 - If several compatible bridges are found, set `managed_bridge_plugin_id` to make the selection explicit.
 - If discovery is incomplete, Loong keeps the bridge-owned surface visible and reports the missing fields instead of pretending the channel is ready.
@@ -110,6 +111,12 @@ Use Loong here for:
 ## Operator Notes
 
 - Keep `allowed_contact_ids` tight. Treat it as the trust boundary, not a convenience list.
+- Loong validates `allowed_contact_ids` locally before forwarding a contact send through the managed bridge runtime.
+- `weixin-serve` retries transient managed bridge runtime failures with bounded backoff; repeated failures still surface as a hard error so the bridge can be inspected.
+- `weixin-serve --stop` requests a cooperative shutdown for the currently selected managed bridge runtime owner.
+- When duplicate runtime owners appear, Loong automatically keeps the preferred live runtime owner and requests cooperative shutdown for the older duplicates when the winner is clear.
+- `weixin-serve --stop-duplicates` remains the operator fallback when duplicate runtime owners persist and you want Loong to keep the preferred live runtime owner while draining the others.
+- While it is retrying, `loong doctor` and `loong channels` surface the current failure count and last bridge error.
 - Prefer one explicit managed bridge per environment. If discovery is ambiguous, fix the ambiguity instead of relying on accidental selection.
 - If you need multiple bridge identities, move to `default_account` plus `accounts.<id>` before inventing ad-hoc routes.
 

--- a/site/use-loong/channel-setup.mdx
+++ b/site/use-loong/channel-setup.mdx
@@ -85,15 +85,18 @@ and upstream session lifecycle stay in an external bridge or managed plugin.
 
 | Surface | What you configure first | Current operator path |
 | --- | --- | --- |
-| Weixin | `weixin.enabled`, `bridge_url`, `bridge_access_token`, `allowed_contact_ids` | `loong doctor`, `loong channels`, managed bridge discovery |
-| QQ Bot | `qqbot.enabled`, `app_id`, `client_secret`, `allowed_peer_ids` | `loong doctor`, `loong channels`, managed bridge discovery |
-| OneBot | `onebot.enabled`, `websocket_url`, `access_token`, `allowed_group_ids` | `loong doctor`, `loong channels`, managed bridge discovery |
+| Weixin | `weixin.enabled`, `bridge_url`, `bridge_access_token`, `allowed_contact_ids` | `loong doctor`, `loong channels`, `weixin-send`, `weixin-serve`, managed bridge discovery |
+| QQ Bot | `qqbot.enabled`, `app_id`, `client_secret`, `allowed_peer_ids` | `loong doctor`, `loong channels`, `qqbot-send`, `qqbot-serve`, managed bridge discovery |
+| OneBot | `onebot.enabled`, `websocket_url`, `access_token`, `allowed_group_ids` | `loong doctor`, `loong channels`, `onebot-send`, `onebot-serve`, managed bridge discovery |
 
 Operational rule:
 
 - these surfaces are actionable and operator-visible today
 - they do not join `gateway run` or `multi-channel-serve` because their runtime owner is still the external bridge
 - the important setup milestone is a passing contract + discovery result, not a native `*-serve` loop that does not exist yet
+- managed bridge command execution also requires `[runtime_plugins].enabled = true` plus one or more `runtime_plugins.roots`
+- `*-serve` retries transient managed bridge runtime failures locally with bounded backoff before surfacing a hard failure
+- retry/failure metadata is surfaced through `loong doctor` and `loong channels`, so operators can see when a bridge is actively retrying instead of guessing from stderr
 
 ## Multi-Account Rule
 
@@ -168,6 +171,11 @@ Weixin is a bridge-first surface:
 - optional `managed_bridge_plugin_id` is the tie-breaker when several compatible managed bridges are installed
 - use `loong doctor` to verify the configured contract and the selected managed bridge
 - use `loong channels` or `loong channels --json` to inspect stable targets and discovery state
+- use `weixin-send --target contact:<id>` or `weixin-send --target weixin:<account>:room:<id>` for proactive sends
+- use `weixin-serve` to run the selected managed bridge reply loop under Loong supervision
+- use `weixin-serve --stop` to request cooperative shutdown for the selected managed bridge runtime owner
+- Loong automatically asks older duplicate owners to stop when it can identify one clear preferred runtime owner
+- use `weixin-serve --stop-duplicates` as the operator fallback when duplicate live owners persist and you want Loong to keep the preferred runtime owner while requesting cooperative shutdown for the older duplicates
 
 ### QQ Bot
 
@@ -177,6 +185,11 @@ QQ Bot is the explicit Tencent gateway / bridge lane:
 - use `allowed_peer_ids` to keep the trusted conversation boundary explicit
 - add `managed_bridge_plugin_id` only when several compatible managed bridges exist and you need one exact selection
 - keep openids and account ids stable so direct, group, and guild routes do not drift between bridge implementations
+- use `qqbot-send --target c2c:<openid>`, `group:<openid>`, or `channel:<id>` for proactive sends
+- use `qqbot-serve` to run the selected managed bridge reply loop under Loong supervision
+- use `qqbot-serve --stop` to request cooperative shutdown for the selected managed bridge runtime owner
+- Loong automatically asks older duplicate owners to stop when it can identify one clear preferred runtime owner
+- use `qqbot-serve --stop-duplicates` as the operator fallback to keep the preferred live runtime owner and cooperatively drain the duplicate owners
 
 ### OneBot
 
@@ -186,6 +199,11 @@ OneBot is the protocol-level bridge lane:
 - keep `allowed_group_ids` explicit so the bridge contract stays narrow
 - use it when the upstream bridge already speaks OneBot v11 and you want Loong to own the stable surface id and target contract
 - verify bridge discovery through `loong doctor` before you treat the surface as ready
+- use `onebot-send --target private:<user_id>` or `group:<group_id>` for proactive sends
+- use `onebot-serve` to run the selected managed bridge reply loop under Loong supervision
+- use `onebot-serve --stop` to request cooperative shutdown for the selected managed bridge runtime owner
+- Loong automatically asks older duplicate owners to stop when it can identify one clear preferred runtime owner
+- use `onebot-serve --stop-duplicates` as the operator fallback to clean up duplicate live runtime owners without fully draining the preferred owner
 
 ## Outbound-Only Surfaces
 

--- a/site/use-loong/common-setups.mdx
+++ b/site/use-loong/common-setups.mdx
@@ -61,7 +61,10 @@ When gateway ownership is involved, add:
 
 ```bash
 loong gateway status --json
+loong status --json
 ```
+
+Use `gateway status --json` for the shortest ownership-specific view and `status --json` for the broader operator summary across gateway, ACP, and work-unit surfaces.
 
 ## Reading Rules
 

--- a/site/use-loong/gateway-and-supervision.mdx
+++ b/site/use-loong/gateway-and-supervision.mdx
@@ -130,14 +130,17 @@ When startup or supervision is unclear, use the shortest diagnostic loop first:
 loong doctor
 loong channels
 loong gateway status --json
+loong status --json
 ```
 
-That combination answers three different questions:
+That combination answers four different questions:
 
 - `doctor` checks provider and channel readiness
 - `channels` shows how Loong currently classifies each surface
 - `gateway status --json` is the quickest way to inspect current ownership from
   another CLI process
+- `loong status --json` provides the broader operator summary across gateway,
+  ACP, and work-unit surfaces
 
 If the runtime still does not start cleanly:
 

--- a/site/use-loong/gateway-rollout-playbook.mdx
+++ b/site/use-loong/gateway-rollout-playbook.mdx
@@ -123,11 +123,14 @@ How to choose:
 ```bash
 loong gateway status
 loong gateway status --json
+loong status --json
 loong gateway stop
 ```
 
-Use `status --json` whenever another process or operator needs the shortest
-machine-readable view of the current owner state.
+Use `gateway status --json` whenever another process or operator needs the shortest
+machine-readable view of the current owner state. Use `loong status --json` when
+you want the broader operator summary that rolls gateway ownership together with
+ACP and work-unit status.
 
 ## Common Failure Modes
 


### PR DESCRIPTION
## Summary

This PR matures bridge-backed and runtime-backed channel operations so they behave like real operator surfaces instead of placeholder-like catalog entries.

It does three things:
- makes bridge-backed channel runtimes operable and self-healing
- adds guarded duplicate-runtime auto-reclaim so the same duplicate owners are not repeatedly spammed with stop requests
- publishes stable machine-readable doctor/security JSON schemas and aligns operator docs with the real status surfaces

## What Changed

- Added executable managed bridge/runtime-backed channel controls, including cooperative stop and duplicate cleanup paths.
- Added conservative duplicate runtime auto-reclaim cooldown handling in the shared serve runtime helper.
- Added stable `schema` blocks to `doctor --json` and `doctor security --json` for automation consumers.
- Clarified docs for `loong gateway status --json` vs `loong status --json`.

## Validation

- `./scripts/cargo-local-toolchain.sh check --workspace --all-features`
- `./scripts/cargo-local-toolchain.sh test --workspace`
- `./scripts/cargo-local-toolchain.sh test --workspace --all-features`
- `./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/cargo-local-toolchain.sh fmt --all -- --check`

Closes #1323
