### PR TITLE
release: prepare v0.1.2-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,45 @@ The format follows Keep a Changelog and semantic versioning intent.
 
 ## [Unreleased]
 
+## [0.1.2-alpha.1] - 2026-04-20
+
+### Added
+
+- Added mailbox-backed delegate result delivery and wakeups, persisted frozen delegate results, and parent-session delegate result announcements.
+- Added workflow-aware daemon sessions shell coverage, latest-session selector support, session search / trajectory artifact CLIs, and richer session inspection surfaces.
+- Added provenance-aware workspace recall, registered pre-assembly memory systems, typed memory stage contracts, staged hydration envelopes, compact-stage seams, and narrower cross-session recall artifacts.
+- Added runtime-capability family readiness indexes, promotion planning, governed apply surfaces, and delta-evidence capture for release and operator workflows.
+- Added gateway localhost control surfaces including health, events, turn endpoints, local clients, event buses, read models, loopback control-plane subscriptions, and remote control-plane hardening.
+- Added manifest-first plugin packaging, plugin inventory / doctor CLIs, typed setup metadata and provenance surfaces, plugin setup-readiness gating, managed bridge discovery, stable-target contracts, and governed plugin bridge handoff flows.
+- Added config-backed outbound surfaces for webhook, Teams, iMessage, email, IRC, Nostr, Twitch, Tlon, WhatsApp, Matrix, WeCom, and wider runtime-backed multi-channel supervision.
+- Added Feishu document, bitable, calendar, websocket, wildcard allowlist, QR onboarding, and emoji reply capabilities.
+- Added Xiaomi and Bailian Coding provider support, multi-provider web-search selection, Firecrawl web search provider support, multi-region onboarding endpoint selection, and stronger provider descriptor projections.
+- Added bash.exec support with AST-governed prefix rules, file.edit text replacement support, tool concurrency metadata, tool execution timeouts, structured developer tracing, bundled skill packs, and expanded external skill intake safety gates.
+- Added typed subagent handles, private operator runtime seams, prompt-orchestrator tool discovery context, prompt personality expansion, durable workspace memory tools, and runtime-self continuity loading.
+- Added background tasks CLI, personalize operator preferences, doctor security audit surfaces, audit inspection CLIs, shell completion generation, Android Termux release builds, Linux musl release contracts, and Windows CI coverage.
+
+### Changed
+
+- Reworked memory continuity so durable recall, staged retrieval, runtime-self continuity, workspace corpus handling, compaction, and recall metadata stay aligned across chat, tools, and daemon flows.
+- Tightened approval, consent, binding-first runtime seams, governed workflow contracts, session tool-policy controls, trust-event projection, and operator approval replay behavior.
+- Productized delegate child orchestration, continuity compaction surfaces, live chat status rendering, fast-lane diagnostics, direct-tool summaries, and shell discoverability while preserving bounded runtime behavior.
+- Matured onboarding UX with clearer provider / web-search guidance, safer credential handling, explicit contract labels, profile-aware defaults, and stronger recovery prompts.
+- Refined plugin, channel, daemon, conversation, runtime, and memory module boundaries to stay within architecture budgets without splitting the shipped `loong` product surface.
+- Refreshed release governance with stricter docs gates, architecture-drift freshness checks, crates.io publish preparation, and stable self-update routing toward the intended release lane.
+- Continued the public Loong rebrand across documentation, site navigation, public guides, README flows, and contributor-facing references.
+
 ### Fixed
 
 - Restored provider-side tool execution when OpenAI-compatible responses emit standalone JSON tool blocks or Ollama-style `<tool_call>...</tool_call>` fallbacks instead of native `tool_calls`.
+- Fixed numerous provider onboarding and auth regressions including auth-profile fallback, missing managed credentials, alternative auth guidance, canonicalized env bindings, quieter auto-model failover logs, and corrected StepPlan endpoint guidance.
+- Fixed Feishu reply ordering, websocket TLS/provider setup, document content preservation, card schema handling, callback approval routing, auth permission guidance, and broader tool/runtime regressions.
+- Fixed browser companion probe retries, gateway stack-overflow follow-ups, MCP snapshot redaction and proxy safety edges, and multi-channel supervisor shutdown / fail-closed behavior.
+- Fixed Windows-specific sqlite, temp-path, UNC-path, worktree cleanup, and locked-file edge cases plus cwd/process-global drift that destabilized tests and runtime cleanup.
+- Fixed bash governance matching, broken-rule visibility, rules-dir semantics, timeout cleanup, discoverability regressions, approval routing, and shell summary redaction.
+- Fixed session continuity, tool discovery prompt boundaries, continuity fallback, durable flush claims, provider route diagnostics, session policy context handling, and latest-runtime narrowing guards.
+- Fixed plugin governance compatibility, setup-readiness validation, manifest write safety, managed discovery rollback, and external-skill policy probing.
+- Fixed outbound HTTP trust enforcement, browser boundary handling, webhook auth/status redaction, channel validation, WhatsApp/Twitch/Nostr/IRC serve/runtime regressions, and truthful bridge-backed diagnostics.
+- Fixed release, CI, and docs drift issues across architecture snapshots, release artifact checks, arm64 packaging, dependency PR blocking, and publish-flow verification.
 
 ## [0.1.0-alpha.2] - 2026-03-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "0fc35b7a14cabdad13795fbbbd26d5ddec0882c01492ceedf2af575aad5f37dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "loong"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "loong-app"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "aes",
  "async-trait",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "loong-bench"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "hex",
  "loong-kernel",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "loong-bridge-runtime"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "loong-contracts",
  "loong-kernel",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "loong-contracts"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "semver",
  "serde",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "loong-kernel"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "loong-protocol"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "loong-spec"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3601,7 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3962,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -4828,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -5614,9 +5614,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -5806,11 +5806,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5819,7 +5819,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5899,12 +5899,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -5968,6 +5968,17 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -6146,22 +6157,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "246.0.2"
+version = "247.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.247.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
 dependencies = [
  "wast",
 ]
@@ -6188,9 +6199,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -6557,6 +6568,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.0-alpha.3"
+version = "0.1.2-alpha.1"
 authors = ["chumyin"]
 repository = "https://github.com/eastreams/loong"
 homepage = "https://github.com/eastreams/loong"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -53,8 +53,8 @@ tool-websearch = []
 test-support = []
 
 [dependencies]
-loong-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
-loong-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loong-contracts = { package = "loong-contracts", version = "0.1.2-alpha.1", path = "../contracts" }
+loong-kernel = { package = "loong-kernel", version = "0.1.2-alpha.1", path = "../kernel" }
 bytes = "1"
 async-trait.workspace = true
 console.workspace = true

--- a/crates/app/src/chat/session_surface.rs
+++ b/crates/app/src/chat/session_surface.rs
@@ -4845,7 +4845,7 @@ mod tests {
     fn sample_render_data() -> SurfaceRenderData {
         SurfaceRenderData {
             header_lines: vec![
-                "LOONG  v0.1.0-alpha.3".to_owned(),
+                "LOONG  v0.1.2-alpha.1".to_owned(),
                 "interactive chat".to_owned(),
             ],
             header_status_line:

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -53,9 +53,10 @@ fn test_tool_runtime_config(root: impl AsRef<Path>) -> ToolTestRuntimeConfig {
 }
 
 fn ready_bash_exec_runtime_policy() -> runtime_config::BashExecRuntimePolicy {
+    let resolved_bash = which::which("bash").unwrap_or_else(|_| PathBuf::from("/bin/bash"));
     runtime_config::BashExecRuntimePolicy {
         available: true,
-        command: Some(PathBuf::from("bash")),
+        command: Some(resolved_bash),
         ..runtime_config::BashExecRuntimePolicy::default()
     }
 }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -15,8 +15,8 @@ name = "loong_bench"
 test-support = []
 
 [dependencies]
-loong-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec" }
-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loong-spec = { package = "loong-spec", version = "0.1.2-alpha.1", path = "../spec" }
+kernel = { package = "loong-kernel", version = "0.1.2-alpha.1", path = "../kernel" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bridge-runtime/Cargo.toml
+++ b/crates/bridge-runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-loong-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
-loong-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
-loong-protocol = { package = "loong-protocol", version = "0.1.0-alpha.3", path = "../protocol" }
+loong-contracts = { package = "loong-contracts", version = "0.1.2-alpha.1", path = "../contracts" }
+loong-kernel = { package = "loong-kernel", version = "0.1.2-alpha.1", path = "../kernel" }
+loong-protocol = { package = "loong-protocol", version = "0.1.2-alpha.1", path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -64,13 +64,13 @@ axum = { workspace = true, features = ["query"] }
 clap.workspace = true
 clap_complete = "4.5"
 dialoguer.workspace = true
-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
-loong-bench = { package = "loong-bench", version = "0.1.0-alpha.3", path = "../bench" }
-loong-app = { package = "loong-app", version = "0.1.0-alpha.3", path = "../app", default-features = false }
-loong-bridge-runtime = { version = "0.1.0-alpha.3", path = "../bridge-runtime" }
-loong-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
-loong-protocol = { package = "loong-protocol", version = "0.1.0-alpha.3", path = "../protocol" }
-loong-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec" }
+kernel = { package = "loong-kernel", version = "0.1.2-alpha.1", path = "../kernel" }
+loong-bench = { package = "loong-bench", version = "0.1.2-alpha.1", path = "../bench" }
+loong-app = { package = "loong-app", version = "0.1.2-alpha.1", path = "../app", default-features = false }
+loong-bridge-runtime = { version = "0.1.2-alpha.1", path = "../bridge-runtime" }
+loong-contracts = { package = "loong-contracts", version = "0.1.2-alpha.1", path = "../contracts" }
+loong-protocol = { package = "loong-protocol", version = "0.1.2-alpha.1", path = "../protocol" }
+loong-spec = { package = "loong-spec", version = "0.1.2-alpha.1", path = "../spec" }
 serde.workspace = true
 serde_json.workspace = true
 futures-util.workspace = true
@@ -94,7 +94,7 @@ wait-timeout = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
-loong-spec = { package = "loong-spec", version = "0.1.0-alpha.3", path = "../spec", features = ["test-hooks"] }
+loong-spec = { package = "loong-spec", version = "0.1.2-alpha.1", path = "../spec", features = ["test-hooks"] }
 syn = { version = "2", features = ["full", "visit"] }
 tower = { version = "0.5", features = ["util"] }
 wat = "1"

--- a/crates/daemon/src/lib_first_run_entry_tests.rs
+++ b/crates/daemon/src/lib_first_run_entry_tests.rs
@@ -72,7 +72,7 @@ fn resolve_default_entry_command_routes_to_welcome_when_default_config_exists() 
 
 #[test]
 fn resolve_default_entry_command_ignores_loongclaw_config_path_without_compat_shim() {
-    let mut env = ScopedEnv::new();
+    let (mut env, _home) = isolated_home("loong-default-entry-legacy-env");
     let config_path = unique_temp_dir("loongclaw-default-entry-env").join("custom-config.toml");
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent).expect("create config parent");
@@ -114,10 +114,10 @@ fn resolve_default_entry_command_honors_loong_config_path_override() {
 
 #[test]
 fn resolve_default_entry_command_routes_to_onboard_when_config_path_is_a_directory() {
-    let mut env = ScopedEnv::new();
-    let config_dir = unique_temp_dir("loongclaw-default-entry-dir");
+    let (mut env, _home) = isolated_home("loong-default-entry-dir");
+    let config_dir = unique_temp_dir("loong-default-entry-dir");
     fs::create_dir_all(&config_dir).expect("create config directory");
-    env.set("LOONGCLAW_CONFIG_PATH", &config_dir);
+    env.set("LOONG_CONFIG_PATH", &config_dir);
 
     assert!(
         matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
@@ -146,9 +146,9 @@ fn redacted_command_name_omits_sensitive_command_payloads() {
 
 #[test]
 fn run_welcome_cli_rejects_missing_config_file() {
-    let mut env = ScopedEnv::new();
-    let config_path = unique_temp_dir("loongclaw-welcome-missing").join("missing-config.toml");
-    env.set("LOONGCLAW_CONFIG_PATH", &config_path);
+    let (mut env, _home) = isolated_home("loong-welcome-missing");
+    let config_path = unique_temp_dir("loong-welcome-missing").join("missing-config.toml");
+    env.set("LOONG_CONFIG_PATH", &config_path);
 
     let error = run_welcome_cli().expect_err("missing config should fail welcome");
 
@@ -164,10 +164,10 @@ fn run_welcome_cli_rejects_missing_config_file() {
 
 #[test]
 fn run_welcome_cli_rejects_directory_config_path() {
-    let mut env = ScopedEnv::new();
-    let config_dir = unique_temp_dir("loongclaw-welcome-dir");
+    let (mut env, _home) = isolated_home("loong-welcome-dir");
+    let config_dir = unique_temp_dir("loong-welcome-dir");
     fs::create_dir_all(&config_dir).expect("create config directory");
-    env.set("LOONGCLAW_CONFIG_PATH", &config_dir);
+    env.set("LOONG_CONFIG_PATH", &config_dir);
 
     let error = run_welcome_cli().expect_err("directory config path should fail welcome");
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)] // CLI daemon binary
 use loong_daemon::*;
 
+#[cfg(debug_assertions)]
 const DEBUG_TOKIO_WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
 const MAX_TOKIO_WORKER_STACK_BYTES: usize = 16 * 1024 * 1024;
 const TOKIO_WORKER_STACK_ENV: &str = "LOONG_TOKIO_WORKER_STACK_BYTES";
@@ -60,6 +61,7 @@ fn redacted_command_name(command: &Commands) -> &'static str {
     command.command_kind_for_logging()
 }
 
+#[cfg(debug_assertions)]
 fn command_prefers_large_tokio_worker_stack(command: &Commands) -> bool {
     matches!(
         command,

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 name = "loong_kernel"
 
 [dependencies]
-loong-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
+loong-contracts = { package = "loong-contracts", version = "0.1.2-alpha.1", path = "../contracts" }
 async-trait.workspace = true
 futures-util.workspace = true
 hex.workspace = true

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -3912,6 +3912,7 @@ mod tests {
 
     #[test]
     fn absorb_allows_shared_and_advisory_slot_claims_and_projects_metadata() {
+        let current_host_version_req = format!(">={}", env!("CARGO_PKG_VERSION"));
         let report = PluginScanReport {
             scanned_files: 2,
             matched_plugins: 2,
@@ -3950,7 +3951,7 @@ mod tests {
                         }],
                         compatibility: Some(PluginCompatibility {
                             host_api: Some(CURRENT_PLUGIN_HOST_API.to_owned()),
-                            host_version_req: Some(">=0.1.0-alpha.1".to_owned()),
+                            host_version_req: Some(current_host_version_req.clone()),
                         }),
                     },
                 },
@@ -4021,7 +4022,7 @@ mod tests {
                 .metadata
                 .get(PLUGIN_COMPATIBILITY_HOST_VERSION_REQ_METADATA_KEY)
                 .map(String::as_str),
-            Some(">=0.1.0-alpha.1")
+            Some(current_host_version_req.as_str())
         );
     }
 

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -17,10 +17,10 @@ test-support = ["test-hooks"]
 
 [dependencies]
 async-trait.workspace = true
-kernel = { package = "loong-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
-loong-contracts = { package = "loong-contracts", version = "0.1.0-alpha.3", path = "../contracts" }
-loong-protocol = { package = "loong-protocol", version = "0.1.0-alpha.3", path = "../protocol" }
-loong-bridge-runtime = { version = "0.1.0-alpha.3", path = "../bridge-runtime" }
+kernel = { package = "loong-kernel", version = "0.1.2-alpha.1", path = "../kernel" }
+loong-contracts = { package = "loong-contracts", version = "0.1.2-alpha.1", path = "../contracts" }
+loong-protocol = { package = "loong-protocol", version = "0.1.2-alpha.1", path = "../protocol" }
+loong-bridge-runtime = { version = "0.1.2-alpha.1", path = "../bridge-runtime" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/docs/releases/v0.1.2-alpha.1-announcement.md
+++ b/docs/releases/v0.1.2-alpha.1-announcement.md
@@ -1,0 +1,31 @@
+# Release v0.1.2-alpha.1 Announcement
+
+Loong v0.1.2-alpha.1 promotes the latest clean `dev` snapshot into the new `0.1.2` prerelease line.
+
+## Highlights
+- Added mailbox-backed delegate delivery, persisted frozen delegate results, richer session shells, and new session / trajectory inspection surfaces.
+- Expanded memory with provenance-aware recall, staged hydration, pre-assembly systems, compact-stage seams, and tighter continuity across chat, tools, and daemon flows.
+- Shipped broader gateway, runtime-capability, plugin, and managed-bridge surfaces for governed operator workflows.
+- Extended channel coverage across Feishu, WhatsApp, Matrix, WeCom, IRC, Nostr, Twitch, Tlon, webhook, email, Teams, and iMessage while improving runtime-backed multi-channel supervision.
+- Added bash.exec governance, file.edit support, tool concurrency metadata, execution timeouts, expanded skill intake, new providers, stronger onboarding, and sturdier release / CI contracts.
+
+## Contributors
+- Chum Yin
+- xj
+- Chummy
+- Mike-7777777
+- dependabot[bot]
+- little_penguin66
+- 梁展波
+- ThreeIce
+- and other contributors in the `v0.1.0-alpha.2..v0.1.2-alpha.1` range
+
+## Links
+- [Canonical release report](./v0.1.2-alpha.1.md)
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow definition](../../.github/workflows/release.yml)
+- [GitHub release page](https://github.com/eastreams/loong/releases/tag/v0.1.2-alpha.1)
+- [crates.io package page](https://crates.io/crates/loong)
+- Generated at: `2026-04-20T15:20:00Z`
+- Trace ID: `7569f827`
+- Trace path: `.docs/traces/20260420T152000Z-post-release-v0.1.2-alpha.1-7569f827`

--- a/docs/releases/v0.1.2-alpha.1.md
+++ b/docs/releases/v0.1.2-alpha.1.md
@@ -1,0 +1,69 @@
+# Release v0.1.2-alpha.1
+
+## Summary
+- Generated at: 2026-04-20T15:20:00Z
+- Release status: queued for publication (draft=false, prerelease=true)
+- Target commitish: `main`
+- Artifact count: pending release workflow assets
+- Trace ID: `7569f827`
+- Trace path: `.docs/traces/20260420T152000Z-post-release-v0.1.2-alpha.1-7569f827`
+
+## Highlights
+- Added mailbox-backed delegate delivery, persisted frozen delegate results, richer session shells, and new session / trajectory inspection surfaces.
+- Expanded memory with provenance-aware recall, staged hydration, pre-assembly systems, compact-stage seams, and tighter continuity across chat, tools, and daemon flows.
+- Shipped broader gateway, runtime-capability, plugin, and managed-bridge surfaces for governed operator workflows.
+- Extended channel coverage across Feishu, WhatsApp, Matrix, WeCom, IRC, Nostr, Twitch, Tlon, webhook, email, Teams, and iMessage while improving runtime-backed multi-channel supervision.
+- Added bash.exec governance, file.edit support, tool concurrency metadata, execution timeouts, expanded skill intake, new providers, stronger onboarding, and sturdier release / CI contracts.
+
+## Contributors
+- Chum Yin
+- xj
+- Chummy
+- Mike-7777777
+- dependabot[bot]
+- little_penguin66
+- 梁展波
+- ThreeIce
+- and other contributors in the `v0.1.0-alpha.2..v0.1.2-alpha.1` range
+
+## Process
+- Date: 2026-04-20T15:20:00Z
+- Owner: chumyin
+- Scope summary: promote the latest clean `dev` snapshot into `main`, publish the full Loong workspace crates as `0.1.2-alpha.1`, and tag `v0.1.2-alpha.1` from `main`.
+- Gates run: local `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `cargo doc --workspace --no-deps`, `scripts/test_publish_crates_io.sh`, `scripts/bootstrap_release_local_artifacts.sh`, `LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`, `scripts/check_dep_graph.sh`, `LOONG_ARCH_STRICT=true scripts/check_architecture_boundaries.sh`, and a release `cargo build --release --locked -p loong --bin loong` verification run.
+- Refactor budget item: fix the crates.io publish chain so the internal `loong-bridge-runtime` crate ships in the same ordered release path as the product crate.
+
+## Artifacts
+| Asset | Size (bytes) | SHA256 | Download |
+|---|---:|---|---|
+| `install.sh` | pending | pending | [link](https://github.com/eastreams/loong/releases/download/v0.1.2-alpha.1/install.sh) |
+| `install.ps1` | pending | pending | [link](https://github.com/eastreams/loong/releases/download/v0.1.2-alpha.1/install.ps1) |
+| `release binaries and checksums` | pending | pending | [release page](https://github.com/eastreams/loong/releases/tag/v0.1.2-alpha.1) |
+
+## Verification
+| Check | Result | Evidence |
+|---|---|---|
+| Release workflow completed successfully | PENDING | [release workflow](https://github.com/eastreams/loong/actions/workflows/release.yml) |
+| GitHub release is not draft | PENDING | [release page](https://github.com/eastreams/loong/releases/tag/v0.1.2-alpha.1) |
+| Workspace crates published in dependency order | PENDING | [crates.io loong page](https://crates.io/crates/loong) |
+
+## Refactor Budget
+- Hotspot metric paid down: release/publish-chain correctness for the full product workspace.
+- Evidence: `scripts/publish_crates_io.sh` and `scripts/test_publish_crates_io.sh` now include `loong-bridge-runtime` in the ordered publish chain used to ship the full `loong` product.
+- If no paydown shipped, rationale: n/a.
+
+## Known Issues
+- crates.io retains the historical `loong` package page and older versions from before the crate transfer; this prerelease continues the Loong-owned line with current metadata, owners, and repository links.
+
+## Rollback
+- Yank the `0.1.2-alpha.1` crates if a publish defect is discovered.
+- Mark the GitHub release draft or remove broken assets, then publish a superseding prerelease.
+- Document any superseding tag in `CHANGELOG.md` and the follow-up release note.
+
+## Detail Links
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow definition](../../.github/workflows/release.yml)
+- [GitHub release page](https://github.com/eastreams/loong/releases/tag/v0.1.2-alpha.1)
+- [crates.io package page](https://crates.io/crates/loong)
+- Trace directory: `.docs/traces/20260420T152000Z-post-release-v0.1.2-alpha.1-7569f827`
+- Local debug log: `.docs/releases/v0.1.2-alpha.1-debug.md`

--- a/scripts/publish_crates_io.sh
+++ b/scripts/publish_crates_io.sh
@@ -8,6 +8,7 @@ PACKAGES=(
   loong-contracts
   loong-protocol
   loong-kernel
+  loong-bridge-runtime
   loong-spec
   loong-bench
   loong-app
@@ -28,7 +29,7 @@ Real publish mode:
   scripts/publish_crates_io.sh --publish
 
 Resume from a package in the publish chain:
-  scripts/publish_crates_io.sh --from loong-spec
+  scripts/publish_crates_io.sh --from loong-bridge-runtime
 EOF
 }
 

--- a/scripts/test_publish_crates_io.sh
+++ b/scripts/test_publish_crates_io.sh
@@ -7,6 +7,7 @@ PACKAGE_CHAIN=(
   loong-contracts
   loong-protocol
   loong-kernel
+  loong-bridge-runtime
   loong-spec
   loong-bench
   loong-app
@@ -157,16 +158,17 @@ run_resume_from_test() {
 
   PATH="$stub_dir:$PATH" \
     FAKE_CARGO_INVOCATION_LOG="$invocation_log" \
-    bash "$SCRIPT_UNDER_TEST" --from loong-spec >"$output_file" 2>&1
+    bash "$SCRIPT_UNDER_TEST" --from loong-bridge-runtime >"$output_file" 2>&1
 
   assert_publish_sequence \
     "$invocation_log" \
     "dry-run" \
+    loong-bridge-runtime \
     loong-spec \
     loong-bench \
     loong-app \
     loong
-  assert_contains "$output_file" "starting from: loong-spec"
+  assert_contains "$output_file" "starting from: loong-bridge-runtime"
 }
 
 run_default_dry_run_test


### PR DESCRIPTION
## Summary
- bump the full workspace release line to 0.1.2-alpha.1
- add release notes/changelog entries and include loong-bridge-runtime in the crates.io publish chain
- harden brittle release-related tests and clean release-build warnings

## Validation
- cargo fmt --all --check
- bash scripts/test_publish_crates_io.sh
- scripts/bootstrap_release_local_artifacts.sh
- LOONG_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --locked
- cargo test --workspace --all-features --locked
- cargo doc --workspace --no-deps
- ./scripts/check_dep_graph.sh
- LOONG_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
- cargo build --release --locked -p loong --bin loong
- ./target/release/loong --version