### PR TITLE
Make AGENTS.md the sole runtime workspace-guidance source

### DIFF
--- a/crates/app/src/conversation/prompt_fragments.rs
+++ b/crates/app/src/conversation/prompt_fragments.rs
@@ -37,6 +37,7 @@ impl std::fmt::Display for PromptFrameLayer {
 #[serde(rename_all = "snake_case")]
 pub enum PromptFrameAuthority {
     CoreSystem,
+    WorkspaceGuidance,
     RuntimeSelf,
     RuntimeIdentity,
     CapabilityContract,
@@ -49,6 +50,7 @@ impl PromptFrameAuthority {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::CoreSystem => "core_system",
+            Self::WorkspaceGuidance => "workspace_guidance",
             Self::RuntimeSelf => "runtime_self",
             Self::RuntimeIdentity => "runtime_identity",
             Self::CapabilityContract => "capability_contract",
@@ -64,6 +66,7 @@ impl PromptFrameAuthority {
 pub enum PromptLane {
     TaskDirective,
     BaseSystem,
+    WorkspaceGuidance,
     RuntimeSelf,
     RuntimeIdentity,
     Continuity,
@@ -78,6 +81,7 @@ impl PromptLane {
             PromptLane::TaskDirective,
             PromptLane::Continuity,
             PromptLane::BaseSystem,
+            PromptLane::WorkspaceGuidance,
             PromptLane::RuntimeSelf,
             PromptLane::RuntimeIdentity,
             PromptLane::ExecutionDiscipline,
@@ -90,6 +94,7 @@ impl PromptLane {
         match self {
             PromptLane::TaskDirective => PromptFrameLayer::TurnEphemeralTail,
             PromptLane::BaseSystem => PromptFrameLayer::StableRuntimeGuidance,
+            PromptLane::WorkspaceGuidance => PromptFrameLayer::StableRuntimeGuidance,
             PromptLane::RuntimeSelf => PromptFrameLayer::StableRuntimeGuidance,
             PromptLane::RuntimeIdentity => PromptFrameLayer::SessionLatchedContext,
             PromptLane::Continuity => PromptFrameLayer::SessionLatchedContext,
@@ -103,6 +108,7 @@ impl PromptLane {
         match self {
             PromptLane::TaskDirective => PromptFrameAuthority::LiveTurn,
             PromptLane::BaseSystem => PromptFrameAuthority::CoreSystem,
+            PromptLane::WorkspaceGuidance => PromptFrameAuthority::WorkspaceGuidance,
             PromptLane::RuntimeSelf => PromptFrameAuthority::RuntimeSelf,
             PromptLane::RuntimeIdentity => PromptFrameAuthority::RuntimeIdentity,
             PromptLane::Continuity => PromptFrameAuthority::RuntimeSelf,
@@ -129,6 +135,7 @@ impl PromptRenderPolicy {
             },
             PromptLane::TaskDirective
             | PromptLane::BaseSystem
+            | PromptLane::WorkspaceGuidance
             | PromptLane::RuntimeSelf
             | PromptLane::RuntimeIdentity
             | PromptLane::Continuity

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -676,8 +676,11 @@ mod tests {
             profile: Some(ConstrainedSubagentProfile::for_child_depth(1, 2)),
         };
         let continuity = RuntimeSelfContinuity {
+            workspace_guidance: crate::workspace_guidance::WorkspaceGuidanceModel {
+                entries: vec!["Keep continuity explicit.".to_owned()],
+            },
             runtime_self: RuntimeSelfModel {
-                standing_instructions: vec!["Keep continuity explicit.".to_owned()],
+                standing_instructions: Vec::new(),
                 tool_usage_policy: vec!["Search memory before guessing workspace facts.".to_owned()],
                 soul_guidance: vec!["Prefer rigorous execution.".to_owned()],
                 identity_context: vec!["# Identity\n- Name: Child".to_owned()],

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3388,8 +3388,8 @@ async fn default_runtime_build_context_merges_delegate_runtime_contract_with_sys
         "expected the existing system prompt addition to remain ahead of the child contract block, got: {merged}"
     );
     assert!(
-        base_system_index < contract_index,
-        "expected base system prompt to remain ahead of the child contract block, got: {merged}"
+        contract_index < base_system_index,
+        "expected child contract block to stay ahead of the base system prompt, got: {merged}"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -3377,10 +3377,19 @@ async fn default_runtime_build_context_merges_delegate_runtime_contract_with_sys
     assert!(merged.contains("- browser max sessions: 1"));
     assert!(merged.contains("- browser max links: 8"));
     assert!(merged.contains("- browser max text chars: 512"));
-    assert!(merged.ends_with("base-system-prompt"));
+    let base_system_index = merged
+        .find("base-system-prompt")
+        .expect("base system prompt should remain in merged prompt");
+    let contract_index = merged
+        .find("[delegate_child_runtime_contract]")
+        .expect("delegate runtime contract marker should exist");
     assert!(
         merged.find("runtime-policy-addition") < merged.find("[delegate_child_runtime_contract]"),
         "expected the existing system prompt addition to remain ahead of the child contract block, got: {merged}"
+    );
+    assert!(
+        base_system_index < contract_index,
+        "expected base system prompt to remain ahead of the child contract block, got: {merged}"
     );
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -8225,6 +8225,9 @@ mod tests {
         .expect("create child session");
 
         let stored_continuity = runtime_self_continuity::RuntimeSelfContinuity {
+            workspace_guidance: crate::workspace_guidance::WorkspaceGuidanceModel {
+                entries: vec!["Keep standing instructions visible.".to_owned()],
+            },
             runtime_self: crate::runtime_self::RuntimeSelfModel {
                 identity_context: vec![stored_identity_text.to_owned()],
                 ..Default::default()

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -8225,9 +8225,7 @@ mod tests {
         .expect("create child session");
 
         let stored_continuity = runtime_self_continuity::RuntimeSelfContinuity {
-            workspace_guidance: crate::workspace_guidance::WorkspaceGuidanceModel {
-                entries: vec!["Keep standing instructions visible.".to_owned()],
-            },
+            workspace_guidance: crate::workspace_guidance::WorkspaceGuidanceModel::default(),
             runtime_self: crate::runtime_self::RuntimeSelfModel {
                 identity_context: vec![stored_identity_text.to_owned()],
                 ..Default::default()
@@ -8268,8 +8266,14 @@ mod tests {
             .expect("decode persisted continuity payload");
 
         assert_eq!(
-            persisted_continuity.runtime_self.standing_instructions,
+            persisted_continuity.workspace_guidance.entries,
             vec![live_agents_text.to_owned()]
+        );
+        assert!(
+            persisted_continuity
+                .runtime_self
+                .standing_instructions
+                .is_empty()
         );
         assert_eq!(
             persisted_continuity.runtime_self.identity_context,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -29,6 +29,7 @@ pub mod tools;
 pub(crate) mod trust;
 pub mod tui_surface;
 pub mod work;
+pub mod workspace_guidance;
 
 mod process_env;
 #[doc(hidden)]

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -770,33 +770,23 @@ mod tests {
 
     #[test]
     fn presentation_wraps_display_line_with_bullet_prefix() {
-        let lines = render_wrapped_display_line(
-            "- workspace guidance: AGENTS.md, CLAUDE.md, and local policy",
-            42,
-        );
+        let lines =
+            render_wrapped_display_line("- workspace guidance: AGENTS.md and local policy", 42);
 
         assert_eq!(
             lines,
-            vec![
-                "- workspace guidance: AGENTS.md,",
-                "  CLAUDE.md, and local policy",
-            ]
+            vec!["- workspace guidance: AGENTS.md and local", "  policy",]
         );
     }
 
     #[test]
     fn presentation_normalizes_markdown_star_bullets() {
-        let lines = render_wrapped_display_line(
-            "* workspace guidance: AGENTS.md, CLAUDE.md, and local policy",
-            42,
-        );
+        let lines =
+            render_wrapped_display_line("* workspace guidance: AGENTS.md and local policy", 42);
 
         assert_eq!(
             lines,
-            vec![
-                "- workspace guidance: AGENTS.md,",
-                "  CLAUDE.md, and local policy",
-            ]
+            vec!["- workspace guidance: AGENTS.md and local", "  policy",]
         );
     }
 
@@ -819,17 +809,12 @@ mod tests {
 
     #[test]
     fn presentation_normalizes_markdown_plus_bullets() {
-        let lines = render_wrapped_display_line(
-            "+ workspace guidance: AGENTS.md, CLAUDE.md, and local policy",
-            42,
-        );
+        let lines =
+            render_wrapped_display_line("+ workspace guidance: AGENTS.md and local policy", 42);
 
         assert_eq!(
             lines,
-            vec![
-                "- workspace guidance: AGENTS.md,",
-                "  CLAUDE.md, and local policy",
-            ]
+            vec!["- workspace guidance: AGENTS.md and local", "  policy",]
         );
     }
 

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -16,6 +16,7 @@ use crate::conversation::{
 use crate::runtime_identity;
 use crate::runtime_self;
 use crate::tools::{self, ToolView};
+use crate::workspace_guidance;
 
 #[cfg(feature = "memory-sqlite")]
 use crate::memory;
@@ -106,15 +107,22 @@ fn build_base_prompt_projection_with_tool_runtime_config(
     }
 
     let workspace_root = tool_runtime_config.effective_workspace_root();
+    let workspace_guidance_model = workspace_root.map(|workspace_root| {
+        workspace_guidance::load_workspace_guidance_model_with_config(
+            workspace_root,
+            tool_runtime_config,
+        )
+    });
     let runtime_self_model = workspace_root.map(|workspace_root| {
         runtime_self::load_runtime_self_model_with_config(workspace_root, tool_runtime_config)
     });
 
-    build_base_prompt_projection_from_runtime_self_model(
+    build_base_prompt_projection_from_prompt_sources(
         config,
         include_system_prompt,
         tool_view,
         tool_runtime_config,
+        workspace_guidance_model,
         runtime_self_model,
         None,
     )
@@ -149,6 +157,17 @@ async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
     }
 
     let workspace_root = tool_runtime_config.effective_workspace_root();
+    let workspace_guidance_model = match workspace_root {
+        Some(workspace_root) => Some(
+            load_workspace_guidance_model_with_binding(
+                workspace_root,
+                tool_runtime_config,
+                binding,
+            )
+            .await,
+        ),
+        None => None,
+    };
     let runtime_self_model = match workspace_root {
         Some(workspace_root) => Some(
             load_runtime_self_model_with_binding(workspace_root, tool_runtime_config, binding)
@@ -157,21 +176,23 @@ async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
         None => None,
     };
 
-    build_base_prompt_projection_from_runtime_self_model(
+    build_base_prompt_projection_from_prompt_sources(
         config,
         include_system_prompt,
         tool_view,
         tool_runtime_config,
+        workspace_guidance_model,
         runtime_self_model,
         Some(render_governed_runtime_binding_section(binding)),
     )
 }
 
-fn build_base_prompt_projection_from_runtime_self_model(
+fn build_base_prompt_projection_from_prompt_sources(
     config: &LoongConfig,
     include_system_prompt: bool,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    workspace_guidance_model: Option<workspace_guidance::WorkspaceGuidanceModel>,
     runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
     extra_section: Option<String>,
 ) -> BasePromptProjection {
@@ -179,10 +200,11 @@ fn build_base_prompt_projection_from_runtime_self_model(
         return BasePromptProjection::default();
     }
 
-    let prompt_fragments = build_prompt_fragments_from_runtime_self_model(
+    let prompt_fragments = build_prompt_fragments_from_prompt_sources(
         config,
         tool_view,
         tool_runtime_config,
+        workspace_guidance_model,
         runtime_self_model,
         extra_section,
     );
@@ -208,10 +230,11 @@ fn build_base_prompt_projection_from_runtime_self_model(
     }
 }
 
-fn build_prompt_fragments_from_runtime_self_model(
+fn build_prompt_fragments_from_prompt_sources(
     config: &LoongConfig,
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    workspace_guidance_model: Option<workspace_guidance::WorkspaceGuidanceModel>,
     runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
     extra_section: Option<String>,
 ) -> Vec<PromptFragment> {
@@ -221,6 +244,9 @@ fn build_prompt_fragments_from_runtime_self_model(
         tools::capability_snapshot_for_view_with_config(tool_view, tool_runtime_config);
     let deferred_tool_text_workflow = render_deferred_tool_text_workflow_section_if_needed(config);
     let execution_discipline_section = render_execution_discipline_section();
+    let workspace_guidance_section = workspace_guidance_model
+        .as_ref()
+        .and_then(workspace_guidance::render_workspace_guidance_section);
     let runtime_self_section = runtime_self_model
         .as_ref()
         .and_then(runtime_self::render_runtime_self_section);
@@ -247,6 +273,19 @@ fn build_prompt_fragments_from_runtime_self_model(
         .with_cacheable(true);
 
         prompt_fragments.push(base_fragment);
+    }
+
+    if let Some(section) = workspace_guidance_section {
+        let workspace_guidance_fragment = PromptFragment::new(
+            "workspace-guidance",
+            PromptLane::WorkspaceGuidance,
+            "workspace-guidance",
+            section,
+            ContextArtifactKind::RuntimeContract,
+        )
+        .with_cacheable(true);
+
+        prompt_fragments.push(workspace_guidance_fragment);
     }
 
     if let Some(section) = runtime_self_section {
@@ -371,6 +410,50 @@ fn render_execution_discipline_section() -> String {
     ];
 
     lines.join("\n")
+}
+
+async fn load_workspace_guidance_model_with_binding(
+    workspace_root: &Path,
+    tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    binding: ProviderRuntimeBinding<'_>,
+) -> workspace_guidance::WorkspaceGuidanceModel {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return workspace_guidance::load_workspace_guidance_model_with_config(
+            workspace_root,
+            tool_runtime_config,
+        );
+    };
+
+    let source_candidates =
+        workspace_guidance::workspace_guidance_source_candidates(workspace_root);
+    let mut loaded_paths = BTreeSet::new();
+    let mut model = workspace_guidance::WorkspaceGuidanceModel::default();
+    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+
+    for source_path in source_candidates {
+        let maybe_content =
+            read_workspace_guidance_source_via_kernel(workspace_root, &source_path, kernel_ctx)
+                .await;
+        let Some(content) = maybe_content else {
+            continue;
+        };
+
+        let budget_was_exhausted = remaining_total_chars == 0;
+        let appended_content = workspace_guidance::ingest_workspace_guidance_source(
+            &mut model,
+            &mut loaded_paths,
+            &mut remaining_total_chars,
+            &source_path,
+            content.as_str(),
+            tool_runtime_config,
+        );
+
+        if budget_was_exhausted && appended_content {
+            break;
+        }
+    }
+
+    model
 }
 
 fn render_deferred_tool_text_workflow_section_if_needed(config: &LoongConfig) -> Option<String> {
@@ -525,7 +608,31 @@ async fn read_runtime_self_source_via_kernel(
     path: &Path,
     kernel_ctx: &KernelContext,
 ) -> Option<String> {
-    let request_path = runtime_self::runtime_self_source_request_path(workspace_root, path)?;
+    let request_path = workspace_guidance::workspace_source_request_path(workspace_root, path)?;
+    let request = ToolCoreRequest {
+        tool_name: "file.read".to_owned(),
+        payload: json!({
+            "path": request_path,
+        }),
+    };
+
+    let outcome = tools::execute_tool(request, kernel_ctx).await.ok()?;
+    let payload_content = outcome.payload.get("content")?;
+    let content = payload_content.as_str()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.to_owned())
+}
+
+async fn read_workspace_guidance_source_via_kernel(
+    workspace_root: &Path,
+    path: &Path,
+    kernel_ctx: &KernelContext,
+) -> Option<String> {
+    let request_path = workspace_guidance::workspace_source_request_path(workspace_root, path)?;
     let request = ToolCoreRequest {
         tool_name: "file.read".to_owned(),
         payload: json!({
@@ -951,20 +1058,24 @@ mod tests {
     use crate::test_support::TurnTestHarness;
     use tempfile::tempdir;
 
-    fn runtime_self_system_content(messages: &[Value]) -> &str {
-        let runtime_self_message = messages
+    fn system_prompt_content(messages: &[Value]) -> &str {
+        let system_message = messages
             .iter()
-            .find(|message| {
-                message["role"] == "system"
-                    && message["content"]
-                        .as_str()
-                        .is_some_and(|content| content.contains("## Runtime Self Context"))
-            })
-            .expect("runtime self system message");
+            .find(|message| message["role"] == "system")
+            .expect("system prompt message");
 
-        runtime_self_message["content"]
+        system_message["content"]
             .as_str()
-            .expect("runtime self content")
+            .expect("system prompt content")
+    }
+
+    fn workspace_guidance_system_content(messages: &[Value]) -> &str {
+        let system_content = system_prompt_content(messages);
+        assert!(
+            system_content.contains("## Workspace Guidance"),
+            "workspace guidance section should be present"
+        );
+        system_content
     }
 
     #[test]
@@ -1127,7 +1238,7 @@ mod tests {
 
         let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
         let messages = build_base_messages_with_binding(&config, true, binding).await;
-        let system_content = runtime_self_system_content(&messages);
+        let system_content = workspace_guidance_system_content(&messages);
 
         assert!(system_content.contains(agents_text));
 
@@ -1172,7 +1283,7 @@ mod tests {
 
         let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
         let messages = build_base_messages_with_binding(&config, true, binding).await;
-        let runtime_self_content = runtime_self_system_content(&messages);
+        let runtime_self_content = workspace_guidance_system_content(&messages);
 
         assert!(runtime_self_content.contains(agents_text));
 
@@ -1253,12 +1364,11 @@ mod tests {
 
         let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
         let messages = build_base_messages_with_binding(&config, true, binding).await;
-        let runtime_self_content = runtime_self_system_content(&messages);
+        let system_content = system_prompt_content(&messages);
 
-        assert!(runtime_self_content.contains(&agents_text));
-        assert!(runtime_self_content.contains("runtime self source truncated"));
-        assert!(runtime_self_content.contains("USER.md"));
-        assert!(runtime_self_content.contains("remaining total budget"));
+        assert!(system_content.contains(&agents_text));
+        assert!(system_content.contains("workspace guidance source truncated"));
+        assert!(system_content.contains("remaining total budget"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1283,11 +1393,11 @@ mod tests {
 
         let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
         let messages = build_base_messages_with_binding(&config, true, binding).await;
-        let runtime_self_content = runtime_self_system_content(&messages);
+        let system_content = system_prompt_content(&messages);
 
-        assert!(runtime_self_content.contains(&agents_text));
-        assert!(runtime_self_content.contains("runtime self truncated"));
-        assert!(!runtime_self_content.contains(raw_user_prefix));
+        assert!(system_content.contains(&agents_text));
+        assert!(system_content.contains("workspace guidance truncated"));
+        assert!(!system_content.contains(raw_user_prefix));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1303,7 +1413,7 @@ mod tests {
 
         let advisory_messages =
             build_base_messages_with_binding(&config, true, ProviderRuntimeBinding::direct()).await;
-        let advisory_content = runtime_self_system_content(&advisory_messages);
+        let advisory_content = system_prompt_content(&advisory_messages);
         assert!(advisory_content.contains("## Governed Runtime Binding"));
         assert!(advisory_content.contains("session_mode: advisory_only"));
         assert!(advisory_content.contains("kernel_binding: absent"));
@@ -1314,7 +1424,7 @@ mod tests {
             ProviderRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await;
-        let mutating_content = runtime_self_system_content(&mutating_messages);
+        let mutating_content = system_prompt_content(&mutating_messages);
         assert!(mutating_content.contains("## Governed Runtime Binding"));
         assert!(mutating_content.contains("session_mode: mutating_capable"));
         assert!(mutating_content.contains("kernel_binding: present"));
@@ -1508,9 +1618,10 @@ mod tests {
         .expect("system message");
         let system_content = system_message["content"].as_str().expect("system content");
 
-        assert!(system_content.contains("## Runtime Self Context"));
-        assert!(system_content.contains("### Standing Instructions"));
+        assert!(system_content.contains("## Workspace Guidance"));
         assert!(system_content.contains(agents_text));
+        assert!(system_content.contains("## Runtime Self Context"));
+        assert!(!system_content.contains("### Standing Instructions"));
         assert!(system_content.contains("### Tool Usage Policy"));
         assert!(system_content.contains(tools_text));
         assert!(system_content.contains("### Soul Guidance"));
@@ -1551,7 +1662,7 @@ mod tests {
         .expect("system message");
         let system_content = system_message["content"].as_str().expect("system content");
 
-        assert!(system_content.contains("## Runtime Self Context"));
+        assert!(system_content.contains("## Workspace Guidance"));
         assert!(system_content.contains(agents_text));
         assert!(system_content.contains("## Resolved Runtime Identity"));
         assert!(system_content.contains("Legacy build copilot"));
@@ -2051,10 +2162,10 @@ mod tests {
         let messages = build_messages_for_session(&config, "runtime-self-budget-session", true)
             .expect("build messages");
 
-        let runtime_self_content = runtime_self_system_content(&messages);
+        let system_content = workspace_guidance_system_content(&messages);
 
-        assert!(runtime_self_content.contains(prefix));
-        assert!(runtime_self_content.contains("runtime self source truncated"));
-        assert!(!runtime_self_content.contains(tail_marker));
+        assert!(system_content.contains(prefix));
+        assert!(system_content.contains("workspace guidance source truncated"));
+        assert!(!system_content.contains(tail_marker));
     }
 }

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -1578,17 +1578,18 @@ mod tests {
         .expect("system message");
         let content = system["content"].as_str().expect("system content");
 
-        let runtime_self_index = content
-            .find("## Runtime Self Context")
-            .expect("runtime self section");
+        let runtime_contract_index = content
+            .find("## Workspace Guidance")
+            .or_else(|| content.find("## Runtime Self Context"))
+            .expect("workspace guidance or runtime self section");
         let execution_discipline_index = content
             .find("## Execution Discipline")
             .expect("execution discipline section");
         let tool_access_index = content.find("## Tool Access").expect("tool access section");
 
         assert!(
-            runtime_self_index < execution_discipline_index,
-            "runtime self should come before execution discipline"
+            runtime_contract_index < execution_discipline_index,
+            "workspace guidance/runtime self should come before execution discipline"
         );
         assert!(
             execution_discipline_index < tool_access_index,

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -107,15 +107,24 @@ fn build_base_prompt_projection_with_tool_runtime_config(
     }
 
     let workspace_root = tool_runtime_config.effective_workspace_root();
-    let workspace_guidance_model = workspace_root.map(|workspace_root| {
-        workspace_guidance::load_workspace_guidance_model_with_config(
-            workspace_root,
-            tool_runtime_config,
-        )
-    });
-    let runtime_self_model = workspace_root.map(|workspace_root| {
-        runtime_self::load_runtime_self_model_with_config(workspace_root, tool_runtime_config)
-    });
+    let (workspace_guidance_model, runtime_self_model) = match workspace_root {
+        Some(workspace_root) => {
+            let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+            let workspace_guidance_model =
+                workspace_guidance::load_workspace_guidance_model_with_budget(
+                    workspace_root,
+                    tool_runtime_config,
+                    &mut remaining_total_chars,
+                );
+            let runtime_self_model = runtime_self::load_runtime_self_model_with_budget(
+                workspace_root,
+                tool_runtime_config,
+                &mut remaining_total_chars,
+            );
+            (Some(workspace_guidance_model), Some(runtime_self_model))
+        }
+        None => (None, None),
+    };
 
     build_base_prompt_projection_from_prompt_sources(
         config,
@@ -157,23 +166,26 @@ async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
     }
 
     let workspace_root = tool_runtime_config.effective_workspace_root();
-    let workspace_guidance_model = match workspace_root {
-        Some(workspace_root) => Some(
-            load_workspace_guidance_model_with_binding(
+    let (workspace_guidance_model, runtime_self_model) = match workspace_root {
+        Some(workspace_root) => {
+            let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+            let workspace_guidance_model = load_workspace_guidance_model_with_binding_and_budget(
                 workspace_root,
                 tool_runtime_config,
+                &mut remaining_total_chars,
                 binding,
             )
-            .await,
-        ),
-        None => None,
-    };
-    let runtime_self_model = match workspace_root {
-        Some(workspace_root) => Some(
-            load_runtime_self_model_with_binding(workspace_root, tool_runtime_config, binding)
-                .await,
-        ),
-        None => None,
+            .await;
+            let runtime_self_model = load_runtime_self_model_with_binding_and_budget(
+                workspace_root,
+                tool_runtime_config,
+                &mut remaining_total_chars,
+                binding,
+            )
+            .await;
+            (Some(workspace_guidance_model), Some(runtime_self_model))
+        }
+        None => (None, None),
     };
 
     build_base_prompt_projection_from_prompt_sources(
@@ -412,15 +424,17 @@ fn render_execution_discipline_section() -> String {
     lines.join("\n")
 }
 
-async fn load_workspace_guidance_model_with_binding(
+async fn load_workspace_guidance_model_with_binding_and_budget(
     workspace_root: &Path,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    remaining_total_chars: &mut usize,
     binding: ProviderRuntimeBinding<'_>,
 ) -> workspace_guidance::WorkspaceGuidanceModel {
     let Some(kernel_ctx) = binding.kernel_context() else {
-        return workspace_guidance::load_workspace_guidance_model_with_config(
+        return workspace_guidance::load_workspace_guidance_model_with_budget(
             workspace_root,
             tool_runtime_config,
+            remaining_total_chars,
         );
     };
 
@@ -428,7 +442,6 @@ async fn load_workspace_guidance_model_with_binding(
         workspace_guidance::workspace_guidance_source_candidates(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = workspace_guidance::WorkspaceGuidanceModel::default();
-    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
 
     for source_path in source_candidates {
         let maybe_content =
@@ -438,11 +451,11 @@ async fn load_workspace_guidance_model_with_binding(
             continue;
         };
 
-        let budget_was_exhausted = remaining_total_chars == 0;
+        let budget_was_exhausted = *remaining_total_chars == 0;
         let appended_content = workspace_guidance::ingest_workspace_guidance_source(
             &mut model,
             &mut loaded_paths,
-            &mut remaining_total_chars,
+            remaining_total_chars,
             &source_path,
             content.as_str(),
             tool_runtime_config,
@@ -560,22 +573,23 @@ fn build_base_artifacts(messages: &[Value]) -> Vec<ContextArtifactDescriptor> {
     ]
 }
 
-async fn load_runtime_self_model_with_binding(
+async fn load_runtime_self_model_with_binding_and_budget(
     workspace_root: &Path,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    remaining_total_chars: &mut usize,
     binding: ProviderRuntimeBinding<'_>,
 ) -> runtime_self::RuntimeSelfModel {
     let Some(kernel_ctx) = binding.kernel_context() else {
-        return runtime_self::load_runtime_self_model_with_config(
+        return runtime_self::load_runtime_self_model_with_budget(
             workspace_root,
             tool_runtime_config,
+            remaining_total_chars,
         );
     };
 
     let source_candidates = runtime_self::runtime_self_source_candidates(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = runtime_self::RuntimeSelfModel::default();
-    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
 
     for (candidate_path, lane) in source_candidates {
         let Some(content) =
@@ -584,11 +598,11 @@ async fn load_runtime_self_model_with_binding(
             continue;
         };
 
-        let budget_was_exhausted = remaining_total_chars == 0;
+        let budget_was_exhausted = *remaining_total_chars == 0;
         let appended_content = runtime_self::ingest_runtime_self_source(
             &mut model,
             &mut loaded_paths,
-            &mut remaining_total_chars,
+            remaining_total_chars,
             lane,
             &candidate_path,
             content.as_str(),
@@ -1367,8 +1381,14 @@ mod tests {
         let system_content = system_prompt_content(&messages);
 
         assert!(system_content.contains(&agents_text));
-        assert!(system_content.contains("workspace guidance source truncated"));
-        assert!(system_content.contains("remaining total budget"));
+        assert!(
+            system_content.contains("runtime self source truncated"),
+            "expected runtime-self truncation notice, got: {system_content}"
+        );
+        assert!(
+            system_content.contains("remaining total budget"),
+            "expected total-budget wording, got: {system_content}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1396,8 +1416,86 @@ mod tests {
         let system_content = system_prompt_content(&messages);
 
         assert!(system_content.contains(&agents_text));
-        assert!(system_content.contains("workspace guidance truncated"));
-        assert!(!system_content.contains(raw_user_prefix));
+        assert!(
+            system_content.contains("runtime self truncated"),
+            "expected compact runtime-self truncation notice, got: {system_content}"
+        );
+        assert!(
+            !system_content.contains(raw_user_prefix),
+            "raw runtime-self prefix should be truncated, got: {system_content}"
+        );
+    }
+
+    #[test]
+    fn build_system_message_shares_total_budget_between_workspace_guidance_and_runtime_self() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
+        let agents_text = "a".repeat(1_024);
+        let tools_prefix = "TOOLS_PREFIX_SHOULD_NOT_SURVIVE";
+        let tools_tail = "TOOLS_TAIL_SHOULD_NOT_SURVIVE";
+        let tools_text = format!("{tools_prefix}\n{}\n{tools_tail}", "b".repeat(900));
+        let mut config = LoongConfig::default();
+
+        std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, &tools_text).expect("write TOOLS");
+
+        config.tools.file_root = Some(workspace_root.display().to_string());
+        config.tools.runtime_self.max_source_chars = 10_000;
+        config.tools.runtime_self.max_total_chars = agents_text.chars().count();
+
+        let system_message =
+            build_system_message(&config, true).expect("system message when enabled");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(system_content.contains(&agents_text));
+        assert!(
+            system_content.contains("runtime self source truncated"),
+            "expected runtime-self truncation notice, got: {system_content}"
+        );
+        assert!(
+            system_content.contains("remaining total budget"),
+            "expected total-budget wording, got: {system_content}"
+        );
+        assert!(!system_content.contains(tools_prefix));
+        assert!(!system_content.contains(tools_tail));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_base_messages_with_binding_shares_total_budget_between_workspace_guidance_and_runtime_self()
+     {
+        let harness = TurnTestHarness::new();
+        let agents_path = harness.temp_dir.join("AGENTS.md");
+        let tools_path = harness.temp_dir.join("TOOLS.md");
+        let agents_text = "a".repeat(1_024);
+        let tools_prefix = "BINDING_TOOLS_PREFIX_SHOULD_NOT_SURVIVE";
+        let tools_tail = "BINDING_TOOLS_TAIL_SHOULD_NOT_SURVIVE";
+        let tools_text = format!("{tools_prefix}\n{}\n{tools_tail}", "b".repeat(900));
+        let mut config = LoongConfig::default();
+
+        std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, &tools_text).expect("write TOOLS");
+
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+        config.tools.runtime_self.max_source_chars = 10_000;
+        config.tools.runtime_self.max_total_chars = agents_text.chars().count();
+
+        let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
+        let messages = build_base_messages_with_binding(&config, true, binding).await;
+        let system_content = system_prompt_content(&messages);
+
+        assert!(system_content.contains(&agents_text));
+        assert!(
+            system_content.contains("runtime self source truncated"),
+            "expected runtime-self truncation notice, got: {system_content}"
+        );
+        assert!(
+            system_content.contains("remaining total budget"),
+            "expected total-budget wording, got: {system_content}"
+        );
+        assert!(!system_content.contains(tools_prefix));
+        assert!(!system_content.contains(tools_tail));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::tools;
+use crate::workspace_guidance::{self, WorkspaceGuidanceSearchScope};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuntimeSelfLane {
@@ -34,14 +35,6 @@ struct TruncatedRuntimeSelfSourceContent {
 }
 
 const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
-    RuntimeSelfSourceSpec {
-        relative_path: "AGENTS.md",
-        lane: RuntimeSelfLane::StandingInstructions,
-    },
-    RuntimeSelfSourceSpec {
-        relative_path: "CLAUDE.md",
-        lane: RuntimeSelfLane::StandingInstructions,
-    },
     RuntimeSelfSourceSpec {
         relative_path: "TOOLS.md",
         lane: RuntimeSelfLane::ToolUsagePolicy,
@@ -161,6 +154,12 @@ pub(crate) fn runtime_self_source_candidates(
     let mut source_candidates = Vec::new();
 
     for root in candidate_roots {
+        for guidance_kind in workspace_guidance::runtime_prompt_workspace_guidance_kinds() {
+            let guidance_path = root.join(guidance_kind.file_name());
+            let guidance_candidate = (guidance_path, RuntimeSelfLane::StandingInstructions);
+            source_candidates.push(guidance_candidate);
+        }
+
         for spec in RUNTIME_SELF_SOURCE_SPECS {
             let candidate_path = root.join(spec.relative_path);
             source_candidates.push((candidate_path, spec.lane));
@@ -171,16 +170,8 @@ pub(crate) fn runtime_self_source_candidates(
 }
 
 pub(crate) fn candidate_workspace_roots(workspace_root: &Path) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
-    let nested_workspace_root = workspace_root.join("workspace");
-
-    roots.push(workspace_root.to_path_buf());
-
-    if nested_workspace_root.is_dir() {
-        roots.push(nested_workspace_root);
-    }
-
-    roots
+    let search_scope = WorkspaceGuidanceSearchScope::WorkspaceAndNestedWorkspace;
+    workspace_guidance::candidate_workspace_roots(workspace_root, search_scope)
 }
 
 fn read_runtime_self_source(
@@ -598,6 +589,28 @@ mod tests {
             .expect("nested tool policy should be rendered");
 
         assert!(root_index < nested_index);
+    }
+
+    #[test]
+    fn load_runtime_self_model_ignores_import_only_workspace_guidance_files() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let gemini_path = workspace_root.join("GEMINI.md");
+        let opencode_path = workspace_root.join("OPENCODE.md");
+
+        std::fs::write(&gemini_path, "gemini import-only guidance").expect("write GEMINI");
+        std::fs::write(&opencode_path, "opencode import-only guidance").expect("write OPENCODE");
+
+        let model = load_runtime_self_model(workspace_root);
+
+        assert!(
+            model.standing_instructions.is_empty(),
+            "import-only guidance files should not enter runtime_self"
+        );
+        assert!(model.tool_usage_policy.is_empty());
+        assert!(model.soul_guidance.is_empty());
+        assert!(model.identity_context.is_empty());
+        assert!(model.user_context.is_empty());
     }
 
     #[test]

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -10,7 +10,6 @@ use crate::workspace_guidance::{self, WorkspaceGuidanceSearchScope};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuntimeSelfLane {
-    StandingInstructions,
     ToolUsagePolicy,
     SoulGuidance,
     IdentityContext,
@@ -66,8 +65,7 @@ pub(crate) struct RuntimeSelfModel {
 impl RuntimeSelfModel {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.standing_instructions.is_empty()
-            && self.tool_usage_policy.is_empty()
+        self.tool_usage_policy.is_empty()
             && self.soul_guidance.is_empty()
             && self.identity_context.is_empty()
             && self.user_context.is_empty()
@@ -119,8 +117,7 @@ pub(crate) fn load_runtime_self_model_with_config(
 }
 
 pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<String> {
-    let has_renderable_content = !model.standing_instructions.is_empty()
-        || !model.tool_usage_policy.is_empty()
+    let has_renderable_content = !model.tool_usage_policy.is_empty()
         || !model.soul_guidance.is_empty()
         || !model.user_context.is_empty();
 
@@ -131,11 +128,6 @@ pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<St
     let mut sections = Vec::new();
     sections.push("## Runtime Self Context".to_owned());
 
-    push_rendered_lane(
-        &mut sections,
-        "### Standing Instructions",
-        &model.standing_instructions,
-    );
     push_rendered_lane(
         &mut sections,
         "### Tool Usage Policy",
@@ -154,12 +146,6 @@ pub(crate) fn runtime_self_source_candidates(
     let mut source_candidates = Vec::new();
 
     for root in candidate_roots {
-        for guidance_kind in workspace_guidance::runtime_prompt_workspace_guidance_kinds() {
-            let guidance_path = root.join(guidance_kind.file_name());
-            let guidance_candidate = (guidance_path, RuntimeSelfLane::StandingInstructions);
-            source_candidates.push(guidance_candidate);
-        }
-
         for spec in RUNTIME_SELF_SOURCE_SPECS {
             let candidate_path = root.join(spec.relative_path);
             source_candidates.push((candidate_path, spec.lane));
@@ -179,7 +165,7 @@ fn read_runtime_self_source(
     path: &Path,
     tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
 ) -> Option<String> {
-    let request_path = runtime_self_source_request_path(workspace_root, path)?;
+    let request_path = workspace_guidance::workspace_source_request_path(workspace_root, path)?;
     let request = ToolCoreRequest {
         tool_name: "file.read".to_owned(),
         payload: json!({
@@ -200,39 +186,12 @@ fn read_runtime_self_source(
 
 #[cfg(test)]
 pub(crate) fn should_attempt_runtime_self_source_read(workspace_root: &Path, path: &Path) -> bool {
-    let request_path = runtime_self_source_request_path(workspace_root, path);
+    let request_path = workspace_guidance::workspace_source_request_path(workspace_root, path);
     request_path.is_some()
 }
 
-pub(crate) fn runtime_self_source_request_path(
-    workspace_root: &Path,
-    path: &Path,
-) -> Option<String> {
-    let path_is_file = path.is_file();
-    if !path_is_file {
-        return None;
-    }
-
-    let canonical_workspace_root = workspace_root.canonicalize().ok()?;
-    let canonical_path = path.canonicalize().ok()?;
-
-    let path_within_workspace = canonical_path.starts_with(canonical_workspace_root);
-    if !path_within_workspace {
-        return None;
-    }
-
-    request_path_from_workspace_root(workspace_root, path)
-}
-
-fn request_path_from_workspace_root(workspace_root: &Path, path: &Path) -> Option<String> {
-    let relative_path = path.strip_prefix(workspace_root).ok()?;
-    let request_path = relative_path.to_string_lossy().to_string();
-    Some(request_path)
-}
-
 pub(crate) fn normalized_path_key(path: &Path) -> String {
-    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    canonical_path.display().to_string()
+    workspace_guidance::normalized_workspace_source_path_key(path)
 }
 
 pub(crate) fn ingest_runtime_self_source(
@@ -275,9 +234,6 @@ pub(crate) fn append_runtime_self_content(
     content: String,
 ) {
     match lane {
-        RuntimeSelfLane::StandingInstructions => {
-            model.standing_instructions.push(content);
-        }
         RuntimeSelfLane::ToolUsagePolicy => {
             model.tool_usage_policy.push(content);
         }
@@ -473,23 +429,24 @@ mod tests {
 
         std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
 
-        let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
         let soul_path = nested_workspace_root.join("SOUL.md");
         let identity_path = workspace_root.join("IDENTITY.md");
         let user_path = nested_workspace_root.join("USER.md");
 
-        std::fs::write(&agents_path, "Keep standing instructions visible.").expect("write AGENTS");
+        std::fs::write(&tools_path, "Use the smallest audited tool path first.")
+            .expect("write TOOLS");
         std::fs::write(&soul_path, "Prefer rigorous execution.").expect("write SOUL");
         std::fs::write(&identity_path, "You are the runtime helper.").expect("write IDENTITY");
         std::fs::write(&user_path, "The operator prefers concise output.").expect("write USER");
 
         let model = load_runtime_self_model(workspace_root);
 
-        assert_eq!(model.standing_instructions.len(), 1);
+        assert_eq!(model.tool_usage_policy.len(), 1);
         assert_eq!(model.soul_guidance.len(), 1);
         assert_eq!(model.identity_context.len(), 1);
         assert_eq!(model.user_context.len(), 1);
-        assert!(model.standing_instructions[0].contains("standing instructions"));
+        assert!(model.tool_usage_policy[0].contains("audited tool path"));
         assert!(model.soul_guidance[0].contains("rigorous execution"));
         assert!(model.identity_context[0].contains("runtime helper"));
         assert!(model.user_context[0].contains("concise output"));
@@ -501,7 +458,8 @@ mod tests {
         let workspace_root = temp_dir.path();
         let missing_tools_path = workspace_root.join("TOOLS.md");
 
-        let request_path = runtime_self_source_request_path(workspace_root, &missing_tools_path);
+        let request_path =
+            workspace_guidance::workspace_source_request_path(workspace_root, &missing_tools_path);
 
         assert_eq!(request_path, None);
     }
@@ -514,27 +472,20 @@ mod tests {
 
         std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
 
-        let root_agents_path = workspace_root.join("AGENTS.md");
-        let root_claude_path = workspace_root.join("CLAUDE.md");
-        let nested_agents_path = nested_workspace_root.join("AGENTS.md");
+        let root_tools_path = workspace_root.join("TOOLS.md");
+        let nested_tools_path = nested_workspace_root.join("TOOLS.md");
 
-        let root_agents_text = "Root AGENTS standing instructions.";
-        let root_claude_text = "Root CLAUDE standing instructions.";
-        let nested_agents_text = "Nested workspace AGENTS standing instructions.";
+        let root_tools_text = "Root TOOLS guidance.";
+        let nested_tools_text = "Nested workspace TOOLS guidance.";
 
-        std::fs::write(&root_agents_path, root_agents_text).expect("write root AGENTS");
-        std::fs::write(&root_claude_path, root_claude_text).expect("write root CLAUDE");
-        std::fs::write(&nested_agents_path, nested_agents_text).expect("write nested AGENTS");
+        std::fs::write(&root_tools_path, root_tools_text).expect("write root TOOLS");
+        std::fs::write(&nested_tools_path, nested_tools_text).expect("write nested TOOLS");
 
         let model = load_runtime_self_model(workspace_root);
 
         assert_eq!(
-            model.standing_instructions,
-            vec![
-                root_agents_text.to_owned(),
-                root_claude_text.to_owned(),
-                nested_agents_text.to_owned(),
-            ]
+            model.tool_usage_policy,
+            vec![root_tools_text.to_owned(), nested_tools_text.to_owned()]
         );
     }
 
@@ -543,20 +494,16 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
 
-        let agents_path = workspace_root.join("AGENTS.md");
         let tools_path = workspace_root.join("TOOLS.md");
 
-        let agents_text = "Keep standing instructions visible.";
         let tools_text = "When durable workspace facts may matter, search memory before answering.";
 
-        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
         std::fs::write(&tools_path, tools_text).expect("write TOOLS");
 
         let model = load_runtime_self_model(workspace_root);
         let rendered = render_runtime_self_section(&model).expect("render runtime self");
 
-        assert!(rendered.contains("### Standing Instructions"));
-        assert!(rendered.contains(agents_text));
+        assert!(!rendered.contains("### Standing Instructions"));
         assert!(rendered.contains("### Tool Usage Policy"));
         assert!(rendered.contains(tools_text));
     }
@@ -595,18 +542,19 @@ mod tests {
     fn load_runtime_self_model_ignores_import_only_workspace_guidance_files() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
+        let agents_path = workspace_root.join("AGENTS.md");
+        let claude_path = workspace_root.join("CLAUDE.md");
         let gemini_path = workspace_root.join("GEMINI.md");
         let opencode_path = workspace_root.join("OPENCODE.md");
 
+        std::fs::write(&agents_path, "agents runtime guidance").expect("write AGENTS");
+        std::fs::write(&claude_path, "claude compatibility guidance").expect("write CLAUDE");
         std::fs::write(&gemini_path, "gemini import-only guidance").expect("write GEMINI");
         std::fs::write(&opencode_path, "opencode import-only guidance").expect("write OPENCODE");
 
         let model = load_runtime_self_model(workspace_root);
 
-        assert!(
-            model.standing_instructions.is_empty(),
-            "import-only guidance files should not enter runtime_self"
-        );
+        assert!(model.standing_instructions.is_empty());
         assert!(model.tool_usage_policy.is_empty());
         assert!(model.soul_guidance.is_empty());
         assert!(model.identity_context.is_empty());
@@ -651,18 +599,18 @@ mod tests {
     fn load_runtime_self_model_truncates_oversized_source_content() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
-        let agents_path = workspace_root.join("AGENTS.md");
-        let prefix = "Keep standing instructions visible.\n";
+        let tools_path = workspace_root.join("TOOLS.md");
+        let prefix = "Keep runtime self bounded.\n";
         let tail_marker = "TAIL_MARKER_SHOULD_NOT_SURVIVE";
         let oversized_content = format!("{prefix}{}\n{tail_marker}", "a".repeat(24_000),);
 
-        std::fs::write(&agents_path, oversized_content).expect("write oversized AGENTS");
+        std::fs::write(&tools_path, oversized_content).expect("write oversized TOOLS");
 
         let model = load_runtime_self_model(workspace_root);
         let rendered = model
-            .standing_instructions
+            .tool_usage_policy
             .first()
-            .expect("standing instructions")
+            .expect("tool usage policy")
             .as_str();
 
         assert!(rendered.contains(prefix));
@@ -681,17 +629,17 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
         let nested_workspace_root = workspace_root.join("workspace");
+        let total_budget = 60_000usize;
 
         std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
 
-        let root_agents = workspace_root.join("AGENTS.md");
-        let root_claude = workspace_root.join("CLAUDE.md");
         let root_tools = workspace_root.join("TOOLS.md");
         let root_soul = workspace_root.join("SOUL.md");
+        let root_identity = workspace_root.join("IDENTITY.md");
         let root_user = workspace_root.join("USER.md");
-        let nested_agents = nested_workspace_root.join("AGENTS.md");
         let nested_tools = nested_workspace_root.join("TOOLS.md");
         let nested_soul = nested_workspace_root.join("SOUL.md");
+        let nested_identity = nested_workspace_root.join("IDENTITY.md");
         let nested_user = nested_workspace_root.join("USER.md");
 
         let repeated_body = "b".repeat(18_500);
@@ -699,32 +647,20 @@ mod tests {
         let root_content = format!("root\n{repeated_body}");
         let nested_user_content = format!("nested user\n{repeated_body}\n{nested_tail_marker}");
 
-        std::fs::write(&root_agents, &root_content).expect("write root AGENTS");
-        std::fs::write(&root_claude, &root_content).expect("write root CLAUDE");
         std::fs::write(&root_tools, &root_content).expect("write root TOOLS");
         std::fs::write(&root_soul, &root_content).expect("write root SOUL");
+        std::fs::write(&root_identity, &root_content).expect("write root IDENTITY");
         std::fs::write(&root_user, &root_content).expect("write root USER");
-        std::fs::write(&nested_agents, &root_content).expect("write nested AGENTS");
         std::fs::write(&nested_tools, &root_content).expect("write nested TOOLS");
         std::fs::write(&nested_soul, &root_content).expect("write nested SOUL");
+        std::fs::write(&nested_identity, &root_content).expect("write nested IDENTITY");
         std::fs::write(&nested_user, &nested_user_content).expect("write nested USER");
 
-        let model = load_runtime_self_model(workspace_root);
-        let total_chars = model
-            .standing_instructions
-            .iter()
-            .chain(model.tool_usage_policy.iter())
-            .chain(model.soul_guidance.iter())
-            .chain(model.identity_context.iter())
-            .chain(model.user_context.iter())
-            .map(|entry| entry.chars().count())
-            .sum::<usize>();
+        let tool_runtime_config =
+            runtime_self_tool_runtime_config(workspace_root, 20_000, total_budget);
+        let model = load_runtime_self_model_with_config(workspace_root, &tool_runtime_config);
         let rendered_user_context = model.user_context.join("\n\n");
 
-        assert!(
-            total_chars <= 150_000,
-            "runtime self total chars should stay within the default budget, got {total_chars}"
-        );
         assert!(
             rendered_user_context.contains("runtime self source truncated"),
             "expected total-budget truncation notice in user context, got: {rendered_user_context}"
@@ -739,21 +675,21 @@ mod tests {
     fn load_runtime_self_model_marks_fully_omitted_later_sources_after_exact_budget_fit() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
-        let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
         let user_path = workspace_root.join("USER.md");
-        let agents_text = "a".repeat(1_024);
+        let tools_text = "a".repeat(1_024);
         let user_text = "later user context should still surface a truncation notice";
-        let total_budget = agents_text.chars().count();
+        let total_budget = tools_text.chars().count();
         let tool_runtime_config =
             runtime_self_tool_runtime_config(workspace_root, 10_000, total_budget);
 
-        std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, &tools_text).expect("write TOOLS");
         std::fs::write(&user_path, user_text).expect("write USER");
 
         let model = load_runtime_self_model_with_config(workspace_root, &tool_runtime_config);
         let rendered_user_context = model.user_context.join("\n\n");
 
-        assert_eq!(model.standing_instructions, vec![agents_text]);
+        assert_eq!(model.tool_usage_policy, vec![tools_text]);
         assert!(rendered_user_context.contains("runtime self source truncated"));
         assert!(rendered_user_context.contains("USER.md"));
         assert!(rendered_user_context.contains("remaining total budget"));
@@ -763,18 +699,18 @@ mod tests {
     fn load_runtime_self_model_uses_compact_notice_when_remaining_budget_cannot_fit_full_notice() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
-        let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
         let user_path = workspace_root.join("USER.md");
-        let agents_text = "a".repeat(1_024);
+        let tools_text = "a".repeat(1_024);
         let compact_budget = 24usize;
         let raw_user_prefix = "later user context raw p";
         let user_text =
             "later user context raw prefix should not leak into compact truncation rendering";
-        let total_budget = agents_text.chars().count() + compact_budget;
+        let total_budget = tools_text.chars().count() + compact_budget;
         let tool_runtime_config =
             runtime_self_tool_runtime_config(workspace_root, 10_000, total_budget);
 
-        std::fs::write(&agents_path, &agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, &tools_text).expect("write TOOLS");
         std::fs::write(&user_path, user_text).expect("write USER");
 
         let model = load_runtime_self_model_with_config(workspace_root, &tool_runtime_config);
@@ -815,8 +751,8 @@ mod tests {
         let model = load_runtime_self_model(workspace_root);
 
         assert!(
-            model.standing_instructions.is_empty(),
-            "linked file outside workspace root should be rejected"
+            model.is_empty(),
+            "workspace-guidance symlink should not leak into runtime-self loading"
         );
     }
 
@@ -843,8 +779,8 @@ mod tests {
         let model = load_runtime_self_model(workspace_root);
 
         assert!(
-            model.standing_instructions.is_empty(),
-            "linked nested workspace outside workspace root should be rejected"
+            model.is_empty(),
+            "nested workspace-guidance symlink should not leak into runtime-self loading"
         );
     }
 }

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -85,10 +85,22 @@ pub(crate) fn load_runtime_self_model_with_config(
     workspace_root: &Path,
     tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
 ) -> RuntimeSelfModel {
+    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+    load_runtime_self_model_with_budget(
+        workspace_root,
+        tool_runtime_config,
+        &mut remaining_total_chars,
+    )
+}
+
+pub(crate) fn load_runtime_self_model_with_budget(
+    workspace_root: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+    remaining_total_chars: &mut usize,
+) -> RuntimeSelfModel {
     let source_candidates = runtime_self_source_candidates(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = RuntimeSelfModel::default();
-    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
 
     for (candidate_path, lane) in source_candidates {
         let Some(content) =
@@ -97,11 +109,11 @@ pub(crate) fn load_runtime_self_model_with_config(
             continue;
         };
 
-        let budget_was_exhausted = remaining_total_chars == 0;
+        let budget_was_exhausted = *remaining_total_chars == 0;
         let appended_content = ingest_runtime_self_source(
             &mut model,
             &mut loaded_paths,
-            &mut remaining_total_chars,
+            remaining_total_chars,
             lane,
             &candidate_path,
             content.as_str(),

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -195,7 +195,7 @@ pub(crate) fn merge_runtime_self_continuity(
     };
 
     let Some(mut merged) = primary else {
-        return Some(fallback.clone());
+        return Some(fallback);
     };
 
     if merged.workspace_guidance.is_empty() {
@@ -219,7 +219,7 @@ pub(crate) fn merge_runtime_self_continuity(
 
     let merged_projection = normalize_projection(merged.session_profile_projection.as_deref());
     if merged_projection.is_none() {
-        merged.session_profile_projection = fallback.session_profile_projection.clone();
+        merged.session_profile_projection = fallback.session_profile_projection;
     }
 
     Some(merged)
@@ -234,7 +234,7 @@ pub(crate) fn missing_runtime_self_continuity(
         .cloned()
         .map(RuntimeSelfContinuity::normalize_legacy_workspace_guidance);
     let Some(live) = live else {
-        return stored.has_prompt_projection().then_some(stored.clone());
+        return stored.has_prompt_projection().then_some(stored);
     };
 
     let mut missing = RuntimeSelfContinuity::default();
@@ -260,7 +260,7 @@ pub(crate) fn missing_runtime_self_continuity(
 
     let live_projection = normalize_projection(live.session_profile_projection.as_deref());
     if live_projection.is_none() {
-        missing.session_profile_projection = stored.session_profile_projection.clone();
+        missing.session_profile_projection = stored.session_profile_projection;
     }
 
     missing.has_prompt_projection().then_some(missing)

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -9,6 +9,7 @@ use crate::runtime_self::{self, RuntimeSelfModel};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{SessionEventRecord, SessionRepository};
 use crate::tools::runtime_config::ToolRuntimeConfig;
+use crate::workspace_guidance::{self, WorkspaceGuidanceModel};
 
 const DURABLE_RECALL_INTRO: &str = concat!(
     "Advisory durable recall exported immediately before context compaction. ",
@@ -42,6 +43,8 @@ const COMPACTION_SUMMARY_SCOPE_NOTE: &str = concat!(
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSelfContinuity {
+    #[serde(default)]
+    pub workspace_guidance: WorkspaceGuidanceModel,
     pub runtime_self: RuntimeSelfModel,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_identity: Option<ResolvedRuntimeIdentity>,
@@ -57,7 +60,8 @@ impl RuntimeSelfContinuity {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         let profile_projection = normalize_projection(self.session_profile_projection.as_deref());
-        self.runtime_self.is_empty()
+        self.workspace_guidance.is_empty()
+            && self.runtime_self.is_empty()
             && self.resolved_identity.is_none()
             && profile_projection.is_none()
     }
@@ -65,9 +69,23 @@ impl RuntimeSelfContinuity {
     #[must_use]
     pub fn has_prompt_projection(&self) -> bool {
         let profile_projection = normalize_projection(self.session_profile_projection.as_deref());
-        !self.runtime_self.is_empty()
+        !self.workspace_guidance.is_empty()
+            || !self.runtime_self.is_empty()
             || self.resolved_identity.is_some()
             || profile_projection.is_some()
+    }
+
+    #[must_use]
+    fn normalize_legacy_workspace_guidance(mut self) -> Self {
+        if self.workspace_guidance.is_empty() && !self.runtime_self.standing_instructions.is_empty()
+        {
+            self.workspace_guidance.entries =
+                std::mem::take(&mut self.runtime_self.standing_instructions);
+        } else if !self.runtime_self.standing_instructions.is_empty() {
+            self.runtime_self.standing_instructions.clear();
+        }
+
+        self
     }
 }
 
@@ -76,6 +94,10 @@ pub(crate) fn resolve_runtime_self_continuity(
     profile_note: Option<&str>,
     personalization: Option<&PersonalizationConfig>,
 ) -> Option<RuntimeSelfContinuity> {
+    let workspace_guidance = match workspace_root {
+        Some(workspace_root) => workspace_guidance::load_workspace_guidance_model(workspace_root),
+        None => WorkspaceGuidanceModel::default(),
+    };
     let runtime_self = match workspace_root {
         Some(workspace_root) => runtime_self::load_runtime_self_model(workspace_root),
         None => RuntimeSelfModel::default(),
@@ -85,6 +107,7 @@ pub(crate) fn resolve_runtime_self_continuity(
     let session_profile_projection =
         runtime_identity::render_session_profile_section(profile_note, personalization);
     let continuity = RuntimeSelfContinuity {
+        workspace_guidance,
         runtime_self,
         resolved_identity,
         session_profile_projection,
@@ -119,7 +142,8 @@ pub(crate) fn runtime_self_continuity_from_event_payload(
     payload: &Value,
 ) -> Option<RuntimeSelfContinuity> {
     let continuity = payload.get("runtime_self_continuity")?.clone();
-    serde_json::from_value(continuity).ok()
+    let continuity: RuntimeSelfContinuity = serde_json::from_value(continuity).ok()?;
+    Some(continuity.normalize_legacy_workspace_guidance())
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -164,6 +188,8 @@ pub(crate) fn merge_runtime_self_continuity(
     primary: Option<RuntimeSelfContinuity>,
     fallback: Option<&RuntimeSelfContinuity>,
 ) -> Option<RuntimeSelfContinuity> {
+    let primary = primary.map(RuntimeSelfContinuity::normalize_legacy_workspace_guidance);
+    let fallback = fallback.map(|value| value.clone().normalize_legacy_workspace_guidance());
     let Some(fallback) = fallback else {
         return primary;
     };
@@ -172,9 +198,8 @@ pub(crate) fn merge_runtime_self_continuity(
         return Some(fallback.clone());
     };
 
-    if merged.runtime_self.standing_instructions.is_empty() {
-        merged.runtime_self.standing_instructions =
-            fallback.runtime_self.standing_instructions.clone();
+    if merged.workspace_guidance.is_empty() {
+        merged.workspace_guidance = fallback.workspace_guidance.clone();
     }
     if merged.runtime_self.tool_usage_policy.is_empty() {
         merged.runtime_self.tool_usage_policy = fallback.runtime_self.tool_usage_policy.clone();
@@ -204,15 +229,18 @@ pub(crate) fn missing_runtime_self_continuity(
     stored: &RuntimeSelfContinuity,
     live: Option<&RuntimeSelfContinuity>,
 ) -> Option<RuntimeSelfContinuity> {
+    let stored = stored.clone().normalize_legacy_workspace_guidance();
+    let live = live
+        .cloned()
+        .map(RuntimeSelfContinuity::normalize_legacy_workspace_guidance);
     let Some(live) = live else {
         return stored.has_prompt_projection().then_some(stored.clone());
     };
 
     let mut missing = RuntimeSelfContinuity::default();
 
-    if live.runtime_self.standing_instructions.is_empty() {
-        missing.runtime_self.standing_instructions =
-            stored.runtime_self.standing_instructions.clone();
+    if live.workspace_guidance.is_empty() {
+        missing.workspace_guidance = stored.workspace_guidance.clone();
     }
     if live.runtime_self.tool_usage_policy.is_empty() {
         missing.runtime_self.tool_usage_policy = stored.runtime_self.tool_usage_policy.clone();
@@ -242,6 +270,7 @@ pub(crate) fn render_runtime_self_continuity_section(
     continuity: &RuntimeSelfContinuity,
     inherited: bool,
 ) -> Option<String> {
+    let continuity = continuity.clone().normalize_legacy_workspace_guidance();
     if !continuity.has_prompt_projection() {
         return None;
     }
@@ -252,6 +281,8 @@ pub(crate) fn render_runtime_self_continuity_section(
         "Rehydrate the preserved runtime self state below when a live lane is missing."
     };
     let continuity_note = "Session-local conversation content must not be promoted into durable self state automatically.";
+    let workspace_guidance_section =
+        workspace_guidance::render_workspace_guidance_section(&continuity.workspace_guidance);
     let runtime_self_section = runtime_self::render_runtime_self_section(&continuity.runtime_self);
     let resolved_identity_section = continuity
         .resolved_identity
@@ -263,6 +294,9 @@ pub(crate) fn render_runtime_self_continuity_section(
     sections.push(continuity_scope.to_owned());
     sections.push(continuity_note.to_owned());
 
+    if let Some(workspace_guidance_section) = workspace_guidance_section {
+        sections.push(workspace_guidance_section);
+    }
     if let Some(runtime_self_section) = runtime_self_section {
         sections.push(runtime_self_section);
     }
@@ -308,8 +342,10 @@ mod tests {
     fn runtime_self_continuity_from_event_payload_defaults_missing_tool_usage_policy_lane() {
         let payload = json!({
             "runtime_self_continuity": {
+                "workspace_guidance": {
+                    "entries": ["Keep continuity explicit."]
+                },
                 "runtime_self": {
-                    "standing_instructions": ["Keep continuity explicit."],
                     "soul_guidance": ["Prefer rigorous execution."],
                     "identity_context": ["# Identity\n\n- Name: Stored continuity identity"],
                     "user_context": ["The operator prefers concise technical summaries."]
@@ -326,14 +362,38 @@ mod tests {
 
         assert!(continuity.runtime_self.tool_usage_policy.is_empty());
         assert_eq!(
-            continuity.runtime_self.standing_instructions,
+            continuity.workspace_guidance.entries,
             vec!["Keep continuity explicit.".to_owned()]
         );
     }
 
     #[test]
+    fn runtime_self_continuity_from_event_payload_promotes_legacy_standing_instructions() {
+        let payload = json!({
+            "runtime_self_continuity": {
+                "runtime_self": {
+                    "standing_instructions": ["Legacy AGENTS guidance."],
+                    "tool_usage_policy": ["Use the smallest audited tool first."]
+                }
+            }
+        });
+
+        let continuity =
+            runtime_self_continuity_from_event_payload(&payload).expect("deserialize continuity");
+
+        assert_eq!(
+            continuity.workspace_guidance.entries,
+            vec!["Legacy AGENTS guidance.".to_owned()]
+        );
+        assert!(continuity.runtime_self.standing_instructions.is_empty());
+    }
+
+    #[test]
     fn missing_runtime_self_continuity_rehydrates_missing_tool_usage_policy_lane() {
         let stored = RuntimeSelfContinuity {
+            workspace_guidance: WorkspaceGuidanceModel {
+                entries: vec!["Keep continuity explicit.".to_owned()],
+            },
             runtime_self: RuntimeSelfModel {
                 tool_usage_policy: vec![
                     "Search memory before guessing workspace facts.".to_owned(),
@@ -348,6 +408,10 @@ mod tests {
             .expect("missing continuity should preserve tool usage policy");
 
         assert_eq!(
+            missing.workspace_guidance.entries,
+            vec!["Keep continuity explicit.".to_owned()]
+        );
+        assert_eq!(
             missing.runtime_self.tool_usage_policy,
             vec!["Search memory before guessing workspace facts.".to_owned()]
         );
@@ -356,6 +420,9 @@ mod tests {
     #[test]
     fn merge_runtime_self_continuity_rehydrates_missing_tool_usage_policy_lane() {
         let fallback = RuntimeSelfContinuity {
+            workspace_guidance: WorkspaceGuidanceModel {
+                entries: vec!["Keep continuity explicit.".to_owned()],
+            },
             runtime_self: RuntimeSelfModel {
                 tool_usage_policy: vec![
                     "Search memory before guessing workspace facts.".to_owned(),
@@ -369,6 +436,10 @@ mod tests {
         let merged = merge_runtime_self_continuity(primary, Some(&fallback))
             .expect("merged continuity should preserve tool usage policy");
 
+        assert_eq!(
+            merged.workspace_guidance.entries,
+            vec!["Keep continuity explicit.".to_owned()]
+        );
         assert_eq!(
             merged.runtime_self.tool_usage_policy,
             vec!["Search memory before guessing workspace facts.".to_owned()]
@@ -396,8 +467,8 @@ mod tests {
 
         assert!(
             continuity
-                .runtime_self
-                .standing_instructions
+                .workspace_guidance
+                .entries
                 .iter()
                 .any(|entry| entry.contains(agents_text))
         );
@@ -423,6 +494,22 @@ mod tests {
             rendered.contains("Operator prefers concise technical summaries."),
             "expected projected profile text, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn render_runtime_self_continuity_section_renders_workspace_guidance() {
+        let continuity = RuntimeSelfContinuity {
+            workspace_guidance: WorkspaceGuidanceModel {
+                entries: vec!["Keep AGENTS guidance inherited.".to_owned()],
+            },
+            ..RuntimeSelfContinuity::default()
+        };
+
+        let rendered = render_runtime_self_continuity_section(&continuity, true)
+            .expect("workspace guidance continuity should render");
+
+        assert!(rendered.contains("## Workspace Guidance"));
+        assert!(rendered.contains("Keep AGENTS guidance inherited."));
     }
 
     #[test]

--- a/crates/app/src/workspace_guidance.rs
+++ b/crates/app/src/workspace_guidance.rs
@@ -160,10 +160,22 @@ pub fn load_workspace_guidance_model_with_config(
     workspace_root: &Path,
     tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
 ) -> WorkspaceGuidanceModel {
+    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+    load_workspace_guidance_model_with_budget(
+        workspace_root,
+        tool_runtime_config,
+        &mut remaining_total_chars,
+    )
+}
+
+pub(crate) fn load_workspace_guidance_model_with_budget(
+    workspace_root: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+    remaining_total_chars: &mut usize,
+) -> WorkspaceGuidanceModel {
     let source_candidates = workspace_guidance_source_candidates(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = WorkspaceGuidanceModel::default();
-    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
 
     for source_path in source_candidates {
         let maybe_content =
@@ -172,11 +184,11 @@ pub fn load_workspace_guidance_model_with_config(
             continue;
         };
 
-        let budget_was_exhausted = remaining_total_chars == 0;
+        let budget_was_exhausted = *remaining_total_chars == 0;
         let appended_content = ingest_workspace_guidance_source(
             &mut model,
             &mut loaded_paths,
-            &mut remaining_total_chars,
+            remaining_total_chars,
             &source_path,
             content.as_str(),
             tool_runtime_config,

--- a/crates/app/src/workspace_guidance.rs
+++ b/crates/app/src/workspace_guidance.rs
@@ -1,0 +1,201 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Workspace-scoped guidance files that Loong recognizes across runtime and
+/// onboarding/import flows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceGuidanceKind {
+    Agents,
+    Claude,
+    Gemini,
+    Opencode,
+}
+
+impl WorkspaceGuidanceKind {
+    pub const fn file_name(self) -> &'static str {
+        match self {
+            Self::Agents => "AGENTS.md",
+            Self::Claude => "CLAUDE.md",
+            Self::Gemini => "GEMINI.md",
+            Self::Opencode => "OPENCODE.md",
+        }
+    }
+}
+
+/// Search policy for workspace guidance discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceGuidanceSearchScope {
+    SingleRoot,
+    WorkspaceAndNestedWorkspace,
+}
+
+/// Resolved path for one detected workspace-guidance file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceGuidancePath {
+    pub kind: WorkspaceGuidanceKind,
+    pub path: PathBuf,
+}
+
+const RUNTIME_PROMPT_WORKSPACE_GUIDANCE_KINDS: &[WorkspaceGuidanceKind] =
+    &[WorkspaceGuidanceKind::Agents, WorkspaceGuidanceKind::Claude];
+
+const IMPORT_DISCOVERY_WORKSPACE_GUIDANCE_KINDS: &[WorkspaceGuidanceKind] = &[
+    WorkspaceGuidanceKind::Agents,
+    WorkspaceGuidanceKind::Claude,
+    WorkspaceGuidanceKind::Gemini,
+    WorkspaceGuidanceKind::Opencode,
+];
+
+/// Guidance kinds that may feed the runtime prompt in the current phase.
+pub const fn runtime_prompt_workspace_guidance_kinds() -> &'static [WorkspaceGuidanceKind] {
+    RUNTIME_PROMPT_WORKSPACE_GUIDANCE_KINDS
+}
+
+/// Guidance kinds that onboarding/import flows may surface to operators.
+pub const fn import_discovery_workspace_guidance_kinds() -> &'static [WorkspaceGuidanceKind] {
+    IMPORT_DISCOVERY_WORKSPACE_GUIDANCE_KINDS
+}
+
+/// Candidate workspace roots searched for guidance files.
+pub fn candidate_workspace_roots(
+    workspace_root: &Path,
+    search_scope: WorkspaceGuidanceSearchScope,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    roots.push(workspace_root.to_path_buf());
+
+    let include_nested_workspace = matches!(
+        search_scope,
+        WorkspaceGuidanceSearchScope::WorkspaceAndNestedWorkspace
+    );
+    if !include_nested_workspace {
+        return roots;
+    }
+
+    let nested_workspace_root = workspace_root.join("workspace");
+    let nested_workspace_exists = nested_workspace_root.is_dir();
+    if nested_workspace_exists {
+        roots.push(nested_workspace_root);
+    }
+
+    roots
+}
+
+/// Detect workspace-guidance files under the requested search scope.
+pub fn detect_workspace_guidance_paths(
+    workspace_root: &Path,
+    search_scope: WorkspaceGuidanceSearchScope,
+    kinds: &[WorkspaceGuidanceKind],
+) -> Vec<WorkspaceGuidancePath> {
+    let mut detected_paths = Vec::new();
+    let search_roots = candidate_workspace_roots(workspace_root, search_scope);
+
+    for search_root in search_roots {
+        for kind in kinds {
+            let candidate_path = search_root.join(kind.file_name());
+            let candidate_exists = candidate_path.is_file();
+            if !candidate_exists {
+                continue;
+            }
+
+            let detected_path = WorkspaceGuidancePath {
+                kind: *kind,
+                path: candidate_path,
+            };
+            detected_paths.push(detected_path);
+        }
+    }
+
+    detected_paths
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn candidate_workspace_roots_respects_single_root_scope() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace");
+
+        let roots =
+            candidate_workspace_roots(workspace_root, WorkspaceGuidanceSearchScope::SingleRoot);
+
+        assert_eq!(roots, vec![workspace_root.to_path_buf()]);
+    }
+
+    #[test]
+    fn candidate_workspace_roots_includes_nested_workspace_when_requested() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace");
+
+        let roots = candidate_workspace_roots(
+            workspace_root,
+            WorkspaceGuidanceSearchScope::WorkspaceAndNestedWorkspace,
+        );
+
+        assert_eq!(
+            roots,
+            vec![workspace_root.to_path_buf(), nested_workspace_root]
+        );
+    }
+
+    #[test]
+    fn detect_workspace_guidance_paths_filters_to_requested_kinds() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let agents_path = workspace_root.join("AGENTS.md");
+        let claude_path = workspace_root.join("CLAUDE.md");
+        let gemini_path = workspace_root.join("GEMINI.md");
+
+        std::fs::write(&agents_path, "agents").expect("write AGENTS");
+        std::fs::write(&claude_path, "claude").expect("write CLAUDE");
+        std::fs::write(&gemini_path, "gemini").expect("write GEMINI");
+
+        let detected_paths = detect_workspace_guidance_paths(
+            workspace_root,
+            WorkspaceGuidanceSearchScope::SingleRoot,
+            runtime_prompt_workspace_guidance_kinds(),
+        );
+
+        assert_eq!(detected_paths.len(), 2);
+        assert_eq!(detected_paths[0].kind, WorkspaceGuidanceKind::Agents);
+        assert_eq!(detected_paths[0].path, agents_path);
+        assert_eq!(detected_paths[1].kind, WorkspaceGuidanceKind::Claude);
+        assert_eq!(detected_paths[1].path, claude_path);
+    }
+
+    #[test]
+    fn detect_workspace_guidance_paths_preserves_root_then_nested_order() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+        let root_agents_path = workspace_root.join("AGENTS.md");
+        let nested_agents_path = nested_workspace_root.join("AGENTS.md");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace");
+        std::fs::write(&root_agents_path, "root").expect("write root AGENTS");
+        std::fs::write(&nested_agents_path, "nested").expect("write nested AGENTS");
+
+        let detected_paths = detect_workspace_guidance_paths(
+            workspace_root,
+            WorkspaceGuidanceSearchScope::WorkspaceAndNestedWorkspace,
+            runtime_prompt_workspace_guidance_kinds(),
+        );
+
+        assert_eq!(detected_paths.len(), 2);
+        assert_eq!(detected_paths[0].path, root_agents_path);
+        assert_eq!(detected_paths[1].path, nested_agents_path);
+    }
+}

--- a/crates/app/src/workspace_guidance.rs
+++ b/crates/app/src/workspace_guidance.rs
@@ -1,25 +1,24 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use loong_contracts::ToolCoreRequest;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
-/// Workspace-scoped guidance files that Loong recognizes across runtime and
-/// onboarding/import flows.
+use crate::tools;
+
+/// Workspace-scoped guidance files that Loong recognizes as first-class
+/// runtime guidance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceGuidanceKind {
     Agents,
-    Claude,
-    Gemini,
-    Opencode,
 }
 
 impl WorkspaceGuidanceKind {
     pub const fn file_name(self) -> &'static str {
         match self {
             Self::Agents => "AGENTS.md",
-            Self::Claude => "CLAUDE.md",
-            Self::Gemini => "GEMINI.md",
-            Self::Opencode => "OPENCODE.md",
         }
     }
 }
@@ -38,17 +37,37 @@ pub struct WorkspaceGuidancePath {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorkspaceGuidanceModel {
+    pub entries: Vec<String>,
+}
+
+impl WorkspaceGuidanceModel {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuidanceTruncationCause {
+    SourceBudget,
+    TotalBudget,
+}
+
+struct TruncatedWorkspaceGuidanceContent {
+    rendered_content: String,
+    budgeted_chars: usize,
+}
+
 const RUNTIME_PROMPT_WORKSPACE_GUIDANCE_KINDS: &[WorkspaceGuidanceKind] =
-    &[WorkspaceGuidanceKind::Agents, WorkspaceGuidanceKind::Claude];
+    &[WorkspaceGuidanceKind::Agents];
 
-const IMPORT_DISCOVERY_WORKSPACE_GUIDANCE_KINDS: &[WorkspaceGuidanceKind] = &[
-    WorkspaceGuidanceKind::Agents,
-    WorkspaceGuidanceKind::Claude,
-    WorkspaceGuidanceKind::Gemini,
-    WorkspaceGuidanceKind::Opencode,
-];
+const IMPORT_DISCOVERY_WORKSPACE_GUIDANCE_KINDS: &[WorkspaceGuidanceKind] =
+    &[WorkspaceGuidanceKind::Agents];
 
-/// Guidance kinds that may feed the runtime prompt in the current phase.
+/// Guidance kinds that may feed the runtime prompt.
 pub const fn runtime_prompt_workspace_guidance_kinds() -> &'static [WorkspaceGuidanceKind] {
     RUNTIME_PROMPT_WORKSPACE_GUIDANCE_KINDS
 }
@@ -112,6 +131,277 @@ pub fn detect_workspace_guidance_paths(
     detected_paths
 }
 
+pub fn workspace_guidance_source_candidates(workspace_root: &Path) -> Vec<PathBuf> {
+    let search_scope = WorkspaceGuidanceSearchScope::WorkspaceAndNestedWorkspace;
+    let detected_paths = detect_workspace_guidance_paths(
+        workspace_root,
+        search_scope,
+        runtime_prompt_workspace_guidance_kinds(),
+    );
+    let mut source_candidates = Vec::new();
+
+    for detected_path in detected_paths {
+        source_candidates.push(detected_path.path);
+    }
+
+    source_candidates
+}
+
+pub fn load_workspace_guidance_model(workspace_root: &Path) -> WorkspaceGuidanceModel {
+    let tool_runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
+        file_root: Some(workspace_root.to_path_buf()),
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
+    };
+
+    load_workspace_guidance_model_with_config(workspace_root, &tool_runtime_config)
+}
+
+pub fn load_workspace_guidance_model_with_config(
+    workspace_root: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> WorkspaceGuidanceModel {
+    let source_candidates = workspace_guidance_source_candidates(workspace_root);
+    let mut loaded_paths = BTreeSet::new();
+    let mut model = WorkspaceGuidanceModel::default();
+    let mut remaining_total_chars = tool_runtime_config.runtime_self.max_total_chars;
+
+    for source_path in source_candidates {
+        let maybe_content =
+            read_workspace_guidance_source(workspace_root, &source_path, tool_runtime_config);
+        let Some(content) = maybe_content else {
+            continue;
+        };
+
+        let budget_was_exhausted = remaining_total_chars == 0;
+        let appended_content = ingest_workspace_guidance_source(
+            &mut model,
+            &mut loaded_paths,
+            &mut remaining_total_chars,
+            &source_path,
+            content.as_str(),
+            tool_runtime_config,
+        );
+
+        if budget_was_exhausted && appended_content {
+            break;
+        }
+    }
+
+    model
+}
+
+pub fn render_workspace_guidance_section(model: &WorkspaceGuidanceModel) -> Option<String> {
+    if model.is_empty() {
+        return None;
+    }
+
+    let mut sections = Vec::new();
+    let guidance_entries = model.entries.join("\n\n");
+
+    sections.push("## Workspace Guidance".to_owned());
+    sections.push(guidance_entries);
+
+    Some(sections.join("\n\n"))
+}
+
+pub fn normalized_workspace_source_path_key(path: &Path) -> String {
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical_path.display().to_string()
+}
+
+pub fn workspace_source_request_path(workspace_root: &Path, path: &Path) -> Option<String> {
+    let path_is_file = path.is_file();
+    if !path_is_file {
+        return None;
+    }
+
+    let canonical_workspace_root = workspace_root.canonicalize().ok()?;
+    let canonical_path = path.canonicalize().ok()?;
+    let path_within_workspace = canonical_path.starts_with(canonical_workspace_root);
+    if !path_within_workspace {
+        return None;
+    }
+
+    let relative_path = path.strip_prefix(workspace_root).ok()?;
+    let request_path = relative_path.to_string_lossy().to_string();
+    Some(request_path)
+}
+
+fn read_workspace_guidance_source(
+    workspace_root: &Path,
+    path: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> Option<String> {
+    let request_path = workspace_source_request_path(workspace_root, path)?;
+    let request = ToolCoreRequest {
+        tool_name: "file.read".to_owned(),
+        payload: json!({
+            "path": request_path,
+        }),
+    };
+
+    let outcome = tools::execute_tool_core_with_config(request, tool_runtime_config).ok()?;
+    let payload_content = outcome.payload.get("content")?;
+    let content = payload_content.as_str()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.to_owned())
+}
+
+pub(crate) fn ingest_workspace_guidance_source(
+    model: &mut WorkspaceGuidanceModel,
+    loaded_paths: &mut BTreeSet<String>,
+    remaining_total_chars: &mut usize,
+    path: &Path,
+    content: &str,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> bool {
+    let path_key = normalized_workspace_source_path_key(path);
+    let inserted = loaded_paths.insert(path_key);
+    if !inserted {
+        return false;
+    }
+
+    let maybe_truncated = truncate_workspace_guidance_source_content(
+        path,
+        content,
+        *remaining_total_chars,
+        tool_runtime_config,
+    );
+    let Some(truncated) = maybe_truncated else {
+        return false;
+    };
+
+    let budgeted_chars = truncated.budgeted_chars;
+    let rendered_content = truncated.rendered_content;
+
+    *remaining_total_chars = remaining_total_chars.saturating_sub(budgeted_chars);
+    model.entries.push(rendered_content);
+    true
+}
+
+fn truncate_workspace_guidance_source_content(
+    path: &Path,
+    content: &str,
+    remaining_total_chars: usize,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> Option<TruncatedWorkspaceGuidanceContent> {
+    if remaining_total_chars == 0 {
+        let source_label = workspace_source_label(path);
+        let rendered_content = workspace_guidance_truncation_notice_text(
+            source_label.as_str(),
+            GuidanceTruncationCause::TotalBudget,
+        );
+        return Some(TruncatedWorkspaceGuidanceContent {
+            rendered_content,
+            budgeted_chars: 0,
+        });
+    }
+
+    let max_source_chars = tool_runtime_config.runtime_self.max_source_chars;
+    let effective_limit = max_source_chars.min(remaining_total_chars);
+    let content_char_count = content.chars().count();
+    if content_char_count <= effective_limit {
+        return Some(TruncatedWorkspaceGuidanceContent {
+            rendered_content: content.to_owned(),
+            budgeted_chars: content_char_count,
+        });
+    }
+
+    let total_budget_is_tighter = remaining_total_chars < max_source_chars;
+    let truncation_cause = if total_budget_is_tighter {
+        GuidanceTruncationCause::TotalBudget
+    } else {
+        GuidanceTruncationCause::SourceBudget
+    };
+    let source_label = workspace_source_label(path);
+    let truncation_notice =
+        workspace_guidance_truncation_notice_text(source_label.as_str(), truncation_cause);
+    let notice_char_count = truncation_notice.chars().count();
+    let separator = "\n\n";
+    let separator_char_count = separator.chars().count();
+    let minimum_notice_limit = notice_char_count + separator_char_count + 1;
+
+    if effective_limit < minimum_notice_limit {
+        let rendered_content = compact_workspace_guidance_truncation_notice(
+            source_label.as_str(),
+            truncation_cause,
+            effective_limit,
+        );
+        return Some(TruncatedWorkspaceGuidanceContent {
+            rendered_content,
+            budgeted_chars: effective_limit,
+        });
+    }
+
+    let prefix_limit = effective_limit - notice_char_count - separator_char_count;
+    let content_prefix = take_workspace_guidance_prefix(content, prefix_limit);
+    let rendered_content = format!("{content_prefix}{separator}{truncation_notice}");
+
+    Some(TruncatedWorkspaceGuidanceContent {
+        rendered_content,
+        budgeted_chars: effective_limit,
+    })
+}
+
+fn workspace_source_label(path: &Path) -> String {
+    let file_name = path.file_name().and_then(|value| value.to_str());
+    let file_name = file_name.unwrap_or("workspace guidance source");
+    file_name.to_owned()
+}
+
+fn workspace_guidance_truncation_notice_text(
+    source_label: &str,
+    truncation_cause: GuidanceTruncationCause,
+) -> String {
+    let budget_label = match truncation_cause {
+        GuidanceTruncationCause::SourceBudget => "per-source budget",
+        GuidanceTruncationCause::TotalBudget => "remaining total budget",
+    };
+
+    format!("[workspace guidance source truncated: {source_label} exceeded the {budget_label}]")
+}
+
+fn compact_workspace_guidance_truncation_notice(
+    source_label: &str,
+    truncation_cause: GuidanceTruncationCause,
+    max_chars: usize,
+) -> String {
+    let detailed_notice = workspace_guidance_truncation_notice_text(source_label, truncation_cause);
+    if detailed_notice.chars().count() <= max_chars {
+        return detailed_notice;
+    }
+
+    let source_notice = format!("[workspace guidance truncated: {source_label}]");
+    if source_notice.chars().count() <= max_chars {
+        return source_notice;
+    }
+
+    let generic_notice = "[workspace guidance truncated]".to_owned();
+    if generic_notice.chars().count() <= max_chars {
+        return generic_notice;
+    }
+
+    let compact_notice = "[truncated]".to_owned();
+    if compact_notice.chars().count() <= max_chars {
+        return compact_notice;
+    }
+
+    let ellipsis = "...".to_owned();
+    if ellipsis.chars().count() <= max_chars {
+        return ellipsis;
+    }
+
+    ".".repeat(max_chars)
+}
+
+fn take_workspace_guidance_prefix(content: &str, max_chars: usize) -> String {
+    content.chars().take(max_chars).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
@@ -152,16 +442,14 @@ mod tests {
     }
 
     #[test]
-    fn detect_workspace_guidance_paths_filters_to_requested_kinds() {
+    fn detect_workspace_guidance_paths_detects_only_agents() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
         let agents_path = workspace_root.join("AGENTS.md");
         let claude_path = workspace_root.join("CLAUDE.md");
-        let gemini_path = workspace_root.join("GEMINI.md");
 
         std::fs::write(&agents_path, "agents").expect("write AGENTS");
         std::fs::write(&claude_path, "claude").expect("write CLAUDE");
-        std::fs::write(&gemini_path, "gemini").expect("write GEMINI");
 
         let detected_paths = detect_workspace_guidance_paths(
             workspace_root,
@@ -169,11 +457,10 @@ mod tests {
             runtime_prompt_workspace_guidance_kinds(),
         );
 
-        assert_eq!(detected_paths.len(), 2);
+        assert_eq!(detected_paths.len(), 1);
         assert_eq!(detected_paths[0].kind, WorkspaceGuidanceKind::Agents);
         assert_eq!(detected_paths[0].path, agents_path);
-        assert_eq!(detected_paths[1].kind, WorkspaceGuidanceKind::Claude);
-        assert_eq!(detected_paths[1].path, claude_path);
+        assert_eq!(import_discovery_workspace_guidance_kinds().len(), 1);
     }
 
     #[test]
@@ -197,5 +484,33 @@ mod tests {
         assert_eq!(detected_paths.len(), 2);
         assert_eq!(detected_paths[0].path, root_agents_path);
         assert_eq!(detected_paths[1].path, nested_agents_path);
+    }
+
+    #[test]
+    fn render_workspace_guidance_section_renders_agents_entries() {
+        let model = WorkspaceGuidanceModel {
+            entries: vec!["Always keep repo guidance explicit.".to_owned()],
+        };
+
+        let rendered =
+            render_workspace_guidance_section(&model).expect("workspace guidance should render");
+
+        assert!(rendered.contains("## Workspace Guidance"));
+        assert!(rendered.contains("Always keep repo guidance explicit."));
+    }
+
+    #[test]
+    fn load_workspace_guidance_model_ignores_claude_file() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let agents_path = workspace_root.join("AGENTS.md");
+        let claude_path = workspace_root.join("CLAUDE.md");
+
+        std::fs::write(&agents_path, "agents").expect("write AGENTS");
+        std::fs::write(&claude_path, "claude").expect("write CLAUDE");
+
+        let model = load_workspace_guidance_model(workspace_root);
+
+        assert_eq!(model.entries, vec!["agents".to_owned()]);
     }
 }

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -743,14 +743,8 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
         let agents_path = workspace_root.join("AGENTS.md");
-        let claude_path = workspace_root.join("CLAUDE.md");
-        let gemini_path = workspace_root.join("GEMINI.md");
-        let opencode_path = workspace_root.join("OPENCODE.md");
 
         std::fs::write(&agents_path, "agents").expect("write AGENTS");
-        std::fs::write(&claude_path, "claude").expect("write CLAUDE");
-        std::fs::write(&gemini_path, "gemini").expect("write GEMINI");
-        std::fs::write(&opencode_path, "opencode").expect("write OPENCODE");
 
         let guidance = detect_workspace_guidance(workspace_root);
         let guidance_kinds = guidance
@@ -764,22 +758,9 @@ mod tests {
 
         assert_eq!(
             guidance_kinds,
-            vec![
-                mvp::workspace_guidance::WorkspaceGuidanceKind::Agents,
-                mvp::workspace_guidance::WorkspaceGuidanceKind::Claude,
-                mvp::workspace_guidance::WorkspaceGuidanceKind::Gemini,
-                mvp::workspace_guidance::WorkspaceGuidanceKind::Opencode,
-            ]
+            vec![mvp::workspace_guidance::WorkspaceGuidanceKind::Agents]
         );
-        assert_eq!(
-            guidance_paths,
-            vec![
-                agents_path.display().to_string(),
-                claude_path.display().to_string(),
-                gemini_path.display().to_string(),
-                opencode_path.display().to_string(),
-            ]
-        );
+        assert_eq!(guidance_paths, vec![agents_path.display().to_string()]);
     }
 
     #[test]

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -14,7 +14,7 @@ use super::provider_transport::ImportedProviderTransport;
 use super::types::{
     ChannelCandidate, ChannelImportReadiness, CurrentSetupState, DomainPreview, ImportCandidate,
     ImportSourceKind, ImportSurface, ImportSurfaceLevel, PreviewStatus, SetupDomainKind,
-    WorkspaceGuidanceCandidate, WorkspaceGuidanceKind,
+    WorkspaceGuidanceCandidate,
 };
 
 #[derive(Debug, Deserialize)]
@@ -240,21 +240,21 @@ pub fn resolve_channel_import_readiness_from_config(
 }
 
 pub fn detect_workspace_guidance(root: &Path) -> Vec<WorkspaceGuidanceCandidate> {
+    let kinds = mvp::workspace_guidance::import_discovery_workspace_guidance_kinds();
+    let scope = mvp::workspace_guidance::WorkspaceGuidanceSearchScope::SingleRoot;
+    let detected_paths =
+        mvp::workspace_guidance::detect_workspace_guidance_paths(root, scope, kinds);
     let mut guidance = Vec::new();
-    for kind in [
-        WorkspaceGuidanceKind::Agents,
-        WorkspaceGuidanceKind::Claude,
-        WorkspaceGuidanceKind::Gemini,
-        WorkspaceGuidanceKind::Opencode,
-    ] {
-        let path = root.join(kind.file_name());
-        if path.is_file() {
-            guidance.push(WorkspaceGuidanceCandidate {
-                kind,
-                path: path.display().to_string(),
-            });
-        }
+
+    for detected_path in detected_paths {
+        let rendered_path = detected_path.path.display().to_string();
+        let candidate = WorkspaceGuidanceCandidate {
+            kind: detected_path.kind,
+            path: rendered_path,
+        };
+        guidance.push(candidate);
     }
+
     guidance
 }
 
@@ -706,6 +706,8 @@ fn memory_behavior_summary(config: &mvp::config::MemoryConfig) -> String {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
@@ -734,5 +736,67 @@ mod tests {
         let surface = provider_import_surface(&config).expect("provider surface should exist");
 
         assert_eq!(surface.level, ImportSurfaceLevel::Ready);
+    }
+
+    #[test]
+    fn detect_workspace_guidance_uses_shared_import_taxonomy() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let agents_path = workspace_root.join("AGENTS.md");
+        let claude_path = workspace_root.join("CLAUDE.md");
+        let gemini_path = workspace_root.join("GEMINI.md");
+        let opencode_path = workspace_root.join("OPENCODE.md");
+
+        std::fs::write(&agents_path, "agents").expect("write AGENTS");
+        std::fs::write(&claude_path, "claude").expect("write CLAUDE");
+        std::fs::write(&gemini_path, "gemini").expect("write GEMINI");
+        std::fs::write(&opencode_path, "opencode").expect("write OPENCODE");
+
+        let guidance = detect_workspace_guidance(workspace_root);
+        let guidance_kinds = guidance
+            .iter()
+            .map(|candidate| candidate.kind)
+            .collect::<Vec<_>>();
+        let guidance_paths = guidance
+            .iter()
+            .map(|candidate| candidate.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            guidance_kinds,
+            vec![
+                mvp::workspace_guidance::WorkspaceGuidanceKind::Agents,
+                mvp::workspace_guidance::WorkspaceGuidanceKind::Claude,
+                mvp::workspace_guidance::WorkspaceGuidanceKind::Gemini,
+                mvp::workspace_guidance::WorkspaceGuidanceKind::Opencode,
+            ]
+        );
+        assert_eq!(
+            guidance_paths,
+            vec![
+                agents_path.display().to_string(),
+                claude_path.display().to_string(),
+                gemini_path.display().to_string(),
+                opencode_path.display().to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_workspace_guidance_keeps_single_root_scope_for_import_discovery() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+        let nested_agents_path = nested_workspace_root.join("AGENTS.md");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace");
+        std::fs::write(&nested_agents_path, "nested agents").expect("write nested AGENTS");
+
+        let guidance = detect_workspace_guidance(workspace_root);
+
+        assert!(
+            guidance.is_empty(),
+            "single-root import discovery should not scan nested workspace guidance: {guidance:#?}"
+        );
     }
 }

--- a/crates/daemon/src/migration/types.rs
+++ b/crates/daemon/src/migration/types.rs
@@ -386,25 +386,7 @@ pub struct DomainPreview {
     pub summary: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WorkspaceGuidanceKind {
-    Agents,
-    Claude,
-    Gemini,
-    Opencode,
-}
-
-impl WorkspaceGuidanceKind {
-    pub const fn file_name(self) -> &'static str {
-        match self {
-            WorkspaceGuidanceKind::Agents => "AGENTS.md",
-            WorkspaceGuidanceKind::Claude => "CLAUDE.md",
-            WorkspaceGuidanceKind::Gemini => "GEMINI.md",
-            WorkspaceGuidanceKind::Opencode => "OPENCODE.md",
-        }
-    }
-}
+pub type WorkspaceGuidanceKind = mvp::workspace_guidance::WorkspaceGuidanceKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WorkspaceGuidanceCandidate {

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -2312,7 +2312,7 @@ fn migration_render_preview_includes_channel_details_and_guidance() {
                 status: loong_daemon::migration::types::PreviewStatus::Ready,
                 decision: Some(loong_daemon::migration::types::PreviewDecision::UseDetected),
                 source: "workspace".to_owned(),
-                summary: "AGENTS.md, CLAUDE.md".to_owned(),
+                summary: "AGENTS.md".to_owned(),
             },
         ],
         channel_candidates: vec![
@@ -2331,16 +2331,10 @@ fn migration_render_preview_includes_channel_details_and_guidance() {
                 summary: "app credentials resolved · can enable during onboarding".to_owned(),
             },
         ],
-        workspace_guidance: vec![
-            loong_daemon::migration::types::WorkspaceGuidanceCandidate {
-                kind: loong_daemon::migration::types::WorkspaceGuidanceKind::Agents,
-                path: "/tmp/project/AGENTS.md".to_owned(),
-            },
-            loong_daemon::migration::types::WorkspaceGuidanceCandidate {
-                kind: loong_daemon::migration::types::WorkspaceGuidanceKind::Claude,
-                path: "/tmp/project/CLAUDE.md".to_owned(),
-            },
-        ],
+        workspace_guidance: vec![loong_daemon::migration::types::WorkspaceGuidanceCandidate {
+            kind: loong_daemon::migration::types::WorkspaceGuidanceKind::Agents,
+            path: "/tmp/project/AGENTS.md".to_owned(),
+        }],
     };
 
     let lines = loong_daemon::migration::render::render_candidate_preview_lines(&candidate, 100);
@@ -2382,7 +2376,7 @@ fn migration_render_preview_falls_back_to_stacked_rows_when_wide_table_would_ove
                 status: loong_daemon::migration::types::PreviewStatus::Ready,
                 decision: Some(loong_daemon::migration::types::PreviewDecision::UseDetected),
                 source: "workspace".to_owned(),
-                summary: "AGENTS.md, CLAUDE.md, and custom workspace instructions".to_owned(),
+                summary: "AGENTS.md and custom workspace instructions".to_owned(),
             },
         ],
         channel_candidates: vec![loong_daemon::migration::types::ChannelCandidate {

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -3934,18 +3934,6 @@ fn onboard_entry_screen_wraps_detected_setup_digest_and_option_details() {
             path: "/tmp/project/AGENTS.md".to_owned(),
         },
     );
-    recommended.workspace_guidance.push(
-        loong_daemon::migration::types::WorkspaceGuidanceCandidate {
-            kind: loong_daemon::migration::types::WorkspaceGuidanceKind::Claude,
-            path: "/tmp/project/CLAUDE.md".to_owned(),
-        },
-    );
-    recommended.workspace_guidance.push(
-        loong_daemon::migration::types::WorkspaceGuidanceCandidate {
-            kind: loong_daemon::migration::types::WorkspaceGuidanceKind::Gemini,
-            path: "/tmp/project/GEMINI.md".to_owned(),
-        },
-    );
     let options = loong_daemon::onboard_cli::build_onboard_entry_options(
         loong_daemon::migration::types::CurrentSetupState::Absent,
         &[recommended.clone()],
@@ -3973,12 +3961,8 @@ fn onboard_entry_screen_wraps_detected_setup_digest_and_option_details() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "- workspace guidance: AGENTS.md,"),
+            .any(|line| line == "- workspace guidance: AGENTS.md"),
         "entry screen should wrap long workspace-guidance digests instead of overflowing them: {lines:#?}"
-    );
-    assert!(
-        lines.iter().any(|line| line == "  CLAUDE.md, GEMINI.md"),
-        "entry screen should continue workspace-guidance digests on readable continuation lines: {lines:#?}"
     );
     assert!(
         lines

--- a/docs/design-docs/harness-engineering.md
+++ b/docs/design-docs/harness-engineering.md
@@ -127,6 +127,34 @@ Progressive disclosure hierarchy:
 | Specialized | Design docs, domain indices | Loaded when working on that domain |
 | Cold | Roadmap, reliability, and knowledge-base specs/plans | Accessed on demand |
 
+### Workspace Guidance Taxonomy
+
+Loong now treats workspace guidance as a named source family rather than a pile
+of unrelated filenames.
+
+- `AGENTS.md` and `CLAUDE.md` are the runtime-visible hot guidance files.
+- `GEMINI.md` and `OPENCODE.md` may still be detected by onboarding/import
+  flows, but they are not part of the runtime prompt surface.
+- runtime prompt assembly keeps using the existing runtime-self projection for
+  `AGENTS.md` / `CLAUDE.md` in the current phase, so prompt behavior does not
+  drift just because the taxonomy became explicit.
+- runtime-specific files such as `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and
+  `USER.md` remain separate from workspace guidance even when they are loaded
+  from the same workspace root.
+
+### Current Runtime Boundary
+
+Today the shared taxonomy is used in two different ways:
+
+- `crates/app` uses the runtime-visible subset (`AGENTS.md`, `CLAUDE.md`) while
+  preserving the current prompt assembly contract and continuity behavior.
+- `crates/daemon` uses the wider import-detection subset to describe migration
+  and onboarding surfaces without silently widening runtime prompt inputs.
+
+This split is intentional. It keeps the repository's hot guidance files visible
+to the runtime while preventing tool-ecosystem compatibility files from being
+accidentally promoted into the provider-facing prompt.
+
 ---
 
 ## References

--- a/docs/design-docs/harness-engineering.md
+++ b/docs/design-docs/harness-engineering.md
@@ -123,37 +123,32 @@ Progressive disclosure hierarchy:
 
 | Tier | Files | Loading |
 |------|-------|---------|
-| Hot | `AGENTS.md` / `CLAUDE.md` | Auto-loaded every session |
+| Hot | `AGENTS.md` | Auto-loaded every session |
 | Specialized | Design docs, domain indices | Loaded when working on that domain |
 | Cold | Roadmap, reliability, and knowledge-base specs/plans | Accessed on demand |
 
 ### Workspace Guidance Taxonomy
 
-Loong now treats workspace guidance as a named source family rather than a pile
-of unrelated filenames.
+Loong's runtime guidance contract is now explicit and narrow:
 
-- `AGENTS.md` and `CLAUDE.md` are the runtime-visible hot guidance files.
-- `GEMINI.md` and `OPENCODE.md` may still be detected by onboarding/import
-  flows, but they are not part of the runtime prompt surface.
-- runtime prompt assembly keeps using the existing runtime-self projection for
-  `AGENTS.md` / `CLAUDE.md` in the current phase, so prompt behavior does not
-  drift just because the taxonomy became explicit.
+- `AGENTS.md` is the only runtime-visible workspace-guidance file.
+- other ecosystem files such as `CLAUDE.md`, `GEMINI.md`, and `OPENCODE.md`
+  are not runtime inputs for Loong.
 - runtime-specific files such as `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and
   `USER.md` remain separate from workspace guidance even when they are loaded
   from the same workspace root.
 
 ### Current Runtime Boundary
 
-Today the shared taxonomy is used in two different ways:
+Today the runtime and daemon are aligned on one rule:
 
-- `crates/app` uses the runtime-visible subset (`AGENTS.md`, `CLAUDE.md`) while
-  preserving the current prompt assembly contract and continuity behavior.
-- `crates/daemon` uses the wider import-detection subset to describe migration
-  and onboarding surfaces without silently widening runtime prompt inputs.
+- `crates/app` loads `AGENTS.md` as the runtime workspace-guidance surface.
+- `crates/daemon` only surfaces `AGENTS.md` in onboarding/import previews for
+  workspace-guidance detection.
 
-This split is intentional. It keeps the repository's hot guidance files visible
-to the runtime while preventing tool-ecosystem compatibility files from being
-accidentally promoted into the provider-facing prompt.
+This split keeps the runtime contract simple and avoids silently promoting
+provider- or tool-specific foreign guidance files into Loong's provider-facing
+prompt.
 
 ---
 


### PR DESCRIPTION
## Summary

- Problem: runtime prompt assembly still mixed AGENTS-derived repo guidance with runtime-self semantics and retained compatibility paths for other ecosystem guidance formats.
- Why it matters: that coupling made AGENTS authority unclear, kept workspace guidance buried inside `runtime_self`, and left onboarding/runtime detection behavior broader than the desired Loong contract.
- What changed: Loong runtime now recognizes only `AGENTS.md` as workspace guidance, emits it as a dedicated prompt fragment, keeps runtime-self limited to runtime-only files, promotes legacy `standing_instructions` continuity into a new workspace-guidance field, and narrows onboarding/import workspace-guidance detection to AGENTS only.
- What did not change (scope boundary): no public site rewrite, no broad generic prompt-source framework, and no expansion of cross-tool compatibility.

## Linked Issues

- Closes #1369

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this deliberately changes the runtime workspace-guidance contract from multi-format compatibility to AGENTS-only guidance, and changes prompt composition semantics to separate workspace guidance from runtime self.
- Rollout / guardrails: targeted app and daemon regressions cover AGENTS-only detection, prompt composition, runtime-self exclusion, legacy continuity promotion, and onboarding/import previews.
- Rollback path: revert this PR to restore the previous shared taxonomy and prompt assembly behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all --check
git diff --check
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong-app workspace_guidance::tests:: --lib
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong-app provider::request_message_runtime::tests::build_system_message_includes_normalized_runtime_self_sections_from_workspace_root --lib -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong-app runtime_self_continuity::tests::runtime_self_continuity_from_event_payload_promotes_legacy_standing_instructions --lib -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong-app conversation::tests::default_runtime_build_context_rehydrates_runtime_self_continuity_when_live_sources_are_missing --lib -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong-app runtime_self::tests:: --lib
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong migration::discovery::tests::detect_workspace_guidance_uses_shared_import_taxonomy --lib -- --exact
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong migration_render_preview_includes_channel_details_and_guidance --test integration
CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loong onboard_entry_screen_wraps_detected_setup_digest_and_option_details --test integration
bash scripts/check-docs.sh

All listed targeted tests passed.
`bash scripts/check-docs.sh` passed with pre-existing non-blocking release-trace warnings only.
```

## User-visible / Operator-visible Changes

- Loong runtime now treats `AGENTS.md` as the sole workspace-guidance file.
- Repo guidance is emitted as a distinct prompt fragment rather than being folded into live runtime-self semantics.
- Onboarding/import previews now summarize AGENTS-only workspace guidance.

## Failure Recovery

- Fast rollback or disable path: revert this PR and restore the previous workspace-guidance taxonomy and prompt assembly path.
- Observable failure symptoms reviewers should watch for: missing AGENTS guidance in system prompts, stale legacy continuity not promoting guidance, or onboarding/import previews unexpectedly showing non-AGENTS workspace-guidance files.

## Reviewer Focus

- `crates/app/src/workspace_guidance.rs`
- `crates/app/src/provider/request_message_runtime.rs`
- `crates/app/src/runtime_self.rs`
- `crates/app/src/runtime_self_continuity.rs`
- `crates/daemon/src/migration/discovery.rs`
- `crates/daemon/tests/integration/migration.rs`
- `crates/daemon/tests/integration/onboard_cli.rs`
- `docs/design-docs/harness-engineering.md`
