### PR TITLE
Skip installer legacy cleanup when loongclaw is not a file

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -105,11 +105,15 @@ function Install-Binary([string]$SourceBinary) {
 function Remove-LegacyBinaryIfPresent {
     $legacyBinaryName = "loongclaw.exe"
     $legacyBinary = Join-Path $Prefix $legacyBinaryName
-    if (-not (Test-Path $legacyBinary)) {
+    $legacyBinaryItem = Get-Item -LiteralPath $legacyBinary -Force -ErrorAction SilentlyContinue
+    if ($null -eq $legacyBinaryItem) {
+        return
+    }
+    if ($legacyBinaryItem.PSIsContainer) {
         return
     }
 
-    Remove-Item -Force $legacyBinary
+    Remove-Item -LiteralPath $legacyBinary -Force
     Write-Host "==> Removed legacy loongclaw compatibility command from $legacyBinary"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -363,15 +363,14 @@ install_binary() {
 remove_legacy_binary_if_present() {
   local legacy_output_name="${1:?legacy_output_name is required}"
   local legacy_output_path="${prefix}/${legacy_output_name}"
-  local legacy_output_exists=0
 
-  if [[ -e "${legacy_output_path}" ]]; then
-    legacy_output_exists=1
-  fi
   if [[ -L "${legacy_output_path}" ]]; then
-    legacy_output_exists=1
+    rm -f "${legacy_output_path}"
+    printf '==> Removed legacy loongclaw compatibility command from %s\n' "${legacy_output_path}"
+    return 0
   fi
-  if [[ "${legacy_output_exists}" -eq 0 ]]; then
+
+  if [[ ! -f "${legacy_output_path}" ]]; then
     return 0
   fi
 

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -36,7 +36,7 @@ assert_installed_binary() {
 
   [[ -x "$install_dir/$PRIMARY_BIN_NAME" ]]
   legacy_path="$install_dir/$LEGACY_BIN_NAME"
-  [[ ! -e "$legacy_path" ]]
+  [[ ! -f "$legacy_path" ]]
   [[ ! -L "$legacy_path" ]]
 
   primary_output="$("$install_dir/$PRIMARY_BIN_NAME")"
@@ -657,6 +657,27 @@ run_release_install_removes_stale_legacy_binary_test() {
   assert_contains "$output_file" "Removed legacy loongclaw compatibility command from"
 }
 
+run_release_install_keeps_legacy_directory_collision_test() {
+  local fixture install_dir output_file stale_legacy_directory
+  fixture="$(make_release_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/install-keep-legacy-directory.out"
+  stale_legacy_directory="$install_dir/$LEGACY_BIN_NAME"
+
+  mkdir -p "$stale_legacy_directory"
+
+  (
+    cd "$REPO_ROOT"
+    LOONG_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_installed_binary "$install_dir" "fixture-binary"
+  [[ -d "$stale_legacy_directory" ]]
+  assert_not_contains "$output_file" "Removed legacy loongclaw compatibility command from"
+}
+
 run_release_install_adds_path_to_bashrc_and_prints_source_hint_test() {
   local fixture
   local home_dir
@@ -1120,6 +1141,7 @@ run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
 
 run_release_override_install_and_onboard_test
 run_release_install_removes_stale_legacy_binary_test
+run_release_install_keeps_legacy_directory_collision_test
 run_release_install_adds_path_to_bashrc_and_prints_source_hint_test
 run_release_install_skips_source_hint_when_path_is_already_available_test
 run_release_install_keeps_source_hint_when_rc_already_has_path_entry_test


### PR DESCRIPTION
## Summary

- Problem: the stale `loongclaw` cleanup added in #1332 removes any same-name path in the install prefix, so the bash installer now fails if `loongclaw` is a directory instead of an old executable.
- Why it matters: the cleanup is meant to narrow the shipped command surface, not mutate arbitrary same-name paths or turn an upgrade into a partial install failure.
- What changed: both installers now only remove stale legacy executable artifacts, and the shell installer regression suite now covers the directory-collision case.
- What did not change (scope boundary): the single-binary `loong` delivery contract, the stale executable cleanup itself, and the rest of the install prefix remain unchanged.

## Linked Issues

- Closes #
- Related #1332

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
bash -n scripts/install.sh
bash -n scripts/test_install_sh.sh
bash scripts/test_install_sh.sh
bash scripts/test_release_workflow_hardening.sh
LOONG_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh test --workspace --locked
./scripts/cargo-local-toolchain.sh test --workspace --all-features --locked
```

Additional behavior check:
- manually reproduced the pre-fix failure by creating `<prefix>/loongclaw/` as a directory before install and verified the fixed installer now leaves that directory alone while still installing `loong` successfully.
- local PowerShell execution was not available, so `scripts/install.ps1` was validated by code review rather than native runtime execution.

## User-visible / Operator-visible Changes

- Re-running the installers still removes stale `loongclaw` executable artifacts.
- Installer runs no longer fail when the install prefix already contains a directory named `loongclaw` / `loongclaw.exe`.

## Failure Recovery

- Fast rollback or disable path: revert the file-type guard in `scripts/install.sh` and the container guard in `scripts/install.ps1`, then remove the new directory-collision regression test.
- Observable failure symptoms reviewers should watch for: installer cleanup starts deleting non-file paths again, or stale executable aliases stop being removed.

## Reviewer Focus

- `scripts/install.sh` for the file-vs-directory guard around legacy cleanup.
- `scripts/install.ps1` for the equivalent literal-path and container check.
- `scripts/test_install_sh.sh` for the new directory-collision regression coverage.
