### PR TITLE
Stabilize hidden skill discovery and Feishu reply idempotency

### DIFF
--- a/crates/app/src/channel/feishu/payload/inbound.rs
+++ b/crates/app/src/channel/feishu/payload/inbound.rs
@@ -15,6 +15,7 @@ use super::crypto::decrypt_payload_if_needed;
 use super::types::{
     FeishuCardCallbackAction, FeishuCardCallbackContext, FeishuCardCallbackEvent,
     FeishuCardCallbackVersion, FeishuInboundEvent, FeishuWebhookAction,
+    feishu_message_reply_idempotency_key,
 };
 
 const FEISHU_STRUCTURED_ONLY_MESSAGE_TYPES: &[&str] = &[
@@ -236,7 +237,11 @@ pub(in crate::channel::feishu) fn parse_feishu_inbound_payload_with_access_polic
         .unwrap_or_else(|| format!("message:{message_id}"));
 
     let mut reply_target = ChannelOutboundTarget::feishu_message_reply(message_id.to_owned())
-        .with_feishu_reply_chat_id(chat_id.to_owned());
+        .with_feishu_reply_chat_id(chat_id.to_owned())
+        .with_idempotency_key(feishu_message_reply_idempotency_key(
+            account_id,
+            message_id.as_str(),
+        ));
     if thread_id.is_some() {
         reply_target = reply_target.with_feishu_reply_in_thread(true);
     }

--- a/crates/app/src/channel/feishu/payload/tests.rs
+++ b/crates/app/src/channel/feishu/payload/tests.rs
@@ -6,6 +6,7 @@ use cbc::cipher::block_padding::Pkcs7;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+use super::types::feishu_message_reply_idempotency_key;
 use super::*;
 use crate::channel::{
     ChannelOutboundTarget, ChannelOutboundTargetKind, ChannelPlatform,
@@ -142,6 +143,8 @@ fn feishu_message_event_parses_text_payload() {
     .expect("parse feishu event");
 
     let event = expect_inbound(action);
+    let expected_idempotency_key =
+        feishu_message_reply_idempotency_key("feishu_cli_a1b2c3", "om_123");
     assert_eq!(event.event_id, "evt_1");
     assert_eq!(event.session.configured_account_id.as_deref(), Some("work"));
     assert_eq!(
@@ -152,12 +155,20 @@ fn feishu_message_event_parses_text_payload() {
         event.reply_target,
         ChannelOutboundTarget::feishu_message_reply("om_123")
             .with_feishu_reply_chat_id("oc_123")
+            .with_idempotency_key(feishu_message_reply_idempotency_key(
+                "feishu_cli_a1b2c3",
+                "om_123",
+            ))
             .with_feishu_reply_in_thread(true)
     );
     assert_eq!(event.reply_target.platform, ChannelPlatform::Feishu);
     assert_eq!(
         event.reply_target.kind,
         ChannelOutboundTargetKind::MessageReply
+    );
+    assert_eq!(
+        event.reply_target.idempotency_key(),
+        Some(expected_idempotency_key.as_str())
     );
     assert_eq!(event.reply_target.feishu_reply_in_thread(), Some(true));
     assert_eq!(event.text, "hello loong");
@@ -241,6 +252,8 @@ fn feishu_websocket_message_event_parses_without_verification_token() {
     .expect("parse websocket feishu event");
 
     let event = expect_inbound(action);
+    let expected_idempotency_key =
+        feishu_message_reply_idempotency_key("feishu_cli_a1b2c3", "om_ws_123");
     assert_eq!(event.event_id, "evt_ws_1");
     assert_eq!(event.text, "hello from websocket");
     assert_eq!(event.session.configured_account_id.as_deref(), Some("work"));
@@ -248,6 +261,7 @@ fn feishu_websocket_message_event_parses_without_verification_token() {
         event.reply_target,
         ChannelOutboundTarget::feishu_message_reply("om_ws_123")
             .with_feishu_reply_chat_id("oc_123")
+            .with_idempotency_key(expected_idempotency_key)
     );
 }
 
@@ -1655,6 +1669,8 @@ fn feishu_encrypted_payload_parses_with_encrypt_key() {
     .expect("parse encrypted payload");
 
     let event = expect_inbound(parsed);
+    let expected_idempotency_key =
+        feishu_message_reply_idempotency_key("feishu_cli_a1b2c3", "om_encrypt");
     assert_eq!(event.event_id, "evt_encrypted_1");
     assert_eq!(
         event.session.session_key(),
@@ -1664,6 +1680,7 @@ fn feishu_encrypted_payload_parses_with_encrypt_key() {
         event.reply_target,
         ChannelOutboundTarget::feishu_message_reply("om_encrypt")
             .with_feishu_reply_chat_id("oc_encrypt")
+            .with_idempotency_key(expected_idempotency_key)
             .with_feishu_reply_in_thread(true)
     );
     assert_eq!(event.reply_target.feishu_reply_in_thread(), Some(true));

--- a/crates/app/src/channel/feishu/payload/types.rs
+++ b/crates/app/src/channel/feishu/payload/types.rs
@@ -1,6 +1,7 @@
 use crate::channel::feishu::api::FeishuUserPrincipal;
 use crate::channel::{ChannelDeliveryResource, ChannelOutboundTarget, ChannelSession};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 pub(in crate::channel::feishu) struct FeishuInboundEvent {
@@ -13,6 +14,12 @@ pub(in crate::channel::feishu) struct FeishuInboundEvent {
     pub(in crate::channel::feishu) reply_target: ChannelOutboundTarget,
     pub(in crate::channel::feishu) text: String,
     pub(in crate::channel::feishu) resources: Vec<ChannelDeliveryResource>,
+}
+
+impl FeishuInboundEvent {
+    pub(in crate::channel::feishu) fn delivery_dedupe_key(&self) -> &str {
+        self.message_id.as_str()
+    }
 }
 
 #[derive(Debug)]
@@ -56,4 +63,36 @@ pub(in crate::channel::feishu) struct FeishuCardCallbackEvent {
     pub(in crate::channel::feishu) action: FeishuCardCallbackAction,
     pub(in crate::channel::feishu) context: FeishuCardCallbackContext,
     pub(in crate::channel::feishu) text: String,
+}
+
+impl FeishuCardCallbackEvent {
+    pub(in crate::channel::feishu) fn delivery_dedupe_key(&self) -> &str {
+        self.event_id.as_str()
+    }
+}
+
+pub(in crate::channel::feishu) fn feishu_message_reply_idempotency_key(
+    account_id: &str,
+    message_id: &str,
+) -> String {
+    feishu_stable_idempotency_key("reply", [Some(account_id), Some(message_id)])
+}
+
+fn feishu_stable_idempotency_key<'a>(
+    namespace: &str,
+    parts: impl IntoIterator<Item = Option<&'a str>>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"loong:feishu:");
+    hasher.update(namespace.as_bytes());
+
+    for part in parts {
+        hasher.update([0x1f]);
+        if let Some(part) = part {
+            hasher.update(part.trim().as_bytes());
+        }
+    }
+
+    let digest = hex::encode(hasher.finalize());
+    format!("feishu-{namespace}-{}", &digest[..24])
 }

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -531,7 +531,7 @@ pub(super) async fn handle_feishu_parsed_action(
             );
             {
                 let mut dedupe = state.seen_events.lock().await;
-                let reservation = dedupe.begin_processing(&event.event_id);
+                let reservation = dedupe.begin_processing(event.delivery_dedupe_key());
                 if !matches!(reservation, RecentIdReservation::Accepted) {
                     tracing::debug!(
                         target: "loong.channel.feishu",
@@ -574,7 +574,7 @@ pub(super) async fn handle_feishu_parsed_action(
             );
             {
                 let mut dedupe = state.seen_events.lock().await;
-                let reservation = dedupe.begin_processing(&event.event_id);
+                let reservation = dedupe.begin_processing(event.delivery_dedupe_key());
                 if !matches!(reservation, RecentIdReservation::Accepted) {
                     tracing::debug!(
                         target: "loong.channel.feishu",
@@ -582,6 +582,8 @@ pub(super) async fn handle_feishu_parsed_action(
                         action = "inbound",
                         configured_account_id = %state.configured_account_id,
                         event_id = %event.event_id,
+                        message_id = %event.message_id,
+                        dedupe_key = %event.delivery_dedupe_key(),
                         reservation = ?reservation,
                         "deduplicated feishu inbound event"
                     );
@@ -591,15 +593,15 @@ pub(super) async fn handle_feishu_parsed_action(
                 }
             }
 
-            let event_id = event.event_id.clone();
+            let delivery_dedupe_key = event.delivery_dedupe_key().to_owned();
             let result = handle_feishu_inbound_event(state, event).await;
 
             {
                 let mut dedupe = state.seen_events.lock().await;
                 if result.is_ok() {
-                    dedupe.mark_completed(&event_id);
+                    dedupe.mark_completed(&delivery_dedupe_key);
                 } else {
-                    dedupe.release(&event_id);
+                    dedupe.release(&delivery_dedupe_key);
                 }
             }
 
@@ -2229,6 +2231,122 @@ data: [DONE]\n\n",
             feishu_requests.iter().all(|request| request.path
                 != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"),
             "failed inbound handling must not send a reply"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[test]
+    fn feishu_webhook_deduplicates_same_message_id_across_replayed_event_ids() {
+        run_feishu_webhook_test_on_large_stack(
+            "feishu-webhook-message-replay-dedupe",
+            || async move {
+                feishu_webhook_deduplicates_same_message_id_across_replayed_event_ids_impl().await;
+            },
+        );
+    }
+
+    async fn feishu_webhook_deduplicates_same_message_id_across_replayed_event_ids_impl() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_dedupe").await;
+
+        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before webhook test");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-message-replay-dedupe",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let payload = |event_id: &str| {
+            json!({
+                "token": "verify-token",
+                "header": {
+                    "event_id": event_id,
+                    "event_type": "im.message.receive_v1"
+                },
+                "event": {
+                    "sender": {
+                        "sender_type": "user",
+                        "sender_id": {
+                            "open_id": "ou_sender_replay"
+                        }
+                    },
+                    "message": {
+                        "chat_id": "oc_demo",
+                        "message_id": "om_inbound_replayed_1",
+                        "message_type": "text",
+                        "content": "{\"text\":\"dedupe this replay\"}"
+                    }
+                }
+            })
+        };
+
+        let first_payload = payload("evt_message_replay_1");
+        let first_raw_body = serde_json::to_string(&first_payload).expect("serialize payload");
+        let first_headers = signed_headers(&first_raw_body, "encrypt-key");
+        let first_response = handle_feishu_webhook_payload(
+            state.clone(),
+            &first_headers,
+            first_raw_body.as_str(),
+            serde_json::from_str(first_raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect("first webhook request should succeed");
+        assert_eq!(first_response.body(), &json!({"code": 0, "msg": "ok"}));
+
+        let replay_payload = payload("evt_message_replay_2");
+        let replay_raw_body = serde_json::to_string(&replay_payload).expect("serialize payload");
+        let replay_headers = signed_headers(&replay_raw_body, "encrypt-key");
+        let replay_response = handle_feishu_webhook_payload(
+            state,
+            &replay_headers,
+            replay_raw_body.as_str(),
+            serde_json::from_str(replay_raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect("replayed webhook request should be deduplicated");
+        assert_eq!(
+            replay_response.body(),
+            &json!({"code": 0, "msg": "duplicate_event"})
+        );
+
+        let provider_requests = wait_for_request_count(&provider_requests, 1).await;
+        assert_eq!(provider_requests.len(), 1);
+
+        let feishu_requests = wait_for_request_count(&feishu_requests, 2).await;
+        assert_eq!(
+            feishu_requests
+                .iter()
+                .filter(|request| request.path
+                    == "/open-apis/im/v1/messages/om_inbound_replayed_1/reply")
+                .count(),
+            1,
+            "replayed inbound message ids must not trigger a second reply send"
         );
 
         provider_server.abort();

--- a/crates/app/src/conversation/turn_coordinator/safe_lane_routing.rs
+++ b/crates/app/src/conversation/turn_coordinator/safe_lane_routing.rs
@@ -16,6 +16,9 @@ impl SafeLaneFailureRoute {
         }
 
         match failure.code.as_str() {
+            "tool_not_found" if failure.supports_discovery_recovery => {
+                return Self::replan(SafeLaneFailureRouteReason::RetryableFailure);
+            }
             "kernel_policy_denied"
             | "tool_not_found"
             | "max_tool_steps_exceeded"

--- a/crates/app/src/conversation/turn_coordinator/tests/turn_coordinator_safe_lane_route_tests.rs
+++ b/crates/app/src/conversation/turn_coordinator/tests/turn_coordinator_safe_lane_route_tests.rs
@@ -65,6 +65,19 @@ fn safe_lane_route_policy_denied_failure_is_terminal() {
 }
 
 #[test]
+fn safe_lane_route_discovery_recovery_tool_not_found_replans() {
+    let failure = TurnFailure::policy_denied_with_discovery_recovery(
+        "tool_not_found",
+        "tool_not_found: requested tool is not available",
+    );
+    let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(2));
+
+    assert_eq!(route.decision, SafeLaneFailureRouteDecision::Replan);
+    assert_eq!(route.reason, SafeLaneFailureRouteReason::RetryableFailure);
+    assert_eq!(route.source, SafeLaneFailureRouteSource::BaseRouting);
+}
+
+#[test]
 fn safe_lane_route_non_retryable_failure_is_terminal() {
     let failure = TurnFailure::non_retryable("safe_lane_plan_node_non_retryable_error", "bad");
     let route = SafeLaneFailureRoute::from_failure(&failure, SafeLaneReplanBudget::new(3));

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -292,6 +292,13 @@ struct RankedBlockedSkillDiscoveryResult {
     match_reasons: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SkillDiscoveryToolHint {
+    pub(super) skill_id: String,
+    pub(super) display_name: String,
+    pub(super) summary: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SkillAudience {
     Model,
@@ -1502,6 +1509,66 @@ fn build_skill_search_summary(skill: &DiscoveredSkillEntry) -> String {
     }
 
     format!("{display_name}. {summary}")
+}
+
+pub(super) fn exact_model_visible_skill_hint(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    skill_id: &str,
+) -> Result<Option<SkillDiscoveryToolHint>, String> {
+    if !config.external_skills.enabled {
+        return Ok(None);
+    }
+
+    let requested_skill_id = skill_id.trim();
+    if requested_skill_id.is_empty() {
+        return Ok(None);
+    }
+
+    let inventory = discover_skill_inventory(config)?;
+    let filtered = filter_inventory_for_audience(inventory, SkillAudience::Model);
+    let matched = filtered
+        .skills
+        .into_iter()
+        .find(|entry| entry.skill_id.eq_ignore_ascii_case(requested_skill_id));
+
+    Ok(matched.map(skill_discovery_tool_hint_from_entry))
+}
+
+pub(super) fn ranked_model_visible_skill_hints(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<SkillDiscoveryToolHint>, String> {
+    if !config.external_skills.enabled {
+        return Ok(Vec::new());
+    }
+
+    let trimmed_query = query.trim();
+    if trimmed_query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let inventory = discover_skill_inventory(config)?;
+    let filtered = filter_inventory_for_audience(inventory, SkillAudience::Model);
+    let results = build_ranked_skill_discovery_results(
+        filtered.skills.as_slice(),
+        trimmed_query,
+        limit,
+        SkillDiscoveryResolution::Active,
+    );
+
+    Ok(results
+        .into_iter()
+        .map(|result| skill_discovery_tool_hint_from_entry(result.skill))
+        .collect())
+}
+
+fn skill_discovery_tool_hint_from_entry(entry: DiscoveredSkillEntry) -> SkillDiscoveryToolHint {
+    SkillDiscoveryToolHint {
+        skill_id: entry.skill_id,
+        display_name: entry.display_name,
+        summary: entry.summary,
+    }
 }
 
 fn build_skill_search_argument_hint(

--- a/crates/app/src/tools/routing.rs
+++ b/crates/app/src/tools/routing.rs
@@ -770,7 +770,10 @@ fn route_hidden_skills_tool_name(payload: &Value) -> Result<&'static str, String
         if invokes_skill {
             return Ok("external_skills.invoke");
         }
-        return Ok("external_skills.inspect");
+        return Err(
+            "hidden_skills_requires_operation_for_skill_id: add `operation` (`inspect` or `run`) when payload.skill_id is present"
+                .to_owned(),
+        );
     }
 
     if payload.as_object().is_some_and(|object| object.is_empty()) {

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -92,39 +92,73 @@ pub(super) fn execute_tool_search_tool_with_config(
             .collect::<Vec<_>>();
     let collapsible_surface_ids =
         super::provider_visible_collapsible_hidden_surface_ids(config, &visible_tool_view);
+    let skill_query_hints = query
+        .as_deref()
+        .map(|value| super::external_skills::ranked_model_visible_skill_hints(config, value, 3))
+        .transpose()?
+        .unwrap_or_default();
+    let exact_skill_hint = requested_exact_tool_id
+        .as_deref()
+        .map(|value| super::external_skills::exact_model_visible_skill_hint(config, value))
+        .transpose()?
+        .flatten();
     let searchable_entries = collapse_hidden_surface_search_entries(
         exact_match_entries.clone(),
         &collapsible_surface_ids,
     );
-    let exact_match_entry = exact_tool_id.as_ref().and_then(|exact_tool_id| {
-        let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
-        let direct_tool_id = direct_tool_id.map(str::to_owned);
+    let searchable_entries = enrich_searchable_entries_for_skill_hints(
+        searchable_entries,
+        skill_query_hints.as_slice(),
+        exact_skill_hint.as_ref(),
+    );
+    let exact_match_entry = exact_tool_id
+        .as_ref()
+        .and_then(|exact_tool_id| {
+            let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
+            let direct_tool_id = direct_tool_id.map(str::to_owned);
 
-        searchable_entries
-            .iter()
-            .find(|entry| {
-                let canonical_match = entry.canonical_name == *exact_tool_id;
-                let tool_id_match = entry.tool_id == *exact_tool_id;
-                let direct_match = direct_tool_id.as_ref().is_some_and(|direct_tool_id| {
-                    entry.canonical_name == *direct_tool_id || entry.tool_id == *direct_tool_id
-                });
-                canonical_match || tool_id_match || direct_match
-            })
-            .cloned()
-            .or_else(|| {
-                exact_match_entries
+            searchable_entries
+                .iter()
+                .find(|entry| {
+                    let canonical_match = entry.canonical_name == *exact_tool_id;
+                    let tool_id_match = entry.tool_id == *exact_tool_id;
+                    let direct_match = direct_tool_id.as_ref().is_some_and(|direct_tool_id| {
+                        entry.canonical_name == *direct_tool_id || entry.tool_id == *direct_tool_id
+                    });
+                    canonical_match || tool_id_match || direct_match
+                })
+                .cloned()
+                .or_else(|| {
+                    exact_match_entries
+                        .iter()
+                        .find(|entry| {
+                            let canonical_match = entry.canonical_name == *exact_tool_id;
+                            let tool_id_match = entry.tool_id == *exact_tool_id;
+                            let direct_match =
+                                direct_tool_id.as_ref().is_some_and(|direct_tool_id| {
+                                    entry.canonical_name == *direct_tool_id
+                                });
+                            canonical_match || tool_id_match || direct_match
+                        })
+                        .cloned()
+                })
+        })
+        .or_else(|| {
+            exact_skill_hint.as_ref().and_then(|hint| {
+                searchable_entries
                     .iter()
-                    .find(|entry| {
-                        let canonical_match = entry.canonical_name == *exact_tool_id;
-                        let tool_id_match = entry.tool_id == *exact_tool_id;
-                        let direct_match = direct_tool_id
-                            .as_ref()
-                            .is_some_and(|direct_tool_id| entry.canonical_name == *direct_tool_id);
-                        canonical_match || tool_id_match || direct_match
-                    })
+                    .find(|entry| entry.tool_id == "skills")
                     .cloned()
+                    .map(|mut entry| {
+                        enrich_skills_surface_entry(
+                            &mut entry,
+                            std::slice::from_ref(hint),
+                            Some(hint),
+                        );
+                        entry
+                    })
             })
-    });
+        });
     let exact_match_found = exact_match_entry.is_some();
     let mut diagnostics_reason = None;
     let results: Vec<Value> = if let Some(entry) = exact_match_entry {
@@ -249,6 +283,166 @@ fn tool_search_diagnostics_json(
     }
 
     Value::Null
+}
+
+fn enrich_searchable_entries_for_skill_hints(
+    entries: Vec<SearchableToolEntry>,
+    skill_hints: &[super::external_skills::SkillDiscoveryToolHint],
+    exact_skill_hint: Option<&super::external_skills::SkillDiscoveryToolHint>,
+) -> Vec<SearchableToolEntry> {
+    entries
+        .into_iter()
+        .map(|mut entry| {
+            if entry.tool_id == "skills" {
+                enrich_skills_surface_entry(&mut entry, skill_hints, exact_skill_hint);
+            }
+            entry
+        })
+        .collect()
+}
+
+fn enrich_skills_surface_entry(
+    entry: &mut SearchableToolEntry,
+    skill_hints: &[super::external_skills::SkillDiscoveryToolHint],
+    exact_skill_hint: Option<&super::external_skills::SkillDiscoveryToolHint>,
+) {
+    let mut matched_skills = Vec::new();
+    if let Some(skill_hint) = exact_skill_hint {
+        matched_skills.push(skill_hint.clone());
+    }
+    for skill_hint in skill_hints {
+        if matched_skills.iter().any(|existing| {
+            existing
+                .skill_id
+                .eq_ignore_ascii_case(skill_hint.skill_id.as_str())
+        }) {
+            continue;
+        }
+        matched_skills.push(skill_hint.clone());
+    }
+    if matched_skills.is_empty() {
+        return;
+    }
+
+    let matched_skill_labels = matched_skills
+        .iter()
+        .map(|skill| {
+            let display_name = skill.display_name.trim();
+            if display_name.is_empty() || display_name.eq_ignore_ascii_case(skill.skill_id.as_str())
+            {
+                skill.skill_id.clone()
+            } else {
+                format!("{} ({display_name})", skill.skill_id)
+            }
+        })
+        .collect::<Vec<_>>();
+    let matched_skill_summary = format!(
+        "Matching installed skills: {}.",
+        matched_skill_labels.join(", ")
+    );
+    entry.summary = append_unique_sentence(entry.summary.as_str(), matched_skill_summary.as_str());
+    entry.search_hint =
+        append_unique_sentence(entry.search_hint.as_str(), matched_skill_summary.as_str());
+
+    let preferred_skill = exact_skill_hint.or_else(|| matched_skills.first());
+    let mut usage_guidance = entry
+        .usage_guidance
+        .clone()
+        .unwrap_or_else(|| "Use this when the task is about capability expansion.".to_owned());
+    if let Some(skill) = preferred_skill {
+        let invoke_example = format!(
+            "{{\"operation\":\"run\",\"skill_id\":\"{}\"}}",
+            skill.skill_id
+        );
+        let inspect_example = format!(
+            "{{\"operation\":\"inspect\",\"skill_id\":\"{}\"}}",
+            skill.skill_id
+        );
+        let guidance = format!(
+            "To load a specific installed skill through this surface, call tool.invoke with the lease from this card and arguments {invoke_example}. Use {inspect_example} to inspect metadata, or {{\"operation\":\"list\"}} to enumerate installed skills."
+        );
+        usage_guidance = append_unique_sentence(usage_guidance.as_str(), guidance.as_str());
+    }
+    entry.usage_guidance = Some(usage_guidance);
+
+    let mut tags = entry.tags.clone();
+    for skill in &matched_skills {
+        if !tags
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(skill.skill_id.as_str()))
+        {
+            tags.push(skill.skill_id.clone());
+        }
+        let display_name = skill.display_name.trim();
+        if !display_name.is_empty()
+            && !tags
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(display_name))
+        {
+            tags.push(display_name.to_owned());
+        }
+    }
+    entry.tags = tags;
+
+    let mut name_fragments = vec![entry.canonical_name.clone(), entry.tool_id.clone()];
+    let mut summary_fragments = vec![entry.summary.clone(), entry.search_hint.clone()];
+    let argument_fragments = build_argument_fragments(
+        entry.argument_hint.as_str(),
+        &entry.required_fields,
+        &entry.required_field_groups,
+    );
+    let schema_fragments = vec![
+        entry.required_fields.join(" "),
+        entry
+            .required_field_groups
+            .iter()
+            .map(|group| group.join(" "))
+            .collect::<Vec<_>>()
+            .join(" "),
+    ]
+    .into_iter()
+    .filter(|fragment| !fragment.trim().is_empty())
+    .collect::<Vec<_>>();
+    let mut tag_fragments = entry.tags.clone();
+
+    for skill in &matched_skills {
+        name_fragments.push(skill.skill_id.clone());
+        let display_name = skill.display_name.trim();
+        if !display_name.is_empty() {
+            name_fragments.push(display_name.to_owned());
+        }
+        let skill_summary = skill.summary.trim();
+        if !skill_summary.is_empty() {
+            summary_fragments.push(skill_summary.to_owned());
+        }
+        tag_fragments.push(skill.skill_id.clone());
+    }
+
+    entry.search_document = SearchDocument::new(
+        name_fragments,
+        summary_fragments,
+        argument_fragments,
+        schema_fragments,
+        tag_fragments,
+    );
+}
+
+fn append_unique_sentence(base: &str, addition: &str) -> String {
+    let trimmed_addition = addition.trim();
+    if trimmed_addition.is_empty() {
+        return base.trim().to_owned();
+    }
+
+    let trimmed_base = base.trim();
+    if trimmed_base.is_empty() {
+        return trimmed_addition.to_owned();
+    }
+
+    if trimmed_base.contains(trimmed_addition) {
+        return trimmed_base.to_owned();
+    }
+
+    format!("{trimmed_base} {trimmed_addition}")
 }
 
 fn tool_search_query_from_payload(

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -3035,6 +3035,131 @@ fn tool_search_hides_app_only_discoverables_from_provider_visible_results() {
 }
 
 #[test]
+fn tool_search_exact_skill_id_returns_skills_surface_with_run_guidance() {
+    use std::fs;
+
+    let root = unique_temp_dir("loongclaw-tool-search-skill-exact");
+    fs::create_dir_all(&root).expect("create fixture root");
+    let skill_root = root.join("skills").join("agent-browser");
+    fs::create_dir_all(&skill_root).expect("create skill root");
+    fs::write(
+        skill_root.join("SKILL.md"),
+        "# Agent Browser\n\nUse this skill for managed browser automation.\n",
+    )
+    .expect("write skill fixture");
+
+    let config = test_tool_runtime_config(&root);
+    execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.install".to_owned(),
+            payload: json!({
+                "path": "skills/agent-browser"
+            }),
+        },
+        &config,
+    )
+    .expect("install should succeed");
+
+    let search = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({
+                "exact_tool_id": "agent-browser"
+            }),
+        },
+        &config,
+    )
+    .expect("tool search should succeed");
+
+    let results = search.payload["results"].as_array().expect("results");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["tool_id"], "skills");
+    assert_eq!(search.payload["exact_tool_id"], "agent-browser");
+    assert!(search.payload["diagnostics"].is_null());
+    assert!(
+        results[0]["summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("Matching installed skills: agent-browser")),
+        "search result should mention the matched installed skill: {results:?}"
+    );
+    assert!(
+        results[0]["usage_guidance"].as_str().is_some_and(
+            |guidance| guidance.contains(r#"{"operation":"run","skill_id":"agent-browser"}"#)
+        ),
+        "skills surface should advertise the explicit run flow: {results:?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn tool_invoke_skills_surface_requires_operation_when_skill_id_is_present() {
+    use std::fs;
+
+    let root = unique_temp_dir("loongclaw-tool-search-skill-operation");
+    fs::create_dir_all(&root).expect("create fixture root");
+    let skill_root = root.join("skills").join("agent-browser");
+    fs::create_dir_all(&skill_root).expect("create skill root");
+    fs::write(
+        skill_root.join("SKILL.md"),
+        "# Agent Browser\n\nUse this skill for managed browser automation.\n",
+    )
+    .expect("write skill fixture");
+
+    let config = test_tool_runtime_config(&root);
+    execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "external_skills.install".to_owned(),
+            payload: json!({
+                "path": "skills/agent-browser"
+            }),
+        },
+        &config,
+    )
+    .expect("install should succeed");
+
+    let search = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({
+                "query": "agent-browser"
+            }),
+        },
+        &config,
+    )
+    .expect("tool search should succeed");
+    let lease = search.payload["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .find(|entry| entry["tool_id"] == "skills")
+        .and_then(|entry| entry["lease"].as_str())
+        .expect("skills lease");
+
+    let error = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "skills",
+                "lease": lease,
+                "arguments": {
+                    "skill_id": "agent-browser"
+                }
+            }),
+        },
+        &config,
+    )
+    .expect_err("skill_id without operation should fail closed");
+
+    assert!(
+        error.contains("tool_not_found:") && error.contains("skills"),
+        "skill_id without operation should fail closed instead of silently inspecting: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn tool_search_hides_tools_exceeding_granted_capabilities() {
     let created_at = std::time::SystemTime::now();
     let duration = created_at


### PR DESCRIPTION
## Summary

- Problem:
  Hidden-surface skill discovery still blurred installed-skill existence, provider-visible tool exposure, grouped-surface routing, and concrete invocation shape. Feishu inbound reply handling also remained vulnerable to duplicate replies when the same logical inbound message was replayed under retries or alternate event ids.
- Why it matters:
  Both failures live on core runtime seams. `tool.search -> tool.invoke` is supposed to stay the governed progressive-disclosure path for hidden capabilities, and runtime-backed channel reply loops must stay idempotent under replay and partial transport failure. If those seams are fuzzy, the same class of bugs resurfaces under new skills and channel flows.
- What changed:
  `tool.search` now enriches the `skills` hidden surface with query-aware installed-skill hints, including exact refresh support for installed skills such as `agent-browser` and explicit `run` / `inspect` guidance. Ambiguous grouped `skills` payloads with only `skill_id` now fail closed instead of silently guessing an action. Safe-lane routing now replans discovery-recoverable `tool_not_found` failures instead of treating them as terminal. Feishu inbound replies now carry a stable idempotency key derived from the logical message identity, and webhook replay dedupe now keys inbound message processing by logical message id instead of only the in-process event envelope.
- What did not change (scope boundary):
  This does not expose installed skills as direct tools, does not bypass the lease-governed `tool.search -> tool.invoke` contract, and does not introduce a cross-process durable replay ledger for Feishu beyond the tightened runtime idempotency and message-level in-process dedupe.

## Linked Issues

- Closes #1351
- Related #1046

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The change alters hidden-surface recovery semantics and Feishu reply-loop idempotency boundaries, so the main risk is behavioral drift around grouped hidden-surface routing or replay handling.
- Rollout / guardrails:
  The change is covered with focused regression tests for exact skill discovery guidance, grouped-surface fail-closed behavior, safe-lane discovery recovery, Feishu payload parsing, and Feishu webhook replay dedupe. Full workspace lint and test suites were re-run after the targeted checks.
- Rollback path:
  Revert this branch to restore the prior grouped-surface routing and Feishu reply behavior. The change is code-local and does not require data migration.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh test --workspace
./scripts/cargo-local-toolchain.sh test --workspace --all-features
./scripts/cargo-local-toolchain.sh test -p loong-app tool_search_exact_skill_id_returns_skills_surface_with_run_guidance
./scripts/cargo-local-toolchain.sh test -p loong-app tool_invoke_skills_surface_requires_operation_when_skill_id_is_present
./scripts/cargo-local-toolchain.sh test -p loong-app safe_lane_route_discovery_recovery_tool_not_found_replans
./scripts/cargo-local-toolchain.sh test -p loong-app feishu_message_event_parses_text_payload
./scripts/cargo-local-toolchain.sh test -p loong-app feishu_websocket_message_event_parses_without_verification_token
./scripts/cargo-local-toolchain.sh test -p loong-app feishu_webhook_deduplicates_same_message_id_across_replayed_event_ids

All listed commands completed successfully on this branch.
```

## User-visible / Operator-visible Changes

- Installed skills matched by `tool.search` now surface clearer grouped-surface guidance instead of degrading into a misleading hidden-tool visibility failure.
- Ambiguous grouped `skills` invocations no longer silently guess `inspect` when only `skill_id` is present.
- Discovery-recoverable hidden-surface `tool_not_found` failures can recover through safe-lane replanning.
- Feishu replay of the same logical inbound message no longer emits duplicate replies just because the event envelope changed.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `e450a31ee423c84f92d712a56907c4a94965b6ba`.
- Observable failure symptoms reviewers should watch for:
  Hidden-surface tool requests unexpectedly terminating instead of replanning, or Feishu inbound replies being dropped when only the event envelope changes but the logical message is the same.

## Reviewer Focus

- [crates/app/src/tools/tool_search.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/tools/tool_search.rs) for the skills-surface enrichment and exact refresh path.
- [crates/app/src/tools/routing.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/tools/routing.rs) for the grouped `skills` fail-closed routing boundary.
- [crates/app/src/conversation/turn_coordinator/safe_lane_routing.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/conversation/turn_coordinator/safe_lane_routing.rs) for the discovery-recoverable replan decision.
- [crates/app/src/channel/feishu/webhook.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/channel/feishu/webhook.rs), [crates/app/src/channel/feishu/payload/inbound.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/channel/feishu/payload/inbound.rs), and [crates/app/src/channel/feishu/payload/types.rs](/Users/chum/.codex/worktrees/e6ac/loong/crates/app/src/channel/feishu/payload/types.rs) for the message-level dedupe and stable reply idempotency seam.
