### PR TITLE
Harden tool follow-up recovery and simplify the core tool surface

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8074,6 +8074,82 @@ async fn handle_turn_with_runtime_repairs_malformed_inline_function_followup_rou
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repairs_malformed_json_tool_block_followup_round() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let note_contents = "hello from malformed-json-tool repair test";
+    std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed note");
+
+    let runtime = FakeRuntime::with_fake_turn_responses(
+        vec![],
+        vec![
+            Ok(FakeTurnResponse::RawBody(json!({
+                "choices": [{
+                    "message": {
+                        "content": "let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": \"{bad\"\n}"
+                    }
+                }]
+            }))),
+            Ok(FakeTurnResponse::Parsed(ProviderTurn {
+                assistant_text: "Now I'm reading the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-malformed-json-followup",
+                    "turn-malformed-json-followup",
+                    "call-read",
+                )],
+                raw_meta: Value::Null,
+            })),
+            Ok(FakeTurnResponse::Parsed(ProviderTurn {
+                assistant_text: format!("The note says: {note_contents}"),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            })),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config_with_file_root(&harness.temp_dir);
+    config.conversation.turn_loop.max_discovery_followup_rounds = 4;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-malformed-json-followup",
+            "read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("malformed json tool block followup should be repaired");
+
+    assert_eq!(reply, format!("The note says: {note_contents}"));
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 3);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 3);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\nmissing_tool_call_followup:")
+                    })
+        }),
+        "second provider turn should receive malformed-json repair context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_repairs_empty_followup_round() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8074,6 +8074,91 @@ async fn handle_turn_with_runtime_repairs_malformed_inline_function_followup_rou
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repairs_empty_followup_round() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let note_contents = "hello from empty-followup repair test";
+    std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-empty-followup-repair",
+                    "turn-empty-followup-repair",
+                    "call-search",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "   ".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'm reading the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-empty-followup-repair",
+                    "turn-empty-followup-repair",
+                    "call-read",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: format!("The note says: {note_contents}"),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config_with_file_root(&harness.temp_dir);
+    config.conversation.turn_loop.max_discovery_followup_rounds = 4;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-empty-followup-repair",
+            "search for the right tool, then read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("empty followup should be repaired");
+
+    assert_eq!(reply, format!("The note says: {note_contents}"));
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 4);
+    assert!(
+        requested_turn_messages[2].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\nmissing_tool_call_followup:")
+                    })
+        }),
+        "third provider turn should receive empty-followup repair context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_bounds_repeated_missing_tool_call_repairs() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7998,6 +7998,77 @@ async fn handle_turn_with_runtime_repairs_missing_tool_call_after_tool_followup_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_bounds_repeated_missing_tool_call_repairs() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-missing-tool-call-bounded",
+                    "turn-missing-tool-call-bounded",
+                    "call-search",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I should use `read` next to open note.md.".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I still need to use `read` to open note.md.".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config_with_file_root(&harness.temp_dir);
+    config.conversation.turn_loop.max_discovery_followup_rounds = 4;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-missing-tool-call-bounded",
+            "search for the right tool, then read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("bounded missing tool call repair should complete");
+
+    assert_eq!(reply, "I still need to use `read` to open note.md.");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 3);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 3);
+    assert!(
+        requested_turn_messages[2].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\nmissing_tool_call_followup:")
+                    })
+        }),
+        "third provider turn should still receive the bounded repair context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_continues_direct_tool_chain_after_initial_tool_result() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12593,6 +12593,95 @@ async fn handle_turn_with_runtime_hidden_agent_followup_includes_operation_guida
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_hidden_channel_followup_includes_operation_guidance() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let lease = crate::tools::issue_tool_lease("channel", &serde_json::Map::new())
+        .expect("issue grouped channel lease");
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "I'll handle the channel action now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({
+                        "tool_id": "channel",
+                        "lease": lease,
+                        "arguments": {
+                            "account_id": "default"
+                        }
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-hidden-channel-followup".to_owned(),
+                    turn_id: "turn-hidden-channel-followup".to_owned(),
+                    tool_call_id: "call-hidden-channel-followup".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_CHANNEL_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-hidden-channel-followup",
+            "send a message through the channel",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("hidden channel repair followup should continue with provider followup");
+
+    assert_eq!(reply, "MODEL_CHANNEL_REPAIR_REPLY");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("assistant")
+                && content.is_some_and(|value| value.starts_with("[tool_request]\n"))
+                && content.is_some_and(|value| value.contains("\"tool\":\"channel\""))
+        }),
+        "provider followup should include the grouped channel request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("user")
+                && content.is_some_and(|value| value.contains("Repair guidance for channel"))
+                && content.is_some_and(|value| value.contains("messages.send"))
+        }),
+        "provider followup should include grouped channel repair guidance: {followup_messages:?}"
+    );
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_auth_rejected_provider_error_marks_rejected_trust_state() {
     let runtime = FakeRuntime::new(vec![], Err(provider_auth_rejected_error_fixture()));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7906,6 +7906,98 @@ async fn handle_turn_with_runtime_continues_multi_step_tool_chain_after_first_to
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repairs_missing_tool_call_after_tool_followup_round() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let note_contents = "hello from missing-tool-call repair test";
+    std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed note");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-missing-tool-call-repair",
+                    "turn-missing-tool-call-repair",
+                    "call-search",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I should use `read` next to open note.md.".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Now I'm reading the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-missing-tool-call-repair",
+                    "turn-missing-tool-call-repair",
+                    "call-read",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: format!("The note says: {note_contents}"),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config_with_file_root(&harness.temp_dir);
+    config.conversation.turn_loop.max_discovery_followup_rounds = 4;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-missing-tool-call-repair",
+            "search for the right tool, then read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("missing tool call repair should succeed");
+
+    assert_eq!(reply, format!("The note says: {note_contents}"));
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 4);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 4);
+    assert!(
+        requested_turn_messages[2].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\nmissing_tool_call_followup:")
+                    })
+        }),
+        "third provider turn should receive missing-tool-call repair context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_continues_direct_tool_chain_after_initial_tool_result() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12682,6 +12682,95 @@ async fn handle_turn_with_runtime_hidden_channel_followup_includes_operation_gui
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_hidden_skills_followup_includes_operation_guidance() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let lease = crate::tools::issue_tool_lease("skills", &serde_json::Map::new())
+        .expect("issue grouped skills lease");
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "I'll handle the skills action now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({
+                        "tool_id": "skills",
+                        "lease": lease,
+                        "arguments": {
+                            "foo": "bar"
+                        }
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-hidden-skills-followup".to_owned(),
+                    turn_id: "turn-hidden-skills-followup".to_owned(),
+                    tool_call_id: "call-hidden-skills-followup".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_SKILLS_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-hidden-skills-followup",
+            "run a skills operation",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("hidden skills repair followup should continue with provider followup");
+
+    assert_eq!(reply, "MODEL_SKILLS_REPAIR_REPLY");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("assistant")
+                && content.is_some_and(|value| value.starts_with("[tool_request]\n"))
+                && content.is_some_and(|value| value.contains("\"tool\":\"skills\""))
+        }),
+        "provider followup should include the grouped skills request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("user")
+                && content.is_some_and(|value| value.contains("Repair guidance for skills"))
+                && content.is_some_and(|value| value.contains("provide `operation`"))
+        }),
+        "provider followup should include grouped skills repair guidance: {followup_messages:?}"
+    );
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_auth_rejected_provider_error_marks_rejected_trust_state() {
     let runtime = FakeRuntime::new(vec![], Err(provider_auth_rejected_error_fixture()));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7998,6 +7998,82 @@ async fn handle_turn_with_runtime_repairs_missing_tool_call_after_tool_followup_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repairs_malformed_inline_function_followup_round() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let note_contents = "hello from malformed-inline-function repair test";
+    std::fs::write(harness.temp_dir.join("note.md"), note_contents).expect("seed note");
+
+    let runtime = FakeRuntime::with_fake_turn_responses(
+        vec![],
+        vec![
+            Ok(FakeTurnResponse::RawBody(json!({
+                "choices": [{
+                    "message": {
+                        "content": "let me retry.\n<function=shell.exec><parameter=command>ls /root</parameter>"
+                    }
+                }]
+            }))),
+            Ok(FakeTurnResponse::Parsed(ProviderTurn {
+                assistant_text: "Now I'm reading the file.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({"path": "note.md"}),
+                    "session-malformed-inline-followup",
+                    "turn-malformed-inline-followup",
+                    "call-read",
+                )],
+                raw_meta: Value::Null,
+            })),
+            Ok(FakeTurnResponse::Parsed(ProviderTurn {
+                assistant_text: format!("The note says: {note_contents}"),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            })),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config_with_file_root(&harness.temp_dir);
+    config.conversation.turn_loop.max_discovery_followup_rounds = 4;
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-malformed-inline-followup",
+            "read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("malformed inline followup should be repaired");
+
+    assert_eq!(reply, format!("The note says: {note_contents}"));
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 3);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 3);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\nmissing_tool_call_followup:")
+                    })
+        }),
+        "second provider turn should receive malformed-followup repair context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_bounds_repeated_missing_tool_call_repairs() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -25760,16 +25760,16 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
         .expect("nested delegate denial reply");
 
     assert!(
-        reply.contains("tool_not_found: requested tool is not available"),
-        "reply should surface generic nested delegate denial, got: {reply}"
+        reply.contains("[ok]"),
+        "raw-output mode should preserve the delegate tool result envelope, got: {reply}"
     );
     assert!(
-        reply.contains("tool.search"),
-        "reply should include discovery recovery guidance, got: {reply}"
+        reply.contains("delegate_depth_exceeded"),
+        "reply should surface the nested delegate depth failure, got: {reply}"
     );
     assert!(
         !reply.contains("tool_not_visible: delegate"),
-        "reply should not leak the nested delegate tool id in the denial reason, got: {reply}"
+        "reply should not leak a hidden-tool visibility denial, got: {reply}"
     );
 }
 
@@ -26215,12 +26215,12 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
         .as_str()
         .expect("delegate child final output");
     assert!(
-        final_output.contains("tool_not_found: requested tool is not available"),
-        "child terminal output should surface generic nested delegate_async denial, got: {waited:?}"
+        final_output.contains("delegate_depth_exceeded"),
+        "child terminal output should surface the nested delegate_async depth denial, got: {waited:?}"
     );
     assert!(
-        final_output.contains("tool.search"),
-        "child terminal output should include discovery recovery guidance, got: {waited:?}"
+        final_output.contains("max_depth 1"),
+        "child terminal output should include the configured depth boundary, got: {waited:?}"
     );
     assert!(
         !final_output.contains("delegate_async"),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12504,6 +12504,95 @@ async fn handle_turn_with_runtime_repair_followup_provider_error_falls_back_to_l
     assert_eq!(payloads[0]["provider_failover"]["reason"], "rate_limited");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_hidden_agent_followup_includes_operation_guidance() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let lease = crate::tools::issue_tool_lease("agent", &serde_json::Map::new())
+        .expect("issue grouped agent lease");
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "I'll manage those sessions now.".to_owned(),
+                tool_intents: vec![ToolIntent {
+                    tool_name: "tool.invoke".to_owned(),
+                    args_json: json!({
+                        "tool_id": "agent",
+                        "lease": lease,
+                        "arguments": {
+                            "session_ids": ["child-1"]
+                        }
+                    }),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-hidden-agent-followup".to_owned(),
+                    turn_id: "turn-hidden-agent-followup".to_owned(),
+                    tool_call_id: "call-hidden-agent-followup".to_owned(),
+                }],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_AGENT_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-hidden-agent-followup",
+            "archive those child sessions",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("hidden agent repair followup should continue with provider followup");
+
+    assert_eq!(reply, "MODEL_AGENT_REPAIR_REPLY");
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("assistant")
+                && content.is_some_and(|value| value.starts_with("[tool_request]\n"))
+                && content.is_some_and(|value| value.contains("\"tool\":\"agent\""))
+        }),
+        "provider followup should include the grouped agent request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("user")
+                && content.is_some_and(|value| value.contains("Repair guidance for agent"))
+                && content.is_some_and(|value| value.contains("Add `operation`"))
+        }),
+        "provider followup should include grouped agent repair guidance: {followup_messages:?}"
+    );
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_auth_rejected_provider_error_marks_rejected_trust_state() {
     let runtime = FakeRuntime::new(vec![], Err(provider_auth_rejected_error_fixture()));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11569,20 +11569,27 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     use crate::test_support::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns_and_completions(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Reading the file now.".to_owned(),
-            tool_intents: vec![provider_tool_intent(
-                "file.read",
-                json!("not an object"),
-                "session-tool-error",
-                "turn-tool-error",
-                "call-tool-error",
-            )],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_ERROR_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Reading the file now.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!("not an object"),
+                    "session-tool-error",
+                    "turn-tool-error",
+                    "call-tool-error",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_ERROR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
     );
 
     let coordinator = ConversationTurnCoordinator::new();
@@ -11609,18 +11616,34 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     );
 
     assert_eq!(
+        *runtime.turn_calls.lock().expect("turn calls lock"),
+        2,
+        "repairable tool error should drive a followup provider turn"
+    );
+    assert_eq!(
         *runtime
             .completion_calls
             .lock()
             .expect("completion calls lock"),
-        1,
-        "tool-error fallback should run a completion pass for language-aware output"
+        0
     );
 
-    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
-    let visible_turns = persisted_visible_turns(&persisted);
-    assert_eq!(visible_turns.len(), 2);
-    assert_eq!(visible_turns[1].2, reply);
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| content.starts_with("[tool_request]\n"))
+        }),
+        "followup provider turn should receive failed request context: {requested_turn_messages:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -11628,20 +11651,27 @@ async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_requ
     use crate::test_support::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns_and_completions(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Trying to read the file now.".to_owned(),
-            tool_intents: vec![provider_tool_intent(
-                "file.read",
-                json!({}),
-                "session-file-read-followup",
-                "turn-file-read-followup",
-                "call-file-read-followup",
-            )],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_FILE_READ_REPAIR_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Trying to read the file now.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({}),
+                    "session-file-read-followup",
+                    "turn-file-read-followup",
+                    "call-file-read-followup",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_FILE_READ_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
     );
 
     let coordinator = ConversationTurnCoordinator::new();
@@ -11655,18 +11685,17 @@ async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_requ
             ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
-        .expect("repairable file.read failure should still return completion fallback");
+        .expect("repairable file.read failure should continue with provider followup");
 
     assert_eq!(reply, "MODEL_FILE_READ_REPAIR_REPLY");
 
-    let completion_requests = runtime
-        .completion_requested_messages
+    let requested_turn_messages = runtime
+        .turn_requested_messages
         .lock()
-        .expect("completion request lock")
+        .expect("turn request lock")
         .clone();
-    assert_eq!(completion_requests.len(), 1);
-
-    let followup_messages = &completion_requests[0];
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
     assert!(
         followup_messages.iter().any(|message| {
             let role = message.get("role").and_then(Value::as_str);
@@ -11678,7 +11707,7 @@ async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_requ
             let shows_empty_request = content.is_some_and(|value| value.contains("\"request\":{}"));
             is_assistant && has_request_marker && mentions_read && shows_empty_request
         }),
-        "completion followup should include the failed read request: {followup_messages:?}"
+        "provider followup should include the failed read request: {followup_messages:?}"
     );
     assert!(
         followup_messages.iter().any(|message| {
@@ -11693,7 +11722,7 @@ async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_requ
                 content.is_some_and(|value| value.contains("file.read payload.path is required"));
             is_assistant && has_failure_marker && mentions_repair && mentions_required_path
         }),
-        "completion followup should include the repairable file.read failure reason: {followup_messages:?}"
+        "provider followup should include the repairable file.read failure reason: {followup_messages:?}"
     );
     assert!(
         followup_messages.iter().any(|message| {
@@ -11710,7 +11739,7 @@ async fn handle_turn_with_runtime_file_read_repair_followup_includes_failed_requ
             });
             is_user && has_guidance && mentions_path && mentions_shape
         }),
-        "completion followup should include file.read repair guidance: {followup_messages:?}"
+        "provider followup should include file.read repair guidance: {followup_messages:?}"
     );
 }
 
@@ -11721,20 +11750,27 @@ async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_fai
     use crate::test_support::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns_and_completions(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Trying the shell command now.".to_owned(),
-            tool_intents: vec![provider_tool_intent(
-                "shell.exec",
-                json!({"command": "/bin/echo", "args": ["hello"]}),
-                "session-shell-followup",
-                "turn-shell-followup",
-                "call-shell-followup",
-            )],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_SHELL_REPAIR_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Trying the shell command now.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "shell.exec",
+                    json!({"command": "/bin/echo", "args": ["hello"]}),
+                    "session-shell-followup",
+                    "turn-shell-followup",
+                    "call-shell-followup",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_SHELL_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
     );
 
     let coordinator = ConversationTurnCoordinator::new();
@@ -11748,18 +11784,17 @@ async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_fai
             ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
-        .expect("repairable shell failure should still return completion fallback");
+        .expect("repairable shell failure should continue with provider followup");
 
     assert_eq!(reply, "MODEL_SHELL_REPAIR_REPLY");
 
-    let completion_requests = runtime
-        .completion_requested_messages
+    let requested_turn_messages = runtime
+        .turn_requested_messages
         .lock()
-        .expect("completion request lock")
+        .expect("turn request lock")
         .clone();
-    assert_eq!(completion_requests.len(), 1);
-
-    let followup_messages = &completion_requests[0];
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
     assert!(
         followup_messages.iter().any(|message| {
             message.get("role").and_then(Value::as_str) == Some("assistant")
@@ -11772,7 +11807,7 @@ async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_fai
                             && content.contains("\"command\":\"/bin/echo\"")
                     })
         }),
-        "completion followup should include the failed exec request: {followup_messages:?}"
+        "provider followup should include the failed exec request: {followup_messages:?}"
     );
     assert!(
         followup_messages.iter().any(|message| {
@@ -11785,7 +11820,7 @@ async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_fai
                             && content.contains("tool input needs repair")
                     })
         }),
-        "completion followup should include the repairable failure reason: {followup_messages:?}"
+        "provider followup should include the repairable failure reason: {followup_messages:?}"
     );
     assert!(
         followup_messages.iter().any(|message| {
@@ -11802,7 +11837,7 @@ async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_fai
                                 .contains("The failed request used `/bin/echo`; retry with `echo`")
                     })
         }),
-        "completion followup should include shell repair guidance: {followup_messages:?}"
+        "provider followup should include shell repair guidance: {followup_messages:?}"
     );
 }
 
@@ -11822,29 +11857,36 @@ async fn handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_faile
             ..crate::tools::runtime_config::ToolRuntimeConfig::default()
         },
     );
-    let runtime = FakeRuntime::with_turn_and_completion(
+    let runtime = FakeRuntime::with_turns_and_completions(
         vec![],
-        Ok(ProviderTurn {
-            assistant_text: "Trying both shell commands now.".to_owned(),
-            tool_intents: vec![
-                provider_tool_intent(
-                    "shell.exec",
-                    json!({"command": "ls", "args": ["."]}),
-                    "session-shell-followup-multi",
-                    "turn-shell-followup-multi",
-                    "call-shell-followup-multi-1",
-                ),
-                provider_tool_intent(
-                    "shell.exec",
-                    json!({"command": "/bin/echo", "args": ["hello"]}),
-                    "session-shell-followup-multi",
-                    "turn-shell-followup-multi",
-                    "call-shell-followup-multi-2",
-                ),
-            ],
-            raw_meta: Value::Null,
-        }),
-        Ok("MODEL_SHELL_MULTI_REPAIR_REPLY".to_owned()),
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Trying both shell commands now.".to_owned(),
+                tool_intents: vec![
+                    provider_tool_intent(
+                        "shell.exec",
+                        json!({"command": "ls", "args": ["."]}),
+                        "session-shell-followup-multi",
+                        "turn-shell-followup-multi",
+                        "call-shell-followup-multi-1",
+                    ),
+                    provider_tool_intent(
+                        "shell.exec",
+                        json!({"command": "/bin/echo", "args": ["hello"]}),
+                        "session-shell-followup-multi",
+                        "turn-shell-followup-multi",
+                        "call-shell-followup-multi-2",
+                    ),
+                ],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "MODEL_SHELL_MULTI_REPAIR_REPLY".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
     );
     let mut config = test_config();
     config.conversation.safe_lane_max_tool_steps_per_turn = 2;
@@ -11862,18 +11904,17 @@ async fn handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_faile
             ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
         )
         .await
-        .expect("repairable shell failure should still return completion fallback");
+        .expect("repairable shell failure should continue with provider followup");
 
     assert_eq!(reply, "MODEL_SHELL_MULTI_REPAIR_REPLY");
 
-    let completion_requests = runtime
-        .completion_requested_messages
+    let requested_turn_messages = runtime
+        .turn_requested_messages
         .lock()
-        .expect("completion request lock")
+        .expect("turn request lock")
         .clone();
-    assert_eq!(completion_requests.len(), 1);
-
-    let followup_messages = &completion_requests[0];
+    assert_eq!(requested_turn_messages.len(), 2);
+    let followup_messages = &requested_turn_messages[1];
     assert!(
         followup_messages.iter().any(|message| {
             message.get("role").and_then(Value::as_str) == Some("assistant")
@@ -11887,7 +11928,7 @@ async fn handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_faile
                             && !content.contains("\"command\":\"echo\",\"args\":[\"ok\"]")
                     })
         }),
-        "completion followup should include only the failed request: {followup_messages:?}"
+        "provider followup should include only the failed request: {followup_messages:?}"
     );
     assert!(
         followup_messages.iter().any(|message| {
@@ -11899,7 +11940,7 @@ async fn handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_faile
                         content.contains("The failed request used `/bin/echo`; retry with `echo`")
                     })
         }),
-        "completion followup should use the failed shell command in repair guidance: {followup_messages:?}"
+        "provider followup should use the failed shell command in repair guidance: {followup_messages:?}"
     );
 }
 #[tokio::test]
@@ -12167,6 +12208,63 @@ async fn handle_turn_with_runtime_discovery_first_followup_provider_error_persis
     assert_eq!(payloads[0]["provider_failover"]["reason"], "rate_limited");
     assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "kernel");
     assert_eq!(payloads[0]["trust_event"]["reason_code"], "rate_limited");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repair_followup_provider_error_falls_back_to_last_raw_reply() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Trying to read the file now.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "file.read",
+                    json!({}),
+                    "session-repair-followup-provider-error",
+                    "turn-repair-followup-provider-error",
+                    "call-file-read-repair-followup",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Err(provider_failover_error_fixture()),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-repair-followup-provider-error",
+            "read the file",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("repair followup provider error should fall back to last raw reply");
+
+    assert_eq!(
+        reply,
+        "Trying to read the file now.\ntool_preflight_denied: tool input needs repair: file.read payload.path is required (string)"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_provider_failover");
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["provider_failover"]["reason"], "rate_limited");
 }
 
 #[tokio::test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -144,13 +144,13 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
     build_tool_driven_followup_tail_with_request_summary, build_tool_loop_guard_tail,
-    decide_provider_turn_request_action, effective_followup_tool_name,
+    compose_assistant_reply, decide_provider_turn_request_action, effective_followup_tool_name,
     effective_followup_visible_tool_name, format_approval_required_reply,
-    next_conversation_turn_id, reduce_followup_payload_for_model,
-    request_completion_with_raw_fallback, summarize_provider_lane_tool_request,
-    summarize_single_tool_followup_request, tool_driven_followup_payload,
-    tool_loop_circuit_breaker_reply, tool_result_contains_truncation_signal,
-    user_requested_raw_tool_output,
+    missing_tool_call_followup_payload, next_conversation_turn_id,
+    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
+    summarize_provider_lane_tool_request, summarize_single_tool_followup_request,
+    tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
+    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(test)]
 use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
@@ -220,6 +220,7 @@ pub struct ConversationTurnCoordinator;
 
 const PRODUCTION_CONVERSATION_RUNTIME_REQUIRES_KERNEL_BINDING: &str =
     "production conversation runtime requires kernel-bound execution";
+const MAX_MISSING_TOOL_CALL_RECOVERY_ROUNDS: usize = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextCompactionReport {
@@ -2935,6 +2936,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     let mut current_preparation = preparation.clone();
     let mut current_continue_phase = continue_phase.clone();
     let mut remaining_provider_rounds = remaining_provider_rounds.max(1);
+    let mut missing_tool_call_retry_count = 0usize;
     let mut provider_round_index = 0usize;
 
     loop {
@@ -2968,11 +2970,24 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                     current_continue_phase.lane_execution.had_tool_intents,
                     &current_continue_phase.lane_execution.turn_result,
                 );
+                let missing_tool_call_followup = provider_turn_missing_tool_call_followup(
+                    &current_continue_phase.lane_execution,
+                    missing_tool_call_retry_count,
+                );
                 if let Some(reason) = current_continue_phase.hard_stop_reason() {
                     ReplyLoopDecision::GuardFollowup {
                         raw_reply: reply.clone(),
                         reason: reason.to_owned(),
                         latest_tool_payload,
+                    }
+                } else if let Some(payload) = missing_tool_call_followup {
+                    ReplyLoopDecision::Followup {
+                        raw_reply: reply.clone(),
+                        payload,
+                        requires_completion_pass: false,
+                        loop_warning_reason: current_continue_phase
+                            .loop_warning_reason()
+                            .map(ToOwned::to_owned),
                     }
                 } else if current_continue_phase
                     .lane_execution
@@ -3039,6 +3054,16 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                 requires_completion_pass,
                 loop_warning_reason,
             } => {
+                let is_missing_tool_call_recovery = matches!(
+                    &followup,
+                    ToolDrivenFollowupPayload::ToolFailure { reason }
+                        if reason.starts_with("missing_tool_call_followup:")
+                );
+                if is_missing_tool_call_recovery {
+                    missing_tool_call_retry_count += 1;
+                } else if current_continue_phase.lane_execution.had_tool_intents {
+                    missing_tool_call_retry_count = 0;
+                }
                 let follow_up_messages = build_turn_reply_followup_messages_with_warning(
                     &current_preparation.session.messages,
                     current_continue_phase
@@ -5001,6 +5026,32 @@ fn assistant_preface_signals_provider_turn_followup(assistant_preface: &str) -> 
 
     contains_first || contains_then || contains_next || contains_after_that || contains_afterwards
 }
+
+fn provider_turn_missing_tool_call_followup(
+    lane_execution: &ProviderTurnLaneExecution,
+    missing_tool_call_retry_count: usize,
+) -> Option<ToolDrivenFollowupPayload> {
+    if !lane_execution.supports_provider_turn_followup {
+        return None;
+    }
+
+    if lane_execution.had_tool_intents {
+        return None;
+    }
+
+    if missing_tool_call_retry_count >= MAX_MISSING_TOOL_CALL_RECOVERY_ROUNDS {
+        return None;
+    }
+
+    let reply_text = compose_assistant_reply(
+        lane_execution.assistant_preface.as_str(),
+        lane_execution.had_tool_intents,
+        lane_execution.turn_result.clone(),
+    );
+
+    missing_tool_call_followup_payload(reply_text.as_str())
+}
+
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     config: &LoongConfig,
     runtime: &R,
@@ -8850,6 +8901,57 @@ mod tests {
         let fast_plan = ProviderTurnLanePlan::from_user_input(&config, "say hello");
         assert_eq!(fast_plan.decision.lane, ExecutionLane::Fast);
         assert!(!fast_plan.should_use_safe_lane_plan_path(&config, &tool_turn));
+    }
+
+    #[test]
+    fn provider_turn_missing_tool_call_followup_detects_pseudo_tool_reply() {
+        let lane_execution = ProviderTurnLaneExecution {
+            lane: ExecutionLane::Safe,
+            assistant_preface: "/tool.search:disk usage".to_owned(),
+            provider_usage: None,
+            had_tool_intents: false,
+            tool_request_summary: None,
+            discovery_search_turn: false,
+            search_tool_intents: 0,
+            supports_provider_turn_followup: true,
+            raw_tool_output_requested: false,
+            turn_result: TurnResult::FinalText("/tool.search:disk usage".to_owned()),
+            safe_lane_terminal_route: None,
+            tool_events: Vec::new(),
+        };
+
+        let payload =
+            provider_turn_missing_tool_call_followup(&lane_execution, 0).expect("repair followup");
+
+        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+            panic!("expected tool failure payload");
+        };
+
+        assert!(reason.contains("missing_tool_call_followup:"));
+    }
+
+    #[test]
+    fn provider_turn_missing_tool_call_followup_ignores_normal_direct_answer() {
+        let lane_execution = ProviderTurnLaneExecution {
+            lane: ExecutionLane::Safe,
+            assistant_preface: "The cache directory is consuming most of the disk.".to_owned(),
+            provider_usage: None,
+            had_tool_intents: false,
+            tool_request_summary: None,
+            discovery_search_turn: false,
+            search_tool_intents: 0,
+            supports_provider_turn_followup: true,
+            raw_tool_output_requested: false,
+            turn_result: TurnResult::FinalText(
+                "The cache directory is consuming most of the disk.".to_owned(),
+            ),
+            safe_lane_terminal_route: None,
+            tool_events: Vec::new(),
+        };
+
+        let payload = provider_turn_missing_tool_call_followup(&lane_execution, 0);
+
+        assert!(payload.is_none());
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3056,7 +3056,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             } => {
                 let is_missing_tool_call_recovery = matches!(
                     &followup,
-                    ToolDrivenFollowupPayload::ToolFailure { reason }
+                    ToolDrivenFollowupPayload::ToolFailure { reason, .. }
                         if reason.starts_with("missing_tool_call_followup:")
                 );
                 if is_missing_tool_call_recovery {
@@ -7363,6 +7363,7 @@ mod tests {
             "preface",
             ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+                retryable: false,
             },
             "summarize note.md",
         );
@@ -8923,11 +8924,12 @@ mod tests {
         let payload =
             provider_turn_missing_tool_call_followup(&lane_execution, 0).expect("repair followup");
 
-        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+        let ToolDrivenFollowupPayload::ToolFailure { reason, retryable } = payload else {
             panic!("expected tool failure payload");
         };
 
         assert!(reason.contains("missing_tool_call_followup:"));
+        assert!(retryable);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4841,7 +4841,10 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         .filter(|intent| effective_followup_tool_name(intent) == "tool.search")
         .count();
     let discovery_search_turn = search_tool_intents > 0;
-    let supports_provider_turn_followup = followup_chain_active || discovery_search_turn;
+    let malformed_parse_followup_turn =
+        provider_turn_has_malformed_parse_followup_signal(&turn.raw_meta);
+    let supports_provider_turn_followup =
+        followup_chain_active || discovery_search_turn || malformed_parse_followup_turn;
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
     let session_context = match runtime.session_context(config, session_id, binding) {
@@ -5010,6 +5013,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         || discovery_search_turn
         || recovery_followup_turn
         || retryable_failure_followup_turn
+        || malformed_parse_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,
@@ -5036,6 +5040,20 @@ fn assistant_preface_signals_provider_turn_followup(assistant_preface: &str) -> 
     let contains_afterwards = normalized_preface.contains("afterwards");
 
     contains_first || contains_then || contains_next || contains_after_that || contains_afterwards
+}
+
+fn provider_turn_has_malformed_parse_followup_signal(raw_meta: &Value) -> bool {
+    let Some(parse_meta) = raw_meta.get("loong_provider_parse") else {
+        return false;
+    };
+    let Some(parse_meta_object) = parse_meta.as_object() else {
+        return false;
+    };
+
+    parse_meta_object.values().any(|entry| {
+        let status = entry.get("status").and_then(Value::as_str);
+        status == Some("malformed")
+    })
 }
 
 fn provider_turn_missing_tool_call_followup(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4994,11 +4994,22 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         .is_some_and(|payload| {
             matches!(payload, ToolDrivenFollowupPayload::DiscoveryRecovery { .. })
         });
+    let retryable_failure_followup_turn =
+        tool_driven_followup_payload(had_tool_intents, &turn_result).is_some_and(|payload| {
+            matches!(
+                payload,
+                ToolDrivenFollowupPayload::ToolFailure {
+                    retryable: true,
+                    ..
+                }
+            )
+        });
     let preface_signals_provider_turn_followup =
         assistant_preface_signals_provider_turn_followup(assistant_preface.as_str());
     let supports_provider_turn_followup = followup_chain_active
         || discovery_search_turn
         || recovery_followup_turn
+        || retryable_failure_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,

--- a/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
+++ b/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
@@ -18,7 +18,10 @@ pub(super) async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         .filter(|intent| effective_followup_tool_name(intent) == "tool.search")
         .count();
     let discovery_search_turn = search_tool_intents > 0;
-    let supports_provider_turn_followup = followup_chain_active || discovery_search_turn;
+    let malformed_parse_followup_turn =
+        provider_turn_has_malformed_parse_followup_signal(&turn.raw_meta);
+    let supports_provider_turn_followup =
+        followup_chain_active || discovery_search_turn || malformed_parse_followup_turn;
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
     let session_context = match runtime.session_context(config, session_id, binding) {
@@ -186,6 +189,7 @@ pub(super) async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         || discovery_search_turn
         || recovery_followup_turn
         || retryable_failure_followup_turn
+        || malformed_parse_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,
@@ -211,4 +215,18 @@ pub(super) fn assistant_preface_signals_provider_turn_followup(assistant_preface
     let contains_afterwards = normalized_preface.contains("afterwards");
 
     contains_first || contains_then || contains_next || contains_after_that || contains_afterwards
+}
+
+fn provider_turn_has_malformed_parse_followup_signal(raw_meta: &Value) -> bool {
+    let Some(parse_meta) = raw_meta.get("loong_provider_parse") else {
+        return false;
+    };
+    let Some(parse_meta_object) = parse_meta.as_object() else {
+        return false;
+    };
+
+    parse_meta_object.values().any(|entry| {
+        let status = entry.get("status").and_then(Value::as_str);
+        status == Some("malformed")
+    })
 }

--- a/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
+++ b/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
@@ -170,11 +170,22 @@ pub(super) async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         .is_some_and(|payload| {
             matches!(payload, ToolDrivenFollowupPayload::DiscoveryRecovery { .. })
         });
+    let retryable_failure_followup_turn = tool_driven_followup_payload(had_tool_intents, &turn_result)
+        .is_some_and(|payload| {
+            matches!(
+                payload,
+                ToolDrivenFollowupPayload::ToolFailure {
+                    retryable: true,
+                    ..
+                }
+            )
+        });
     let preface_signals_provider_turn_followup =
         assistant_preface_signals_provider_turn_followup(assistant_preface.as_str());
     let supports_provider_turn_followup = followup_chain_active
         || discovery_search_turn
         || recovery_followup_turn
+        || retryable_failure_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2465,6 +2465,14 @@ fn tool_intent_is_visible(
         if descriptor.name != "tool.invoke" {
             return true;
         }
+        let grouped_hidden_surface = intent
+            .args_json
+            .get("tool_id")
+            .and_then(Value::as_str)
+            .is_some_and(|tool_id| matches!(tool_id, "agent" | "skills" | "channel"));
+        if grouped_hidden_surface {
+            return true;
+        }
         let effective_name = effective_visible_tool_name(intent, descriptor);
         return effective_name == descriptor.name
             || session_context.tool_view.contains(effective_name.as_str());

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -423,7 +423,7 @@ fn update_missing_tool_call_retry_state(
             session.followup_chain_active = true;
             let is_missing_tool_call_recovery = matches!(
                 payload,
-                ToolDrivenFollowupPayload::ToolFailure { reason }
+                ToolDrivenFollowupPayload::ToolFailure { reason, .. }
                     if reason.starts_with("missing_tool_call_followup:")
             );
             if is_missing_tool_call_recovery {
@@ -1157,6 +1157,7 @@ mod tests {
             "preface",
             &ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+                retryable: false,
             },
             "summarize note.md",
             &mut budget,
@@ -1191,6 +1192,7 @@ mod tests {
             "preface",
             &ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_preflight_denied: tool input needs repair".to_owned(),
+                retryable: true,
             },
             "retry the command",
             &mut budget,
@@ -1207,6 +1209,10 @@ mod tests {
         assert!(user_prompt.contains("Repair guidance for exec:"));
         assert!(user_prompt.contains("CMD.EXE"));
         assert!(user_prompt.contains("cmd.exe"));
+        assert!(
+            user_prompt
+                .contains(crate::conversation::turn_shared::RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT)
+        );
     }
 
     #[test]
@@ -1749,6 +1755,7 @@ mod tests {
                     latest_tool_payload:
                         Some(ToolDrivenFollowupPayload::ToolFailure {
                             reason: tool_reason,
+                            retryable: true,
                         }),
                 },
         } = decision
@@ -1814,11 +1821,12 @@ mod tests {
         );
 
         if let RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
-            payload: ToolDrivenFollowupPayload::ToolFailure { reason },
+            payload: ToolDrivenFollowupPayload::ToolFailure { reason, retryable },
             ..
         }) = decision
         {
             assert!(reason.contains("missing_tool_call_followup:"));
+            assert!(retryable);
         } else {
             panic!("unexpected decision: {decision:?}");
         }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -22,10 +22,13 @@ use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupLabel,
     ToolDrivenFollowupPayload, ToolDrivenFollowupTextRef, ToolDrivenReplyBaseDecision,
     ToolDrivenReplyPhase, build_tool_driven_followup_tail_with_request_summary,
-    build_tool_loop_guard_tail, decide_provider_turn_request_action,
-    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    tool_loop_circuit_breaker_reply, user_requested_raw_tool_output,
+    build_tool_loop_guard_tail, compose_assistant_reply, decide_provider_turn_request_action,
+    missing_tool_call_followup_payload, reduce_followup_payload_for_model,
+    request_completion_with_raw_fallback, tool_loop_circuit_breaker_reply,
+    user_requested_raw_tool_output,
 };
+
+const MAX_MISSING_TOOL_CALL_RECOVERY_ROUNDS: usize = 1;
 
 #[derive(Default)]
 pub struct ConversationTurnLoop;
@@ -37,6 +40,8 @@ struct TurnLoopSessionState {
     last_raw_reply: String,
     loop_supervisor: ToolLoopSupervisor,
     followup_payload_budget: FollowupPayloadBudget,
+    followup_chain_active: bool,
+    missing_tool_call_retry_count: usize,
     total_tool_calls: usize,
 }
 
@@ -234,6 +239,11 @@ impl ConversationTurnLoop {
             session.total_tool_calls = prospective_total;
 
             let reply_phase = evaluation.reply_phase(session.raw_tool_output_requested);
+            let missing_tool_call_followup = missing_tool_call_followup_for_round(
+                session.followup_chain_active,
+                session.missing_tool_call_retry_count,
+                &evaluation,
+            );
             if let Some(raw_reply) = reply_phase.raw_reply() {
                 session.last_raw_reply = raw_reply.to_owned();
             }
@@ -241,7 +251,9 @@ impl ConversationTurnLoop {
                 TurnRoundBudget::for_round_index(round_index, policy.max_rounds),
                 evaluation,
                 reply_phase,
+                missing_tool_call_followup,
             );
+            update_missing_tool_call_retry_state(&mut session, &decision);
 
             if let Some(action) = resolve_round_kernel_terminal_action(
                 runtime,
@@ -370,7 +382,64 @@ fn initialize_turn_loop_session(
             policy.max_followup_tool_payload_chars,
             policy.max_followup_tool_payload_chars_total,
         ),
+        followup_chain_active: false,
+        missing_tool_call_retry_count: 0,
         total_tool_calls: 0,
+    }
+}
+
+fn missing_tool_call_followup_for_round(
+    followup_chain_active: bool,
+    missing_tool_call_retry_count: usize,
+    evaluation: &RoundKernelEvaluation,
+) -> Option<ToolDrivenFollowupPayload> {
+    if !followup_chain_active {
+        return None;
+    }
+
+    if evaluation.had_tool_intents {
+        return None;
+    }
+
+    if missing_tool_call_retry_count >= MAX_MISSING_TOOL_CALL_RECOVERY_ROUNDS {
+        return None;
+    }
+
+    let reply_text = compose_assistant_reply(
+        evaluation.assistant_preface.as_str(),
+        evaluation.had_tool_intents,
+        evaluation.turn_result.clone(),
+    );
+
+    missing_tool_call_followup_payload(reply_text.as_str())
+}
+
+fn update_missing_tool_call_retry_state(
+    session: &mut TurnLoopSessionState,
+    decision: &RoundKernelDecision,
+) {
+    match decision {
+        RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool { payload, .. }) => {
+            session.followup_chain_active = true;
+            let is_missing_tool_call_recovery = matches!(
+                payload,
+                ToolDrivenFollowupPayload::ToolFailure { reason }
+                    if reason.starts_with("missing_tool_call_followup:")
+            );
+            if is_missing_tool_call_recovery {
+                session.missing_tool_call_retry_count += 1;
+            } else {
+                session.missing_tool_call_retry_count = 0;
+            }
+        }
+        RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Guard { .. }) => {
+            session.followup_chain_active = true;
+        }
+        RoundKernelDecision::FinalizeDirect { .. }
+        | RoundKernelDecision::FinalizeWithCompletionPass { .. } => {
+            session.followup_chain_active = false;
+            session.missing_tool_call_retry_count = 0;
+        }
     }
 }
 
@@ -471,9 +540,25 @@ fn decide_round_kernel_action(
     round_budget: TurnRoundBudget,
     evaluation: RoundKernelEvaluation,
     reply_phase: ToolDrivenReplyPhase,
+    missing_tool_call_followup: Option<ToolDrivenFollowupPayload>,
 ) -> RoundKernelDecision {
+    let followup_decision = round_budget.followup_decision();
     let (raw_reply, tool_payload) = match reply_phase.into_decision() {
         ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => {
+            if let Some(followup_payload) = missing_tool_call_followup
+                && matches!(
+                    followup_decision,
+                    TurnRoundBudgetDecision::ContinueWithFollowup
+                )
+            {
+                let loop_warning_reason = evaluation.loop_warning_reason();
+                return RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
+                    assistant_preface: evaluation.assistant_preface,
+                    payload: followup_payload,
+                    tool_request_summary: evaluation.tool_request_summary,
+                    loop_warning_reason,
+                });
+            }
             return RoundKernelDecision::FinalizeDirect { reply };
         }
         ToolDrivenReplyBaseDecision::RequireFollowup { raw_reply, payload } => (raw_reply, payload),
@@ -498,7 +583,7 @@ fn decide_round_kernel_action(
         loop_warning_reason,
     };
 
-    match round_budget.followup_decision() {
+    match followup_decision {
         TurnRoundBudgetDecision::ContinueWithFollowup => {
             RoundKernelDecision::ContinueWithFollowup(followup)
         }
@@ -1573,6 +1658,7 @@ mod tests {
             TurnRoundBudget::for_round_index(0, 3),
             evaluation,
             reply_phase,
+            None,
         );
 
         if let RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
@@ -1609,6 +1695,7 @@ mod tests {
             TurnRoundBudget::for_round_index(0, 3),
             evaluation,
             reply_phase,
+            None,
         );
 
         if let RoundKernelDecision::FinalizeWithCompletionPass {
@@ -1650,6 +1737,7 @@ mod tests {
             TurnRoundBudget::for_round_index(0, 3),
             evaluation,
             reply_phase,
+            None,
         );
 
         if let RoundKernelDecision::FinalizeWithCompletionPass {
@@ -1691,10 +1779,73 @@ mod tests {
             TurnRoundBudget::for_round_index(0, 3),
             evaluation,
             reply_phase,
+            None,
         );
 
         if let RoundKernelDecision::FinalizeDirect { reply } = decision {
             assert_eq!(reply, "preface\ntool output");
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_round_kernel_action_repairs_missing_tool_call_when_followup_budget_remains() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: "I should use `bash` next to retry with a simpler command."
+                .to_owned(),
+            had_tool_intents: false,
+            tool_request_summary: None,
+            turn_result: TurnResult::FinalText(
+                "I should use `bash` next to retry with a simpler command.".to_owned(),
+            ),
+            loop_verdict: None,
+        };
+
+        let reply_phase = evaluation.reply_phase(false);
+        let missing_tool_call_followup = missing_tool_call_followup_payload(
+            "I should use `bash` next to retry with a simpler command.",
+        );
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+            missing_tool_call_followup,
+        );
+
+        if let RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
+            payload: ToolDrivenFollowupPayload::ToolFailure { reason },
+            ..
+        }) = decision
+        {
+            assert!(reason.contains("missing_tool_call_followup:"));
+        } else {
+            panic!("unexpected decision: {decision:?}");
+        }
+    }
+
+    #[test]
+    fn decide_round_kernel_action_keeps_direct_reply_without_missing_tool_call_signal() {
+        let evaluation = RoundKernelEvaluation {
+            assistant_preface: String::new(),
+            had_tool_intents: false,
+            tool_request_summary: None,
+            turn_result: TurnResult::FinalText(
+                "The cache directory is consuming most of the disk.".to_owned(),
+            ),
+            loop_verdict: None,
+        };
+
+        let reply_phase = evaluation.reply_phase(false);
+        let decision = decide_round_kernel_action(
+            TurnRoundBudget::for_round_index(0, 3),
+            evaluation,
+            reply_phase,
+            None,
+        );
+
+        if let RoundKernelDecision::FinalizeDirect { reply } = decision {
+            assert_eq!(reply, "The cache directory is consuming most of the disk.");
         } else {
             panic!("unexpected decision: {decision:?}");
         }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -25,6 +25,7 @@ use crate::CliResult;
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to continue solving the original user request. If more tool work is needed, emit the next tool call instead of only describing the plan in natural language. Only answer directly when the current evidence is already sufficient. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
+pub const RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT: &str = "The previous tool step is retryable or repairable. Prefer emitting a corrected or narrower tool call now. Do not end the turn with only a narrated retry plan.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const DISCOVERY_RECOVERY_FOLLOWUP_PROMPT: &str = "The previous tool call could not be executed as requested. If you still need a hidden or discoverable capability, call tool.search with a short natural-language description of the missing capability. If tool.search returns a grouped hidden surface such as `skills`, `agent`, or `channel`, do not call that surface name directly; reuse its fresh lease through tool.invoke and place the requested operation inside payload.arguments. Otherwise, provide the best possible answer with the currently available evidence.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
@@ -110,7 +111,10 @@ pub fn missing_tool_call_followup_payload(reply_text: &str) -> Option<ToolDriven
         ),
     };
 
-    Some(ToolDrivenFollowupPayload::ToolFailure { reason })
+    Some(ToolDrivenFollowupPayload::ToolFailure {
+        reason,
+        retryable: true,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -251,7 +255,7 @@ pub fn tool_loop_circuit_breaker_reply(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolDrivenFollowupPayload {
     ToolResult { text: String },
-    ToolFailure { reason: String },
+    ToolFailure { reason: String, retryable: bool },
     DiscoveryRecovery { reason: String },
 }
 
@@ -427,7 +431,9 @@ impl ToolDrivenFollowupPayload {
         let label = self.label();
         match self {
             Self::ToolResult { text } => ToolDrivenFollowupTextRef::new(label, text.as_str()),
-            Self::ToolFailure { reason } => ToolDrivenFollowupTextRef::new(label, reason.as_str()),
+            Self::ToolFailure { reason, .. } => {
+                ToolDrivenFollowupTextRef::new(label, reason.as_str())
+            }
             Self::DiscoveryRecovery { reason } => {
                 ToolDrivenFollowupTextRef::new(label, reason.as_str())
             }
@@ -467,6 +473,7 @@ pub fn tool_driven_followup_payload(
         TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
             Some(ToolDrivenFollowupPayload::ToolFailure {
                 reason: failure.reason.clone(),
+                retryable: failure.retryable,
             })
         }
         TurnResult::ProviderError(_) => None,
@@ -1496,6 +1503,24 @@ pub fn build_tool_followup_user_prompt_with_context(
     sections.join("\n\n")
 }
 
+pub fn build_retryable_tool_failure_followup_user_prompt(
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    extra_context: Option<&str>,
+) -> String {
+    let mut sections = vec![RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT.to_owned()];
+    if let Some(reason) = loop_warning_reason {
+        sections.push(format!(
+            "Loop warning:\n{reason}\nDo not repeat the same narrated retry. Either emit a corrected tool call or provide the best possible final answer with clear limits."
+        ));
+    }
+    if let Some(extra_context) = extra_context {
+        sections.push(extra_context.to_owned());
+    }
+    sections.push(format!("Original request:\n{user_input}"));
+    sections.join("\n\n")
+}
+
 pub fn build_discovery_recovery_followup_user_prompt(
     user_input: &str,
     loop_warning_reason: Option<&str>,
@@ -1883,6 +1908,7 @@ where
 pub fn build_tool_failure_followup_tail<F>(
     assistant_preface: &str,
     tool_failure_reason: &str,
+    retryable: bool,
     tool_request_summary: Option<&str>,
     user_input: &str,
     loop_warning_reason: Option<&str>,
@@ -1894,6 +1920,7 @@ where
     build_tool_failure_followup_tail_with_request_summary(
         assistant_preface,
         tool_failure_reason,
+        retryable,
         user_input,
         loop_warning_reason,
         tool_request_summary,
@@ -1904,6 +1931,7 @@ where
 pub fn build_tool_failure_followup_tail_with_request_summary<F>(
     assistant_preface: &str,
     tool_failure_reason: &str,
+    retryable: bool,
     user_input: &str,
     loop_warning_reason: Option<&str>,
     tool_request_summary: Option<&str>,
@@ -1939,13 +1967,21 @@ where
     append_followup_warning(&mut messages, loop_warning_reason);
     messages.push(serde_json::json!({
         "role": "user",
-        "content": build_tool_followup_user_prompt_with_context(
-            user_input,
-            loop_warning_reason,
-            None,
-            None,
-            repair_guidance.as_deref(),
-        ),
+        "content": if retryable {
+            build_retryable_tool_failure_followup_user_prompt(
+                user_input,
+                loop_warning_reason,
+                repair_guidance.as_deref(),
+            )
+        } else {
+            build_tool_followup_user_prompt_with_context(
+                user_input,
+                loop_warning_reason,
+                None,
+                None,
+                repair_guidance.as_deref(),
+            )
+        },
     }));
     messages
 }
@@ -2024,10 +2060,11 @@ where
             loop_warning_reason,
             payload_mapper,
         ),
-        ToolDrivenFollowupPayload::ToolFailure { reason } => {
+        ToolDrivenFollowupPayload::ToolFailure { reason, retryable } => {
             build_tool_failure_followup_tail_with_request_summary(
                 assistant_preface,
                 reason.as_str(),
+                *retryable,
                 user_input,
                 loop_warning_reason,
                 tool_request_summary,
@@ -2549,6 +2586,7 @@ mod tests {
             kernel.followup_payload(),
             Some(ToolDrivenFollowupPayload::ToolFailure {
                 reason: "temporary failure".to_owned(),
+                retryable: true,
             })
         );
     }
@@ -2601,6 +2639,7 @@ mod tests {
     fn tool_driven_followup_payload_reports_failure_kind_and_context() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool failed".to_owned(),
+            retryable: false,
         };
         let message_context = payload.message_context();
 
@@ -2755,6 +2794,7 @@ mod tests {
                 raw_reply: "preface\ntemporary failure".to_owned(),
                 payload: ToolDrivenFollowupPayload::ToolFailure {
                     reason: "temporary failure".to_owned(),
+                    retryable: true,
                 },
             }
         );
@@ -2837,6 +2877,7 @@ mod tests {
                 raw_reply: "preface\ntemporary failure".to_owned(),
                 payload: ToolDrivenFollowupPayload::ToolFailure {
                     reason: "temporary failure".to_owned(),
+                    retryable: true,
                 },
             }
         );
@@ -3024,6 +3065,7 @@ mod tests {
         let tail = build_tool_failure_followup_tail(
             "preface",
             "tool_timeout ...(truncated 200 chars)",
+            false,
             None,
             "summarize note.md",
             Some("warning"),
@@ -3082,6 +3124,7 @@ mod tests {
     fn tool_driven_followup_tail_dispatches_failure_payload() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
+            retryable: false,
         };
         let tail = build_tool_driven_followup_tail(
             "preface",
@@ -3113,6 +3156,7 @@ mod tests {
     fn tool_driven_followup_tail_preserves_request_summary_for_failure_payloads() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "payload.command contains path separators".to_owned(),
+            retryable: false,
         };
         let tool_request_summary =
             r#"{"tool":"exec","request":{"command":"C:\\Windows\\System32\\RM.EXE"}}"#;
@@ -3236,6 +3280,7 @@ mod tests {
     fn tool_failure_followup_tail_strips_shell_arguments_from_repair_guidance() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.command must be a bare executable name; move arguments into payload.args.".to_owned(),
+            retryable: true,
         };
         let tool_request_summary = r#"{"tool":"exec","request":{"command":"ls -la"}}"#;
         let tail = build_tool_driven_followup_tail(
@@ -3255,12 +3300,14 @@ mod tests {
 
         assert!(user_prompt.contains("Repair guidance for exec"));
         assert!(user_prompt.contains("The failed request used `ls -la`; retry with `ls`"));
+        assert!(user_prompt.contains(RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT));
     }
 
     #[test]
     fn tool_failure_followup_tail_strips_quoted_shell_arguments_from_repair_guidance() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.command must be a bare executable name; move arguments into payload.args.".to_owned(),
+            retryable: true,
         };
         let tool_request_summary = r#"{"tool":"exec","request":{"command":"\"ls -la\" "}}"#;
         let tail = build_tool_driven_followup_tail(
@@ -3288,6 +3335,7 @@ mod tests {
             reason:
                 "tool_preflight_denied: tool input needs repair: file.read payload.path is required (string)"
                     .to_owned(),
+            retryable: true,
         };
         let tool_request_summary = r#"{"tool":"read","request":{}}"#;
         let tail = build_tool_driven_followup_tail(
@@ -3310,6 +3358,7 @@ mod tests {
         assert!(user_prompt.contains(
             "Expected payload shape: path:string,offset?:integer,limit?:integer,max_bytes?:integer."
         ));
+        assert!(user_prompt.contains(RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT));
     }
 
     #[test]
@@ -3317,6 +3366,7 @@ mod tests {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.args must be array"
                 .to_owned(),
+            retryable: true,
         };
         let tool_request_summary = r#"{"tool":"exec","request":{"command":"echo"}}"#;
         let tail = build_tool_driven_followup_tail(
@@ -3475,12 +3525,13 @@ mod tests {
         )
         .expect("pseudo-tool lines should trigger missing-tool-call recovery");
 
-        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+        let ToolDrivenFollowupPayload::ToolFailure { reason, retryable } = payload else {
             panic!("expected tool failure payload");
         };
 
         assert!(reason.contains("pseudo-tool text"));
         assert!(reason.contains("Reply excerpt"));
+        assert!(retryable);
     }
 
     #[test]
@@ -3490,12 +3541,13 @@ mod tests {
         )
         .expect("narrated tool plan should trigger missing-tool-call recovery");
 
-        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+        let ToolDrivenFollowupPayload::ToolFailure { reason, retryable } = payload else {
             panic!("expected tool failure payload");
         };
 
         assert!(reason.contains("described another tool step"));
         assert!(reason.contains("emit the exact next tool call"));
+        assert!(retryable);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -103,6 +103,9 @@ pub fn missing_tool_call_followup_payload(reply_text: &str) -> Option<ToolDriven
     let detection_kind = detect_missing_tool_call_kind(sanitized_reply.as_str())?;
     let excerpt = truncated_missing_tool_call_excerpt(sanitized_reply.as_str());
     let reason = match detection_kind {
+        MissingToolCallKind::EmptyFollowup => format!(
+            "{MISSING_TOOL_CALL_REASON_PREFIX} previous assistant reply ended the tool-followup round without any content or tool call. If more tool work is needed, emit the exact next tool call now instead of returning an empty follow-up."
+        ),
         MissingToolCallKind::PseudoToolCommand => format!(
             "{MISSING_TOOL_CALL_REASON_PREFIX} previous assistant reply emitted pseudo-tool text instead of a real tool call. If another tool is required, emit the exact next tool call now instead of formatting it as plain text.\nReply excerpt:\n{excerpt}"
         ),
@@ -119,6 +122,7 @@ pub fn missing_tool_call_followup_payload(reply_text: &str) -> Option<ToolDriven
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MissingToolCallKind {
+    EmptyFollowup,
     PseudoToolCommand,
     NarratedToolPlan,
 }
@@ -126,7 +130,7 @@ enum MissingToolCallKind {
 fn detect_missing_tool_call_kind(reply_text: &str) -> Option<MissingToolCallKind> {
     let normalized_reply = reply_text.trim();
     if normalized_reply.is_empty() {
-        return None;
+        return Some(MissingToolCallKind::EmptyFollowup);
     }
 
     let has_pseudo_tool_command = normalized_reply
@@ -2153,6 +2157,14 @@ fn render_direct_routing_failure_repair_guidance(
         "Provide `query` for search mode, or `url` for fetch/request mode.".to_owned()
     } else if tool_failure_reason.starts_with("direct_web_ambiguous:") {
         "Choose either search mode (`query`) or request/fetch mode (`url` plus optional request fields), but not both at once.".to_owned()
+    } else if tool_failure_reason.starts_with("hidden_agent_requires_operation:") {
+        "Add `operation` for grouped agent/runtime control requests such as session archive, cancel, recover, or approval workflows.".to_owned()
+    } else if tool_failure_reason.starts_with("hidden_agent_requires_actionable_fields:") {
+        "Add the concrete session / approval / delegate / provider / config fields needed for the request, or set `operation` when the grouped `tool.invoke` request is ambiguous.".to_owned()
+    } else if tool_failure_reason.starts_with("hidden_skills_requires_actionable_fields:") {
+        "Add search, inspect, install, run, or list fields for the grouped `skills` surface, or provide `operation` to make the request explicit.".to_owned()
+    } else if tool_failure_reason.starts_with("hidden_channel_requires_operation:") {
+        "Add `operation` for the grouped channel surface, for example `messages.send`, `messages.reply`, `card.update`, or `feishu.whoami`.".to_owned()
     } else {
         return None;
     };
@@ -3465,6 +3477,60 @@ mod tests {
     }
 
     #[test]
+    fn tool_failure_followup_tail_renders_hidden_agent_operation_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "hidden_agent_requires_operation: provide `operation` for archive, cancel, recover, or other multi-session control work".to_owned(),
+            retryable: true,
+        };
+        let tool_request_summary = r#"{"tool":"agent","request":{"session_ids":["child-1"]}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "archive these sessions",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for agent"));
+        assert!(user_prompt.contains("Add `operation`"));
+        assert!(user_prompt.contains(r#"Current request preview: {"session_ids":["child-1"]}"#));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_renders_hidden_channel_operation_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "hidden_channel_requires_operation: provide `operation`, such as `messages.send`, `messages.reply`, `card.update`, or `feishu.whoami`".to_owned(),
+            retryable: true,
+        };
+        let tool_request_summary = r#"{"tool":"channel","request":{"account_id":"default"}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "send a message",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for channel"));
+        assert!(user_prompt.contains("messages.send"));
+        assert!(user_prompt.contains(r#"Current request preview: {"account_id":"default"}"#));
+    }
+
+    #[test]
     fn tool_failure_followup_tail_uses_failure_reason_when_shell_summary_redacts_args_type() {
         let payload = ToolDrivenFollowupPayload::ToolFailure {
             reason: "tool_preflight_denied: tool input needs repair: shell.exec payload.args must be array"
@@ -3634,6 +3700,19 @@ mod tests {
 
         assert!(reason.contains("pseudo-tool text"));
         assert!(reason.contains("Reply excerpt"));
+        assert!(retryable);
+    }
+
+    #[test]
+    fn missing_tool_call_followup_detects_empty_followup() {
+        let payload = missing_tool_call_followup_payload("   ")
+            .expect("empty followup should trigger missing-tool-call recovery");
+
+        let ToolDrivenFollowupPayload::ToolFailure { reason, retryable } = payload else {
+            panic!("expected tool failure payload");
+        };
+
+        assert!(reason.contains("without any content or tool call"));
         assert!(retryable);
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -2092,6 +2092,14 @@ fn render_tool_failure_repair_guidance(
     let summary_tool_name = request_summary_json.get("tool").and_then(Value::as_str)?;
     let repair_tool_name = repair_guidance_tool_name(summary_tool_name, tool_failure_reason);
     let request_summary_request = request_summary_json.get("request");
+    let routing_guidance = render_direct_routing_failure_repair_guidance(
+        repair_tool_name.as_str(),
+        request_summary_request,
+        tool_failure_reason,
+    );
+    if routing_guidance.is_some() {
+        return routing_guidance;
+    }
     let reason_mentions_repairable_shape = tool_failure_reason.contains("tool input needs repair")
         || tool_failure_reason.contains("payload must be an object")
         || tool_failure_reason.contains("payload.");
@@ -2118,6 +2126,45 @@ fn render_tool_failure_repair_guidance(
     }
 
     render_tool_input_repair_guidance_from_reason(repair_tool_name.as_str(), tool_failure_reason)
+}
+
+fn render_direct_routing_failure_repair_guidance(
+    tool_name: &str,
+    request_summary_request: Option<&Value>,
+    tool_failure_reason: &str,
+) -> Option<String> {
+    let guidance = if tool_failure_reason.starts_with("direct_read_requires_one_of:") {
+        "Provide exactly one of `path`, `query`, or `pattern`. Use `path` to read one file, `query` to search file contents, or `pattern` to run a glob search.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_read_ambiguous:") {
+        "Remove the extra fields and keep only one of `path`, `query`, or `pattern`.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_exec_requires_command:") {
+        "Add `command` for direct program execution. If the request is really a shell string, switch to `bash` instead.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_exec_shell_moved_to_bash:")
+        || tool_failure_reason.starts_with("direct_exec_shell_syntax_moved_to_bash:")
+    {
+        "Use `bash` for shell command strings, pipelines, redirects, chaining, or shell builtins. Keep `exec` only for direct argv-style program execution.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_bash_argv_moved_to_exec:") {
+        "Use `exec` when you already have a program plus argv-style arguments. Keep `bash` for a single shell command string.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_bash_requires_command_or_script:") {
+        "Provide `command` for a shell command string, or legacy `script` if you are replaying an older payload.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_write_requires_content:") {
+        "Add whole-file `content`, or switch to `edit` if you meant an exact replacement instead of rewriting the entire file.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_web_requires_query_or_url:") {
+        "Provide `query` for search mode, or `url` for fetch/request mode.".to_owned()
+    } else if tool_failure_reason.starts_with("direct_web_ambiguous:") {
+        "Choose either search mode (`query`) or request/fetch mode (`url` plus optional request fields), but not both at once.".to_owned()
+    } else {
+        return None;
+    };
+
+    let visible_tool_name = repair_guidance_visible_tool_name(tool_name);
+    let request_preview = request_summary_request
+        .and_then(|request| serde_json::to_string(request).ok())
+        .unwrap_or_else(|| "{}".to_owned());
+
+    Some(format!(
+        "Repair guidance for {visible_tool_name}:\n{guidance}\nCurrent request preview: {request_preview}"
+    ))
 }
 
 fn repair_guidance_tool_name(summary_tool_name: &str, tool_failure_reason: &str) -> String {
@@ -3359,6 +3406,62 @@ mod tests {
             "Expected payload shape: path:string,offset?:integer,limit?:integer,max_bytes?:integer."
         ));
         assert!(user_prompt.contains(RETRYABLE_TOOL_FAILURE_FOLLOWUP_PROMPT));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_renders_direct_read_mode_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason:
+                "direct_read_requires_one_of: expected exactly one of `path`, `query`, or `pattern`"
+                    .to_owned(),
+            retryable: true,
+        };
+        let tool_request_summary = r#"{"tool":"read","request":{}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "read the file",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for read"));
+        assert!(user_prompt.contains("Provide exactly one of `path`, `query`, or `pattern`"));
+        assert!(user_prompt.contains("Current request preview: {}"));
+    }
+
+    #[test]
+    fn tool_failure_followup_tail_renders_direct_exec_to_bash_guidance() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "direct_exec_shell_syntax_moved_to_bash: `exec` does not accept shell syntax; use `bash` for pipelines, redirects, chaining, or shell builtins".to_owned(),
+            retryable: true,
+        };
+        let tool_request_summary = r#"{"tool":"exec","request":{"command":"ls | wc -l"}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "count files",
+            None,
+            |_, text| text.to_owned(),
+        );
+
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for exec"));
+        assert!(user_prompt.contains("Use `bash` for shell command strings"));
+        assert!(user_prompt.contains(r#"Current request preview: {"command":"ls | wc -l"}"#));
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -22,7 +22,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::CliResult;
 
-pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
+pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to continue solving the original user request. If more tool work is needed, emit the next tool call instead of only describing the plan in natural language. Only answer directly when the current evidence is already sufficient. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
@@ -30,6 +30,8 @@ pub const DISCOVERY_RECOVERY_FOLLOWUP_PROMPT: &str = "The previous tool call cou
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
+const MISSING_TOOL_CALL_REASON_PREFIX: &str = "missing_tool_call_followup:";
+const MISSING_TOOL_CALL_REPLY_EXCERPT_CHARS: usize = 240;
 const SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_OMISSION_MARKER: &str = "\n[... omitted ...]\n";
 const THINK_OPEN_TAG: &str = "<think>";
@@ -94,6 +96,136 @@ fn sanitize_reply_text(text: &str) -> String {
     let trimmed_text = stripped_text.trim();
     trimmed_text.to_owned()
 }
+
+pub fn missing_tool_call_followup_payload(reply_text: &str) -> Option<ToolDrivenFollowupPayload> {
+    let sanitized_reply = sanitize_reply_text(reply_text);
+    let detection_kind = detect_missing_tool_call_kind(sanitized_reply.as_str())?;
+    let excerpt = truncated_missing_tool_call_excerpt(sanitized_reply.as_str());
+    let reason = match detection_kind {
+        MissingToolCallKind::PseudoToolCommand => format!(
+            "{MISSING_TOOL_CALL_REASON_PREFIX} previous assistant reply emitted pseudo-tool text instead of a real tool call. If another tool is required, emit the exact next tool call now instead of formatting it as plain text.\nReply excerpt:\n{excerpt}"
+        ),
+        MissingToolCallKind::NarratedToolPlan => format!(
+            "{MISSING_TOOL_CALL_REASON_PREFIX} previous assistant reply described another tool step in prose but did not emit the tool call. If another tool is required, emit the exact next tool call now instead of narrating the plan.\nReply excerpt:\n{excerpt}"
+        ),
+    };
+
+    Some(ToolDrivenFollowupPayload::ToolFailure { reason })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MissingToolCallKind {
+    PseudoToolCommand,
+    NarratedToolPlan,
+}
+
+fn detect_missing_tool_call_kind(reply_text: &str) -> Option<MissingToolCallKind> {
+    let normalized_reply = reply_text.trim();
+    if normalized_reply.is_empty() {
+        return None;
+    }
+
+    let has_pseudo_tool_command = normalized_reply
+        .lines()
+        .map(str::trim)
+        .any(line_looks_like_pseudo_tool_command);
+    if has_pseudo_tool_command {
+        return Some(MissingToolCallKind::PseudoToolCommand);
+    }
+
+    let normalized_reply = normalized_reply.to_ascii_lowercase();
+    let has_tool_marker = missing_tool_call_tool_markers()
+        .iter()
+        .any(|marker| normalized_reply.contains(marker));
+    if !has_tool_marker {
+        return None;
+    }
+
+    let has_intent_phrase = missing_tool_call_intent_phrases()
+        .iter()
+        .any(|phrase| normalized_reply.contains(phrase));
+    if !has_intent_phrase {
+        return None;
+    }
+
+    Some(MissingToolCallKind::NarratedToolPlan)
+}
+
+fn line_looks_like_pseudo_tool_command(line: &str) -> bool {
+    let Some(trimmed_line) = line.strip_prefix('/') else {
+        return false;
+    };
+    let Some((surface, remainder)) = trimmed_line.split_once(':') else {
+        return false;
+    };
+    let has_surface = !surface.trim().is_empty();
+    let has_remainder = !remainder.trim().is_empty();
+    let surface_is_tool_like = surface
+        .chars()
+        .all(|character| character.is_ascii_lowercase() || ".-_".contains(character));
+
+    has_surface && has_remainder && surface_is_tool_like
+}
+
+fn missing_tool_call_tool_markers() -> &'static [&'static str] {
+    &[
+        "tool.search",
+        "tool_search",
+        "tool.invoke",
+        "tool_invoke",
+        "shell.exec",
+        "bash.exec",
+        "file.read",
+        "file.write",
+        "file.edit",
+        "`read`",
+        "`edit`",
+        "`write`",
+        "`bash`",
+        "`exec`",
+        "`web`",
+        "`browser`",
+        "`memory`",
+    ]
+}
+
+fn missing_tool_call_intent_phrases() -> &'static [&'static str] {
+    &[
+        "i will ",
+        "i'll ",
+        "let me ",
+        "i need to ",
+        "i should ",
+        "i can try ",
+        "i can use ",
+        "next i ",
+        "then i ",
+        "after that i ",
+        "retry with ",
+        "rerun with ",
+        "call ",
+        "invoke ",
+        "use ",
+    ]
+}
+
+fn truncated_missing_tool_call_excerpt(reply_text: &str) -> String {
+    let total_chars = reply_text.chars().count();
+    if total_chars <= MISSING_TOOL_CALL_REPLY_EXCERPT_CHARS {
+        return reply_text.to_owned();
+    }
+
+    let truncated_reply = reply_text
+        .chars()
+        .take(MISSING_TOOL_CALL_REPLY_EXCERPT_CHARS)
+        .collect::<String>();
+
+    format!(
+        "{truncated_reply}\n[reply_excerpt_truncated] omitted_chars={}",
+        total_chars - MISSING_TOOL_CALL_REPLY_EXCERPT_CHARS
+    )
+}
+
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
     let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -3283,6 +3415,7 @@ mod tests {
             None,
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
+        assert!(prompt.contains("emit the next tool call"));
         assert!(prompt.contains("Original request:\nsummarize this result"));
     }
 
@@ -3333,6 +3466,45 @@ mod tests {
 
         assert!(prompt.contains(DISCOVERY_RESULT_FOLLOWUP_PROMPT));
         assert!(prompt.contains("Original request:\nfind the latest ai news and summarize it"));
+    }
+
+    #[test]
+    fn missing_tool_call_followup_detects_pseudo_tool_commands() {
+        let payload = missing_tool_call_followup_payload(
+            "/workspace:df -h\n/tool.search:disk usage\n/web:disk usage command line",
+        )
+        .expect("pseudo-tool lines should trigger missing-tool-call recovery");
+
+        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+            panic!("expected tool failure payload");
+        };
+
+        assert!(reason.contains("pseudo-tool text"));
+        assert!(reason.contains("Reply excerpt"));
+    }
+
+    #[test]
+    fn missing_tool_call_followup_detects_narrated_tool_plan() {
+        let payload = missing_tool_call_followup_payload(
+            "I should use `bash` next to retry with a simpler shell command.",
+        )
+        .expect("narrated tool plan should trigger missing-tool-call recovery");
+
+        let ToolDrivenFollowupPayload::ToolFailure { reason } = payload else {
+            panic!("expected tool failure payload");
+        };
+
+        assert!(reason.contains("described another tool step"));
+        assert!(reason.contains("emit the exact next tool call"));
+    }
+
+    #[test]
+    fn missing_tool_call_followup_ignores_normal_final_answer_text() {
+        let payload = missing_tool_call_followup_payload(
+            "The disk is nearly full because the cache directory is consuming most of the space.",
+        );
+
+        assert!(payload.is_none());
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -2137,33 +2137,37 @@ fn render_direct_routing_failure_repair_guidance(
     request_summary_request: Option<&Value>,
     tool_failure_reason: &str,
 ) -> Option<String> {
-    let guidance = if tool_failure_reason.starts_with("direct_read_requires_one_of:") {
+    let normalized_reason = tool_failure_reason
+        .strip_prefix("tool execution failed: ")
+        .unwrap_or(tool_failure_reason);
+
+    let guidance = if normalized_reason.starts_with("direct_read_requires_one_of:") {
         "Provide exactly one of `path`, `query`, or `pattern`. Use `path` to read one file, `query` to search file contents, or `pattern` to run a glob search.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_read_ambiguous:") {
+    } else if normalized_reason.starts_with("direct_read_ambiguous:") {
         "Remove the extra fields and keep only one of `path`, `query`, or `pattern`.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_exec_requires_command:") {
+    } else if normalized_reason.starts_with("direct_exec_requires_command:") {
         "Add `command` for direct program execution. If the request is really a shell string, switch to `bash` instead.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_exec_shell_moved_to_bash:")
-        || tool_failure_reason.starts_with("direct_exec_shell_syntax_moved_to_bash:")
+    } else if normalized_reason.starts_with("direct_exec_shell_moved_to_bash:")
+        || normalized_reason.starts_with("direct_exec_shell_syntax_moved_to_bash:")
     {
         "Use `bash` for shell command strings, pipelines, redirects, chaining, or shell builtins. Keep `exec` only for direct argv-style program execution.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_bash_argv_moved_to_exec:") {
+    } else if normalized_reason.starts_with("direct_bash_argv_moved_to_exec:") {
         "Use `exec` when you already have a program plus argv-style arguments. Keep `bash` for a single shell command string.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_bash_requires_command_or_script:") {
+    } else if normalized_reason.starts_with("direct_bash_requires_command_or_script:") {
         "Provide `command` for a shell command string, or legacy `script` if you are replaying an older payload.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_write_requires_content:") {
+    } else if normalized_reason.starts_with("direct_write_requires_content:") {
         "Add whole-file `content`, or switch to `edit` if you meant an exact replacement instead of rewriting the entire file.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_web_requires_query_or_url:") {
+    } else if normalized_reason.starts_with("direct_web_requires_query_or_url:") {
         "Provide `query` for search mode, or `url` for fetch/request mode.".to_owned()
-    } else if tool_failure_reason.starts_with("direct_web_ambiguous:") {
+    } else if normalized_reason.starts_with("direct_web_ambiguous:") {
         "Choose either search mode (`query`) or request/fetch mode (`url` plus optional request fields), but not both at once.".to_owned()
-    } else if tool_failure_reason.starts_with("hidden_agent_requires_operation:") {
+    } else if normalized_reason.starts_with("hidden_agent_requires_operation:") {
         "Add `operation` for grouped agent/runtime control requests such as session archive, cancel, recover, or approval workflows.".to_owned()
-    } else if tool_failure_reason.starts_with("hidden_agent_requires_actionable_fields:") {
+    } else if normalized_reason.starts_with("hidden_agent_requires_actionable_fields:") {
         "Add the concrete session / approval / delegate / provider / config fields needed for the request, or set `operation` when the grouped `tool.invoke` request is ambiguous.".to_owned()
-    } else if tool_failure_reason.starts_with("hidden_skills_requires_actionable_fields:") {
+    } else if normalized_reason.starts_with("hidden_skills_requires_actionable_fields:") {
         "Add search, inspect, install, run, or list fields for the grouped `skills` surface, or provide `operation` to make the request explicit.".to_owned()
-    } else if tool_failure_reason.starts_with("hidden_channel_requires_operation:") {
+    } else if normalized_reason.starts_with("hidden_channel_requires_operation:") {
         "Add `operation` for the grouped channel surface, for example `messages.send`, `messages.reply`, `card.update`, or `feishu.whoami`.".to_owned()
     } else {
         return None;

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -23,9 +23,9 @@ use metadata_support::{
 #[path = "catalog_core_definition_support.rs"]
 mod core_definition_support;
 use core_definition_support::{
-    direct_browser_definition, direct_exec_definition, direct_memory_definition,
-    direct_read_definition, direct_web_definition, direct_write_definition, tool_invoke_definition,
-    tool_search_definition,
+    direct_bash_definition, direct_browser_definition, direct_edit_definition,
+    direct_exec_definition, direct_memory_definition, direct_read_definition,
+    direct_web_definition, direct_write_definition, tool_invoke_definition, tool_search_definition,
 };
 #[path = "catalog_browser_definition_support.rs"]
 mod browser_definition_support;
@@ -272,6 +272,7 @@ pub enum ToolExposureClass {
     Direct,
     Gateway,
     Discoverable,
+    Internal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -311,7 +312,17 @@ pub struct ToolDescriptor {
 fn primary_surface_id(raw: &str) -> bool {
     matches!(
         raw,
-        "read" | "write" | "exec" | "web" | "browser" | "memory" | "agent" | "skills" | "channel"
+        "read"
+            | "edit"
+            | "write"
+            | "bash"
+            | "exec"
+            | "web"
+            | "browser"
+            | "memory"
+            | "agent"
+            | "skills"
+            | "channel"
     )
 }
 
@@ -331,14 +342,18 @@ impl ToolDescriptor {
             return false;
         }
 
-        let discovery_name = super::tool_surface::discovery_tool_name_for_tool_name(self.name);
-        if discovery_name == raw {
-            return true;
+        if self.is_discoverable() {
+            let discovery_name = super::tool_surface::discovery_tool_name_for_tool_name(self.name);
+            if discovery_name == raw {
+                return true;
+            }
+
+            return super::tool_surface::legacy_discovery_tool_names_for_tool_name(self.name)
+                .iter()
+                .any(|legacy_name| legacy_name == raw);
         }
 
-        super::tool_surface::legacy_discovery_tool_names_for_tool_name(self.name)
-            .iter()
-            .any(|legacy_name| legacy_name == raw)
+        false
     }
 
     pub fn provider_definition(&self) -> Value {
@@ -387,6 +402,10 @@ impl ToolDescriptor {
 
     pub fn is_discoverable(&self) -> bool {
         self.exposure == ToolExposureClass::Discoverable
+    }
+
+    pub fn is_provider_invokable_discoverable(&self) -> bool {
+        self.is_discoverable() && self.execution_kind == ToolExecutionKind::Core
     }
 
     pub fn capability_action_class(&self) -> CapabilityActionClass {
@@ -739,10 +758,24 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: direct_read_definition,
         },
         ToolDescriptor {
+            name: "edit",
+            provider_name: "edit",
+            aliases: &[],
+            description: "Apply one or more exact text edits to an existing workspace file",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Direct,
+            visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: direct_edit_definition,
+        },
+        ToolDescriptor {
             name: "write",
             provider_name: "write",
             aliases: &[],
-            description: "Write workspace files or apply one or more exact text edits",
+            description: "Create a workspace file or replace one file with whole-file content",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Direct,
@@ -753,10 +786,24 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: direct_write_definition,
         },
         ToolDescriptor {
+            name: "bash",
+            provider_name: "bash",
+            aliases: &[],
+            description: "Run shell commands or shell scripts in the workspace",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Direct,
+            visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: direct_bash_definition,
+        },
+        ToolDescriptor {
             name: "exec",
             provider_name: "exec",
             aliases: &[],
-            description: "Run guarded workspace commands or raw shell scripts",
+            description: "Execute a program directly with argv-style arguments",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Direct,
@@ -829,7 +876,7 @@ fn build_tool_catalog() -> ToolCatalog {
             description: "Download external skills artifacts with domain policy and approval guards",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
-            exposure: ToolExposureClass::Discoverable,
+            exposure: ToolExposureClass::Internal,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::CapabilityFetch,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
@@ -843,7 +890,7 @@ fn build_tool_catalog() -> ToolCatalog {
             description: "Normalize an external skill reference into a source-aware candidate",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
-            exposure: ToolExposureClass::Discoverable,
+            exposure: ToolExposureClass::Internal,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
@@ -871,7 +918,7 @@ fn build_tool_catalog() -> ToolCatalog {
             description: "Recommend the best-fit resolved external skills for an operator goal",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
-            exposure: ToolExposureClass::Discoverable,
+            exposure: ToolExposureClass::Internal,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
@@ -885,7 +932,7 @@ fn build_tool_catalog() -> ToolCatalog {
             description: "Search preferred external skill ecosystems and return normalized source-aware candidates",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
-            exposure: ToolExposureClass::Discoverable,
+            exposure: ToolExposureClass::Internal,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
@@ -969,7 +1016,7 @@ fn build_tool_catalog() -> ToolCatalog {
             description: "Remove an installed external skill from the managed runtime",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
-            exposure: ToolExposureClass::Discoverable,
+            exposure: ToolExposureClass::Internal,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,

--- a/crates/app/src/tools/catalog_core_definition_support.rs
+++ b/crates/app/src/tools/catalog_core_definition_support.rs
@@ -157,6 +157,27 @@ pub(super) fn direct_write_definition(descriptor: &ToolDescriptor) -> Value {
                     "overwrite": {
                         "type": "boolean",
                         "description": "Allow replacing an existing file. Defaults to false."
+                    }
+                },
+                "required": ["path", "content"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+pub(super) fn direct_edit_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Target file path."
                     },
                     "edits": {
                         "type": "array",
@@ -181,9 +202,6 @@ pub(super) fn direct_write_definition(descriptor: &ToolDescriptor) -> Value {
                 "required": ["path"],
                 "anyOf": [
                     {
-                        "required": ["content"]
-                    },
-                    {
                         "required": ["edits"]
                     },
                     {
@@ -207,16 +225,47 @@ pub(super) fn direct_exec_definition(descriptor: &ToolDescriptor) -> Value {
                 "properties": {
                     "command": {
                         "type": "string",
-                        "description": "Executable command or simple shell command. Routes to argv mode unless it clearly uses shell syntax."
-                    },
-                    "script": {
-                        "type": "string",
-                        "description": "Raw shell or bash script text. Use this for pipes, redirects, chaining, or multi-line commands."
+                        "description": "Program or command to execute in argv mode."
                     },
                     "args": {
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Optional command arguments for argv mode."
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "minimum": 1000,
+                        "maximum": 600000,
+                        "description": "Optional command timeout in milliseconds."
+                    },
+                    "cwd": {
+                        "type": "string",
+                        "description": "Optional working directory."
+                    }
+                },
+                "required": ["command"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+pub(super) fn direct_bash_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Shell command string. Use this for pipes, redirects, shell builtins, or normal shell workflows."
+                    },
+                    "script": {
+                        "type": "string",
+                        "description": "Legacy alias for a shell command string. Prefer `command` for new requests."
                     },
                     "timeout_ms": {
                         "type": "integer",

--- a/crates/app/src/tools/catalog_tests.rs
+++ b/crates/app/src/tools/catalog_tests.rs
@@ -485,13 +485,23 @@ fn tool_catalog_entries_expose_concurrency_class() {
     assert!(
         file_write
             .usage_guidance
-            .is_some_and(|guidance| guidance.contains("normal patching and file creation"))
+            .is_some_and(|guidance| guidance.contains("new files and full rewrites"))
+    );
+
+    let file_edit = find_tool_catalog_entry("file.edit").expect("file.edit catalog entry");
+    assert_eq!(file_edit.scheduling_class, ToolSchedulingClass::SerialOnly);
+    assert_eq!(file_edit.concurrency_class, ToolConcurrencyClass::Mutating);
+    assert_eq!(file_edit.surface_id, Some("edit"));
+    assert!(
+        file_edit
+            .usage_guidance
+            .is_some_and(|guidance| guidance.contains("surgical changes"))
     );
 
     let bash_exec = find_tool_catalog_entry("bash.exec").expect("bash.exec catalog entry");
     assert_eq!(bash_exec.scheduling_class, ToolSchedulingClass::SerialOnly);
     assert_eq!(bash_exec.concurrency_class, ToolConcurrencyClass::Mutating);
-    assert_eq!(bash_exec.surface_id, Some("exec"));
+    assert_eq!(bash_exec.surface_id, Some("bash"));
 }
 
 #[test]
@@ -908,6 +918,36 @@ fn external_skills_policy_definition_surfaces_update_controls() {
     assert!(properties["blocked_domains"].is_object());
 }
 
+#[test]
+fn external_skills_plumbing_tools_are_internal_only() {
+    let catalog = tool_catalog();
+    let internal_only = [
+        "external_skills.fetch",
+        "external_skills.resolve",
+        "external_skills.recommend",
+        "external_skills.source_search",
+        "external_skills.remove",
+    ];
+
+    for tool_name in internal_only {
+        let descriptor = catalog
+            .descriptor(tool_name)
+            .unwrap_or_else(|| panic!("missing descriptor `{tool_name}`"));
+        assert!(
+            descriptor.exposure == ToolExposureClass::Internal,
+            "{tool_name} should be internal-only"
+        );
+        assert!(
+            !descriptor.is_discoverable(),
+            "{tool_name} should not be discoverable"
+        );
+        assert!(
+            !descriptor.is_provider_exposed(),
+            "{tool_name} should not be provider-exposed"
+        );
+    }
+}
+
 #[cfg(feature = "tool-websearch")]
 #[test]
 fn web_search_definition_requires_query_and_exposes_provider_override() {
@@ -1014,13 +1054,31 @@ fn read_definitions_surface_line_window_fields() {
 }
 
 #[test]
-fn exec_definition_supports_script_mode() {
+fn exec_definition_uses_direct_program_shape() {
     let catalog = tool_catalog();
     let descriptor = catalog.descriptor("exec").expect("exec descriptor");
     let definition = descriptor.provider_definition();
     let properties = &definition["function"]["parameters"]["properties"];
+
+    assert!(properties.get("script").is_none());
+    assert!(descriptor.argument_hint().contains("args?:string[]"));
+    assert!(descriptor.parameter_types().contains(&("args", "array")));
+    assert_eq!(descriptor.required_fields(), vec!["command"]);
+    assert_eq!(
+        definition["function"]["parameters"]["required"],
+        json!(["command"])
+    );
+}
+
+#[test]
+fn bash_definition_supports_shell_command_shape() {
+    let catalog = tool_catalog();
+    let descriptor = catalog.descriptor("bash").expect("bash descriptor");
+    let definition = descriptor.provider_definition();
+    let properties = &definition["function"]["parameters"]["properties"];
     let any_of = &definition["function"]["parameters"]["anyOf"];
 
+    assert!(properties.get("command").is_some());
     assert!(properties.get("script").is_some());
     assert!(descriptor.argument_hint().contains("script?:string"));
     assert!(descriptor.parameter_types().contains(&("script", "string")));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -17,7 +17,7 @@ use tool_search::searchable_entry_from_provider_definition;
 use tool_search::{
     SearchableToolEntry, collapse_hidden_surface_search_entries,
     execute_tool_search_tool_with_config, searchable_entry_from_descriptor,
-    tool_search_entry_is_runtime_usable,
+    searchable_entry_from_manual_definition, tool_search_entry_is_runtime_usable,
 };
 
 use crate::KernelContext;
@@ -621,10 +621,15 @@ fn required_capabilities_for_tool_name_and_payload(
         | "session_tool_policy_status" => {
             caps.insert(Capability::MemoryRead);
         }
-        "write" | "file.write" | "file.edit" => {
+        "edit" | "write" | "file.write" | "file.edit" => {
             caps.insert(Capability::FilesystemWrite);
         }
-        "exec" | BASH_EXEC_TOOL_NAME => {
+        "bash" | "bash.exec" => {
+            caps.insert(Capability::FilesystemRead);
+            caps.insert(Capability::FilesystemWrite);
+            caps.insert(Capability::NetworkEgress);
+        }
+        "exec" | SHELL_EXEC_TOOL_NAME => {
             caps.insert(Capability::FilesystemRead);
             caps.insert(Capability::FilesystemWrite);
             caps.insert(Capability::NetworkEgress);
@@ -670,6 +675,7 @@ fn tool_requires_network_egress(tool_name: &str) -> bool {
             | "web.search"
             | "browser.open"
             | "browser.click"
+            | "bash"
             | "exec"
             | "external_skills.fetch"
             | "external_skills.source_search"
@@ -864,7 +870,7 @@ pub fn execute_tool_core_with_config(
         match canonical_name {
             "tool.search" => execute_tool_search_tool_with_config(request, config),
             "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
-            "read" | "write" | "exec" | "web" | "browser" | "memory" => {
+            "read" | "edit" | "write" | "bash" | "exec" | "web" | "browser" | "memory" => {
                 execute_direct_tool_core_with_config(request, config)
             }
             _ => execute_discoverable_tool_core_with_config(request, config),
@@ -1230,7 +1236,16 @@ pub(crate) fn tool_registry_with_config(
         }
     };
 
-    let discoverable_entries = runtime_discoverable_tool_entries(config, None);
+    let visible_tool_view = effective_runtime_visible_tool_view(config, None);
+    let discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(&visible_tool_view), false);
+    let collapsible_surface_ids = BTreeSet::from([
+        HIDDEN_AGENT_TOOL_NAME.to_owned(),
+        HIDDEN_SKILLS_TOOL_NAME.to_owned(),
+        HIDDEN_CHANNEL_TOOL_NAME.to_owned(),
+    ]);
+    let discoverable_entries =
+        collapse_hidden_surface_search_entries(discoverable_entries, &collapsible_surface_ids);
     let mut entries = Vec::new();
 
     for entry in discoverable_entries {
@@ -1372,7 +1387,8 @@ pub fn runtime_discoverable_tool_surface_summary_with_config(
     visible_tool_view: Option<&ToolView>,
 ) -> DiscoverableToolSurfaceSummary {
     let effective_view = effective_runtime_visible_tool_view(config, visible_tool_view);
-    let discoverable_entries = runtime_discoverable_tool_entries(config, Some(&effective_view));
+    let discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(&effective_view), true);
     let direct_states = tool_surface::visible_direct_tool_states_for_view(&effective_view);
     summarize_discoverable_tool_surface(discoverable_entries.as_slice(), direct_states)
 }
@@ -1532,9 +1548,11 @@ fn runtime_tool_search_entries(
         }
     }
 
-    let hidden_entries = runtime_discoverable_tool_entries(config, Some(&visible_tool_view));
+    let hidden_entries = runtime_discoverable_tool_entries(config, Some(&visible_tool_view), true);
     let hidden_entries = if collapse_hidden_surfaces {
-        collapse_hidden_surface_search_entries(hidden_entries)
+        let collapsible_surface_ids =
+            provider_visible_collapsible_hidden_surface_ids(config, &visible_tool_view);
+        collapse_hidden_surface_search_entries(hidden_entries, &collapsible_surface_ids)
     } else {
         hidden_entries
     };
@@ -1545,12 +1563,24 @@ fn runtime_tool_search_entries(
 fn runtime_discoverable_tool_entries(
     config: &runtime_config::ToolRuntimeConfig,
     visible_tool_view: Option<&ToolView>,
+    provider_invokable_only: bool,
 ) -> Vec<SearchableToolEntry> {
     let visible_tool_view = effective_runtime_visible_tool_view(config, visible_tool_view);
-    catalog::tool_catalog()
+    let mut entries = catalog::tool_catalog()
         .descriptors()
         .iter()
-        .filter(|descriptor| descriptor.is_discoverable())
+        .filter(|descriptor| {
+            let is_discoverable = descriptor.is_discoverable();
+            if !is_discoverable {
+                return false;
+            }
+
+            if !provider_invokable_only {
+                return true;
+            }
+
+            descriptor.is_provider_invokable_discoverable()
+        })
         .filter(|descriptor| visible_tool_view.contains(descriptor.name))
         .filter(|descriptor| {
             descriptor.name == SHELL_EXEC_TOOL_NAME
@@ -1563,7 +1593,117 @@ fn runtime_discoverable_tool_entries(
             )
         })
         .map(searchable_entry_from_descriptor)
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+
+    entries.extend(grouped_internal_hidden_surface_entries(&visible_tool_view));
+    entries
+}
+
+fn grouped_internal_hidden_surface_entries(
+    visible_tool_view: &ToolView,
+) -> Vec<SearchableToolEntry> {
+    let mut tags_by_surface_id = BTreeMap::<String, BTreeSet<String>>::new();
+
+    for descriptor in catalog::tool_catalog().descriptors().iter() {
+        if descriptor.exposure != catalog::ToolExposureClass::Internal {
+            continue;
+        }
+
+        if !visible_tool_view.contains(descriptor.name) {
+            continue;
+        }
+
+        let Some(surface_id) = tool_surface::tool_surface_id_for_name(descriptor.name) else {
+            continue;
+        };
+        let is_grouped_hidden_surface = matches!(
+            surface_id,
+            HIDDEN_AGENT_TOOL_NAME | HIDDEN_SKILLS_TOOL_NAME | HIDDEN_CHANNEL_TOOL_NAME
+        );
+        if !is_grouped_hidden_surface {
+            continue;
+        }
+
+        let tags = tags_by_surface_id
+            .entry(surface_id.to_owned())
+            .or_insert_with(|| BTreeSet::from([surface_id.to_owned()]));
+        tags.insert(descriptor.name.to_owned());
+        for tag in descriptor.tags() {
+            tags.insert((*tag).to_owned());
+        }
+    }
+
+    let mut entries = Vec::new();
+    for (surface_id, tags) in tags_by_surface_id {
+        if tags.len() == 1 {
+            continue;
+        }
+
+        let Some(summary) = tool_surface::hidden_surface_search_summary(surface_id.as_str()) else {
+            continue;
+        };
+        let Some(argument_hint) =
+            tool_surface::hidden_surface_search_argument_hint(surface_id.as_str())
+        else {
+            continue;
+        };
+        let entry = searchable_entry_from_manual_definition(
+            surface_id.as_str(),
+            summary,
+            argument_hint,
+            Vec::new(),
+            Vec::new(),
+            tags.into_iter().collect(),
+        );
+        entries.push(entry);
+    }
+
+    entries
+}
+
+fn hidden_surface_entry_counts(entries: &[SearchableToolEntry]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+
+    for entry in entries {
+        let Some(surface_id) = entry.surface_id.as_deref() else {
+            continue;
+        };
+        let is_grouped_surface = matches!(surface_id, "agent" | "skills" | "channel");
+        if !is_grouped_surface {
+            continue;
+        }
+
+        let entry_count = counts.entry(surface_id.to_owned()).or_insert(0);
+        *entry_count += 1;
+    }
+
+    counts
+}
+
+pub(super) fn provider_visible_collapsible_hidden_surface_ids(
+    config: &runtime_config::ToolRuntimeConfig,
+    visible_tool_view: &ToolView,
+) -> BTreeSet<String> {
+    let all_discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(visible_tool_view), false);
+    let provider_discoverable_entries =
+        runtime_discoverable_tool_entries(config, Some(visible_tool_view), true);
+    let all_entry_counts = hidden_surface_entry_counts(all_discoverable_entries.as_slice());
+    let provider_entry_counts =
+        hidden_surface_entry_counts(provider_discoverable_entries.as_slice());
+    let mut surface_ids = BTreeSet::new();
+
+    for (surface_id, all_entry_count) in all_entry_counts {
+        let Some(provider_entry_count) = provider_entry_counts.get(surface_id.as_str()).copied()
+        else {
+            continue;
+        };
+        if provider_entry_count == all_entry_count {
+            surface_ids.insert(surface_id);
+        }
+    }
+
+    surface_ids
 }
 
 #[cfg(test)]

--- a/crates/app/src/tools/routing.rs
+++ b/crates/app/src/tools/routing.rs
@@ -23,7 +23,7 @@ pub(super) fn resolved_inner_tool_name_for_logs(canonical_name: &str, payload: &
 
     let is_direct_tool = matches!(
         canonical_name,
-        "read" | "write" | "exec" | "web" | "browser" | "memory"
+        "read" | "edit" | "write" | "bash" | "exec" | "web" | "browser" | "memory"
     );
     if !is_direct_tool {
         return "-".to_owned();
@@ -50,7 +50,7 @@ fn route_direct_tool_request(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreRequest, String> {
     let tool_name = request.tool_name;
-    let payload = request.payload;
+    let mut payload = request.payload;
     let runtime_view = runtime_tool_view_for_runtime_config(config);
     let routed_tool_name =
         route_direct_tool_name_for_view(tool_name.as_str(), &payload, &runtime_view)?;
@@ -64,10 +64,36 @@ fn route_direct_tool_request(
         ));
     }
 
+    if tool_name == "bash" {
+        normalize_direct_bash_payload(&mut payload)?;
+    }
+
     Ok(ToolCoreRequest {
         tool_name: routed_tool_name.to_owned(),
         payload,
     })
+}
+
+fn normalize_direct_bash_payload(payload: &mut Value) -> Result<(), String> {
+    let Some(payload_object) = payload.as_object_mut() else {
+        return Err("direct_bash_requires_object_payload".to_owned());
+    };
+
+    let command_value = payload_object.get("command").cloned();
+    let script_value = payload_object.get("script").cloned();
+
+    let Some(script_value) = script_value else {
+        return Ok(());
+    };
+
+    if command_value.is_some() {
+        payload_object.remove("script");
+        return Ok(());
+    }
+
+    payload_object.insert("command".to_owned(), script_value);
+    payload_object.remove("script");
+    Ok(())
 }
 
 fn route_direct_tool_name_for_view(
@@ -87,7 +113,9 @@ pub(crate) fn route_direct_tool_name(
 ) -> Result<&'static str, String> {
     match tool_name {
         "read" => route_direct_read_tool_name(payload),
+        "edit" => route_direct_edit_tool_name(payload),
         "write" => route_direct_write_tool_name(payload),
+        "bash" => route_direct_bash_tool_name(payload),
         "exec" => route_direct_exec_tool_name(payload),
         "web" => route_direct_web_tool_name(payload),
         "browser" => route_direct_browser_tool_name(payload),
@@ -107,47 +135,80 @@ fn route_direct_exec_tool_name(payload: &Value) -> Result<&'static str, String> 
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let has_script = payload_has_non_null_field(payload, "script");
+
+    match script {
+        Some(script_value) if command == Some(script_value) => {
+            let uses_shell_syntax = command_uses_shell_syntax(script_value);
+            if uses_shell_syntax {
+                return Ok(BASH_EXEC_TOOL_NAME);
+            }
+            return Ok(SHELL_EXEC_TOOL_NAME);
+        }
+        _ => {}
+    }
+
+    if has_script {
+        return Err(
+            "direct_exec_shell_moved_to_bash: `exec` only supports direct program execution; use `bash` for shell command strings or scripts"
+                .to_owned(),
+        );
+    }
+
+    let command = command.ok_or_else(|| {
+        "direct_exec_requires_command: expected `command` for direct program execution".to_owned()
+    })?;
+    let uses_shell_syntax = command_uses_shell_syntax(command);
+
+    if uses_shell_syntax {
+        return Err(
+            "direct_exec_shell_syntax_moved_to_bash: `exec` does not accept shell syntax; use `bash` for pipelines, redirects, chaining, or shell builtins"
+                .to_owned(),
+        );
+    }
+
+    Ok(SHELL_EXEC_TOOL_NAME)
+}
+
+fn route_direct_bash_tool_name(payload: &Value) -> Result<&'static str, String> {
+    let command = payload
+        .get("command")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let script = payload
+        .get("script")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     let has_args = payload_has_non_null_field(payload, "args");
     let mode_count = count_true([command.is_some(), script.is_some()]);
 
+    if has_args {
+        return Err(
+            "direct_bash_argv_moved_to_exec: `bash` accepts shell command strings; use `exec` for argv-style process execution"
+                .to_owned(),
+        );
+    }
+
     if mode_count == 0 {
         return Err(
-            "direct_exec_requires_command_or_script: expected `command` for argv mode, or `script` for raw shell mode"
+            "direct_bash_requires_command_or_script: expected `command` for a shell command string, or `script` for legacy shell-script mode"
                 .to_owned(),
         );
     }
 
     if mode_count > 1 {
-        if command == script
-            && let Some(value) = command
-        {
-            return Ok(if !has_args && command_uses_shell_syntax(value) {
-                BASH_EXEC_TOOL_NAME
-            } else {
-                SHELL_EXEC_TOOL_NAME
-            });
+        if command == script {
+            return Ok(BASH_EXEC_TOOL_NAME);
         }
 
         return Err(
-            "direct_exec_ambiguous: provide either `command` or `script`, not both".to_owned(),
+            "direct_bash_ambiguous: provide either `command` or `script`, not both".to_owned(),
         );
     }
 
-    if script.is_some() {
-        return Ok(BASH_EXEC_TOOL_NAME);
-    }
-
-    let command = command.ok_or_else(|| {
-        "direct_exec_requires_command_or_script: expected `command` for argv mode, or `script` for raw shell mode"
-            .to_owned()
-    })?;
-    let uses_shell_syntax = command_uses_shell_syntax(command);
-
-    if !has_args && uses_shell_syntax {
-        return Ok(BASH_EXEC_TOOL_NAME);
-    }
-
-    Ok(SHELL_EXEC_TOOL_NAME)
+    Ok(BASH_EXEC_TOOL_NAME)
 }
 
 fn command_uses_shell_syntax(command: &str) -> bool {
@@ -193,36 +254,37 @@ fn route_direct_read_tool_name(payload: &Value) -> Result<&'static str, String> 
     Ok("glob.search")
 }
 
-fn route_direct_write_tool_name(payload: &Value) -> Result<&'static str, String> {
-    let has_content = payload_has_non_null_field(payload, "content");
+fn route_direct_edit_tool_name(payload: &Value) -> Result<&'static str, String> {
+    if !payload_has_non_null_field(payload, "path") {
+        return Err("direct_edit_requires_path: expected `path` for direct edit".to_owned());
+    }
+
     let has_edits = payload_has_non_null_field(payload, "edits");
     let has_old_string = payload_has_non_null_field(payload, "old_string");
     let has_new_string = payload_has_non_null_field(payload, "new_string");
+    let has_content = payload_has_non_null_field(payload, "content");
     let legacy_exact_edit_mode = has_old_string || has_new_string;
-    let exact_edit_mode = has_edits || legacy_exact_edit_mode;
-    let create_mode = has_content;
-    let mode_count = count_true([create_mode, exact_edit_mode]);
+    let mode_count = count_true([has_edits, legacy_exact_edit_mode]);
+
+    if has_content {
+        return Err(
+            "direct_edit_ambiguous: `edit` only supports exact replacement mode; use `write` for whole-file content"
+                .to_owned(),
+        );
+    }
 
     if mode_count == 0 {
         return Err(
-            "direct_write_requires_one_mode: expected `path` plus `content`, `path` plus `edits`, or legacy `path` plus `old_string` and `new_string`"
+            "direct_edit_requires_one_mode: expected `path` plus `edits`, or legacy `path` plus `old_string` and `new_string`"
                 .to_owned(),
         );
     }
 
     if mode_count > 1 {
         return Err(
-            "direct_write_ambiguous: do not mix whole-file write fields with exact-edit fields"
+            "direct_edit_ambiguous: do not mix `edits` with legacy `old_string` / `new_string` fields"
                 .to_owned(),
         );
-    }
-
-    if !payload_has_non_null_field(payload, "path") {
-        return Err("direct_write_requires_path: expected `path` for direct write".to_owned());
-    }
-
-    if create_mode {
-        return Ok("file.write");
     }
 
     if has_edits {
@@ -231,12 +293,38 @@ fn route_direct_write_tool_name(payload: &Value) -> Result<&'static str, String>
 
     if !has_old_string || !has_new_string {
         return Err(
-            "direct_write_edit_requires_complete_legacy_fields: expected `edits`, or legacy `old_string` and `new_string` for exact-edit mode"
+            "direct_edit_requires_complete_legacy_fields: expected `edits`, or legacy `old_string` and `new_string` for exact-edit mode"
                 .to_owned(),
         );
     }
 
     Ok("file.edit")
+}
+
+fn route_direct_write_tool_name(payload: &Value) -> Result<&'static str, String> {
+    let has_content = payload_has_non_null_field(payload, "content");
+    let has_edits = payload_has_non_null_field(payload, "edits");
+    let has_old_string = payload_has_non_null_field(payload, "old_string");
+    let has_new_string = payload_has_non_null_field(payload, "new_string");
+    if !payload_has_non_null_field(payload, "path") {
+        return Err("direct_write_requires_path: expected `path` for direct write".to_owned());
+    }
+
+    if has_edits || has_old_string || has_new_string {
+        return Err(
+            "direct_write_exact_edit_moved: `write` only supports whole-file content; use `edit` for exact replacements"
+                .to_owned(),
+        );
+    }
+
+    if !has_content {
+        return Err(
+            "direct_write_requires_content: expected `path` plus `content` for whole-file write mode"
+                .to_owned(),
+        );
+    }
+
+    Ok("file.write")
 }
 
 pub(super) fn route_direct_web_tool_name(payload: &Value) -> Result<&'static str, String> {
@@ -710,9 +798,6 @@ fn route_hidden_skills_tool_name(payload: &Value) -> Result<&'static str, String
             "run" | "invoke" => Ok("external_skills.invoke"),
             "list" => Ok("external_skills.list"),
             "policy" => Ok("external_skills.policy"),
-            "fetch" => Ok("external_skills.fetch"),
-            "resolve" => Ok("external_skills.resolve"),
-            "remove" => Ok("external_skills.remove"),
             _ => Err(format!(
                 "hidden_skills_unknown_operation: unknown skills operation `{operation}`"
             )),
@@ -721,9 +806,6 @@ fn route_hidden_skills_tool_name(payload: &Value) -> Result<&'static str, String
 
     let has_query = payload_has_non_null_field(payload, "query");
     let has_sources = payload_has_non_null_field(payload, "sources");
-    let has_url = payload_has_non_null_field(payload, "url");
-    let has_reference = payload_has_non_null_field(payload, "reference");
-    let has_save_as = payload_has_non_null_field(payload, "save_as");
     let has_skill_id = payload_has_non_null_field(payload, "skill_id");
     let has_path = payload_has_non_null_field(payload, "path");
     let has_bundled_skill_id = payload_has_non_null_field(payload, "bundled_skill_id");
@@ -742,19 +824,6 @@ fn route_hidden_skills_tool_name(payload: &Value) -> Result<&'static str, String
 
     if has_path || has_bundled_skill_id || has_source_skill_id {
         return Ok("external_skills.install");
-    }
-
-    if has_url || has_save_as {
-        return Ok("external_skills.fetch");
-    }
-
-    if has_reference {
-        let fetch_by_reference = payload_has_non_null_field(payload, "approval_granted")
-            || payload_has_non_null_field(payload, "max_bytes");
-        if fetch_by_reference {
-            return Ok("external_skills.fetch");
-        }
-        return Ok("external_skills.resolve");
     }
 
     if has_query {
@@ -778,7 +847,7 @@ fn route_hidden_skills_tool_name(payload: &Value) -> Result<&'static str, String
     }
 
     Err(
-        "hidden_skills_requires_actionable_fields: expected search, inspect, install, fetch, resolve, policy, or list fields; add `operation` when the request is ambiguous"
+        "hidden_skills_requires_actionable_fields: expected search, inspect, install, run, or list fields; add `operation` when the request is ambiguous"
             .to_owned(),
     )
 }
@@ -852,9 +921,6 @@ pub(crate) fn hidden_operation_for_tool_name(raw: &str) -> Option<String> {
             "external_skills.invoke" => Some("run".to_owned()),
             "external_skills.list" => Some("list".to_owned()),
             "external_skills.policy" => Some("policy".to_owned()),
-            "external_skills.fetch" => Some("fetch".to_owned()),
-            "external_skills.resolve" => Some("resolve".to_owned()),
-            "external_skills.remove" => Some("remove".to_owned()),
             _ => None,
         },
         HIDDEN_CHANNEL_TOOL_NAME => canonical_name.strip_prefix("feishu.").map(str::to_owned),
@@ -926,14 +992,14 @@ mod tests {
     }
 
     #[test]
-    fn direct_exec_ignores_blank_aliases() {
-        let routed = route_direct_exec_tool_name(&json!({
+    fn direct_exec_rejects_blank_command_shell_alias() {
+        let error = route_direct_exec_tool_name(&json!({
             "command": "   ",
             "script": "echo hello"
         }))
-        .expect("blank command alias should be ignored");
+        .expect_err("blank command alias should not keep exec in shell mode");
 
-        assert_eq!(routed, BASH_EXEC_TOOL_NAME);
+        assert!(error.contains("direct_exec_shell_moved_to_bash"));
     }
 
     #[test]

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -95,7 +95,7 @@ fn tool_search_hides_bash_exec_when_governance_rules_failed_to_load() {
 
 #[cfg(feature = "tool-shell")]
 #[test]
-fn tool_search_routes_bash_capabilities_to_exec_when_runtime_is_available() {
+fn tool_search_routes_bash_capabilities_to_bash_when_runtime_is_available() {
     let root = unique_tool_temp_dir("loong-bash-tool-search-visible");
     std::fs::create_dir_all(&root).expect("create root dir");
 
@@ -114,17 +114,17 @@ fn tool_search_routes_bash_capabilities_to_exec_when_runtime_is_available() {
     .expect("tool search should succeed");
 
     let results = outcome.payload["results"].as_array().expect("results");
-    let exec_entry = results
+    let bash_entry = results
         .iter()
-        .find(|entry| entry["tool_id"] == "exec")
-        .expect("exec should absorb bash-oriented search queries");
+        .find(|entry| entry["tool_id"] == "bash")
+        .expect("bash should surface shell-oriented search queries");
 
-    assert!(exec_entry.get("lease").is_none());
+    assert!(bash_entry.get("lease").is_none());
 }
 
 #[cfg(feature = "tool-shell")]
 #[test]
-fn tool_search_exact_bash_query_surfaces_exec() {
+fn tool_search_exact_bash_query_surfaces_bash() {
     let root = unique_tool_temp_dir("loong-bash-tool-search-exact-query");
     std::fs::create_dir_all(&root).expect("create root dir");
 
@@ -144,8 +144,8 @@ fn tool_search_exact_bash_query_surfaces_exec() {
 
     let results = outcome.payload["results"].as_array().expect("results");
     assert!(
-        results.iter().any(|entry| entry["tool_id"] == "exec"),
-        "exact bash query should surface exec, got: {results:?}"
+        results.iter().any(|entry| entry["tool_id"] == "bash"),
+        "exact bash query should surface bash, got: {results:?}"
     );
 }
 
@@ -776,10 +776,24 @@ fn bash_exec_times_out_when_timeout_ms_is_small() {
 
 #[cfg(all(feature = "tool-shell", unix))]
 #[test]
-fn direct_exec_routes_script_mode_to_bash_exec() {
+fn direct_exec_rejects_script_mode() {
+    let error = route_direct_tool_name(
+        "exec",
+        &json!({
+            "script": "printf 'script-mode' | cat"
+        }),
+    )
+    .expect_err("script mode should be rejected for exec");
+
+    assert!(error.contains("direct_exec_shell_moved_to_bash"));
+}
+
+#[cfg(all(feature = "tool-shell", unix))]
+#[test]
+fn direct_bash_routes_script_mode_to_bash_exec() {
     assert_eq!(
         route_direct_tool_name(
-            "exec",
+            "bash",
             &json!({
                 "script": "printf 'script-mode' | cat"
             })

--- a/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
+++ b/crates/app/src/tools/tests/mod_tests_search_and_shell.rs
@@ -63,7 +63,7 @@ fn tool_search_includes_shell_exec_when_runtime_allowlist_is_empty() {
     let shell_entry = results
         .iter()
         .find(|entry| entry["tool_id"] == "exec")
-        .expect("direct exec should remain discoverable");
+        .expect("direct exec should remain discoverable for shell.exec refresh");
 
     assert!(shell_entry.get("lease").is_none());
 
@@ -787,7 +787,8 @@ fn tool_search_result_includes_compact_argument_hints() {
     let root = std::env::temp_dir().join(format!("loong-tool-search-hints-{}", std::process::id()));
     std::fs::create_dir_all(&root).expect("create fixture root");
 
-    let config = test_tool_runtime_config(root.clone());
+    let mut config = test_tool_runtime_config(root.clone());
+    config.bash_exec = ready_bash_exec_runtime_policy();
     let outcome = execute_tool_core_with_config(
         ToolCoreRequest {
             tool_name: "tool.search".to_owned(),
@@ -799,9 +800,9 @@ fn tool_search_result_includes_compact_argument_hints() {
 
     let results = outcome.payload["results"].as_array().expect("results");
     assert!(results.iter().any(|entry| {
-        let is_exec = entry["tool_id"] == "exec";
+        let is_bash = entry["tool_id"] == "bash";
         let argument_hint = entry["argument_hint"].as_str().unwrap_or_default();
-        is_exec && argument_hint.contains("command?:string")
+        is_bash && argument_hint.contains("command?:string")
     }));
 
     std::fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/tool_lease.rs
+++ b/crates/app/src/tools/tool_lease.rs
@@ -40,28 +40,25 @@ pub(crate) fn resolve_tool_invoke_request(
     }
 
     let routed_hidden_tool_name = super::route_hidden_discoverable_tool_name(tool_id, &arguments);
-    let tool_lease_id = match routed_hidden_tool_name {
-        Ok(_resolved_hidden_tool_name)
-            if matches!(
-                tool_id,
-                super::HIDDEN_AGENT_TOOL_NAME
-                    | super::HIDDEN_SKILLS_TOOL_NAME
-                    | super::HIDDEN_CHANNEL_TOOL_NAME
-            ) =>
-        {
-            tool_id
-        }
-        _ => tool_id,
-    };
-    tool_lease_authority::validate_tool_lease(tool_lease_id, lease, payload)?;
-
-    if matches!(
+    let grouped_hidden_surface = matches!(
         tool_id,
         super::HIDDEN_AGENT_TOOL_NAME
             | super::HIDDEN_SKILLS_TOOL_NAME
             | super::HIDDEN_CHANNEL_TOOL_NAME
-    ) && let Some(arguments_object) = arguments.as_object_mut()
+    );
+    let tool_lease_id = match routed_hidden_tool_name {
+        Ok(_resolved_hidden_tool_name) if grouped_hidden_surface => tool_id,
+        _ => tool_id,
+    };
+    tool_lease_authority::validate_tool_lease(tool_lease_id, lease, payload)?;
+
+    if let Err(route_error) = &routed_hidden_tool_name
+        && grouped_hidden_surface
     {
+        return Err(route_error.clone());
+    }
+
+    if grouped_hidden_surface && let Some(arguments_object) = arguments.as_object_mut() {
         arguments_object.remove("operation");
     }
 

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -90,7 +90,12 @@ pub(super) fn execute_tool_search_tool_with_config(
                 )
             })
             .collect::<Vec<_>>();
-    let searchable_entries = collapse_hidden_surface_search_entries(exact_match_entries.clone());
+    let collapsible_surface_ids =
+        super::provider_visible_collapsible_hidden_surface_ids(config, &visible_tool_view);
+    let searchable_entries = collapse_hidden_surface_search_entries(
+        exact_match_entries.clone(),
+        &collapsible_surface_ids,
+    );
     let exact_match_entry = exact_tool_id.as_ref().and_then(|exact_tool_id| {
         let direct_tool_id = super::direct_tool_name_for_hidden_tool(exact_tool_id);
         let direct_tool_id = direct_tool_id.map(str::to_owned);
@@ -661,6 +666,7 @@ fn build_schema_preview(
 
 pub(super) fn collapse_hidden_surface_search_entries(
     entries: Vec<SearchableToolEntry>,
+    collapsible_surface_ids: &BTreeSet<String>,
 ) -> Vec<SearchableToolEntry> {
     let mut grouped_members = BTreeMap::<String, Vec<SearchableToolEntry>>::new();
     let mut passthrough_entries = Vec::new();
@@ -670,10 +676,7 @@ pub(super) fn collapse_hidden_surface_search_entries(
             passthrough_entries.push(entry);
             continue;
         };
-        // Collapse grouped hidden lanes into one high-signal card per surface.
-        // `channel` stays separate from `agent`/`skills`, but it is still one
-        // addon surface instead of a long tail of individual ids.
-        let collapse_surface = matches!(surface_id, "agent" | "skills" | "channel");
+        let collapse_surface = collapsible_surface_ids.contains(surface_id);
         if !collapse_surface {
             passthrough_entries.push(entry);
             continue;

--- a/crates/app/src/tools/tool_surface.rs
+++ b/crates/app/src/tools/tool_surface.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use super::ToolView;
 
 pub(crate) const DIRECT_READ_TOOL_NAME: &str = "read";
+pub(crate) const DIRECT_EDIT_TOOL_NAME: &str = "edit";
 pub(crate) const DIRECT_WRITE_TOOL_NAME: &str = "write";
+pub(crate) const DIRECT_BASH_TOOL_NAME: &str = "bash";
 pub(crate) const DIRECT_EXEC_TOOL_NAME: &str = "exec";
 pub(crate) const DIRECT_WEB_TOOL_NAME: &str = "web";
 pub(crate) const DIRECT_BROWSER_TOOL_NAME: &str = "browser";
@@ -139,14 +141,20 @@ const READ_GUIDELINES: &[&str] = &[
     "Use read for repo inspection before shelling out.",
     "Use `offset` and `limit` to page through large files instead of reading everything at once.",
 ];
-const WRITE_GUIDELINES: &[&str] = &[
-    "Use write for new files or whole-file rewrites.",
-    "For surgical changes, use exact edit mode with `edits`, or legacy `old_string` and `new_string` when needed.",
+const WRITE_GUIDELINES: &[&str] = &["Use write for new files or whole-file rewrites."];
+const EDIT_GUIDELINES: &[&str] = &[
+    "Use edit for precise changes to existing files.",
+    "When one file needs multiple disjoint changes, prefer one edit call with multiple exact edit blocks.",
+    "Prefer edit for surgical changes to existing files instead of whole-file rewrites.",
 ];
 const EXEC_GUIDELINES: &[&str] = &[
-    "Use exec for normal command-line work.",
-    "Use `script` when the task needs shell syntax, pipelines, redirects, or multiple commands.",
+    "Use exec for direct program execution with explicit argv-style arguments.",
+    "Prefer bash when the task depends on shell syntax, pipelines, redirects, builtins, or multi-line shell scripts.",
     "If exec output is truncated, prefer `details.handoff.recommended_payload` with `read`; if needed, inspect `details.handoff.recipes.*` for alternate first-page / last-page / wider-byte windows.",
+];
+const BASH_GUIDELINES: &[&str] = &[
+    "Use bash for shell commands, shell builtins, pipelines, redirects, and multi-line shell workflows.",
+    "Prefer bash over exec when the task is naturally expressed as a shell command string.",
 ];
 const WEB_GUIDELINES: &[&str] = &[
     "Use web for public docs, APIs, and references.",
@@ -189,19 +197,27 @@ const READ_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
     ("case_sensitive", "boolean"),
     ("include_directories", "boolean"),
 ];
-const WRITE_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
+const EDIT_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
     ("path", "string"),
-    ("content", "string"),
-    ("create_dirs", "boolean"),
-    ("overwrite", "boolean"),
     ("edits", "array"),
     ("old_string", "string"),
     ("new_string", "string"),
     ("replace_all", "boolean"),
 ];
-const EXEC_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
+const WRITE_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
+    ("path", "string"),
+    ("content", "string"),
+    ("create_dirs", "boolean"),
+    ("overwrite", "boolean"),
+];
+const BASH_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
     ("command", "string"),
     ("script", "string"),
+    ("timeout_ms", "integer"),
+    ("cwd", "string"),
+];
+const EXEC_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
+    ("command", "string"),
     ("args", "array"),
     ("timeout_ms", "integer"),
     ("cwd", "string"),
@@ -235,8 +251,10 @@ const MEMORY_DIRECT_PARAMETER_TYPES: &[(&str, &str)] = &[
 ];
 
 const READ_COVERED_TOOL_NAMES: &[&str] = &["file.read", "glob.search", "content.search"];
-const WRITE_COVERED_TOOL_NAMES: &[&str] = &["file.write", "file.edit"];
-const EXEC_COVERED_TOOL_NAMES: &[&str] = &["shell.exec", "bash.exec"];
+const EDIT_COVERED_TOOL_NAMES: &[&str] = &["file.edit"];
+const WRITE_COVERED_TOOL_NAMES: &[&str] = &["file.write"];
+const BASH_COVERED_TOOL_NAMES: &[&str] = &["bash.exec"];
+const EXEC_COVERED_TOOL_NAMES: &[&str] = &["shell.exec"];
 const WEB_COVERED_TOOL_NAMES: &[&str] = &["web.fetch", "web.search", "http.request"];
 const BROWSER_COVERED_TOOL_NAMES: &[&str] = &["browser.open", "browser.extract", "browser.click"];
 const MEMORY_COVERED_TOOL_NAMES: &[&str] = &["memory_search", "memory_get"];
@@ -248,19 +266,33 @@ const READ_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadat
     required_fields: &[],
     tags: &["surface", "read", "file", "search"],
 };
-const WRITE_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
-    argument_hint: "path:string,content?:string,create_dirs?:boolean,overwrite?:boolean,edits?:array,old_string?:string,new_string?:string,replace_all?:boolean",
-    search_hint: "create a file or apply one or more exact text edits through one direct tool",
-    parameter_types: WRITE_DIRECT_PARAMETER_TYPES,
+const EDIT_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
+    argument_hint: "path:string,edits?:array,old_string?:string,new_string?:string,replace_all?:boolean",
+    search_hint: "edit an existing workspace file with exact replacement blocks through one direct tool",
+    parameter_types: EDIT_DIRECT_PARAMETER_TYPES,
     required_fields: &["path"],
-    tags: &["surface", "write", "file", "edit"],
+    tags: &["surface", "edit", "file", "replace"],
+};
+const WRITE_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
+    argument_hint: "path:string,content:string,create_dirs?:boolean,overwrite?:boolean",
+    search_hint: "create a file or rewrite one file through one direct tool",
+    parameter_types: WRITE_DIRECT_PARAMETER_TYPES,
+    required_fields: &["path", "content"],
+    tags: &["surface", "write", "file", "create"],
+};
+const BASH_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
+    argument_hint: "command?:string,script?:string,timeout_ms?:integer,cwd?:string",
+    search_hint: "run shell commands, pipelines, redirects, or shell scripts through one direct tool",
+    parameter_types: BASH_DIRECT_PARAMETER_TYPES,
+    required_fields: &[],
+    tags: &["surface", "bash", "shell", "script"],
 };
 const EXEC_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
-    argument_hint: "command?:string,script?:string,args?:string[],timeout_ms?:integer,cwd?:string",
-    search_hint: "run one command, or execute a raw shell or bash script, through one direct tool",
+    argument_hint: "command:string,args?:string[],timeout_ms?:integer,cwd?:string",
+    search_hint: "execute a program directly with optional argv arguments through one direct tool",
     parameter_types: EXEC_DIRECT_PARAMETER_TYPES,
-    required_fields: &[],
-    tags: &["surface", "exec", "shell", "command"],
+    required_fields: &["command"],
+    tags: &["surface", "exec", "process", "argv"],
 };
 const WEB_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
     argument_hint: "url?:string,mode?:string,max_bytes?:integer,query?:string,provider?:string,max_results?:integer",
@@ -296,10 +328,22 @@ const READ_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
     hidden_search_argument_hint: None,
 };
 
+const EDIT_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
+    id: "edit",
+    prompt_snippet: "apply exact text edits to existing files.",
+    prompt_guidance: "Use edit for surgical changes to files you have already inspected.",
+    prompt_guidelines: EDIT_GUIDELINES,
+    direct_tool_name: Some(DIRECT_EDIT_TOOL_NAME),
+    covered_tool_names: EDIT_COVERED_TOOL_NAMES,
+    direct_metadata: Some(EDIT_DIRECT_METADATA),
+    hidden_search_summary: None,
+    hidden_search_argument_hint: None,
+};
+
 const WRITE_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
     id: "write",
-    prompt_snippet: "create files or apply exact text edits.",
-    prompt_guidance: "Use write for normal patching and file creation.",
+    prompt_snippet: "create files or replace whole-file contents.",
+    prompt_guidance: "Use write for new files and full rewrites.",
     prompt_guidelines: WRITE_GUIDELINES,
     direct_tool_name: Some(DIRECT_WRITE_TOOL_NAME),
     covered_tool_names: WRITE_COVERED_TOOL_NAMES,
@@ -308,10 +352,22 @@ const WRITE_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
     hidden_search_argument_hint: None,
 };
 
+const BASH_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
+    id: "bash",
+    prompt_snippet: "run shell commands or shell scripts in the workspace.",
+    prompt_guidance: "Use bash for shell-native command strings and shell workflows.",
+    prompt_guidelines: BASH_GUIDELINES,
+    direct_tool_name: Some(DIRECT_BASH_TOOL_NAME),
+    covered_tool_names: BASH_COVERED_TOOL_NAMES,
+    direct_metadata: Some(BASH_DIRECT_METADATA),
+    hidden_search_summary: None,
+    hidden_search_argument_hint: None,
+};
+
 const EXEC_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
     id: "exec",
-    prompt_snippet: "run commands or raw shell scripts in the workspace.",
-    prompt_guidance: "Use exec for normal command-line work, including simple scripts.",
+    prompt_snippet: "execute a program directly with argv-style arguments.",
+    prompt_guidance: "Use exec for direct program execution rather than shell syntax.",
     prompt_guidelines: EXEC_GUIDELINES,
     direct_tool_name: Some(DIRECT_EXEC_TOOL_NAME),
     covered_tool_names: EXEC_COVERED_TOOL_NAMES,
@@ -384,10 +440,10 @@ const SKILLS_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
     covered_tool_names: &[],
     direct_metadata: None,
     hidden_search_summary: Some(
-        "Search, inspect, install, fetch, run, remove, or manage external skills through one hidden capability tool.",
+        "Search, inspect, install, or run external skills through one hidden capability tool.",
     ),
     hidden_search_argument_hint: Some(
-        "operation?:string,query?:string,skill_id?:string,reference?:string,url?:string,path?:string,limit?:integer",
+        "operation?:string,query?:string,skill_id?:string,path?:string,bundled_skill_id?:string,source_skill_id?:string,limit?:integer",
     ),
 };
 
@@ -411,7 +467,9 @@ const CHANNEL_SURFACE: ToolSurfaceDescriptor = ToolSurfaceDescriptor {
 
 const ALL_TOOL_SURFACES: &[ToolSurfaceDescriptor] = &[
     READ_SURFACE,
+    EDIT_SURFACE,
     WRITE_SURFACE,
+    BASH_SURFACE,
     EXEC_SURFACE,
     WEB_SURFACE,
     BROWSER_SURFACE,
@@ -540,17 +598,12 @@ pub(crate) fn tool_surface_for_name(tool_name: &str) -> Option<&'static ToolSurf
         &AGENT_SURFACE
     } else if tool_name == "skills"
         || tool_name.starts_with("external_skills.")
-        || matches_surface_name(tool_name, "external_skills.fetch")
-        || matches_surface_name(tool_name, "external_skills.resolve")
         || matches_surface_name(tool_name, "external_skills.search")
-        || matches_surface_name(tool_name, "external_skills.recommend")
-        || matches_surface_name(tool_name, "external_skills.source_search")
+        || matches_surface_name(tool_name, "external_skills.policy")
         || matches_surface_name(tool_name, "external_skills.inspect")
         || matches_surface_name(tool_name, "external_skills.install")
         || matches_surface_name(tool_name, "external_skills.invoke")
         || matches_surface_name(tool_name, "external_skills.list")
-        || matches_surface_name(tool_name, "external_skills.policy")
-        || matches_surface_name(tool_name, "external_skills.remove")
     {
         &SKILLS_SURFACE
     } else if tool_name == "channel"
@@ -677,7 +730,15 @@ pub(crate) fn hidden_facade_tool_name_for_hidden_tool(tool_name: &str) -> Option
         return Some("agent");
     }
 
-    if tool_name.starts_with("external_skills.") {
+    if matches!(
+        tool_name,
+        "external_skills.search"
+            | "external_skills.policy"
+            | "external_skills.inspect"
+            | "external_skills.install"
+            | "external_skills.invoke"
+            | "external_skills.list"
+    ) {
         return Some("skills");
     }
 
@@ -815,6 +876,7 @@ mod tests {
             "file.read",
             "file.write",
             "file.edit",
+            "bash.exec",
             "shell.exec",
             "web.fetch",
             "memory_search",
@@ -826,7 +888,10 @@ mod tests {
             .map(|state| state.surface_id.as_str())
             .collect();
 
-        assert_eq!(state_ids, vec!["read", "write", "exec", "web", "memory"]);
+        assert_eq!(
+            state_ids,
+            vec!["read", "edit", "write", "bash", "exec", "web", "memory"]
+        );
     }
 
     #[test]
@@ -839,8 +904,8 @@ mod tests {
         ]);
 
         assert_eq!(states.len(), 2);
-        assert_eq!(states[0].surface_id, "exec");
-        assert_eq!(states[0].tool_ids, vec!["exec"]);
+        assert_eq!(states[0].surface_id, "bash");
+        assert_eq!(states[0].tool_ids, vec!["bash"]);
         assert_eq!(states[1].surface_id, "agent");
         assert_eq!(states[1].tool_ids, vec!["agent"]);
     }
@@ -848,6 +913,7 @@ mod tests {
     #[test]
     fn direct_surface_coverage_only_applies_to_common_hidden_tools() {
         let view = ToolView::from_tool_names([
+            "bash.exec",
             "shell.exec",
             "browser.open",
             "browser.companion.snapshot",
@@ -859,15 +925,15 @@ mod tests {
             &view
         ));
         assert!(hidden_tool_is_covered_by_visible_direct_tool(
+            "bash.exec",
+            &view
+        ));
+        assert!(hidden_tool_is_covered_by_visible_direct_tool(
             "browser.open",
             &view
         ));
         assert!(hidden_tool_is_covered_by_visible_direct_tool(
             "browser.companion.snapshot",
-            &view
-        ));
-        assert!(hidden_tool_is_covered_by_visible_direct_tool(
-            "bash.exec",
             &view
         ));
         assert!(hidden_tool_is_covered_by_visible_direct_tool(
@@ -880,10 +946,22 @@ mod tests {
     fn direct_surface_metadata_stays_definition_first() {
         let exec_parameter_types =
             direct_tool_parameter_types(DIRECT_EXEC_TOOL_NAME).expect("exec parameter types");
-        assert!(exec_parameter_types.contains(&("script", "string")));
+        assert!(exec_parameter_types.contains(&("args", "array")));
+        assert!(!exec_parameter_types.contains(&("script", "string")));
+        let bash_parameter_types =
+            direct_tool_parameter_types(DIRECT_BASH_TOOL_NAME).expect("bash parameter types");
+        assert!(bash_parameter_types.contains(&("script", "string")));
+        assert!(
+            direct_tool_required_fields(DIRECT_BASH_TOOL_NAME)
+                .is_some_and(|fields| fields.is_empty())
+        );
+        assert_eq!(
+            direct_tool_required_fields(DIRECT_EDIT_TOOL_NAME),
+            Some(["path"].as_slice())
+        );
         assert_eq!(
             direct_tool_required_fields(DIRECT_WRITE_TOOL_NAME),
-            Some(["path"].as_slice())
+            Some(["path", "content"].as_slice())
         );
         assert_eq!(
             direct_tool_tags(DIRECT_WEB_TOOL_NAME),
@@ -905,6 +983,11 @@ mod tests {
                 .contains("browser sessions")
         );
         assert!(
+            direct_tool_search_hint(DIRECT_BASH_TOOL_NAME)
+                .expect("bash search hint")
+                .contains("shell commands")
+        );
+        assert!(
             direct_tool_parameter_types(DIRECT_BROWSER_TOOL_NAME)
                 .expect("browser parameter types")
                 .contains(&("text", "string"))
@@ -920,7 +1003,7 @@ mod tests {
         );
         assert_eq!(
             discovery_tool_name_for_tool_name("bash.exec"),
-            DIRECT_EXEC_TOOL_NAME
+            DIRECT_BASH_TOOL_NAME
         );
         assert_eq!(
             discovery_tool_name_for_tool_name("browser.companion.session.start"),
@@ -943,6 +1026,7 @@ mod tests {
     #[test]
     fn surface_visibility_checks_support_grouped_hidden_and_direct_paths() {
         let view = ToolView::from_tool_names([
+            "bash.exec",
             "file.read",
             "shell.exec",
             "browser.companion.snapshot",
@@ -951,6 +1035,7 @@ mod tests {
         ]);
 
         assert!(tool_surface_visible_in_view("read", &view));
+        assert!(tool_surface_visible_in_view("bash", &view));
         assert!(tool_surface_visible_in_view("exec", &view));
         assert!(tool_surface_visible_in_view("browser", &view));
         assert!(tool_surface_visible_in_view("agent", &view));

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -120,7 +120,7 @@ fn expected_tool_request_error_classifies_validation_failures() {
         "tool `tool.invoke` payload._loong is reserved for trusted internal tool context; retry without that field"
     ));
     assert!(super::is_expected_tool_request_error(
-        "direct_exec_ambiguous: provide either `command` or `script`, not both"
+        "direct_exec_shell_moved_to_bash: `exec` only supports direct program execution; use `bash` for shell command strings or scripts"
     ));
     assert!(super::is_expected_tool_request_error(
         "tool_surface_unavailable: `browser` cannot route to `managed browser actions` in this runtime; read-only browser inspection is still available"
@@ -221,7 +221,9 @@ fn capability_snapshot_is_deterministic() {
     assert!(snapshot.starts_with("[tool_discovery_runtime]"));
     assert!(snapshot.contains("Available tools:"));
     assert!(snapshot.contains("- read:"));
+    assert!(snapshot.contains("- edit:"));
     assert!(snapshot.contains("- write:"));
+    assert!(snapshot.contains("- bash:"));
     assert!(snapshot.contains("- exec:"));
     assert!(snapshot.contains("Available tools:"));
     assert!(snapshot.contains(
@@ -233,10 +235,12 @@ fn capability_snapshot_is_deterministic() {
     assert!(snapshot.contains("Guidelines:"));
     assert!(snapshot.contains("Keep tool.search queries short and capability-focused."));
     assert!(snapshot.contains("Use read for repo inspection before shelling out."));
+    assert!(snapshot.contains("Use edit for precise changes to existing files."));
+    assert!(snapshot.contains("Use bash for shell commands"));
     assert!(snapshot.contains(
             "Use `offset` and `limit` to page through large files instead of reading everything at once."
         ));
-    assert!(snapshot.contains("Use exec for normal command-line work."));
+    assert!(snapshot.contains("Use exec for direct program execution"));
     assert!(snapshot.contains(
             "Use agent only for Loong's own approvals, sessions, delegation, provider routing, or config work."
         ));
@@ -311,7 +315,9 @@ fn capability_snapshot_only_lists_visible_direct_and_gateway_tools() {
     let snapshot = capability_snapshot();
     assert!(snapshot.contains("Available tools:"));
     assert!(snapshot.contains("- read:"));
+    assert!(snapshot.contains("- edit:"));
     assert!(snapshot.contains("- write:"));
+    assert!(snapshot.contains("- bash:"));
     assert!(snapshot.contains("- exec:"));
     assert!(snapshot.contains("Available tools:"));
     assert!(snapshot.contains(
@@ -322,6 +328,8 @@ fn capability_snapshot_only_lists_visible_direct_and_gateway_tools() {
     assert!(snapshot.contains("Additional specialized tools available through tool.search:"));
     assert!(snapshot.contains("Guidelines:"));
     assert!(snapshot.contains("Keep tool.search queries short and capability-focused."));
+    assert!(snapshot.contains("Use edit for precise changes to existing files."));
+    assert!(snapshot.contains("Use bash for shell commands"));
     assert!(snapshot.contains("Use write for new files or whole-file rewrites."));
     assert!(!snapshot.contains("claw.migrate"));
     assert!(!snapshot.contains("external_skills.fetch"));
@@ -348,29 +356,7 @@ fn tool_registry_returns_runtime_discoverable_tools_for_default_config() {
         .iter()
         .map(|entry| entry.name.as_str())
         .collect::<BTreeSet<_>>();
-    let expected = BTreeSet::from([
-        "approval_request_resolve",
-        "approval_request_status",
-        "approval_requests_list",
-        "config.import",
-        "delegate",
-        "delegate_async",
-        "external_skills.policy",
-        "provider.switch",
-        "session_archive",
-        "session_cancel",
-        "session_continue",
-        "session_events",
-        "session_recover",
-        "session_search",
-        "session_status",
-        "session_tool_policy_clear",
-        "session_tool_policy_set",
-        "session_tool_policy_status",
-        "session_wait",
-        "sessions_history",
-        "sessions_list",
-    ]);
+    let expected = BTreeSet::from(["agent", "skills"]);
     assert_eq!(names, expected);
 }
 
@@ -388,29 +374,7 @@ fn tool_registry_returns_runtime_discoverable_tools_for_default_config_no_websea
         .iter()
         .map(|entry| entry.name.as_str())
         .collect::<BTreeSet<_>>();
-    let expected = BTreeSet::from([
-        "approval_request_resolve",
-        "approval_request_status",
-        "approval_requests_list",
-        "config.import",
-        "delegate",
-        "delegate_async",
-        "external_skills.policy",
-        "provider.switch",
-        "session_archive",
-        "session_cancel",
-        "session_continue",
-        "session_events",
-        "session_recover",
-        "session_search",
-        "session_status",
-        "session_tool_policy_clear",
-        "session_tool_policy_set",
-        "session_tool_policy_status",
-        "session_wait",
-        "sessions_history",
-        "sessions_list",
-    ]);
+    let expected = BTreeSet::from(["agent", "skills"]);
 
     assert_eq!(names, expected);
 }
@@ -430,12 +394,30 @@ fn tool_registry_re_exposes_session_mutation_tools_when_runtime_policy_allows_th
         .map(|entry| entry.name.clone())
         .collect::<Vec<_>>();
 
-    assert!(names.contains(&"session_archive".to_owned()));
-    assert!(names.contains(&"session_cancel".to_owned()));
-    assert!(names.contains(&"session_continue".to_owned()));
-    assert!(names.contains(&"session_recover".to_owned()));
-    assert!(names.contains(&"session_tool_policy_set".to_owned()));
-    assert!(names.contains(&"session_tool_policy_clear".to_owned()));
+    assert_eq!(names, vec!["agent".to_owned(), "skills".to_owned()]);
+}
+
+#[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+#[test]
+fn tool_registry_groups_external_skills_behind_skills_surface_when_runtime_enabled() {
+    let root = unique_tool_temp_dir("loong-tool-registry-skills-surface");
+    std::fs::create_dir_all(&root).expect("create fixture root");
+
+    let config = test_tool_runtime_config(root.clone());
+    let entries = tool_registry_with_config(Some(&config));
+    let names = entries
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert!(names.contains("skills"));
+    assert!(!names.contains("external_skills.search"));
+    assert!(!names.contains("external_skills.inspect"));
+    assert!(!names.contains("external_skills.install"));
+    assert!(!names.contains("external_skills.invoke"));
+    assert!(!names.contains("external_skills.list"));
+
+    std::fs::remove_dir_all(&root).ok();
 }
 
 #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
@@ -695,6 +677,7 @@ fn provider_tool_definitions_are_stable_and_cover_direct_surface() {
     let defs = provider_tool_definitions_with_config(Some(&config));
     let expected_names = vec![
         "browser",
+        "edit",
         "exec",
         "read",
         "tool_invoke",
@@ -795,9 +778,33 @@ fn provider_tool_definitions_are_stable_and_cover_direct_surface() {
     );
 }
 
+#[cfg(all(
+    feature = "tool-file",
+    feature = "tool-shell",
+    feature = "memory-sqlite"
+))]
+#[test]
+fn provider_tool_definitions_include_bash_when_runtime_is_available() {
+    let config = runtime_config::ToolRuntimeConfig {
+        bash_exec: ready_bash_exec_runtime_policy(),
+        ..runtime_config::ToolRuntimeConfig::default()
+    };
+
+    let defs = provider_tool_definitions_with_config(Some(&config));
+    let names: Vec<&str> = defs
+        .iter()
+        .filter_map(|item| item.get("function"))
+        .filter_map(|function| function.get("name"))
+        .filter_map(Value::as_str)
+        .collect();
+
+    assert!(names.contains(&"bash"));
+}
+
 #[test]
 fn provider_exposed_tool_gate_covers_direct_and_gateway_tools() {
     assert!(is_provider_exposed_tool_name("read"));
+    assert!(is_provider_exposed_tool_name("edit"));
     assert!(is_provider_exposed_tool_name("write"));
     assert!(is_provider_exposed_tool_name("exec"));
     assert!(is_provider_exposed_tool_name("tool.search"));
@@ -911,35 +918,35 @@ fn file_write_catalog_exposes_overwrite_flag() {
 fn file_edit_catalog_exposes_exact_edit_blocks() {
     let catalog = tool_catalog();
     let direct_descriptor = catalog
-        .descriptor("write")
-        .expect("write should be in the catalog");
+        .descriptor("edit")
+        .expect("edit should be in the catalog");
     let direct_definition = direct_descriptor.provider_definition();
     let direct_properties = direct_definition["function"]["parameters"]["properties"]
         .as_object()
-        .expect("write parameters");
+        .expect("edit parameters");
     let direct_any_of = direct_definition["function"]["parameters"]["anyOf"]
         .as_array()
-        .expect("write anyOf");
+        .expect("edit anyOf");
 
     assert!(
         direct_properties.contains_key("edits"),
-        "write schema should expose exact edit blocks"
+        "edit schema should expose exact edit blocks"
     );
     assert!(
         direct_descriptor.argument_hint().contains("edits?:array"),
-        "write argument hint should expose edits"
+        "edit argument hint should expose edits"
     );
     assert!(
         direct_descriptor
             .parameter_types()
             .contains(&("edits", "array")),
-        "write parameter types should expose edits"
+        "edit parameter types should expose edits"
     );
     assert!(
         direct_any_of
             .iter()
             .any(|branch| branch["required"] == json!(["edits"])),
-        "write anyOf should include edits mode"
+        "edit anyOf should include edits mode"
     );
 
     let file_edit_descriptor = catalog
@@ -1674,7 +1681,7 @@ fn tool_search_matches_prompt_style_queries_across_tool_surfaces() {
 
     let config = test_tool_runtime_config(root.clone());
     let cases = vec![
-        ("edit file", "write"),
+        ("edit file", "edit"),
         ("read repo file", "read"),
         ("search memory notes", "memory"),
         ("search the web", "web"),
@@ -1758,14 +1765,14 @@ fn tool_search_uses_coarse_listing_fallback_when_query_is_missing() {
 
 #[cfg(feature = "tool-file")]
 #[test]
-fn direct_write_routes_exact_edit_blocks_to_file_edit() {
+fn direct_write_rejects_exact_edit_blocks() {
     let root = unique_tool_temp_dir("loongclaw-direct-write-edit-blocks");
     std::fs::create_dir_all(&root).expect("create fixture root");
     let target = root.join("notes.txt");
     std::fs::write(&target, "alpha\nbeta\ngamma\n").expect("seed target file");
 
     let config = test_tool_runtime_config(root.clone());
-    let outcome = execute_tool_core_with_config(
+    let error = execute_tool_core_with_config(
         ToolCoreRequest {
             tool_name: "write".to_owned(),
             payload: json!({
@@ -1778,7 +1785,39 @@ fn direct_write_routes_exact_edit_blocks_to_file_edit() {
         },
         &config,
     )
-    .expect("direct write edit mode should succeed");
+    .expect_err("direct write should reject exact-edit payloads");
+
+    assert!(
+        error.contains("direct_write_exact_edit_moved"),
+        "error={error}"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn direct_edit_routes_exact_edit_blocks_to_file_edit() {
+    let root = unique_tool_temp_dir("loongclaw-direct-edit-edit-blocks");
+    std::fs::create_dir_all(&root).expect("create fixture root");
+    let target = root.join("notes.txt");
+    std::fs::write(&target, "alpha\nbeta\ngamma\n").expect("seed target file");
+
+    let config = test_tool_runtime_config(root.clone());
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "edit".to_owned(),
+            payload: json!({
+                "path": "notes.txt",
+                "edits": [
+                    {"old_text": "alpha", "new_text": "ALPHA"},
+                    {"old_text": "gamma", "new_text": "GAMMA"}
+                ]
+            }),
+        },
+        &config,
+    )
+    .expect("direct edit mode should succeed");
 
     assert_eq!(outcome.status, "ok");
     assert_eq!(outcome.payload["edit_blocks_applied"], 2);
@@ -2340,7 +2379,7 @@ fn runtime_discoverable_tool_entries_intersect_injected_view_with_runtime_surfac
     config.sessions_enabled = false;
 
     let injected = ToolView::from_tool_names(["sessions_list", "config.import"]);
-    let names = runtime_discoverable_tool_entries(&config, Some(&injected))
+    let names = runtime_discoverable_tool_entries(&config, Some(&injected), false)
         .into_iter()
         .map(|entry| entry.canonical_name)
         .collect::<Vec<_>>();
@@ -3068,19 +3107,7 @@ fn tool_registry_with_config_includes_feishu_tools_when_runtime_configured() {
         .map(|entry| entry.name.clone())
         .collect::<Vec<_>>();
 
-    assert!(names.contains(&"feishu.whoami".to_owned()));
-    assert!(names.contains(&"feishu.doc.create".to_owned()));
-    assert!(names.contains(&"feishu.doc.append".to_owned()));
-    assert!(names.contains(&"feishu.doc.read".to_owned()));
-    assert!(names.contains(&"feishu.messages.history".to_owned()));
-    assert!(names.contains(&"feishu.messages.get".to_owned()));
-    assert!(names.contains(&"feishu.messages.resource.get".to_owned()));
-    assert!(names.contains(&"feishu.messages.search".to_owned()));
-    assert!(names.contains(&"feishu.messages.send".to_owned()));
-    assert!(names.contains(&"feishu.messages.reply".to_owned()));
-    assert!(names.contains(&"feishu.card.update".to_owned()));
-    assert!(names.contains(&"feishu.calendar.list".to_owned()));
-    assert!(names.contains(&"feishu.calendar.freebusy".to_owned()));
+    assert!(names.contains(&"channel".to_owned()));
 }
 
 #[cfg(feature = "feishu-integration")]
@@ -3106,13 +3133,14 @@ fn provider_tool_definitions_with_config_keeps_direct_surface_when_feishu_runtim
         .collect::<Vec<_>>();
 
     assert!(names.contains(&"browser"));
+    assert!(names.contains(&"edit"));
     assert!(names.contains(&"exec"));
     assert!(names.contains(&"read"));
     assert!(names.contains(&"tool_invoke"));
     assert!(names.contains(&"tool_search"));
     assert!(names.contains(&"web"));
     assert!(names.contains(&"write"));
-    assert_eq!(names.len(), 7);
+    assert_eq!(names.len(), 8);
 }
 
 #[cfg(feature = "feishu-integration")]

--- a/crates/app/tests/conversation_integration.rs
+++ b/crates/app/tests/conversation_integration.rs
@@ -6,6 +6,15 @@ use loong_app::tools::runtime_config::ToolRuntimeConfig;
 use loong_contracts::Capability;
 use serde_json::json;
 
+fn shell_exec_capabilities() -> BTreeSet<Capability> {
+    BTreeSet::from([
+        Capability::InvokeTool,
+        Capability::FilesystemRead,
+        Capability::FilesystemWrite,
+        Capability::NetworkEgress,
+    ])
+}
+
 #[test]
 fn fake_provider_builder_text_only() {
     let turn = FakeProviderBuilder::new().with_text("hello world").build();
@@ -138,11 +147,7 @@ async fn integ_file_write_then_read_round_trip() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn integ_shell_exec_echo() {
     let harness = TurnTestHarness::with_tool_config(
-        BTreeSet::from([
-            Capability::InvokeTool,
-            Capability::FilesystemRead,
-            Capability::FilesystemWrite,
-        ]),
+        shell_exec_capabilities(),
         ToolRuntimeConfig {
             shell_allow: BTreeSet::from(["echo".to_owned()]),
             ..ToolRuntimeConfig::default()
@@ -169,7 +174,7 @@ async fn integ_shell_exec_echo() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn integ_shell_exec_blocked_command() {
     let harness = TurnTestHarness::with_tool_config(
-        BTreeSet::from([Capability::InvokeTool]),
+        shell_exec_capabilities(),
         ToolRuntimeConfig {
             shell_deny: BTreeSet::from(["echo".to_owned()]),
             ..ToolRuntimeConfig::default()
@@ -242,11 +247,7 @@ async fn integ_missing_capability_denies_tool() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn integ_audit_captures_tool_plane_invocation() {
     let harness = TurnTestHarness::with_tool_config(
-        BTreeSet::from([
-            Capability::InvokeTool,
-            Capability::FilesystemRead,
-            Capability::FilesystemWrite,
-        ]),
+        shell_exec_capabilities(),
         ToolRuntimeConfig {
             shell_allow: BTreeSet::from(["echo".to_owned()]),
             ..ToolRuntimeConfig::default()

--- a/docs/design-docs/tool-surface-exposure.md
+++ b/docs/design-docs/tool-surface-exposure.md
@@ -51,7 +51,9 @@ They must be short, high-prior, and assistant-first.
 Current direct tool vocabulary:
 
 - `read`
+- `edit`
 - `write`
+- `bash`
 - `exec`
 - `web`
 - `browser`
@@ -66,11 +68,12 @@ Examples:
 - `read { path, offset, limit }` -> `file.read`
 - `read { query }` -> `content.search`
 - `read { pattern }` -> `glob.search`
+- `edit { path, edits }` -> `file.edit`
+- `edit { path, old_string, new_string }` -> `file.edit` (legacy exact-edit mode)
 - `write { path, content }` -> `file.write`
-- `write { path, edits }` -> `file.edit`
-- `write { path, old_string, new_string }` -> `file.edit` (legacy exact-edit mode)
-- `exec { command }` -> `shell.exec`
-- `exec { script }` -> `bash.exec`
+- `bash { command }` -> `bash.exec`
+- `bash { script }` -> `bash.exec` (legacy alias mode)
+- `exec { command, args }` -> `shell.exec`
 
 Exec results keep a stable structured payload. Inline `stdout` / `stderr` previews remain easy to read, while `details.stdout` / `details.stderr` report truncation metadata and expose any saved `full_output_path` handoff targets. When output is truncated, callers should first try `details.handoff.recommended_payload` with `read`; `details.handoff.recipes.<stream>.*` then exposes alternate first-page / last-page / wider-byte windows without forcing the model to invent paging arguments.
 - `web { url }` -> `web.fetch`
@@ -132,7 +135,9 @@ lease-bearing tool card.
 Every tool belongs to a structured surface such as:
 
 - `read`
+- `edit`
 - `write`
+- `bash`
 - `exec`
 - `web`
 - `browser`
@@ -173,7 +178,7 @@ system prompt short while still teaching high-frequency behaviors like:
 - read before shell for normal inspection
 - `offset` / `limit` paging for large files
 - `edits` for surgical exact replacements
-- `script` for shell-heavy exec tasks
+- `bash` for shell-heavy command strings and scripts
 
 The shared metadata keeps prompt guidance, discovery cards, followup/approval
 surfaces, and operator-facing read models aligned without exposing every


### PR DESCRIPTION
## Summary

- Problem:
  Tool-driven turns were still brittle in two ways: the provider-visible core surface mixed shell/process semantics more than it should, and followup rounds could end prematurely when the assistant narrated the next tool step instead of emitting the actual tool call.
- Why it matters:
  These failures land as user-visible "Loong can't do a simple tool workflow" moments, especially after discovery results or repairable tool failures.
- What changed:
  Added an explicit `bash` direct surface, narrowed `exec` to argv-style process execution, promoted `edit` as a first-class direct tool, hid low-level external-skills plumbing behind the grouped hidden surface, strengthened tool-followup prompt guidance, and added a bounded missing-tool-call repair path in the turn loop/coordinator for narrated retry plans and pseudo-tool text.
- What did not change (scope boundary):
  This PR does not synthesize tool calls directly from narrated prose, does not add unbounded retry loops, and does not reopen the provider-visible tool surface beyond the small direct facade set.

## Linked Issues

- Closes #1384
- Related #990

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The PR changes both model-facing tool guidance and the runtime behavior of tool-followup rounds. False positives in the new missing-tool-call repair branch could keep a turn alive when a direct answer would have been acceptable.
- Rollout / guardrails:
  Recovery is bounded to one narrated missing-tool-call repair round. Regression coverage now distinguishes pseudo-tool/narrated retry cases from normal direct answers.
- Rollback path:
  Revert the two commits on this branch to remove the `bash`/`exec` surface split and the missing-tool-call repair path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
cargo check --workspace
cargo test -p loong-app tools::routing::tests:: -- --nocapture
cargo test -p loong-app tools::tests::bash_exec_tests -- --nocapture
cargo test -p loong-app tools::catalog::tests -- --nocapture
cargo test -p loong-app --test conversation_integration -- --nocapture
cargo test -p loong-app missing_tool_call_followup -- --nocapture
cargo test -p loong-app decide_round_kernel_action_ -- --nocapture
cargo test -p loong-app provider_turn_missing_tool_call_followup -- --nocapture
cargo test -p loong-app handle_turn_with_runtime_repairs_missing_tool_call_after_tool_followup_round -- --nocapture
cargo test -p loong-app -- --skip feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings

Key results:
- loong-app package tests: 3540 passed, 0 failed, 1 filtered out
- conversation_integration: 14 passed, 0 failed
- new missing-tool-call repair regression: passed
- fmt/check/clippy: passed
```

## User-visible / Operator-visible Changes

- Models now see `bash` as the shell-native direct surface and `exec` as argv-style process execution.
- Tool-driven followup rounds now explicitly demand the next tool call when more tool work is needed.
- Narrated retry plans or pseudo-tool text in a tool-followup round trigger one bounded repair round instead of ending the turn immediately.

## Failure Recovery

- Fast rollback or disable path:
  Revert `d81a6741` and `b92ad729` from this branch.
- Observable failure symptoms reviewers should watch for:
  Turns that should end directly but instead perform one extra provider round after a tool-followup chain.

## Reviewer Focus

- `crates/app/src/conversation/turn_shared.rs`
  Check the new prompt wording and missing-tool-call detection heuristics.
- `crates/app/src/conversation/turn_loop.rs`
  Check the bounded repair branch in the fast tool loop.
- `crates/app/src/conversation/turn_coordinator.rs`
  Check the equivalent safe-lane/provider-turn followup repair path.
- `crates/app/src/conversation/tests.rs`
  Check the new end-to-end regression for narrated tool retries after a tool-followup round.
