### PR TITLE
Make Agent Skills loading read-first and loong-native

### DIFF
--- a/crates/app/src/conversation/active_external_skills.rs
+++ b/crates/app/src/conversation/active_external_skills.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use super::turn_shared::parse_external_skill_invoke_context;
+use super::turn_shared::{
+    ToolResultLine, external_skill_invoke_context_from_payload_summary,
+    parse_external_skill_invoke_context,
+};
+use crate::tools::runtime_config::ToolRuntimeConfig;
 
 pub(crate) const ACTIVE_EXTERNAL_SKILLS_EVENT_KIND: &str = "active_external_skills_refreshed";
 const ACTIVE_EXTERNAL_SKILLS_MARKER: &str = "[active_external_skills]";
@@ -36,6 +40,65 @@ pub(crate) fn collect_active_external_skills_from_tool_result_text(
 
     for line in tool_result_text.lines() {
         let Some(skill_context) = parse_external_skill_invoke_context(line) else {
+            continue;
+        };
+
+        upsert_active_external_skill(
+            &mut active_skills,
+            ActiveExternalSkill {
+                skill_id: skill_context.skill_id,
+                display_name: skill_context.display_name,
+                instructions: skill_context.instructions,
+                skill_root: skill_context
+                    .skill_root
+                    .map(|skill_root| skill_root.display().to_string()),
+                allowed_tools: skill_context.allowed_tools,
+                blocked_tools: skill_context.blocked_tools,
+            },
+        );
+    }
+
+    active_skills
+}
+
+pub(crate) fn collect_active_external_skills_from_tool_result_text_with_config(
+    tool_result_text: &str,
+    config: &ToolRuntimeConfig,
+) -> Vec<ActiveExternalSkill> {
+    let mut active_skills = collect_active_external_skills_from_tool_result_text(tool_result_text);
+
+    for line in tool_result_text.lines() {
+        let Some(tool_result_line) = ToolResultLine::parse(line) else {
+            continue;
+        };
+        if crate::tools::canonical_tool_name(tool_result_line.tool_name()) != "file.read" {
+            continue;
+        }
+        if tool_result_line.payload_truncated() {
+            continue;
+        }
+        let Some(payload_json) = tool_result_line.payload_summary_json() else {
+            continue;
+        };
+        let Some(path) = payload_json
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let Ok(Some(skill_payload)) =
+            crate::tools::model_visible_external_skill_context_payload_for_path(
+                config,
+                std::path::Path::new(path),
+            )
+        else {
+            continue;
+        };
+        let Some(skill_context) =
+            external_skill_invoke_context_from_payload_summary(&skill_payload)
+        else {
             continue;
         };
 
@@ -147,6 +210,10 @@ fn upsert_active_external_skill(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::unique_temp_dir;
+    use crate::tools::runtime_config::{ExternalSkillsRuntimePolicy, ToolRuntimeConfig};
+    use std::collections::BTreeSet;
+    use std::fs;
 
     #[test]
     fn collect_active_external_skills_from_tool_result_text_deduplicates_by_skill_id() {
@@ -237,5 +304,70 @@ mod tests {
         assert!(rendered.contains("Allowed tools: shell.exec"));
         assert!(rendered.contains("Blocked tools: web.fetch"));
         assert!(rendered.contains("<skill_content name=\"Demo Skill\">demo</skill_content>"));
+    }
+
+    #[test]
+    fn collect_active_external_skills_from_skill_file_read_activates_visible_skill() {
+        let root = unique_temp_dir("loong-active-skill-file-read");
+        fs::create_dir_all(root.join(".loong/skills/demo-skill")).expect("create skill root");
+        let skill_path = root.join(".loong/skills/demo-skill/SKILL.md");
+        fs::write(
+            &skill_path,
+            "---\nname: demo-skill\ndescription: Use this skill for demo verification.\ninvocation_policy: both\n---\n\n# Demo Skill\n\nFollow the demo workflow.\n",
+        )
+        .expect("write skill file");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root.clone()),
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: false,
+            },
+            ..Default::default()
+        };
+        let tool_result_text = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-1",
+                "payload_summary": serde_json::to_string(&serde_json::json!({
+                    "path": skill_path.display().to_string(),
+                    "content": "# Demo Skill\n\nFollow the demo workflow.\n"
+                }))
+                .expect("encode payload"),
+                "payload_chars": 180,
+                "payload_truncated": false
+            })
+        );
+
+        let active_skills = collect_active_external_skills_from_tool_result_text_with_config(
+            tool_result_text.as_str(),
+            &config,
+        );
+        let expected_skill_root = std::fs::canonicalize(root.join(".loong/skills/demo-skill"))
+            .expect("canonical skill root")
+            .display()
+            .to_string();
+
+        assert_eq!(active_skills.len(), 1);
+        assert_eq!(active_skills[0].skill_id, "demo-skill");
+        assert_eq!(active_skills[0].display_name, "Demo Skill");
+        assert_eq!(
+            active_skills[0].skill_root.as_deref(),
+            Some(expected_skill_root.as_str())
+        );
+        assert!(
+            active_skills[0]
+                .instructions
+                .contains("<skill_content name=\"Demo Skill\""),
+            "skill file reads should synthesize structured activation instructions"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/app/src/conversation/active_external_skills.rs
+++ b/crates/app/src/conversation/active_external_skills.rs
@@ -11,6 +11,10 @@ pub(crate) struct ActiveExternalSkill {
     pub display_name: String,
     pub instructions: String,
     pub skill_root: Option<String>,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub blocked_tools: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -44,6 +48,8 @@ pub(crate) fn collect_active_external_skills_from_tool_result_text(
                 skill_root: skill_context
                     .skill_root
                     .map(|skill_root| skill_root.display().to_string()),
+                allowed_tools: skill_context.allowed_tools,
+                blocked_tools: skill_context.blocked_tools,
             },
         );
     }
@@ -84,6 +90,12 @@ pub(crate) fn render_active_external_skills_section(
         ));
         if let Some(skill_root) = skill.skill_root.as_deref() {
             sections.push(format!("Skill directory: {skill_root}"));
+        }
+        if !skill.allowed_tools.is_empty() {
+            sections.push(format!("Allowed tools: {}", skill.allowed_tools.join(", ")));
+        }
+        if !skill.blocked_tools.is_empty() {
+            sections.push(format!("Blocked tools: {}", skill.blocked_tools.join(", ")));
         }
         sections.push(skill.instructions.clone());
     }
@@ -165,7 +177,10 @@ mod tests {
                 "payload_summary": serde_json::to_string(&serde_json::json!({
                     "skill_id": "demo-skill",
                     "display_name": "Demo Skill",
-                    "instructions": "updated"
+                    "instructions": "updated",
+                    "metadata": {
+                        "blocked_tools": ["web.fetch"]
+                    }
                 }))
                 .expect("encode payload"),
                 "payload_chars": 128,
@@ -197,6 +212,7 @@ mod tests {
         assert_eq!(active_skills.len(), 2);
         assert_eq!(active_skills[0].skill_id, "demo-skill");
         assert_eq!(active_skills[0].instructions, "updated");
+        assert_eq!(active_skills[0].blocked_tools, vec!["web.fetch"]);
         assert_eq!(active_skills[1].skill_id, "other-skill");
     }
 
@@ -208,6 +224,8 @@ mod tests {
                 display_name: "Demo Skill".to_owned(),
                 instructions: "<skill_content name=\"Demo Skill\">demo</skill_content>".to_owned(),
                 skill_root: Some("/tmp/demo-skill".to_owned()),
+                allowed_tools: vec!["shell.exec".to_owned()],
+                blocked_tools: vec!["web.fetch".to_owned()],
             }],
         })
         .expect("render active skills");
@@ -216,6 +234,8 @@ mod tests {
         assert!(rendered.contains("demo-skill"));
         assert!(rendered.contains("Demo Skill"));
         assert!(rendered.contains("Skill directory: /tmp/demo-skill"));
+        assert!(rendered.contains("Allowed tools: shell.exec"));
+        assert!(rendered.contains("Blocked tools: web.fetch"));
         assert!(rendered.contains("<skill_content name=\"Demo Skill\">demo</skill_content>"));
     }
 }

--- a/crates/app/src/conversation/active_external_skills.rs
+++ b/crates/app/src/conversation/active_external_skills.rs
@@ -74,9 +74,6 @@ pub(crate) fn collect_active_external_skills_from_tool_result_text_with_config(
         if crate::tools::canonical_tool_name(tool_result_line.tool_name()) != "file.read" {
             continue;
         }
-        if tool_result_line.payload_truncated() {
-            continue;
-        }
         let Some(payload_json) = tool_result_line.payload_summary_json() else {
             continue;
         };
@@ -366,6 +363,66 @@ mod tests {
                 .instructions
                 .contains("<skill_content name=\"Demo Skill\""),
             "skill file reads should synthesize structured activation instructions"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn collect_active_external_skills_from_truncated_skill_file_read_activates_visible_skill() {
+        let root = unique_temp_dir("loong-active-skill-file-read-truncated");
+        fs::create_dir_all(root.join(".loong/skills/demo-skill")).expect("create skill root");
+        let skill_path = root.join(".loong/skills/demo-skill/SKILL.md");
+        let long_body = format!(
+            "---\nname: demo-skill\ndescription: Use this skill for demo verification.\ninvocation_policy: both\n---\n\n# Demo Skill\n\n{}\n",
+            "Follow the demo workflow.\n".repeat(40)
+        );
+        fs::write(&skill_path, long_body).expect("write skill file");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root.clone()),
+            external_skills: ExternalSkillsRuntimePolicy {
+                enabled: true,
+                require_download_approval: true,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                install_root: None,
+                auto_expose_installed: false,
+            },
+            ..Default::default()
+        };
+        let tool_result_text = format!(
+            "[ok] {}",
+            serde_json::json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-1",
+                "payload_summary": serde_json::to_string(&serde_json::json!({
+                    "path": skill_path.display().to_string(),
+                    "bytes": 1200,
+                    "truncated": false,
+                    "content_preview": "preview",
+                    "content_chars": 1200,
+                    "content_truncated": true
+                }))
+                .expect("encode payload"),
+                "payload_chars": 180,
+                "payload_truncated": true
+            })
+        );
+
+        let active_skills = collect_active_external_skills_from_tool_result_text_with_config(
+            tool_result_text.as_str(),
+            &config,
+        );
+
+        assert_eq!(active_skills.len(), 1);
+        assert_eq!(active_skills[0].skill_id, "demo-skill");
+        assert!(
+            active_skills[0]
+                .instructions
+                .contains("<skill_content name=\"Demo Skill\""),
+            "truncated file.read summaries should still activate visible skills from path context"
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -63,6 +63,7 @@ pub struct SessionContext {
     pub tool_view: ToolView,
     pub workspace_root: Option<PathBuf>,
     pub active_external_skill_roots: Vec<PathBuf>,
+    pub visible_external_skill_roots: Vec<PathBuf>,
     pub runtime_narrowing: Option<ToolRuntimeNarrowing>,
     pub subagent_execution: Option<ConstrainedSubagentExecution>,
     pub subagent_contract: Option<ConstrainedSubagentContractView>,
@@ -80,6 +81,7 @@ impl SessionContext {
             tool_view,
             workspace_root: None,
             active_external_skill_roots: Vec::new(),
+            visible_external_skill_roots: Vec::new(),
             runtime_narrowing: None,
             subagent_execution: None,
             subagent_contract: None,
@@ -103,6 +105,7 @@ impl SessionContext {
             tool_view,
             workspace_root: None,
             active_external_skill_roots: Vec::new(),
+            visible_external_skill_roots: Vec::new(),
             runtime_narrowing: None,
             subagent_execution: None,
             subagent_contract: None,
@@ -122,6 +125,18 @@ impl SessionContext {
         active_external_skill_roots: Vec<PathBuf>,
     ) -> Self {
         self.active_external_skill_roots = active_external_skill_roots
+            .into_iter()
+            .map(|path| std::fs::canonicalize(&path).unwrap_or(path))
+            .collect();
+        self
+    }
+
+    #[must_use]
+    pub fn with_visible_external_skill_roots(
+        mut self,
+        visible_external_skill_roots: Vec<PathBuf>,
+    ) -> Self {
+        self.visible_external_skill_roots = visible_external_skill_roots
             .into_iter()
             .map(|path| std::fs::canonicalize(&path).unwrap_or(path))
             .collect();
@@ -634,6 +649,12 @@ fn active_external_skill_roots_from_state(
     roots
 }
 
+fn model_visible_external_skill_roots_from_config(config: &LoongConfig) -> Vec<PathBuf> {
+    let tool_runtime_config =
+        crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
+    crate::tools::model_visible_external_skill_roots_for_runtime_config(&tool_runtime_config)
+}
+
 #[cfg(feature = "memory-sqlite")]
 fn apply_active_external_skill_blocked_tools_to_tool_view(
     base_tool_view: ToolView,
@@ -724,6 +745,7 @@ fn build_session_context_from_snapshot(
     base_tool_view: ToolView,
     snapshot: PersistedSessionSnapshot,
 ) -> CliResult<SessionContext> {
+    let visible_external_skill_roots = model_visible_external_skill_roots_from_config(config);
     let tool_view = apply_active_external_skill_blocked_tools_to_tool_view(
         apply_session_tool_policy_to_tool_view(
             base_tool_view,
@@ -750,6 +772,10 @@ fn build_session_context_from_snapshot(
     if !snapshot.active_external_skill_roots.is_empty() {
         session_context =
             session_context.with_active_external_skill_roots(snapshot.active_external_skill_roots);
+    }
+    if !visible_external_skill_roots.is_empty() {
+        session_context =
+            session_context.with_visible_external_skill_roots(visible_external_skill_roots);
     }
     if snapshot.is_delegate_child {
         if let Some(label) = snapshot.label {
@@ -1474,7 +1500,13 @@ pub trait ConversationRuntime: Send + Sync {
             return Ok(session_context);
         }
 
-        Ok(SessionContext::root_with_tool_view(session_id, tool_view))
+        let visible_external_skill_roots = model_visible_external_skill_roots_from_config(config);
+        let mut session_context = SessionContext::root_with_tool_view(session_id, tool_view);
+        if !visible_external_skill_roots.is_empty() {
+            session_context =
+                session_context.with_visible_external_skill_roots(visible_external_skill_roots);
+        }
+        Ok(session_context)
     }
 
     fn tool_view(
@@ -1855,16 +1887,28 @@ where
                 );
             }
 
-            Ok(SessionContext::root_with_tool_view(
-                session_id,
-                base_tool_view,
-            ))
+            let visible_external_skill_roots =
+                model_visible_external_skill_roots_from_config(config);
+            let mut session_context =
+                SessionContext::root_with_tool_view(session_id, base_tool_view);
+            if !visible_external_skill_roots.is_empty() {
+                session_context =
+                    session_context.with_visible_external_skill_roots(visible_external_skill_roots);
+            }
+            Ok(session_context)
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
         {
             let tool_view = self.tool_view(config, session_id, _binding)?;
-            Ok(SessionContext::root_with_tool_view(session_id, tool_view))
+            let visible_external_skill_roots =
+                model_visible_external_skill_roots_from_config(config);
+            let mut session_context = SessionContext::root_with_tool_view(session_id, tool_view);
+            if !visible_external_skill_roots.is_empty() {
+                session_context =
+                    session_context.with_visible_external_skill_roots(visible_external_skill_roots);
+            }
+            Ok(session_context)
         }
     }
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -478,6 +478,7 @@ struct PersistedSessionSnapshot {
     delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
     delegate_profile: Option<DelegateBuiltinProfile>,
     workspace_root: Option<PathBuf>,
+    active_external_skills: Option<active_external_skills::ActiveExternalSkillsState>,
     active_external_skill_roots: Vec<PathBuf>,
     runtime_self_continuity: Option<RuntimeSelfContinuity>,
 }
@@ -527,8 +528,10 @@ fn load_persisted_session_snapshot(
             None
         };
         let runtime_self_continuity = load_session_runtime_self_continuity(repo, session_id)?;
+        let active_external_skills =
+            load_active_external_skills_state(repo, session_id).unwrap_or_default();
         let active_external_skill_roots =
-            load_active_external_skill_roots(repo, session_id).unwrap_or_default();
+            active_external_skill_roots_from_state(active_external_skills.as_ref());
         let snapshot = PersistedSessionSnapshot {
             session_id: session.session_id,
             parent_session_id,
@@ -539,6 +542,7 @@ fn load_persisted_session_snapshot(
             delegate_runtime_narrowing,
             delegate_profile,
             workspace_root,
+            active_external_skills,
             active_external_skill_roots,
             runtime_self_continuity,
         };
@@ -576,8 +580,10 @@ fn load_persisted_session_snapshot(
         None
     };
     let runtime_self_continuity = load_session_runtime_self_continuity(repo, session_id)?;
+    let active_external_skills =
+        load_active_external_skills_state(repo, session_id).unwrap_or_default();
     let active_external_skill_roots =
-        load_active_external_skill_roots(repo, session_id).unwrap_or_default();
+        active_external_skill_roots_from_state(active_external_skills.as_ref());
     let snapshot = PersistedSessionSnapshot {
         session_id: summary.session_id,
         parent_session_id: summary.parent_session_id,
@@ -588,6 +594,7 @@ fn load_persisted_session_snapshot(
         delegate_runtime_narrowing,
         delegate_profile,
         workspace_root,
+        active_external_skills,
         active_external_skill_roots,
         runtime_self_continuity,
     };
@@ -595,17 +602,22 @@ fn load_persisted_session_snapshot(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn load_active_external_skill_roots(
+fn load_active_external_skills_state(
     repo: &SessionRepository,
     session_id: &str,
-) -> Result<Vec<PathBuf>, String> {
-    let active_skills =
-        active_external_skills::load_persisted_active_external_skills(repo, session_id)?;
+) -> Result<Option<active_external_skills::ActiveExternalSkillsState>, String> {
+    active_external_skills::load_persisted_active_external_skills(repo, session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn active_external_skill_roots_from_state(
+    active_skills: Option<&active_external_skills::ActiveExternalSkillsState>,
+) -> Vec<PathBuf> {
     let Some(active_skills) = active_skills else {
-        return Ok(Vec::new());
+        return Vec::new();
     };
     let mut roots = Vec::new();
-    for skill in active_skills.skills {
+    for skill in &active_skills.skills {
         let Some(skill_root) = skill.skill_root.as_deref() else {
             continue;
         };
@@ -619,7 +631,49 @@ fn load_active_external_skill_roots(
             roots.push(canonical);
         }
     }
-    Ok(roots)
+    roots
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_active_external_skill_blocked_tools_to_tool_view(
+    base_tool_view: ToolView,
+    active_skills: Option<&active_external_skills::ActiveExternalSkillsState>,
+) -> ToolView {
+    let Some(active_skills) = active_skills else {
+        return base_tool_view;
+    };
+
+    let mut blocked_names = BTreeSet::new();
+    for skill in &active_skills.skills {
+        for blocked_tool in &skill.blocked_tools {
+            let blocked_tool = blocked_tool.trim();
+            if blocked_tool.is_empty() {
+                continue;
+            }
+            let canonical_name = crate::tools::canonical_tool_name(blocked_tool);
+            blocked_names.insert(canonical_name.to_owned());
+            if let Some(direct_tool_name) =
+                crate::tools::direct_tool_name_for_hidden_tool(blocked_tool)
+            {
+                blocked_names.insert(direct_tool_name.to_owned());
+            }
+            if let Some(hidden_facade_tool_name) =
+                crate::tools::hidden_facade_tool_name_for_hidden_tool(blocked_tool)
+            {
+                blocked_names.insert(hidden_facade_tool_name.to_owned());
+            }
+        }
+    }
+
+    if blocked_names.is_empty() {
+        return base_tool_view;
+    }
+
+    ToolView::from_tool_names(
+        base_tool_view
+            .tool_names()
+            .filter(|tool_name| !blocked_names.contains(*tool_name)),
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -670,9 +724,12 @@ fn build_session_context_from_snapshot(
     base_tool_view: ToolView,
     snapshot: PersistedSessionSnapshot,
 ) -> CliResult<SessionContext> {
-    let tool_view = apply_session_tool_policy_to_tool_view(
-        base_tool_view,
-        snapshot.session_tool_policy.as_ref(),
+    let tool_view = apply_active_external_skill_blocked_tools_to_tool_view(
+        apply_session_tool_policy_to_tool_view(
+            base_tool_view,
+            snapshot.session_tool_policy.as_ref(),
+        ),
+        snapshot.active_external_skills.as_ref(),
     );
     let runtime_narrowing = merge_effective_runtime_narrowing(
         snapshot.delegate_runtime_narrowing.clone(),
@@ -1823,12 +1880,17 @@ where
             let snapshot = load_persisted_session_snapshot(&repo, session_id)?;
             let base_tool_view =
                 build_base_tool_view_from_snapshot(config, &repo, session_id, snapshot.as_ref())?;
-            let session_tool_policy = snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.session_tool_policy.as_ref());
-            Ok(apply_session_tool_policy_to_tool_view(
+            let tool_view = apply_session_tool_policy_to_tool_view(
                 base_tool_view,
-                session_tool_policy,
+                snapshot
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.session_tool_policy.as_ref()),
+            );
+            Ok(apply_active_external_skill_blocked_tools_to_tool_view(
+                tool_view,
+                snapshot
+                    .as_ref()
+                    .and_then(|snapshot| snapshot.active_external_skills.as_ref()),
             ))
         }
 
@@ -2552,6 +2614,8 @@ mod tests {
                         display_name: "Release Guard".to_owned(),
                         instructions: "<skill_content name=\"Release Guard\">protect releases</skill_content>".to_owned(),
                         skill_root: Some("/tmp/release-guard".to_owned()),
+                        allowed_tools: vec!["shell.exec".to_owned()],
+                        blocked_tools: vec!["web.fetch".to_owned()],
                     }],
                 },
             }),
@@ -2586,6 +2650,74 @@ mod tests {
         assert!(
             system_content.contains("protect releases"),
             "expected skill instructions in system prompt, got: {system_content}"
+        );
+        assert!(
+            system_content.contains("Allowed tools: shell.exec"),
+            "expected allowed tool summary in system prompt, got: {system_content}"
+        );
+        assert!(
+            system_content.contains("Blocked tools: web.fetch"),
+            "expected blocked tool summary in system prompt, got: {system_content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_runtime_tool_view_excludes_active_external_skill_blocked_tools() {
+        let runtime = DefaultConversationRuntime::default();
+        let session_id = "session-active-external-skill-tool-block";
+        let root = unique_temp_dir("active-external-skill-tool-block");
+        let sqlite_path = root.join("memory.db");
+
+        let mut config = LoongConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+
+        let base_tool_view = crate::tools::runtime_tool_view_from_loong_config(&config);
+        assert!(
+            base_tool_view.contains("web"),
+            "default runtime should expose the direct web surface"
+        );
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.append_event(NewSessionEvent {
+            session_id: session_id.to_owned(),
+            event_kind: ACTIVE_EXTERNAL_SKILLS_EVENT_KIND.to_owned(),
+            actor_session_id: Some(session_id.to_owned()),
+            payload_json: json!({
+                "source": "test",
+                "active_external_skills": ActiveExternalSkillsState {
+                    skills: vec![ActiveExternalSkill {
+                        skill_id: "release-guard".to_owned(),
+                        display_name: "Release Guard".to_owned(),
+                        instructions: "<skill_content name=\"Release Guard\">protect releases</skill_content>".to_owned(),
+                        skill_root: Some("/tmp/release-guard".to_owned()),
+                        allowed_tools: Vec::new(),
+                        blocked_tools: vec!["web.fetch".to_owned()],
+                    }],
+                },
+            }),
+        })
+        .expect("append active skills event");
+
+        let tool_view = runtime
+            .tool_view(&config, session_id, ConversationRuntimeBinding::direct())
+            .expect("runtime tool view");
+
+        assert!(
+            !tool_view.contains("web"),
+            "blocked hidden tool should also remove its direct surface"
+        );
+        assert!(
+            tool_view.contains("read"),
+            "unrelated direct tools should remain visible"
         );
     }
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3569,8 +3569,13 @@ fn persist_active_external_skills_from_followup_payload_if_needed(
         return;
     };
 
+    let tool_runtime_config =
+        crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
     let updates =
-        active_external_skills::collect_active_external_skills_from_tool_result_text(text);
+        active_external_skills::collect_active_external_skills_from_tool_result_text_with_config(
+            text,
+            &tool_runtime_config,
+        );
     if updates.is_empty() {
         return;
     }
@@ -6365,10 +6370,10 @@ mod tests {
     async fn handle_turn_with_runtime_explicit_skill_activation_prefix_injects_skill_context() {
         let workspace_root =
             crate::test_support::unique_temp_dir("turn-coordinator-explicit-skill-activation");
-        std::fs::create_dir_all(workspace_root.join(".agents/skills/demo-skill"))
+        std::fs::create_dir_all(workspace_root.join(".loong/skills/demo-skill"))
             .expect("create skill root");
         std::fs::write(
-            workspace_root.join(".agents/skills/demo-skill/SKILL.md"),
+            workspace_root.join(".loong/skills/demo-skill/SKILL.md"),
             "---\nname: demo-skill\ndescription: Summarize notes with release discipline.\n---\n\n# Demo Skill\n\nFollow the managed skill instruction before answering.\n",
         )
         .expect("write skill");

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1919,12 +1919,21 @@ fn inject_active_skill_workspace_root_context_trusted(
     session_context: &SessionContext,
     preserve_existing_internal_context: bool,
 ) -> AugmentedToolPayload {
-    let Some(workspace_root) = active_skill_workspace_root_for_tool_payload(
+    let workspace_root = active_skill_workspace_root_for_tool_payload(
         canonical_tool_name,
         invoked_tool_name,
         &payload,
         session_context,
-    ) else {
+    )
+    .or_else(|| {
+        visible_skill_workspace_root_for_tool_payload(
+            canonical_tool_name,
+            invoked_tool_name,
+            &payload,
+            session_context,
+        )
+    });
+    let Some(workspace_root) = workspace_root else {
         return AugmentedToolPayload {
             payload,
             trusted_internal_context: preserve_existing_internal_context,
@@ -1979,6 +1988,46 @@ fn active_skill_workspace_root_for_tool_payload(
         &session_context.active_external_skill_roots,
         requested_path.as_path(),
     )
+}
+
+fn visible_skill_workspace_root_for_tool_payload(
+    canonical_tool_name: &str,
+    invoked_tool_name: &Option<String>,
+    payload: &serde_json::Value,
+    session_context: &SessionContext,
+) -> Option<std::path::PathBuf> {
+    if session_context.visible_external_skill_roots.is_empty() {
+        return None;
+    }
+
+    let target_tool_name = invoked_tool_name.as_deref().unwrap_or(canonical_tool_name);
+    if !matches!(
+        target_tool_name,
+        "file.read" | "glob.search" | "content.search"
+    ) {
+        return None;
+    }
+
+    let requested_path = if canonical_tool_name == "tool.invoke" {
+        requested_file_tool_path("tool.invoke", payload)?
+    } else {
+        requested_file_tool_path(target_tool_name, payload)?
+    };
+    if !requested_path.is_absolute() {
+        return None;
+    }
+
+    let normalized_requested_path = if requested_path.exists() {
+        std::fs::canonicalize(&requested_path).unwrap_or(requested_path)
+    } else {
+        requested_path
+    };
+
+    session_context
+        .visible_external_skill_roots
+        .iter()
+        .find(|root| normalized_requested_path.starts_with(root))
+        .cloned()
 }
 
 fn resolve_active_skill_root_for_relative_path(
@@ -6529,7 +6578,7 @@ mod tests {
     fn augment_tool_payload_uses_active_skill_root_for_absolute_file_read_targets() {
         let workspace_root =
             crate::test_support::unique_temp_dir("turn-engine-active-skill-workspace");
-        let skill_root = workspace_root.join(".agents/skills/demo-skill");
+        let skill_root = workspace_root.join(".loong/skills/demo-skill");
         std::fs::create_dir_all(skill_root.join("references")).expect("create skill root");
         let reference_path = skill_root.join("references/guide.md");
         std::fs::write(&reference_path, "# Guide\n").expect("write guide");
@@ -6560,11 +6609,79 @@ mod tests {
     }
 
     #[test]
+    fn augment_tool_payload_uses_visible_skill_root_for_absolute_skill_file_reads() {
+        let workspace_root =
+            crate::test_support::unique_temp_dir("turn-engine-visible-skill-workspace");
+        let skill_root = workspace_root.join(".loong/skills/demo-skill");
+        std::fs::create_dir_all(&skill_root).expect("create skill root");
+        let skill_path = skill_root.join("SKILL.md");
+        std::fs::write(&skill_path, "# Demo Skill\n").expect("write skill file");
+        let canonical_skill_root =
+            std::fs::canonicalize(&skill_root).expect("canonical skill root");
+
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(["tool.invoke"]),
+        )
+        .with_workspace_root(workspace_root)
+        .with_visible_external_skill_roots(vec![skill_root]);
+        let payload = json!({
+            "tool_id": "file.read",
+            "lease": "lease-file-read",
+            "arguments": {
+                "path": skill_path.display().to_string()
+            },
+        });
+
+        let augmented = augment_tool_payload_for_kernel("tool.invoke", payload, &session_context);
+
+        assert_eq!(
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONG_INTERNAL_WORKSPACE_ROOT_KEY],
+            json!(canonical_skill_root.display().to_string())
+        );
+    }
+
+    #[test]
+    fn augment_tool_payload_uses_visible_skill_root_for_absolute_skill_resource_reads() {
+        let workspace_root =
+            crate::test_support::unique_temp_dir("turn-engine-visible-skill-resource-workspace");
+        let skill_root = workspace_root.join(".loong/skills/demo-skill");
+        std::fs::create_dir_all(skill_root.join("references")).expect("create skill root");
+        let reference_path = skill_root.join("references/guide.md");
+        std::fs::write(&reference_path, "# Guide\n").expect("write guide");
+        let canonical_skill_root =
+            std::fs::canonicalize(&skill_root).expect("canonical skill root");
+
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(["tool.invoke"]),
+        )
+        .with_workspace_root(workspace_root)
+        .with_visible_external_skill_roots(vec![skill_root]);
+        let payload = json!({
+            "tool_id": "file.read",
+            "lease": "lease-file-read",
+            "arguments": {
+                "path": reference_path.display().to_string()
+            },
+        });
+
+        let augmented = augment_tool_payload_for_kernel("tool.invoke", payload, &session_context);
+
+        assert_eq!(
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONG_INTERNAL_WORKSPACE_ROOT_KEY],
+            json!(canonical_skill_root.display().to_string())
+        );
+    }
+
+    #[test]
     fn augment_tool_payload_uses_unique_active_skill_root_for_relative_file_read_targets() {
         let workspace_root =
             crate::test_support::unique_temp_dir("turn-engine-active-skill-relative-workspace");
-        let first_skill_root = workspace_root.join(".agents/skills/demo-skill");
-        let second_skill_root = workspace_root.join(".agents/skills/other-skill");
+        let first_skill_root = workspace_root.join(".loong/skills/demo-skill");
+        let second_skill_root = workspace_root.join(".loong/skills/other-skill");
         std::fs::create_dir_all(first_skill_root.join("references")).expect("create first skill");
         std::fs::create_dir_all(second_skill_root.join("references")).expect("create second skill");
         std::fs::write(first_skill_root.join("references/guide.md"), "# First\n")
@@ -6601,8 +6718,8 @@ mod tests {
     fn augment_tool_payload_does_not_guess_when_relative_file_read_matches_multiple_skill_roots() {
         let workspace_root =
             crate::test_support::unique_temp_dir("turn-engine-active-skill-relative-ambiguous");
-        let first_skill_root = workspace_root.join(".agents/skills/demo-skill");
-        let second_skill_root = workspace_root.join(".agents/skills/other-skill");
+        let first_skill_root = workspace_root.join(".loong/skills/demo-skill");
+        let second_skill_root = workspace_root.join(".loong/skills/other-skill");
         std::fs::create_dir_all(first_skill_root.join("references")).expect("create first skill");
         std::fs::create_dir_all(second_skill_root.join("references")).expect("create second skill");
         std::fs::write(first_skill_root.join("references/shared.md"), "# First\n")

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1961,21 +1961,39 @@ fn active_skill_workspace_root_for_tool_payload(
     } else {
         requested_file_tool_path(target_tool_name, payload)?
     };
-    if !requested_path.is_absolute() {
-        return None;
+    if requested_path.is_absolute() {
+        let normalized_requested_path = if requested_path.exists() {
+            std::fs::canonicalize(&requested_path).unwrap_or(requested_path)
+        } else {
+            requested_path
+        };
+
+        return session_context
+            .active_external_skill_roots
+            .iter()
+            .find(|root| normalized_requested_path.starts_with(root))
+            .cloned();
     }
 
-    let normalized_requested_path = if requested_path.exists() {
-        std::fs::canonicalize(&requested_path).unwrap_or(requested_path)
-    } else {
-        requested_path
-    };
+    resolve_active_skill_root_for_relative_path(
+        &session_context.active_external_skill_roots,
+        requested_path.as_path(),
+    )
+}
 
-    session_context
-        .active_external_skill_roots
+fn resolve_active_skill_root_for_relative_path(
+    active_skill_roots: &[std::path::PathBuf],
+    requested_path: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let mut matches = active_skill_roots
         .iter()
-        .find(|root| normalized_requested_path.starts_with(root))
-        .cloned()
+        .filter_map(|root| {
+            let candidate = root.join(requested_path);
+            candidate.exists().then(|| root.clone())
+        })
+        .collect::<Vec<_>>();
+    matches.dedup();
+    (matches.len() == 1).then(|| matches.remove(0))
 }
 
 fn requested_file_tool_path(
@@ -6538,6 +6556,81 @@ mod tests {
             augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
                 [crate::tools::LOONG_INTERNAL_WORKSPACE_ROOT_KEY],
             json!(canonical_skill_root.display().to_string())
+        );
+    }
+
+    #[test]
+    fn augment_tool_payload_uses_unique_active_skill_root_for_relative_file_read_targets() {
+        let workspace_root =
+            crate::test_support::unique_temp_dir("turn-engine-active-skill-relative-workspace");
+        let first_skill_root = workspace_root.join(".agents/skills/demo-skill");
+        let second_skill_root = workspace_root.join(".agents/skills/other-skill");
+        std::fs::create_dir_all(first_skill_root.join("references")).expect("create first skill");
+        std::fs::create_dir_all(second_skill_root.join("references")).expect("create second skill");
+        std::fs::write(first_skill_root.join("references/guide.md"), "# First\n")
+            .expect("write first guide");
+        std::fs::write(second_skill_root.join("references/other.md"), "# Second\n")
+            .expect("write second guide");
+        let canonical_first_skill_root =
+            std::fs::canonicalize(&first_skill_root).expect("canonical first skill root");
+
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(["tool.invoke"]),
+        )
+        .with_workspace_root(workspace_root)
+        .with_active_external_skill_roots(vec![first_skill_root, second_skill_root]);
+        let payload = json!({
+            "tool_id": "file.read",
+            "lease": "lease-file-read",
+            "arguments": {
+                "path": "references/guide.md"
+            },
+        });
+
+        let augmented = augment_tool_payload_for_kernel("tool.invoke", payload, &session_context);
+
+        assert_eq!(
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONG_INTERNAL_WORKSPACE_ROOT_KEY],
+            json!(canonical_first_skill_root.display().to_string())
+        );
+    }
+
+    #[test]
+    fn augment_tool_payload_does_not_guess_when_relative_file_read_matches_multiple_skill_roots() {
+        let workspace_root =
+            crate::test_support::unique_temp_dir("turn-engine-active-skill-relative-ambiguous");
+        let first_skill_root = workspace_root.join(".agents/skills/demo-skill");
+        let second_skill_root = workspace_root.join(".agents/skills/other-skill");
+        std::fs::create_dir_all(first_skill_root.join("references")).expect("create first skill");
+        std::fs::create_dir_all(second_skill_root.join("references")).expect("create second skill");
+        std::fs::write(first_skill_root.join("references/shared.md"), "# First\n")
+            .expect("write first guide");
+        std::fs::write(second_skill_root.join("references/shared.md"), "# Second\n")
+            .expect("write second guide");
+        let expected_workspace_root = workspace_root.display().to_string();
+
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(["tool.invoke"]),
+        )
+        .with_workspace_root(workspace_root)
+        .with_active_external_skill_roots(vec![first_skill_root, second_skill_root]);
+        let payload = json!({
+            "tool_id": "file.read",
+            "lease": "lease-file-read",
+            "arguments": {
+                "path": "references/shared.md"
+            },
+        });
+
+        let augmented = augment_tool_payload_for_kernel("tool.invoke", payload, &session_context);
+
+        assert_eq!(
+            augmented.payload[crate::tools::LOONG_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONG_INTERNAL_WORKSPACE_ROOT_KEY],
+            json!(expected_workspace_root)
         );
     }
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -850,6 +850,8 @@ pub struct ExternalSkillInvokeContext {
     pub display_name: String,
     pub instructions: String,
     pub skill_root: Option<PathBuf>,
+    pub allowed_tools: Vec<String>,
+    pub blocked_tools: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2177,12 +2179,35 @@ fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillI
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from);
+    let metadata = payload_json.get("metadata").and_then(Value::as_object);
+    let allowed_tools = metadata
+        .and_then(|metadata| metadata.get("allowed_tools"))
+        .map(parse_external_skill_tool_restrictions)
+        .unwrap_or_default();
+    let blocked_tools = metadata
+        .and_then(|metadata| metadata.get("blocked_tools"))
+        .map(parse_external_skill_tool_restrictions)
+        .unwrap_or_default();
     Some(ExternalSkillInvokeContext {
         skill_id,
         display_name,
         instructions,
         skill_root,
+        allowed_tools,
+        blocked_tools,
     })
+}
+
+fn parse_external_skill_tool_restrictions(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 #[cfg(test)]
@@ -3553,6 +3578,10 @@ mod tests {
             "skill_id": "demo-skill",
             "display_name": "Demo Skill",
             "instructions": instructions,
+            "metadata": {
+                "allowed_tools": ["shell.exec"],
+                "blocked_tools": ["web.fetch"]
+            }
         });
         let line = format!(
             "[ok] {}",
@@ -3572,6 +3601,8 @@ mod tests {
         assert_eq!(parsed.skill_id, "demo-skill");
         assert_eq!(parsed.display_name, "Demo Skill");
         assert!(parsed.instructions.contains("suffix-marker"));
+        assert_eq!(parsed.allowed_tools, vec!["shell.exec"]);
+        assert_eq!(parsed.blocked_tools, vec!["web.fetch"]);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -1418,6 +1418,54 @@ pub fn parse_external_skill_invoke_context(
         .next()
 }
 
+pub fn external_skill_invoke_context_from_payload_summary(
+    payload_json: &Value,
+) -> Option<ExternalSkillInvokeContext> {
+    let instructions = payload_json
+        .get("instructions")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let skill_id = payload_json
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("external-skill")
+        .to_owned();
+    let display_name = payload_json
+        .get("display_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(skill_id.as_str())
+        .to_owned();
+    let skill_root = payload_json
+        .get("skill_root")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let metadata = payload_json.get("metadata").and_then(Value::as_object);
+    let allowed_tools = metadata
+        .and_then(|metadata| metadata.get("allowed_tools"))
+        .map(parse_external_skill_tool_restrictions)
+        .unwrap_or_default();
+    let blocked_tools = metadata
+        .and_then(|metadata| metadata.get("blocked_tools"))
+        .map(parse_external_skill_tool_restrictions)
+        .unwrap_or_default();
+    Some(ExternalSkillInvokeContext {
+        skill_id,
+        display_name,
+        instructions,
+        skill_root,
+        allowed_tools,
+        blocked_tools,
+    })
+}
+
 pub fn reduce_followup_payload_for_model<'a>(label: &str, text: &'a str) -> Cow<'a, str> {
     if label != "tool_result" {
         return Cow::Borrowed(text);
@@ -2153,49 +2201,7 @@ fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillI
         return None;
     }
     let payload_json = tool_result_line.payload_summary_json()?;
-    let instructions = payload_json
-        .get("instructions")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?
-        .to_owned();
-    let skill_id = payload_json
-        .get("skill_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("external-skill")
-        .to_owned();
-    let display_name = payload_json
-        .get("display_name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(skill_id.as_str())
-        .to_owned();
-    let skill_root = payload_json
-        .get("skill_root")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from);
-    let metadata = payload_json.get("metadata").and_then(Value::as_object);
-    let allowed_tools = metadata
-        .and_then(|metadata| metadata.get("allowed_tools"))
-        .map(parse_external_skill_tool_restrictions)
-        .unwrap_or_default();
-    let blocked_tools = metadata
-        .and_then(|metadata| metadata.get("blocked_tools"))
-        .map(parse_external_skill_tool_restrictions)
-        .unwrap_or_default();
-    Some(ExternalSkillInvokeContext {
-        skill_id,
-        display_name,
-        instructions,
-        skill_root,
-        allowed_tools,
-        blocked_tools,
-    })
+    external_skill_invoke_context_from_payload_summary(&payload_json)
 }
 
 fn parse_external_skill_tool_restrictions(value: &Value) -> Vec<String> {

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -145,6 +145,12 @@ impl From<DiscoveredSkillEntry> for DiscoveredSkillModelView {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ModelVisibleSkillIdentity {
+    pub(super) skill_id: String,
+    pub(super) display_name: String,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum SkillModelVisibility {
@@ -4257,6 +4263,37 @@ pub(super) fn model_skill_catalog_section_with_config(
     }
 
     Some(lines.join("\n"))
+}
+
+pub(super) fn model_visible_skill_identities_with_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Vec<ModelVisibleSkillIdentity> {
+    let policy = match resolve_effective_policy(config) {
+        Ok(policy) => policy,
+        Err(_) => return Vec::new(),
+    };
+    if !policy.enabled {
+        return Vec::new();
+    }
+
+    let inventory = match discover_skill_inventory(config) {
+        Ok(inventory) => inventory,
+        Err(_) => return Vec::new(),
+    };
+    let filtered = filter_inventory_for_audience(inventory, SkillAudience::Model);
+
+    filtered
+        .skills
+        .into_iter()
+        .map(|skill| ModelVisibleSkillIdentity {
+            skill_id: skill.skill_id,
+            display_name: skill.display_name,
+        })
+        .collect()
+}
+
+pub(super) fn normalize_skill_lookup_id(raw: &str) -> Option<String> {
+    normalize_skill_id(raw).ok()
 }
 
 fn discover_managed_skill_candidates(

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -3692,6 +3692,7 @@ fn skill_is_visible_to_audience(entry: &DiscoveredSkillEntry, audience: SkillAud
         SkillAudience::Model => {
             entry.active
                 && entry.model_visibility == SkillModelVisibility::Visible
+                && entry.invocation_policy != SkillInvocationPolicy::Manual
                 && entry.eligibility.available
         }
     }
@@ -3715,6 +3716,10 @@ fn ensure_skill_access_for_audience(
     if skill.model_visibility == SkillModelVisibility::Hidden {
         blockers.push("the skill is operator-only and hidden from the model surface".to_owned());
     }
+    if skill.invocation_policy == SkillInvocationPolicy::Manual {
+        blockers
+            .push("the skill is manual-only and not invokable from the model surface".to_owned());
+    }
     if !skill.eligibility.missing_env.is_empty() {
         blockers.push(format!(
             "missing env vars: {}",
@@ -3731,6 +3736,12 @@ fn ensure_skill_access_for_audience(
         blockers.push(format!(
             "missing required paths: {}",
             skill.eligibility.missing_paths.join(", ")
+        ));
+    }
+    if !skill.eligibility.missing_config.is_empty() {
+        blockers.push(format!(
+            "disabled or unavailable config gates: {}",
+            skill.eligibility.missing_config.join(", ")
         ));
     }
 
@@ -4077,7 +4088,29 @@ fn runtime_config_selector_enabled(
     config: &super::runtime_config::ToolRuntimeConfig,
     selector: &str,
 ) -> Option<bool> {
-    match selector.trim().to_ascii_lowercase().as_str() {
+    let normalized_selector = selector.trim().to_ascii_lowercase();
+
+    if let Some(server_name) = mcp_server_selector_name(normalized_selector.as_str()) {
+        return load_runtime_mcp_snapshot(config).map(|snapshot| {
+            snapshot
+                .servers
+                .iter()
+                .any(|server| server.name == server_name && mcp_server_satisfies_skill_gate(server))
+        });
+    }
+
+    if let Some(server_name) = acp_bootstrap_mcp_server_selector_name(normalized_selector.as_str())
+    {
+        return load_runtime_mcp_snapshot(config).map(|snapshot| {
+            snapshot.servers.iter().any(|server| {
+                server.name == server_name
+                    && server.selected_for_acp_bootstrap
+                    && mcp_server_satisfies_skill_gate(server)
+            })
+        });
+    }
+
+    match normalized_selector.as_str() {
         "external_skills.enabled" | "tools.external_skills.enabled" => {
             Some(config.external_skills.enabled)
         }
@@ -4094,6 +4127,52 @@ fn runtime_config_selector_enabled(
         "web_search.enabled" | "tools.web_search.enabled" => Some(config.web_search.enabled),
         _ => None,
     }
+}
+
+fn mcp_server_selector_name(selector: &str) -> Option<String> {
+    [
+        "mcp.server.",
+        "mcp.servers.",
+        "tools.mcp.server.",
+        "tools.mcp.servers.",
+    ]
+    .iter()
+    .find_map(|prefix| selector.strip_prefix(prefix))
+    .and_then(canonical_mcp_server_selector_name)
+}
+
+fn acp_bootstrap_mcp_server_selector_name(selector: &str) -> Option<String> {
+    [
+        "acp.bootstrap_mcp_server.",
+        "acp.bootstrap_mcp_servers.",
+        "acp.dispatch.bootstrap_mcp_server.",
+        "acp.dispatch.bootstrap_mcp_servers.",
+    ]
+    .iter()
+    .find_map(|prefix| selector.strip_prefix(prefix))
+    .and_then(canonical_mcp_server_selector_name)
+}
+
+fn canonical_mcp_server_selector_name(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn load_runtime_mcp_snapshot(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Option<crate::mcp::McpRuntimeSnapshot> {
+    let config_path = config.config_path.as_ref()?;
+    let config_path = config_path.to_string_lossy();
+    let (_, loong_config) = crate::config::load(Some(config_path.as_ref())).ok()?;
+    crate::mcp::collect_mcp_runtime_snapshot(&loong_config).ok()
+}
+
+fn mcp_server_satisfies_skill_gate(server: &crate::mcp::McpRuntimeServerSnapshot) -> bool {
+    server.enabled
+        && matches!(
+            server.status.kind,
+            crate::mcp::McpServerStatusKind::Pending | crate::mcp::McpServerStatusKind::Connected
+        )
 }
 
 fn invocation_policy_id(policy: SkillInvocationPolicy) -> &'static str {
@@ -4161,6 +4240,7 @@ pub(super) fn model_skill_catalog_section_with_config(
     let mut lines = vec![
         "[available_external_skills]".to_owned(),
         "The following external skills provide specialized instructions for specific tasks.".to_owned(),
+        "Only skills listed here are currently model-visible and invokable from the provider surface; manual-only or runtime-ineligible skills stay on the operator surface.".to_owned(),
         "When a task matches a listed skill, use `tool.search` to lease `external_skills.invoke`, then call `tool.invoke` with the selected `skill_id` to load the full skill instructions.".to_owned(),
         "The activation result includes the structured skill content, the skill directory, and a bundled resource listing for on-demand file reads.".to_owned(),
     ];
@@ -4797,6 +4877,7 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+    use crate::config::{LoongConfig, McpServerConfig, McpServerTransportConfig};
     use crate::tools::runtime_config::{ExternalSkillsRuntimePolicy, ToolRuntimeConfig};
 
     static POLICY_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -4929,6 +5010,11 @@ mod tests {
             },
             ..ToolRuntimeConfig::default()
         }
+    }
+
+    fn write_loong_config(path: &Path, config: &LoongConfig) {
+        let rendered = crate::config::render(config).expect("render loong config");
+        fs::write(path, rendered).expect("write loong config");
     }
 
     #[derive(Default)]
@@ -6159,6 +6245,112 @@ mod tests {
     }
 
     #[test]
+    fn model_surface_hides_manual_only_skills() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loong-ext-skill-manual-only-model-surface");
+            fs::create_dir_all(&root).expect("create fixture root");
+            write_file(
+                &root,
+                ".agents/skills/manual-only/SKILL.md",
+                "---
+name: manual-only
+description: operator-only workflow.
+invocation_policy: manual
+---
+
+# Manual Only
+
+Use this skill only for operator-driven checks.
+",
+            );
+            write_file(
+                &root,
+                ".agents/skills/model-ready/SKILL.md",
+                "---
+name: model-ready
+description: model-invokable workflow.
+invocation_policy: both
+---
+
+# Model Ready
+
+Safe for model-driven activation.
+",
+            );
+            let config = managed_runtime_config(&root);
+
+            let model_list = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("model list should succeed");
+            let model_skill_ids = model_list.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .filter_map(|skill| skill["skill_id"].as_str())
+                .collect::<Vec<_>>();
+            assert!(
+                !model_skill_ids.contains(&"manual-only"),
+                "manual-only skills must stay off the model surface: {model_skill_ids:?}"
+            );
+            assert!(
+                model_skill_ids.contains(&"model-ready"),
+                "model-invokable skills should remain visible: {model_skill_ids:?}"
+            );
+
+            let manual_inspect_error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.inspect".to_owned(),
+                    payload: json!({
+                        "skill_id": "manual-only"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("manual-only skill should be hidden from model inspect");
+            assert!(
+                manual_inspect_error.contains("manual-only"),
+                "expected manual-only blocker in inspect error, got: {manual_inspect_error}"
+            );
+
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            assert!(
+                operator_list.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "manual-only"),
+                "operator surface should continue to expose manual-only skills"
+            );
+
+            let catalog = model_skill_catalog_section_with_config(&config)
+                .expect("model skill catalog should be rendered");
+            assert!(
+                !catalog
+                    .lines()
+                    .any(|line| line.starts_with("- manual-only:")),
+                "manual-only skill must not be advertised in the model catalog: {catalog}"
+            );
+            assert!(
+                catalog.contains("model-ready"),
+                "model catalog should still advertise invokable skills: {catalog}"
+            );
+            assert!(
+                catalog
+                    .contains("Only skills listed here are currently model-visible and invokable"),
+                "catalog should explain that it excludes manual-only skills: {catalog}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
     fn invoke_rejects_manual_or_ineligible_skill_metadata_contracts() {
         with_managed_runtime_test(|| {
             let root = unique_temp_dir("loong-ext-skill-metadata-contract-reject");
@@ -6204,7 +6396,11 @@ mod tests {
                 &config,
             )
             .expect_err("manual-only skills should reject model invocation");
-            assert!(manual_error.contains("invocation_policy=manual"));
+            assert!(
+                manual_error.contains("manual-only")
+                    || manual_error.contains("not available on the provider surface"),
+                "expected manual-only provider-surface rejection, got: {manual_error}"
+            );
 
             let env_error = crate::tools::execute_tool_core_with_config(
                 ToolCoreRequest {
@@ -7000,6 +7196,146 @@ mod tests {
             assert!(
                 error.contains("DEMO_SKILL_TOKEN"),
                 "expected missing env variable in error, got: {error}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn provider_surface_hides_skills_with_missing_required_mcp_server_selector() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loong-ext-skill-required-mcp");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let config_path = root.join("loong.toml");
+            write_loong_config(&config_path, &LoongConfig::default());
+            write_file(
+                &root,
+                ".agents/skills/mcp-guarded/SKILL.md",
+                "---\nname: mcp-guarded\ndescription: requires a configured MCP server.\nrequired_config:\n  - mcp.server.filesystem\n---\n\n# MCP Guarded Skill\n\nOnly run when the filesystem MCP server is available.\n",
+            );
+
+            let mut config = managed_runtime_config(&root);
+            config.config_path = Some(config_path);
+
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let operator_skill = operator_list.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "mcp-guarded")
+                .cloned()
+                .expect("operator list should include mcp-guarded");
+            assert_eq!(operator_skill["eligibility"]["available"], json!(false));
+            assert!(
+                operator_skill["eligibility"]["issues"]
+                    .as_array()
+                    .expect("eligibility issues should be an array")
+                    .iter()
+                    .any(|issue| issue.as_str()
+                        == Some("config gate `mcp.server.filesystem` is disabled"))
+            );
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("model list should succeed");
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "mcp-guarded"),
+                "skills with missing MCP config gates should stay hidden from provider list: {}",
+                list_outcome.payload
+            );
+
+            let inspect_error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.inspect".to_owned(),
+                    payload: json!({
+                        "skill_id": "mcp-guarded"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("inspect should reject skills with missing required MCP config");
+            assert!(
+                inspect_error.contains("mcp.server.filesystem"),
+                "expected missing MCP selector in inspect error, got: {inspect_error}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn required_mcp_server_and_bootstrap_selectors_accept_enabled_bootstrap_server() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loong-ext-skill-required-bootstrap-mcp");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let config_path = root.join("loong.toml");
+            let mut loong_config = LoongConfig::default();
+            loong_config.mcp.servers.insert(
+                " Filesystem ".to_owned(),
+                McpServerConfig {
+                    transport: McpServerTransportConfig::Stdio {
+                        command: "uvx".to_owned(),
+                        args: vec!["context7-mcp".to_owned()],
+                        env: BTreeMap::new(),
+                        cwd: None,
+                    },
+                    enabled: true,
+                    required: false,
+                    startup_timeout_ms: None,
+                    tool_timeout_ms: None,
+                    enabled_tools: Vec::new(),
+                    disabled_tools: Vec::new(),
+                },
+            );
+            loong_config.acp.dispatch.bootstrap_mcp_servers = vec![" filesystem ".to_owned()];
+            write_loong_config(&config_path, &loong_config);
+            write_file(
+                &root,
+                ".agents/skills/mcp-bootstrap/SKILL.md",
+                "---\nname: mcp-bootstrap\ndescription: requires a configured and bootstrapped MCP server.\nrequired_config:\n  - mcp.server.filesystem\n  - acp.bootstrap_mcp_server.filesystem\n---\n\n# MCP Bootstrap Skill\n\nOnly run when the filesystem MCP server is present in ACP bootstrap selection.\n",
+            );
+
+            let mut config = managed_runtime_config(&root);
+            config.config_path = Some(config_path);
+
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let operator_skill = operator_list.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "mcp-bootstrap")
+                .cloned()
+                .expect("operator list should include mcp-bootstrap");
+            assert_eq!(operator_skill["eligibility"]["available"], json!(true));
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("model list should succeed");
+            assert!(
+                list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "mcp-bootstrap"),
+                "skills with satisfied MCP selectors should stay visible on the provider surface: {}",
+                list_outcome.payload
             );
 
             fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -37,16 +37,18 @@ const HARD_MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
 const DEFAULT_SKILL_RESOURCE_LIST_LIMIT: usize = 64;
 #[cfg(test)]
 const INSTALLED_SKILL_SNAPSHOT_HINT: &str = "installed managed external skill; use external_skills.inspect or external_skills.invoke for details";
-const PROJECT_DISCOVERY_DIRS: [(&str, usize); 4] = [
-    (".agents/skills", 0),
-    (".codex/skills", 1),
-    (".claude/skills", 2),
-    ("skills", 3),
+const PROJECT_DISCOVERY_DIRS: [(&str, usize); 5] = [
+    (".loong/skills", 0),
+    (".agents/skills", 1),
+    (".codex/skills", 2),
+    (".claude/skills", 3),
+    ("skills", 4),
 ];
-const USER_DISCOVERY_DIRS: [(&str, usize); 3] = [
-    (".agents/skills", 0),
-    (".codex/skills", 1),
-    (".claude/skills", 2),
+const USER_DISCOVERY_DIRS: [(&str, usize); 4] = [
+    (".loong/skills", 0),
+    (".agents/skills", 1),
+    (".codex/skills", 2),
+    (".claude/skills", 3),
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -146,9 +148,11 @@ impl From<DiscoveredSkillEntry> for DiscoveredSkillModelView {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ModelVisibleSkillIdentity {
+pub(crate) struct ModelVisibleSkillCatalogEntry {
     pub(super) skill_id: String,
-    pub(super) display_name: String,
+    pub(super) description: String,
+    pub(super) location: String,
+    pub(super) skill_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -1098,7 +1102,6 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
     let inventory = discover_skill_inventory(config)?;
     let skill = resolve_discovered_skill(&inventory, skill_id)?;
     ensure_skill_access_for_audience(&skill, SkillAudience::Model)?;
-    let raw_instructions = load_discovered_skill_markdown(config, &skill)?;
     if !skill.eligibility.available {
         return Err(format!(
             "external skill `{skill_id}` is not eligible in the current runtime: {}",
@@ -1115,42 +1118,24 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
         skill.allowed_tools.as_slice(),
         skill.blocked_tools.as_slice(),
     );
-    let skill_root = resolved_skill_root_path(&skill);
-    let resource_listing = skill_root
-        .as_deref()
-        .map(|path| list_skill_resources(path, DEFAULT_SKILL_RESOURCE_LIST_LIMIT))
-        .transpose()?
-        .unwrap_or_default();
-    let instructions = render_structured_skill_instructions(
-        &skill,
-        raw_instructions.as_str(),
-        skill_root.as_deref(),
-        &resource_listing,
+    let mut payload_object = build_external_skill_context_payload(config, &skill)?
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "external skill context payload must be an object".to_owned())?;
+    payload_object.insert("adapter".to_owned(), json!("core-tools"));
+    payload_object.insert("tool_name".to_owned(), json!(request.tool_name));
+    payload_object.insert(
+        "invocation_summary".to_owned(),
+        json!(format!(
+            "Loaded external skill `{}` with invocation_policy={}. Apply the structured skill content before continuing the task{}.",
+            skill_id,
+            invocation_policy_id,
+            tool_restrictions_suffix
+        )),
     );
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload: json!({
-            "adapter": "core-tools",
-            "tool_name": request.tool_name,
-            "skill_id": skill.skill_id,
-            "display_name": skill.display_name,
-            "summary": skill.summary,
-            "scope": skill.scope,
-            "source_path": skill.source_path,
-            "install_path": skill.install_path,
-            "skill_md_path": skill.skill_md_path,
-            "skill_root": skill_root,
-            "resource_listing": resource_listing,
-            "instructions": instructions,
-            "metadata": metadata_payload_from_skill(&skill),
-            "eligibility": skill.eligibility,
-            "invocation_summary": format!(
-                "Loaded external skill `{}` with invocation_policy={}. Apply the structured skill content before continuing the task{}.",
-                skill_id,
-                invocation_policy_id,
-                tool_restrictions_suffix
-            ),
-        }),
+        payload: Value::Object(payload_object),
     })
 }
 
@@ -4232,42 +4217,45 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
 pub(super) fn model_skill_catalog_section_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Option<String> {
-    let policy = resolve_effective_policy(config).ok()?;
-    if !policy.enabled {
-        return None;
-    }
-
-    let inventory = discover_skill_inventory(config).ok()?;
-    let filtered = filter_inventory_for_audience(inventory, SkillAudience::Model);
-    if filtered.skills.is_empty() {
+    let visible_skills = model_visible_skill_catalog_entries_with_config(config);
+    if visible_skills.is_empty() {
         return None;
     }
 
     let mut lines = vec![
         "[available_external_skills]".to_owned(),
         "The following external skills provide specialized instructions for specific tasks.".to_owned(),
-        "Only skills listed here are currently model-visible and invokable from the provider surface; manual-only or runtime-ineligible skills stay on the operator surface.".to_owned(),
-        "When a task matches a listed skill, use `tool.search` to lease `external_skills.invoke`, then call `tool.invoke` with the selected `skill_id` to load the full skill instructions.".to_owned(),
-        "The activation result includes the structured skill content, the skill directory, and a bundled resource listing for on-demand file reads.".to_owned(),
+        "Only skills listed here are currently model-visible and runtime-eligible; manual-only or ineligible skills stay off this list.".to_owned(),
+        "Use the read tool to load a listed skill's SKILL.md file when the task matches its description.".to_owned(),
+        "Do not use tool.search or tool.invoke for routine model-driven skill loading; skills are read-first, not tool-discovery-first.".to_owned(),
+        "When a skill file references a relative path, resolve it against the skill directory (the parent of SKILL.md) and use that absolute path in tool commands.".to_owned(),
+        "<available_skills>".to_owned(),
     ];
 
-    for skill in filtered.skills {
-        let mut line = format!("- {}: {}", skill.skill_id, skill.summary);
-        if let Some(compatibility) = skill.compatibility.as_deref()
-            && !compatibility.is_empty()
-        {
-            line.push_str(" Compatibility: ");
-            line.push_str(compatibility);
-        }
-        lines.push(line);
+    for skill in visible_skills {
+        lines.push("  <skill>".to_owned());
+        lines.push(format!(
+            "    <name>{}</name>",
+            xml_escape(skill.skill_id.as_str())
+        ));
+        lines.push(format!(
+            "    <description>{}</description>",
+            xml_escape(skill.description.as_str())
+        ));
+        lines.push(format!(
+            "    <location>{}</location>",
+            xml_escape(skill.location.as_str())
+        ));
+        lines.push("  </skill>".to_owned());
     }
+    lines.push("</available_skills>".to_owned());
 
     Some(lines.join("\n"))
 }
 
-pub(super) fn model_visible_skill_identities_with_config(
+fn model_visible_skill_entries_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
-) -> Vec<ModelVisibleSkillIdentity> {
+) -> Vec<DiscoveredSkillEntry> {
     let policy = match resolve_effective_policy(config) {
         Ok(policy) => policy,
         Err(_) => return Vec::new(),
@@ -4282,18 +4270,98 @@ pub(super) fn model_visible_skill_identities_with_config(
     };
     let filtered = filter_inventory_for_audience(inventory, SkillAudience::Model);
 
-    filtered
-        .skills
+    filtered.skills
+}
+
+pub(crate) fn model_visible_skill_catalog_entries_with_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Vec<ModelVisibleSkillCatalogEntry> {
+    model_visible_skill_entries_with_config(config)
         .into_iter()
-        .map(|skill| ModelVisibleSkillIdentity {
-            skill_id: skill.skill_id,
-            display_name: skill.display_name,
+        .map(|skill| {
+            let skill_root = resolved_skill_root_path(&skill);
+            ModelVisibleSkillCatalogEntry {
+                skill_id: skill.skill_id,
+                description: skill.summary,
+                location: skill.skill_md_path,
+                skill_root,
+            }
         })
         .collect()
 }
 
-pub(super) fn normalize_skill_lookup_id(raw: &str) -> Option<String> {
-    normalize_skill_id(raw).ok()
+pub(crate) fn model_visible_skill_roots_with_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for skill in model_visible_skill_catalog_entries_with_config(config) {
+        let Some(skill_root) = skill.skill_root else {
+            continue;
+        };
+        let canonical = fs::canonicalize(&skill_root).unwrap_or(skill_root);
+        if !roots.contains(&canonical) {
+            roots.push(canonical);
+        }
+    }
+    roots
+}
+
+fn build_external_skill_context_payload(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    skill: &DiscoveredSkillEntry,
+) -> Result<Value, String> {
+    let raw_instructions = load_discovered_skill_markdown(config, skill)?;
+    let skill_root = resolved_skill_root_path(skill);
+    let resource_listing = skill_root
+        .as_deref()
+        .map(|path| list_skill_resources(path, DEFAULT_SKILL_RESOURCE_LIST_LIMIT))
+        .transpose()?
+        .unwrap_or_default();
+    let instructions = render_structured_skill_instructions(
+        skill,
+        raw_instructions.as_str(),
+        skill_root.as_deref(),
+        &resource_listing,
+    );
+
+    Ok(json!({
+        "skill_id": skill.skill_id,
+        "display_name": skill.display_name,
+        "summary": skill.summary,
+        "scope": skill.scope,
+        "source_path": skill.source_path,
+        "install_path": skill.install_path,
+        "skill_md_path": skill.skill_md_path,
+        "skill_root": skill_root,
+        "resource_listing": resource_listing,
+        "instructions": instructions,
+        "metadata": metadata_payload_from_skill(skill),
+        "eligibility": skill.eligibility,
+    }))
+}
+
+pub(crate) fn model_visible_skill_context_payload_for_path(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    raw_path: &Path,
+) -> Result<Option<Value>, String> {
+    let requested_path = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else if let Some(file_root) = config.file_root.as_deref() {
+        file_root.join(raw_path)
+    } else {
+        raw_path.to_path_buf()
+    };
+    let normalized_requested_path = fs::canonicalize(&requested_path).unwrap_or(requested_path);
+
+    for skill in model_visible_skill_entries_with_config(config) {
+        let skill_md_path = PathBuf::from(skill.skill_md_path.as_str());
+        let normalized_skill_md_path = fs::canonicalize(&skill_md_path).unwrap_or(skill_md_path);
+        if normalized_skill_md_path == normalized_requested_path {
+            return build_external_skill_context_payload(config, &skill).map(Some);
+        }
+    }
+
+    Ok(None)
 }
 
 fn discover_managed_skill_candidates(
@@ -6378,9 +6446,16 @@ Safe for model-driven activation.
                 "model catalog should still advertise invokable skills: {catalog}"
             );
             assert!(
-                catalog
-                    .contains("Only skills listed here are currently model-visible and invokable"),
-                "catalog should explain that it excludes manual-only skills: {catalog}"
+                catalog.contains("Use the read tool to load a listed skill's SKILL.md file"),
+                "catalog should describe the read-first loading path: {catalog}"
+            );
+            assert!(
+                catalog.contains("<available_skills>") && catalog.contains("<location>"),
+                "catalog should include structured skill locations for read-first loading: {catalog}"
+            );
+            assert!(
+                !catalog.contains("use `tool.search` to lease `external_skills.invoke`"),
+                "catalog should not steer routine skill loading through tool discovery leases: {catalog}"
             );
 
             fs::remove_dir_all(&root).ok();
@@ -6521,7 +6596,7 @@ Safe for model-driven activation.
             );
             write_file(
                 &root,
-                ".agents/skills/demo-skill/SKILL.md",
+                ".loong/skills/demo-skill/SKILL.md",
                 "---\nname: demo-skill\ndescription: Project-scoped demo skill.\n---\n\n# Project Demo Skill\n\nProject copy should be shadowed by managed.\n",
             );
             write_file(
@@ -6531,12 +6606,12 @@ Safe for model-driven activation.
             );
             write_file(
                 &home,
-                ".agents/skills/demo-skill/SKILL.md",
+                ".loong/skills/demo-skill/SKILL.md",
                 "---\nname: demo-skill\ndescription: User-scoped demo skill.\n---\n\n# User Demo Skill\n\nUser copy should be shadowed by managed.\n",
             );
             write_file(
                 &home,
-                ".agents/skills/user-only/SKILL.md",
+                ".loong/skills/user-only/SKILL.md",
                 "---\nname: user-only\ndescription: User-only skill.\n---\n\nUser-only instructions.\n",
             );
 
@@ -6793,7 +6868,7 @@ Safe for model-driven activation.
             let home = unique_temp_dir("loong-ext-skill-discovery-symlink-home");
             let shared = unique_temp_dir("loong-ext-skill-discovery-symlink-target");
             fs::create_dir_all(&root).expect("create fixture root");
-            fs::create_dir_all(home.join(".agents/skills")).expect("create user skills root");
+            fs::create_dir_all(home.join(".loong/skills")).expect("create user skills root");
             fs::create_dir_all(&shared).expect("create shared skill root");
             write_file(
                 &shared,
@@ -6802,7 +6877,7 @@ Safe for model-driven activation.
             );
             symlink(
                 shared.join("portable-skill"),
-                home.join(".agents/skills/portable-skill"),
+                home.join(".loong/skills/portable-skill"),
             )
             .expect("create user skill symlink");
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -720,6 +720,19 @@ pub(crate) fn direct_tool_name_for_hidden_tool(raw: &str) -> Option<&'static str
     tool_surface::direct_tool_name_for_hidden_tool(canonical_name)
 }
 
+pub(crate) fn model_visible_external_skill_roots_for_runtime_config(
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Vec<PathBuf> {
+    external_skills::model_visible_skill_roots_with_config(config)
+}
+
+pub(crate) fn model_visible_external_skill_context_payload_for_path(
+    config: &runtime_config::ToolRuntimeConfig,
+    raw_path: &Path,
+) -> Result<Option<Value>, String> {
+    external_skills::model_visible_skill_context_payload_for_path(config, raw_path)
+}
+
 pub fn user_visible_tool_name(raw: &str) -> String {
     let canonical_name = canonical_tool_name(raw);
 

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -79,6 +79,8 @@ pub(super) fn execute_tool_search_tool_with_config(
         .cloned()
         .and_then(|value| serde_json::from_value::<BTreeSet<Capability>>(value).ok());
     let visible_tool_view = search_tool_view_from_payload(payload, config);
+    let visible_external_skills =
+        super::external_skills::model_visible_skill_identities_with_config(config);
 
     let exact_match_entries =
         super::runtime_tool_search_entries(config, Some(&visible_tool_view), false)
@@ -90,7 +92,10 @@ pub(super) fn execute_tool_search_tool_with_config(
                 )
             })
             .collect::<Vec<_>>();
-    let searchable_entries = collapse_hidden_surface_search_entries(exact_match_entries.clone());
+    let searchable_entries = augment_hidden_skills_surface_with_external_skill_identities(
+        collapse_hidden_surface_search_entries(exact_match_entries.clone()),
+        visible_external_skills.as_slice(),
+    );
     let exact_match_entry = exact_tool_id.as_ref().and_then(|exact_tool_id| {
         let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
         let direct_tool_id = direct_tool_id.map(str::to_owned);
@@ -106,6 +111,14 @@ pub(super) fn execute_tool_search_tool_with_config(
                 canonical_match || tool_id_match || direct_match
             })
             .cloned()
+            .or_else(|| {
+                exact_tool_id_matches_visible_external_skill(
+                    exact_tool_id,
+                    visible_external_skills.as_slice(),
+                )
+                .then(|| hidden_skills_surface_entry(&searchable_entries))
+                .flatten()
+            })
             .or_else(|| {
                 exact_match_entries
                     .iter()
@@ -244,6 +257,75 @@ fn tool_search_diagnostics_json(
     }
 
     Value::Null
+}
+
+fn augment_hidden_skills_surface_with_external_skill_identities(
+    entries: Vec<SearchableToolEntry>,
+    visible_external_skills: &[super::external_skills::ModelVisibleSkillIdentity],
+) -> Vec<SearchableToolEntry> {
+    if visible_external_skills.is_empty() {
+        return entries;
+    }
+
+    let mut discovery_terms = BTreeSet::new();
+    for skill in visible_external_skills {
+        discovery_terms.insert(skill.skill_id.clone());
+        let display_name = skill.display_name.trim();
+        if !display_name.is_empty() {
+            discovery_terms.insert(display_name.to_owned());
+        }
+    }
+    if discovery_terms.is_empty() {
+        return entries;
+    }
+
+    entries
+        .into_iter()
+        .map(|entry| augment_hidden_skills_surface_entry(entry, &discovery_terms))
+        .collect()
+}
+
+fn augment_hidden_skills_surface_entry(
+    entry: SearchableToolEntry,
+    discovery_terms: &BTreeSet<String>,
+) -> SearchableToolEntry {
+    if entry.canonical_name != "skills" && entry.tool_id != "skills" {
+        return entry;
+    }
+
+    let mut merged_tags = entry.tags.iter().cloned().collect::<BTreeSet<_>>();
+    merged_tags.extend(discovery_terms.iter().cloned());
+
+    searchable_entry_from_manual_definition(
+        entry.canonical_name.as_str(),
+        entry.summary.as_str(),
+        entry.argument_hint.as_str(),
+        entry.required_fields,
+        entry.required_field_groups,
+        merged_tags.into_iter().collect(),
+    )
+}
+
+fn exact_tool_id_matches_visible_external_skill(
+    exact_tool_id: &str,
+    visible_external_skills: &[super::external_skills::ModelVisibleSkillIdentity],
+) -> bool {
+    let Some(normalized_skill_id) =
+        super::external_skills::normalize_skill_lookup_id(exact_tool_id)
+    else {
+        return false;
+    };
+
+    visible_external_skills
+        .iter()
+        .any(|skill| skill.skill_id == normalized_skill_id)
+}
+
+fn hidden_skills_surface_entry(entries: &[SearchableToolEntry]) -> Option<SearchableToolEntry> {
+    entries
+        .iter()
+        .find(|entry| entry.canonical_name == "skills" || entry.tool_id == "skills")
+        .cloned()
 }
 
 fn tool_search_query_from_payload(

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -79,9 +79,6 @@ pub(super) fn execute_tool_search_tool_with_config(
         .cloned()
         .and_then(|value| serde_json::from_value::<BTreeSet<Capability>>(value).ok());
     let visible_tool_view = search_tool_view_from_payload(payload, config);
-    let visible_external_skills =
-        super::external_skills::model_visible_skill_identities_with_config(config);
-
     let exact_match_entries =
         super::runtime_tool_search_entries(config, Some(&visible_tool_view), false)
             .into_iter()
@@ -92,10 +89,7 @@ pub(super) fn execute_tool_search_tool_with_config(
                 )
             })
             .collect::<Vec<_>>();
-    let searchable_entries = augment_hidden_skills_surface_with_external_skill_identities(
-        collapse_hidden_surface_search_entries(exact_match_entries.clone()),
-        visible_external_skills.as_slice(),
-    );
+    let searchable_entries = collapse_hidden_surface_search_entries(exact_match_entries.clone());
     let exact_match_entry = exact_tool_id.as_ref().and_then(|exact_tool_id| {
         let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
         let direct_tool_id = direct_tool_id.map(str::to_owned);
@@ -111,14 +105,6 @@ pub(super) fn execute_tool_search_tool_with_config(
                 canonical_match || tool_id_match || direct_match
             })
             .cloned()
-            .or_else(|| {
-                exact_tool_id_matches_visible_external_skill(
-                    exact_tool_id,
-                    visible_external_skills.as_slice(),
-                )
-                .then(|| hidden_skills_surface_entry(&searchable_entries))
-                .flatten()
-            })
             .or_else(|| {
                 exact_match_entries
                     .iter()
@@ -257,75 +243,6 @@ fn tool_search_diagnostics_json(
     }
 
     Value::Null
-}
-
-fn augment_hidden_skills_surface_with_external_skill_identities(
-    entries: Vec<SearchableToolEntry>,
-    visible_external_skills: &[super::external_skills::ModelVisibleSkillIdentity],
-) -> Vec<SearchableToolEntry> {
-    if visible_external_skills.is_empty() {
-        return entries;
-    }
-
-    let mut discovery_terms = BTreeSet::new();
-    for skill in visible_external_skills {
-        discovery_terms.insert(skill.skill_id.clone());
-        let display_name = skill.display_name.trim();
-        if !display_name.is_empty() {
-            discovery_terms.insert(display_name.to_owned());
-        }
-    }
-    if discovery_terms.is_empty() {
-        return entries;
-    }
-
-    entries
-        .into_iter()
-        .map(|entry| augment_hidden_skills_surface_entry(entry, &discovery_terms))
-        .collect()
-}
-
-fn augment_hidden_skills_surface_entry(
-    entry: SearchableToolEntry,
-    discovery_terms: &BTreeSet<String>,
-) -> SearchableToolEntry {
-    if entry.canonical_name != "skills" && entry.tool_id != "skills" {
-        return entry;
-    }
-
-    let mut merged_tags = entry.tags.iter().cloned().collect::<BTreeSet<_>>();
-    merged_tags.extend(discovery_terms.iter().cloned());
-
-    searchable_entry_from_manual_definition(
-        entry.canonical_name.as_str(),
-        entry.summary.as_str(),
-        entry.argument_hint.as_str(),
-        entry.required_fields,
-        entry.required_field_groups,
-        merged_tags.into_iter().collect(),
-    )
-}
-
-fn exact_tool_id_matches_visible_external_skill(
-    exact_tool_id: &str,
-    visible_external_skills: &[super::external_skills::ModelVisibleSkillIdentity],
-) -> bool {
-    let Some(normalized_skill_id) =
-        super::external_skills::normalize_skill_lookup_id(exact_tool_id)
-    else {
-        return false;
-    };
-
-    visible_external_skills
-        .iter()
-        .any(|skill| skill.skill_id == normalized_skill_id)
-}
-
-fn hidden_skills_surface_entry(entries: &[SearchableToolEntry]) -> Option<SearchableToolEntry> {
-    entries
-        .iter()
-        .find(|entry| entry.canonical_name == "skills" || entry.tool_id == "skills")
-        .cloned()
 }
 
 fn tool_search_query_from_payload(

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -1720,6 +1720,96 @@ fn tool_search_matches_prompt_style_queries_across_tool_surfaces() {
 
 #[cfg(feature = "tool-file")]
 #[test]
+fn tool_search_matches_model_visible_skill_ids_to_skills_surface() {
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directory");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_tool_temp_dir("loongclaw-tool-search-visible-skill-id");
+    std::fs::create_dir_all(&root).expect("create fixture root");
+    write_file(
+        &root,
+        ".agents/skills/agent-browser/SKILL.md",
+        "---\nname: agent-browser\ndescription: managed browser automation.\ninvocation_policy: both\n---\n\n# Agent Browser\n\nUse this skill for browser automation.\n",
+    );
+
+    let config = test_tool_runtime_config(root.clone());
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({
+                "query": "agent-browser",
+                "limit": 3
+            }),
+        },
+        &config,
+    )
+    .expect("tool search should succeed");
+
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert!(
+        results.iter().any(|entry| entry["tool_id"] == "skills"),
+        "model-visible skill ids should route to the grouped skills surface: {results:?}"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn tool_search_exact_skill_id_returns_grouped_skills_surface() {
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent directory");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    let root = unique_tool_temp_dir("loongclaw-tool-search-exact-skill-id");
+    std::fs::create_dir_all(&root).expect("create fixture root");
+    write_file(
+        &root,
+        ".agents/skills/agent-browser/SKILL.md",
+        "---\nname: agent-browser\ndescription: managed browser automation.\ninvocation_policy: both\n---\n\n# Agent Browser\n\nUse this skill for browser automation.\n",
+    );
+
+    let config = test_tool_runtime_config(root.clone());
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({
+                "exact_tool_id": "agent-browser",
+                "query": "browser automation",
+                "limit": 3
+            }),
+        },
+        &config,
+    )
+    .expect("tool search should succeed");
+
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert_eq!(
+        results.len(),
+        1,
+        "exact skill id should resolve to one grouped result"
+    );
+    assert_eq!(results[0]["tool_id"], "skills");
+    assert!(
+        outcome.payload["diagnostics"].is_null(),
+        "exact model-visible skill ids should not report not-visible diagnostics: {}",
+        outcome.payload["diagnostics"]
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
 fn tool_search_uses_coarse_listing_fallback_when_query_is_missing() {
     let root = unique_tool_temp_dir("loongclaw-tool-search-missing-query");
     std::fs::create_dir_all(&root).expect("create fixture root");

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -296,7 +296,16 @@ fn capability_snapshot_stays_compact_when_external_skills_are_installed() {
     assert!(snapshot.starts_with("[tool_discovery_runtime]"));
     assert!(snapshot.contains("[available_external_skills]"));
     assert!(snapshot.contains("demo-skill"));
-    assert!(snapshot.contains("external_skills.invoke"));
+    assert!(snapshot.contains("Use the read tool to load a listed skill's SKILL.md file"));
+    assert!(snapshot.contains("<available_skills>"));
+    assert!(
+        snapshot.contains(
+            &root
+                .join("external-skills-installed/demo-skill/SKILL.md")
+                .display()
+                .to_string()
+        )
+    );
 
     fs::remove_dir_all(&root).ok();
 }
@@ -1714,96 +1723,6 @@ fn tool_search_matches_prompt_style_queries_across_tool_surfaces() {
             "expected semantic match for `{query}`, got coarse fallback: {expected_entry:?}"
         );
     }
-
-    std::fs::remove_dir_all(&root).ok();
-}
-
-#[cfg(feature = "tool-file")]
-#[test]
-fn tool_search_matches_model_visible_skill_ids_to_skills_surface() {
-    fn write_file(root: &Path, relative: &str, content: &str) {
-        let path = root.join(relative);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).expect("create parent directory");
-        }
-        std::fs::write(path, content).expect("write fixture");
-    }
-
-    let root = unique_tool_temp_dir("loongclaw-tool-search-visible-skill-id");
-    std::fs::create_dir_all(&root).expect("create fixture root");
-    write_file(
-        &root,
-        ".agents/skills/agent-browser/SKILL.md",
-        "---\nname: agent-browser\ndescription: managed browser automation.\ninvocation_policy: both\n---\n\n# Agent Browser\n\nUse this skill for browser automation.\n",
-    );
-
-    let config = test_tool_runtime_config(root.clone());
-    let outcome = execute_tool_core_with_config(
-        ToolCoreRequest {
-            tool_name: "tool.search".to_owned(),
-            payload: json!({
-                "query": "agent-browser",
-                "limit": 3
-            }),
-        },
-        &config,
-    )
-    .expect("tool search should succeed");
-
-    let results = outcome.payload["results"].as_array().expect("results");
-    assert!(
-        results.iter().any(|entry| entry["tool_id"] == "skills"),
-        "model-visible skill ids should route to the grouped skills surface: {results:?}"
-    );
-
-    std::fs::remove_dir_all(&root).ok();
-}
-
-#[cfg(feature = "tool-file")]
-#[test]
-fn tool_search_exact_skill_id_returns_grouped_skills_surface() {
-    fn write_file(root: &Path, relative: &str, content: &str) {
-        let path = root.join(relative);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).expect("create parent directory");
-        }
-        std::fs::write(path, content).expect("write fixture");
-    }
-
-    let root = unique_tool_temp_dir("loongclaw-tool-search-exact-skill-id");
-    std::fs::create_dir_all(&root).expect("create fixture root");
-    write_file(
-        &root,
-        ".agents/skills/agent-browser/SKILL.md",
-        "---\nname: agent-browser\ndescription: managed browser automation.\ninvocation_policy: both\n---\n\n# Agent Browser\n\nUse this skill for browser automation.\n",
-    );
-
-    let config = test_tool_runtime_config(root.clone());
-    let outcome = execute_tool_core_with_config(
-        ToolCoreRequest {
-            tool_name: "tool.search".to_owned(),
-            payload: json!({
-                "exact_tool_id": "agent-browser",
-                "query": "browser automation",
-                "limit": 3
-            }),
-        },
-        &config,
-    )
-    .expect("tool search should succeed");
-
-    let results = outcome.payload["results"].as_array().expect("results");
-    assert_eq!(
-        results.len(),
-        1,
-        "exact skill id should resolve to one grouped result"
-    );
-    assert_eq!(results[0]["tool_id"], "skills");
-    assert!(
-        outcome.payload["diagnostics"].is_null(),
-        "exact model-visible skill ids should not report not-visible diagnostics: {}",
-        outcome.payload["diagnostics"]
-    );
 
     std::fs::remove_dir_all(&root).ok();
 }

--- a/docs/design-docs/tool-surface-exposure.md
+++ b/docs/design-docs/tool-surface-exposure.md
@@ -201,6 +201,11 @@ The direct surface should stay the normal path for common work.
 - lower-level HTTP access
 - channel-specific operator tools
 
+When the runtime advertises external skills to the model, the advertised set must
+already reflect invocation truth: hide manual-only skills and other runtime-
+ineligible skills from model-facing catalogs, lists, and inspect paths instead of
+teaching the model to invoke them and then rejecting the call later.
+
 Managed browser workflows stay under the direct `browser` surface for normal model-facing use, even when the canonical implementation routes into internal `browser.companion.*` tools.
 
 Hidden search results should prefer surface-level ids instead of spraying many


### PR DESCRIPTION
## Summary

This follow-up changes the Agent Skills runtime from discovery-plane-first back to read-first progressive disclosure.

- makes model-visible skill loading prefer core `read` over `tool.search`
- exposes model-visible skills with structured `name`, `description`, and `location`
- prioritizes `.loong/skills` as the LoongClaw-native skill directory while keeping legacy compatibility directories
- lets visible skill file/resource reads inherit a trusted skill root even when the skill lives outside the main workspace root
- synthesizes active-skill continuity when a visible `SKILL.md` is loaded through `read`
- keeps explicit `$skill-name ...` activation as an operator-driven escape hatch rather than the default model path

## Why

The earlier integration closed important activation and continuity gaps, but it still taught the model to think about routine skill loading through the hidden `skills` surface. That was the wrong execution plane.

For ordinary model-driven use, skills should behave like readable instruction artifacts:

- list them in the prompt with locations
- load them via `read`
- continue with the same runtime continuity semantics after the read succeeds

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- real local smoke test with a temporary `.loong/skills/demo-skill/SKILL.md`, a local OpenAI-compatible stub provider, `loong ask`, and persisted runtime history proving `file.read` hit the skill file path before the final answer

Related: #1329
Closes #1355
