### PR TITLE
Harden discovery-first tool execution against stale leases and launch drift

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8630,6 +8630,127 @@ async fn handle_turn_with_runtime_auto_recovers_provider_unknown_tool_into_disco
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_auto_recovers_invalid_tool_invoke_lease_into_discovery_followup()
+{
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let input_path = harness.temp_dir.join("note.md");
+    let note_contents = "hello from invalid lease recovery";
+
+    std::fs::write(&input_path, note_contents).expect("seed input note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "I'll reuse the previous tool card.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({
+                        "tool_id": "file.read",
+                        "lease": "invalid.lease",
+                        "arguments": {
+                            "path": "note.md"
+                        }
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-invalid-lease-recovery".to_owned(),
+                    turn_id: "turn-invalid-lease-recovery-1".to_owned(),
+                    tool_call_id: "call-invalid-lease-recovery-1".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Let me refresh that tool card.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({
+                        "query": "read note.md",
+                        "exact_tool_id": "file.read",
+                        "limit": 1
+                    }),
+                    "session-invalid-lease-recovery",
+                    "turn-invalid-lease-recovery-2",
+                    "call-invalid-lease-recovery-2",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'll read the file with the fresh lease.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-invalid-lease-recovery",
+                    "turn-invalid-lease-recovery-3",
+                    "call-invalid-lease-recovery-3",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: note_contents.to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config();
+    config.conversation.turn_loop.max_discovery_followup_rounds = 3;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-invalid-lease-recovery",
+            "read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("invalid lease recovery followup turn should succeed");
+
+    assert_eq!(reply, note_contents);
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 4);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_recovery]\n")
+                            && content.contains("fresh lease")
+                            && !content.contains("invalid_tool_lease")
+                    })
+        }),
+        "second provider turn should receive bounded invalid-lease recovery context: {requested_turn_messages:?}"
+    );
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.contains("tool.search")
+                            && content.contains("fresh lease")
+                            && !content.contains("invalid_tool_lease")
+                    })
+        }),
+        "second provider turn should receive fresh-lease recovery instructions: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[allow(clippy::await_holding_lock)] // env override state is process-global; keep lock for full test body.
 async fn handle_turn_with_runtime_provider_shape_function_calls_multi_step_chain_continues() {
     use crate::test_support::TurnTestHarness;

--- a/crates/app/src/conversation/tool_input_contract.rs
+++ b/crates/app/src/conversation/tool_input_contract.rs
@@ -132,6 +132,12 @@ fn render_tool_input_repair_guidance_from_reason_with_descriptor(
     descriptor: &tools::ToolDescriptor,
     tool_failure_reason: &str,
 ) -> Option<String> {
+    if let Some(guidance) =
+        render_invalid_tool_lease_repair_guidance(tool_name, tool_failure_reason)
+    {
+        return Some(guidance);
+    }
+
     let issue = parse_tool_input_contract_issue_from_reason(descriptor, tool_failure_reason)?;
     let guidance = render_tool_input_repair_guidance_for_issue(tool_name, descriptor, &issue);
     Some(guidance)
@@ -148,6 +154,31 @@ fn strip_tool_input_reason_prefix(reason: &str) -> &str {
     let followup_prefix = "tool input needs repair: ";
     let stripped_followup_reason = trimmed_reason.strip_prefix(followup_prefix);
     stripped_followup_reason.unwrap_or(trimmed_reason)
+}
+
+fn render_invalid_tool_lease_repair_guidance(
+    tool_name: &str,
+    tool_failure_reason: &str,
+) -> Option<String> {
+    if tool_name != "tool.invoke" {
+        return None;
+    }
+
+    let stripped_reason = tool_failure_reason.trim();
+    let mentions_invalid_tool_lease = stripped_reason.contains("invalid_tool_lease:");
+    if !mentions_invalid_tool_lease {
+        return None;
+    }
+
+    Some([
+        "Repair guidance for tool.invoke:".to_owned(),
+        "The lease is invalid, expired, or scoped to a different turn/session.".to_owned(),
+        "Refresh the tool card with `tool.search` before retrying `tool.invoke`.".to_owned(),
+        "If you already know the tool id, call `tool.search` with `exact_tool_id` to fetch a fresh lease.".to_owned(),
+        "Do not reuse older leases from earlier search results.".to_owned(),
+        "Expected payload shape: tool_id:string,lease:string,arguments:object.".to_owned(),
+    ]
+    .join("\n"))
 }
 
 fn parse_tool_input_contract_issue_from_reason(
@@ -525,5 +556,23 @@ mod tests {
         assert!(guidance.contains(
             "Expected payload shape: command:string,args?:string[],timeout_ms?:integer,cwd?:string."
         ));
+    }
+
+    #[test]
+    fn render_tool_input_repair_guidance_from_reason_recovers_invalid_tool_lease_refresh_steps() {
+        let guidance = render_tool_input_repair_guidance_from_reason(
+            "tool.invoke",
+            "invalid_tool_lease: expired lease",
+        )
+        .expect("guidance");
+
+        assert!(guidance.contains("Repair guidance for tool.invoke:"));
+        assert!(guidance.contains("tool.search"));
+        assert!(guidance.contains("exact_tool_id"));
+        assert!(guidance.contains("Do not reuse older leases"));
+        assert!(
+            guidance
+                .contains("Expected payload shape: tool_id:string,lease:string,arguments:object.")
+        );
     }
 }

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2445,6 +2445,25 @@ fn tool_search_recovery_hint() -> &'static str {
     " If you need a non-core capability, call tool.search with a short natural-language description of the task. If tool.search returns a grouped hidden surface such as `skills`, `agent`, or `channel`, do not call that surface name directly; use tool.invoke with the fresh lease and put the requested operation inside payload.arguments."
 }
 
+fn tool_invoke_recovery_failure(reason: &str) -> Option<TurnFailure> {
+    let (code, message) = if reason.starts_with("invalid_tool_lease:") {
+        (
+            "invalid_tool_lease",
+            "tool.invoke needs a fresh lease from the current tool.search result.",
+        )
+    } else {
+        return None;
+    };
+
+    let mut recovery_reason = message.to_owned();
+    recovery_reason.push_str(tool_search_recovery_hint());
+
+    Some(TurnFailure::policy_denied_with_discovery_recovery(
+        code,
+        recovery_reason,
+    ))
+}
+
 fn provider_tool_denial_reason(reason: &str, source: &str) -> String {
     let is_provider_source = source.starts_with("provider_");
     if !is_provider_source {
@@ -2483,9 +2502,18 @@ async fn execute_tool_intent_via_kernel(
     kernel_ctx: &KernelContext,
     trusted_internal_context: bool,
 ) -> Result<ToolCoreOutcome, TurnFailure> {
+    let requested_tool_name =
+        crate::tools::canonical_tool_name(request.tool_name.as_str()).to_owned();
     crate::tools::execute_kernel_tool_request(kernel_ctx, request, trusted_internal_context)
         .await
         .map_err(|error| {
+            if requested_tool_name == "tool.invoke"
+                && let KernelError::ToolPlane(ToolPlaneError::Execution(reason)) = &error
+                && let Some(recovery_failure) = tool_invoke_recovery_failure(reason)
+            {
+                return recovery_failure;
+            }
+
             let reason = render_kernel_error_reason(&error);
             match classify_kernel_error(&error) {
                 KernelFailureClass::PolicyDenied => {
@@ -2792,6 +2820,7 @@ impl<'a, 'b, D: AppToolDispatcher + ?Sized> ToolIntentPreparationHarness<'a, 'b,
             tool_name: resolved_tool.canonical_name.to_owned(),
             payload: augmented_payload.payload,
         };
+        let request = prepare_conversation_kernel_tool_request(request, self.binding, intent);
         let normalized_intent = ToolIntent {
             tool_name: resolved_tool.canonical_name.to_owned(),
             args_json: normalized_payload,
@@ -3546,6 +3575,29 @@ fn resolve_effective_tool_metadata(
     })
 }
 
+fn prepare_conversation_kernel_tool_request(
+    request: ToolCoreRequest,
+    binding: ConversationRuntimeBinding<'_>,
+    _intent: &ToolIntent,
+) -> ToolCoreRequest {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return request;
+    };
+
+    let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
+    if canonical_tool_name != "tool.search" {
+        return request;
+    }
+
+    crate::tools::prepare_kernel_tool_request(
+        request,
+        &kernel_ctx.token.allowed_capabilities,
+        None,
+        None,
+        None,
+    )
+}
+
 impl TurnEngine {
     pub fn new(max_tool_steps: usize) -> Self {
         Self::with_parallel_tool_execution(
@@ -4186,6 +4238,132 @@ mod tests {
         );
     }
 
+    #[test]
+    fn prepare_tool_intent_injects_capability_filter_prep_for_tool_search() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let intent = ToolIntent {
+            tool_name: "tool.search".to_owned(),
+            args_json: json!({
+                "query": "read note.md",
+                "limit": 3,
+            }),
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-tool-search-prep".to_owned(),
+            turn_id: "turn-tool-search-prep".to_owned(),
+            tool_call_id: "call-tool-search-prep".to_owned(),
+        };
+        let session_context =
+            SessionContext::root_with_tool_view("session-tool-search-prep", runtime_tool_view());
+        let engine = TurnEngine::new(4);
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let prepared_intent = runtime.block_on(async {
+            let autonomy_budget_state = AutonomyTurnBudgetState::default();
+            engine
+                .prepare_tool_intent(
+                    &intent,
+                    0,
+                    &session_context,
+                    &DefaultAppToolDispatcher::runtime(),
+                    ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+                    &autonomy_budget_state,
+                    None,
+                )
+                .await
+                .expect("tool.search request should prepare successfully")
+        });
+
+        let expected_capabilities = serde_json::to_value(
+            harness
+                .kernel_ctx
+                .token
+                .allowed_capabilities
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+        )
+        .expect("serialize granted capabilities");
+
+        assert_eq!(prepared_intent.request.tool_name, "tool.search");
+        assert_eq!(
+            prepared_intent.request.payload[crate::tools::TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD],
+            expected_capabilities
+        );
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_TOKEN_ID_FIELD)
+                .is_none()
+        );
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_SESSION_ID_FIELD)
+                .is_none()
+        );
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_TURN_ID_FIELD)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn prepare_tool_intent_injects_kernel_request_prep_for_tool_invoke() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call(
+            "shell.exec",
+            json!({
+                "command": "echo",
+                "args": ["hello"],
+            }),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-tool-invoke-prep".to_owned(),
+            turn_id: "turn-tool-invoke-prep".to_owned(),
+            tool_call_id: "call-tool-invoke-prep".to_owned(),
+        };
+        let session_context =
+            SessionContext::root_with_tool_view("session-tool-invoke-prep", runtime_tool_view());
+        let engine = TurnEngine::new(4);
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let prepared_intent = runtime.block_on(async {
+            let autonomy_budget_state = AutonomyTurnBudgetState::default();
+            engine
+                .prepare_tool_intent(
+                    &intent,
+                    0,
+                    &session_context,
+                    &DefaultAppToolDispatcher::runtime(),
+                    ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+                    &autonomy_budget_state,
+                    None,
+                )
+                .await
+                .expect("tool.invoke request should prepare successfully")
+        });
+
+        assert_eq!(prepared_intent.request.tool_name, "shell.exec");
+        assert_eq!(
+            prepared_intent.decision.tool_name, "shell.exec",
+            "shell.exec should still rebind to the inner tool for execution metadata"
+        );
+        assert_eq!(
+            prepared_intent.intent.tool_name, "shell.exec",
+            "tool.invoke shell requests should continue using inner tool intent metadata"
+        );
+    }
+
     #[cfg(feature = "tool-file")]
     #[test]
     fn prepare_tool_intent_uses_inner_parallel_safe_metadata_for_tool_invoke_file_read_requests() {
@@ -4253,6 +4431,75 @@ mod tests {
         assert_eq!(
             prepared_intent.scheduling_class,
             crate::tools::ToolSchedulingClass::ParallelSafe
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn prepare_tool_intent_keeps_followup_tool_invoke_wrapper_unbound_to_current_turn() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call(
+            "file.read",
+            json!({
+                "path": "README.md",
+            }),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-tool-invoke-wrapper-prep".to_owned(),
+            turn_id: "turn-tool-invoke-wrapper-prep".to_owned(),
+            tool_call_id: "call-tool-invoke-wrapper-prep".to_owned(),
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "session-tool-invoke-wrapper-prep",
+            runtime_tool_view(),
+        );
+        let engine = TurnEngine::new(4);
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let prepared_intent = runtime.block_on(async {
+            let autonomy_budget_state = AutonomyTurnBudgetState::default();
+            engine
+                .prepare_tool_intent(
+                    &intent,
+                    0,
+                    &session_context,
+                    &DefaultAppToolDispatcher::runtime(),
+                    ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+                    &autonomy_budget_state,
+                    None,
+                )
+                .await
+                .expect("tool.invoke file.read request should prepare successfully")
+        });
+
+        assert_eq!(prepared_intent.request.tool_name, "tool.invoke");
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_TOKEN_ID_FIELD)
+                .is_none(),
+            "conversation follow-up invoke wrapper should not be rebound to the current turn"
+        );
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_SESSION_ID_FIELD)
+                .is_none(),
+            "conversation follow-up invoke wrapper should not be rebound to the current turn"
+        );
+        assert!(
+            prepared_intent
+                .request
+                .payload
+                .get(crate::tools::TOOL_LEASE_TURN_ID_FIELD)
+                .is_none(),
+            "conversation follow-up invoke wrapper should not be rebound to the current turn"
         );
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -304,9 +304,7 @@ impl ToolDrivenFollowupPayload {
 }
 
 pub fn turn_failure_supports_discovery_recovery(failure: &TurnFailure) -> bool {
-    let is_tool_not_found = failure.code == "tool_not_found";
-    let has_recovery_hint = failure.supports_discovery_recovery;
-    is_tool_not_found && has_recovery_hint
+    failure.supports_discovery_recovery
 }
 
 pub fn tool_driven_followup_payload(
@@ -2520,12 +2518,12 @@ mod tests {
     #[test]
     fn turn_failure_supports_discovery_recovery_requires_structured_metadata() {
         let recovery_failure = TurnFailure::policy_denied_with_discovery_recovery(
-            "tool_not_found",
-            "tool_not_found: requested tool is not available If you need a non-core capability, call tool.search with a short natural-language description of the task.",
+            "invalid_tool_lease",
+            "tool.invoke needs a fresh lease from the current tool.search result. If you need a non-core capability, call tool.search with a short natural-language description of the task.",
         );
         let plain_failure = TurnFailure::policy_denied(
-            "tool_not_found",
-            "tool_not_found: requested tool is not available",
+            "invalid_tool_lease",
+            "tool execution failed: invalid_tool_lease: expired lease",
         );
 
         assert!(turn_failure_supports_discovery_recovery(&recovery_failure));

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::io;
 #[cfg(unix)]
 use std::io::Read;
+#[cfg(windows)]
+use std::path::PathBuf;
 #[cfg(unix)]
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -123,9 +125,18 @@ where
         .map(|value| OsString::from(value.as_ref()))
         .collect::<Vec<_>>();
 
-    #[cfg(unix)]
-    if let Some(invocation) = resolve_shebang_invocation(command, &collected_args) {
-        return invocation;
+    if let Some(resolved_path) = resolve_existing_command_path(command) {
+        #[cfg(unix)]
+        if let Some(invocation) =
+            resolve_shebang_invocation_from_path(resolved_path.as_path(), &collected_args)
+        {
+            return invocation;
+        }
+
+        return ResolvedCommandInvocation {
+            program: resolved_path.into_os_string(),
+            args: collected_args,
+        };
     }
 
     ResolvedCommandInvocation {
@@ -135,12 +146,11 @@ where
 }
 
 #[cfg(unix)]
-fn resolve_shebang_invocation(
-    command: &str,
+fn resolve_shebang_invocation_from_path(
+    script_path: &Path,
     collected_args: &[OsString],
 ) -> Option<ResolvedCommandInvocation> {
-    let script_path = resolve_existing_command_path(command)?;
-    let shebang = read_shebang(script_path.as_path())?;
+    let shebang = read_shebang(script_path)?;
     let trimmed_shebang = shebang.trim();
     let separator_index = trimmed_shebang.find(char::is_whitespace);
     let interpreter = match separator_index {
@@ -155,7 +165,7 @@ fn resolve_shebang_invocation(
     {
         resolved_args.push(OsString::from(remainder));
     }
-    let script_arg = script_path.into_os_string();
+    let script_arg = script_path.to_path_buf().into_os_string();
     resolved_args.push(script_arg);
     for argument in collected_args {
         let cloned_argument = argument.clone();
@@ -175,7 +185,61 @@ fn resolve_existing_command_path(command: &str) -> Option<PathBuf> {
         return Some(direct_path.to_path_buf());
     }
 
-    which::which(command).ok()
+    if let Ok(discovered) = which::which(command) {
+        return Some(discovered);
+    }
+
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    which::which_in(command, Some(stable_command_search_path()), current_dir).ok()
+}
+
+#[cfg(unix)]
+fn stable_command_search_path() -> OsString {
+    let fallback = std::env::var_os("PATH")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| OsString::from("/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"));
+
+    let output = std::process::Command::new("/usr/bin/getconf")
+        .arg("PATH")
+        .output();
+    let Ok(output) = output else {
+        return fallback;
+    };
+    if !output.status.success() {
+        return fallback;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return fallback;
+    }
+
+    OsString::from(trimmed)
+}
+
+#[cfg(windows)]
+fn resolve_existing_command_path(command: &str) -> Option<PathBuf> {
+    let direct_path = std::path::Path::new(command);
+    if direct_path.is_file() {
+        return Some(direct_path.to_path_buf());
+    }
+
+    if let Ok(discovered) = which::which(command) {
+        return Some(discovered);
+    }
+
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    which::which_in(command, Some(stable_command_search_path()), current_dir).ok()
+}
+
+#[cfg(windows)]
+fn stable_command_search_path() -> OsString {
+    std::env::var_os("PATH")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            OsString::from(r"C:\Windows\System32;C:\Windows;C:\Program Files\Git\cmd")
+        })
 }
 
 #[cfg(unix)]
@@ -331,6 +395,29 @@ mod tests {
             vec![
                 script_path.into_os_string(),
                 std::ffi::OsString::from("--flag"),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_invocation_falls_back_to_stable_search_path_when_env_path_is_empty() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("PATH", "");
+
+        let resolved = resolve_command_invocation("sh", ["-c", "printf ok"]);
+
+        assert_ne!(resolved.program, std::ffi::OsString::from("sh"));
+        assert!(
+            std::path::Path::new(&resolved.program).is_absolute(),
+            "expected absolute fallback path, got {:?}",
+            resolved.program
+        );
+        assert_eq!(
+            resolved.args,
+            vec![
+                std::ffi::OsString::from("-c"),
+                std::ffi::OsString::from("printf ok"),
             ]
         );
     }

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -373,6 +373,9 @@ fn render_deferred_tool_text_workflow_section() -> String {
         "When you need a tool, emit the raw JSON call instead of only describing the missing capability.".to_owned(),
         "Direct tool example:".to_owned(),
         direct_call_example,
+        "In raw JSON tool calls, use the provider tool names `tool_search` and `tool_invoke`.".to_owned(),
+        "tool_invoke leases are short-lived; after any invalid_tool_lease response, refresh with tool_search before retrying.".to_owned(),
+        "If you already know the tool id, refresh directly with exact_tool_id to fetch a fresh lease card.".to_owned(),
         "Hidden-tool discovery example:".to_owned(),
         discovery_call_example,
         "Hidden-tool invocation example:".to_owned(),
@@ -1147,6 +1150,8 @@ mod tests {
         assert!(system_content.contains("`web { query }` uses web-search providers"));
         assert!(system_content.contains("\"name\": \"tool_search\""));
         assert!(system_content.contains("\"name\": \"tool_invoke\""));
+        assert!(system_content.contains("invalid_tool_lease"));
+        assert!(system_content.contains("exact_tool_id"));
     }
 
     #[test]

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -120,10 +120,9 @@ fn provider_tool_bridge_context_from_messages(messages: &[Value]) -> ProviderToo
         .rev()
         .filter(|message| message.get("role").and_then(Value::as_str) == Some("assistant"))
         .filter_map(|message| {
-            message
-                .get("content")
-                .and_then(Value::as_str)
-                .and_then(parse_discovery_followup_leases_from_message_content)
+            let content = message.get("content")?;
+            let content_text = extract_content_text(content)?;
+            parse_discovery_followup_leases_from_message_content(content_text.as_str())
         })
         .find(|context| !context.discoverable_leases.is_empty())
         .unwrap_or_default()
@@ -175,9 +174,7 @@ fn parse_discovery_followup_leases_from_message_content(
             let Some(discoverable_tool_name) = discoverable_tool_name(tool_id) else {
                 continue;
             };
-            discoverable_leases
-                .entry(discoverable_tool_name.to_owned())
-                .or_insert_with(|| lease.to_owned());
+            discoverable_leases.insert(discoverable_tool_name.to_owned(), lease.to_owned());
         }
     }
 
@@ -2559,6 +2556,34 @@ mod tests {
         })]
     }
 
+    fn discovery_followup_part_messages(tool_id: &str, lease: &str) -> Vec<Value> {
+        let payload_summary = serde_json::to_string(&json!({
+            "results": [
+                {
+                    "tool_id": tool_id,
+                    "lease": lease,
+                }
+            ]
+        }))
+        .expect("encode search payload summary");
+        let envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search",
+            "payload_summary": payload_summary,
+            "payload_chars": payload_summary.chars().count(),
+            "payload_truncated": false,
+        }))
+        .expect("encode search envelope");
+        vec![json!({
+            "role": "assistant",
+            "content": [{
+                "type": "input_text",
+                "text": format!("[tool_result]\n[ok] {envelope}"),
+            }],
+        })]
+    }
+
     #[test]
     fn extract_provider_turn_parses_tool_calls() {
         let body = serde_json::json!({
@@ -2869,6 +2894,134 @@ mod tests {
     }
 
     #[test]
+    fn provider_shape_discovery_followup_uses_latest_hidden_lease_in_multiline_source_order() {
+        let first_summary = serde_json::to_string(&json!({
+            "query": "external skills policy",
+            "results": [
+                {
+                    "tool_id": "skills",
+                    "summary": "Manage installable external skills and related policy surfaces.",
+                    "argument_hint": "operation:string",
+                    "required_fields": ["operation"],
+                    "required_field_groups": [["operation"]],
+                    "lease": "lease-first"
+                }
+            ]
+        }))
+        .expect("encode first search payload summary");
+        let second_summary = serde_json::to_string(&json!({
+            "query": "external skills policy again",
+            "results": [
+                {
+                    "tool_id": "skills",
+                    "summary": "Manage installable external skills and related policy surfaces.",
+                    "argument_hint": "operation:string",
+                    "required_fields": ["operation"],
+                    "required_field_groups": [["operation"]],
+                    "lease": "lease-second"
+                }
+            ]
+        }))
+        .expect("encode second search payload summary");
+        let first_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-1",
+            "payload_summary": first_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode first search envelope");
+        let second_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-2",
+            "payload_summary": second_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode second search envelope");
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": format!("[tool_result]\n[ok] {first_envelope}\n[ok] {second_envelope}"),
+        })];
+
+        let context = provider_tool_bridge_context_from_messages(&messages);
+        assert_eq!(
+            context.discoverable_leases.get("skills"),
+            Some(&"lease-second".to_owned())
+        );
+    }
+
+    #[test]
+    fn provider_shape_discovery_followup_ignores_newer_mixed_content_messages() {
+        let latest_summary = serde_json::to_string(&json!({
+            "query": "external skills policy",
+            "results": [
+                {
+                    "tool_id": "skills",
+                    "summary": "Manage installable external skills and related policy surfaces.",
+                    "argument_hint": "operation:string",
+                    "required_fields": ["operation"],
+                    "required_field_groups": [["operation"]],
+                    "lease": "lease-latest"
+                }
+            ]
+        }))
+        .expect("encode latest search payload summary");
+        let stale_summary = serde_json::to_string(&json!({
+            "query": "older external skills card",
+            "results": [
+                {
+                    "tool_id": "skills",
+                    "summary": "Manage installable external skills and related policy surfaces.",
+                    "argument_hint": "operation:string",
+                    "required_fields": ["operation"],
+                    "required_field_groups": [["operation"]],
+                    "lease": "lease-stale"
+                }
+            ]
+        }))
+        .expect("encode stale search payload summary");
+        let latest_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-latest",
+            "payload_summary": latest_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode latest search envelope");
+        let stale_envelope = serde_json::to_string(&json!({
+            "status": "ok",
+            "tool": "tool.search",
+            "tool_call_id": "call-search-stale",
+            "payload_summary": stale_summary,
+            "payload_chars": 0,
+            "payload_truncated": false,
+        }))
+        .expect("encode stale search envelope");
+        let messages = vec![
+            json!({
+                "role": "assistant",
+                "content": format!("[tool_result]\n[ok] {latest_envelope}"),
+            }),
+            json!({
+                "role": "assistant",
+                "content": format!(
+                    "I am quoting an older card for context.\n[tool_result]\n[ok] {stale_envelope}\nPlease refresh before reusing it."
+                ),
+            }),
+        ];
+
+        let context = provider_tool_bridge_context_from_messages(&messages);
+        assert_eq!(
+            context.discoverable_leases.get("skills"),
+            Some(&"lease-latest".to_owned())
+        );
+    }
+
+    #[test]
     fn extract_provider_turn_handles_text_only() {
         let body = serde_json::json!({
             "choices": [{
@@ -2962,6 +3115,47 @@ mod tests {
                 "command": "echo",
                 "args": ["hello"]
             })
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_supports_responses_function_calls_with_array_followup_messages() {
+        let body = serde_json::json!({
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Reading the file."}
+                    ]
+                },
+                {
+                    "type": "function_call",
+                    "name": "file_read",
+                    "arguments": "{\"path\":\"README.md\"}",
+                    "call_id": "call_resp_1"
+                }
+            ]
+        });
+        let messages = discovery_followup_part_messages("file.read", "lease-responses-parts");
+
+        let turn = extract_provider_turn_with_scope_and_messages(
+            &body,
+            Some("session-responses"),
+            Some("turn-responses"),
+            &messages,
+        )
+        .expect("responses turn with array-form search context");
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({"path": "README.md"})
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["lease"],
+            "lease-responses-parts"
         );
     }
 

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -3147,16 +3147,8 @@ mod tests {
         )
         .expect("responses turn with array-form search context");
         assert_eq!(turn.tool_intents.len(), 1);
-        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
-        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
-        assert_eq!(
-            turn.tool_intents[0].args_json["arguments"],
-            json!({"path": "README.md"})
-        );
-        assert_eq!(
-            turn.tool_intents[0].args_json["lease"],
-            "lease-responses-parts"
-        );
+        assert_eq!(turn.tool_intents[0].tool_name, "read");
+        assert_eq!(turn.tool_intents[0].args_json, json!({"path": "README.md"}));
     }
 
     #[test]

--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -138,11 +138,15 @@ pub(super) fn execute_bash_tool_with_config(
             .as_deref()
             .ok_or_else(|| "bash unavailable".to_owned())?;
         let args = bash_exec_args(command, runtime.login_shell);
+        let resolved_invocation = crate::process_launch::resolve_command_invocation(
+            runtime_command.to_string_lossy().as_ref(),
+            args.iter().map(String::as_str),
+        );
         let runtime_event_sink = current_tool_runtime_event_sink();
         let output = process_exec::run_tool_async(
             process_exec::run_process_with_timeout_with_sink(
-                runtime_command,
-                &args,
+                resolved_invocation.program.as_os_str(),
+                resolved_invocation.args.as_slice(),
                 cwd.as_path(),
                 timeout_ms,
                 "bash command",

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -389,6 +389,10 @@ impl ToolDescriptor {
         self.exposure == ToolExposureClass::Discoverable
     }
 
+    pub fn is_provider_invokable_discoverable(&self) -> bool {
+        self.is_discoverable() && self.execution_kind == ToolExecutionKind::Core
+    }
+
     pub fn capability_action_class(&self) -> CapabilityActionClass {
         self.capability_action_class
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1230,7 +1230,7 @@ pub(crate) fn tool_registry_with_config(
         }
     };
 
-    let discoverable_entries = runtime_discoverable_tool_entries(config, None);
+    let discoverable_entries = runtime_discoverable_tool_entries(config, None, false);
     let mut entries = Vec::new();
 
     for entry in discoverable_entries {
@@ -1372,7 +1372,8 @@ pub fn runtime_discoverable_tool_surface_summary_with_config(
     visible_tool_view: Option<&ToolView>,
 ) -> DiscoverableToolSurfaceSummary {
     let effective_view = effective_runtime_visible_tool_view(config, visible_tool_view);
-    let discoverable_entries = runtime_discoverable_tool_entries(config, Some(&effective_view));
+    let discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(&effective_view), true);
     let direct_states = tool_surface::visible_direct_tool_states_for_view(&effective_view);
     summarize_discoverable_tool_surface(discoverable_entries.as_slice(), direct_states)
 }
@@ -1532,9 +1533,11 @@ fn runtime_tool_search_entries(
         }
     }
 
-    let hidden_entries = runtime_discoverable_tool_entries(config, Some(&visible_tool_view));
+    let hidden_entries = runtime_discoverable_tool_entries(config, Some(&visible_tool_view), true);
     let hidden_entries = if collapse_hidden_surfaces {
-        collapse_hidden_surface_search_entries(hidden_entries)
+        let collapsible_surface_ids =
+            provider_visible_collapsible_hidden_surface_ids(config, &visible_tool_view);
+        collapse_hidden_surface_search_entries(hidden_entries, &collapsible_surface_ids)
     } else {
         hidden_entries
     };
@@ -1545,12 +1548,24 @@ fn runtime_tool_search_entries(
 fn runtime_discoverable_tool_entries(
     config: &runtime_config::ToolRuntimeConfig,
     visible_tool_view: Option<&ToolView>,
+    provider_invokable_only: bool,
 ) -> Vec<SearchableToolEntry> {
     let visible_tool_view = effective_runtime_visible_tool_view(config, visible_tool_view);
     catalog::tool_catalog()
         .descriptors()
         .iter()
-        .filter(|descriptor| descriptor.is_discoverable())
+        .filter(|descriptor| {
+            let is_discoverable = descriptor.is_discoverable();
+            if !is_discoverable {
+                return false;
+            }
+
+            if !provider_invokable_only {
+                return true;
+            }
+
+            descriptor.is_provider_invokable_discoverable()
+        })
         .filter(|descriptor| visible_tool_view.contains(descriptor.name))
         .filter(|descriptor| {
             descriptor.name == SHELL_EXEC_TOOL_NAME
@@ -1564,6 +1579,54 @@ fn runtime_discoverable_tool_entries(
         })
         .map(searchable_entry_from_descriptor)
         .collect::<Vec<_>>()
+}
+
+fn hidden_surface_entry_counts(entries: &[SearchableToolEntry]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+
+    for entry in entries {
+        let Some(surface_id) = entry.surface_id.as_deref() else {
+            continue;
+        };
+        let is_grouped_surface = matches!(surface_id, "agent" | "skills" | "channel");
+        if !is_grouped_surface {
+            continue;
+        }
+
+        let entry_count = counts.entry(surface_id.to_owned()).or_insert(0);
+        *entry_count += 1;
+    }
+
+    counts
+}
+
+pub(super) fn provider_visible_collapsible_hidden_surface_ids(
+    config: &runtime_config::ToolRuntimeConfig,
+    visible_tool_view: &ToolView,
+) -> BTreeSet<String> {
+    let all_discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(visible_tool_view), false);
+    let provider_discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(visible_tool_view), true);
+    let all_entry_counts = hidden_surface_entry_counts(all_discoverable_entries.as_slice());
+    let provider_entry_counts =
+        hidden_surface_entry_counts(provider_discoverable_entries.as_slice());
+    let mut surface_ids = BTreeSet::new();
+
+    for (surface_id, all_entry_count) in all_entry_counts {
+        let Some(provider_entry_count) = provider_entry_counts.get(surface_id.as_str()).copied()
+        else {
+            continue;
+        };
+        let surface_is_fully_provider_visible = provider_entry_count == all_entry_count;
+        if !surface_is_fully_provider_visible {
+            continue;
+        }
+
+        surface_ids.insert(surface_id);
+    }
+
+    surface_ids
 }
 
 #[cfg(test)]

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -75,12 +75,16 @@ pub(super) fn execute_shell_tool_with_config(
         }
 
         let runtime_event_sink = current_tool_runtime_event_sink();
+        let resolved_invocation = crate::process_launch::resolve_command_invocation(
+            normalized_command.as_str(),
+            args.iter().map(String::as_str),
+        );
         // process_exec owns runtime command metrics emission. Keep shell.exec
         // focused on payload construction so the live surface observes one
         // metrics event per command.
         let output = run_shell_async(run_shell_command_with_timeout(
-            normalized_command.as_str(),
-            &args,
+            resolved_invocation.program.as_os_str(),
+            resolved_invocation.args.as_slice(),
             cwd.as_path(),
             timeout_ms,
             runtime_event_sink.clone(),
@@ -128,8 +132,8 @@ where
 
 #[cfg(feature = "tool-shell")]
 async fn run_shell_command_with_timeout(
-    command: &str,
-    args: &[String],
+    command: &std::ffi::OsStr,
+    args: &[std::ffi::OsString],
     cwd: &std::path::Path,
     timeout_ms: u64,
     runtime_event_sink: Option<

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -393,7 +393,7 @@ fn bash_exec_falls_back_to_file_root_when_current_dir_is_unavailable() {
 }
 
 #[cfg(all(feature = "tool-shell", unix))]
-const BASH_EMPTY_PATH_PROBE_ENV: &str = "LOONGCLAW_BASH_EMPTY_PATH_PROBE";
+const BASH_EMPTY_PATH_PROBE_ENV: &str = "LOONG_BASH_EMPTY_PATH_PROBE";
 
 #[cfg(all(feature = "tool-shell", unix))]
 #[test]
@@ -424,7 +424,7 @@ fn bash_exec_empty_path_probe() {
         return;
     }
 
-    let root = unique_tool_temp_dir("loongclaw-bash-empty-path-fallback");
+    let root = unique_tool_temp_dir("loong-bash-empty-path-fallback");
     fs::create_dir_all(&root).expect("create fixture root");
 
     let mut env = ScopedEnv::new();

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -393,6 +393,70 @@ fn bash_exec_falls_back_to_file_root_when_current_dir_is_unavailable() {
 }
 
 #[cfg(all(feature = "tool-shell", unix))]
+const BASH_EMPTY_PATH_PROBE_ENV: &str = "LOONGCLAW_BASH_EMPTY_PATH_PROBE";
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
+fn bash_exec_succeeds_when_path_is_empty_but_stable_search_path_can_find_runtime() {
+    let _subprocess_guard = crate::test_support::acquire_subprocess_test_guard();
+    let output = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("--exact")
+        .arg("tools::tests::bash_exec_tests::bash_exec_empty_path_probe")
+        .arg("--nocapture")
+        .env(BASH_EMPTY_PATH_PROBE_ENV, "1")
+        .output()
+        .expect("spawn bash empty PATH probe");
+
+    assert!(
+        output.status.success(),
+        "bash empty PATH probe failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
+fn bash_exec_empty_path_probe() {
+    use std::fs;
+
+    if std::env::var_os(BASH_EMPTY_PATH_PROBE_ENV).is_none() {
+        return;
+    }
+
+    let root = unique_tool_temp_dir("loongclaw-bash-empty-path-fallback");
+    fs::create_dir_all(&root).expect("create fixture root");
+
+    let mut env = ScopedEnv::new();
+    env.set("PATH", "");
+
+    let mut config = test_tool_runtime_config(root.clone());
+    config.shell_default_mode = shell_policy_ext::ShellPolicyDefault::Allow;
+    config.bash_exec = runtime_config::BashExecRuntimePolicy {
+        available: true,
+        command: Some(std::path::PathBuf::from("bash")),
+        ..runtime_config::BashExecRuntimePolicy::default()
+    };
+
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "bash.exec".to_owned(),
+            payload: json!({"command": "printf bash-path-fallback"}),
+        },
+        &config,
+    )
+    .expect("bash.exec should succeed even when PATH is empty");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(
+        outcome.payload["stdout"].as_str(),
+        Some("bash-path-fallback")
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(all(feature = "tool-shell", unix))]
 #[test]
 fn bash_exec_defaults_cwd_to_configured_file_root() {
     use std::fs;
@@ -760,7 +824,7 @@ fn bash_exec_times_out_when_timeout_ms_is_small() {
         ToolCoreRequest {
             tool_name: "bash.exec".to_owned(),
             payload: json!({
-                "command": "sleep 10",
+                "command": "/bin/sleep 10",
                 "timeout_ms": 1,
             }),
         },

--- a/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
+++ b/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
@@ -91,7 +91,7 @@ fn shell_exec_rejects_path_qualified_commands() {
 }
 
 #[cfg(all(feature = "tool-shell", unix))]
-const SHELL_EMPTY_PATH_PROBE_ENV: &str = "LOONGCLAW_SHELL_EMPTY_PATH_PROBE";
+const SHELL_EMPTY_PATH_PROBE_ENV: &str = "LOONG_SHELL_EMPTY_PATH_PROBE";
 
 #[cfg(all(feature = "tool-shell", unix))]
 #[test]
@@ -120,7 +120,7 @@ fn shell_exec_empty_path_probe() {
         return;
     }
 
-    let root = unique_tool_temp_dir("loongclaw-shell-empty-path-fallback");
+    let root = unique_tool_temp_dir("loong-shell-empty-path-fallback");
     std::fs::create_dir_all(&root).expect("create root");
 
     let mut env = ScopedEnv::new();

--- a/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
+++ b/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
@@ -90,6 +90,64 @@ fn shell_exec_rejects_path_qualified_commands() {
     }
 }
 
+#[cfg(all(feature = "tool-shell", unix))]
+const SHELL_EMPTY_PATH_PROBE_ENV: &str = "LOONGCLAW_SHELL_EMPTY_PATH_PROBE";
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
+fn shell_exec_succeeds_when_path_is_empty_but_stable_search_path_can_find_command() {
+    let _subprocess_guard = crate::test_support::acquire_subprocess_test_guard();
+    let output = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("--exact")
+        .arg("tools::tests::search_and_shell::shell_exec_empty_path_probe")
+        .arg("--nocapture")
+        .env(SHELL_EMPTY_PATH_PROBE_ENV, "1")
+        .output()
+        .expect("spawn shell empty PATH probe");
+
+    assert!(
+        output.status.success(),
+        "shell empty PATH probe failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
+fn shell_exec_empty_path_probe() {
+    if std::env::var_os(SHELL_EMPTY_PATH_PROBE_ENV).is_none() {
+        return;
+    }
+
+    let root = unique_tool_temp_dir("loongclaw-shell-empty-path-fallback");
+    std::fs::create_dir_all(&root).expect("create root");
+
+    let mut env = ScopedEnv::new();
+    env.set("PATH", "");
+
+    let config = test_tool_runtime_config(root.clone());
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({
+                "command": "echo",
+                "args": ["shell-path-fallback"]
+            }),
+        },
+        &config,
+    )
+    .expect("shell.exec should succeed even when PATH is empty");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(
+        outcome.payload["stdout"].as_str(),
+        Some("shell-path-fallback")
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
 #[cfg(feature = "tool-shell")]
 #[test]
 fn shell_exec_rejects_cwd_outside_file_root() {
@@ -523,7 +581,7 @@ fn shell_exec_times_out_when_timeout_ms_is_small() {
 #[test]
 fn shell_exec_timeout_returns_without_waiting_for_descendant_pipe_holders() {
     let mut config = test_tool_runtime_config(std::env::temp_dir());
-    let args = vec!["-c", "sleep 5 & wait"];
+    let args = vec!["-c", "/bin/sleep 5 & wait"];
     let started_at = std::time::Instant::now();
 
     config.shell_allow.insert("sh".to_owned());

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -90,7 +90,12 @@ pub(super) fn execute_tool_search_tool_with_config(
                 )
             })
             .collect::<Vec<_>>();
-    let searchable_entries = collapse_hidden_surface_search_entries(exact_match_entries.clone());
+    let collapsible_surface_ids =
+        super::provider_visible_collapsible_hidden_surface_ids(config, &visible_tool_view);
+    let searchable_entries = collapse_hidden_surface_search_entries(
+        exact_match_entries.clone(),
+        &collapsible_surface_ids,
+    );
     let exact_match_entry = exact_tool_id.as_ref().and_then(|exact_tool_id| {
         let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
         let direct_tool_id = direct_tool_id.map(str::to_owned);
@@ -661,6 +666,7 @@ fn build_schema_preview(
 
 pub(super) fn collapse_hidden_surface_search_entries(
     entries: Vec<SearchableToolEntry>,
+    collapsible_surface_ids: &BTreeSet<String>,
 ) -> Vec<SearchableToolEntry> {
     let mut grouped_members = BTreeMap::<String, Vec<SearchableToolEntry>>::new();
     let mut passthrough_entries = Vec::new();
@@ -670,10 +676,7 @@ pub(super) fn collapse_hidden_surface_search_entries(
             passthrough_entries.push(entry);
             continue;
         };
-        // Collapse grouped hidden lanes into one high-signal card per surface.
-        // `channel` stays separate from `agent`/`skills`, but it is still one
-        // addon surface instead of a long tail of individual ids.
-        let collapse_surface = matches!(surface_id, "agent" | "skills" | "channel");
+        let collapse_surface = collapsible_surface_ids.contains(surface_id);
         if !collapse_surface {
             passthrough_entries.push(entry);
             continue;

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -2763,6 +2763,71 @@ fn tool_invoke_rejects_tampered_or_missing_leases() {
 
 #[cfg(feature = "tool-file")]
 #[test]
+fn tool_invoke_rejects_missing_outer_lease_field() {
+    let root = std::env::temp_dir().join(format!(
+        "loongclaw-tool-invoke-missing-lease-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create fixture root");
+
+    let config = test_tool_runtime_config(root.clone());
+    let error = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "skills",
+                "arguments": {
+                    "operation": "policy-status"
+                }
+            }),
+        },
+        &config,
+    )
+    .expect_err("missing lease should fail");
+
+    assert!(error.contains("requires payload.lease"), "error: {error}");
+    assert!(
+        !error.contains("invalid_tool_lease"),
+        "outer payload validation should fail before invalid lease recovery paths: {error}"
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn tool_invoke_rejects_non_string_outer_lease_field() {
+    let root = std::env::temp_dir().join(format!(
+        "loongclaw-tool-invoke-non-string-lease-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create fixture root");
+
+    let config = test_tool_runtime_config(root.clone());
+    let error = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "skills",
+                "lease": 123,
+                "arguments": {
+                    "operation": "policy-status"
+                }
+            }),
+        },
+        &config,
+    )
+    .expect_err("non-string lease should fail");
+
+    assert!(error.contains("requires payload.lease"), "error: {error}");
+    assert!(
+        !error.contains("invalid_tool_lease"),
+        "outer payload validation should fail before invalid lease recovery paths: {error}"
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
 fn tool_invoke_rejects_leases_replayed_in_another_turn() {
     let root = std::env::temp_dir().join(format!(
         "loongclaw-tool-invoke-replay-{}",

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -1866,7 +1866,7 @@ fn capability_snapshot_summarizes_hidden_tags_without_tool_names() {
 #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
 #[test]
 fn runtime_discoverable_tool_surface_summary_groups_visible_direct_and_hidden_surfaces() {
-    let root = unique_tool_temp_dir("loongclaw-tool-surface-summary");
+    let root = unique_tool_temp_dir("loong-tool-surface-summary");
     std::fs::create_dir_all(&root).expect("create fixture root");
 
     let config = test_tool_runtime_config(root.clone());
@@ -1889,6 +1889,35 @@ fn runtime_discoverable_tool_surface_summary_groups_visible_direct_and_hidden_su
     assert!(agent_surface.tool_ids.contains(&"agent".to_owned()));
 
     std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn runtime_discoverable_tool_surface_summary_uses_provider_invokable_hidden_entries() {
+    let config = runtime_config::ToolRuntimeConfig::default();
+    let view = runtime_tool_view_for_runtime_config(&config);
+    let all_discoverable_entries = runtime_discoverable_tool_entries(&config, Some(&view), false);
+    let provider_discoverable_entries =
+        runtime_discoverable_tool_entries(&config, Some(&view), true);
+    let all_discoverable_names = all_discoverable_entries
+        .iter()
+        .map(|entry| entry.canonical_name.as_str())
+        .collect::<BTreeSet<_>>();
+    let provider_discoverable_names = provider_discoverable_entries
+        .iter()
+        .map(|entry| entry.canonical_name.as_str())
+        .collect::<BTreeSet<_>>();
+    let summary = runtime_discoverable_tool_surface_summary_with_config(&config, Some(&view));
+
+    assert!(all_discoverable_names.contains("session_status"));
+    assert!(all_discoverable_names.contains("delegate"));
+    assert!(!provider_discoverable_names.contains("session_status"));
+    assert!(!provider_discoverable_names.contains("delegate"));
+    assert!(provider_discoverable_names.contains("provider.switch"));
+    assert_eq!(
+        summary.hidden_tool_count,
+        provider_discoverable_entries.len()
+    );
 }
 
 #[cfg(feature = "tool-webfetch")]
@@ -2340,7 +2369,7 @@ fn runtime_discoverable_tool_entries_intersect_injected_view_with_runtime_surfac
     config.sessions_enabled = false;
 
     let injected = ToolView::from_tool_names(["sessions_list", "config.import"]);
-    let names = runtime_discoverable_tool_entries(&config, Some(&injected))
+    let names = runtime_discoverable_tool_entries(&config, Some(&injected), false)
         .into_iter()
         .map(|entry| entry.canonical_name)
         .collect::<Vec<_>>();
@@ -2735,10 +2764,8 @@ fn discovered_tool_lease_uses_current_catalog_digest() {
 #[cfg(feature = "tool-file")]
 #[test]
 fn tool_invoke_rejects_tampered_or_missing_leases() {
-    let root = std::env::temp_dir().join(format!(
-        "loongclaw-tool-invoke-invalid-{}",
-        std::process::id()
-    ));
+    let root =
+        std::env::temp_dir().join(format!("loong-tool-invoke-invalid-{}", std::process::id()));
     std::fs::create_dir_all(&root).expect("create fixture root");
 
     let config = test_tool_runtime_config(root.clone());
@@ -2765,7 +2792,7 @@ fn tool_invoke_rejects_tampered_or_missing_leases() {
 #[test]
 fn tool_invoke_rejects_missing_outer_lease_field() {
     let root = std::env::temp_dir().join(format!(
-        "loongclaw-tool-invoke-missing-lease-{}",
+        "loong-tool-invoke-missing-lease-{}",
         std::process::id()
     ));
     std::fs::create_dir_all(&root).expect("create fixture root");
@@ -2797,7 +2824,7 @@ fn tool_invoke_rejects_missing_outer_lease_field() {
 #[test]
 fn tool_invoke_rejects_non_string_outer_lease_field() {
     let root = std::env::temp_dir().join(format!(
-        "loongclaw-tool-invoke-non-string-lease-{}",
+        "loong-tool-invoke-non-string-lease-{}",
         std::process::id()
     ));
     std::fs::create_dir_all(&root).expect("create fixture root");
@@ -2968,6 +2995,43 @@ fn tool_invoke_rejects_forged_reserved_internal_context_inside_arguments() {
     );
 
     std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn tool_search_hides_app_only_discoverables_from_provider_visible_results() {
+    let config = runtime_config::ToolRuntimeConfig::default();
+    let result = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({
+                "exact_tool_id": "session_status"
+            }),
+        },
+        &config,
+    )
+    .expect("search should succeed");
+
+    let results = result.payload["results"].as_array().expect("results array");
+
+    let grouped_agent_summary = "Inspect approvals, sessions, delegation, provider routing, or config migration through one hidden control tool.";
+
+    assert!(
+        results
+            .iter()
+            .all(|entry| entry["tool_id"] != "session_status"),
+        "session_status should stay out of provider-visible discovery: {results:?}"
+    );
+    assert!(
+        results
+            .iter()
+            .all(|entry| entry["summary"] != grouped_agent_summary),
+        "exact app-tool refresh should not fall back to the grouped agent card: {results:?}"
+    );
+    assert_eq!(
+        result.payload["diagnostics"]["reason"],
+        json!("exact_tool_id_not_visible")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This hardens discovery-first tool execution across the provider/runtime boundary.

- narrow provider-visible discovery to tools that the provider-facing `tool.invoke` path can actually execute
- stop rebinding follow-up `tool.invoke` requests to the current turn while preserving capability filtering for `tool.search`
- improve invalid lease repair guidance and provider lease extraction behavior
- centralize stable command resolution for `shell.exec` and `bash.exec` so launch remains stable under `PATH` drift

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`

Closes #1325
