### PR TITLE
Project local gateway control maturity through node posture and handler hardening

### DIFF
--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -1100,6 +1100,15 @@ pub struct ControlPlanePairingRequestRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlaneApprovedDeviceSummary {
+    pub device_id: String,
+    pub public_key: String,
+    pub role: String,
+    pub approved_scopes: BTreeSet<String>,
+    pub issued_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ControlPlanePairingConnectDecision {
     Authorized,
     PairingRequired {
@@ -1301,6 +1310,28 @@ impl ControlPlanePairingRegistry {
             .read()
             .unwrap_or_else(|error| error.into_inner())
             .len()
+    }
+
+    pub fn list_approved_devices(&self, limit: usize) -> Vec<ControlPlaneApprovedDeviceSummary> {
+        let mut approved_devices = self
+            .approved_devices
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        approved_devices.sort_by(|left, right| {
+            right
+                .approved_at_ms
+                .cmp(&left.approved_at_ms)
+                .then_with(|| left.device_id.cmp(&right.device_id))
+        });
+        approved_devices.truncate(limit.max(1));
+
+        approved_devices
+            .iter()
+            .map(approved_device_summary_from_record)
+            .collect()
     }
 
     pub fn last_activity_ms(&self) -> Option<u64> {
@@ -1598,6 +1629,18 @@ fn approved_device_requires_pairing(
     }
     let scopes_within_approved = requested_scopes.is_subset(&approved.approved_scopes);
     !scopes_within_approved
+}
+
+fn approved_device_summary_from_record(
+    approved: &ControlPlaneApprovedDeviceRecord,
+) -> ControlPlaneApprovedDeviceSummary {
+    ControlPlaneApprovedDeviceSummary {
+        device_id: approved.device_id.clone(),
+        public_key: approved.public_key.clone(),
+        role: approved.role.clone(),
+        approved_scopes: approved.approved_scopes.clone(),
+        issued_at_ms: approved.approved_at_ms,
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -57,6 +57,59 @@ pub struct GatewayPairingRequestsRequest<'a> {
     pub limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GatewayPairingEventsRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_seq: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ack_seq: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayPairingStaleCursorReplayWindow {
+    pub oldest_retained_seq: Option<u64>,
+    pub latest_seq: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayPairingStaleCursorError {
+    pub code: String,
+    pub message: String,
+    pub last_acknowledged_seq: Option<u64>,
+    pub earliest_resumable_after_seq: u64,
+    pub replay_window: GatewayPairingStaleCursorReplayWindow,
+}
+
+impl GatewayPairingStaleCursorError {
+    pub fn resume_after_seq(&self) -> u64 {
+        self.earliest_resumable_after_seq
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GatewayPairingEventsOutcome {
+    Events(GatewayPairingEventsReadModel),
+    StaleCursor(GatewayPairingStaleCursorError),
+}
+
+impl GatewayPairingEventsOutcome {
+    pub fn events(&self) -> Option<&GatewayPairingEventsReadModel> {
+        match self {
+            Self::Events(events) => Some(events),
+            Self::StaleCursor(_) => None,
+        }
+    }
+
+    pub fn stale_cursor(&self) -> Option<&GatewayPairingStaleCursorError> {
+        match self {
+            Self::Events(_) => None,
+            Self::StaleCursor(error) => Some(error),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GatewayLocalDiscovery {
     runtime_dir: PathBuf,
@@ -377,49 +430,51 @@ impl GatewayLocalClient {
         self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
             .await
     }
-
     pub async fn pairing_session(
         &self,
         session_token: &str,
     ) -> CliResult<GatewayPairingSessionReadModel> {
         let path = "/v1/pairing/session";
-        let endpoint = self.endpoint_url(path)?;
-        let request_builder = self.http_client.get(endpoint.as_str());
-        let request_builder = request_builder.bearer_auth(session_token);
-        let response = self
-            .send_gateway_request(request_builder, endpoint.as_str())
-            .await?;
-        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+        self.request_pairing_json(Method::GET, path, session_token)
             .await
     }
 
     pub async fn pairing_events(
         &self,
         session_token: &str,
-        after_seq: Option<u64>,
-        limit: Option<usize>,
-        ack_seq: Option<u64>,
-    ) -> CliResult<GatewayPairingEventsReadModel> {
+        request: &GatewayPairingEventsRequest,
+    ) -> CliResult<GatewayPairingEventsOutcome> {
         let path = "/v1/pairing/events";
         let endpoint = self.endpoint_url(path)?;
-        let mut query = Vec::new();
-        if let Some(after_seq) = after_seq {
-            query.push(("after_seq", after_seq.to_string()));
-        }
-        if let Some(limit) = limit {
-            query.push(("limit", limit.to_string()));
-        }
-        if let Some(ack_seq) = ack_seq {
-            query.push(("ack_seq", ack_seq.to_string()));
-        }
         let request_builder = self.http_client.get(endpoint.as_str());
-        let request_builder = request_builder.query(&query);
+        let request_builder = request_builder.query(request);
         let request_builder = request_builder.bearer_auth(session_token);
         let response = self
             .send_gateway_request(request_builder, endpoint.as_str())
             .await?;
-        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+        let status = response.status();
+        let response_text = response
+            .text()
             .await
+            .map_err(|error| format!("read gateway response failed for {endpoint}: {error}"))?;
+
+        if status == reqwest::StatusCode::CONFLICT
+            && let Ok(parsed_error) =
+                serde_json::from_str::<GatewayPairingStaleCursorEnvelope>(response_text.as_str())
+            && parsed_error.error.code == "stale_cursor"
+        {
+            return Ok(GatewayPairingEventsOutcome::StaleCursor(parsed_error.error));
+        }
+
+        if !status.is_success() {
+            let error_message = decode_gateway_error_message_from_text(response_text.as_str());
+            let error = format!("gateway GET {path} failed with status {status}: {error_message}");
+            return Err(error);
+        }
+
+        let payload = serde_json::from_str::<GatewayPairingEventsReadModel>(response_text.as_str())
+            .map_err(|error| format!("decode gateway response failed for {endpoint}: {error}"))?;
+        Ok(GatewayPairingEventsOutcome::Events(payload))
     }
 
     pub async fn pairing_stream(
@@ -502,6 +557,26 @@ impl GatewayLocalClient {
         let request_builder = self.http_client.request(method, endpoint.as_str());
         let request_builder = request_builder.query(query);
         let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), method_name.as_str(), path)
+            .await
+    }
+
+    async fn request_pairing_json<T>(
+        &self,
+        method: Method,
+        path: &str,
+        session_token: &str,
+    ) -> CliResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let endpoint = self.endpoint_url(path)?;
+        let method_name = method.as_str().to_owned();
+        let request_builder = self.http_client.request(method, endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(session_token);
         let response = self
             .send_gateway_request(request_builder, endpoint.as_str())
             .await?;
@@ -634,6 +709,11 @@ struct GatewayErrorEnvelope {
 }
 
 #[derive(Debug, Deserialize)]
+struct GatewayPairingStaleCursorEnvelope {
+    error: GatewayPairingStaleCursorError,
+}
+
+#[derive(Debug, Deserialize)]
 struct GatewayErrorBody {
     code: String,
     message: String,
@@ -702,7 +782,11 @@ async fn decode_gateway_error_message(response: Response) -> String {
         }
     };
 
-    let parsed_error = serde_json::from_str::<GatewayErrorEnvelope>(response_text.as_str());
+    decode_gateway_error_message_from_text(response_text.as_str())
+}
+
+fn decode_gateway_error_message_from_text(response_text: &str) -> String {
+    let parsed_error = serde_json::from_str::<GatewayErrorEnvelope>(response_text);
     if let Ok(parsed_error) = parsed_error {
         let code = parsed_error.error.code;
         let message = parsed_error.error.message;
@@ -720,6 +804,7 @@ async fn decode_gateway_error_message(response: Response) -> String {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::BTreeSet,
         fs,
         io::{Read, Write},
         net::TcpListener,
@@ -730,6 +815,7 @@ mod tests {
 
     use super::*;
     use crate::gateway::state::GatewayPortSource;
+    use loong_protocol::{ControlPlanePrincipal, ControlPlaneRole, ControlPlaneScope};
 
     fn gateway_owner_status_fixture() -> GatewayOwnerStatus {
         let now_ms = SystemTime::now()
@@ -823,6 +909,50 @@ mod tests {
         let socket_address = listener.local_addr().expect("ephemeral probe addr");
         drop(listener);
         socket_address
+    }
+
+    fn spawn_gateway_json_server_once(
+        status_line: &str,
+        body: String,
+    ) -> (SocketAddr, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind gateway json server");
+        let socket_address = listener.local_addr().expect("gateway json server addr");
+        let status_line = status_line.to_owned();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept gateway json request");
+            let mut request_buffer = [0_u8; 8192];
+            let read = stream
+                .read(&mut request_buffer)
+                .expect("read gateway json request");
+            let request_text = String::from_utf8_lossy(&request_buffer[..read]).into_owned();
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write gateway json response");
+            request_text
+        });
+        (socket_address, server)
+    }
+
+    fn gateway_local_client_for_test(
+        socket_address: SocketAddr,
+        bearer_token: &str,
+    ) -> GatewayLocalClient {
+        let mut owner_status = gateway_owner_status_fixture();
+        owner_status.port = Some(socket_address.port());
+        let discovery = GatewayLocalDiscovery {
+            runtime_dir: unique_temp_path("client-runtime"),
+            owner_status,
+            socket_address,
+            base_url: format!("http://{socket_address}"),
+            bearer_token: bearer_token.to_owned(),
+            source: GatewayLocalDiscoverySource::DefaultBootstrap,
+        };
+        GatewayLocalClient::from_discovery(discovery)
     }
 
     #[test]
@@ -934,5 +1064,163 @@ mod tests {
         );
 
         fs::remove_dir_all(runtime_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn gateway_local_client_pairing_session_uses_session_token() {
+        let payload = GatewayPairingSessionReadModel {
+            status: "active".to_owned(),
+            connection_token_expires_at_ms: 1_700_000_000_000,
+            principal: ControlPlanePrincipal {
+                connection_id: "conn-1".to_owned(),
+                client_id: "client-1".to_owned(),
+                role: ControlPlaneRole::Operator,
+                scopes: BTreeSet::from([ControlPlaneScope::OperatorRead]),
+                device_id: Some("device-1".to_owned()),
+            },
+            last_acknowledged_seq: Some(7),
+            resume_status: "resumed".to_owned(),
+            resume_from_after_seq: 7,
+            earliest_resumable_after_seq: 4,
+            replay_window: super::super::read_models::GatewayPairingReplayWindowReadModel {
+                oldest_retained_seq: Some(5),
+                latest_seq: Some(9),
+            },
+        };
+        let (socket_address, server) =
+            spawn_gateway_json_server_once("200 OK", serde_json::to_string(&payload).unwrap());
+        let client = gateway_local_client_for_test(socket_address, "control-token");
+
+        let session = client
+            .pairing_session("session-token")
+            .await
+            .expect("pairing session payload");
+
+        assert_eq!(session.resume_status, "resumed");
+        assert_eq!(session.resume_from_after_seq, 7);
+
+        let request_text = server.join().expect("join gateway json server");
+        assert!(
+            request_text.starts_with("GET /v1/pairing/session HTTP/1.1"),
+            "unexpected request line: {request_text}"
+        );
+        let request_text_lower = request_text.to_ascii_lowercase();
+        assert!(
+            request_text_lower.contains("authorization: bearer session-token"),
+            "expected session token auth header: {request_text}"
+        );
+        assert!(
+            !request_text_lower.contains("authorization: bearer control-token"),
+            "control token should not be reused for paired-session calls: {request_text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_local_client_pairing_events_surfaces_stale_cursor_outcome() {
+        let stale_cursor = serde_json::json!({
+            "error": {
+                "code": "stale_cursor",
+                "message": "requested after_seq=0 is older than retained replay window 5..9",
+                "last_acknowledged_seq": 7,
+                "earliest_resumable_after_seq": 4,
+                "replay_window": {
+                    "oldest_retained_seq": 5,
+                    "latest_seq": 9
+                }
+            }
+        });
+        let (socket_address, server) = spawn_gateway_json_server_once(
+            "409 Conflict",
+            serde_json::to_string(&stale_cursor).unwrap(),
+        );
+        let client = gateway_local_client_for_test(socket_address, "control-token");
+
+        let outcome = client
+            .pairing_events(
+                "session-token",
+                &GatewayPairingEventsRequest {
+                    after_seq: Some(0),
+                    limit: Some(10),
+                    ack_seq: Some(7),
+                },
+            )
+            .await
+            .expect("stale cursor outcome");
+
+        let stale_cursor = outcome
+            .stale_cursor()
+            .expect("stale cursor should surface as a recoverable outcome");
+        assert_eq!(stale_cursor.resume_after_seq(), 4);
+        assert_eq!(stale_cursor.last_acknowledged_seq, Some(7));
+        assert_eq!(stale_cursor.replay_window.oldest_retained_seq, Some(5));
+        assert_eq!(stale_cursor.replay_window.latest_seq, Some(9));
+
+        let request_text = server.join().expect("join gateway json server");
+        assert!(
+            request_text
+                .starts_with("GET /v1/pairing/events?after_seq=0&limit=10&ack_seq=7 HTTP/1.1"),
+            "unexpected request line: {request_text}"
+        );
+        assert!(
+            request_text
+                .to_ascii_lowercase()
+                .contains("authorization: bearer session-token"),
+            "expected session token auth header: {request_text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_local_client_pairing_events_decodes_event_payloads() {
+        let payload = serde_json::json!({
+            "after_seq": 7,
+            "effective_after_seq": 7,
+            "returned_count": 2,
+            "last_acknowledged_seq": 9,
+            "resume_status": "resumed",
+            "next_after_seq": 9,
+            "earliest_resumable_after_seq": 4,
+            "replay_window": {
+                "oldest_retained_seq": 5,
+                "latest_seq": 9
+            },
+            "events": [
+                {
+                    "seq": 8,
+                    "payload": {"event_type": "gateway.status"}
+                },
+                {
+                    "seq": 9,
+                    "payload": {"event_type": "gateway.turn.completed"}
+                }
+            ]
+        });
+        let (socket_address, server) =
+            spawn_gateway_json_server_once("200 OK", serde_json::to_string(&payload).unwrap());
+        let client = gateway_local_client_for_test(socket_address, "control-token");
+
+        let outcome = client
+            .pairing_events(
+                "session-token",
+                &GatewayPairingEventsRequest {
+                    after_seq: Some(7),
+                    limit: Some(10),
+                    ack_seq: Some(9),
+                },
+            )
+            .await
+            .expect("event payload outcome");
+
+        let events = outcome.events().expect("event payload");
+        assert_eq!(events.returned_count, 2);
+        assert_eq!(events.next_after_seq, 9);
+        assert_eq!(events.last_acknowledged_seq, Some(9));
+        assert_eq!(events.events.len(), 2);
+
+        let request_text = server.join().expect("join gateway json server");
+        assert!(
+            request_text
+                .starts_with("GET /v1/pairing/events?after_seq=7&limit=10&ack_seq=9 HTTP/1.1"),
+            "unexpected request line: {request_text}"
+        );
     }
 }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -17,9 +17,9 @@ use crate::CliResult;
 
 use super::{
     read_models::{
-        GatewayOperatorSummaryReadModel, GatewayPairingCompleteReadModel,
-        GatewayPairingEventsReadModel, GatewayPairingSessionReadModel,
-        GatewayPairingStartReadModel,
+        GatewayNodeInventoryReadModel, GatewayOperatorSummaryReadModel,
+        GatewayPairingCompleteReadModel, GatewayPairingEventsReadModel,
+        GatewayPairingSessionReadModel, GatewayPairingStartReadModel,
     },
     state::{
         GatewayOwnerStatus, default_gateway_runtime_state_dir, gateway_control_token_path,
@@ -318,7 +318,7 @@ impl GatewayLocalClient {
         self.request_json(Method::GET, path).await
     }
 
-    pub async fn nodes(&self) -> CliResult<Value> {
+    pub async fn nodes(&self) -> CliResult<GatewayNodeInventoryReadModel> {
         let path = "/v1/nodes";
         self.request_json(Method::GET, path).await
     }

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use loong_protocol::{
-    ControlPlanePairingListResponse, ControlPlanePairingResolveRequest,
+    ControlPlaneConnectRequest, ControlPlanePairingListResponse, ControlPlanePairingResolveRequest,
     ControlPlanePairingResolveResponse,
 };
 use reqwest::blocking::Client as BlockingClient;
@@ -16,7 +16,11 @@ use serde_json::Value;
 use crate::CliResult;
 
 use super::{
-    read_models::GatewayOperatorSummaryReadModel,
+    read_models::{
+        GatewayOperatorSummaryReadModel, GatewayPairingCompleteReadModel,
+        GatewayPairingEventsReadModel, GatewayPairingSessionReadModel,
+        GatewayPairingStartReadModel,
+    },
     state::{
         GatewayOwnerStatus, default_gateway_runtime_state_dir, gateway_control_token_path,
         load_gateway_owner_status,
@@ -261,6 +265,11 @@ impl GatewayLocalClient {
         self.request_json(Method::GET, path).await
     }
 
+    pub async fn nodes(&self) -> CliResult<Value> {
+        let path = "/v1/nodes";
+        self.request_json(Method::GET, path).await
+    }
+
     pub async fn acp_sessions(&self, request: &GatewayAcpSessionsRequest) -> CliResult<Value> {
         let path = "/api/gateway/acp/sessions";
         self.request_json_with_query(Method::GET, path, request)
@@ -332,6 +341,11 @@ impl GatewayLocalClient {
             .await
     }
 
+    pub async fn pairing_start(&self) -> CliResult<GatewayPairingStartReadModel> {
+        let path = "/v1/pairing/start";
+        self.request_json(Method::POST, path).await
+    }
+
     pub async fn pairing_resolve(
         &self,
         request: &ControlPlanePairingResolveRequest,
@@ -345,6 +359,88 @@ impl GatewayLocalClient {
             .send_gateway_request(request_builder, endpoint.as_str())
             .await?;
         self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
+            .await
+    }
+
+    pub async fn pairing_complete(
+        &self,
+        request: &ControlPlaneConnectRequest,
+    ) -> CliResult<GatewayPairingCompleteReadModel> {
+        let path = "/v1/pairing/complete";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.post(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let request_builder = request_builder.json(request);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "POST", path)
+            .await
+    }
+
+    pub async fn pairing_session(
+        &self,
+        session_token: &str,
+    ) -> CliResult<GatewayPairingSessionReadModel> {
+        let path = "/v1/pairing/session";
+        let endpoint = self.endpoint_url(path)?;
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(session_token);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+            .await
+    }
+
+    pub async fn pairing_events(
+        &self,
+        session_token: &str,
+        after_seq: Option<u64>,
+        limit: Option<usize>,
+        ack_seq: Option<u64>,
+    ) -> CliResult<GatewayPairingEventsReadModel> {
+        let path = "/v1/pairing/events";
+        let endpoint = self.endpoint_url(path)?;
+        let mut query = Vec::new();
+        if let Some(after_seq) = after_seq {
+            query.push(("after_seq", after_seq.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(ack_seq) = ack_seq {
+            query.push(("ack_seq", ack_seq.to_string()));
+        }
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.query(&query);
+        let request_builder = request_builder.bearer_auth(session_token);
+        let response = self
+            .send_gateway_request(request_builder, endpoint.as_str())
+            .await?;
+        self.decode_gateway_json_response(response, endpoint.as_str(), "GET", path)
+            .await
+    }
+
+    pub async fn pairing_stream(
+        &self,
+        session_token: &str,
+        after_seq: Option<u64>,
+        limit: Option<usize>,
+    ) -> CliResult<Response> {
+        let path = "/v1/pairing/stream";
+        let endpoint = self.endpoint_url(path)?;
+        let mut query = Vec::new();
+        if let Some(after_seq) = after_seq {
+            query.push(("after_seq", after_seq.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        let request_builder = self.http_client.get(endpoint.as_str());
+        let request_builder = request_builder.query(&query);
+        let request_builder = request_builder.bearer_auth(session_token);
+        self.send_gateway_request(request_builder, endpoint.as_str())
             .await
     }
 

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -79,6 +79,122 @@ struct GatewayPortResolution {
     source: GatewayPortSource,
 }
 
+struct GatewayControlRequest<'a> {
+    app_state: &'a GatewayControlAppState,
+}
+
+impl<'a> GatewayControlRequest<'a> {
+    fn authorize(
+        headers: &HeaderMap,
+        app_state: &'a GatewayControlAppState,
+    ) -> Result<Self, GatewayControlJsonResponse> {
+        authorize_request_from_state(headers, app_state).map_err(|error| {
+            json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str())
+        })?;
+        Ok(Self { app_state })
+    }
+
+    fn app_state(&self) -> &'a GatewayControlAppState {
+        self.app_state
+    }
+
+    fn status(&self) -> Result<super::state::GatewayOwnerStatus, GatewayControlJsonResponse> {
+        load_gateway_owner_status(self.app_state.runtime_dir.as_path()).ok_or_else(|| {
+            json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "status_unavailable",
+                "gateway owner status is unavailable",
+            )
+        })
+    }
+
+    fn config(&self) -> Result<&'a LoongConfig, GatewayControlJsonResponse> {
+        gateway_control_config(self.app_state).map_err(|error| {
+            json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            )
+        })
+    }
+
+    fn acp_manager(&self) -> Result<&'a AcpSessionManager, GatewayControlJsonResponse> {
+        gateway_control_acp_manager(self.app_state).map_err(|error| {
+            json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "acp_unavailable",
+                error.as_str(),
+            )
+        })
+    }
+
+    fn pairing_registry(
+        &self,
+    ) -> Result<mvp::control_plane::ControlPlanePairingRegistry, GatewayControlJsonResponse> {
+        gateway_pairing_registry(self.app_state).map_err(|error| {
+            json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "pairing_unavailable",
+                error.as_str(),
+            )
+        })
+    }
+}
+
+struct GatewayPairingSessionRequest {
+    token: String,
+    lease: mvp::control_plane::ControlPlaneConnectionLease,
+}
+
+impl GatewayPairingSessionRequest {
+    fn authorize(
+        headers: &HeaderMap,
+        app_state: &GatewayControlAppState,
+        required_scope: ControlPlaneScope,
+    ) -> Result<Self, GatewayControlJsonResponse> {
+        let token = extract_gateway_pairing_session_token(headers).ok_or_else(|| {
+            json_error(
+                StatusCode::UNAUTHORIZED,
+                "missing_session_token",
+                "missing gateway pairing session token",
+            )
+        })?;
+        let lease = resolve_gateway_pairing_session_lease(app_state, token.as_str())?;
+        ensure_gateway_pairing_session_scope(&lease, required_scope)?;
+        Ok(Self { token, lease })
+    }
+
+    fn lease(&self) -> &mvp::control_plane::ControlPlaneConnectionLease {
+        &self.lease
+    }
+
+    fn acknowledge_seq(
+        mut self,
+        app_state: &GatewayControlAppState,
+        ack_seq: u64,
+    ) -> Result<Self, GatewayControlJsonResponse> {
+        let lease = app_state
+            .connection_registry
+            .acknowledge_seq(self.token.as_str(), ack_seq)
+            .map_err(|error| {
+                json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "session_registry_failed",
+                    error.as_str(),
+                )
+            })?
+            .ok_or_else(|| {
+                json_error(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_session_token",
+                    "invalid or expired gateway pairing session token",
+                )
+            })?;
+        self.lease = lease;
+        Ok(self)
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct GatewayAcpSessionsQuery {
     limit: Option<usize>,
@@ -468,106 +584,64 @@ async fn handle_gateway_status(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let status = load_gateway_owner_status(app_state.runtime_dir.as_path());
-    let Some(status) = status else {
-        return json_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "status_unavailable",
-            "gateway owner status is unavailable",
-        );
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
     };
-
-    let payload_result = serialize_json_value(&status, "gateway status payload");
-    match payload_result {
-        Ok(payload) => json_response(StatusCode::OK, payload),
-        Err(error) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "serialize_failed",
-            error.as_str(),
-        ),
-    }
+    let status = match request.status() {
+        Ok(status) => status,
+        Err(response) => return response,
+    };
+    gateway_control_payload_response(&status, "gateway status payload")
 }
 
 async fn handle_gateway_channels(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let payload = serialize_json_value(
-        app_state.channel_inventory.as_ref(),
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    gateway_control_payload_response(
+        request.app_state().channel_inventory.as_ref(),
         "gateway channels payload",
-    );
-    match payload {
-        Ok(payload) => json_response(StatusCode::OK, payload),
-        Err(error) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "serialize_failed",
-            error.as_str(),
-        ),
-    }
+    )
 }
 
 async fn handle_gateway_runtime_snapshot(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let payload = serialize_json_value(
-        app_state.runtime_snapshot.as_ref(),
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    gateway_control_payload_response(
+        request.app_state().runtime_snapshot.as_ref(),
         "gateway runtime snapshot payload",
-    );
-    match payload {
-        Ok(payload) => json_response(StatusCode::OK, payload),
-        Err(error) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "serialize_failed",
-            error.as_str(),
-        ),
-    }
+    )
 }
 
 async fn handle_gateway_operator_summary(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let status = load_gateway_owner_status(app_state.runtime_dir.as_path());
-    let Some(status) = status else {
-        return json_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "status_unavailable",
-            "gateway owner status is unavailable",
-        );
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
     };
-
+    let status = match request.status() {
+        Ok(status) => status,
+        Err(response) => return response,
+    };
     let summary = build_gateway_operator_summary_read_model(
         &status,
-        app_state.channel_inventory.as_ref(),
-        app_state.runtime_snapshot.as_ref(),
-        app_state.as_ref(),
+        request.app_state().channel_inventory.as_ref(),
+        request.app_state().runtime_snapshot.as_ref(),
+        request.app_state(),
     );
-    let payload = serialize_json_value(&summary, "gateway operator summary payload");
-    match payload {
-        Ok(payload) => json_response(StatusCode::OK, payload),
-        Err(error) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "serialize_failed",
-            error.as_str(),
-        ),
-    }
+    gateway_control_payload_response(&summary, "gateway operator summary payload")
 }
 
 async fn handle_gateway_acp_sessions(
@@ -575,19 +649,13 @@ async fn handle_gateway_acp_sessions(
     State(app_state): State<Arc<GatewayControlAppState>>,
     Query(query): Query<GatewayAcpSessionsQuery>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    let manager = match request.acp_manager() {
         Ok(manager) => manager,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "acp_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     let sessions_result = manager.list_sessions();
@@ -608,22 +676,11 @@ async fn handle_gateway_acp_sessions(
     sessions.truncate(limit);
 
     let payload = build_acp_session_list_read_model(
-        app_state.config_path.as_str(),
+        request.app_state().config_path.as_str(),
         matched_count,
         sessions.as_slice(),
     );
-    let payload = match serialize_json_value(&payload, "gateway ACP sessions payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway ACP sessions payload")
 }
 
 async fn handle_gateway_acp_status(
@@ -631,29 +688,17 @@ async fn handle_gateway_acp_status(
     State(app_state): State<Arc<GatewayControlAppState>>,
     Query(query): Query<GatewayAcpStatusQuery>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let config = match gateway_control_config(app_state.as_ref()) {
-        Ok(config) => config,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "acp_unavailable",
-                error.as_str(),
-            );
-        }
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
     };
-    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+    let config = match request.config() {
+        Ok(config) => config,
+        Err(response) => return response,
+    };
+    let manager = match request.acp_manager() {
         Ok(manager) => manager,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "acp_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     let resolved_session_key = crate::resolve_acp_status_session_key(
@@ -690,54 +735,31 @@ async fn handle_gateway_acp_status(
     };
 
     let payload = build_acp_status_read_model(
-        app_state.config_path.as_str(),
+        request.app_state().config_path.as_str(),
         query.session.as_deref(),
         query.conversation_id.as_deref(),
         query.route_session_id.as_deref(),
         resolved_session_key.as_str(),
         &status,
     );
-    let payload = match serialize_json_value(&payload, "gateway ACP status payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway ACP status payload")
 }
 
 async fn handle_gateway_acp_observability(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let config = match gateway_control_config(app_state.as_ref()) {
-        Ok(config) => config,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "acp_unavailable",
-                error.as_str(),
-            );
-        }
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
     };
-    let manager = match gateway_control_acp_manager(app_state.as_ref()) {
+    let config = match request.config() {
+        Ok(config) => config,
+        Err(response) => return response,
+    };
+    let manager = match request.acp_manager() {
         Ok(manager) => manager,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "acp_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     let snapshot_result = manager.observability_snapshot(config).await;
@@ -752,19 +774,9 @@ async fn handle_gateway_acp_observability(
         }
     };
 
-    let payload = build_acp_observability_read_model(app_state.config_path.as_str(), &snapshot);
-    let payload = match serialize_json_value(&payload, "gateway ACP observability payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    let payload =
+        build_acp_observability_read_model(request.app_state().config_path.as_str(), &snapshot);
+    gateway_control_payload_response(&payload, "gateway ACP observability payload")
 }
 
 async fn handle_gateway_pairing_requests(
@@ -772,19 +784,13 @@ async fn handle_gateway_pairing_requests(
     State(app_state): State<Arc<GatewayControlAppState>>,
     Query(query): Query<GatewayPairingListQuery>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+    let request = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    let pairing_registry = match request.pairing_registry() {
         Ok(pairing_registry) => pairing_registry,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "pairing_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     let status = match query.status.as_deref() {
@@ -810,26 +816,15 @@ async fn handle_gateway_pairing_requests(
             .map(map_gateway_pairing_request)
             .collect::<Vec<_>>(),
     };
-    let payload = match serialize_json_value(&payload, "gateway pairing requests payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway pairing requests payload")
 }
 
 async fn handle_gateway_pairing_start(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    if let Err(response) = GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        return response;
     }
 
     let challenge = app_state.challenge_registry.issue();
@@ -839,18 +834,7 @@ async fn handle_gateway_pairing_start(
         expires_at_ms: challenge.expires_at_ms,
     };
     let payload = build_gateway_pairing_start_read_model(challenge);
-    let payload = match serialize_json_value(&payload, "gateway pairing start payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway pairing start payload")
 }
 
 async fn handle_gateway_nodes(
@@ -881,19 +865,13 @@ async fn handle_gateway_pairing_resolve(
     State(app_state): State<Arc<GatewayControlAppState>>,
     Json(request): Json<ControlPlanePairingResolveRequest>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
-
-    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+    let request_context = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
+    let pairing_registry = match request_context.pairing_registry() {
         Ok(pairing_registry) => pairing_registry,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "pairing_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     match pairing_registry.resolve_request(request.pairing_request_id.as_str(), request.approve) {
@@ -902,17 +880,7 @@ async fn handle_gateway_pairing_resolve(
                 request: map_gateway_pairing_request(record.clone()),
                 device_token: record.device_token,
             };
-            let payload = match serialize_json_value(&payload, "gateway pairing resolve payload") {
-                Ok(payload) => payload,
-                Err(error) => {
-                    return json_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "serialize_failed",
-                        error.as_str(),
-                    );
-                }
-            };
-            json_response(StatusCode::OK, payload)
+            gateway_control_payload_response(&payload, "gateway pairing resolve payload")
         }
         Ok(None) => json_error(
             StatusCode::NOT_FOUND,
@@ -936,9 +904,10 @@ async fn handle_gateway_pairing_complete(
     State(app_state): State<Arc<GatewayControlAppState>>,
     Json(request): Json<ControlPlaneConnectRequest>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
-    }
+    let request_context = match GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
 
     if request.max_protocol < loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION
         || request.min_protocol > loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION
@@ -968,15 +937,9 @@ async fn handle_gateway_pairing_complete(
         return response;
     }
 
-    let pairing_registry = match gateway_pairing_registry(app_state.as_ref()) {
+    let pairing_registry = match request_context.pairing_registry() {
         Ok(pairing_registry) => pairing_registry,
-        Err(error) => {
-            return json_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "pairing_unavailable",
-                error.as_str(),
-            );
-        }
+        Err(response) => return response,
     };
 
     let requested_scopes = request
@@ -1008,17 +971,7 @@ async fn handle_gateway_pairing_complete(
                 requested_scopes,
                 lease,
             );
-            let payload = match serialize_json_value(&payload, "gateway pairing complete payload") {
-                Ok(payload) => payload,
-                Err(error) => {
-                    return json_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "serialize_failed",
-                        error.as_str(),
-                    );
-                }
-            };
-            json_response(StatusCode::OK, payload)
+            gateway_control_payload_response(&payload, "gateway pairing complete payload")
         }
         Ok(mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
             request: pairing_request,
@@ -1064,16 +1017,16 @@ async fn handle_gateway_pairing_session(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    let lease = match authorize_gateway_pairing_session_scope_request(
+    let session = match GatewayPairingSessionRequest::authorize(
         &headers,
         app_state.as_ref(),
         ControlPlaneScope::OperatorRead,
     ) {
-        Ok(lease) => lease,
+        Ok(session) => session,
         Err(response) => return response,
     };
 
-    let principal = gateway_pairing_protocol_principal(&lease);
+    let principal = gateway_pairing_protocol_principal(session.lease());
     let replay_window = app_state
         .event_bus
         .as_ref()
@@ -1084,25 +1037,14 @@ async fn handle_gateway_pairing_session(
         });
     let payload = build_gateway_pairing_session_read_model(
         GatewayPairingSessionLeaseReadModel {
-            connection_token: lease.token,
-            connection_token_expires_at_ms: lease.expires_at_ms,
+            connection_token: session.lease().token.clone(),
+            connection_token_expires_at_ms: session.lease().expires_at_ms,
             principal,
-            last_acknowledged_seq: lease.acknowledged_seq,
+            last_acknowledged_seq: session.lease().acknowledged_seq,
         },
         replay_window,
     );
-    let payload = match serialize_json_value(&payload, "gateway pairing session payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway pairing session payload")
 }
 
 async fn handle_gateway_pairing_events(
@@ -1110,93 +1052,49 @@ async fn handle_gateway_pairing_events(
     Query(query): Query<GatewayPairingEventsQuery>,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    let session_token = match extract_gateway_pairing_session_token(&headers) {
-        Some(token) => token,
-        None => {
-            return json_error(
-                StatusCode::UNAUTHORIZED,
-                "missing_session_token",
-                "missing gateway pairing session token",
-            );
-        }
-    };
-
-    let lease = match authorize_gateway_pairing_session_scope_request(
+    let session = match GatewayPairingSessionRequest::authorize(
         &headers,
         app_state.as_ref(),
         ControlPlaneScope::OperatorRead,
     ) {
-        Ok(lease) => lease,
+        Ok(session) => session,
         Err(response) => return response,
     };
 
-    let Some(event_bus) = app_state.event_bus.as_ref() else {
-        return json_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "event_stream_unavailable",
-            "gateway event streaming is not available",
-        );
+    let event_bus = match gateway_pairing_event_bus(app_state.as_ref()) {
+        Ok(event_bus) => event_bus,
+        Err(response) => return response,
     };
 
     let after_seq = query.after_seq.unwrap_or(0);
     let limit = query.limit.unwrap_or(50).clamp(1, 256);
-    let lease = if let Some(ack_seq) = query.ack_seq {
-        match app_state
-            .connection_registry
-            .acknowledge_seq(session_token.as_str(), ack_seq)
-        {
-            Ok(Some(updated)) => updated,
-            Ok(None) => {
-                return json_error(
-                    StatusCode::UNAUTHORIZED,
-                    "invalid_session_token",
-                    "invalid or expired gateway pairing session token",
-                );
-            }
-            Err(error) => {
-                return json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "session_registry_failed",
-                    error.as_str(),
-                );
-            }
+    let session = if let Some(ack_seq) = query.ack_seq {
+        match session.acknowledge_seq(app_state.as_ref(), ack_seq) {
+            Ok(session) => session,
+            Err(response) => return response,
         }
     } else {
-        lease
+        session
     };
     if query.ack_seq.is_some() {
         let _ = persist_gateway_pairing_runtime_state(app_state.as_ref());
     }
     let replay_window = event_bus.replay_window();
     if gateway_pairing_after_seq_is_stale(after_seq, replay_window) {
-        let message = match (replay_window.oldest_retained_seq, replay_window.latest_seq) {
-            (Some(oldest), Some(latest)) => format!(
-                "requested after_seq={} is older than retained replay window {}..{}",
-                after_seq, oldest, latest
-            ),
-            _ => format!("requested after_seq={after_seq} is outside the retained replay window"),
-        };
-        return json_stale_cursor_error(message.as_str(), lease.acknowledged_seq, replay_window);
+        return gateway_pairing_stale_cursor_response(
+            after_seq,
+            session.lease().acknowledged_seq,
+            replay_window,
+        );
     }
     let events = event_bus.recent_events_after(after_seq, limit);
     let payload = build_gateway_pairing_events_read_model(
         after_seq,
-        lease.acknowledged_seq,
+        session.lease().acknowledged_seq,
         replay_window,
         events,
     );
-    let payload = match serialize_json_value(&payload, "gateway pairing events payload") {
-        Ok(payload) => payload,
-        Err(error) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "serialize_failed",
-                error.as_str(),
-            );
-        }
-    };
-
-    json_response(StatusCode::OK, payload)
+    gateway_control_payload_response(&payload, "gateway pairing events payload")
 }
 
 async fn handle_gateway_pairing_stream(
@@ -1204,35 +1102,29 @@ async fn handle_gateway_pairing_stream(
     Query(query): Query<GatewayEventsQuery>,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> Response {
-    let lease = match authorize_gateway_pairing_session_scope_request(
+    let session = match GatewayPairingSessionRequest::authorize(
         &headers,
         app_state.as_ref(),
         ControlPlaneScope::OperatorRead,
     ) {
-        Ok(lease) => lease,
+        Ok(session) => session,
         Err(response) => return response.into_response(),
     };
 
-    let Some(event_bus) = app_state.event_bus.as_ref() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(serde_json::json!({"error": "gateway event streaming is not available"})),
-        )
-            .into_response();
+    let event_bus = match gateway_pairing_event_bus(app_state.as_ref()) {
+        Ok(event_bus) => event_bus,
+        Err(response) => return response.into_response(),
     };
 
     let after_seq = query.after_seq.unwrap_or(0);
     let replay_window = event_bus.replay_window();
     if gateway_pairing_after_seq_is_stale(after_seq, replay_window) {
-        let message = match (replay_window.oldest_retained_seq, replay_window.latest_seq) {
-            (Some(oldest), Some(latest)) => format!(
-                "requested after_seq={} is older than retained replay window {}..{}",
-                after_seq, oldest, latest
-            ),
-            _ => format!("requested after_seq={after_seq} is outside the retained replay window"),
-        };
-        return json_stale_cursor_error(message.as_str(), lease.acknowledged_seq, replay_window)
-            .into_response();
+        return gateway_pairing_stale_cursor_response(
+            after_seq,
+            session.lease().acknowledged_seq,
+            replay_window,
+        )
+        .into_response();
     }
 
     let limit = bounded_gateway_event_limit(query.limit);
@@ -1246,8 +1138,8 @@ async fn handle_gateway_stop(
     headers: HeaderMap,
     State(app_state): State<Arc<GatewayControlAppState>>,
 ) -> GatewayControlJsonResponse {
-    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
-        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    if let Err(response) = GatewayControlRequest::authorize(&headers, app_state.as_ref()) {
+        return response;
     }
 
     let stop_result = request_gateway_stop(app_state.runtime_dir.as_path());
@@ -1597,20 +1489,13 @@ fn gateway_pairing_protocol_principal(
     }
 }
 
-fn authorize_gateway_pairing_session_request(
-    headers: &HeaderMap,
+fn resolve_gateway_pairing_session_lease(
     app_state: &GatewayControlAppState,
+    token: &str,
 ) -> Result<mvp::control_plane::ControlPlaneConnectionLease, GatewayControlJsonResponse> {
-    let Some(token) = extract_gateway_pairing_session_token(headers) else {
-        return Err(json_error(
-            StatusCode::UNAUTHORIZED,
-            "missing_session_token",
-            "missing gateway pairing session token",
-        ));
-    };
     let lease = app_state
         .connection_registry
-        .resolve(token.as_str())
+        .resolve(token)
         .map_err(|error| {
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1628,12 +1513,10 @@ fn authorize_gateway_pairing_session_request(
     Ok(lease)
 }
 
-fn authorize_gateway_pairing_session_scope_request(
-    headers: &HeaderMap,
-    app_state: &GatewayControlAppState,
+fn ensure_gateway_pairing_session_scope(
+    lease: &mvp::control_plane::ControlPlaneConnectionLease,
     required_scope: ControlPlaneScope,
-) -> Result<mvp::control_plane::ControlPlaneConnectionLease, GatewayControlJsonResponse> {
-    let lease = authorize_gateway_pairing_session_request(headers, app_state)?;
+) -> Result<(), GatewayControlJsonResponse> {
     let has_required_scope = lease.principal.scopes.iter().any(|scope| {
         scope == required_scope.as_str() || scope == ControlPlaneScope::OperatorAdmin.as_str()
     });
@@ -1644,7 +1527,7 @@ fn authorize_gateway_pairing_session_scope_request(
             "gateway pairing session token does not grant the required scope",
         ));
     }
-    Ok(lease)
+    Ok(())
 }
 
 fn extract_gateway_pairing_session_token(headers: &HeaderMap) -> Option<String> {
@@ -1673,6 +1556,33 @@ fn gateway_pairing_after_seq_is_stale(
         return false;
     };
     after_seq < oldest_retained_seq.saturating_sub(1)
+}
+
+fn gateway_pairing_event_bus(
+    app_state: &GatewayControlAppState,
+) -> Result<&GatewayEventBus, GatewayControlJsonResponse> {
+    app_state.event_bus.as_ref().ok_or_else(|| {
+        json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "event_stream_unavailable",
+            "gateway event streaming is not available",
+        )
+    })
+}
+
+fn gateway_pairing_stale_cursor_response(
+    after_seq: u64,
+    last_acknowledged_seq: Option<u64>,
+    replay_window: super::event_bus::GatewayEventReplayWindow,
+) -> GatewayControlJsonResponse {
+    let message = match (replay_window.oldest_retained_seq, replay_window.latest_seq) {
+        (Some(oldest), Some(latest)) => format!(
+            "requested after_seq={} is older than retained replay window {}..{}",
+            after_seq, oldest, latest
+        ),
+        _ => format!("requested after_seq={after_seq} is outside the retained replay window"),
+    };
+    json_stale_cursor_error(message.as_str(), last_acknowledged_seq, replay_window)
 }
 
 fn verify_gateway_pairing_device_challenge(
@@ -2083,6 +1993,20 @@ fn gateway_stop_outcome_code(outcome: GatewayStopRequestOutcome) -> &'static str
     }
 }
 
+fn gateway_control_payload_response<T: Serialize>(
+    value: &T,
+    context: &str,
+) -> GatewayControlJsonResponse {
+    match serialize_json_value(value, context) {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
+}
+
 fn json_response(status_code: StatusCode, payload: Value) -> GatewayControlJsonResponse {
     (status_code, Json(payload))
 }
@@ -2136,6 +2060,28 @@ pub fn build_gateway_acp_test_router(
 }
 
 /// Minimal router for gateway pairing endpoint integration tests.
+#[doc(hidden)]
+pub fn build_gateway_pairing_test_router_without_event_bus(
+    bearer_token: String,
+    config: LoongConfig,
+) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/pairing/start", post(handle_gateway_pairing_start))
+        .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
+        .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
+        .route(
+            "/v1/pairing/complete",
+            post(handle_gateway_pairing_complete),
+        )
+        .route("/v1/pairing/session", get(handle_gateway_pairing_session))
+        .route("/v1/pairing/events", get(handle_gateway_pairing_events))
+        .route("/v1/pairing/stream", get(handle_gateway_pairing_stream))
+        .with_state(app_state)
+}
+
 #[doc(hidden)]
 pub fn build_gateway_pairing_test_router(bearer_token: String, config: LoongConfig) -> Router {
     let event_bus = GatewayEventBus::new(64);

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -55,6 +55,7 @@ use super::read_models::{
     build_acp_session_list_read_model, build_acp_status_read_model,
     build_gateway_pairing_complete_read_model, build_gateway_pairing_events_read_model,
     build_gateway_pairing_session_read_model, build_gateway_pairing_start_read_model,
+    build_node_inventory_read_model, build_operator_nodes_summary_read_model,
     build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use super::state::{
@@ -416,6 +417,7 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
             "/api/gateway/pairing/start",
             post(handle_gateway_pairing_start),
         )
+        .route("/api/gateway/nodes", get(handle_gateway_nodes))
         .route(
             "/api/gateway/pairing/resolve",
             post(handle_gateway_pairing_resolve),
@@ -443,6 +445,7 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route("/v1/acp/status", get(handle_acp_status))
         .route("/v1/acp/observability", get(handle_acp_observability))
         .route("/v1/acp/dispatch", get(handle_acp_dispatch))
+        .route("/v1/nodes", get(handle_gateway_nodes))
         .route("/v1/pairing/start", post(handle_gateway_pairing_start))
         .route("/v1/pairing/requests", get(handle_gateway_pairing_requests))
         .route("/v1/pairing/resolve", post(handle_gateway_pairing_resolve))
@@ -837,6 +840,29 @@ async fn handle_gateway_pairing_start(
     };
     let payload = build_gateway_pairing_start_read_model(challenge);
     let payload = match serialize_json_value(&payload, "gateway pairing start payload") {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialize_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_nodes(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let payload = build_gateway_node_inventory_read_model(app_state.as_ref());
+    let payload = match serialize_json_value(&payload, "gateway node inventory payload") {
         Ok(payload) => payload,
         Err(error) => {
             return json_error(
@@ -1318,7 +1344,9 @@ fn build_gateway_operator_summary_read_model(
     app_state: &GatewayControlAppState,
 ) -> GatewayOperatorSummaryReadModel {
     let pairing = build_gateway_pairing_summary_read_model(app_state);
-    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot, pairing)
+    let node_inventory = build_gateway_node_inventory_read_model(app_state);
+    let nodes = build_operator_nodes_summary_read_model(&node_inventory);
+    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot, pairing, nodes)
 }
 
 fn build_gateway_pairing_summary_read_model(
@@ -1335,6 +1363,26 @@ fn build_gateway_pairing_summary_read_model(
             approved_device_count: 0,
             last_activity_ms: None,
         },
+    }
+}
+
+fn build_gateway_node_inventory_read_model(
+    app_state: &GatewayControlAppState,
+) -> super::read_models::GatewayNodeInventoryReadModel {
+    match gateway_pairing_registry(app_state) {
+        Ok(pairing_registry) => {
+            let paired_devices = pairing_registry.list_approved_devices(256);
+            build_node_inventory_read_model(
+                app_state.config_path.as_str(),
+                app_state.channel_inventory.as_ref(),
+                paired_devices.as_slice(),
+            )
+        }
+        Err(_) => build_node_inventory_read_model(
+            app_state.config_path.as_str(),
+            app_state.channel_inventory.as_ref(),
+            &[],
+        ),
     }
 }
 
@@ -2115,6 +2163,22 @@ pub fn build_gateway_pairing_test_router_with_event_bus(
         .route("/v1/pairing/session", get(handle_gateway_pairing_session))
         .route("/v1/pairing/events", get(handle_gateway_pairing_events))
         .route("/v1/pairing/stream", get(handle_gateway_pairing_stream))
+        .with_state(app_state)
+}
+
+/// Minimal router for gateway node inventory integration tests.
+#[doc(hidden)]
+pub fn build_gateway_nodes_test_router(
+    bearer_token: String,
+    config: LoongConfig,
+    channel_inventory: GatewayChannelInventoryReadModel,
+) -> Router {
+    let mut state = GatewayControlAppState::test_minimal(bearer_token);
+    state.config = Some(config);
+    state.channel_inventory = Arc::new(channel_inventory);
+    let app_state = Arc::new(state);
+    Router::new()
+        .route("/v1/nodes", get(handle_gateway_nodes))
         .with_state(app_state)
 }
 

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -398,6 +398,58 @@ pub struct GatewayOperatorPairingSummaryReadModel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayNodeInventorySummaryReadModel {
+    pub paired_device_count: usize,
+    pub managed_bridge_count: usize,
+    pub total_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorNodesSummaryReadModel {
+    pub paired_device_count: usize,
+    pub managed_bridge_count: usize,
+    pub total_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayPairedDeviceNodeReadModel {
+    pub node_id: String,
+    pub node_kind: String,
+    pub trust_state: String,
+    pub role: String,
+    pub public_key: String,
+    pub approved_scopes: Vec<String>,
+    pub issued_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayManagedBridgeNodeReadModel {
+    pub node_id: String,
+    pub node_kind: String,
+    pub trust_state: String,
+    pub channel_id: String,
+    pub implementation_status: String,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub configured_plugin_id: Option<String>,
+    pub selected_plugin_id: Option<String>,
+    pub discovery_status: Option<String>,
+    pub selection_status: Option<String>,
+    pub compatible_plugins: usize,
+    pub incomplete_plugins: usize,
+    pub incompatible_plugins: usize,
+    pub account_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayNodeInventoryReadModel {
+    pub config: String,
+    pub summary: GatewayNodeInventorySummaryReadModel,
+    pub paired_devices: Vec<GatewayPairedDeviceNodeReadModel>,
+    pub managed_bridges: Vec<GatewayManagedBridgeNodeReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayToolCallingReadModel {
     pub availability: String,
     pub structured_tool_schema_enabled: bool,
@@ -413,6 +465,7 @@ pub struct GatewayOperatorSummaryReadModel {
     pub channels: GatewayOperatorChannelsSummaryReadModel,
     pub runtime: GatewayOperatorRuntimeSummaryReadModel,
     pub pairing: GatewayOperatorPairingSummaryReadModel,
+    pub nodes: GatewayOperatorNodesSummaryReadModel,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -716,6 +769,7 @@ pub fn build_operator_summary_read_model(
     channel_inventory: &GatewayChannelInventoryReadModel,
     runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
     pairing: GatewayOperatorPairingSummaryReadModel,
+    nodes: GatewayOperatorNodesSummaryReadModel,
 ) -> GatewayOperatorSummaryReadModel {
     let owner = owner_status.clone();
     let control_surface = build_operator_control_surface_read_model(owner_status);
@@ -728,6 +782,39 @@ pub fn build_operator_summary_read_model(
         channels,
         runtime,
         pairing,
+        nodes,
+    }
+}
+
+pub fn build_node_inventory_read_model(
+    config_path: &str,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    paired_devices: &[mvp::control_plane::ControlPlaneApprovedDeviceSummary],
+) -> GatewayNodeInventoryReadModel {
+    let config = config_path.to_owned();
+    let paired_devices = build_paired_device_nodes_read_model(paired_devices);
+    let managed_bridges = build_managed_bridge_nodes_read_model(channel_inventory);
+    let summary = GatewayNodeInventorySummaryReadModel {
+        paired_device_count: paired_devices.len(),
+        managed_bridge_count: managed_bridges.len(),
+        total_count: paired_devices.len() + managed_bridges.len(),
+    };
+
+    GatewayNodeInventoryReadModel {
+        config,
+        summary,
+        paired_devices,
+        managed_bridges,
+    }
+}
+
+pub fn build_operator_nodes_summary_read_model(
+    inventory: &GatewayNodeInventoryReadModel,
+) -> GatewayOperatorNodesSummaryReadModel {
+    GatewayOperatorNodesSummaryReadModel {
+        paired_device_count: inventory.summary.paired_device_count,
+        managed_bridge_count: inventory.summary.managed_bridge_count,
+        total_count: inventory.summary.total_count,
     }
 }
 
@@ -1446,6 +1533,103 @@ fn build_operator_runtime_summary_read_model(
         active_provider_label,
         tool_calling,
         web_access,
+    }
+}
+
+fn build_paired_device_nodes_read_model(
+    paired_devices: &[mvp::control_plane::ControlPlaneApprovedDeviceSummary],
+) -> Vec<GatewayPairedDeviceNodeReadModel> {
+    paired_devices
+        .iter()
+        .map(|device| GatewayPairedDeviceNodeReadModel {
+            node_id: device.device_id.clone(),
+            node_kind: paired_device_node_kind(device.role.as_str()).to_owned(),
+            trust_state: "paired".to_owned(),
+            role: device.role.clone(),
+            public_key: device.public_key.clone(),
+            approved_scopes: device.approved_scopes.iter().cloned().collect(),
+            issued_at_ms: device.issued_at_ms,
+        })
+        .collect()
+}
+
+fn build_managed_bridge_nodes_read_model(
+    channel_inventory: &GatewayChannelInventoryReadModel,
+) -> Vec<GatewayManagedBridgeNodeReadModel> {
+    let mut nodes = channel_inventory
+        .channel_surfaces
+        .iter()
+        .filter_map(|surface| {
+            let discovery = surface.surface.plugin_bridge_discovery.as_ref()?;
+            let enabled_account_count = surface
+                .surface
+                .configured_accounts
+                .iter()
+                .filter(|snapshot| snapshot.enabled)
+                .count();
+            let has_operator_relevant_surface = enabled_account_count > 0
+                || discovery.selected_plugin_id.is_some()
+                || discovery.configured_plugin_id.is_some()
+                || discovery.compatible_plugins > 0;
+            if !has_operator_relevant_surface {
+                return None;
+            }
+            Some(GatewayManagedBridgeNodeReadModel {
+                node_id: format!("managed_bridge:{}", surface.surface.catalog.id),
+                node_kind: "managed_bridge".to_owned(),
+                trust_state: managed_bridge_trust_state(discovery).to_owned(),
+                channel_id: surface.surface.catalog.id.to_owned(),
+                implementation_status: surface
+                    .surface
+                    .catalog
+                    .implementation_status
+                    .as_str()
+                    .to_owned(),
+                configured_account_count: surface.surface.configured_accounts.len(),
+                enabled_account_count,
+                configured_plugin_id: discovery.configured_plugin_id.clone(),
+                selected_plugin_id: discovery.selected_plugin_id.clone(),
+                discovery_status: Some(discovery.status.as_str().to_owned()),
+                selection_status: discovery
+                    .selection_status
+                    .map(|status| status.as_str().to_owned()),
+                compatible_plugins: discovery.compatible_plugins,
+                incomplete_plugins: discovery.incomplete_plugins,
+                incompatible_plugins: discovery.incompatible_plugins,
+                account_summary: surface.plugin_bridge_account_summary.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    nodes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+    nodes
+}
+
+fn paired_device_node_kind(role: &str) -> &'static str {
+    match role {
+        "operator" => "operator_ui",
+        _ => "node_client",
+    }
+}
+
+fn managed_bridge_trust_state(
+    discovery: &mvp::channel::ChannelPluginBridgeDiscovery,
+) -> &'static str {
+    use mvp::channel::ChannelPluginBridgeDiscoveryStatus as DiscoveryStatus;
+
+    match discovery.status {
+        DiscoveryStatus::NotConfigured => "not_configured",
+        DiscoveryStatus::ScanFailed => "scan_failed",
+        DiscoveryStatus::NoMatches => "unresolved",
+        DiscoveryStatus::MatchesFound => {
+            if discovery
+                .selection_status
+                .is_some_and(|status| status.selects_ready_plugin())
+            {
+                "ready"
+            } else {
+                "review_required"
+            }
+        }
     }
 }
 

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -3,9 +3,11 @@ use loong_spec::CliResult;
 use serde::Serialize;
 use std::path::Path;
 
+use crate::gateway::client::GatewayLocalClient;
 use crate::gateway::read_models::{
     GatewayAcpObservabilityReadModel, GatewayOperatorChannelsSummaryReadModel,
     GatewayOperatorSummaryReadModel, build_acp_observability_read_model,
+    build_node_inventory_read_model, build_operator_nodes_summary_read_model,
     build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use crate::gateway::service::default_gateway_owner_status;
@@ -95,27 +97,14 @@ pub async fn collect_status_cli_read_model(
         crate::build_channels_cli_json_payload(config_path_text, &snapshot.channels);
     let runtime_snapshot = build_runtime_snapshot_read_model(&snapshot);
     let runtime_dir = default_gateway_runtime_state_dir();
-    let owner_status_option = load_gateway_owner_status(runtime_dir.as_path());
-    let owner_status = select_gateway_owner_status_for_config(
+    let gateway = build_status_cli_local_gateway_summary(
         runtime_dir.as_path(),
         config_path_text,
-        owner_status_option,
-    );
-    let gateway = build_operator_summary_read_model(
-        &owner_status,
         &channel_inventory,
         &runtime_snapshot,
-        crate::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
-            pending_request_count: 0,
-            approved_device_count: 0,
-            last_activity_ms: None,
-        },
-        crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
-            paired_device_count: 0,
-            managed_bridge_count: 0,
-            total_count: 0,
-        },
     );
+    let gateway =
+        collect_status_cli_gateway_summary(config_path_text, runtime_dir.as_path(), gateway).await;
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
     let mut next_actions = collect_status_runtime_attention_actions(config_path_text, &gateway);
@@ -146,6 +135,66 @@ pub async fn collect_status_cli_read_model(
         next_actions,
         recipes,
     })
+}
+
+fn build_status_cli_local_gateway_summary(
+    runtime_dir: &Path,
+    config_path: &str,
+    channel_inventory: &crate::gateway::read_models::GatewayChannelInventoryReadModel,
+    runtime_snapshot: &crate::gateway::read_models::GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let owner_status_option = load_gateway_owner_status(runtime_dir);
+    let owner_status =
+        select_gateway_owner_status_for_config(runtime_dir, config_path, owner_status_option);
+    let node_inventory = build_node_inventory_read_model(config_path, channel_inventory, &[]);
+    let node_summary = build_operator_nodes_summary_read_model(&node_inventory);
+
+    build_operator_summary_read_model(
+        &owner_status,
+        channel_inventory,
+        runtime_snapshot,
+        crate::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 0,
+            approved_device_count: 0,
+            last_activity_ms: None,
+        },
+        node_summary,
+    )
+}
+
+async fn collect_status_cli_gateway_summary(
+    config_path: &str,
+    runtime_dir: &Path,
+    local_gateway: GatewayOperatorSummaryReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let client = match GatewayLocalClient::discover(runtime_dir) {
+        Ok(client) => client,
+        Err(_) => return local_gateway,
+    };
+
+    if !gateway_owner_status_matches_config(client.discovery().owner_status(), config_path) {
+        return local_gateway;
+    }
+
+    let live_gateway = match client.operator_summary().await {
+        Ok(gateway) => gateway,
+        Err(_) => return local_gateway,
+    };
+
+    if !gateway_owner_status_matches_config(&live_gateway.owner, config_path) {
+        return local_gateway;
+    }
+
+    live_gateway
+}
+
+fn gateway_owner_status_matches_config(
+    owner_status: &crate::gateway::state::GatewayOwnerStatus,
+    config_path: &str,
+) -> bool {
+    let owner_config_path = Path::new(owner_status.config_path.as_str());
+    let requested_config_path = Path::new(config_path);
+    owner_config_path == requested_config_path
 }
 
 fn select_gateway_owner_status_for_config(
@@ -481,6 +530,18 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
             loong_app::tui_surface::TuiKeyValueSpec::Plain {
                 key: "control base url".to_owned(),
                 value: base_url.to_owned(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "paired devices".to_owned(),
+                value: gateway.nodes.paired_device_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "managed bridges".to_owned(),
+                value: gateway.nodes.managed_bridge_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "known nodes".to_owned(),
+                value: gateway.nodes.total_count.to_string(),
             },
             loong_app::tui_surface::TuiKeyValueSpec::Plain {
                 key: "visible tools".to_owned(),
@@ -1116,9 +1177,9 @@ mod tests {
                 last_activity_ms: None,
             },
             nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
-                paired_device_count: 0,
-                managed_bridge_count: 0,
-                total_count: 0,
+                paired_device_count: 2,
+                managed_bridge_count: 1,
+                total_count: 3,
             },
         };
         let status = StatusCliReadModel {
@@ -1180,6 +1241,9 @@ mod tests {
         assert!(rendered.contains("runtime attention ids"));
         assert!(rendered.contains("saved runtime"));
         assert!(rendered.contains("gateway summary"));
+        assert!(rendered.contains("paired devices: 2"));
+        assert!(rendered.contains("managed bridges: 1"));
+        assert!(rendered.contains("known nodes: 3"));
         assert!(rendered.contains("visible tools: 4"));
         assert!(rendered.contains("direct tools: read,exec"));
         assert!(rendered.contains("hidden surfaces: agent,web"));

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -110,6 +110,11 @@ pub async fn collect_status_cli_read_model(
             approved_device_count: 0,
             last_activity_ms: None,
         },
+        crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+            paired_device_count: 0,
+            managed_bridge_count: 0,
+            total_count: 0,
+        },
     );
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
@@ -1110,6 +1115,11 @@ mod tests {
                 approved_device_count: 0,
                 last_activity_ms: None,
             },
+            nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 0,
+                managed_bridge_count: 0,
+                total_count: 0,
+            },
         };
         let status = StatusCliReadModel {
             config: "/tmp/config.toml".to_owned(),
@@ -1308,6 +1318,11 @@ mod tests {
                 approved_device_count: 0,
                 last_activity_ms: None,
             },
+            nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 0,
+                managed_bridge_count: 0,
+                total_count: 0,
+            },
         };
 
         let actions = collect_status_runtime_attention_actions("/tmp/config.toml", &gateway);
@@ -1451,6 +1466,11 @@ mod tests {
                 approved_device_count: 0,
                 last_activity_ms: None,
             },
+            nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 0,
+                managed_bridge_count: 0,
+                total_count: 0,
+            },
         };
 
         let actions = collect_status_runtime_attention_actions("/tmp/config.toml", &gateway);
@@ -1581,6 +1601,11 @@ mod tests {
                 pending_request_count: 0,
                 approved_device_count: 0,
                 last_activity_ms: None,
+            },
+            nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+                paired_device_count: 0,
+                managed_bridge_count: 0,
+                total_count: 0,
             },
         };
         let status = StatusCliReadModel {

--- a/crates/daemon/tests/integration/gateway_api_pairing.rs
+++ b/crates/daemon/tests/integration/gateway_api_pairing.rs
@@ -93,7 +93,7 @@ fn gateway_pairing_signature_message(
 #[tokio::test]
 async fn gateway_pairing_requests_reject_missing_auth() {
     let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-auth");
-    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router(
+    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router_without_event_bus(
         "test-token".to_owned(),
         config,
     );
@@ -109,6 +109,89 @@ async fn gateway_pairing_requests_reject_missing_auth() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_start_resolve_and_complete_reject_missing_auth() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-mutate-auth");
+    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router_without_event_bus(
+        "test-token".to_owned(),
+        config,
+    );
+    let resolve_request = ControlPlanePairingResolveRequest {
+        pairing_request_id: "missing-request".to_owned(),
+        approve: true,
+    };
+    let connect_request = ControlPlaneConnectRequest {
+        min_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        max_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        client: ControlPlaneClientIdentity {
+            id: "cli-auth-check".to_owned(),
+            version: "1.0.0".to_owned(),
+            mode: "operator_ui".to_owned(),
+            platform: "macos".to_owned(),
+            display_name: Some("Gateway pairing auth test".to_owned()),
+        },
+        role: ControlPlaneRole::Operator,
+        scopes: BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        caps: BTreeSet::new(),
+        commands: BTreeSet::new(),
+        permissions: std::collections::BTreeMap::new(),
+        auth: Some(ControlPlaneAuthClaims::default()),
+        device: None,
+    };
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/start")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start_response.status(), StatusCode::UNAUTHORIZED);
+    let start_json: serde_json::Value = decode_json(start_response).await;
+    assert_eq!(start_json["error"]["code"], "unauthorized");
+
+    let resolve_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/resolve")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&resolve_request).expect("encode resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolve_response.status(), StatusCode::UNAUTHORIZED);
+    let resolve_json: serde_json::Value = decode_json(resolve_response).await;
+    assert_eq!(resolve_json["error"]["code"], "unauthorized");
+
+    let complete_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/complete")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&connect_request).expect("encode connect request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(complete_response.status(), StatusCode::UNAUTHORIZED);
+    let complete_json: serde_json::Value = decode_json(complete_response).await;
+    assert_eq!(complete_json["error"]["code"], "unauthorized");
+
     std::fs::remove_dir_all(root_dir).ok();
 }
 
@@ -492,6 +575,173 @@ async fn gateway_pairing_session_and_events_reject_invalid_session_token() {
     assert_eq!(events_response.status(), StatusCode::UNAUTHORIZED);
     let events_json: serde_json::Value = decode_json(events_response).await;
     assert_eq!(events_json["error"]["code"], "invalid_session_token");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_session_routes_require_session_token_and_surface_missing_event_bus() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-missing-event-bus");
+    let signing_key = SigningKey::from_bytes(&rand::random::<[u8; 32]>());
+    let public_key = STANDARD.encode(signing_key.verifying_key().as_bytes());
+    let pairing_request_id = seed_pending_pairing_request(&config, public_key.as_str());
+    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router_without_event_bus(
+        "test-token".to_owned(),
+        config,
+    );
+
+    for path in [
+        "/v1/pairing/session",
+        "/v1/pairing/events?after_seq=0&limit=10",
+        "/v1/pairing/stream?after_seq=0&limit=10",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{path}");
+        let body: serde_json::Value = decode_json(response).await;
+        assert_eq!(body["error"]["code"], "missing_session_token", "{path}");
+    }
+
+    let resolve_request = ControlPlanePairingResolveRequest {
+        pairing_request_id,
+        approve: true,
+    };
+    let resolve_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/resolve")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&resolve_request).expect("encode resolve request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolve_response.status(), StatusCode::OK);
+    let resolved: ControlPlanePairingResolveResponse = decode_json(resolve_response).await;
+    let device_token = resolved.device_token.expect("approved device token");
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/start")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start_response.status(), StatusCode::OK);
+    let start_payload: loong_daemon::gateway::read_models::GatewayPairingStartReadModel =
+        decode_json(start_response).await;
+
+    let challenge = start_payload.challenge.clone();
+    let signed_at_ms = challenge.issued_at_ms;
+    let mut connect_request = ControlPlaneConnectRequest {
+        min_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        max_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        client: ControlPlaneClientIdentity {
+            id: "cli-test".to_owned(),
+            version: "1.0.0".to_owned(),
+            mode: "operator_ui".to_owned(),
+            platform: "macos".to_owned(),
+            display_name: Some("Gateway pairing missing event bus test".to_owned()),
+        },
+        role: ControlPlaneRole::Operator,
+        scopes: BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        caps: BTreeSet::new(),
+        commands: BTreeSet::new(),
+        permissions: std::collections::BTreeMap::new(),
+        auth: Some(ControlPlaneAuthClaims {
+            token: None,
+            device_token: Some(device_token),
+            bootstrap_token: None,
+            password: None,
+        }),
+        device: None,
+    };
+    let message = gateway_pairing_signature_message(
+        &connect_request,
+        "device-1",
+        challenge.nonce.as_str(),
+        signed_at_ms,
+    );
+    let signature = signing_key.sign(&message);
+    connect_request.device = Some(loong_protocol::ControlPlaneDeviceIdentity {
+        device_id: "device-1".to_owned(),
+        public_key,
+        signature: STANDARD.encode(signature.to_bytes()),
+        signed_at_ms,
+        nonce: challenge.nonce,
+    });
+
+    let complete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/complete")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&connect_request).expect("encode connect request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(complete_response.status(), StatusCode::OK);
+    let complete_payload: loong_daemon::gateway::read_models::GatewayPairingCompleteReadModel =
+        decode_json(complete_response).await;
+    let session_token = complete_payload.lease.connection_token.clone();
+
+    let session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/session")
+                .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(session_response.status(), StatusCode::OK);
+    let session_payload: loong_daemon::gateway::read_models::GatewayPairingSessionReadModel =
+        decode_json(session_response).await;
+    assert_eq!(session_payload.status, "active");
+    assert_eq!(session_payload.resume_status, "fresh");
+    assert_eq!(session_payload.replay_window.oldest_retained_seq, None);
+    assert_eq!(session_payload.replay_window.latest_seq, None);
+
+    for path in [
+        "/v1/pairing/events?after_seq=0&limit=10",
+        "/v1/pairing/stream?after_seq=0&limit=10",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .header(AUTHORIZATION, format!("Bearer {session_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE, "{path}");
+        let body: serde_json::Value = decode_json(response).await;
+        assert_eq!(body["error"]["code"], "event_stream_unavailable", "{path}");
+    }
 
     std::fs::remove_dir_all(root_dir).ok();
 }

--- a/crates/daemon/tests/integration/gateway_api_pairing.rs
+++ b/crates/daemon/tests/integration/gateway_api_pairing.rs
@@ -366,3 +366,132 @@ async fn gateway_pairing_requests_and_resolve_roundtrip_pending_request() {
 
     std::fs::remove_dir_all(root_dir).ok();
 }
+
+#[tokio::test]
+async fn gateway_pairing_complete_rejects_invalid_signature() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-invalid-signature");
+    let signing_key = SigningKey::from_bytes(&rand::random::<[u8; 32]>());
+    let other_signing_key = SigningKey::from_bytes(&rand::random::<[u8; 32]>());
+    let public_key = STANDARD.encode(signing_key.verifying_key().as_bytes());
+    let event_bus = GatewayEventBus::new(2);
+    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router_with_event_bus(
+        "test-token".to_owned(),
+        config,
+        event_bus,
+    );
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/start")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start_response.status(), StatusCode::OK);
+    let start_payload: loong_daemon::gateway::read_models::GatewayPairingStartReadModel =
+        decode_json(start_response).await;
+
+    let challenge = start_payload.challenge;
+    let signed_at_ms = challenge.issued_at_ms;
+    let mut connect_request = ControlPlaneConnectRequest {
+        min_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        max_protocol: loong_protocol::CONTROL_PLANE_PROTOCOL_VERSION,
+        client: ControlPlaneClientIdentity {
+            id: "cli-invalid-signature".to_owned(),
+            version: "1.0.0".to_owned(),
+            mode: "operator_ui".to_owned(),
+            platform: "macos".to_owned(),
+            display_name: Some("Gateway pairing invalid signature test".to_owned()),
+        },
+        role: ControlPlaneRole::Operator,
+        scopes: BTreeSet::from([ControlPlaneScope::OperatorRead]),
+        caps: BTreeSet::new(),
+        commands: BTreeSet::new(),
+        permissions: std::collections::BTreeMap::new(),
+        auth: Some(ControlPlaneAuthClaims::default()),
+        device: None,
+    };
+    let message = gateway_pairing_signature_message(
+        &connect_request,
+        "device-invalid-signature",
+        challenge.nonce.as_str(),
+        signed_at_ms,
+    );
+    let invalid_signature = other_signing_key.sign(&message);
+    connect_request.device = Some(loong_protocol::ControlPlaneDeviceIdentity {
+        device_id: "device-invalid-signature".to_owned(),
+        public_key,
+        signature: STANDARD.encode(invalid_signature.to_bytes()),
+        signed_at_ms,
+        nonce: challenge.nonce,
+    });
+
+    let complete_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/pairing/complete")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&connect_request).expect("encode connect request"),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(complete_response.status(), StatusCode::UNAUTHORIZED);
+    let error_json: serde_json::Value = decode_json(complete_response).await;
+    assert_eq!(error_json["code"], "device_signature_invalid");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_pairing_session_and_events_reject_invalid_session_token() {
+    let (config, root_dir) = gateway_pairing_test_config("gateway-pairing-invalid-token");
+    let event_bus = GatewayEventBus::new(2);
+    let app = loong_daemon::gateway::control::build_gateway_pairing_test_router_with_event_bus(
+        "test-token".to_owned(),
+        config,
+        event_bus,
+    );
+
+    let session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/session")
+                .header(AUTHORIZATION, "Bearer invalid-session-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(session_response.status(), StatusCode::UNAUTHORIZED);
+    let session_json: serde_json::Value = decode_json(session_response).await;
+    assert_eq!(session_json["error"]["code"], "invalid_session_token");
+
+    let events_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairing/events?after_seq=0&limit=10")
+                .header(AUTHORIZATION, "Bearer invalid-session-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(events_response.status(), StatusCode::UNAUTHORIZED);
+    let events_json: serde_json::Value = decode_json(events_response).await;
+    assert_eq!(events_json["error"]["code"], "invalid_session_token");
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -168,6 +168,7 @@ fn gateway_turn_loaded_config_fixture(
     let mut config = LoongConfig::default();
     let sqlite_path_text = sqlite_path.display().to_string();
     config.memory.sqlite_path = sqlite_path_text;
+    config.gateway.port = 0;
     config.audit.mode = loong_app::config::AuditMode::InMemory;
     config.gateway.port = 0;
     config.acp = AcpConfig {

--- a/crates/daemon/tests/integration/gateway_nodes.rs
+++ b/crates/daemon/tests/integration/gateway_nodes.rs
@@ -1,0 +1,139 @@
+use std::collections::BTreeSet;
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::AUTHORIZATION},
+};
+use tower::ServiceExt;
+
+use super::*;
+
+fn gateway_nodes_test_config(label: &str) -> (mvp::config::LoongConfig, std::path::PathBuf) {
+    let root_dir = unique_temp_dir(label);
+    std::fs::create_dir_all(root_dir.as_path()).expect("create gateway nodes test dir");
+
+    let sqlite_path = root_dir.join("memory.sqlite3");
+    let sqlite_path_text = sqlite_path.display().to_string();
+    let install_root = root_dir.join("managed-bridges");
+    let mut config = mixed_account_weixin_plugin_bridge_config();
+    config.memory.sqlite_path = sqlite_path_text;
+    config.external_skills.install_root = Some(install_root.display().to_string());
+
+    (config, root_dir)
+}
+
+fn seed_approved_pairing_device(config: &mvp::config::LoongConfig) {
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let registry =
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+            .expect("pairing registry");
+    let requested_scopes =
+        BTreeSet::from(["operator.read".to_owned(), "operator.pairing".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "device-1",
+            "cli",
+            "public-key-1",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    let pairing_request_id = match decision {
+        mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request, ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    };
+    let resolved = registry
+        .resolve_request(pairing_request_id.as_str(), true)
+        .expect("resolve request")
+        .expect("resolved record");
+    assert!(resolved.device_token.is_some());
+}
+
+async fn decode_json(response: axum::response::Response) -> serde_json::Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&body).expect("decode json")
+}
+
+#[tokio::test]
+async fn gateway_nodes_reject_missing_auth() {
+    let (config, root_dir) = gateway_nodes_test_config("gateway-nodes-auth");
+    install_ready_weixin_managed_bridge(root_dir.join("managed-bridges").as_path());
+    let inventory = mvp::channel::channel_inventory(&config);
+    let channels_payload =
+        loong_daemon::build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let app = loong_daemon::gateway::control::build_gateway_nodes_test_router(
+        "test-token".to_owned(),
+        config,
+        channels_payload,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/nodes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    std::fs::remove_dir_all(root_dir).ok();
+}
+
+#[tokio::test]
+async fn gateway_nodes_return_paired_devices_and_managed_bridges() {
+    let (config, root_dir) = gateway_nodes_test_config("gateway-nodes-inventory");
+    install_ready_weixin_managed_bridge(root_dir.join("managed-bridges").as_path());
+    seed_approved_pairing_device(&config);
+    let inventory = mvp::channel::channel_inventory(&config);
+    let channels_payload =
+        loong_daemon::build_channels_cli_json_payload("/tmp/loong.toml", &inventory);
+    let app = loong_daemon::gateway::control::build_gateway_nodes_test_router(
+        "test-token".to_owned(),
+        config,
+        channels_payload,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/nodes")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = decode_json(response).await;
+
+    assert_eq!(body["summary"]["paired_device_count"], 1);
+    assert_eq!(body["summary"]["managed_bridge_count"], 1);
+    assert_eq!(body["summary"]["total_count"], 2);
+
+    assert_eq!(body["paired_devices"][0]["node_id"], "device-1");
+    assert_eq!(body["paired_devices"][0]["node_kind"], "operator_ui");
+    assert_eq!(body["paired_devices"][0]["trust_state"], "paired");
+
+    assert_eq!(
+        body["managed_bridges"][0]["node_id"],
+        "managed_bridge:weixin"
+    );
+    assert_eq!(body["managed_bridges"][0]["node_kind"], "managed_bridge");
+    assert_eq!(body["managed_bridges"][0]["trust_state"], "ready");
+    assert_eq!(body["managed_bridges"][0]["channel_id"], "weixin");
+    assert_eq!(
+        body["managed_bridges"][0]["implementation_status"],
+        "plugin_backed"
+    );
+
+    std::fs::remove_dir_all(root_dir).ok();
+}

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -938,6 +938,7 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
         .operator_summary()
         .await
         .expect("read gateway operator summary");
+    let nodes = client.nodes().await.expect("read gateway nodes");
     let channel_surfaces = channels["channel_surfaces"]
         .as_array()
         .expect("channel surfaces array");
@@ -978,6 +979,27 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
         weixin_operator_surface
             .plugin_bridge_account_summary
             .as_deref(),
+        Some(expected_summary)
+    );
+    assert_eq!(
+        operator_summary.nodes.paired_device_count,
+        nodes.summary.paired_device_count
+    );
+    assert_eq!(
+        operator_summary.nodes.managed_bridge_count,
+        nodes.summary.managed_bridge_count
+    );
+    assert_eq!(
+        operator_summary.nodes.total_count,
+        nodes.summary.total_count
+    );
+    let weixin_managed_bridge = nodes
+        .managed_bridges
+        .iter()
+        .find(|node| node.channel_id == "weixin")
+        .expect("weixin managed bridge node");
+    assert_eq!(
+        weixin_managed_bridge.account_summary.as_deref(),
         Some(expected_summary)
     );
 

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -474,20 +474,31 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     let base_url = format!("http://127.0.0.1:{port}");
     let client = reqwest::Client::new();
 
-    let unauthorized_status_response = client
-        .get(format!("{base_url}/api/gateway/status"))
-        .send()
-        .await
-        .expect("send unauthorized gateway status request");
-    assert_eq!(
-        unauthorized_status_response.status(),
-        reqwest::StatusCode::UNAUTHORIZED
-    );
-    let unauthorized_status_json: Value = unauthorized_status_response
-        .json()
-        .await
-        .expect("decode unauthorized gateway status response");
-    assert_eq!(unauthorized_status_json["error"]["code"], "unauthorized");
+    for path in [
+        "/api/gateway/status",
+        "/api/gateway/channels",
+        "/api/gateway/runtime-snapshot",
+        "/api/gateway/operator-summary",
+        "/api/gateway/acp/sessions",
+        "/api/gateway/acp/observability",
+        "/api/gateway/acp/status?session=missing-session",
+    ] {
+        let response = client
+            .get(format!("{base_url}{path}"))
+            .send()
+            .await
+            .unwrap_or_else(|_| panic!("send unauthorized gateway request for {path}"));
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "{path}"
+        );
+        let response_json: Value = response
+            .json()
+            .await
+            .unwrap_or_else(|_| panic!("decode unauthorized gateway response for {path}"));
+        assert_eq!(response_json["error"]["code"], "unauthorized", "{path}");
+    }
 
     let authorized_status_response = client
         .get(format!("{base_url}/api/gateway/status"))
@@ -547,16 +558,6 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
         runtime_snapshot_json["tools"]["visible_tool_count"]
             .as_u64()
             .is_some()
-    );
-
-    let unauthorized_acp_sessions_response = client
-        .get(format!("{base_url}/api/gateway/acp/sessions"))
-        .send()
-        .await
-        .expect("send unauthorized gateway ACP sessions request");
-    assert_eq!(
-        unauthorized_acp_sessions_response.status(),
-        reqwest::StatusCode::UNAUTHORIZED
     );
 
     let authorized_acp_sessions_response = client
@@ -673,6 +674,21 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
         conflicting_selector_json["error"]["code"],
         "invalid_selector"
     );
+
+    let unauthorized_stop_response = client
+        .post(format!("{base_url}/api/gateway/stop"))
+        .send()
+        .await
+        .expect("send unauthorized gateway stop request");
+    assert_eq!(
+        unauthorized_stop_response.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    let unauthorized_stop_json: Value = unauthorized_stop_response
+        .json()
+        .await
+        .expect("decode unauthorized gateway stop response");
+    assert_eq!(unauthorized_stop_json["error"]["code"], "unauthorized");
 
     let stop_response = client
         .post(format!("{base_url}/api/gateway/stop"))

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -605,6 +605,9 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
         summary.channels.surfaces.len(),
         inventory.channel_surfaces.len()
     );
+    assert_eq!(summary.nodes.paired_device_count, 0);
+    assert_eq!(summary.nodes.managed_bridge_count, 0);
+    assert_eq!(summary.nodes.total_count, 0);
     assert_eq!(
         summary.runtime.visible_tool_count,
         runtime_snapshot.tools.visible_tool_count

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -543,6 +543,11 @@ fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups()
             approved_device_count: 0,
             last_activity_ms: None,
         },
+        gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+            paired_device_count: 0,
+            managed_bridge_count: 0,
+            total_count: 0,
+        },
     );
     let encoded = serde_json::to_value(&summary).expect("serialize operator summary read model");
 

--- a/crates/daemon/tests/integration/managed_bridge_parity.rs
+++ b/crates/daemon/tests/integration/managed_bridge_parity.rs
@@ -105,6 +105,11 @@ fn managed_bridge_parity_keeps_summary_aligned_across_text_json_and_operator_vie
             approved_device_count: 0,
             last_activity_ms: None,
         },
+        loong_daemon::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
+            paired_device_count: 0,
+            managed_bridge_count: 0,
+            total_count: 0,
+        },
     );
     let weixin_channels_surface = channels_payload
         .channel_surfaces

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -21,6 +21,7 @@ mod gateway_api_events;
 mod gateway_api_health;
 mod gateway_api_pairing;
 mod gateway_api_turn;
+mod gateway_nodes;
 mod gateway_owner_state;
 mod gateway_read_models;
 mod import_cli;

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -1,13 +1,36 @@
 use super::*;
 use loong_contracts::SecretRef;
+use loong_daemon::{
+    CliResult,
+    gateway::{
+        service::run_gateway_run_with_hooks_for_test,
+        state::{
+            default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
+        },
+    },
+    supervisor::{LoadedSupervisorConfig, SupervisorRuntimeHooks},
+};
 use serde_json::Value;
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fs,
+    future::Future,
     path::{Path, PathBuf},
+    pin::Pin,
     process::Command,
-    sync::atomic::{AtomicUsize, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use tokio::time::{sleep, timeout};
+
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
+
+const STATUS_GATEWAY_TEST_TIMEOUT: Duration = Duration::from_secs(2);
+const STATUS_GATEWAY_WAIT_ATTEMPTS: usize = 400;
+const STATUS_GATEWAY_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
@@ -62,6 +85,90 @@ fn write_status_config(
 
 fn render_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn pending_shutdown_future() -> BoxedShutdownFuture {
+    Box::pin(async move {
+        std::future::pending::<()>().await;
+        Ok(String::new())
+    })
+}
+
+fn load_status_config_fixture(config_path: &Path) -> LoadedSupervisorConfig {
+    let config_path_text = config_path
+        .to_str()
+        .expect("status config path should be valid utf-8");
+    let (resolved_path, config) =
+        mvp::config::load(Some(config_path_text)).expect("load status config fixture");
+
+    LoadedSupervisorConfig {
+        resolved_path,
+        config,
+    }
+}
+
+fn seed_approved_pairing_device(config: &mvp::config::LoongConfig) {
+    let memory_config =
+        loong_daemon::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+            &config.memory,
+        );
+    let registry =
+        loong_daemon::mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(
+            memory_config,
+        )
+        .expect("pairing registry");
+    let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "status-device",
+            "status-cli",
+            "status-public-key",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    let pairing_request_id = match decision {
+        loong_daemon::mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request,
+            ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    };
+
+    let resolved = registry
+        .resolve_request(pairing_request_id.as_str(), true)
+        .expect("resolve pairing request")
+        .expect("resolved pairing request");
+    assert!(
+        resolved.device_token.is_some(),
+        "approved pairing should return a device token"
+    );
+}
+
+async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
+    for _ in 0..STATUS_GATEWAY_WAIT_ATTEMPTS {
+        if let Some(status) = load_gateway_owner_status(runtime_dir) {
+            if status.phase == "failed" {
+                let error_message = status
+                    .last_error
+                    .unwrap_or_else(|| "unknown gateway owner failure".to_owned());
+                panic!("gateway owner failed before control surface binding: {error_message}");
+            }
+
+            if status.running
+                && status.bind_address.is_some()
+                && status.port.is_some()
+                && status.token_path.is_some()
+            {
+                return;
+            }
+        }
+
+        sleep(STATUS_GATEWAY_WAIT_INTERVAL).await;
+    }
+
+    panic!("timed out waiting for gateway control surface binding");
 }
 
 fn run_status_cli_process(
@@ -171,6 +278,9 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
         payload["gateway"]["runtime"]["tool_calling"]["structured_tool_schema_enabled"],
         true
     );
+    assert_eq!(payload["gateway"]["nodes"]["paired_device_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["managed_bridge_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["total_count"], 0);
     assert_eq!(payload["acp"]["enabled"], true);
     let acp_availability = payload["acp"]["availability"]
         .as_str()
@@ -204,6 +314,79 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
             .unwrap_or(false),
         "status JSON should include drill-down recipes: {payload:#?}"
     );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn status_cli_prefers_live_gateway_operator_summary_for_matching_config() {
+    let root = unique_temp_dir("loong-status-cli-live-gateway");
+    let home_root = root.join("home");
+    fs::create_dir_all(&home_root).expect("create home root");
+    let _env = MigrationEnvironmentGuard::set(&[(
+        "LOONG_HOME",
+        Some(home_root.to_str().expect("home root should be valid utf-8")),
+    )]);
+    let config_path = write_status_config(
+        &root,
+        false,
+        mvp::config::ProviderToolSchemaModeConfig::EnabledWithDowngrade,
+    );
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8")
+        .to_owned();
+    let loaded_config = load_status_config_fixture(config_path.as_path());
+    seed_approved_pairing_device(&loaded_config.config);
+
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new({
+            let config_path = config_path.clone();
+            move |_| Ok(load_status_config_fixture(config_path.as_path()))
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("status CLI gateway test should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+
+    let status =
+        loong_daemon::status_cli::collect_status_cli_read_model(Some(config_path_text.as_str()))
+            .await
+            .expect("collect status CLI read model");
+
+    assert_eq!(status.gateway.owner.phase, "running");
+    assert_eq!(status.gateway.owner.config_path, config_path_text);
+    assert_eq!(status.gateway.pairing.approved_device_count, 1);
+    assert_eq!(status.gateway.nodes.paired_device_count, 1);
+    assert_eq!(status.gateway.nodes.total_count, 1);
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(STATUS_GATEWAY_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -54,6 +54,7 @@ fn write_status_config(
     let mut config = mvp::config::LoongConfig::default();
     config.memory.sqlite_path = sqlite_path.display().to_string();
     config.tools.file_root = Some(root.display().to_string());
+    config.gateway.port = 0;
     config.set_active_provider_profile(
         "demo-openai",
         mvp::config::ProviderProfileConfig {

--- a/docs/design-docs/local-product-control-plane.md
+++ b/docs/design-docs/local-product-control-plane.md
@@ -1,0 +1,180 @@
+# Local Product Control Plane
+
+This document defines the localhost-first product control plane exposed by
+Loong's daemon-owned gateway.
+
+It is the repository-native contract for contributors who need to understand
+how the gateway, control-plane pairing authority, paired-session continuity,
+and operator read models fit together without widening into remote or relay
+design yet.
+
+## Why This Exists
+
+Loong has multiple runtime entrypoints, but the local product control plane
+needs one stable noun that operators and local clients can rely on:
+
+- a stable localhost front door
+- one pairing authority
+- one paired-session lease authority
+- one replay contract for JSON and SSE consumers
+
+Without that, pairing and continuity drift into several partial surfaces that
+each appear to work but do not recover consistently across lifecycle changes.
+
+## Current Boundary
+
+The local product control plane is intentionally:
+
+- loopback-first
+- bearer-token protected
+- grounded in existing control-plane and runtime stores
+- explicit about replay continuity
+
+Out of scope for this document:
+
+- remote/public bind expansion
+- relay pairing
+- internet-facing bootstrap
+- a second durable pairing or lease store
+
+## Authority Model
+
+The local product control plane keeps one authority per concern:
+
+| Concern | Authority |
+| --- | --- |
+| pairing request lifecycle | `ControlPlanePairingRegistry` |
+| paired-session lease lifecycle | `ControlPlaneConnectionRegistry` |
+| retained event window | `GatewayEventBus` |
+| durable runtime continuity snapshot | `gateway/state.rs` runtime-owned snapshot files |
+| operator posture views | gateway read-model projection only |
+
+The gateway may expose richer session/bootstrap surfaces, but it must not
+replace the pairing or lease authorities with a gateway-local business store.
+
+## Front Door Contract
+
+The gateway front door is the stable localhost control surface.
+
+Bootstrap precedence:
+
+1. explicit CLI `--port`
+2. `LOONGCLAW_GATEWAY_PORT`
+3. config `[gateway].port`
+4. built-in default `127.0.0.1:26306`
+
+Discovery precedence:
+
+1. try the stable localhost front door with the local bearer token
+2. fall back to persisted owner-state when the front door is unavailable or
+   intentionally diverges (for example explicit ephemeral mode)
+
+This keeps one predictable bootstrap noun while still preserving labs/tests and
+override-heavy setups.
+
+## Pairing Contract
+
+The gateway now exposes five paired-session surfaces:
+
+- `POST /v1/pairing/start`
+- `POST /v1/pairing/complete`
+- `GET /v1/pairing/session`
+- `GET /v1/pairing/events`
+- `GET /v1/pairing/stream`
+
+And the operator pairing inbox remains visible through:
+
+- `GET /v1/pairing/requests`
+- `POST /v1/pairing/resolve`
+
+### `pairing/start`
+
+Issues a challenge and returns bootstrap metadata telling local clients how to
+continue the flow.
+
+### `pairing/complete`
+
+Consumes the challenge, verifies the device signature, reuses the pairing
+registry's decision logic, and issues a paired-session lease on success.
+
+### `pairing/session`
+
+Returns the live paired-session state:
+
+- principal
+- lease expiry
+- last acknowledged replay position
+- replay window metadata
+- recovery contract (`fresh`, `resumed`, `stale`)
+
+### `pairing/events`
+
+Returns retained events after a cursor, updates the acknowledged replay
+position when requested, and surfaces `stale_cursor` explicitly when the caller
+requests a replay position outside the retained window.
+
+### `pairing/stream`
+
+SSE companion to `pairing/events`. It must use the same replay window and stale
+cursor semantics as JSON fetch.
+
+## Replay Semantics
+
+The replay contract is intentionally explicit:
+
+- `fresh`: no acknowledged replay position yet
+- `resumed`: the retained window can resume from the last acknowledged replay
+  point
+- `stale`: the last acknowledged replay point fell outside the retained window;
+  the client must resume from the earliest resumable boundary
+
+`stale_cursor` is a contract outcome, not a hidden best-effort downgrade.
+
+JSON and SSE consumers must stay aligned on:
+
+- cursor interpretation
+- earliest resumable boundary
+- stale detection
+- acknowledgement behavior
+
+## Durability
+
+Durability is split intentionally:
+
+- pairing/business truth remains in the existing pairing and session stores
+- runtime-owned continuity snapshots keep:
+  - non-expired paired-session leases
+  - acknowledged replay position
+  - retained gateway event window
+
+This split allows restart continuity without creating a second business
+authority.
+
+## Operator Read Models
+
+Operator surfaces remain projections, not authorities.
+
+The gateway operator summary should expose:
+
+- gateway owner/front-door posture
+- channel/runtime posture
+- pairing posture
+- node inventory posture
+
+Node inventory is a read-model aggregation over:
+
+- approved paired devices
+- managed bridge surfaces
+
+This document intentionally keeps node inventory projection-only for now.
+
+## Modifier Rules
+
+When changing this area:
+
+1. keep one pairing authority
+2. keep one lease authority
+3. keep JSON and SSE replay semantics aligned
+4. keep localhost bootstrap stable before widening the trust surface
+5. treat operator summaries and node inventory as projections unless a larger
+   design explicitly promotes them

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -1,0 +1,108 @@
+# Local Product Control Plane
+
+## Goal
+
+Expose one stable localhost control surface for operators and local paired
+clients so pairing, paired-session continuity, replay recovery, and operator
+status all route through a consistent product contract.
+
+## In Scope
+
+- stable localhost gateway front door
+- local bearer-token bootstrap
+- pairing bootstrap and approval flow
+- paired-session lease issuance
+- paired-session JSON replay and SSE stream recovery
+- operator summary and node/trust posture projection
+
+## Out of Scope
+
+- remote/public exposure
+- relay pairing
+- browser/public onboarding beyond localhost
+- second durable pairing/session authority
+
+## User Stories
+
+### Operator
+
+- As an operator, I can inspect gateway ownership and pairing posture from one
+  local surface.
+- As an operator, I can approve or reject pairing requests without leaving the
+  gateway contract.
+- As an operator, I can understand whether the current control surface came
+  from the default front door, config, env, or CLI override.
+
+### Local Paired Client
+
+- As a local client, I can discover the gateway through one stable localhost
+  front door before falling back to owner-state.
+- As a local client, I can start pairing, complete pairing, obtain a paired
+  session lease, and use that lease for session inspection and replay.
+- As a local client, I get explicit replay recovery signals instead of silent
+  truncation when my cursor is stale.
+
+## Functional Contract
+
+### Front Door
+
+- default host: `127.0.0.1`
+- default port: `26306`
+- precedence: CLI > env > config > default
+- explicit ephemeral mode remains available through `--port 0`
+
+### Pairing Bootstrap
+
+- `POST /v1/pairing/start`
+  - returns a challenge and bootstrap metadata
+- `POST /v1/pairing/complete`
+  - requires device identity + signature + challenge
+  - reuses the existing pairing registry
+  - returns a paired-session lease on success
+
+### Paired Session
+
+- `GET /v1/pairing/session`
+  - returns session principal, expiry, replay posture, and replay window
+- `GET /v1/pairing/events`
+  - returns retained events after a cursor
+  - optionally updates the acknowledged replay position
+- `GET /v1/pairing/stream`
+  - SSE form of the same replay contract
+
+### Pairing Inbox
+
+- `GET /v1/pairing/requests`
+- `POST /v1/pairing/resolve`
+
+These remain the operator-facing pairing review and resolution surfaces.
+
+## Replay Recovery Rules
+
+The contract must expose:
+
+- `fresh`
+- `resumed`
+- `stale_cursor`
+- `earliest_resumable_after_seq`
+
+Clients must never be forced to infer replay safety from missing rows or
+truncated SSE output.
+
+## Product Constraints
+
+- Pairing and lease authority remain on existing control-plane primitives.
+- Operator summaries and node inventory are projections only.
+- Restart continuity may persist runtime-owned replay state, but that does not
+  create a second business database.
+
+## Acceptance Signals
+
+- operators can complete pairing and inspect status entirely through the local
+  gateway surface
+- local clients can bootstrap, pair, inspect, replay, and stream through one
+  paired-session contract
+- replay errors are explicit and actionable
+- restart continuity preserves valid leases and replay posture
+- operator summary reflects front-door, pairing, and node/trust posture without
+  inventing new authority


### PR DESCRIPTION
## Summary
- project paired-device inventory and managed-bridge trust posture into the localhost gateway contract and operator summary read models
- harden local pairing recovery paths, including stale-cursor decoding, invalid session token handling, and invalid signature coverage
- refactor gateway control handlers through shared request/session guards and pin the consolidated auth and no-event-bus behavior with regression tests

## Testing
- cargo check --workspace --locked --quiet
- cargo clippy -p loong --tests --no-deps -- -D warnings
- cargo test -p loong --test integration gateway_pairing_ -- --nocapture
- cargo test -p loong --test integration gateway_owner_state_localhost_control_surface_requires_auth_and_stops_runtime -- --nocapture
- cargo test -p loong gateway_nodes_ -- --nocapture
- cargo test -p loong gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups -- --nocapture

## Stack
- base: #1373

Related: #1232
Related: #1300
