### PR TITLE
Remove stale loongclaw installer aliases after the loong migration

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -99,9 +99,18 @@ function Install-Binary([string]$SourceBinary) {
     New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
     $primaryBinary = Join-Path $Prefix "$BinName.exe"
     Copy-Item -Force $SourceBinary $primaryBinary
-    return @{
-        Primary = $primaryBinary
+    return $primaryBinary
+}
+
+function Remove-LegacyBinaryIfPresent {
+    $legacyBinaryName = "loongclaw.exe"
+    $legacyBinary = Join-Path $Prefix $legacyBinaryName
+    if (-not (Test-Path $legacyBinary)) {
+        return
     }
+
+    Remove-Item -Force $legacyBinary
+    Write-Host "==> Removed legacy loongclaw compatibility command from $legacyBinary"
 }
 
 function Install-FromSource {
@@ -201,9 +210,10 @@ function Resolve-NormalizedPathEntryOrNull([string]$PathEntry) {
     }
 }
 
-$installResult = if ($Source) { Install-FromSource } else { Install-FromRelease }
+$primaryBinary = if ($Source) { Install-FromSource } else { Install-FromRelease }
+Remove-LegacyBinaryIfPresent
 
-Write-Host "==> Installed loong to $($installResult.Primary)"
+Write-Host "==> Installed loong to $primaryBinary"
 
 $normalizedPrefix = $Prefix
 $pathItems = ($env:PATH -split [IO.Path]::PathSeparator) |
@@ -238,7 +248,7 @@ if (-not $alreadyInSessionPath) {
 if ($Onboard) {
     Write-Host "==> Running guided onboarding"
     try {
-        & $installResult.Primary onboard | Out-Host
+        & $primaryBinary onboard | Out-Host
         if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
             Write-Host "==> Onboarding exited with code $LASTEXITCODE"
             Write-Host "==> You can run 'loong onboard' later to complete setup"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -207,6 +207,7 @@ release_base_url="${LOONG_INSTALL_RELEASE_BASE_URL:-${LOONG_INSTALL_RELEASE_BASE
 target_libc="${LOONG_INSTALL_TARGET_LIBC:-${LOONG_INSTALL_TARGET_LIBC:-auto}}"
 package_name="loong"
 bin_name="loong"
+legacy_bin_name="loongclaw"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -357,6 +358,25 @@ install_binary() {
 
   mkdir -p "${prefix}"
   install -m 755 "${source_path}" "${prefix}/${primary_output_name}"
+}
+
+remove_legacy_binary_if_present() {
+  local legacy_output_name="${1:?legacy_output_name is required}"
+  local legacy_output_path="${prefix}/${legacy_output_name}"
+  local legacy_output_exists=0
+
+  if [[ -e "${legacy_output_path}" ]]; then
+    legacy_output_exists=1
+  fi
+  if [[ -L "${legacy_output_path}" ]]; then
+    legacy_output_exists=1
+  fi
+  if [[ "${legacy_output_exists}" -eq 0 ]]; then
+    return 0
+  fi
+
+  rm -f "${legacy_output_path}"
+  printf '==> Removed legacy loongclaw compatibility command from %s\n' "${legacy_output_path}"
 }
 
 install_web_search_provider_display_name() {
@@ -854,6 +874,8 @@ if [[ "${install_source}" -eq 1 ]]; then
 else
   install_from_release
 fi
+
+remove_legacy_binary_if_present "${legacy_bin_name}"
 
 printf '==> Installed loong to %s\n' "${prefix}/${bin_name}"
 

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -6,6 +6,7 @@ SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/install.sh"
 . "$REPO_ROOT/scripts/release_artifact_lib.sh"
 PACKAGE_NAME="loong"
 PRIMARY_BIN_NAME="loong"
+LEGACY_BIN_NAME="loongclaw"
 
 assert_contains() {
   local file="$1"
@@ -31,8 +32,12 @@ assert_installed_binary() {
   local install_dir="$1"
   local expected_output="$2"
   local primary_output
+  local legacy_path
 
   [[ -x "$install_dir/$PRIMARY_BIN_NAME" ]]
+  legacy_path="$install_dir/$LEGACY_BIN_NAME"
+  [[ ! -e "$legacy_path" ]]
+  [[ ! -L "$legacy_path" ]]
 
   primary_output="$("$install_dir/$PRIMARY_BIN_NAME")"
 
@@ -630,6 +635,28 @@ run_release_override_install_and_onboard_test() {
   assert_contains "$marker" "onboard"
 }
 
+run_release_install_removes_stale_legacy_binary_test() {
+  local fixture install_dir output_file stale_legacy_binary
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install-remove-legacy.out"
+  stale_legacy_binary="$install_dir/$LEGACY_BIN_NAME"
+
+  mkdir -p "$install_dir"
+  printf 'stale legacy binary\n' >"$stale_legacy_binary"
+  chmod +x "$stale_legacy_binary"
+
+  (
+    cd "$REPO_ROOT"
+    LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary "$install_dir" "fixture-binary"
+  assert_contains "$output_file" "Removed legacy loongclaw compatibility command from"
+}
+
 run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
   local fixture
   local home_dir
@@ -1092,6 +1119,7 @@ run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
 }
 
 run_release_override_install_and_onboard_test
+run_release_install_removes_stale_legacy_binary_test
 run_release_install_adds_path_to_bashrc_and_prints_source_hint_test
 run_release_install_skips_source_hint_when_path_is_already_available_test
 run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test


### PR DESCRIPTION
## Summary

- Problem: the repo already migrated to shipping only `loong`, but installer runs could still leave an old `loongclaw` executable behind in the install prefix from previous releases.
- Why it matters: that stale alias makes local machines look like the dual-binary contract still exists, which is confusing for operators and weakens the single-command migration.
- What changed: both installers now remove a stale `loongclaw` binary after installing `loong`, and the shell installer regression suite now proves that cleanup path.
- What did not change (scope boundary): the current single-binary build/release contract, Cargo targets, and active docs remain as they already are on `dev`.

## Linked Issues

- Closes #1331
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-features --locked
LOONG_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
bash scripts/test_install_sh.sh
bash scripts/test_release_workflow_hardening.sh
```

## User-visible / Operator-visible Changes

- Re-running the Bash or PowerShell installer now removes a stale `loongclaw` executable from the install prefix if one is present.
- Fresh installs still ship only `loong`.

## Failure Recovery

- Fast rollback or disable path: remove the post-install cleanup step from `scripts/install.sh` and `scripts/install.ps1`, and delete the stale-alias regression assertion from `scripts/test_install_sh.sh`.
- Observable failure symptoms reviewers should watch for: installer runs unexpectedly deleting a non-Loong file named `loongclaw` in the selected prefix.

## Reviewer Focus

- `scripts/install.sh` and `scripts/install.ps1` for the stale-alias cleanup behavior.
- `scripts/test_install_sh.sh` for the new regression coverage and absence assertion.
