### PR TITLE
feat(feishu): render onboard QR locally via qrcode crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2954,6 +2954,7 @@ dependencies = [
  "loong-kernel",
  "loong-protocol",
  "loong-spec",
+ "qrcode",
  "rand 0.10.1",
  "reqwest",
  "rusqlite",
@@ -3861,6 +3862,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quick-error"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -91,6 +91,7 @@ dunce = "1"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 wait-timeout = "0.2"
+qrcode = { version = "0.14", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/daemon/src/feishu_onboarding.rs
+++ b/crates/daemon/src/feishu_onboarding.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
-use std::process::Command;
 use std::time::Duration;
 
 use loong_contracts::SecretRef;
+use qrcode::QrCode;
+use qrcode::render::unicode;
 use serde_json::Value;
 
 use crate::CliResult;
@@ -182,16 +183,16 @@ pub fn apply_manual_feishu_onboarding(
 pub fn render_qr_instructions(url: &str, qr_rendered: bool) -> Vec<String> {
     if qr_rendered {
         return vec![
-            format!("Scan the QR code above, or open this URL directly: {url}"),
+            "Scan the QR code above with Feishu/Lark on your phone,".to_owned(),
+            format!("or open this link on your desktop: {url}"),
             "The command will keep polling until Feishu/Lark returns the generated bot credentials."
                 .to_owned(),
         ];
     }
 
-    vec![
-        format!("Open this URL in Feishu/Lark on your phone: {url}"),
-        "Install `qrencode` to display a scannable QR code in the terminal next time.".to_owned(),
-    ]
+    vec![format!(
+        "Open this link in Feishu/Lark to activate the bot: {url}"
+    )]
 }
 
 fn apply_onboard_result_to_config(
@@ -612,24 +613,27 @@ async fn post_registration(
 }
 
 fn render_terminal_qr(url: &str) -> bool {
-    let output = Command::new("qrencode")
-        .args(["-t", "ANSIUTF8", url])
-        .output();
-    let Ok(output) = output else {
+    let Some(rendered) = encode_terminal_qr(url) else {
         return false;
     };
-    if !output.status.success() {
-        return false;
-    }
-    let rendered = String::from_utf8(output.stdout).ok();
-    let Some(rendered) = rendered.map(|value| value.trim().to_owned()) else {
-        return false;
-    };
-    if rendered.is_empty() {
-        return false;
-    }
     println!("{rendered}");
     true
+}
+
+fn encode_terminal_qr(url: &str) -> Option<String> {
+    let code = QrCode::new(url.as_bytes()).ok()?;
+    let rendered = code
+        .render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .quiet_zone(true)
+        .build();
+    let trimmed = rendered.trim().to_owned();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 fn required_string(payload: &Value, field: &str) -> CliResult<String> {
@@ -723,11 +727,30 @@ mod tests {
     }
 
     #[test]
-    fn render_qr_instructions_switches_to_fallback_copy_when_qr_is_unavailable() {
+    fn render_qr_instructions_shows_both_scan_and_desktop_paths_when_qr_rendered() {
+        let rendered = render_qr_instructions("https://scan.example/activate", true).join("\n");
+
+        assert!(rendered.contains("Scan the QR code above"));
+        assert!(rendered.contains("open this link on your desktop"));
+        assert!(rendered.contains("https://scan.example/activate"));
+    }
+
+    #[test]
+    fn render_qr_instructions_falls_back_to_link_only_when_qr_is_unavailable() {
         let rendered = render_qr_instructions("https://scan.example/activate", false).join("\n");
 
-        assert!(rendered.contains("Open this URL in Feishu/Lark on your phone"));
-        assert!(rendered.contains("qrencode"));
+        assert!(rendered.contains("https://scan.example/activate"));
+        assert!(!rendered.contains("qrencode"));
+    }
+
+    #[test]
+    fn encode_terminal_qr_returns_non_empty_unicode_art() {
+        let rendered =
+            encode_terminal_qr("https://scan.example/activate?device=device-123&from=loong")
+                .expect("qr encoding should succeed");
+
+        assert!(!rendered.is_empty());
+        assert!(rendered.lines().count() >= 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the external `qrencode` CLI with the pure-Rust [`qrcode`](https://crates.io/crates/qrcode) crate (0.14, no default features) so Feishu/Lark onboarding prints a scannable terminal QR out of the box — no system binary required.
- Keep the verification link printed alongside the QR so desktop users can click through in a browser while mobile users scan on their phone.
- Refresh `render_qr_instructions` copy to present both paths clearly; drop the stale "install `qrencode`" hint.

## Test plan
- [x] `cargo test -p loong --lib feishu_onboarding::` → 10/10 pass (including 3 new tests: two for the updated copy, one for the QR encoder)
- [x] `cargo clippy -p loong --lib --all-features -- -D warnings` (scoped — avoids a pre-existing `duplicated_attributes` warning at `crates/daemon/src/lib.rs:1778`)
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check_architecture_boundaries.sh`
- [x] Visual smoke-test of the rendered QR (Dense1x2 unicode half-blocks, quiet zone on) — scans cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)