### PR TITLE
Adopt the localhost gateway contract in local status surfaces

### DIFF
--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -17,9 +17,9 @@ use crate::CliResult;
 
 use super::{
     read_models::{
-        GatewayOperatorSummaryReadModel, GatewayPairingCompleteReadModel,
-        GatewayPairingEventsReadModel, GatewayPairingSessionReadModel,
-        GatewayPairingStartReadModel,
+        GatewayNodeInventoryReadModel, GatewayOperatorSummaryReadModel,
+        GatewayPairingCompleteReadModel, GatewayPairingEventsReadModel,
+        GatewayPairingSessionReadModel, GatewayPairingStartReadModel,
     },
     state::{
         GatewayOwnerStatus, default_gateway_runtime_state_dir, gateway_control_token_path,
@@ -318,7 +318,7 @@ impl GatewayLocalClient {
         self.request_json(Method::GET, path).await
     }
 
-    pub async fn nodes(&self) -> CliResult<Value> {
+    pub async fn nodes(&self) -> CliResult<GatewayNodeInventoryReadModel> {
         let path = "/v1/nodes";
         self.request_json(Method::GET, path).await
     }

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -3,9 +3,11 @@ use loong_spec::CliResult;
 use serde::Serialize;
 use std::path::Path;
 
+use crate::gateway::client::GatewayLocalClient;
 use crate::gateway::read_models::{
     GatewayAcpObservabilityReadModel, GatewayOperatorChannelsSummaryReadModel,
     GatewayOperatorSummaryReadModel, build_acp_observability_read_model,
+    build_node_inventory_read_model, build_operator_nodes_summary_read_model,
     build_operator_summary_read_model, build_runtime_snapshot_read_model,
 };
 use crate::gateway::service::default_gateway_owner_status;
@@ -95,27 +97,14 @@ pub async fn collect_status_cli_read_model(
         crate::build_channels_cli_json_payload(config_path_text, &snapshot.channels);
     let runtime_snapshot = build_runtime_snapshot_read_model(&snapshot);
     let runtime_dir = default_gateway_runtime_state_dir();
-    let owner_status_option = load_gateway_owner_status(runtime_dir.as_path());
-    let owner_status = select_gateway_owner_status_for_config(
+    let gateway = build_status_cli_local_gateway_summary(
         runtime_dir.as_path(),
         config_path_text,
-        owner_status_option,
-    );
-    let gateway = build_operator_summary_read_model(
-        &owner_status,
         &channel_inventory,
         &runtime_snapshot,
-        crate::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
-            pending_request_count: 0,
-            approved_device_count: 0,
-            last_activity_ms: None,
-        },
-        crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
-            paired_device_count: 0,
-            managed_bridge_count: 0,
-            total_count: 0,
-        },
     );
+    let gateway =
+        collect_status_cli_gateway_summary(config_path_text, runtime_dir.as_path(), gateway).await;
     let acp = collect_status_cli_acp_read_model(config_path_text, &config).await;
     let work_units = collect_status_cli_work_unit_read_model(&config);
     let mut next_actions = collect_status_runtime_attention_actions(config_path_text, &gateway);
@@ -146,6 +135,66 @@ pub async fn collect_status_cli_read_model(
         next_actions,
         recipes,
     })
+}
+
+fn build_status_cli_local_gateway_summary(
+    runtime_dir: &Path,
+    config_path: &str,
+    channel_inventory: &crate::gateway::read_models::GatewayChannelInventoryReadModel,
+    runtime_snapshot: &crate::gateway::read_models::GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let owner_status_option = load_gateway_owner_status(runtime_dir);
+    let owner_status =
+        select_gateway_owner_status_for_config(runtime_dir, config_path, owner_status_option);
+    let node_inventory = build_node_inventory_read_model(config_path, channel_inventory, &[]);
+    let node_summary = build_operator_nodes_summary_read_model(&node_inventory);
+
+    build_operator_summary_read_model(
+        &owner_status,
+        channel_inventory,
+        runtime_snapshot,
+        crate::gateway::read_models::GatewayOperatorPairingSummaryReadModel {
+            pending_request_count: 0,
+            approved_device_count: 0,
+            last_activity_ms: None,
+        },
+        node_summary,
+    )
+}
+
+async fn collect_status_cli_gateway_summary(
+    config_path: &str,
+    runtime_dir: &Path,
+    local_gateway: GatewayOperatorSummaryReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let client = match GatewayLocalClient::discover(runtime_dir) {
+        Ok(client) => client,
+        Err(_) => return local_gateway,
+    };
+
+    if !gateway_owner_status_matches_config(client.discovery().owner_status(), config_path) {
+        return local_gateway;
+    }
+
+    let live_gateway = match client.operator_summary().await {
+        Ok(gateway) => gateway,
+        Err(_) => return local_gateway,
+    };
+
+    if !gateway_owner_status_matches_config(&live_gateway.owner, config_path) {
+        return local_gateway;
+    }
+
+    live_gateway
+}
+
+fn gateway_owner_status_matches_config(
+    owner_status: &crate::gateway::state::GatewayOwnerStatus,
+    config_path: &str,
+) -> bool {
+    let owner_config_path = Path::new(owner_status.config_path.as_str());
+    let requested_config_path = Path::new(config_path);
+    owner_config_path == requested_config_path
 }
 
 fn select_gateway_owner_status_for_config(
@@ -480,6 +529,18 @@ fn render_status_cli_text(status: &StatusCliReadModel) -> String {
             loong_app::tui_surface::TuiKeyValueSpec::Plain {
                 key: "control base url".to_owned(),
                 value: base_url.to_owned(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "paired devices".to_owned(),
+                value: gateway.nodes.paired_device_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "managed bridges".to_owned(),
+                value: gateway.nodes.managed_bridge_count.to_string(),
+            },
+            loong_app::tui_surface::TuiKeyValueSpec::Plain {
+                key: "known nodes".to_owned(),
+                value: gateway.nodes.total_count.to_string(),
             },
             loong_app::tui_surface::TuiKeyValueSpec::Plain {
                 key: "visible tools".to_owned(),
@@ -1099,9 +1160,9 @@ mod tests {
                 last_activity_ms: None,
             },
             nodes: crate::gateway::read_models::GatewayOperatorNodesSummaryReadModel {
-                paired_device_count: 0,
-                managed_bridge_count: 0,
-                total_count: 0,
+                paired_device_count: 2,
+                managed_bridge_count: 1,
+                total_count: 3,
             },
         };
         let status = StatusCliReadModel {
@@ -1163,6 +1224,9 @@ mod tests {
         assert!(rendered.contains("runtime attention ids"));
         assert!(rendered.contains("saved runtime"));
         assert!(rendered.contains("gateway summary"));
+        assert!(rendered.contains("paired devices: 2"));
+        assert!(rendered.contains("managed bridges: 1"));
+        assert!(rendered.contains("known nodes: 3"));
         assert!(rendered.contains("visible tools: 4"));
         assert!(rendered.contains("direct tools: read,exec"));
         assert!(rendered.contains("hidden surfaces: agent,web"));

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -168,6 +168,7 @@ fn gateway_turn_loaded_config_fixture(
     let mut config = LoongConfig::default();
     let sqlite_path_text = sqlite_path.display().to_string();
     config.memory.sqlite_path = sqlite_path_text;
+    config.gateway.port = 0;
     config.audit.mode = loong_app::config::AuditMode::InMemory;
     config.acp = AcpConfig {
         enabled: true,

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -60,6 +60,7 @@ fn headless_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSuperv
     let mut config = mvp::config::LoongConfig::default();
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.gateway.port = 0;
 
     LoadedSupervisorConfig {
         resolved_path: runtime_dir.join("loong.toml"),
@@ -72,6 +73,7 @@ fn telegram_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSuperv
     config.telegram.enabled = true;
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.gateway.port = 0;
     LoadedSupervisorConfig {
         resolved_path: runtime_dir.join("loong.toml"),
         config,
@@ -82,6 +84,7 @@ fn plugin_backed_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedS
     let mut config = super::mixed_account_weixin_plugin_bridge_config();
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
+    config.gateway.port = 0;
 
     LoadedSupervisorConfig {
         resolved_path: runtime_dir.join("loong.toml"),

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -935,6 +935,7 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
         .operator_summary()
         .await
         .expect("read gateway operator summary");
+    let nodes = client.nodes().await.expect("read gateway nodes");
     let channel_surfaces = channels["channel_surfaces"]
         .as_array()
         .expect("channel surfaces array");
@@ -975,6 +976,27 @@ async fn gateway_owner_state_local_client_channels_and_operator_summary_keep_plu
         weixin_operator_surface
             .plugin_bridge_account_summary
             .as_deref(),
+        Some(expected_summary)
+    );
+    assert_eq!(
+        operator_summary.nodes.paired_device_count,
+        nodes.summary.paired_device_count
+    );
+    assert_eq!(
+        operator_summary.nodes.managed_bridge_count,
+        nodes.summary.managed_bridge_count
+    );
+    assert_eq!(
+        operator_summary.nodes.total_count,
+        nodes.summary.total_count
+    );
+    let weixin_managed_bridge = nodes
+        .managed_bridges
+        .iter()
+        .find(|node| node.channel_id == "weixin")
+        .expect("weixin managed bridge node");
+    assert_eq!(
+        weixin_managed_bridge.account_summary.as_deref(),
         Some(expected_summary)
     );
 

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -1,13 +1,36 @@
 use super::*;
 use loong_contracts::SecretRef;
+use loong_daemon::{
+    CliResult,
+    gateway::{
+        service::run_gateway_run_with_hooks_for_test,
+        state::{
+            default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
+        },
+    },
+    supervisor::{LoadedSupervisorConfig, SupervisorRuntimeHooks},
+};
 use serde_json::Value;
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fs,
+    future::Future,
     path::{Path, PathBuf},
+    pin::Pin,
     process::Command,
-    sync::atomic::{AtomicUsize, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use tokio::time::{sleep, timeout};
+
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
+
+const STATUS_GATEWAY_TEST_TIMEOUT: Duration = Duration::from_secs(2);
+const STATUS_GATEWAY_WAIT_ATTEMPTS: usize = 400;
+const STATUS_GATEWAY_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
@@ -62,6 +85,90 @@ fn write_status_config(
 
 fn render_output(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn pending_shutdown_future() -> BoxedShutdownFuture {
+    Box::pin(async move {
+        std::future::pending::<()>().await;
+        Ok(String::new())
+    })
+}
+
+fn load_status_config_fixture(config_path: &Path) -> LoadedSupervisorConfig {
+    let config_path_text = config_path
+        .to_str()
+        .expect("status config path should be valid utf-8");
+    let (resolved_path, config) =
+        mvp::config::load(Some(config_path_text)).expect("load status config fixture");
+
+    LoadedSupervisorConfig {
+        resolved_path,
+        config,
+    }
+}
+
+fn seed_approved_pairing_device(config: &mvp::config::LoongConfig) {
+    let memory_config =
+        loong_daemon::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+            &config.memory,
+        );
+    let registry =
+        loong_daemon::mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(
+            memory_config,
+        )
+        .expect("pairing registry");
+    let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);
+    let decision = registry
+        .evaluate_connect(
+            "status-device",
+            "status-cli",
+            "status-public-key",
+            "operator",
+            &requested_scopes,
+            None,
+        )
+        .expect("evaluate connect");
+    let pairing_request_id = match decision {
+        loong_daemon::mvp::control_plane::ControlPlanePairingConnectDecision::PairingRequired {
+            request,
+            ..
+        } => request.pairing_request_id,
+        other => panic!("expected pending pairing request, got {other:?}"),
+    };
+
+    let resolved = registry
+        .resolve_request(pairing_request_id.as_str(), true)
+        .expect("resolve pairing request")
+        .expect("resolved pairing request");
+    assert!(
+        resolved.device_token.is_some(),
+        "approved pairing should return a device token"
+    );
+}
+
+async fn wait_for_gateway_control_surface(runtime_dir: &Path) {
+    for _ in 0..STATUS_GATEWAY_WAIT_ATTEMPTS {
+        if let Some(status) = load_gateway_owner_status(runtime_dir) {
+            if status.phase == "failed" {
+                let error_message = status
+                    .last_error
+                    .unwrap_or_else(|| "unknown gateway owner failure".to_owned());
+                panic!("gateway owner failed before control surface binding: {error_message}");
+            }
+
+            if status.running
+                && status.bind_address.is_some()
+                && status.port.is_some()
+                && status.token_path.is_some()
+            {
+                return;
+            }
+        }
+
+        sleep(STATUS_GATEWAY_WAIT_INTERVAL).await;
+    }
+
+    panic!("timed out waiting for gateway control surface binding");
 }
 
 fn run_status_cli_process(
@@ -171,6 +278,9 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
         payload["gateway"]["runtime"]["tool_calling"]["structured_tool_schema_enabled"],
         true
     );
+    assert_eq!(payload["gateway"]["nodes"]["paired_device_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["managed_bridge_count"], 0);
+    assert_eq!(payload["gateway"]["nodes"]["total_count"], 0);
     assert_eq!(payload["acp"]["enabled"], true);
     let acp_availability = payload["acp"]["availability"]
         .as_str()
@@ -204,6 +314,79 @@ fn status_cli_json_rolls_up_gateway_acp_and_work_unit_sections() {
             .unwrap_or(false),
         "status JSON should include drill-down recipes: {payload:#?}"
     );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn status_cli_prefers_live_gateway_operator_summary_for_matching_config() {
+    let root = unique_temp_dir("loong-status-cli-live-gateway");
+    let home_root = root.join("home");
+    fs::create_dir_all(&home_root).expect("create home root");
+    let _env = MigrationEnvironmentGuard::set(&[(
+        "LOONG_HOME",
+        Some(home_root.to_str().expect("home root should be valid utf-8")),
+    )]);
+    let config_path = write_status_config(
+        &root,
+        false,
+        mvp::config::ProviderToolSchemaModeConfig::EnabledWithDowngrade,
+    );
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8")
+        .to_owned();
+    let loaded_config = load_status_config_fixture(config_path.as_path());
+    seed_approved_pairing_device(&loaded_config.config);
+
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new({
+            let config_path = config_path.clone();
+            move |_| Ok(load_status_config_fixture(config_path.as_path()))
+        }),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("status CLI gateway test should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+
+    let status =
+        loong_daemon::status_cli::collect_status_cli_read_model(Some(config_path_text.as_str()))
+            .await
+            .expect("collect status CLI read model");
+
+    assert_eq!(status.gateway.owner.phase, "running");
+    assert_eq!(status.gateway.owner.config_path, config_path_text);
+    assert_eq!(status.gateway.pairing.approved_device_count, 1);
+    assert_eq!(status.gateway.nodes.paired_device_count, 1);
+    assert_eq!(status.gateway.nodes.total_count, 1);
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    let supervisor = timeout(STATUS_GATEWAY_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -54,6 +54,7 @@ fn write_status_config(
     let mut config = mvp::config::LoongConfig::default();
     config.memory.sqlite_path = sqlite_path.display().to_string();
     config.tools.file_root = Some(root.display().to_string());
+    config.gateway.port = 0;
     config.set_active_provider_profile(
         "demo-openai",
         mvp::config::ProviderProfileConfig {


### PR DESCRIPTION
## Summary
- make `status_cli` prefer the running localhost gateway operator summary when it belongs to the same config instead of rebuilding a lossy local duplicate
- type `GatewayLocalClient::nodes()` and prove node inventory parity between `operator_summary` and the local client node surface
- surface node posture in status text output and add live regression coverage for status adoption of gateway-backed pairing and node counts

## Testing
- cargo check --workspace --locked --quiet
- cargo test -p loong --test integration status_cli_ -- --nocapture
- cargo test -p loong --test integration gateway_owner_state_local_client_channels_and_operator_summary_keep_plugin_backed_parity -- --nocapture
- cargo test -p loong status_cli::tests::render_status_cli_text_surfaces_drill_down_recipes -- --nocapture
- cargo clippy -p loong --tests --no-deps -- -D warnings

## Stack
- base: #1377

Related: #1232
Related: #1300
