### PR TITLE
Mature automation into a manifest-backed segmented event log

### DIFF
--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -3309,6 +3309,7 @@ pub(crate) async fn send_text_to_known_session(
     Err(format!("sessions_send_channel_unsupported: `{session_id}`"))
 }
 
+#[cfg(test)]
 #[cfg(any(
     feature = "channel-plugin-bridge",
     feature = "channel-telegram",

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -2586,8 +2586,7 @@ data: [DONE]\n\n",
             feishu_requests
                 .iter()
                 .filter(|request| {
-                    request.path
-                        == "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"
+                    request.path == "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"
                 })
                 .count()
                 == 1,

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -853,7 +853,7 @@ async fn handle_feishu_inbound_event(
                 let mut adapter = state.adapter.lock().await;
                 if let Err(first_error) = send_channel_message_via_message_send_api(
                     &*adapter,
-                    &reply_target,
+                    reply_target,
                     outbound.clone(),
                 )
                 .await
@@ -866,7 +866,7 @@ async fn handle_feishu_inbound_event(
                             ),
                         ));
                     }
-                    send_channel_message_via_message_send_api(&*adapter, &reply_target, outbound)
+                    send_channel_message_via_message_send_api(&*adapter, reply_target, outbound)
                         .await
                         .map_err(|error| {
                             (
@@ -885,7 +885,7 @@ async fn handle_feishu_inbound_event(
             let outbound = outbound_reply_message_from_text(render_feishu_user_facing_reply(reply));
             let mut adapter = state.adapter.lock().await;
             if let Err(first_error) =
-                send_channel_message_via_message_send_api(&*adapter, &reply_target, outbound.clone())
+                send_channel_message_via_message_send_api(&*adapter, reply_target, outbound.clone())
                     .await
             {
                 if let Err(error) = adapter.refresh_tenant_token().await {
@@ -896,7 +896,7 @@ async fn handle_feishu_inbound_event(
                         ),
                     ));
                 }
-                send_channel_message_via_message_send_api(&*adapter, &reply_target, outbound)
+                send_channel_message_via_message_send_api(&*adapter, reply_target, outbound)
                     .await
                     .map_err(|error| {
                         (
@@ -2550,30 +2550,29 @@ data: [DONE]\n\n",
         });
         let raw_body = serde_json::to_string(&payload).expect("serialize payload");
         let headers = signed_headers(&raw_body, "encrypt-key");
-        let error = handle_feishu_webhook_payload(
+        let first_response = handle_feishu_webhook_payload(
             state.clone(),
             &headers,
             raw_body.as_str(),
             serde_json::from_str(raw_body.as_str()).expect("payload value"),
         )
         .await
-        .expect_err("webhook should surface provider failure");
+        .expect("webhook should return a safe success response after failure handling");
+        assert_eq!(first_response.body["code"], 0);
+        assert_eq!(first_response.body["msg"], "ok");
 
-        assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(error.1.contains("provider processing failed"));
-
-        let error_retry = handle_feishu_webhook_payload(
+        let retry_response = handle_feishu_webhook_payload(
             state,
             &headers,
             raw_body.as_str(),
             serde_json::from_str(raw_body.as_str()).expect("payload value"),
         )
         .await
-        .expect_err("webhook retry should still surface provider failure");
-        assert_eq!(error_retry.0, StatusCode::INTERNAL_SERVER_ERROR);
+        .expect("webhook retry should stay safely handled after failure finalization");
+        assert_eq!(retry_response.body["code"], 0);
+        assert_eq!(retry_response.body["msg"], "duplicate_event");
 
         let feishu_requests = wait_for_request_count(&feishu_requests, 2).await;
-        assert_eq!(feishu_requests.len(), 2);
         assert_eq!(
             feishu_requests
                 .iter()
@@ -2584,9 +2583,15 @@ data: [DONE]\n\n",
             "retrying a failed inbound turn must not duplicate ack reactions"
         );
         assert!(
-            feishu_requests.iter().all(|request| request.path
-                != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"),
-            "failed inbound handling must not send a reply"
+            feishu_requests
+                .iter()
+                .filter(|request| {
+                    request.path
+                        == "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"
+                })
+                .count()
+                == 1,
+            "retrying a failed inbound turn must not duplicate retry-status replies"
         );
 
         provider_server.abort();

--- a/crates/app/src/config/automation.rs
+++ b/crates/app/src/config/automation.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_AUTOMATION_EVENT_PATH: &str = "/automation/events";
+const DEFAULT_AUTOMATION_POLL_MS: u64 = 1_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutomationConfig {
+    #[serde(default = "default_automation_event_path")]
+    pub event_path: String,
+    #[serde(default = "default_automation_poll_ms")]
+    pub poll_ms: u64,
+    #[serde(default)]
+    pub retain_last_sealed_segments: usize,
+    #[serde(default)]
+    pub retain_min_age_seconds: Option<u64>,
+    #[serde(default)]
+    pub internal_event_segment_max_bytes: Option<u64>,
+}
+
+impl Default for AutomationConfig {
+    fn default() -> Self {
+        Self {
+            event_path: default_automation_event_path(),
+            poll_ms: default_automation_poll_ms(),
+            retain_last_sealed_segments: 0,
+            retain_min_age_seconds: None,
+            internal_event_segment_max_bytes: None,
+        }
+    }
+}
+
+impl AutomationConfig {
+    #[must_use]
+    pub fn is_default(config: &Self) -> bool {
+        *config == Self::default()
+    }
+
+    #[must_use]
+    pub fn resolved_event_path(&self) -> String {
+        let trimmed_event_path = self.event_path.trim();
+        if trimmed_event_path.is_empty() {
+            return default_automation_event_path();
+        }
+        trimmed_event_path.to_owned()
+    }
+
+    #[must_use]
+    pub fn resolved_poll_ms(&self) -> u64 {
+        if self.poll_ms == 0 {
+            return default_automation_poll_ms();
+        }
+        self.poll_ms
+    }
+}
+
+fn default_automation_event_path() -> String {
+    DEFAULT_AUTOMATION_EVENT_PATH.to_owned()
+}
+
+const fn default_automation_poll_ms() -> u64 {
+    DEFAULT_AUTOMATION_POLL_MS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn automation_config_defaults_match_operator_surface_defaults() {
+        let config = AutomationConfig::default();
+        assert_eq!(config.event_path, "/automation/events");
+        assert_eq!(config.poll_ms, 1_000);
+        assert_eq!(config.retain_last_sealed_segments, 0);
+        assert_eq!(config.retain_min_age_seconds, None);
+        assert_eq!(config.internal_event_segment_max_bytes, None);
+        assert!(AutomationConfig::is_default(&config));
+    }
+
+    #[test]
+    fn automation_config_blank_event_path_and_zero_poll_fall_back_to_defaults() {
+        let config = AutomationConfig {
+            event_path: "   ".to_owned(),
+            poll_ms: 0,
+            ..AutomationConfig::default()
+        };
+        assert_eq!(config.resolved_event_path(), "/automation/events");
+        assert_eq!(config.resolved_poll_ms(), 1_000);
+    }
+}

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod automation;
 mod channels;
 mod conversation;
 mod feishu_integration;
@@ -22,6 +23,8 @@ pub use crate::channel::{
 pub use crate::mcp::{McpConfig, McpServerConfig, McpServerTransportConfig};
 #[allow(unused_imports)]
 pub use audit::{AuditConfig, AuditMode};
+#[allow(unused_imports)]
+pub use automation::AutomationConfig;
 #[allow(unused_imports)]
 pub use channels::bridge::{
     OnebotAccountConfig, OnebotChannelConfig, QqbotAccountConfig, QqbotChannelConfig,

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -18,6 +18,7 @@ use loong_contracts::{SecretRef, SecretResolver};
 use super::{
     OnebotChannelConfig, QqbotChannelConfig, WeixinChannelConfig,
     audit::AuditConfig,
+    automation::AutomationConfig,
     channels::{
         CliChannelConfig, DingtalkChannelConfig, DiscordChannelConfig, EmailChannelConfig,
         FeishuChannelConfig, GoogleChatChannelConfig, ImessageChannelConfig, IrcChannelConfig,
@@ -185,6 +186,8 @@ pub struct LoongConfig {
     pub memory: MemoryConfig,
     #[serde(default)]
     pub audit: AuditConfig,
+    #[serde(default, skip_serializing_if = "AutomationConfig::is_default")]
+    pub automation: AutomationConfig,
     #[serde(default, skip_serializing_if = "ControlPlaneConfig::is_default")]
     pub control_plane: ControlPlaneConfig,
     #[serde(default)]
@@ -2122,9 +2125,10 @@ pub fn write_template(path: Option<&str>, force: bool) -> CliResult<PathBuf> {
     }
 
     let encoded = format!(
-        "{}{}{}",
+        "{}{}{}{}",
         template_secret_usage_comment(),
         template_web_search_usage_comment(),
+        template_automation_usage_comment(),
         encode_toml_config(&LoongConfig::default())?
     );
     fs::write(&output_path, encoded).map_err(|error| {
@@ -2255,6 +2259,14 @@ fn template_web_search_usage_comment() -> String {
     )
 }
 
+fn template_automation_usage_comment() -> &'static str {
+    "# Automation policy notes:\n\
+# - `[automation].event_path` sets the default webhook route path for `automation serve`.\n\
+# - `[automation].poll_ms`, `retain_last_sealed_segments`, and `retain_min_age_seconds` become the default serve / journal-prune policy when explicit flags are omitted.\n\
+# - `[automation].internal_event_segment_max_bytes` controls automatic internal-event journal rotation.\n\
+\n"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2372,6 +2384,30 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
         assert!(raw.contains(WEB_SEARCH_JINA_API_KEY_ENV));
         assert!(raw.contains(WEB_SEARCH_JINA_AUTH_TOKEN_ENV));
         assert!(raw.contains("These settings affect only `web { query }` / `web.search`"));
+
+        std::fs::remove_file(&config_path).ok();
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_template_includes_automation_policy_notes() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir =
+            std::env::temp_dir().join(format!("loong-template-automation-notes-{unique}"));
+        std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+        let config_path = temp_dir.join("config.toml");
+
+        write_template(Some(config_path.to_string_lossy().as_ref()), true)
+            .expect("write template should succeed");
+
+        let raw = std::fs::read_to_string(&config_path).expect("read template");
+        assert!(raw.contains("# Automation policy notes:"));
+        assert!(raw.contains("[automation].event_path"));
+        assert!(raw.contains("internal_event_segment_max_bytes"));
 
         std::fs::remove_file(&config_path).ok();
         std::fs::remove_dir_all(&temp_dir).ok();
@@ -3824,6 +3860,22 @@ model = "gpt-5"
         let parsed = toml::from_str::<LoongConfig>(&encoded).expect("parse encoded config");
 
         assert_eq!(parsed.audit, config.audit);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn automation_config_round_trips_policy_defaults() {
+        let mut config = LoongConfig::default();
+        config.automation.event_path = "/automation/from-config".to_owned();
+        config.automation.poll_ms = 250;
+        config.automation.retain_last_sealed_segments = 2;
+        config.automation.retain_min_age_seconds = Some(45);
+        config.automation.internal_event_segment_max_bytes = Some(32_768);
+
+        let encoded = encode_toml_config(&config).expect("encode config");
+        let parsed = toml::from_str::<LoongConfig>(&encoded).expect("parse encoded config");
+
+        assert_eq!(parsed.automation, config.automation);
     }
 
     #[test]

--- a/crates/app/src/internal_events.rs
+++ b/crates/app/src/internal_events.rs
@@ -85,6 +85,33 @@ pub struct InternalEventJournalLayoutInfo {
     pub segments: Vec<InternalEventJournalSegmentInfo>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InternalEventJournalGcPolicy {
+    pub retain_floor_segment_id: Option<String>,
+    pub retain_last_sealed_segments: usize,
+    pub retain_min_age_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InternalEventJournalGcDecision {
+    pub segment_id: String,
+    pub path: String,
+    pub status: String,
+    pub created_at_ms: Option<i64>,
+    pub sealed_at_ms: Option<i64>,
+    pub action: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InternalEventJournalGcPlan {
+    pub active_segment_id: String,
+    pub retain_floor_segment_id: Option<String>,
+    pub retain_last_sealed_segments: usize,
+    pub retain_min_age_ms: Option<u64>,
+    pub decisions: Vec<InternalEventJournalGcDecision>,
+}
+
 fn internal_event_sink_registry() -> &'static RwLock<Option<InternalEventSink>> {
     static REGISTRY: OnceLock<RwLock<Option<InternalEventSink>>> = OnceLock::new();
     REGISTRY.get_or_init(|| RwLock::new(None))
@@ -376,6 +403,172 @@ pub fn prune_internal_event_journal_segments(
         store_internal_event_journal_state(&state)?;
     }
     Ok(pruned)
+}
+
+pub fn plan_internal_event_journal_gc(
+    policy: &InternalEventJournalGcPolicy,
+) -> Result<InternalEventJournalGcPlan, String> {
+    let layout = discover_internal_event_journal_layout()?;
+    let state = load_internal_event_journal_state()?;
+    let retain_floor_segment_id = policy.retain_floor_segment_id.clone();
+
+    if let Some(retain_floor_segment_id) = retain_floor_segment_id.as_deref() {
+        let floor_exists = layout
+            .segments
+            .iter()
+            .any(|segment| segment.segment_id == retain_floor_segment_id);
+        if !floor_exists {
+            return Err(format!(
+                "internal event journal GC floor segment `{retain_floor_segment_id}` does not exist"
+            ));
+        }
+    }
+
+    let older_than_floor = layout
+        .segments
+        .iter()
+        .filter(|segment| {
+            if segment.segment_id == layout.active_segment.segment_id {
+                return false;
+            }
+            let Some(retain_floor_segment_id) = retain_floor_segment_id.as_deref() else {
+                return true;
+            };
+            compare_internal_event_segment_ids(segment.segment_id.as_str(), retain_floor_segment_id)
+                .is_lt()
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let mut recent_retained_segment_ids = older_than_floor
+        .iter()
+        .rev()
+        .take(policy.retain_last_sealed_segments)
+        .map(|segment| segment.segment_id.clone())
+        .collect::<Vec<_>>();
+    recent_retained_segment_ids
+        .sort_by(|left, right| compare_internal_event_segment_ids(left.as_str(), right.as_str()));
+
+    let now_ms = now_ms();
+    let decisions = layout
+        .segments
+        .iter()
+        .map(|segment| {
+            let state_entry = state.as_ref().and_then(|state| {
+                state
+                    .segments
+                    .iter()
+                    .find(|entry| entry.segment_id == segment.segment_id)
+            });
+            let status = state_entry
+                .map(|entry| match entry.status {
+                    InternalEventJournalSegmentStatus::Active => "active".to_owned(),
+                    InternalEventJournalSegmentStatus::Sealed => "sealed".to_owned(),
+                    InternalEventJournalSegmentStatus::Legacy => "legacy".to_owned(),
+                })
+                .unwrap_or_else(|| {
+                    if segment.segment_id == layout.active_segment.segment_id {
+                        "active".to_owned()
+                    } else if segment.segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+                        "legacy".to_owned()
+                    } else {
+                        "sealed".to_owned()
+                    }
+                });
+            let created_at_ms = state_entry.and_then(|entry| entry.created_at_ms);
+            let sealed_at_ms = state_entry.and_then(|entry| entry.sealed_at_ms);
+
+            let action_and_reason = if segment.segment_id == layout.active_segment.segment_id {
+                ("retain".to_owned(), "active_segment".to_owned())
+            } else if retain_floor_segment_id
+                .as_deref()
+                .is_some_and(|retain_floor_segment_id| {
+                    compare_internal_event_segment_ids(
+                        segment.segment_id.as_str(),
+                        retain_floor_segment_id,
+                    )
+                    .is_ge()
+                })
+            {
+                ("retain".to_owned(), "floor_segment_or_newer".to_owned())
+            } else if recent_retained_segment_ids
+                .iter()
+                .any(|retained_segment_id| retained_segment_id == &segment.segment_id)
+            {
+                ("retain".to_owned(), "retain_last_sealed".to_owned())
+            } else if policy.retain_min_age_ms.is_some_and(|retain_min_age_ms| {
+                let reference_ms = sealed_at_ms.or(created_at_ms).unwrap_or_default();
+                if reference_ms <= 0 {
+                    return false;
+                }
+                let age_ms = now_ms.saturating_sub(reference_ms);
+                age_ms < i64::try_from(retain_min_age_ms).unwrap_or(i64::MAX)
+            }) {
+                ("retain".to_owned(), "retain_min_age".to_owned())
+            } else {
+                ("prune".to_owned(), "eligible".to_owned())
+            };
+
+            InternalEventJournalGcDecision {
+                segment_id: segment.segment_id.clone(),
+                path: segment.path.display().to_string(),
+                status,
+                created_at_ms,
+                sealed_at_ms,
+                action: action_and_reason.0,
+                reason: action_and_reason.1,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(InternalEventJournalGcPlan {
+        active_segment_id: layout.active_segment.segment_id,
+        retain_floor_segment_id,
+        retain_last_sealed_segments: policy.retain_last_sealed_segments,
+        retain_min_age_ms: policy.retain_min_age_ms,
+        decisions,
+    })
+}
+
+pub fn gc_internal_event_journal_segments(
+    policy: &InternalEventJournalGcPolicy,
+) -> Result<InternalEventJournalGcPlan, String> {
+    let plan = plan_internal_event_journal_gc(policy)?;
+    let pruned_segment_ids = plan
+        .decisions
+        .iter()
+        .filter(|decision| decision.action == "prune")
+        .map(|decision| decision.segment_id.clone())
+        .collect::<Vec<_>>();
+
+    for decision in &plan.decisions {
+        if decision.action != "prune" {
+            continue;
+        }
+        let path = PathBuf::from(decision.path.as_str());
+        if !path.exists() {
+            continue;
+        }
+        fs::remove_file(path.as_path()).map_err(|error| {
+            format!(
+                "remove sealed internal event segment {} failed: {error}",
+                path.display()
+            )
+        })?;
+    }
+
+    if !pruned_segment_ids.is_empty()
+        && let Some(mut state) = load_internal_event_journal_state()?
+    {
+        state.segments.retain(|segment| {
+            !pruned_segment_ids
+                .iter()
+                .any(|pruned_segment_id| pruned_segment_id == &segment.segment_id)
+        });
+        store_internal_event_journal_state(&state)?;
+    }
+
+    Ok(plan)
 }
 
 pub fn read_internal_event_journal_since(

--- a/crates/app/src/internal_events.rs
+++ b/crates/app/src/internal_events.rs
@@ -1,0 +1,412 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+type InternalEventSink = Arc<dyn Fn(&str, Value) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InternalEventJournalRecord {
+    pub line_cursor: u64,
+    pub event_name: String,
+    pub payload: Value,
+    pub recorded_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct InternalEventJournalCursor {
+    pub line_cursor: u64,
+    pub byte_offset: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub journal_fingerprint: Option<String>,
+}
+
+fn internal_event_sink_registry() -> &'static RwLock<Option<InternalEventSink>> {
+    static REGISTRY: OnceLock<RwLock<Option<InternalEventSink>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| RwLock::new(None))
+}
+
+pub fn install_internal_event_sink(sink: InternalEventSink) {
+    let registry = internal_event_sink_registry();
+    let mut guard = registry
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(sink);
+}
+
+pub fn emit_internal_event(event_name: &str, payload: Value) {
+    let _ = append_internal_event_journal_record(event_name, &payload);
+    let registry = internal_event_sink_registry();
+    let sink = registry
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(sink) = sink {
+        sink(event_name, payload);
+    }
+}
+
+pub fn append_internal_event_to_journal(event_name: &str, payload: &Value) -> Result<(), String> {
+    append_internal_event_journal_record(event_name, payload)
+}
+
+pub fn emit_internal_event_with_metadata(event_name: &str, source_surface: &str, payload: Value) {
+    let metadata = json!({
+        "event_name": event_name,
+        "source_surface": source_surface,
+    });
+    match payload {
+        Value::Object(mut object) => {
+            object.insert("_automation".to_owned(), metadata);
+            emit_internal_event(event_name, Value::Object(object));
+        }
+        other @ Value::Null
+        | other @ Value::Bool(_)
+        | other @ Value::Number(_)
+        | other @ Value::String(_)
+        | other @ Value::Array(_) => emit_internal_event(
+            event_name,
+            json!({
+                "_automation": metadata,
+                "value": other,
+            }),
+        ),
+    }
+}
+
+pub fn internal_event_journal_path() -> PathBuf {
+    crate::config::default_loong_home()
+        .join("automation")
+        .join("internal-events.jsonl")
+}
+
+pub fn probe_internal_event_journal_runtime_ready() -> Result<(), String> {
+    let path = internal_event_journal_path();
+    let journal = open_internal_event_journal(path.as_path())?;
+    lock_internal_event_journal(&journal, path.as_path())?;
+    unlock_internal_event_journal(&journal, path.as_path())
+}
+
+pub fn read_internal_event_journal_since(
+    after_cursor: u64,
+) -> Result<Vec<InternalEventJournalRecord>, String> {
+    let cursor = internal_event_journal_cursor_from_line_cursor(after_cursor)?;
+    let (events, _) = read_internal_event_journal_after(cursor)?;
+    Ok(events)
+}
+
+pub fn read_internal_event_journal_after(
+    cursor: InternalEventJournalCursor,
+) -> Result<(Vec<InternalEventJournalRecord>, InternalEventJournalCursor), String> {
+    let path = internal_event_journal_path();
+    if !path.exists() {
+        return Ok((Vec::new(), cursor));
+    }
+    let current_fingerprint = load_internal_event_journal_fingerprint(path.as_path())?;
+    let mut file = fs::File::open(path.as_path()).map_err(|error| {
+        format!(
+            "open internal event journal {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        format!(
+            "read internal event journal metadata {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let mut cursor = if cursor.byte_offset > metadata.len()
+        || cursor.journal_fingerprint != current_fingerprint
+    {
+        InternalEventJournalCursor::default()
+    } else {
+        cursor
+    };
+    cursor.journal_fingerprint = current_fingerprint;
+    file.seek(SeekFrom::Start(cursor.byte_offset))
+        .map_err(|error| {
+            format!(
+                "seek internal event journal {} to {} failed: {error}",
+                path.display(),
+                cursor.byte_offset
+            )
+        })?;
+    let mut reader = BufReader::new(file);
+    let mut events = Vec::new();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes_read = reader.read_line(&mut line).map_err(|error| {
+            format!(
+                "read internal event journal line {} from {} failed: {error}",
+                cursor.line_cursor.saturating_add(1),
+                path.display()
+            )
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+        cursor.line_cursor = cursor.line_cursor.saturating_add(1);
+        cursor.byte_offset = cursor.byte_offset.saturating_add(
+            u64::try_from(bytes_read)
+                .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
+        );
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(&line).map_err(|error| {
+            format!(
+                "parse internal event journal line {} from {} failed: {error}",
+                cursor.line_cursor,
+                path.display()
+            )
+        })?;
+        let event_name = value
+            .get("event_name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                format!(
+                    "internal event journal line {} in {} is missing string event_name",
+                    cursor.line_cursor,
+                    path.display()
+                )
+            })?
+            .to_owned();
+        let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+        let recorded_at_ms = value
+            .get("recorded_at_ms")
+            .and_then(Value::as_i64)
+            .unwrap_or_default();
+        events.push(InternalEventJournalRecord {
+            line_cursor: cursor.line_cursor,
+            event_name,
+            payload,
+            recorded_at_ms,
+        });
+    }
+    Ok((events, cursor))
+}
+
+pub fn internal_event_journal_cursor_from_line_cursor(
+    line_cursor: u64,
+) -> Result<InternalEventJournalCursor, String> {
+    if line_cursor == 0 {
+        return Ok(InternalEventJournalCursor {
+            journal_fingerprint: load_internal_event_journal_fingerprint(
+                internal_event_journal_path().as_path(),
+            )?,
+            ..InternalEventJournalCursor::default()
+        });
+    }
+    let path = internal_event_journal_path();
+    if !path.exists() {
+        return Ok(InternalEventJournalCursor::default());
+    }
+    let file = fs::File::open(path.as_path()).map_err(|error| {
+        format!(
+            "open internal event journal {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let mut reader = BufReader::new(file);
+    let mut cursor = InternalEventJournalCursor::default();
+    let mut line = String::new();
+    while cursor.line_cursor < line_cursor {
+        line.clear();
+        let bytes_read = reader.read_line(&mut line).map_err(|error| {
+            format!(
+                "read internal event journal line {} from {} failed: {error}",
+                cursor.line_cursor.saturating_add(1),
+                path.display()
+            )
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+        cursor.line_cursor = cursor.line_cursor.saturating_add(1);
+        cursor.byte_offset = cursor.byte_offset.saturating_add(
+            u64::try_from(bytes_read)
+                .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
+        );
+    }
+    cursor.journal_fingerprint = load_internal_event_journal_fingerprint(path.as_path())?;
+    Ok(cursor)
+}
+
+fn append_internal_event_journal_record(event_name: &str, payload: &Value) -> Result<(), String> {
+    let path = internal_event_journal_path();
+    let recorded_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as i64)
+        .unwrap_or_default();
+    let encoded = serde_json::to_string(&json!({
+        "event_name": event_name,
+        "payload": payload,
+        "recorded_at_ms": recorded_at_ms,
+    }))
+    .map_err(|error| format!("serialize internal event journal record failed: {error}"))?;
+    let mut file = open_internal_event_journal(path.as_path())?;
+    lock_internal_event_journal(&file, path.as_path())?;
+    let append_result = (|| -> Result<(), String> {
+        file.write_all(encoded.as_bytes()).map_err(|error| {
+            format!(
+                "append internal event journal {} failed: {error}",
+                path.display()
+            )
+        })?;
+        file.write_all(b"\n").map_err(|error| {
+            format!(
+                "append newline to internal event journal {} failed: {error}",
+                path.display()
+            )
+        })?;
+        file.flush().map_err(|error| {
+            format!(
+                "flush internal event journal {} failed: {error}",
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    let unlock_result = unlock_internal_event_journal(&file, path.as_path());
+    append_result?;
+    unlock_result
+}
+
+fn prepare_internal_event_journal_parent(path: &std::path::Path) -> Result<(), String> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create internal event journal directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn open_internal_event_journal(path: &std::path::Path) -> Result<File, String> {
+    prepare_internal_event_journal_parent(path)?;
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "open internal event journal {} failed: {error}",
+                path.display()
+            )
+        })
+}
+
+fn lock_internal_event_journal(file: &File, path: &std::path::Path) -> Result<(), String> {
+    file.lock().map_err(|error| {
+        format!(
+            "lock internal event journal {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn unlock_internal_event_journal(file: &File, path: &std::path::Path) -> Result<(), String> {
+    file.unlock().map_err(|error| {
+        format!(
+            "unlock internal event journal {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn load_internal_event_journal_fingerprint(
+    path: &std::path::Path,
+) -> Result<Option<String>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let file = fs::File::open(path).map_err(|error| {
+        format!(
+            "open internal event journal {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line.map_err(|error| {
+            format!(
+                "read internal event journal {} for fingerprint failed: {error}",
+                path.display()
+            )
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let digest = Sha256::digest(line.as_bytes());
+        return Ok(Some(hex::encode(digest)));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::ScopedLoongHome;
+    use std::sync::Mutex;
+
+    #[test]
+    fn emit_internal_event_with_metadata_wraps_object_payload() {
+        let captured = Arc::new(Mutex::new(None::<Value>));
+        let sink_capture = captured.clone();
+        install_internal_event_sink(Arc::new(move |_event_name, payload| {
+            *sink_capture.lock().expect("capture lock") = Some(payload);
+        }));
+
+        emit_internal_event_with_metadata(
+            "session.cancelled",
+            "app.tools.session",
+            json!({
+                "session_id": "abc"
+            }),
+        );
+
+        let payload = captured
+            .lock()
+            .expect("capture lock")
+            .clone()
+            .expect("captured payload");
+        assert_eq!(payload["session_id"], "abc");
+        assert_eq!(payload["_automation"]["event_name"], "session.cancelled");
+        assert_eq!(
+            payload["_automation"]["source_surface"],
+            "app.tools.session"
+        );
+    }
+
+    #[test]
+    fn emit_internal_event_writes_and_reads_journal_records() {
+        let _home = ScopedLoongHome::new("internal-events-journal-records");
+        emit_internal_event_with_metadata(
+            "session.cancelled",
+            "app.tools.session",
+            json!({
+                "session_id": "abc"
+            }),
+        );
+
+        let events = read_internal_event_journal_since(0).expect("read internal event journal");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].line_cursor, 1);
+        assert_eq!(events[0].event_name, "session.cancelled");
+        assert_eq!(events[0].payload["session_id"], "abc");
+        assert_eq!(
+            events[0].payload["_automation"]["source_surface"],
+            "app.tools.session"
+        );
+    }
+}

--- a/crates/app/src/internal_events.rs
+++ b/crates/app/src/internal_events.rs
@@ -988,10 +988,13 @@ fn resolve_internal_event_read_start(
                 .is_ge()
         })
     {
+        let Some(normalized_segment) = segments.get(index) else {
+            return (0, InternalEventJournalCursor::default());
+        };
         return (
             index,
             InternalEventJournalCursor {
-                segment_id: Some(segments[index].segment_id.clone()),
+                segment_id: Some(normalized_segment.segment_id.clone()),
                 ..InternalEventJournalCursor::default()
             },
         );

--- a/crates/app/src/internal_events.rs
+++ b/crates/app/src/internal_events.rs
@@ -8,6 +8,9 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 type InternalEventSink = Arc<dyn Fn(&str, Value) + Send + Sync + 'static>;
+const DEFAULT_INTERNAL_EVENT_SEGMENT_ID: &str = "segment-000001";
+const LEGACY_INTERNAL_EVENT_SEGMENT_ID: &str = "legacy";
+const DEFAULT_INTERNAL_EVENT_SEGMENT_MAX_BYTES: u64 = 1_048_576;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InternalEventJournalRecord {
@@ -19,10 +22,67 @@ pub struct InternalEventJournalRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct InternalEventJournalCursor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_id: Option<String>,
     pub line_cursor: u64,
     pub byte_offset: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub journal_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InternalEventJournalSegment {
+    segment_id: String,
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InternalEventJournalLayout {
+    segments: Vec<InternalEventJournalSegment>,
+    active_segment: InternalEventJournalSegment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct InternalEventJournalState {
+    #[serde(default = "default_internal_event_journal_state_schema_version")]
+    schema_version: u32,
+    active_segment_id: String,
+    #[serde(default)]
+    segments: Vec<InternalEventJournalStateSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct InternalEventJournalStateSegment {
+    segment_id: String,
+    status: InternalEventJournalSegmentStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    created_at_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sealed_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InternalEventJournalSegmentStatus {
+    Active,
+    Sealed,
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InternalEventJournalSegmentInfo {
+    pub segment_id: String,
+    pub path: String,
+    pub is_active: bool,
+    pub status: String,
+    pub created_at_ms: Option<i64>,
+    pub sealed_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InternalEventJournalLayoutInfo {
+    pub active_segment_id: String,
+    pub segments: Vec<InternalEventJournalSegmentInfo>,
 }
 
 fn internal_event_sink_registry() -> &'static RwLock<Option<InternalEventSink>> {
@@ -79,9 +139,7 @@ pub fn emit_internal_event_with_metadata(event_name: &str, source_surface: &str,
 }
 
 pub fn internal_event_journal_path() -> PathBuf {
-    crate::config::default_loong_home()
-        .join("automation")
-        .join("internal-events.jsonl")
+    current_internal_event_journal_segment_path()
 }
 
 pub fn probe_internal_event_journal_runtime_ready() -> Result<(), String> {
@@ -89,6 +147,235 @@ pub fn probe_internal_event_journal_runtime_ready() -> Result<(), String> {
     let journal = open_internal_event_journal(path.as_path())?;
     lock_internal_event_journal(&journal, path.as_path())?;
     unlock_internal_event_journal(&journal, path.as_path())
+}
+
+pub fn inspect_internal_event_journal_layout() -> Result<InternalEventJournalLayoutInfo, String> {
+    let layout = discover_internal_event_journal_layout()?;
+    let state = load_internal_event_journal_state()?;
+    Ok(InternalEventJournalLayoutInfo {
+        active_segment_id: layout.active_segment.segment_id.clone(),
+        segments: layout
+            .segments
+            .iter()
+            .map(|segment| InternalEventJournalSegmentInfo {
+                status: state
+                    .as_ref()
+                    .and_then(|value| {
+                        value
+                            .segments
+                            .iter()
+                            .find(|entry| entry.segment_id == segment.segment_id)
+                    })
+                    .map(|entry| {
+                        match entry.status {
+                            InternalEventJournalSegmentStatus::Active => "active",
+                            InternalEventJournalSegmentStatus::Sealed => "sealed",
+                            InternalEventJournalSegmentStatus::Legacy => "legacy",
+                        }
+                        .to_owned()
+                    })
+                    .unwrap_or_else(|| {
+                        if segment.segment_id == layout.active_segment.segment_id {
+                            "active".to_owned()
+                        } else if segment.segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+                            "legacy".to_owned()
+                        } else {
+                            "sealed".to_owned()
+                        }
+                    }),
+                created_at_ms: state
+                    .as_ref()
+                    .and_then(|value| {
+                        value
+                            .segments
+                            .iter()
+                            .find(|entry| entry.segment_id == segment.segment_id)
+                    })
+                    .and_then(|entry| entry.created_at_ms),
+                sealed_at_ms: state
+                    .as_ref()
+                    .and_then(|value| {
+                        value
+                            .segments
+                            .iter()
+                            .find(|entry| entry.segment_id == segment.segment_id)
+                    })
+                    .and_then(|entry| entry.sealed_at_ms),
+                segment_id: segment.segment_id.clone(),
+                path: segment.path.display().to_string(),
+                is_active: segment.segment_id == layout.active_segment.segment_id,
+            })
+            .collect(),
+    })
+}
+
+pub fn repair_internal_event_journal_state() -> Result<InternalEventJournalLayoutInfo, String> {
+    let existing_state = load_internal_event_journal_state()?;
+    let mut layout = discover_internal_event_journal_layout()?;
+    let shadow_active_segment_id = load_internal_event_active_segment_shadow_id()?;
+    let active_segment_path = layout.active_segment.path.clone();
+    if !active_segment_path.exists()
+        && let Some(shadow_active_segment_id) = shadow_active_segment_id
+    {
+        let shadow_active_path = if shadow_active_segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+            legacy_internal_event_journal_segment().path
+        } else {
+            internal_event_segment_path(shadow_active_segment_id.as_str())
+        };
+        if shadow_active_path.exists() {
+            if !layout
+                .segments
+                .iter()
+                .any(|segment| segment.segment_id == shadow_active_segment_id)
+            {
+                let shadow_segment = InternalEventJournalSegment {
+                    segment_id: shadow_active_segment_id.clone(),
+                    path: shadow_active_path,
+                };
+                layout.segments.push(shadow_segment);
+                layout.segments.sort_by(|left, right| {
+                    compare_internal_event_segment_ids(&left.segment_id, &right.segment_id)
+                });
+            }
+            if let Some(repaired_active_segment) = layout
+                .segments
+                .iter()
+                .find(|segment| segment.segment_id == shadow_active_segment_id)
+                .cloned()
+            {
+                layout.active_segment = repaired_active_segment;
+            }
+        }
+    }
+
+    let mut repaired_segments = Vec::new();
+    for segment in &layout.segments {
+        let should_keep_segment =
+            segment.path.exists() || segment.segment_id == layout.active_segment.segment_id;
+        if !should_keep_segment {
+            continue;
+        }
+        let existing_entry = existing_state.as_ref().and_then(|state| {
+            state
+                .segments
+                .iter()
+                .find(|entry| entry.segment_id == segment.segment_id)
+        });
+
+        let repaired_status = if segment.segment_id == layout.active_segment.segment_id {
+            InternalEventJournalSegmentStatus::Active
+        } else if segment.segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+            InternalEventJournalSegmentStatus::Legacy
+        } else {
+            InternalEventJournalSegmentStatus::Sealed
+        };
+
+        let created_at_ms = existing_entry.and_then(|entry| entry.created_at_ms);
+        let sealed_at_ms = if repaired_status == InternalEventJournalSegmentStatus::Active {
+            None
+        } else {
+            existing_entry.and_then(|entry| entry.sealed_at_ms)
+        };
+
+        let repaired_segment = InternalEventJournalStateSegment {
+            segment_id: segment.segment_id.clone(),
+            status: repaired_status,
+            created_at_ms,
+            sealed_at_ms,
+        };
+        repaired_segments.push(repaired_segment);
+    }
+
+    let repaired_state = InternalEventJournalState {
+        schema_version: default_internal_event_journal_state_schema_version(),
+        active_segment_id: layout.active_segment.segment_id.clone(),
+        segments: repaired_segments,
+    };
+
+    store_internal_event_journal_state(&repaired_state)?;
+    store_internal_event_active_segment_id_shadow(layout.active_segment.segment_id.as_str())?;
+
+    inspect_internal_event_journal_layout()
+}
+
+pub fn rotate_internal_event_journal_segment() -> Result<String, String> {
+    let legacy = legacy_internal_event_journal_segment();
+    let current_active_segment_id = load_internal_event_active_segment_id()?
+        .unwrap_or_else(|| DEFAULT_INTERNAL_EVENT_SEGMENT_ID.to_owned());
+    if !internal_event_active_segment_id_path().exists() && legacy.path.exists() {
+        let legacy_target = internal_event_segment_path(DEFAULT_INTERNAL_EVENT_SEGMENT_ID);
+        prepare_internal_event_journal_parent(legacy_target.as_path())?;
+        if !legacy_target.exists() {
+            fs::rename(legacy.path.as_path(), legacy_target.as_path()).map_err(|error| {
+                format!(
+                    "migrate legacy internal event journal {} to {} failed: {error}",
+                    legacy.path.display(),
+                    legacy_target.display()
+                )
+            })?;
+        }
+    }
+    let next_segment_id = next_internal_event_segment_id(current_active_segment_id.as_str())?;
+    let mut state = load_internal_event_journal_state()?.unwrap_or_else(|| {
+        bootstrap_internal_event_journal_state(current_active_segment_id.as_str())
+    });
+    for segment in &mut state.segments {
+        if segment.segment_id == current_active_segment_id {
+            segment.status = InternalEventJournalSegmentStatus::Sealed;
+            if segment.sealed_at_ms.is_none() {
+                segment.sealed_at_ms = Some(now_ms());
+            }
+        }
+    }
+    if !state
+        .segments
+        .iter()
+        .any(|segment| segment.segment_id == next_segment_id)
+    {
+        state.segments.push(InternalEventJournalStateSegment {
+            segment_id: next_segment_id.clone(),
+            status: InternalEventJournalSegmentStatus::Active,
+            created_at_ms: Some(now_ms()),
+            sealed_at_ms: None,
+        });
+    }
+    state.active_segment_id = next_segment_id.clone();
+    store_internal_event_journal_state(&state)?;
+    store_internal_event_active_segment_id_shadow(next_segment_id.as_str())?;
+    Ok(next_segment_id)
+}
+
+pub fn prune_internal_event_journal_segments(
+    consumed_cursor: &InternalEventJournalCursor,
+) -> Result<Vec<String>, String> {
+    let layout = discover_internal_event_journal_layout()?;
+    let eligible = internal_event_segments_eligible_for_deletion(
+        layout.segments.as_slice(),
+        layout.active_segment.segment_id.as_str(),
+        Some(consumed_cursor),
+    );
+    let mut pruned = Vec::new();
+    for segment in eligible {
+        if !segment.path.exists() {
+            continue;
+        }
+        fs::remove_file(segment.path.as_path()).map_err(|error| {
+            format!(
+                "remove sealed internal event segment {} failed: {error}",
+                segment.path.display()
+            )
+        })?;
+        pruned.push(segment.segment_id);
+    }
+    if !pruned.is_empty()
+        && let Some(mut state) = load_internal_event_journal_state()?
+    {
+        state
+            .segments
+            .retain(|segment| !pruned.contains(&segment.segment_id));
+        store_internal_event_journal_state(&state)?;
+    }
+    Ok(pruned)
 }
 
 pub fn read_internal_event_journal_since(
@@ -102,177 +389,160 @@ pub fn read_internal_event_journal_since(
 pub fn read_internal_event_journal_after(
     cursor: InternalEventJournalCursor,
 ) -> Result<(Vec<InternalEventJournalRecord>, InternalEventJournalCursor), String> {
-    let path = internal_event_journal_path();
-    if !path.exists() {
+    let layout = discover_internal_event_journal_layout()?;
+    if layout.segments.is_empty() {
         return Ok((Vec::new(), cursor));
     }
-    let current_fingerprint = load_internal_event_journal_fingerprint(path.as_path())?;
-    let mut file = fs::File::open(path.as_path()).map_err(|error| {
-        format!(
-            "open internal event journal {} failed: {error}",
-            path.display()
-        )
-    })?;
-    let metadata = file.metadata().map_err(|error| {
-        format!(
-            "read internal event journal metadata {} failed: {error}",
-            path.display()
-        )
-    })?;
-    let mut cursor = if cursor.byte_offset > metadata.len()
-        || cursor.journal_fingerprint != current_fingerprint
-    {
-        InternalEventJournalCursor::default()
-    } else {
-        cursor
-    };
-    cursor.journal_fingerprint = current_fingerprint;
-    file.seek(SeekFrom::Start(cursor.byte_offset))
-        .map_err(|error| {
-            format!(
-                "seek internal event journal {} to {} failed: {error}",
-                path.display(),
-                cursor.byte_offset
-            )
-        })?;
-    let mut reader = BufReader::new(file);
-    let mut events = Vec::new();
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let bytes_read = reader.read_line(&mut line).map_err(|error| {
-            format!(
-                "read internal event journal line {} from {} failed: {error}",
-                cursor.line_cursor.saturating_add(1),
-                path.display()
-            )
-        })?;
-        if bytes_read == 0 {
-            break;
-        }
-        cursor.line_cursor = cursor.line_cursor.saturating_add(1);
-        cursor.byte_offset = cursor.byte_offset.saturating_add(
-            u64::try_from(bytes_read)
-                .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
-        );
-        if line.trim().is_empty() {
-            continue;
-        }
-        let value: Value = serde_json::from_str(&line).map_err(|error| {
-            format!(
-                "parse internal event journal line {} from {} failed: {error}",
-                cursor.line_cursor,
-                path.display()
-            )
-        })?;
-        let event_name = value
-            .get("event_name")
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                format!(
-                    "internal event journal line {} in {} is missing string event_name",
-                    cursor.line_cursor,
-                    path.display()
-                )
-            })?
-            .to_owned();
-        let payload = value.get("payload").cloned().unwrap_or(Value::Null);
-        let recorded_at_ms = value
-            .get("recorded_at_ms")
-            .and_then(Value::as_i64)
-            .unwrap_or_default();
-        events.push(InternalEventJournalRecord {
-            line_cursor: cursor.line_cursor,
-            event_name,
-            payload,
-            recorded_at_ms,
-        });
+    let (start_index, normalized_cursor) =
+        resolve_internal_event_read_start(layout.segments.as_slice(), cursor);
+    let mut aggregate_events = Vec::new();
+    let mut next_cursor = normalized_cursor;
+
+    for (index, segment) in layout.segments.iter().enumerate().skip(start_index) {
+        let seed_cursor = if index == start_index {
+            if next_cursor.segment_id.is_none() {
+                InternalEventJournalCursor {
+                    segment_id: Some(segment.segment_id.clone()),
+                    ..next_cursor
+                }
+            } else {
+                next_cursor.clone()
+            }
+        } else {
+            InternalEventJournalCursor {
+                segment_id: Some(segment.segment_id.clone()),
+                ..InternalEventJournalCursor::default()
+            }
+        };
+        let (segment_events, segment_cursor) =
+            read_internal_event_journal_segment_after(segment, seed_cursor)?;
+        aggregate_events.extend(segment_events);
+        next_cursor = segment_cursor;
     }
-    Ok((events, cursor))
+
+    Ok((aggregate_events, next_cursor))
 }
 
 pub fn internal_event_journal_cursor_from_line_cursor(
     line_cursor: u64,
 ) -> Result<InternalEventJournalCursor, String> {
+    let layout = discover_internal_event_journal_layout()?;
+    let initial_segment = layout
+        .segments
+        .first()
+        .cloned()
+        .unwrap_or_else(default_internal_event_journal_segment);
     if line_cursor == 0 {
         return Ok(InternalEventJournalCursor {
+            segment_id: Some(initial_segment.segment_id.clone()),
             journal_fingerprint: load_internal_event_journal_fingerprint(
-                internal_event_journal_path().as_path(),
+                initial_segment.path.as_path(),
             )?,
             ..InternalEventJournalCursor::default()
         });
     }
-    let path = internal_event_journal_path();
-    if !path.exists() {
+    let segment = initial_segment;
+    if !segment.path.exists() {
         return Ok(InternalEventJournalCursor::default());
     }
-    let file = fs::File::open(path.as_path()).map_err(|error| {
-        format!(
-            "open internal event journal {} failed: {error}",
-            path.display()
-        )
-    })?;
-    let mut reader = BufReader::new(file);
-    let mut cursor = InternalEventJournalCursor::default();
-    let mut line = String::new();
-    while cursor.line_cursor < line_cursor {
-        line.clear();
-        let bytes_read = reader.read_line(&mut line).map_err(|error| {
+    let file = open_internal_event_journal(segment.path.as_path())?;
+    lock_internal_event_journal(&file, segment.path.as_path())?;
+    let read_result = (|| -> Result<_, String> {
+        let mut cursor = InternalEventJournalCursor {
+            segment_id: Some(segment.segment_id.clone()),
+            journal_fingerprint: load_internal_event_journal_fingerprint_from_handle(
+                &file,
+                segment.path.as_path(),
+            )?,
+            ..InternalEventJournalCursor::default()
+        };
+        let reader_file = file.try_clone().map_err(|error| {
             format!(
-                "read internal event journal line {} from {} failed: {error}",
-                cursor.line_cursor.saturating_add(1),
-                path.display()
+                "clone internal event journal handle {} failed: {error}",
+                segment.path.display()
             )
         })?;
-        if bytes_read == 0 {
-            break;
+        let mut reader_file = reader_file;
+        reader_file.seek(SeekFrom::Start(0)).map_err(|error| {
+            format!(
+                "seek internal event journal {} to start failed: {error}",
+                segment.path.display()
+            )
+        })?;
+        let mut reader = BufReader::new(reader_file);
+        let mut line = String::new();
+        while cursor.line_cursor < line_cursor {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line).map_err(|error| {
+                format!(
+                    "read internal event journal line {} from {} failed: {error}",
+                    cursor.line_cursor.saturating_add(1),
+                    segment.path.display()
+                )
+            })?;
+            if bytes_read == 0 {
+                break;
+            }
+            cursor.line_cursor = cursor.line_cursor.saturating_add(1);
+            cursor.byte_offset = cursor.byte_offset.saturating_add(
+                u64::try_from(bytes_read)
+                    .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
+            );
         }
-        cursor.line_cursor = cursor.line_cursor.saturating_add(1);
-        cursor.byte_offset = cursor.byte_offset.saturating_add(
-            u64::try_from(bytes_read)
-                .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
-        );
-    }
-    cursor.journal_fingerprint = load_internal_event_journal_fingerprint(path.as_path())?;
+        Ok(cursor)
+    })();
+    let unlock_result = unlock_internal_event_journal(&file, segment.path.as_path());
+    let cursor = read_result?;
+    unlock_result?;
     Ok(cursor)
 }
 
 fn append_internal_event_journal_record(event_name: &str, payload: &Value) -> Result<(), String> {
-    let path = internal_event_journal_path();
-    let recorded_at_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|value| value.as_millis() as i64)
-        .unwrap_or_default();
-    let encoded = serde_json::to_string(&json!({
-        "event_name": event_name,
-        "payload": payload,
-        "recorded_at_ms": recorded_at_ms,
-    }))
-    .map_err(|error| format!("serialize internal event journal record failed: {error}"))?;
-    let mut file = open_internal_event_journal(path.as_path())?;
-    lock_internal_event_journal(&file, path.as_path())?;
+    let control_lock_path = internal_event_journal_control_lock_path();
+    let control_lock = open_internal_event_journal_control_lock(control_lock_path.as_path())?;
+    lock_internal_event_journal_control_lock(&control_lock, control_lock_path.as_path())?;
     let append_result = (|| -> Result<(), String> {
-        file.write_all(encoded.as_bytes()).map_err(|error| {
-            format!(
-                "append internal event journal {} failed: {error}",
-                path.display()
-            )
-        })?;
-        file.write_all(b"\n").map_err(|error| {
-            format!(
-                "append newline to internal event journal {} failed: {error}",
-                path.display()
-            )
-        })?;
-        file.flush().map_err(|error| {
-            format!(
-                "flush internal event journal {} failed: {error}",
-                path.display()
-            )
-        })?;
-        Ok(())
+        maybe_rotate_internal_event_journal_segment_for_size()?;
+        let path = current_internal_event_journal_segment_path();
+        let recorded_at_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|value| value.as_millis() as i64)
+            .unwrap_or_default();
+        let encoded = serde_json::to_string(&json!({
+            "event_name": event_name,
+            "payload": payload,
+            "recorded_at_ms": recorded_at_ms,
+        }))
+        .map_err(|error| format!("serialize internal event journal record failed: {error}"))?;
+        let mut file = open_internal_event_journal(path.as_path())?;
+        lock_internal_event_journal(&file, path.as_path())?;
+        let append_result = (|| -> Result<(), String> {
+            file.write_all(encoded.as_bytes()).map_err(|error| {
+                format!(
+                    "append internal event journal {} failed: {error}",
+                    path.display()
+                )
+            })?;
+            file.write_all(b"\n").map_err(|error| {
+                format!(
+                    "append newline to internal event journal {} failed: {error}",
+                    path.display()
+                )
+            })?;
+            file.flush().map_err(|error| {
+                format!(
+                    "flush internal event journal {} failed: {error}",
+                    path.display()
+                )
+            })?;
+            Ok(())
+        })();
+        let unlock_result = unlock_internal_event_journal(&file, path.as_path());
+        append_result?;
+        unlock_result
     })();
-    let unlock_result = unlock_internal_event_journal(&file, path.as_path());
+    let unlock_result =
+        unlock_internal_event_journal_control_lock(&control_lock, control_lock_path.as_path());
     append_result?;
     unlock_result
 }
@@ -306,6 +576,49 @@ fn open_internal_event_journal(path: &std::path::Path) -> Result<File, String> {
         })
 }
 
+fn open_internal_event_journal_control_lock(path: &std::path::Path) -> Result<File, String> {
+    prepare_internal_event_journal_parent(path)?;
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "open internal event journal control lock {} failed: {error}",
+                path.display()
+            )
+        })
+}
+
+pub fn internal_event_segments_dir() -> PathBuf {
+    crate::config::default_loong_home()
+        .join("automation")
+        .join("internal-events")
+}
+
+pub fn internal_event_active_segment_id_path() -> PathBuf {
+    crate::config::default_loong_home()
+        .join("automation")
+        .join("internal-events.active")
+}
+
+pub fn internal_event_journal_state_path() -> PathBuf {
+    crate::config::default_loong_home()
+        .join("automation")
+        .join("internal-events.state.json")
+}
+
+pub fn internal_event_segment_path(segment_id: &str) -> PathBuf {
+    internal_event_segments_dir().join(format!("{segment_id}.jsonl"))
+}
+
+fn internal_event_journal_control_lock_path() -> PathBuf {
+    crate::config::default_loong_home()
+        .join("automation")
+        .join("internal-events.control.lock")
+}
+
 fn lock_internal_event_journal(file: &File, path: &std::path::Path) -> Result<(), String> {
     file.lock().map_err(|error| {
         format!(
@@ -315,10 +628,559 @@ fn lock_internal_event_journal(file: &File, path: &std::path::Path) -> Result<()
     })
 }
 
+fn lock_internal_event_journal_control_lock(
+    file: &File,
+    path: &std::path::Path,
+) -> Result<(), String> {
+    file.lock().map_err(|error| {
+        format!(
+            "lock internal event journal control lock {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn default_internal_event_journal_segment() -> InternalEventJournalSegment {
+    InternalEventJournalSegment {
+        segment_id: DEFAULT_INTERNAL_EVENT_SEGMENT_ID.to_owned(),
+        path: internal_event_segment_path(DEFAULT_INTERNAL_EVENT_SEGMENT_ID),
+    }
+}
+
+fn legacy_internal_event_journal_segment() -> InternalEventJournalSegment {
+    InternalEventJournalSegment {
+        segment_id: LEGACY_INTERNAL_EVENT_SEGMENT_ID.to_owned(),
+        path: crate::config::default_loong_home()
+            .join("automation")
+            .join("internal-events.jsonl"),
+    }
+}
+
+fn current_internal_event_journal_segment_path() -> PathBuf {
+    discover_internal_event_journal_layout()
+        .ok()
+        .map(|layout| layout.active_segment.path)
+        .unwrap_or_else(|| default_internal_event_journal_segment().path)
+}
+
+fn load_internal_event_active_segment_id() -> Result<Option<String>, String> {
+    if let Some(state) = load_internal_event_journal_state()? {
+        return Ok(Some(state.active_segment_id));
+    }
+    load_internal_event_active_segment_shadow_id()
+}
+
+fn load_internal_event_active_segment_shadow_id() -> Result<Option<String>, String> {
+    let path = internal_event_active_segment_id_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path.as_path()).map_err(|error| {
+        format!(
+            "read internal event active segment {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+fn store_internal_event_active_segment_id_shadow(segment_id: &str) -> Result<(), String> {
+    let path = internal_event_active_segment_id_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create internal event active segment directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let tmp_path = path.with_extension("active.tmp");
+    fs::write(&tmp_path, format!("{segment_id}\n")).map_err(|error| {
+        format!(
+            "write internal event active segment temp file {} failed: {error}",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, &path).map_err(|error| {
+        format!(
+            "publish internal event active segment {} from {} failed: {error}",
+            path.display(),
+            tmp_path.display()
+        )
+    })
+}
+
+fn load_internal_event_journal_state() -> Result<Option<InternalEventJournalState>, String> {
+    let path = internal_event_journal_state_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path.as_path()).map_err(|error| {
+        format!(
+            "read internal event journal state {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if let Ok(state) = serde_json::from_str::<InternalEventJournalState>(trimmed) {
+        return Ok(Some(state));
+    }
+    let legacy_state = serde_json::from_str::<serde_json::Value>(trimmed).map_err(|error| {
+        format!(
+            "parse internal event journal state {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let Some(active_segment_id) = legacy_state
+        .get("active_segment_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Err(format!(
+            "parse internal event journal state {} failed: missing string active_segment_id",
+            path.display()
+        ));
+    };
+    Ok(Some(bootstrap_internal_event_journal_state(
+        active_segment_id,
+    )))
+}
+
+fn store_internal_event_journal_state(state: &InternalEventJournalState) -> Result<(), String> {
+    let path = internal_event_journal_state_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create internal event journal state directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(state)
+        .map_err(|error| format!("serialize internal event journal state failed: {error}"))?;
+    let tmp_path = path.with_extension("state.tmp");
+    fs::write(&tmp_path, format!("{encoded}\n")).map_err(|error| {
+        format!(
+            "write internal event journal temp state {} failed: {error}",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, &path).map_err(|error| {
+        format!(
+            "publish internal event journal state {} from {} failed: {error}",
+            path.display(),
+            tmp_path.display()
+        )
+    })
+}
+
+fn default_internal_event_journal_state_schema_version() -> u32 {
+    1
+}
+
+fn next_internal_event_segment_id(current: &str) -> Result<String, String> {
+    let Some(raw_suffix) = current.strip_prefix("segment-") else {
+        return Err(format!(
+            "current internal event segment id `{current}` does not use `segment-` numeric format"
+        ));
+    };
+    let parsed = raw_suffix.parse::<u64>().map_err(|error| {
+        format!("parse internal event segment suffix `{raw_suffix}` failed: {error}")
+    })?;
+    let next = parsed.saturating_add(1);
+    Ok(format!("segment-{next:06}"))
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as i64)
+        .unwrap_or_default()
+}
+
+fn internal_event_segment_max_bytes() -> u64 {
+    let value = std::env::var("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0);
+    value.unwrap_or(DEFAULT_INTERNAL_EVENT_SEGMENT_MAX_BYTES)
+}
+
+fn maybe_rotate_internal_event_journal_segment_for_size() -> Result<(), String> {
+    let threshold_bytes = internal_event_segment_max_bytes();
+    let current_path = current_internal_event_journal_segment_path();
+    let current_len = if current_path.exists() {
+        fs::metadata(current_path.as_path())
+            .map_err(|error| {
+                format!(
+                    "read internal event journal metadata {} failed: {error}",
+                    current_path.display()
+                )
+            })?
+            .len()
+    } else {
+        0
+    };
+    if current_len < threshold_bytes {
+        return Ok(());
+    }
+    let _ = rotate_internal_event_journal_segment()?;
+    Ok(())
+}
+
+fn bootstrap_internal_event_journal_state(active_segment_id: &str) -> InternalEventJournalState {
+    let mut segments = Vec::new();
+    let legacy = legacy_internal_event_journal_segment();
+    if legacy.path.exists() && active_segment_id != LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+        segments.push(InternalEventJournalStateSegment {
+            segment_id: LEGACY_INTERNAL_EVENT_SEGMENT_ID.to_owned(),
+            status: InternalEventJournalSegmentStatus::Legacy,
+            created_at_ms: None,
+            sealed_at_ms: None,
+        });
+    }
+    if !segments
+        .iter()
+        .any(|segment| segment.segment_id == active_segment_id)
+    {
+        segments.push(InternalEventJournalStateSegment {
+            segment_id: active_segment_id.to_owned(),
+            status: InternalEventJournalSegmentStatus::Active,
+            created_at_ms: Some(now_ms()),
+            sealed_at_ms: None,
+        });
+    }
+    InternalEventJournalState {
+        schema_version: default_internal_event_journal_state_schema_version(),
+        active_segment_id: active_segment_id.to_owned(),
+        segments,
+    }
+}
+
+fn discover_internal_event_journal_layout() -> Result<InternalEventJournalLayout, String> {
+    let manifest_state = load_internal_event_journal_state()?;
+    let mut segments = Vec::new();
+    let legacy = legacy_internal_event_journal_segment();
+    if legacy.path.exists() {
+        segments.push(legacy);
+    }
+
+    if let Some(state) = manifest_state.as_ref() {
+        for entry in &state.segments {
+            let path = if entry.segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID {
+                legacy_internal_event_journal_segment().path
+            } else {
+                internal_event_segment_path(entry.segment_id.as_str())
+            };
+            if segments
+                .iter()
+                .any(|segment| segment.segment_id == entry.segment_id)
+            {
+                continue;
+            }
+            segments.push(InternalEventJournalSegment {
+                segment_id: entry.segment_id.clone(),
+                path,
+            });
+        }
+    }
+
+    let segments_dir = internal_event_segments_dir();
+    if segments_dir.exists() {
+        let entries = fs::read_dir(segments_dir.as_path()).map_err(|error| {
+            format!(
+                "read internal event segments directory {} failed: {error}",
+                segments_dir.display()
+            )
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "read internal event segment entry under {} failed: {error}",
+                    segments_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if segments.iter().any(|segment| segment.segment_id == stem) {
+                continue;
+            }
+            segments.push(InternalEventJournalSegment {
+                segment_id: stem.to_owned(),
+                path,
+            });
+        }
+    }
+
+    let active_segment = if let Some(active_segment_id) = manifest_state
+        .as_ref()
+        .map(|state| state.active_segment_id.clone())
+    {
+        InternalEventJournalSegment {
+            segment_id: active_segment_id.clone(),
+            path: internal_event_segment_path(active_segment_id.as_str()),
+        }
+    } else if let Some(active_segment_id) = load_internal_event_active_segment_id()? {
+        InternalEventJournalSegment {
+            segment_id: active_segment_id.clone(),
+            path: internal_event_segment_path(active_segment_id.as_str()),
+        }
+    } else if let Some(existing_segment) = segments
+        .iter()
+        .filter(|segment| segment.segment_id != LEGACY_INTERNAL_EVENT_SEGMENT_ID)
+        .max_by(|left, right| {
+            compare_internal_event_segment_ids(&left.segment_id, &right.segment_id)
+        })
+        .cloned()
+    {
+        existing_segment
+    } else if let Some(legacy_segment) = segments
+        .iter()
+        .find(|segment| segment.segment_id == LEGACY_INTERNAL_EVENT_SEGMENT_ID)
+        .cloned()
+    {
+        legacy_segment
+    } else {
+        default_internal_event_journal_segment()
+    };
+
+    if !segments
+        .iter()
+        .any(|segment| segment.segment_id == active_segment.segment_id)
+    {
+        segments.push(active_segment.clone());
+    }
+    segments.sort_by(|left, right| {
+        compare_internal_event_segment_ids(&left.segment_id, &right.segment_id)
+    });
+
+    Ok(InternalEventJournalLayout {
+        segments,
+        active_segment,
+    })
+}
+
+fn resolve_internal_event_read_start(
+    segments: &[InternalEventJournalSegment],
+    cursor: InternalEventJournalCursor,
+) -> (usize, InternalEventJournalCursor) {
+    if let Some(segment_id) = cursor.segment_id.as_deref()
+        && let Some(index) = segments
+            .iter()
+            .position(|segment| segment.segment_id == segment_id)
+    {
+        return (index, cursor);
+    }
+    if let Some(stale_segment_id) = cursor.segment_id.as_deref()
+        && let Some(index) = segments.iter().position(|segment| {
+            compare_internal_event_segment_ids(segment.segment_id.as_str(), stale_segment_id)
+                .is_ge()
+        })
+    {
+        return (
+            index,
+            InternalEventJournalCursor {
+                segment_id: Some(segments[index].segment_id.clone()),
+                ..InternalEventJournalCursor::default()
+            },
+        );
+    }
+    let Some(first_segment) = segments.first() else {
+        return (0, cursor);
+    };
+    (
+        0,
+        InternalEventJournalCursor {
+            segment_id: Some(first_segment.segment_id.clone()),
+            ..InternalEventJournalCursor::default()
+        },
+    )
+}
+
+fn internal_event_segments_eligible_for_deletion(
+    segments: &[InternalEventJournalSegment],
+    active_segment_id: &str,
+    floor_cursor: Option<&InternalEventJournalCursor>,
+) -> Vec<InternalEventJournalSegment> {
+    let Some(floor_segment_id) = floor_cursor.and_then(|cursor| cursor.segment_id.as_deref())
+    else {
+        return Vec::new();
+    };
+    if !segments
+        .iter()
+        .any(|segment| segment.segment_id == floor_segment_id)
+    {
+        return Vec::new();
+    }
+    segments
+        .iter()
+        .filter(|segment| {
+            segment.segment_id != active_segment_id
+                && compare_internal_event_segment_ids(segment.segment_id.as_str(), floor_segment_id)
+                    .is_lt()
+        })
+        .cloned()
+        .collect()
+}
+
+fn compare_internal_event_segment_ids(left: &str, right: &str) -> std::cmp::Ordering {
+    match (
+        parse_internal_event_segment_sequence(left),
+        parse_internal_event_segment_sequence(right),
+    ) {
+        (Some(left_sequence), Some(right_sequence)) => left_sequence.cmp(&right_sequence),
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (None, None) => left.cmp(right),
+    }
+}
+
+fn parse_internal_event_segment_sequence(segment_id: &str) -> Option<u64> {
+    segment_id
+        .strip_prefix("segment-")
+        .and_then(|suffix| suffix.parse::<u64>().ok())
+}
+
+fn read_internal_event_journal_segment_after(
+    segment: &InternalEventJournalSegment,
+    cursor: InternalEventJournalCursor,
+) -> Result<(Vec<InternalEventJournalRecord>, InternalEventJournalCursor), String> {
+    let path = segment.path.as_path();
+    if !path.exists() {
+        return Ok((
+            Vec::new(),
+            InternalEventJournalCursor {
+                segment_id: Some(segment.segment_id.clone()),
+                ..cursor
+            },
+        ));
+    }
+    let file = open_internal_event_journal(path)?;
+    lock_internal_event_journal(&file, path)?;
+    let read_result = (|| -> Result<_, String> {
+        let metadata = file.metadata().map_err(|error| {
+            format!(
+                "read internal event journal metadata {} failed: {error}",
+                path.display()
+            )
+        })?;
+        let current_fingerprint = load_internal_event_journal_fingerprint_from_handle(&file, path)?;
+        let mut cursor = if cursor.byte_offset > metadata.len()
+            || cursor.journal_fingerprint != current_fingerprint
+        {
+            InternalEventJournalCursor {
+                segment_id: Some(segment.segment_id.clone()),
+                ..InternalEventJournalCursor::default()
+            }
+        } else {
+            cursor
+        };
+        cursor.segment_id = Some(segment.segment_id.clone());
+        cursor.journal_fingerprint = current_fingerprint;
+
+        let mut reader_file = file.try_clone().map_err(|error| {
+            format!(
+                "clone internal event journal handle {} failed: {error}",
+                path.display()
+            )
+        })?;
+        reader_file
+            .seek(SeekFrom::Start(cursor.byte_offset))
+            .map_err(|error| {
+                format!(
+                    "seek internal event journal {} to {} failed: {error}",
+                    path.display(),
+                    cursor.byte_offset
+                )
+            })?;
+        let mut reader = BufReader::new(reader_file);
+        let mut events = Vec::new();
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line).map_err(|error| {
+                format!(
+                    "read internal event journal line {} from {} failed: {error}",
+                    cursor.line_cursor.saturating_add(1),
+                    path.display()
+                )
+            })?;
+            if bytes_read == 0 {
+                break;
+            }
+            cursor.line_cursor = cursor.line_cursor.saturating_add(1);
+            cursor.byte_offset = cursor.byte_offset.saturating_add(
+                u64::try_from(bytes_read)
+                    .map_err(|error| format!("internal event cursor overflowed u64: {error}"))?,
+            );
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(&line).map_err(|error| {
+                format!(
+                    "parse internal event journal line {} from {} failed: {error}",
+                    cursor.line_cursor,
+                    path.display()
+                )
+            })?;
+            let event_name = value
+                .get("event_name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    format!(
+                        "internal event journal line {} in {} is missing string event_name",
+                        cursor.line_cursor,
+                        path.display()
+                    )
+                })?
+                .to_owned();
+            let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+            let recorded_at_ms = value
+                .get("recorded_at_ms")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            events.push(InternalEventJournalRecord {
+                line_cursor: cursor.line_cursor,
+                event_name,
+                payload,
+                recorded_at_ms,
+            });
+        }
+        Ok((events, cursor))
+    })();
+    let unlock_result = unlock_internal_event_journal(&file, path);
+    let output = read_result?;
+    unlock_result?;
+    Ok(output)
+}
+
 fn unlock_internal_event_journal(file: &File, path: &std::path::Path) -> Result<(), String> {
     file.unlock().map_err(|error| {
         format!(
             "unlock internal event journal {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn unlock_internal_event_journal_control_lock(
+    file: &File,
+    path: &std::path::Path,
+) -> Result<(), String> {
+    file.unlock().map_err(|error| {
+        format!(
+            "unlock internal event journal control lock {} failed: {error}",
             path.display()
         )
     })
@@ -336,7 +1198,27 @@ fn load_internal_event_journal_fingerprint(
             path.display()
         )
     })?;
-    let reader = BufReader::new(file);
+    load_internal_event_journal_fingerprint_from_handle(&file, path)
+}
+
+fn load_internal_event_journal_fingerprint_from_handle(
+    file: &File,
+    path: &std::path::Path,
+) -> Result<Option<String>, String> {
+    let cloned = file.try_clone().map_err(|error| {
+        format!(
+            "clone internal event journal handle {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let mut cloned = cloned;
+    cloned.seek(SeekFrom::Start(0)).map_err(|error| {
+        format!(
+            "seek internal event journal {} to start failed: {error}",
+            path.display()
+        )
+    })?;
+    let reader = BufReader::new(cloned);
     for line in reader.lines() {
         let line = line.map_err(|error| {
             format!(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod control_plane;
 pub mod conversation;
 pub mod crypto;
+pub mod internal_events;
 pub mod mcp;
 pub mod memory;
 pub mod migration;

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -847,7 +847,13 @@ where
                             "provider response shape invalid for model `{}` on attempt {}/{}: {error}",
                             this.model, this.attempt, this.max_attempts
                         ),
-                        _ => format!(
+                        ProviderFailoverReason::ModelMismatch
+                        | ProviderFailoverReason::RateLimited
+                        | ProviderFailoverReason::ProviderOverloaded
+                        | ProviderFailoverReason::AuthRejected
+                        | ProviderFailoverReason::PayloadIncompatible
+                        | ProviderFailoverReason::TransportFailure
+                        | ProviderFailoverReason::RequestRejected => format!(
                             "streaming response error for model `{}` on attempt {}/{}: {error}",
                             this.model, this.attempt, this.max_attempts
                         ),

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -46,6 +46,13 @@ pub fn initialize_runtime_environment(config: &LoongConfig, resolved_config_path
         Some(profile_note) => set_env_var("LOONG_MEMORY_PROFILE_NOTE", profile_note),
         None => remove_env_var("LOONG_MEMORY_PROFILE_NOTE"),
     }
+    match config.automation.internal_event_segment_max_bytes {
+        Some(segment_max_bytes) => set_env_var(
+            "LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES",
+            segment_max_bytes.to_string(),
+        ),
+        None => remove_env_var("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES"),
+    }
 
     set_env_var("LOONG_SHELL_ALLOWLIST", config.tools.shell_allow.join(","));
     set_env_var("LOONG_SHELL_DENY", config.tools.shell_deny.join(","));
@@ -223,6 +230,7 @@ mod tests {
             "LOONG_SLIDING_WINDOW",
             "LOONG_MEMORY_SUMMARY_MAX_CHARS",
             "LOONG_MEMORY_PROFILE_NOTE",
+            "LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES",
             "LOONG_SHELL_ALLOWLIST",
             "LOONG_SHELL_DENY",
             "LOONG_SHELL_DEFAULT_MODE",
@@ -263,6 +271,7 @@ mod tests {
         config.memory.profile = MemoryProfile::WindowPlusSummary;
         config.memory.summary_max_chars = 900;
         config.memory.profile_note = Some("Imported NanoBot preferences".to_owned());
+        config.automation.internal_event_segment_max_bytes = Some(8_192);
         config.tools.file_root = Some("/tmp/loong-runtime-file-root".to_owned());
         config.tools.sessions.allow_mutation = true;
         config.tools.browser.enabled = false;
@@ -302,6 +311,12 @@ mod tests {
         assert_eq!(
             std::env::var("LOONG_MEMORY_PROFILE_NOTE").ok().as_deref(),
             Some("Imported NanoBot preferences")
+        );
+        assert_eq!(
+            std::env::var("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES")
+                .ok()
+                .as_deref(),
+            Some("8192")
         );
         assert_eq!(
             std::env::var("LOONG_FILE_ROOT").ok().as_deref(),
@@ -413,6 +428,22 @@ mod tests {
                 .ok()
                 .as_deref(),
             Some("1")
+        );
+    }
+
+    #[test]
+    fn initialize_runtime_environment_clears_internal_event_segment_threshold_when_unset() {
+        let mut env = ScopedEnv::new();
+        clear_runtime_environment_exports(&mut env);
+        env.set("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES", "8192");
+
+        let config = LoongConfig::default();
+
+        initialize_runtime_environment(&config, None);
+
+        assert!(
+            std::env::var("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES").is_err(),
+            "unset automation config should clear stale segment threshold exports"
         );
     }
 

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1114,6 +1114,14 @@ fn execute_session_recover(
         if let Some(object) = payload.as_object_mut() {
             object.insert("recovery_action".to_owned(), outcome.action);
         }
+        crate::internal_events::emit_internal_event_with_metadata(
+            "session.recovered",
+            "app.tools.session",
+            json!({
+                "session_id": target_session_id,
+                "inspection": payload,
+            }),
+        );
         return Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
             payload,
@@ -1129,6 +1137,21 @@ fn execute_session_recover(
             tool_config,
             request.dry_run,
         )?);
+    }
+    if !request.dry_run {
+        for result in &results {
+            if result.result == "applied" {
+                crate::internal_events::emit_internal_event_with_metadata(
+                    "session.recovered",
+                    "app.tools.session",
+                    json!({
+                        "session_id": result.session_id,
+                        "action": result.action,
+                        "inspection": result.inspection,
+                    }),
+                );
+            }
+        }
     }
 
     Ok(ToolCoreOutcome {
@@ -1181,6 +1204,14 @@ fn execute_session_cancel(
         if let Some(object) = payload.as_object_mut() {
             object.insert("cancel_action".to_owned(), outcome.action);
         }
+        crate::internal_events::emit_internal_event_with_metadata(
+            "session.cancelled",
+            "app.tools.session",
+            json!({
+                "session_id": target_session_id,
+                "inspection": payload,
+            }),
+        );
         return Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
             payload,
@@ -1196,6 +1227,21 @@ fn execute_session_cancel(
             tool_config,
             request.dry_run,
         )?);
+    }
+    if !request.dry_run {
+        for result in &results {
+            if result.result == "applied" {
+                crate::internal_events::emit_internal_event_with_metadata(
+                    "session.cancelled",
+                    "app.tools.session",
+                    json!({
+                        "session_id": result.session_id,
+                        "action": result.action,
+                        "inspection": result.inspection,
+                    }),
+                );
+            }
+        }
     }
 
     Ok(ToolCoreOutcome {
@@ -1248,6 +1294,14 @@ fn execute_session_archive(
         if let Some(object) = payload.as_object_mut() {
             object.insert("archive_action".to_owned(), outcome.action);
         }
+        crate::internal_events::emit_internal_event_with_metadata(
+            "session.archived",
+            "app.tools.session",
+            json!({
+                "session_id": target_session_id,
+                "inspection": payload,
+            }),
+        );
         return Ok(ToolCoreOutcome {
             status: "ok".to_owned(),
             payload,
@@ -1263,6 +1317,21 @@ fn execute_session_archive(
             tool_config,
             request.dry_run,
         )?);
+    }
+    if !request.dry_run {
+        for result in &results {
+            if result.result == "applied" {
+                crate::internal_events::emit_internal_event_with_metadata(
+                    "session.archived",
+                    "app.tools.session",
+                    json!({
+                        "session_id": result.session_id,
+                        "action": result.action,
+                        "inspection": result.inspection,
+                    }),
+                );
+            }
+        }
     }
 
     Ok(ToolCoreOutcome {

--- a/crates/app/src/work/repository.rs
+++ b/crates/app/src/work/repository.rs
@@ -295,8 +295,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit create transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)?
-            .ok_or_else(|| format!("work unit `{work_unit_id}` disappeared after insert"))
+        let snapshot = self
+            .load_work_unit_snapshot(&work_unit_id)?
+            .ok_or_else(|| format!("work unit `{work_unit_id}` disappeared after insert"))?;
+        emit_work_unit_snapshot_event("work_unit.created", &snapshot, json!({}));
+        Ok(snapshot)
     }
 
     pub fn load_work_unit_snapshot(
@@ -447,7 +450,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit lease transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&raw_record.work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&raw_record.work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.leased", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn mark_leased_running(
@@ -507,7 +514,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit start transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.started", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn heartbeat_lease(
@@ -568,7 +579,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit heartbeat transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.heartbeat", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn complete_work_unit(
@@ -664,7 +679,17 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit complete transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            let event_name = match request.disposition {
+                WorkUnitCompletionDisposition::Completed => "work_unit.completed",
+                WorkUnitCompletionDisposition::RetryPending => "work_unit.retry_pending",
+                WorkUnitCompletionDisposition::FailedTerminal => "work_unit.failed_terminal",
+                WorkUnitCompletionDisposition::Cancelled => "work_unit.cancelled",
+            };
+            emit_work_unit_snapshot_event(event_name, snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn archive_work_unit(
@@ -719,7 +744,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit archive transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.archived", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn update_work_unit(
@@ -883,7 +912,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit update transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.updated", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn assign_work_unit(
@@ -942,7 +975,11 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit assignment transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event("work_unit.assigned", snapshot, json!({}));
+        }
+        Ok(snapshot)
     }
 
     pub fn add_dependency(
@@ -1014,7 +1051,18 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit dependency transaction failed: {error}"))?;
 
-        self.load_work_unit_snapshot(&blocked_work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&blocked_work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event(
+                "work_unit.dependency_added",
+                snapshot,
+                json!({
+                    "blocking_work_unit_id": blocking_work_unit_id,
+                    "blocked_work_unit_id": blocked_work_unit_id,
+                }),
+            );
+        }
+        Ok(snapshot)
     }
 
     pub fn remove_dependency(
@@ -1071,7 +1119,18 @@ impl WorkUnitRepository {
             format!("commit work unit dependency removal transaction failed: {error}")
         })?;
 
-        self.load_work_unit_snapshot(&blocked_work_unit_id)
+        let snapshot = self.load_work_unit_snapshot(&blocked_work_unit_id)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            emit_work_unit_snapshot_event(
+                "work_unit.dependency_removed",
+                snapshot,
+                json!({
+                    "blocking_work_unit_id": blocking_work_unit_id,
+                    "blocked_work_unit_id": blocked_work_unit_id,
+                }),
+            );
+        }
+        Ok(snapshot)
     }
 
     pub fn append_note(
@@ -1109,6 +1168,7 @@ impl WorkUnitRepository {
             .commit()
             .map_err(|error| format!("commit work unit note transaction failed: {error}"))?;
 
+        emit_work_unit_event_record("work_unit.noted", &event);
         Ok(Some(event))
     }
 
@@ -1190,6 +1250,7 @@ impl WorkUnitRepository {
             let snapshot = self
                 .load_work_unit_snapshot(&recovered_id)?
                 .ok_or_else(|| format!("recovered work unit `{recovered_id}` disappeared"))?;
+            emit_work_unit_snapshot_event("work_unit.recovered", &snapshot, json!({}));
             recovered_snapshots.push(snapshot);
         }
 
@@ -1335,6 +1396,35 @@ impl WorkUnitRepository {
         Connection::open(&self.db_path)
             .map_err(|error| format!("open work unit repository sqlite db failed: {error}"))
     }
+}
+
+fn emit_work_unit_snapshot_event(event_name: &str, snapshot: &WorkUnitSnapshot, extra: Value) {
+    let snapshot_json = match serde_json::to_value(snapshot) {
+        Ok(value) => value,
+        Err(_) => {
+            return;
+        }
+    };
+    crate::internal_events::emit_internal_event_with_metadata(
+        event_name,
+        "app.work.repository",
+        json!({
+            "work_unit": snapshot_json,
+            "extra": extra,
+        }),
+    );
+}
+
+fn emit_work_unit_event_record(event_name: &str, event: &WorkUnitEventRecord) {
+    let payload = match serde_json::to_value(event) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    crate::internal_events::emit_internal_event_with_metadata(
+        event_name,
+        "app.work.repository",
+        payload,
+    );
 }
 
 fn insert_event_in_tx(

--- a/crates/app/tests/internal_events.rs
+++ b/crates/app/tests/internal_events.rs
@@ -5,9 +5,12 @@ use std::time::Duration;
 
 use loong_app::internal_events::{
     InternalEventJournalCursor, append_internal_event_to_journal,
-    emit_internal_event_with_metadata, internal_event_journal_cursor_from_line_cursor,
-    internal_event_journal_path, probe_internal_event_journal_runtime_ready,
+    emit_internal_event_with_metadata, inspect_internal_event_journal_layout,
+    internal_event_active_segment_id_path, internal_event_journal_cursor_from_line_cursor,
+    internal_event_journal_path, internal_event_journal_state_path, internal_event_segment_path,
+    probe_internal_event_journal_runtime_ready, prune_internal_event_journal_segments,
     read_internal_event_journal_after, read_internal_event_journal_since,
+    repair_internal_event_journal_state, rotate_internal_event_journal_segment,
 };
 use loong_app::test_support::ScopedEnv;
 use serde_json::json;
@@ -304,4 +307,457 @@ fn append_internal_event_to_journal_waits_for_existing_file_lock() {
 
     let contents = fs::read_to_string(&journal_path).expect("read journal contents");
     assert_eq!(contents.lines().count(), 1);
+}
+
+#[test]
+fn read_internal_event_journal_after_continues_across_segment_boundary_without_replay() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let active_segment_path = internal_event_segment_path("segment-000001");
+    fs::create_dir_all(active_segment_path.parent().expect("segment parent"))
+        .expect("create segment parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000002\n")
+        .expect("write active segment id");
+    fs::write(
+        &active_segment_path,
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"seg-a\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write sealed segment");
+    fs::write(
+        internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"seg-b\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write active segment");
+
+    let (events, next_cursor) =
+        read_internal_event_journal_after(InternalEventJournalCursor::default())
+            .expect("read across segment boundary");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].payload["session_id"], "seg-a");
+    assert_eq!(events[1].payload["session_id"], "seg-b");
+    assert_eq!(next_cursor.segment_id.as_deref(), Some("segment-000002"));
+
+    let (follow_up_events, follow_up_cursor) =
+        read_internal_event_journal_after(next_cursor.clone()).expect("read after final cursor");
+    assert!(follow_up_events.is_empty());
+    assert_eq!(follow_up_cursor, next_cursor);
+}
+
+#[test]
+fn internal_event_journal_cursor_from_line_cursor_maps_legacy_numeric_cursor_across_segment_boundary()
+ {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let first_segment_path = internal_event_segment_path("segment-000001");
+    fs::create_dir_all(first_segment_path.parent().expect("segment parent"))
+        .expect("create segment parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000002\n")
+        .expect("write active segment id");
+    fs::write(
+        &first_segment_path,
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"legacy-a\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write first segment");
+    fs::write(
+        internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"legacy-b\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write second segment");
+
+    let cursor = internal_event_journal_cursor_from_line_cursor(1).expect("migrate numeric cursor");
+    assert_eq!(cursor.segment_id.as_deref(), Some("segment-000001"));
+    assert_eq!(cursor.line_cursor, 1);
+
+    let (events, next_cursor) =
+        read_internal_event_journal_after(cursor).expect("read after migrated cursor");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_name, "session.archived");
+    assert_eq!(events[0].payload["session_id"], "legacy-b");
+    assert_eq!(next_cursor.segment_id.as_deref(), Some("segment-000002"));
+}
+
+#[test]
+fn rotate_internal_event_journal_segment_moves_legacy_journal_into_first_segment() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let legacy_path = temp_home
+        .path()
+        .join("automation")
+        .join("internal-events.jsonl");
+    fs::create_dir_all(legacy_path.parent().expect("legacy parent")).expect("create legacy parent");
+    fs::write(
+        &legacy_path,
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"legacy\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("seed legacy journal row");
+
+    let next_segment_id = rotate_internal_event_journal_segment().expect("rotate legacy segment");
+    assert_eq!(next_segment_id, "segment-000002");
+    assert_eq!(
+        fs::read_to_string(internal_event_active_segment_id_path()).expect("read active segment"),
+        "segment-000002\n"
+    );
+    let sealed_segment_path = internal_event_segment_path("segment-000001");
+    assert!(sealed_segment_path.exists());
+    let sealed_contents =
+        fs::read_to_string(&sealed_segment_path).expect("read sealed legacy segment");
+    assert!(
+        sealed_contents.contains("\"session_id\":\"legacy\""),
+        "sealed legacy segment should preserve the migrated row: {sealed_contents}"
+    );
+
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "active" }))
+        .expect("append active segment row");
+    let active_segment_path = internal_event_segment_path("segment-000002");
+    assert!(active_segment_path.exists());
+}
+
+#[test]
+fn rotate_internal_event_journal_segment_advances_active_segment_for_new_appends() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_active_segment_id_path()
+            .parent()
+            .expect("active segment parent"),
+    )
+    .expect("create active segment parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000001\n")
+        .expect("seed active segment id");
+    append_internal_event_to_journal("session.cancelled", &json!({ "session_id": "first" }))
+        .expect("append first active row");
+
+    let next_segment_id = rotate_internal_event_journal_segment().expect("rotate active segment");
+    assert_eq!(next_segment_id, "segment-000002");
+
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "second" }))
+        .expect("append second active row");
+    assert!(internal_event_segment_path("segment-000001").exists());
+    assert!(internal_event_segment_path("segment-000002").exists());
+}
+
+#[test]
+fn prune_internal_event_journal_segments_removes_only_fully_consumed_sealed_segments() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000003\n")
+        .expect("write active segment");
+    fs::write(
+        internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"oldest\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write first sealed segment");
+    fs::write(
+        internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"cursor\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write cursor segment");
+    fs::write(
+        internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"active\"},\"recorded_at_ms\":3}\n",
+    )
+    .expect("write active segment");
+
+    let pruned = prune_internal_event_journal_segments(&InternalEventJournalCursor {
+        segment_id: Some("segment-000002".to_owned()),
+        line_cursor: 1,
+        byte_offset: 1,
+        journal_fingerprint: None,
+    })
+    .expect("prune consumed segments");
+    assert_eq!(pruned, vec!["segment-000001".to_owned()]);
+    assert!(!internal_event_segment_path("segment-000001").exists());
+    assert!(internal_event_segment_path("segment-000002").exists());
+    assert!(internal_event_segment_path("segment-000003").exists());
+}
+
+#[test]
+fn read_internal_event_journal_after_missing_segment_cursor_skips_older_surviving_segments() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000003\n")
+        .expect("write active segment id");
+    fs::write(
+        internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"older\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write older surviving segment");
+    fs::write(
+        internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"newer\"},\"recorded_at_ms\":3}\n",
+    )
+    .expect("write newer surviving segment");
+
+    let (events, next_cursor) = read_internal_event_journal_after(InternalEventJournalCursor {
+        segment_id: Some("segment-000002".to_owned()),
+        line_cursor: 5,
+        byte_offset: 99,
+        journal_fingerprint: Some("stale".to_owned()),
+    })
+    .expect("read after missing segment cursor");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_name, "session.archived");
+    assert_eq!(events[0].payload["session_id"], "newer");
+    assert_eq!(next_cursor.segment_id.as_deref(), Some("segment-000003"));
+}
+
+#[test]
+fn inspect_internal_event_journal_layout_reports_active_and_legacy_segments() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let legacy_path = temp_home
+        .path()
+        .join("automation")
+        .join("internal-events.jsonl");
+    fs::create_dir_all(legacy_path.parent().expect("legacy parent")).expect("create legacy parent");
+    fs::write(
+        &legacy_path,
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"legacy\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write legacy journal");
+    fs::write(internal_event_active_segment_id_path(), "segment-000002\n")
+        .expect("write active segment id");
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"sealed\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write sealed segment");
+
+    let layout = inspect_internal_event_journal_layout().expect("inspect journal layout");
+    assert_eq!(layout.active_segment_id, "segment-000002");
+    assert_eq!(layout.segments.len(), 3);
+    assert_eq!(layout.segments[0].segment_id, "legacy");
+    assert!(!layout.segments[0].is_active);
+    assert_eq!(layout.segments[1].segment_id, "segment-000001");
+    assert!(!layout.segments[1].is_active);
+    assert_eq!(layout.segments[2].segment_id, "segment-000002");
+    assert!(layout.segments[2].is_active);
+}
+
+#[test]
+fn rotate_internal_event_journal_segment_persists_layout_state_and_active_marker() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let next_segment_id = rotate_internal_event_journal_segment().expect("rotate segment");
+    assert_eq!(next_segment_id, "segment-000002");
+
+    let state_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(internal_event_journal_state_path()).expect("read journal state"),
+    )
+    .expect("parse journal state");
+    assert_eq!(state_payload["schema_version"], 1);
+    assert_eq!(state_payload["active_segment_id"], "segment-000002");
+    assert_eq!(
+        state_payload["segments"]
+            .as_array()
+            .expect("segments array")
+            .len(),
+        2
+    );
+    assert_eq!(state_payload["segments"][0]["segment_id"], "segment-000001");
+    assert_eq!(state_payload["segments"][0]["status"], "sealed");
+    assert_eq!(state_payload["segments"][1]["segment_id"], "segment-000002");
+    assert_eq!(state_payload["segments"][1]["status"], "active");
+    assert_eq!(
+        fs::read_to_string(internal_event_active_segment_id_path()).expect("read active marker"),
+        "segment-000002\n"
+    );
+}
+
+#[test]
+fn append_internal_event_to_journal_auto_rotates_when_segment_exceeds_threshold() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+    env.set("LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES", "1");
+
+    append_internal_event_to_journal("session.cancelled", &json!({ "session_id": "first" }))
+        .expect("append first row");
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "second" }))
+        .expect("append second row");
+
+    let first_segment = internal_event_segment_path("segment-000001");
+    let second_segment = internal_event_segment_path("segment-000002");
+    let first_contents = fs::read_to_string(&first_segment).expect("read first segment");
+    let second_contents = fs::read_to_string(&second_segment).expect("read second segment");
+    assert!(first_contents.contains("\"session_id\":\"first\""));
+    assert!(second_contents.contains("\"session_id\":\"second\""));
+
+    let layout = inspect_internal_event_journal_layout().expect("inspect journal layout");
+    assert_eq!(layout.active_segment_id, "segment-000002");
+}
+
+#[test]
+fn inspect_internal_event_journal_layout_prefers_state_file_over_stale_active_marker() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_active_segment_id_path()
+            .parent()
+            .expect("automation parent"),
+    )
+    .expect("create automation parent");
+    fs::write(internal_event_active_segment_id_path(), "segment-000001\n")
+        .expect("write stale active marker");
+    fs::write(
+        internal_event_journal_state_path(),
+        "{\n  \"active_segment_id\": \"segment-000003\"\n}\n",
+    )
+    .expect("write journal state");
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"sealed\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write sealed segment");
+
+    let layout = inspect_internal_event_journal_layout().expect("inspect journal layout");
+    assert_eq!(layout.active_segment_id, "segment-000003");
+    assert_eq!(
+        layout
+            .segments
+            .last()
+            .expect("active segment entry")
+            .segment_id,
+        "segment-000003"
+    );
+    assert!(
+        layout
+            .segments
+            .last()
+            .expect("active segment entry")
+            .is_active
+    );
+}
+
+#[test]
+fn repair_internal_event_journal_state_reconciles_disk_layout_and_preserves_known_metadata() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000003\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"active\",\"created_at_ms\":30}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    fs::write(
+        internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"sealed\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write sealed segment");
+    fs::write(
+        internal_event_segment_path("segment-000004"),
+        "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"new-active\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write recovered active segment");
+    fs::write(internal_event_active_segment_id_path(), "segment-000004\n")
+        .expect("write newer active marker");
+
+    let repaired_layout =
+        repair_internal_event_journal_state().expect("repair internal event journal state");
+    assert_eq!(repaired_layout.active_segment_id, "segment-000004");
+    assert_eq!(repaired_layout.segments.len(), 2);
+    assert_eq!(repaired_layout.segments[0].segment_id, "segment-000001");
+    assert_eq!(repaired_layout.segments[0].status, "sealed");
+    assert_eq!(repaired_layout.segments[0].created_at_ms, Some(10));
+    assert_eq!(repaired_layout.segments[0].sealed_at_ms, Some(20));
+    assert_eq!(repaired_layout.segments[1].segment_id, "segment-000004");
+    assert_eq!(repaired_layout.segments[1].status, "active");
+}
+
+#[test]
+fn inspect_internal_event_journal_layout_reads_manifest_statuses() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_journal_state_path()
+            .parent()
+            .expect("automation parent"),
+    )
+    .expect("create automation parent");
+    fs::write(
+        internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000003\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"legacy\",\"status\":\"legacy\"},\n",
+            "    {\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"active\",\"created_at_ms\":30}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write manifest state");
+
+    let layout = inspect_internal_event_journal_layout().expect("inspect journal layout");
+    assert_eq!(layout.active_segment_id, "segment-000003");
+    assert_eq!(layout.segments[0].status, "legacy");
+    assert_eq!(layout.segments[1].status, "sealed");
+    assert_eq!(layout.segments[1].created_at_ms, Some(10));
+    assert_eq!(layout.segments[1].sealed_at_ms, Some(20));
+    assert_eq!(layout.segments[2].status, "active");
+    assert_eq!(layout.segments[2].created_at_ms, Some(30));
+    assert_eq!(layout.segments[2].sealed_at_ms, None);
 }

--- a/crates/app/tests/internal_events.rs
+++ b/crates/app/tests/internal_events.rs
@@ -1,0 +1,307 @@
+use std::fs;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use loong_app::internal_events::{
+    InternalEventJournalCursor, append_internal_event_to_journal,
+    emit_internal_event_with_metadata, internal_event_journal_cursor_from_line_cursor,
+    internal_event_journal_path, probe_internal_event_journal_runtime_ready,
+    read_internal_event_journal_after, read_internal_event_journal_since,
+};
+use loong_app::test_support::ScopedEnv;
+use serde_json::json;
+
+#[test]
+fn read_internal_event_journal_since_filters_by_cursor() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    emit_internal_event_with_metadata(
+        "session.cancelled",
+        "app.tools.session",
+        json!({
+            "session_id": "s1"
+        }),
+    );
+    emit_internal_event_with_metadata(
+        "session.archived",
+        "app.tools.session",
+        json!({
+            "session_id": "s2"
+        }),
+    );
+
+    let events = read_internal_event_journal_since(1).expect("read journal after cursor");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].line_cursor, 2);
+    assert_eq!(events[0].event_name, "session.archived");
+    assert_eq!(events[0].payload["session_id"], "s2");
+}
+
+#[test]
+fn read_internal_event_journal_preserves_scalar_payloads_via_value_wrapper() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    emit_internal_event_with_metadata("session.cancelled", "app.tools.session", json!("hello"));
+
+    let events = read_internal_event_journal_since(0).expect("read journal");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].payload["value"], "hello");
+    assert_eq!(
+        events[0].payload["_automation"]["source_surface"],
+        "app.tools.session"
+    );
+}
+
+#[test]
+fn read_internal_event_journal_accepts_legacy_rows_and_blank_lines() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+    let journal_path = internal_event_journal_path();
+    if let Some(parent) = journal_path.parent() {
+        fs::create_dir_all(parent).expect("create journal parent");
+    }
+    fs::write(
+        &journal_path,
+        concat!(
+            "{\"event_name\":\"legacy.one\"}\n",
+            "\n",
+            "{\"event_name\":\"legacy.two\",\"payload\":{\"ok\":true}}\n"
+        ),
+    )
+    .expect("write legacy journal");
+
+    let events = read_internal_event_journal_since(0).expect("read legacy journal");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].line_cursor, 1);
+    assert_eq!(events[0].event_name, "legacy.one");
+    assert_eq!(events[0].payload, serde_json::Value::Null);
+    assert_eq!(events[0].recorded_at_ms, 0);
+    assert_eq!(events[1].line_cursor, 3);
+    assert_eq!(events[1].event_name, "legacy.two");
+    assert_eq!(events[1].payload["ok"], true);
+}
+
+#[test]
+fn append_internal_event_to_journal_writes_rows_in_readable_order() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &json!({
+            "session_id": "s1"
+        }),
+    )
+    .expect("append first journal row");
+    append_internal_event_to_journal(
+        "session.archived",
+        &json!({
+            "session_id": "s2"
+        }),
+    )
+    .expect("append second journal row");
+
+    let events = read_internal_event_journal_since(0).expect("read appended journal");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].line_cursor, 1);
+    assert_eq!(events[0].event_name, "session.cancelled");
+    assert_eq!(events[0].payload["session_id"], "s1");
+    assert!(events[0].recorded_at_ms > 0);
+    assert_eq!(events[1].line_cursor, 2);
+    assert_eq!(events[1].event_name, "session.archived");
+    assert_eq!(events[1].payload["session_id"], "s2");
+    assert!(events[1].recorded_at_ms > 0);
+}
+
+#[test]
+fn read_internal_event_journal_after_uses_byte_offset_for_incremental_reads() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    append_internal_event_to_journal("session.cancelled", &json!({ "session_id": "s1" }))
+        .expect("append first row");
+    let (first_events, first_cursor) =
+        read_internal_event_journal_after(InternalEventJournalCursor::default())
+            .expect("read first batch");
+    assert_eq!(first_events.len(), 1);
+    assert_eq!(first_events[0].payload["session_id"], "s1");
+    assert_eq!(first_cursor.line_cursor, 1);
+    assert!(first_cursor.byte_offset > 0);
+
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "s2" }))
+        .expect("append second row");
+    let (second_events, second_cursor) =
+        read_internal_event_journal_after(first_cursor.clone()).expect("read second batch");
+    assert_eq!(second_events.len(), 1);
+    assert_eq!(second_events[0].payload["session_id"], "s2");
+    assert_eq!(second_cursor.line_cursor, 2);
+    assert!(second_cursor.byte_offset > first_cursor.byte_offset);
+}
+
+#[test]
+fn internal_event_journal_cursor_from_line_cursor_preserves_legacy_numeric_position() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    append_internal_event_to_journal("session.cancelled", &json!({ "session_id": "s1" }))
+        .expect("append first row");
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "s2" }))
+        .expect("append second row");
+
+    let cursor =
+        internal_event_journal_cursor_from_line_cursor(1).expect("migrate line cursor to offset");
+    assert_eq!(cursor.line_cursor, 1);
+    assert!(cursor.byte_offset > 0);
+
+    let (events, next_cursor) =
+        read_internal_event_journal_after(cursor.clone()).expect("read after migrated cursor");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_name, "session.archived");
+    assert_eq!(events[0].payload["session_id"], "s2");
+    assert_eq!(next_cursor.line_cursor, 2);
+    assert!(next_cursor.byte_offset > cursor.byte_offset);
+}
+
+#[test]
+fn read_internal_event_journal_after_resets_stale_offset_after_truncation() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    append_internal_event_to_journal("session.cancelled", &json!({ "session_id": "s1" }))
+        .expect("append first row");
+    append_internal_event_to_journal("session.archived", &json!({ "session_id": "s2" }))
+        .expect("append second row");
+
+    let (_, stale_cursor) =
+        read_internal_event_journal_after(InternalEventJournalCursor::default())
+            .expect("read initial journal");
+    let journal_path = internal_event_journal_path();
+    fs::write(
+        &journal_path,
+        "{\"event_name\":\"session.recovered\",\"payload\":{\"session_id\":\"s3\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("truncate journal to retained subset");
+
+    let (events, recovered_cursor) =
+        read_internal_event_journal_after(stale_cursor).expect("read after stale cursor");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_name, "session.recovered");
+    assert_eq!(events[0].line_cursor, 1);
+    assert_eq!(events[0].payload["session_id"], "s3");
+    assert_eq!(recovered_cursor.line_cursor, 1);
+    assert!(recovered_cursor.byte_offset > 0);
+}
+
+#[test]
+fn read_internal_event_journal_after_resets_stale_offset_after_same_size_rotation() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &json!({ "session_id": "first-rotation-source" }),
+    )
+    .expect("append first source row");
+    append_internal_event_to_journal(
+        "session.archived",
+        &json!({ "session_id": "second-rotation-source" }),
+    )
+    .expect("append second source row");
+
+    let (_, stale_cursor) =
+        read_internal_event_journal_after(InternalEventJournalCursor::default())
+            .expect("read initial journal");
+    let stale_fingerprint = stale_cursor.journal_fingerprint.clone();
+    let journal_path = internal_event_journal_path();
+    fs::write(
+        &journal_path,
+        concat!(
+            "{\"event_name\":\"session.recovered\",\"payload\":{\"session_id\":\"rotation-target-a\"},\"recorded_at_ms\":2}\n",
+            "{\"event_name\":\"session.recovered\",\"payload\":{\"session_id\":\"rotation-target-b\"},\"recorded_at_ms\":3}\n"
+        ),
+    )
+    .expect("replace journal with same-size-or-larger rotated file");
+
+    let (events, recovered_cursor) =
+        read_internal_event_journal_after(stale_cursor).expect("read after rotated journal");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].line_cursor, 1);
+    assert_eq!(events[0].event_name, "session.recovered");
+    assert_eq!(events[0].payload["session_id"], "rotation-target-a");
+    assert_eq!(events[1].line_cursor, 2);
+    assert_eq!(events[1].payload["session_id"], "rotation-target-b");
+    assert_eq!(recovered_cursor.line_cursor, 2);
+    assert!(recovered_cursor.byte_offset > 0);
+    assert_ne!(
+        recovered_cursor.journal_fingerprint, stale_fingerprint,
+        "rotation should produce a different journal fingerprint"
+    );
+}
+
+#[test]
+fn probe_internal_event_journal_runtime_ready_accepts_fresh_path() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    probe_internal_event_journal_runtime_ready().expect("probe runtime readiness");
+    assert!(
+        internal_event_journal_path().exists(),
+        "probe should create the journal path when it does not exist yet"
+    );
+}
+
+#[test]
+fn append_internal_event_to_journal_waits_for_existing_file_lock() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    probe_internal_event_journal_runtime_ready().expect("probe runtime readiness");
+    let journal_path = internal_event_journal_path();
+    let external_lock = fs::OpenOptions::new()
+        .read(true)
+        .append(true)
+        .open(&journal_path)
+        .expect("open external journal handle");
+    external_lock.lock().expect("hold external journal lock");
+
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = append_internal_event_to_journal(
+            "session.cancelled",
+            &json!({
+                "session_id": "locked"
+            }),
+        );
+        tx.send(result).expect("send append result");
+    });
+
+    match rx.recv_timeout(Duration::from_millis(100)) {
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Ok(result) => panic!("journal append should block on external file lock, got {result:?}"),
+        Err(error) => panic!("journal append channel closed unexpectedly: {error:?}"),
+    }
+
+    external_lock
+        .unlock()
+        .expect("release external journal lock");
+    rx.recv_timeout(Duration::from_secs(1))
+        .expect("append should complete after lock release")
+        .expect("append should succeed after lock release");
+    handle.join().expect("join journal writer thread");
+
+    let contents = fs::read_to_string(&journal_path).expect("read journal contents");
+    assert_eq!(contents.lines().count(), 1);
+}

--- a/crates/app/tests/internal_events.rs
+++ b/crates/app/tests/internal_events.rs
@@ -4,10 +4,11 @@ use std::thread;
 use std::time::Duration;
 
 use loong_app::internal_events::{
-    InternalEventJournalCursor, append_internal_event_to_journal,
-    emit_internal_event_with_metadata, inspect_internal_event_journal_layout,
-    internal_event_active_segment_id_path, internal_event_journal_cursor_from_line_cursor,
-    internal_event_journal_path, internal_event_journal_state_path, internal_event_segment_path,
+    InternalEventJournalCursor, InternalEventJournalGcPolicy, append_internal_event_to_journal,
+    emit_internal_event_with_metadata, gc_internal_event_journal_segments,
+    inspect_internal_event_journal_layout, internal_event_active_segment_id_path,
+    internal_event_journal_cursor_from_line_cursor, internal_event_journal_path,
+    internal_event_journal_state_path, internal_event_segment_path, plan_internal_event_journal_gc,
     probe_internal_event_journal_runtime_ready, prune_internal_event_journal_segments,
     read_internal_event_journal_after, read_internal_event_journal_since,
     repair_internal_event_journal_state, rotate_internal_event_journal_segment,
@@ -485,6 +486,168 @@ fn prune_internal_event_journal_segments_removes_only_fully_consumed_sealed_segm
     assert!(!internal_event_segment_path("segment-000001").exists());
     assert!(internal_event_segment_path("segment-000002").exists());
     assert!(internal_event_segment_path("segment-000003").exists());
+}
+
+#[test]
+fn plan_internal_event_journal_gc_retains_recent_and_young_segments() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    let young_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_millis() as i64;
+    let old_ms = young_ms - 1_000_000;
+
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        internal_event_journal_state_path(),
+        format!(
+            concat!(
+                "{{\n",
+                "  \"schema_version\": 1,\n",
+                "  \"active_segment_id\": \"segment-000004\",\n",
+                "  \"segments\": [\n",
+                "    {{\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":{old_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":40}},\n",
+                "    {{\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}}\n",
+                "  ]\n",
+                "}}\n"
+            ),
+            old_ms = old_ms,
+            young_ms = young_ms,
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+
+    let plan = plan_internal_event_journal_gc(&InternalEventJournalGcPolicy {
+        retain_floor_segment_id: Some("segment-000004".to_owned()),
+        retain_last_sealed_segments: 1,
+        retain_min_age_ms: Some(60_000),
+    })
+    .expect("plan journal GC");
+
+    let segment_000001 = plan
+        .decisions
+        .iter()
+        .find(|decision| decision.segment_id == "segment-000001")
+        .expect("segment-000001 decision");
+    let segment_000002 = plan
+        .decisions
+        .iter()
+        .find(|decision| decision.segment_id == "segment-000002")
+        .expect("segment-000002 decision");
+    let segment_000003 = plan
+        .decisions
+        .iter()
+        .find(|decision| decision.segment_id == "segment-000003")
+        .expect("segment-000003 decision");
+    let segment_000004 = plan
+        .decisions
+        .iter()
+        .find(|decision| decision.segment_id == "segment-000004")
+        .expect("segment-000004 decision");
+
+    assert_eq!(segment_000001.action, "prune");
+    assert_eq!(segment_000001.reason, "eligible");
+    assert_eq!(segment_000002.action, "retain");
+    assert_eq!(segment_000002.reason, "retain_min_age");
+    assert_eq!(segment_000003.action, "retain");
+    assert_eq!(segment_000003.reason, "retain_last_sealed");
+    assert_eq!(segment_000004.action, "retain");
+    assert_eq!(segment_000004.reason, "active_segment");
+}
+
+#[test]
+fn gc_internal_event_journal_segments_applies_policy_and_updates_manifest() {
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    let mut env = ScopedEnv::new();
+    env.set("LOONG_HOME", temp_home.path().as_os_str());
+
+    fs::create_dir_all(
+        internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000004\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":30},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":40},\n",
+            "    {\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+
+    let plan = gc_internal_event_journal_segments(&InternalEventJournalGcPolicy {
+        retain_floor_segment_id: Some("segment-000004".to_owned()),
+        retain_last_sealed_segments: 1,
+        retain_min_age_ms: None,
+    })
+    .expect("apply journal GC");
+
+    let pruned_segment_ids = plan
+        .decisions
+        .iter()
+        .filter(|decision| decision.action == "prune")
+        .map(|decision| decision.segment_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(pruned_segment_ids, vec!["segment-000001", "segment-000002"]);
+    assert!(!internal_event_segment_path("segment-000001").exists());
+    assert!(!internal_event_segment_path("segment-000002").exists());
+    assert!(internal_event_segment_path("segment-000003").exists());
+    assert!(internal_event_segment_path("segment-000004").exists());
+
+    let layout = inspect_internal_event_journal_layout().expect("inspect journal layout");
+    let segment_ids = layout
+        .segments
+        .iter()
+        .map(|segment| segment.segment_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(segment_ids, vec!["segment-000003", "segment-000004"]);
 }
 
 #[test]

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -602,7 +602,7 @@ fn validate_json_pointer(raw: Option<&str>) -> CliResult<Option<String>> {
     let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(None);
     };
-    if raw == "" || raw.starts_with('/') {
+    if raw.is_empty() || raw.starts_with('/') {
         return Ok(Some(raw.to_owned()));
     }
     Err("automation event filters require RFC6901 json pointers beginning with `/`".to_owned())
@@ -744,12 +744,34 @@ fn parse_cron_expression(raw: &str) -> CliResult<CronExpression> {
                 .to_owned(),
         );
     }
+
+    let minute_field = fields
+        .first()
+        .copied()
+        .ok_or_else(|| "cron expression missing minute field".to_owned())?;
+    let hour_field = fields
+        .get(1)
+        .copied()
+        .ok_or_else(|| "cron expression missing hour field".to_owned())?;
+    let day_of_month_field = fields
+        .get(2)
+        .copied()
+        .ok_or_else(|| "cron expression missing day_of_month field".to_owned())?;
+    let month_field = fields
+        .get(3)
+        .copied()
+        .ok_or_else(|| "cron expression missing month field".to_owned())?;
+    let day_of_week_field = fields
+        .get(4)
+        .copied()
+        .ok_or_else(|| "cron expression missing day_of_week field".to_owned())?;
+
     Ok(CronExpression {
-        minute: parse_cron_field(fields[0], 0, 59, false)?,
-        hour: parse_cron_field(fields[1], 0, 23, false)?,
-        day_of_month: parse_cron_field(fields[2], 1, 31, false)?,
-        month: parse_cron_field(fields[3], 1, 12, false)?,
-        day_of_week: parse_cron_field(fields[4], 0, 6, true)?,
+        minute: parse_cron_field(minute_field, 0, 59, false)?,
+        hour: parse_cron_field(hour_field, 0, 23, false)?,
+        day_of_month: parse_cron_field(day_of_month_field, 1, 31, false)?,
+        month: parse_cron_field(month_field, 1, 12, false)?,
+        day_of_week: parse_cron_field(day_of_week_field, 0, 6, true)?,
     })
 }
 
@@ -770,7 +792,7 @@ fn next_cron_fire_at_ms(expression: &str, after_ms: i64) -> CliResult<i64> {
         let hour_matches = cron_field_matches(&parsed.hour, candidate.hour());
         let month_matches = cron_field_matches(&parsed.month, candidate.month() as u8);
         let dom_matches = cron_field_matches(&parsed.day_of_month, candidate.day());
-        let weekday = candidate.weekday().number_days_from_sunday() as u8;
+        let weekday = candidate.weekday().number_days_from_sunday();
         let dow_matches = cron_field_matches(&parsed.day_of_week, weekday);
         let day_matches = if parsed.day_of_month.any && parsed.day_of_week.any {
             true
@@ -1323,7 +1345,7 @@ async fn execute_emit_command(
 ) -> CliResult<Value> {
     let normalized_event_name = normalize_event_name(event_name)?;
     let parsed_payload = payload_json
-        .map(|raw| serde_json::from_str::<Value>(raw))
+        .map(serde_json::from_str::<Value>)
         .transpose()
         .map_err(|error| format!("parse --payload-json failed: {error}"))?;
     execute_emit_value_command(
@@ -1436,21 +1458,23 @@ fn execute_journal_health_command() -> CliResult<Value> {
         .map(Value::String)
         .unwrap_or(Value::Null);
     let cursor_segment_id = cursor.get("segment_id").cloned().unwrap_or(Value::Null);
-    let layout_segments = layout["segments"]
-        .as_array()
+    let layout_segments = layout
+        .get("segments")
+        .and_then(Value::as_array)
         .ok_or_else(|| "automation journal inspect payload missing segments".to_owned())?;
     let cursor_segment_exists = cursor_segment_id.as_str().is_some_and(|segment_id| {
-        layout_segments
-            .iter()
-            .any(|segment| segment["segment_id"].as_str() == Some(segment_id))
+        layout_segments.iter().any(|segment| {
+            let layout_segment_id = segment.get("segment_id").and_then(Value::as_str);
+            layout_segment_id == Some(segment_id)
+        })
     });
-    let active_segment_exists = layout["active_segment_id"]
-        .as_str()
-        .is_some_and(|segment_id| {
-            layout_segments
-                .iter()
-                .any(|segment| segment["segment_id"].as_str() == Some(segment_id))
-        });
+    let layout_active_segment_id = layout.get("active_segment_id").and_then(Value::as_str);
+    let active_segment_exists = layout_active_segment_id.is_some_and(|segment_id| {
+        layout_segments.iter().any(|segment| {
+            let layout_segment_id = segment.get("segment_id").and_then(Value::as_str);
+            layout_segment_id == Some(segment_id)
+        })
+    });
     let active_marker_matches_state = match (
         active_marker_segment_id.as_str(),
         state_active_segment_id.as_str(),
@@ -1568,11 +1592,9 @@ pub(crate) async fn publish_daemon_internal_event(
 }
 
 pub(crate) fn install_daemon_automation_event_sink(config: Option<String>) {
-    let sink_config = config.clone();
     let sink = std::sync::Arc::new(move |event_name: &str, payload: Value| {
-        let config = sink_config.clone();
+        let config = config.clone();
         let event_name = event_name.to_owned();
-        let payload = payload.clone();
         let handle = std::thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -1812,18 +1834,18 @@ async fn process_due_schedule_triggers(
     let now = now_ms();
     let mut changed = false;
     for trigger in &mut store.triggers {
-        let is_due = trigger.status == AutomationTriggerStatus::Active
-            && matches!(
-                &trigger.source,
-                AutomationTriggerSource::Schedule { schedule }
-                    if schedule.next_fire_at_ms <= now
-            )
-            || trigger.status == AutomationTriggerStatus::Active
-                && matches!(
-                    &trigger.source,
-                    AutomationTriggerSource::Cron { cron }
-                        if cron.next_fire_at_ms <= now
-                );
+        let is_active = trigger.status == AutomationTriggerStatus::Active;
+        let schedule_due = matches!(
+            &trigger.source,
+            AutomationTriggerSource::Schedule { schedule }
+                if schedule.next_fire_at_ms <= now
+        );
+        let cron_due = matches!(
+            &trigger.source,
+            AutomationTriggerSource::Cron { cron }
+                if cron.next_fire_at_ms <= now
+        );
+        let is_due = is_active && (schedule_due || cron_due);
         if !is_due {
             continue;
         }
@@ -2116,31 +2138,49 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
     }
 }
 
+fn json_pointer_array<'a>(value: &'a Value, pointer: &str) -> Option<&'a Vec<Value>> {
+    value.pointer(pointer).and_then(Value::as_array)
+}
+
+fn json_pointer_i64(value: &Value, pointer: &str) -> Option<i64> {
+    value.pointer(pointer).and_then(Value::as_i64)
+}
+
+fn json_pointer_str<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn json_pointer_u64(value: &Value, pointer: &str) -> Option<u64> {
+    value.pointer(pointer).and_then(Value::as_u64)
+}
+
+fn json_pointer_value<'a>(value: &'a Value, pointer: &str) -> Option<&'a Value> {
+    value.pointer(pointer)
+}
+
 fn render_trigger_list(payload: &Value) -> CliResult<String> {
-    let triggers = payload["triggers"]
-        .as_array()
+    let triggers = json_pointer_array(payload, "/triggers")
         .ok_or_else(|| "automation list payload missing triggers".to_owned())?;
     if triggers.is_empty() {
         return Ok("No automation triggers found.".to_owned());
     }
     let mut lines = vec!["Automation triggers".to_owned(), String::new()];
     for trigger in triggers {
-        let id = trigger["trigger_id"].as_str().unwrap_or("unknown");
-        let name = trigger["name"].as_str().unwrap_or("unnamed");
-        let status = trigger["status"].as_str().unwrap_or("unknown");
-        let kind = trigger["source"]["type"].as_str().unwrap_or("unknown");
+        let id = json_pointer_str(trigger, "/trigger_id").unwrap_or("unknown");
+        let name = json_pointer_str(trigger, "/name").unwrap_or("unnamed");
+        let status = json_pointer_str(trigger, "/status").unwrap_or("unknown");
+        let kind = json_pointer_str(trigger, "/source/type").unwrap_or("unknown");
         lines.push(format!("- {id} [{status}] {kind} {name}"));
     }
     Ok(lines.join("\n"))
 }
 
 fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
-    let id = trigger["trigger_id"]
-        .as_str()
+    let id = json_pointer_str(trigger, "/trigger_id")
         .ok_or_else(|| "automation trigger missing trigger_id".to_owned())?;
-    let name = trigger["name"].as_str().unwrap_or("unnamed");
-    let status = trigger["status"].as_str().unwrap_or("unknown");
-    let source_kind = trigger["source"]["type"].as_str().unwrap_or("unknown");
+    let name = json_pointer_str(trigger, "/name").unwrap_or("unnamed");
+    let status = json_pointer_str(trigger, "/status").unwrap_or("unknown");
+    let source_kind = json_pointer_str(trigger, "/source/type").unwrap_or("unknown");
     let mut lines = vec![
         format!("{name} ({id})"),
         format!("status: {status}"),
@@ -2149,78 +2189,62 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
 
     match source_kind {
         "schedule" => {
-            lines.push(format!(
-                "next_fire_at_ms: {}",
-                trigger["source"]["schedule"]["next_fire_at_ms"]
-                    .as_i64()
-                    .unwrap_or_default()
-            ));
-            if let Some(interval_ms) = trigger["source"]["schedule"]["interval_ms"].as_u64() {
+            let next_fire_at_ms =
+                json_pointer_i64(trigger, "/source/schedule/next_fire_at_ms").unwrap_or_default();
+            lines.push(format!("next_fire_at_ms: {next_fire_at_ms}"));
+            let interval_ms = json_pointer_u64(trigger, "/source/schedule/interval_ms");
+            if let Some(interval_ms) = interval_ms {
                 lines.push(format!("interval_ms: {interval_ms}"));
             } else {
                 lines.push("interval_ms: none".to_owned());
             }
         }
         "event" => {
-            lines.push(format!(
-                "event: {}",
-                trigger["source"]["event"]["event_name"]
-                    .as_str()
-                    .unwrap_or("unknown")
-            ));
-            if let Some(pointer) = trigger["source"]["event"]["json_pointer"].as_str() {
+            let event_name =
+                json_pointer_str(trigger, "/source/event/event_name").unwrap_or("unknown");
+            lines.push(format!("event: {event_name}"));
+            let json_pointer = json_pointer_str(trigger, "/source/event/json_pointer");
+            if let Some(pointer) = json_pointer {
                 lines.push(format!("json_pointer: {pointer}"));
             }
-            if !trigger["source"]["event"]["equals_json"].is_null() {
-                lines.push(format!(
-                    "equals_json: {}",
-                    trigger["source"]["event"]["equals_json"]
-                ));
+            let equals_json = json_pointer_value(trigger, "/source/event/equals_json");
+            if let Some(equals_json) = equals_json
+                && !equals_json.is_null()
+            {
+                lines.push(format!("equals_json: {equals_json}"));
             }
-            if let Some(contains_text) = trigger["source"]["event"]["contains_text"].as_str() {
+            let contains_text = json_pointer_str(trigger, "/source/event/contains_text");
+            if let Some(contains_text) = contains_text {
                 lines.push(format!("contains_text: {contains_text}"));
             }
         }
         "cron" => {
-            lines.push(format!(
-                "cron: {}",
-                trigger["source"]["cron"]["expression"]
-                    .as_str()
-                    .unwrap_or("unknown")
-            ));
-            lines.push(format!(
-                "next_fire_at_ms: {}",
-                trigger["source"]["cron"]["next_fire_at_ms"]
-                    .as_i64()
-                    .unwrap_or_default()
-            ));
+            let expression =
+                json_pointer_str(trigger, "/source/cron/expression").unwrap_or("unknown");
+            lines.push(format!("cron: {expression}"));
+            let next_fire_at_ms =
+                json_pointer_i64(trigger, "/source/cron/next_fire_at_ms").unwrap_or_default();
+            lines.push(format!("next_fire_at_ms: {next_fire_at_ms}"));
         }
         _ => {}
     }
 
-    lines.push(format!(
-        "session: {}",
-        trigger["action"]["background_task"]["session"]
-            .as_str()
-            .unwrap_or("unknown")
-    ));
-    lines.push(format!(
-        "task: {}",
-        trigger["action"]["background_task"]["task"]
-            .as_str()
-            .unwrap_or("")
-    ));
-    if let Some(label) = trigger["action"]["background_task"]["label"].as_str() {
+    let session = json_pointer_str(trigger, "/action/background_task/session").unwrap_or("unknown");
+    lines.push(format!("session: {session}"));
+    let task = json_pointer_str(trigger, "/action/background_task/task").unwrap_or("");
+    lines.push(format!("task: {task}"));
+    let label = json_pointer_str(trigger, "/action/background_task/label");
+    if let Some(label) = label {
         lines.push(format!("label: {label}"));
     }
-    if let Some(timeout_seconds) = trigger["action"]["background_task"]["timeout_seconds"].as_u64()
-    {
+    let timeout_seconds = json_pointer_u64(trigger, "/action/background_task/timeout_seconds");
+    if let Some(timeout_seconds) = timeout_seconds {
         lines.push(format!("timeout_seconds: {timeout_seconds}"));
     }
-    if let Some(last_fired_at_ms) = trigger["last_fired_at_ms"].as_i64() {
+    if let Some(last_fired_at_ms) = json_pointer_i64(trigger, "/last_fired_at_ms") {
         lines.push(format!("last_fired_at_ms: {last_fired_at_ms}"));
     }
-    if let Some(last_task_id) = trigger["last_task_id"].as_str() {
+    if let Some(last_task_id) = json_pointer_str(trigger, "/last_task_id") {
         lines.push(format!("last_task_id: {last_task_id}"));
     }
     if let Some(last_error) = trigger["last_error"].as_str() {

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -1,0 +1,1951 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::Json;
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::CliResult;
+use crate::mvp;
+
+const AUTOMATION_SCHEMA_VERSION: u32 = 1;
+const AUTOMATION_DEFAULT_POLL_MS: u64 = 1_000;
+const AUTOMATION_DEFAULT_EVENT_PATH: &str = "/automation/events";
+const AUTOMATION_FAILURE_RETRY_MS: i64 = 60_000;
+
+static AUTOMATION_TRIGGER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum AutomationCommands {
+    /// Create one schedule-based automation trigger
+    CreateSchedule(AutomationCreateScheduleCommandOptions),
+    /// Create one cron-style automation trigger
+    CreateCron(AutomationCreateCronCommandOptions),
+    /// Create one event-triggered automation rule
+    CreateEvent(AutomationCreateEventCommandOptions),
+    /// List durable automation triggers
+    List(AutomationListCommandOptions),
+    /// Show one durable automation trigger
+    Show(AutomationShowCommandOptions),
+    /// Remove one durable automation trigger
+    Remove(AutomationRemoveCommandOptions),
+    /// Pause one durable automation trigger
+    Pause(AutomationPauseCommandOptions),
+    /// Resume one durable automation trigger
+    Resume(AutomationResumeCommandOptions),
+    /// Fire one trigger immediately
+    Fire(AutomationFireCommandOptions),
+    /// Emit one named event to matching triggers
+    Emit(AutomationEmitCommandOptions),
+    /// Run the scheduler loop and optional webhook ingress
+    Serve(AutomationServeCommandOptions),
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomationCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub command: AutomationCommands,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationCreateScheduleCommandOptions {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub session: String,
+    #[arg(long)]
+    pub task: String,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long)]
+    pub timeout_seconds: Option<u64>,
+    #[arg(long)]
+    pub run_at: Option<String>,
+    #[arg(long)]
+    pub run_at_ms: Option<i64>,
+    #[arg(long)]
+    pub every_seconds: Option<u64>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationCreateEventCommandOptions {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub event: String,
+    #[arg(long)]
+    pub json_pointer: Option<String>,
+    #[arg(long)]
+    pub equals_json: Option<String>,
+    #[arg(long)]
+    pub equals_text: Option<String>,
+    #[arg(long)]
+    pub contains_text: Option<String>,
+    #[arg(long)]
+    pub session: String,
+    #[arg(long)]
+    pub task: String,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long)]
+    pub timeout_seconds: Option<u64>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationCreateCronCommandOptions {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub cron: String,
+    #[arg(long)]
+    pub session: String,
+    #[arg(long)]
+    pub task: String,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long)]
+    pub timeout_seconds: Option<u64>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationListCommandOptions {
+    #[arg(long, default_value_t = 50)]
+    pub limit: usize,
+    #[arg(long, default_value_t = false)]
+    pub include_completed: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationShowCommandOptions {
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationRemoveCommandOptions {
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationPauseCommandOptions {
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationResumeCommandOptions {
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationFireCommandOptions {
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationEmitCommandOptions {
+    #[arg(long)]
+    pub event: String,
+    #[arg(long)]
+    pub payload_json: Option<String>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationServeCommandOptions {
+    #[arg(long)]
+    pub bind: Option<String>,
+    #[arg(long)]
+    pub auth_token: Option<String>,
+    #[arg(long, default_value = AUTOMATION_DEFAULT_EVENT_PATH)]
+    pub path: String,
+    #[arg(long, default_value_t = AUTOMATION_DEFAULT_POLL_MS)]
+    pub poll_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum AutomationTriggerStatus {
+    Active,
+    Paused,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationScheduleSpec {
+    next_fire_at_ms: i64,
+    interval_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationEventSpec {
+    event_name: String,
+    json_pointer: Option<String>,
+    equals_json: Option<Value>,
+    contains_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationCronSpec {
+    expression: String,
+    next_fire_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AutomationTriggerSource {
+    Schedule { schedule: AutomationScheduleSpec },
+    Cron { cron: AutomationCronSpec },
+    Event { event: AutomationEventSpec },
+}
+
+impl AutomationTriggerSource {
+    fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Schedule { .. } => "schedule",
+            Self::Cron { .. } => "cron",
+            Self::Event { .. } => "event",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct BackgroundTaskAction {
+    session: String,
+    task: String,
+    label: Option<String>,
+    timeout_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AutomationAction {
+    BackgroundTask {
+        background_task: BackgroundTaskAction,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationTriggerRecord {
+    trigger_id: String,
+    name: String,
+    status: AutomationTriggerStatus,
+    source: AutomationTriggerSource,
+    action: AutomationAction,
+    created_at_ms: i64,
+    updated_at_ms: i64,
+    last_fired_at_ms: Option<i64>,
+    last_task_id: Option<String>,
+    last_error: Option<String>,
+    fire_count: u64,
+    #[serde(default)]
+    run_history: Vec<AutomationRunRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationStore {
+    schema_version: u32,
+    triggers: Vec<AutomationTriggerRecord>,
+}
+
+impl Default for AutomationStore {
+    fn default() -> Self {
+        Self {
+            schema_version: AUTOMATION_SCHEMA_VERSION,
+            triggers: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AutomationFireResult {
+    trigger_id: String,
+    name: String,
+    source_kind: String,
+    queued_task_id: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AutomationRunRecord {
+    fired_at_ms: i64,
+    source_kind: String,
+    queued_task_id: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+struct AutomationServeState {
+    config: Option<String>,
+    auth_token: Option<String>,
+}
+
+struct AutomationServeLock {
+    path: PathBuf,
+}
+
+impl Drop for AutomationServeLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CronField {
+    any: bool,
+    allowed: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CronExpression {
+    minute: CronField,
+    hour: CronField,
+    day_of_month: CronField,
+    month: CronField,
+    day_of_week: CronField,
+}
+
+pub async fn run_automation_cli(options: AutomationCommandOptions) -> CliResult<()> {
+    let payload = execute_automation_command(options.clone()).await?;
+    if options.json {
+        let rendered = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize automation CLI payload failed: {error}"))?;
+        println!("{rendered}");
+        return Ok(());
+    }
+
+    let rendered = render_automation_text(&payload)?;
+    println!("{rendered}");
+    Ok(())
+}
+
+pub async fn execute_automation_command(options: AutomationCommandOptions) -> CliResult<Value> {
+    let store_path = automation_store_path();
+    match options.command {
+        AutomationCommands::CreateSchedule(command) => {
+            execute_create_schedule_command(store_path.as_path(), command).await
+        }
+        AutomationCommands::CreateCron(command) => {
+            execute_create_cron_command(store_path.as_path(), command).await
+        }
+        AutomationCommands::CreateEvent(command) => {
+            execute_create_event_command(store_path.as_path(), command).await
+        }
+        AutomationCommands::List(command) => execute_list_command(store_path.as_path(), command),
+        AutomationCommands::Show(command) => {
+            execute_show_command(store_path.as_path(), &command.id)
+        }
+        AutomationCommands::Remove(command) => {
+            execute_remove_command(store_path.as_path(), &command.id)
+        }
+        AutomationCommands::Pause(command) => execute_status_update_command(
+            store_path.as_path(),
+            &command.id,
+            AutomationTriggerStatus::Paused,
+        ),
+        AutomationCommands::Resume(command) => execute_status_update_command(
+            store_path.as_path(),
+            &command.id,
+            AutomationTriggerStatus::Active,
+        ),
+        AutomationCommands::Fire(command) => {
+            execute_fire_command(store_path.as_path(), options.config, &command.id).await
+        }
+        AutomationCommands::Emit(command) => {
+            execute_emit_command(
+                store_path.as_path(),
+                options.config,
+                command.event.as_str(),
+                command.payload_json.as_deref(),
+            )
+            .await
+        }
+        AutomationCommands::Serve(command) => {
+            execute_serve_command(store_path.as_path(), options.config, command).await
+        }
+    }
+}
+
+fn automation_store_path() -> PathBuf {
+    crate::mvp::config::default_loong_home()
+        .join("automation")
+        .join("triggers.json")
+}
+
+fn automation_serve_lock_path() -> PathBuf {
+    crate::mvp::config::default_loong_home()
+        .join("automation")
+        .join("serve.lock")
+}
+
+pub(crate) fn automation_serve_owner_is_active() -> bool {
+    automation_serve_lock_path().exists()
+}
+
+fn automation_event_cursor_path() -> PathBuf {
+    crate::mvp::config::default_loong_home()
+        .join("automation")
+        .join("internal-events.cursor")
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn generate_trigger_id() -> String {
+    let counter = AUTOMATION_TRIGGER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("atrg-{:016x}{counter:04x}", now_ms())
+}
+
+fn normalize_event_name(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Err("automation event name must not be empty".to_owned());
+    }
+    if !normalized
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-'))
+    {
+        return Err(
+            "automation event names may only contain lowercase ascii letters, digits, `.`, `_`, and `-`"
+                .to_owned(),
+        );
+    }
+    Ok(normalized)
+}
+
+fn parse_run_at_ms(raw_text: Option<String>, raw_ms: Option<i64>) -> CliResult<i64> {
+    match (raw_text, raw_ms) {
+        (Some(_), Some(_)) => Err(
+            "automation schedule create accepts either --run-at or --run-at-ms, not both"
+                .to_owned(),
+        ),
+        (None, None) => {
+            Err("automation schedule create requires --run-at or --run-at-ms".to_owned())
+        }
+        (None, Some(run_at_ms)) => Ok(run_at_ms),
+        (Some(text), None) => {
+            let parsed = OffsetDateTime::parse(text.trim(), &Rfc3339)
+                .map_err(|error| format!("parse automation --run-at failed: {error}"))?;
+            let millis = parsed.unix_timestamp_nanos() / 1_000_000;
+            let millis = i64::try_from(millis).map_err(|error| {
+                format!("automation --run-at overflowed i64 milliseconds: {error}")
+            })?;
+            Ok(millis)
+        }
+    }
+}
+
+fn ensure_positive_interval(every_seconds: Option<u64>) -> CliResult<Option<u64>> {
+    match every_seconds {
+        Some(0) => Err("--every-seconds must be greater than zero".to_owned()),
+        Some(value) => Ok(Some(value * 1_000)),
+        None => Ok(None),
+    }
+}
+
+fn validate_json_pointer(raw: Option<&str>) -> CliResult<Option<String>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    if raw == "" || raw.starts_with('/') {
+        return Ok(Some(raw.to_owned()));
+    }
+    Err("automation event filters require RFC6901 json pointers beginning with `/`".to_owned())
+}
+
+fn parse_event_equals_value(
+    equals_json: Option<&str>,
+    equals_text: Option<String>,
+) -> CliResult<Option<Value>> {
+    match (
+        equals_json.map(str::trim).filter(|value| !value.is_empty()),
+        equals_text,
+    ) {
+        (Some(_), Some(_)) => Err(
+            "use either --equals-json or --equals-text for automation event filters, not both"
+                .to_owned(),
+        ),
+        (Some(raw), None) => serde_json::from_str(raw)
+            .map(Some)
+            .map_err(|error| format!("parse --equals-json failed: {error}")),
+        (None, Some(text)) => Ok(Some(Value::String(text))),
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_event_filter_shape(
+    json_pointer: Option<&str>,
+    equals_json: Option<&Value>,
+    contains_text: Option<&str>,
+) -> CliResult<()> {
+    if contains_text.is_some() && equals_json.is_some() {
+        return Err(
+            "use either equality matching or contains_text for automation event filters, not both"
+                .to_owned(),
+        );
+    }
+    if (equals_json.is_some() || contains_text.is_some()) && json_pointer.is_none() {
+        return Err(
+            "automation event filters require --json-pointer when using equality or contains_text matching"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn cron_field_matches(field: &CronField, value: u8) -> bool {
+    if field.any {
+        return true;
+    }
+    field.allowed.contains(&value)
+}
+
+fn parse_cron_field(raw: &str, min: u8, max: u8, wrap_sunday: bool) -> CliResult<CronField> {
+    let trimmed = raw.trim();
+    if trimmed == "*" {
+        return Ok(CronField {
+            any: true,
+            allowed: Vec::new(),
+        });
+    }
+
+    let mut allowed = Vec::new();
+    for part in trimmed.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(format!("invalid cron field `{raw}`"));
+        }
+
+        let (range_part, step) = match part.split_once('/') {
+            Some((range_part, step_part)) => {
+                let step = step_part
+                    .trim()
+                    .parse::<u8>()
+                    .map_err(|error| format!("invalid cron step `{step_part}`: {error}"))?;
+                if step == 0 {
+                    return Err("cron step must be greater than zero".to_owned());
+                }
+                (range_part.trim(), step)
+            }
+            None => (part, 1),
+        };
+
+        let (start, end) = if range_part == "*" {
+            (min, max)
+        } else if let Some((start, end)) = range_part.split_once('-') {
+            let start = parse_cron_value(start.trim(), min, max, wrap_sunday)?;
+            let end = parse_cron_value(end.trim(), min, max, wrap_sunday)?;
+            if start > end {
+                return Err(format!(
+                    "cron range start `{start}` must be <= end `{end}` in `{part}`"
+                ));
+            }
+            (start, end)
+        } else {
+            let value = parse_cron_value(range_part, min, max, wrap_sunday)?;
+            (value, value)
+        };
+
+        let mut candidate = start;
+        loop {
+            if !allowed.contains(&candidate) {
+                allowed.push(candidate);
+            }
+            let Some(next) = candidate.checked_add(step) else {
+                break;
+            };
+            if next > end {
+                break;
+            }
+            candidate = next;
+        }
+    }
+
+    allowed.sort_unstable();
+    Ok(CronField {
+        any: false,
+        allowed,
+    })
+}
+
+fn parse_cron_value(raw: &str, min: u8, max: u8, wrap_sunday: bool) -> CliResult<u8> {
+    let mut value = raw
+        .parse::<u8>()
+        .map_err(|error| format!("invalid cron value `{raw}`: {error}"))?;
+    if wrap_sunday && value == 7 {
+        value = 0;
+    }
+    if !(min..=max).contains(&value) {
+        return Err(format!("cron value `{value}` out of range {min}..={max}"));
+    }
+    Ok(value)
+}
+
+fn parse_cron_expression(raw: &str) -> CliResult<CronExpression> {
+    let fields = raw.split_whitespace().collect::<Vec<_>>();
+    if fields.len() != 5 {
+        return Err(
+            "automation cron expressions currently require 5 fields: minute hour day_of_month month day_of_week"
+                .to_owned(),
+        );
+    }
+    Ok(CronExpression {
+        minute: parse_cron_field(fields[0], 0, 59, false)?,
+        hour: parse_cron_field(fields[1], 0, 23, false)?,
+        day_of_month: parse_cron_field(fields[2], 1, 31, false)?,
+        month: parse_cron_field(fields[3], 1, 12, false)?,
+        day_of_week: parse_cron_field(fields[4], 0, 6, true)?,
+    })
+}
+
+fn next_cron_fire_at_ms(expression: &str, after_ms: i64) -> CliResult<i64> {
+    let parsed = parse_cron_expression(expression)?;
+    let next_minute_ms = after_ms
+        .checked_div(60_000)
+        .and_then(|value| value.checked_add(1))
+        .and_then(|value| value.checked_mul(60_000))
+        .ok_or_else(|| "cron next-fire computation overflowed".to_owned())?;
+    let mut candidate =
+        OffsetDateTime::from_unix_timestamp_nanos(i128::from(next_minute_ms) * 1_000_000)
+            .map_err(|error| format!("cron next-fire anchor failed: {error}"))?;
+
+    let max_attempts = 366 * 24 * 60;
+    for _ in 0..max_attempts {
+        let minute_matches = cron_field_matches(&parsed.minute, candidate.minute());
+        let hour_matches = cron_field_matches(&parsed.hour, candidate.hour());
+        let month_matches = cron_field_matches(&parsed.month, candidate.month() as u8);
+        let dom_matches = cron_field_matches(&parsed.day_of_month, candidate.day());
+        let weekday = candidate.weekday().number_days_from_sunday() as u8;
+        let dow_matches = cron_field_matches(&parsed.day_of_week, weekday);
+        let day_matches = if parsed.day_of_month.any && parsed.day_of_week.any {
+            true
+        } else if parsed.day_of_month.any {
+            dow_matches
+        } else if parsed.day_of_week.any {
+            dom_matches
+        } else {
+            dom_matches || dow_matches
+        };
+
+        if minute_matches && hour_matches && month_matches && day_matches {
+            let millis = candidate.unix_timestamp_nanos() / 1_000_000;
+            let millis = i64::try_from(millis)
+                .map_err(|error| format!("cron next-fire overflowed i64 milliseconds: {error}"))?;
+            return Ok(millis);
+        }
+
+        candidate += Duration::from_secs(60);
+    }
+
+    Err(format!(
+        "automation cron expression `{expression}` did not match within the next 366 days"
+    ))
+}
+
+fn acquire_automation_serve_lock() -> CliResult<AutomationServeLock> {
+    let path = automation_serve_lock_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create automation runtime directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let write_lock = |path: &Path| -> CliResult<()> {
+        let payload = json!({
+            "pid": std::process::id(),
+            "started_at_ms": now_ms(),
+        });
+        let bytes = serde_json::to_vec_pretty(&payload)
+            .map_err(|error| format!("serialize automation serve lock failed: {error}"))?;
+        fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .and_then(|mut file| std::io::Write::write_all(&mut file, &bytes))
+            .map_err(|error| {
+                format!(
+                    "write automation serve lock {} failed: {error}",
+                    path.display()
+                )
+            })
+    };
+
+    match write_lock(path.as_path()) {
+        Ok(()) => Ok(AutomationServeLock { path }),
+        Err(error) if error.contains("File exists") || error.contains("file exists") => {
+            Err(format!(
+                "automation serve lock {} already exists; stop the active automation runner or remove the stale lock file manually",
+                path.display()
+            ))
+        }
+        Err(error) => Err(format!(
+            "automation serve is already active or lock acquisition failed: {error}"
+        )),
+    }
+}
+
+fn load_store(path: &Path) -> CliResult<AutomationStore> {
+    if !path.exists() {
+        return Ok(AutomationStore::default());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("read automation store {} failed: {error}", path.display()))?;
+    if raw.trim().is_empty() {
+        return Ok(AutomationStore::default());
+    }
+    let store: AutomationStore = serde_json::from_str(&raw)
+        .map_err(|error| format!("parse automation store {} failed: {error}", path.display()))?;
+    Ok(store)
+}
+
+fn save_store(path: &Path, store: &AutomationStore) -> CliResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create automation store directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_vec_pretty(store)
+        .map_err(|error| format!("serialize automation store failed: {error}"))?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, encoded).map_err(|error| {
+        format!(
+            "write automation temp store {} failed: {error}",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, path).map_err(|error| {
+        format!(
+            "publish automation store {} from {} failed: {error}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+async fn execute_create_schedule_command(
+    store_path: &Path,
+    options: AutomationCreateScheduleCommandOptions,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let created_at_ms = now_ms();
+    let next_fire_at_ms = parse_run_at_ms(options.run_at, options.run_at_ms)?;
+    let interval_ms = ensure_positive_interval(options.every_seconds)?;
+    let trigger = AutomationTriggerRecord {
+        trigger_id: generate_trigger_id(),
+        name: options.name,
+        status: AutomationTriggerStatus::Active,
+        source: AutomationTriggerSource::Schedule {
+            schedule: AutomationScheduleSpec {
+                next_fire_at_ms,
+                interval_ms,
+            },
+        },
+        action: AutomationAction::BackgroundTask {
+            background_task: BackgroundTaskAction {
+                session: options.session,
+                task: options.task,
+                label: options.label,
+                timeout_seconds: options.timeout_seconds,
+            },
+        },
+        created_at_ms,
+        updated_at_ms: created_at_ms,
+        last_fired_at_ms: None,
+        last_task_id: None,
+        last_error: None,
+        fire_count: 0,
+        run_history: Vec::new(),
+    };
+    store.triggers.push(trigger.clone());
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "create_schedule",
+        "store_path": store_path.display().to_string(),
+        "trigger": trigger,
+    }))
+}
+
+async fn execute_create_cron_command(
+    store_path: &Path,
+    options: AutomationCreateCronCommandOptions,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let created_at_ms = now_ms();
+    let next_fire_at_ms = next_cron_fire_at_ms(options.cron.as_str(), created_at_ms)?;
+    let trigger = AutomationTriggerRecord {
+        trigger_id: generate_trigger_id(),
+        name: options.name,
+        status: AutomationTriggerStatus::Active,
+        source: AutomationTriggerSource::Cron {
+            cron: AutomationCronSpec {
+                expression: options.cron,
+                next_fire_at_ms,
+            },
+        },
+        action: AutomationAction::BackgroundTask {
+            background_task: BackgroundTaskAction {
+                session: options.session,
+                task: options.task,
+                label: options.label,
+                timeout_seconds: options.timeout_seconds,
+            },
+        },
+        created_at_ms,
+        updated_at_ms: created_at_ms,
+        last_fired_at_ms: None,
+        last_task_id: None,
+        last_error: None,
+        fire_count: 0,
+        run_history: Vec::new(),
+    };
+    store.triggers.push(trigger.clone());
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "create_cron",
+        "store_path": store_path.display().to_string(),
+        "trigger": trigger,
+    }))
+}
+
+async fn execute_create_event_command(
+    store_path: &Path,
+    options: AutomationCreateEventCommandOptions,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let created_at_ms = now_ms();
+    let event_name = normalize_event_name(options.event.as_str())?;
+    let json_pointer = validate_json_pointer(options.json_pointer.as_deref())?;
+    let equals_json =
+        parse_event_equals_value(options.equals_json.as_deref(), options.equals_text)?;
+    validate_event_filter_shape(
+        json_pointer.as_deref(),
+        equals_json.as_ref(),
+        options.contains_text.as_deref(),
+    )?;
+    let trigger = AutomationTriggerRecord {
+        trigger_id: generate_trigger_id(),
+        name: options.name,
+        status: AutomationTriggerStatus::Active,
+        source: AutomationTriggerSource::Event {
+            event: AutomationEventSpec {
+                event_name,
+                json_pointer,
+                equals_json,
+                contains_text: options.contains_text,
+            },
+        },
+        action: AutomationAction::BackgroundTask {
+            background_task: BackgroundTaskAction {
+                session: options.session,
+                task: options.task,
+                label: options.label,
+                timeout_seconds: options.timeout_seconds,
+            },
+        },
+        created_at_ms,
+        updated_at_ms: created_at_ms,
+        last_fired_at_ms: None,
+        last_task_id: None,
+        last_error: None,
+        fire_count: 0,
+        run_history: Vec::new(),
+    };
+    store.triggers.push(trigger.clone());
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "create_event",
+        "store_path": store_path.display().to_string(),
+        "trigger": trigger,
+    }))
+}
+
+fn execute_list_command(
+    store_path: &Path,
+    options: AutomationListCommandOptions,
+) -> CliResult<Value> {
+    let store = load_store(store_path)?;
+    let mut triggers = store.triggers;
+    if !options.include_completed {
+        triggers.retain(|trigger| trigger.status != AutomationTriggerStatus::Completed);
+    }
+    triggers.truncate(options.limit.clamp(1, 200));
+    Ok(json!({
+        "command": "list",
+        "store_path": store_path.display().to_string(),
+        "triggers": triggers,
+    }))
+}
+
+fn execute_show_command(store_path: &Path, trigger_id: &str) -> CliResult<Value> {
+    let store = load_store(store_path)?;
+    let trigger = store
+        .triggers
+        .into_iter()
+        .find(|trigger| trigger.trigger_id == trigger_id)
+        .ok_or_else(|| format!("automation trigger `{trigger_id}` not found"))?;
+    Ok(json!({
+        "command": "show",
+        "store_path": store_path.display().to_string(),
+        "trigger": trigger,
+    }))
+}
+
+fn execute_remove_command(store_path: &Path, trigger_id: &str) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let original_count = store.triggers.len();
+    store
+        .triggers
+        .retain(|trigger| trigger.trigger_id != trigger_id);
+    if store.triggers.len() == original_count {
+        return Err(format!("automation trigger `{trigger_id}` not found"));
+    }
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "remove",
+        "store_path": store_path.display().to_string(),
+        "trigger_id": trigger_id,
+    }))
+}
+
+fn execute_status_update_command(
+    store_path: &Path,
+    trigger_id: &str,
+    status: AutomationTriggerStatus,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let updated_at_ms = now_ms();
+    let trigger = store
+        .triggers
+        .iter_mut()
+        .find(|trigger| trigger.trigger_id == trigger_id)
+        .ok_or_else(|| format!("automation trigger `{trigger_id}` not found"))?;
+    trigger.status = status;
+    trigger.updated_at_ms = updated_at_ms;
+    let trigger = trigger.clone();
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "status_update",
+        "store_path": store_path.display().to_string(),
+        "trigger": trigger,
+    }))
+}
+
+async fn execute_fire_command(
+    store_path: &Path,
+    config: Option<String>,
+    trigger_id: &str,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let trigger_index = store
+        .triggers
+        .iter()
+        .position(|trigger| trigger.trigger_id == trigger_id)
+        .ok_or_else(|| format!("automation trigger `{trigger_id}` not found"))?;
+    let result = {
+        let trigger = store
+            .triggers
+            .get_mut(trigger_index)
+            .ok_or_else(|| format!("automation trigger `{trigger_id}` not found"))?;
+        fire_trigger_record(trigger, config.as_ref()).await
+    };
+    let result_json = serde_json::to_value(&result)
+        .map_err(|error| format!("serialize automation fire result failed: {error}"))?;
+    let trigger = store
+        .triggers
+        .get(trigger_index)
+        .cloned()
+        .ok_or_else(|| format!("automation trigger `{trigger_id}` disappeared during fire"))?;
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "fire",
+        "store_path": store_path.display().to_string(),
+        "result": result_json,
+        "trigger": trigger,
+    }))
+}
+
+async fn execute_emit_command(
+    store_path: &Path,
+    config: Option<String>,
+    event_name: &str,
+    payload_json: Option<&str>,
+) -> CliResult<Value> {
+    let normalized_event_name = normalize_event_name(event_name)?;
+    let parsed_payload = payload_json
+        .map(|raw| serde_json::from_str::<Value>(raw))
+        .transpose()
+        .map_err(|error| format!("parse --payload-json failed: {error}"))?;
+    execute_emit_value_command(
+        store_path,
+        config,
+        normalized_event_name.as_str(),
+        parsed_payload,
+    )
+    .await
+}
+
+async fn execute_emit_value_command(
+    store_path: &Path,
+    config: Option<String>,
+    normalized_event_name: &str,
+    payload: Option<Value>,
+) -> CliResult<Value> {
+    let mut store = load_store(store_path)?;
+    let mut results = Vec::new();
+    for trigger in &mut store.triggers {
+        let matches_event = trigger_matches_event(trigger, normalized_event_name, payload.as_ref());
+        if !matches_event {
+            continue;
+        }
+        results.push(Box::pin(fire_trigger_record(trigger, config.as_ref())).await);
+    }
+    save_store(store_path, &store)?;
+    Ok(json!({
+        "command": "emit",
+        "store_path": store_path.display().to_string(),
+        "event_name": normalized_event_name,
+        "payload": payload,
+        "matched_count": results.len(),
+        "results": results,
+    }))
+}
+
+pub(crate) async fn emit_named_automation_event(
+    config: Option<String>,
+    event_name: &str,
+    payload: Option<Value>,
+) -> CliResult<Value> {
+    let normalized_event_name = normalize_event_name(event_name)?;
+    let store_path = automation_store_path();
+    execute_emit_value_command(
+        store_path.as_path(),
+        config,
+        normalized_event_name.as_str(),
+        payload,
+    )
+    .await
+}
+
+pub(crate) async fn publish_daemon_internal_event(
+    config: Option<String>,
+    event_name: &str,
+    source_surface: &str,
+    payload: Option<Value>,
+) -> CliResult<Value> {
+    let augmented_payload = augment_internal_event_payload(event_name, source_surface, payload);
+    mvp::internal_events::append_internal_event_to_journal(event_name, &augmented_payload)?;
+    if automation_serve_owner_is_active() {
+        return Ok(json!({
+            "published": true,
+            "delivery_mode": "journal_only",
+            "event_name": event_name,
+        }));
+    }
+    emit_named_automation_event(config, event_name, Some(augmented_payload)).await
+}
+
+pub(crate) fn install_daemon_automation_event_sink(config: Option<String>) {
+    let sink_config = config.clone();
+    let sink = std::sync::Arc::new(move |event_name: &str, payload: Value| {
+        let config = sink_config.clone();
+        let event_name = event_name.to_owned();
+        let payload = payload.clone();
+        let handle = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build();
+            let Ok(runtime) = runtime else {
+                return;
+            };
+            let _ = runtime.block_on(async move {
+                emit_named_automation_event(config, event_name.as_str(), Some(payload)).await
+            });
+        });
+        let _ = handle.join();
+    });
+    mvp::internal_events::install_internal_event_sink(sink);
+}
+
+fn augment_internal_event_payload(
+    event_name: &str,
+    source_surface: &str,
+    payload: Option<Value>,
+) -> Value {
+    let metadata = json!({
+        "event_name": event_name,
+        "source_surface": source_surface,
+        "emitted_at_ms": now_ms(),
+    });
+
+    match payload {
+        Some(Value::Object(mut object)) => {
+            object.insert("_automation".to_owned(), metadata);
+            Value::Object(object)
+        }
+        Some(other) => json!({
+            "_automation": metadata,
+            "value": other,
+        }),
+        None => json!({
+            "_automation": metadata,
+        }),
+    }
+}
+
+async fn execute_serve_command(
+    store_path: &Path,
+    config: Option<String>,
+    options: AutomationServeCommandOptions,
+) -> CliResult<Value> {
+    let _serve_lock = acquire_automation_serve_lock()?;
+    let poll_ms = options.poll_ms.max(250);
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    let scheduler_stop = stop_requested.clone();
+    let scheduler_store_path = store_path.to_path_buf();
+    let scheduler_config = config.clone();
+    let scheduler_task = tokio::spawn(async move {
+        while !scheduler_stop.load(Ordering::SeqCst) {
+            if let Err(error) = process_due_schedule_triggers(
+                scheduler_store_path.as_path(),
+                scheduler_config.as_ref(),
+            )
+            .await
+            {
+                eprintln!("automation scheduler error: {error}");
+            }
+            if let Err(error) = process_internal_journal_events(scheduler_config.as_ref()).await {
+                eprintln!("automation internal event journal error: {error}");
+            }
+            tokio::time::sleep(Duration::from_millis(poll_ms)).await;
+        }
+    });
+
+    let shutdown_requested = stop_requested.clone();
+    let shutdown_signal = async move {
+        let _ = tokio::signal::ctrl_c().await;
+        shutdown_requested.store(true, Ordering::SeqCst);
+    };
+
+    if let Some(bind) = options.bind {
+        let normalized_path = normalize_event_path(options.path.as_str())?;
+        let route_path = format!("{normalized_path}/:event_name");
+        let listener = tokio::net::TcpListener::bind(bind.as_str())
+            .await
+            .map_err(|error| format!("bind automation webhook listener failed: {error}"))?;
+        let state = AutomationServeState {
+            config,
+            auth_token: options.auth_token,
+        };
+        let router = Router::new()
+            .route(route_path.as_str(), post(automation_event_webhook_handler))
+            .with_state(state);
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal)
+            .await
+            .map_err(|error| format!("automation webhook server stopped: {error}"))?;
+    } else {
+        shutdown_signal.await;
+    }
+
+    stop_requested.store(true, Ordering::SeqCst);
+    let _ = scheduler_task.await;
+
+    Ok(json!({
+        "command": "serve",
+        "store_path": store_path.display().to_string(),
+        "poll_ms": poll_ms,
+        "status": "stopped",
+    }))
+}
+
+async fn process_internal_journal_events(config: Option<&String>) -> CliResult<()> {
+    let cursor_path = automation_event_cursor_path();
+    let current_cursor = load_internal_event_cursor(cursor_path.as_path())?;
+    let (events, next_cursor) =
+        mvp::internal_events::read_internal_event_journal_after(current_cursor.clone())?;
+    if events.is_empty() {
+        if next_cursor != current_cursor {
+            store_internal_event_cursor(cursor_path.as_path(), next_cursor)?;
+        }
+        return Ok(());
+    }
+
+    let store_path = automation_store_path();
+    let mut store = load_store(store_path.as_path())?;
+    let mut changed = false;
+
+    for event in events {
+        for trigger in &mut store.triggers {
+            if !trigger_matches_event(trigger, event.event_name.as_str(), Some(&event.payload)) {
+                continue;
+            }
+            let _ = fire_trigger_record(trigger, config).await;
+            changed = true;
+        }
+    }
+
+    if changed {
+        save_store(store_path.as_path(), &store)?;
+    }
+    store_internal_event_cursor(cursor_path.as_path(), next_cursor)?;
+    Ok(())
+}
+
+fn load_internal_event_cursor(
+    path: &Path,
+) -> CliResult<mvp::internal_events::InternalEventJournalCursor> {
+    if !path.exists() {
+        return Ok(mvp::internal_events::InternalEventJournalCursor::default());
+    }
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read automation event cursor {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(mvp::internal_events::InternalEventJournalCursor::default());
+    }
+    if let Ok(line_cursor) = trimmed.parse::<u64>() {
+        return mvp::internal_events::internal_event_journal_cursor_from_line_cursor(line_cursor);
+    }
+    serde_json::from_str(trimmed).map_err(|error| {
+        format!(
+            "parse automation event cursor {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn store_internal_event_cursor(
+    path: &Path,
+    cursor: mvp::internal_events::InternalEventJournalCursor,
+) -> CliResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create automation event cursor directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(&cursor)
+        .map_err(|error| format!("serialize automation event cursor failed: {error}"))?;
+    fs::write(path, format!("{encoded}\n")).map_err(|error| {
+        format!(
+            "write automation event cursor {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+async fn process_due_schedule_triggers(
+    store_path: &Path,
+    config: Option<&String>,
+) -> CliResult<()> {
+    let mut store = load_store(store_path)?;
+    let now = now_ms();
+    let mut changed = false;
+    for trigger in &mut store.triggers {
+        let is_due = trigger.status == AutomationTriggerStatus::Active
+            && matches!(
+                &trigger.source,
+                AutomationTriggerSource::Schedule { schedule }
+                    if schedule.next_fire_at_ms <= now
+            )
+            || trigger.status == AutomationTriggerStatus::Active
+                && matches!(
+                    &trigger.source,
+                    AutomationTriggerSource::Cron { cron }
+                        if cron.next_fire_at_ms <= now
+                );
+        if !is_due {
+            continue;
+        }
+        let _ = fire_trigger_record(trigger, config).await;
+        changed = true;
+    }
+    if changed {
+        save_store(store_path, &store)?;
+    }
+    Ok(())
+}
+
+async fn fire_trigger_record(
+    trigger: &mut AutomationTriggerRecord,
+    config: Option<&String>,
+) -> AutomationFireResult {
+    let fired_at_ms = now_ms();
+    let source_kind = trigger.source.kind_str().to_owned();
+    let mut result = AutomationFireResult {
+        trigger_id: trigger.trigger_id.clone(),
+        name: trigger.name.clone(),
+        source_kind,
+        queued_task_id: None,
+        error: None,
+    };
+
+    let queue_outcome = match &trigger.action {
+        AutomationAction::BackgroundTask { background_task } => {
+            queue_background_task(config.cloned(), background_task).await
+        }
+    };
+
+    match queue_outcome {
+        Ok(task_id) => {
+            result.queued_task_id = task_id.clone();
+            trigger.last_fired_at_ms = Some(fired_at_ms);
+            trigger.last_task_id = task_id;
+            trigger.last_error = None;
+            trigger.fire_count += 1;
+            push_run_history(
+                trigger,
+                AutomationRunRecord {
+                    fired_at_ms,
+                    source_kind: result.source_kind.clone(),
+                    queued_task_id: result.queued_task_id.clone(),
+                    error: None,
+                },
+            );
+            apply_post_fire_schedule_state(trigger, fired_at_ms, /*succeeded*/ true);
+        }
+        Err(error) => {
+            result.error = Some(error.clone());
+            trigger.last_error = Some(error);
+            push_run_history(
+                trigger,
+                AutomationRunRecord {
+                    fired_at_ms,
+                    source_kind: result.source_kind.clone(),
+                    queued_task_id: None,
+                    error: result.error.clone(),
+                },
+            );
+            apply_post_fire_schedule_state(trigger, fired_at_ms, /*succeeded*/ false);
+        }
+    }
+
+    trigger.updated_at_ms = fired_at_ms;
+    result
+}
+
+fn push_run_history(trigger: &mut AutomationTriggerRecord, run: AutomationRunRecord) {
+    const MAX_RUN_HISTORY: usize = 10;
+    trigger.run_history.push(run);
+    if trigger.run_history.len() > MAX_RUN_HISTORY {
+        let overflow = trigger.run_history.len() - MAX_RUN_HISTORY;
+        trigger.run_history.drain(0..overflow);
+    }
+}
+
+fn apply_post_fire_schedule_state(
+    trigger: &mut AutomationTriggerRecord,
+    fired_at_ms: i64,
+    succeeded: bool,
+) {
+    match &mut trigger.source {
+        AutomationTriggerSource::Schedule { schedule } => match schedule.interval_ms {
+            Some(interval_ms) => {
+                let next_fire_at_ms = if succeeded {
+                    fired_at_ms.saturating_add(i64::try_from(interval_ms).unwrap_or(i64::MAX))
+                } else {
+                    fired_at_ms.saturating_add(AUTOMATION_FAILURE_RETRY_MS)
+                };
+                schedule.next_fire_at_ms = next_fire_at_ms;
+            }
+            None => {
+                if succeeded {
+                    trigger.status = AutomationTriggerStatus::Completed;
+                } else {
+                    schedule.next_fire_at_ms =
+                        fired_at_ms.saturating_add(AUTOMATION_FAILURE_RETRY_MS);
+                }
+            }
+        },
+        AutomationTriggerSource::Cron { cron } => {
+            let recompute_anchor = if succeeded {
+                fired_at_ms
+            } else {
+                fired_at_ms.saturating_add(AUTOMATION_FAILURE_RETRY_MS)
+            };
+            match next_cron_fire_at_ms(cron.expression.as_str(), recompute_anchor) {
+                Ok(next_fire_at_ms) => {
+                    cron.next_fire_at_ms = next_fire_at_ms;
+                }
+                Err(error) => {
+                    trigger.last_error = Some(error);
+                    trigger.status = AutomationTriggerStatus::Paused;
+                }
+            }
+        }
+        AutomationTriggerSource::Event { .. } => {}
+    }
+}
+
+fn trigger_matches_event(
+    trigger: &AutomationTriggerRecord,
+    normalized_event_name: &str,
+    payload: Option<&Value>,
+) -> bool {
+    if trigger.status != AutomationTriggerStatus::Active {
+        return false;
+    }
+    let AutomationTriggerSource::Event { event } = &trigger.source else {
+        return false;
+    };
+    if event.event_name != normalized_event_name {
+        return false;
+    }
+    let Some(json_pointer) = event.json_pointer.as_deref() else {
+        return true;
+    };
+    let Some(payload) = payload else {
+        return false;
+    };
+    let Some(actual_value) = payload.pointer(json_pointer) else {
+        return false;
+    };
+    if let Some(expected_value) = event.equals_json.as_ref() {
+        return actual_value == expected_value;
+    }
+    if let Some(needle) = event.contains_text.as_deref() {
+        return actual_value
+            .as_str()
+            .is_some_and(|haystack| haystack.contains(needle));
+    }
+    true
+}
+
+async fn queue_background_task(
+    config: Option<String>,
+    action: &BackgroundTaskAction,
+) -> Result<Option<String>, String> {
+    let execution =
+        crate::tasks_cli::execute_tasks_command(crate::tasks_cli::TasksCommandOptions {
+            config,
+            json: true,
+            session: action.session.clone(),
+            command: crate::tasks_cli::TasksCommands::Create {
+                task: action.task.clone(),
+                label: action.label.clone(),
+                timeout_seconds: action.timeout_seconds,
+            },
+        })
+        .await?;
+
+    let queued_task_id = execution
+        .payload
+        .pointer("/queued_outcome/child_session_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    Ok(queued_task_id)
+}
+
+fn normalize_event_path(raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("automation event path must not be empty".to_owned());
+    }
+    let with_leading = if trimmed.starts_with('/') {
+        trimmed.to_owned()
+    } else {
+        format!("/{trimmed}")
+    };
+    if with_leading == "/" {
+        return Err("automation event path must not be `/`".to_owned());
+    }
+    Ok(with_leading.trim_end_matches('/').to_owned())
+}
+
+fn verify_webhook_token(headers: &HeaderMap, required_token: Option<&str>) -> CliResult<()> {
+    let Some(required_token) = required_token else {
+        return Ok(());
+    };
+    let auth_header = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+    if let Some(auth_header) = auth_header
+        && let Some(presented) = auth_header.strip_prefix("Bearer ")
+        && presented == required_token
+    {
+        return Ok(());
+    }
+    let legacy_header = headers
+        .get("x-loong-automation-token")
+        .and_then(|value| value.to_str().ok());
+    if legacy_header == Some(required_token) {
+        return Ok(());
+    }
+    Err("automation webhook token missing or invalid".to_owned())
+}
+
+async fn automation_event_webhook_handler(
+    State(state): State<AutomationServeState>,
+    AxumPath(event_name): AxumPath<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(error) = verify_webhook_token(&headers, state.auth_token.as_deref()) {
+        return (StatusCode::UNAUTHORIZED, Json(json!({"error": error}))).into_response();
+    }
+
+    let store_path = automation_store_path();
+    let payload_json = if body.is_empty() {
+        None
+    } else {
+        match std::str::from_utf8(body.as_ref()) {
+            Ok(text) => Some(text.to_owned()),
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("automation webhook body is not valid utf-8: {error}")})),
+                )
+                    .into_response();
+            }
+        }
+    };
+    match execute_emit_command(
+        store_path.as_path(),
+        state.config.clone(),
+        event_name.as_str(),
+        payload_json.as_deref(),
+    )
+    .await
+    {
+        Ok(payload) => (StatusCode::OK, Json(payload)).into_response(),
+        Err(error) => (StatusCode::BAD_REQUEST, Json(json!({"error": error}))).into_response(),
+    }
+}
+
+fn render_automation_text(payload: &Value) -> CliResult<String> {
+    let command = payload
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation payload missing command".to_owned())?;
+    match command {
+        "create_schedule" | "create_cron" | "create_event" | "show" | "status_update" => {
+            let trigger = payload
+                .get("trigger")
+                .ok_or_else(|| "automation payload missing trigger".to_owned())?;
+            render_trigger_detail(trigger)
+        }
+        "list" => render_trigger_list(payload),
+        "remove" => Ok(format!(
+            "Removed automation trigger `{}`.",
+            payload["trigger_id"].as_str().unwrap_or("unknown")
+        )),
+        "fire" => {
+            let result = payload
+                .get("result")
+                .ok_or_else(|| "automation payload missing result".to_owned())?;
+            render_fire_result(result)
+        }
+        "emit" => render_emit_result(payload),
+        "serve" => Ok("Automation runner stopped.".to_owned()),
+        other => Err(format!("unsupported automation render command `{other}`")),
+    }
+}
+
+fn render_trigger_list(payload: &Value) -> CliResult<String> {
+    let triggers = payload["triggers"]
+        .as_array()
+        .ok_or_else(|| "automation list payload missing triggers".to_owned())?;
+    if triggers.is_empty() {
+        return Ok("No automation triggers found.".to_owned());
+    }
+    let mut lines = vec!["Automation triggers".to_owned(), String::new()];
+    for trigger in triggers {
+        let id = trigger["trigger_id"].as_str().unwrap_or("unknown");
+        let name = trigger["name"].as_str().unwrap_or("unnamed");
+        let status = trigger["status"].as_str().unwrap_or("unknown");
+        let kind = trigger["source"]["type"].as_str().unwrap_or("unknown");
+        lines.push(format!("- {id} [{status}] {kind} {name}"));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
+    let id = trigger["trigger_id"]
+        .as_str()
+        .ok_or_else(|| "automation trigger missing trigger_id".to_owned())?;
+    let name = trigger["name"].as_str().unwrap_or("unnamed");
+    let status = trigger["status"].as_str().unwrap_or("unknown");
+    let source_kind = trigger["source"]["type"].as_str().unwrap_or("unknown");
+    let mut lines = vec![
+        format!("{name} ({id})"),
+        format!("status: {status}"),
+        format!("source: {source_kind}"),
+    ];
+
+    match source_kind {
+        "schedule" => {
+            lines.push(format!(
+                "next_fire_at_ms: {}",
+                trigger["source"]["schedule"]["next_fire_at_ms"]
+                    .as_i64()
+                    .unwrap_or_default()
+            ));
+            if let Some(interval_ms) = trigger["source"]["schedule"]["interval_ms"].as_u64() {
+                lines.push(format!("interval_ms: {interval_ms}"));
+            } else {
+                lines.push("interval_ms: none".to_owned());
+            }
+        }
+        "event" => {
+            lines.push(format!(
+                "event: {}",
+                trigger["source"]["event"]["event_name"]
+                    .as_str()
+                    .unwrap_or("unknown")
+            ));
+            if let Some(pointer) = trigger["source"]["event"]["json_pointer"].as_str() {
+                lines.push(format!("json_pointer: {pointer}"));
+            }
+            if !trigger["source"]["event"]["equals_json"].is_null() {
+                lines.push(format!(
+                    "equals_json: {}",
+                    trigger["source"]["event"]["equals_json"]
+                ));
+            }
+            if let Some(contains_text) = trigger["source"]["event"]["contains_text"].as_str() {
+                lines.push(format!("contains_text: {contains_text}"));
+            }
+        }
+        "cron" => {
+            lines.push(format!(
+                "cron: {}",
+                trigger["source"]["cron"]["expression"]
+                    .as_str()
+                    .unwrap_or("unknown")
+            ));
+            lines.push(format!(
+                "next_fire_at_ms: {}",
+                trigger["source"]["cron"]["next_fire_at_ms"]
+                    .as_i64()
+                    .unwrap_or_default()
+            ));
+        }
+        _ => {}
+    }
+
+    lines.push(format!(
+        "session: {}",
+        trigger["action"]["background_task"]["session"]
+            .as_str()
+            .unwrap_or("unknown")
+    ));
+    lines.push(format!(
+        "task: {}",
+        trigger["action"]["background_task"]["task"]
+            .as_str()
+            .unwrap_or("")
+    ));
+    if let Some(label) = trigger["action"]["background_task"]["label"].as_str() {
+        lines.push(format!("label: {label}"));
+    }
+    if let Some(timeout_seconds) = trigger["action"]["background_task"]["timeout_seconds"].as_u64()
+    {
+        lines.push(format!("timeout_seconds: {timeout_seconds}"));
+    }
+    if let Some(last_fired_at_ms) = trigger["last_fired_at_ms"].as_i64() {
+        lines.push(format!("last_fired_at_ms: {last_fired_at_ms}"));
+    }
+    if let Some(last_task_id) = trigger["last_task_id"].as_str() {
+        lines.push(format!("last_task_id: {last_task_id}"));
+    }
+    if let Some(last_error) = trigger["last_error"].as_str() {
+        lines.push(format!("last_error: {last_error}"));
+    }
+    if let Some(run_history) = trigger["run_history"].as_array() {
+        lines.push(format!("run_history_count: {}", run_history.len()));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn render_fire_result(result: &Value) -> CliResult<String> {
+    let id = result["trigger_id"]
+        .as_str()
+        .ok_or_else(|| "automation fire result missing trigger_id".to_owned())?;
+    let name = result["name"].as_str().unwrap_or("unnamed");
+    if let Some(error) = result["error"].as_str() {
+        return Ok(format!(
+            "Automation trigger `{name}` ({id}) failed: {error}"
+        ));
+    }
+    let queued_task_id = result["queued_task_id"].as_str().unwrap_or("unknown");
+    Ok(format!(
+        "Automation trigger `{name}` ({id}) queued background task `{queued_task_id}`."
+    ))
+}
+
+fn render_emit_result(payload: &Value) -> CliResult<String> {
+    let event_name = payload["event_name"]
+        .as_str()
+        .ok_or_else(|| "automation emit payload missing event_name".to_owned())?;
+    let results = payload["results"]
+        .as_array()
+        .ok_or_else(|| "automation emit payload missing results".to_owned())?;
+    if results.is_empty() {
+        return Ok(format!(
+            "No active automation triggers matched event `{event_name}`."
+        ));
+    }
+    let mut lines = vec![format!("Matched event `{event_name}`."), String::new()];
+    for result in results {
+        lines.push(render_fire_result(result)?);
+    }
+    Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_schedule_trigger(interval_ms: Option<u64>) -> AutomationTriggerRecord {
+        AutomationTriggerRecord {
+            trigger_id: "atrg-test".to_owned(),
+            name: "Sample".to_owned(),
+            status: AutomationTriggerStatus::Active,
+            source: AutomationTriggerSource::Schedule {
+                schedule: AutomationScheduleSpec {
+                    next_fire_at_ms: 1_000,
+                    interval_ms,
+                },
+            },
+            action: AutomationAction::BackgroundTask {
+                background_task: BackgroundTaskAction {
+                    session: "default".to_owned(),
+                    task: "check status".to_owned(),
+                    label: None,
+                    timeout_seconds: None,
+                },
+            },
+            created_at_ms: 100,
+            updated_at_ms: 100,
+            last_fired_at_ms: None,
+            last_task_id: None,
+            last_error: None,
+            fire_count: 0,
+            run_history: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn normalize_event_name_accepts_stable_event_tokens() {
+        let normalized = normalize_event_name("Hook.Task.Completed");
+        assert!(normalized.is_ok());
+        assert_eq!(normalized.unwrap_or_default(), "hook.task.completed");
+    }
+
+    #[test]
+    fn normalize_event_name_rejects_invalid_characters() {
+        let error = normalize_event_name("hook task").expect_err("spaces should fail");
+        assert!(error.contains("may only contain"));
+    }
+
+    #[test]
+    fn one_shot_schedule_completes_after_successful_fire() {
+        let mut trigger = sample_schedule_trigger(None);
+        apply_post_fire_schedule_state(&mut trigger, 5_000, true);
+        assert_eq!(trigger.status, AutomationTriggerStatus::Completed);
+    }
+
+    #[test]
+    fn recurring_schedule_reschedules_from_fire_time() {
+        let mut trigger = sample_schedule_trigger(Some(30_000));
+        apply_post_fire_schedule_state(&mut trigger, 5_000, true);
+        let AutomationTriggerSource::Schedule { schedule } = &trigger.source else {
+            panic!("expected schedule trigger");
+        };
+        assert_eq!(schedule.next_fire_at_ms, 35_000);
+        assert_eq!(trigger.status, AutomationTriggerStatus::Active);
+    }
+
+    #[test]
+    fn failed_one_shot_retries_instead_of_completing() {
+        let mut trigger = sample_schedule_trigger(None);
+        apply_post_fire_schedule_state(&mut trigger, 5_000, false);
+        let AutomationTriggerSource::Schedule { schedule } = &trigger.source else {
+            panic!("expected schedule trigger");
+        };
+        assert_eq!(
+            schedule.next_fire_at_ms,
+            5_000 + AUTOMATION_FAILURE_RETRY_MS
+        );
+        assert_eq!(trigger.status, AutomationTriggerStatus::Active);
+    }
+
+    #[test]
+    fn parse_cron_expression_accepts_wildcards_ranges_lists_and_steps() {
+        let expression = parse_cron_expression("*/15 9-17 * 1,6,12 1-5");
+        assert!(expression.is_ok());
+    }
+
+    #[test]
+    fn next_cron_fire_finds_future_match() {
+        let next = next_cron_fire_at_ms("0 0 1 1 *", 1_700_000_000_000);
+        assert!(next.is_ok());
+        assert!(next.unwrap_or_default() > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn trigger_matches_event_uses_json_pointer_filter() {
+        let trigger = AutomationTriggerRecord {
+            trigger_id: "atrg-event".to_owned(),
+            name: "Filtered".to_owned(),
+            status: AutomationTriggerStatus::Active,
+            source: AutomationTriggerSource::Event {
+                event: AutomationEventSpec {
+                    event_name: "work_unit.completed".to_owned(),
+                    json_pointer: Some("/work_unit/status".to_owned()),
+                    equals_json: Some(Value::String("completed".to_owned())),
+                    contains_text: None,
+                },
+            },
+            action: AutomationAction::BackgroundTask {
+                background_task: BackgroundTaskAction {
+                    session: "default".to_owned(),
+                    task: "noop".to_owned(),
+                    label: None,
+                    timeout_seconds: None,
+                },
+            },
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            last_fired_at_ms: None,
+            last_task_id: None,
+            last_error: None,
+            fire_count: 0,
+            run_history: Vec::new(),
+        };
+
+        assert!(trigger_matches_event(
+            &trigger,
+            "work_unit.completed",
+            Some(&json!({"work_unit": {"status": "completed"}})),
+        ));
+        assert!(!trigger_matches_event(
+            &trigger,
+            "work_unit.completed",
+            Some(&json!({"work_unit": {"status": "failed_terminal"}})),
+        ));
+    }
+
+    #[test]
+    fn trigger_matches_event_supports_pointer_exists_without_equality() {
+        let trigger = AutomationTriggerRecord {
+            trigger_id: "atrg-exists".to_owned(),
+            name: "Exists".to_owned(),
+            status: AutomationTriggerStatus::Active,
+            source: AutomationTriggerSource::Event {
+                event: AutomationEventSpec {
+                    event_name: "build.ready".to_owned(),
+                    json_pointer: Some("/reason".to_owned()),
+                    equals_json: None,
+                    contains_text: None,
+                },
+            },
+            action: AutomationAction::BackgroundTask {
+                background_task: BackgroundTaskAction {
+                    session: "default".to_owned(),
+                    task: "noop".to_owned(),
+                    label: None,
+                    timeout_seconds: None,
+                },
+            },
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            last_fired_at_ms: None,
+            last_task_id: None,
+            last_error: None,
+            fire_count: 0,
+            run_history: Vec::new(),
+        };
+
+        assert!(trigger_matches_event(
+            &trigger,
+            "build.ready",
+            Some(&json!({"reason": "ready to ship"})),
+        ));
+        assert!(!trigger_matches_event(
+            &trigger,
+            "build.ready",
+            Some(&json!({"other": "value"})),
+        ));
+    }
+
+    #[test]
+    fn trigger_matches_event_supports_contains_text() {
+        let trigger = AutomationTriggerRecord {
+            trigger_id: "atrg-contains".to_owned(),
+            name: "Contains".to_owned(),
+            status: AutomationTriggerStatus::Active,
+            source: AutomationTriggerSource::Event {
+                event: AutomationEventSpec {
+                    event_name: "build.ready".to_owned(),
+                    json_pointer: Some("/reason".to_owned()),
+                    equals_json: None,
+                    contains_text: Some("ship".to_owned()),
+                },
+            },
+            action: AutomationAction::BackgroundTask {
+                background_task: BackgroundTaskAction {
+                    session: "default".to_owned(),
+                    task: "noop".to_owned(),
+                    label: None,
+                    timeout_seconds: None,
+                },
+            },
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            last_fired_at_ms: None,
+            last_task_id: None,
+            last_error: None,
+            fire_count: 0,
+            run_history: Vec::new(),
+        };
+
+        assert!(trigger_matches_event(
+            &trigger,
+            "build.ready",
+            Some(&json!({"reason": "ready to ship"})),
+        ));
+        assert!(!trigger_matches_event(
+            &trigger,
+            "build.ready",
+            Some(&json!({"reason": "ready to review"})),
+        ));
+    }
+
+    #[test]
+    fn normalize_event_path_rejects_root_path() {
+        let error = normalize_event_path("/").expect_err("root should fail");
+        assert!(error.contains("must not be `/`"));
+    }
+}

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -31,6 +31,8 @@ static AUTOMATION_TRIGGER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum AutomationCommands {
+    /// Explain when to use schedule, cron, or event triggers
+    Guide(AutomationGuideCommandOptions),
     /// Create one schedule-based automation trigger
     CreateSchedule(AutomationCreateScheduleCommandOptions),
     /// Create one cron-style automation trigger
@@ -67,6 +69,9 @@ pub struct AutomationCommandOptions {
     pub json: bool,
     pub command: AutomationCommands,
 }
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationGuideCommandOptions {}
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct AutomationCreateScheduleCommandOptions {
@@ -532,6 +537,7 @@ pub async fn run_automation_cli(options: AutomationCommandOptions) -> CliResult<
 pub async fn execute_automation_command(options: AutomationCommandOptions) -> CliResult<Value> {
     let store_path = automation_store_path();
     match options.command {
+        AutomationCommands::Guide(command) => execute_guide_command(command),
         AutomationCommands::CreateSchedule(command) => {
             execute_create_schedule_command(store_path.as_path(), command).await
         }
@@ -1032,6 +1038,119 @@ fn execute_cron_command(options: AutomationCronCommandOptions) -> CliResult<Valu
     match options.command {
         AutomationCronCommands::Preview(command) => execute_cron_preview_command(command),
     }
+}
+
+fn execute_guide_command(_options: AutomationGuideCommandOptions) -> CliResult<Value> {
+    let command_name = crate::active_cli_command_name();
+    let preview_cron_command =
+        format!("{command_name} automation cron preview --cron '0 9 * * 1-5'");
+    let create_schedule_command = format!(
+        "{command_name} automation create-schedule --name <name> --session <session> --task '<task>' --run-at <rfc3339>"
+    );
+    let create_interval_command = format!(
+        "{command_name} automation create-schedule --name <name> --session <session> --task '<task>' --every-seconds <seconds>"
+    );
+    let create_cron_command = format!(
+        "{command_name} automation create-cron --name <name> --cron '<expr>' --session <session> --task '<task>'"
+    );
+    let create_event_command = format!(
+        "{command_name} automation create-event --name <name> --event <event_name> --session <session> --task '<task>'"
+    );
+    let emit_test_command =
+        format!("{command_name} automation emit --event <event_name> --payload-json '{{}}'");
+    let serve_command = format!("{command_name} automation serve --config <path>");
+    let list_command = format!("{command_name} automation list");
+    let runner_inspect_command = format!("{command_name} automation runner inspect");
+
+    let trigger_sources = vec![
+        json!({
+            "type": "schedule",
+            "use_when": "Use schedule for one known future run or a fixed every-N-seconds cadence.",
+            "avoid_when": "Avoid schedule when you need calendar-style wall-clock recurrence such as weekdays at 09:00 UTC.",
+            "create_commands": [
+                create_schedule_command,
+                create_interval_command,
+            ],
+        }),
+        json!({
+            "type": "cron",
+            "use_when": "Use cron for wall-clock recurrence such as weekdays at 09:00 UTC.",
+            "avoid_when": "Avoid cron when a one-shot schedule or a fixed every-N-seconds interval is enough.",
+            "preview_command": preview_cron_command,
+            "create_command": create_cron_command,
+        }),
+        json!({
+            "type": "event",
+            "use_when": "Use event triggers when a webhook, runtime mutation, or named internal event already exists.",
+            "avoid_when": "Avoid event triggers when there is no truthful event producer and you are really trying to express time.",
+            "create_command": create_event_command,
+            "test_command": emit_test_command,
+        }),
+    ];
+
+    let operational_notes = vec![
+        "All automation triggers queue background tasks; they do not create a second worker runtime.",
+        "Run `automation serve` for durable cron delivery, webhook ingress, and journal-backed internal-event consumption.",
+        "Use `automation emit` to dry-test an event trigger before wiring a real producer.",
+        "Use `automation cron preview` before `create-cron` so the wall-clock cadence is reviewed before it is persisted.",
+    ];
+
+    let recipes = vec![
+        json!({
+            "name": "preview_cron",
+            "command": preview_cron_command,
+            "purpose": "Review future UTC fire times before creating a cron trigger.",
+        }),
+        json!({
+            "name": "create_schedule_once",
+            "command": create_schedule_command,
+            "purpose": "Queue one background task at a specific future time.",
+        }),
+        json!({
+            "name": "create_schedule_interval",
+            "command": create_interval_command,
+            "purpose": "Queue recurring work on a fixed interval measured in seconds.",
+        }),
+        json!({
+            "name": "create_cron",
+            "command": create_cron_command,
+            "purpose": "Queue recurring work on a wall-clock cadence.",
+        }),
+        json!({
+            "name": "create_event",
+            "command": create_event_command,
+            "purpose": "Queue work from a named webhook or runtime event.",
+        }),
+        json!({
+            "name": "test_event",
+            "command": emit_test_command,
+            "purpose": "Dry-test event matching before a real producer is live.",
+        }),
+        json!({
+            "name": "start_runner",
+            "command": serve_command,
+            "purpose": "Run the live automation scheduler and webhook/journal consumer.",
+        }),
+        json!({
+            "name": "inspect_runner",
+            "command": runner_inspect_command,
+            "purpose": "Confirm the live runner cadence, lease state, and retention policy.",
+        }),
+        json!({
+            "name": "list_triggers",
+            "command": list_command,
+            "purpose": "Review the currently persisted automation triggers.",
+        }),
+    ];
+
+    Ok(json!({
+        "command": "guide",
+        "entrypoint": "automation",
+        "summary": "Pick schedule for one future time or fixed intervals, cron for wall-clock recurrence, and event when a truthful producer already exists.",
+        "trigger_sources": trigger_sources,
+        "operational_notes": operational_notes,
+        "recipes": recipes,
+    }))
 }
 
 fn execute_cron_preview_command(options: AutomationCronPreviewCommandOptions) -> CliResult<Value> {
@@ -2599,6 +2718,7 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
         .and_then(Value::as_str)
         .ok_or_else(|| "automation payload missing command".to_owned())?;
     match command {
+        "guide" => render_guide(payload),
         "cron_preview" => render_cron_preview(payload),
         "create_schedule" | "create_cron" | "create_event" | "show" | "status_update" => {
             let trigger = payload
@@ -2691,6 +2811,10 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
             } else {
                 lines.push("interval_ms: none".to_owned());
             }
+            lines.push(
+                "guidance: use schedule for one future run or a fixed every-N-seconds cadence."
+                    .to_owned(),
+            );
         }
         "event" => {
             let event_name =
@@ -2710,6 +2834,10 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
             if let Some(contains_text) = contains_text {
                 lines.push(format!("contains_text: {contains_text}"));
             }
+            lines.push(
+                "guidance: use event triggers when a webhook or runtime surface can already emit a truthful named event."
+                    .to_owned(),
+            );
         }
         "cron" => {
             let expression =
@@ -2718,6 +2846,10 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
             let next_fire_at_ms =
                 json_pointer_i64(trigger, "/source/cron/next_fire_at_ms").unwrap_or_default();
             lines.push(format!("next_fire_at_ms: {next_fire_at_ms}"));
+            lines.push(
+                "guidance: use cron for wall-clock recurrence and prefer `automation cron preview` before editing the expression."
+                    .to_owned(),
+            );
         }
         _ => {}
     }
@@ -2746,6 +2878,107 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
     if let Some(run_history) = trigger["run_history"].as_array() {
         lines.push(format!("run_history_count: {}", run_history.len()));
     }
+    lines.push(
+        "delivery: all automation triggers queue background tasks instead of creating a second worker runtime."
+            .to_owned(),
+    );
+    Ok(lines.join("\n"))
+}
+
+fn render_guide(payload: &Value) -> CliResult<String> {
+    let summary = payload
+        .get("summary")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation guide payload missing summary".to_owned())?;
+    let trigger_sources = payload
+        .get("trigger_sources")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "automation guide payload missing trigger_sources".to_owned())?;
+    let operational_notes = payload
+        .get("operational_notes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "automation guide payload missing operational_notes".to_owned())?;
+    let recipes = payload
+        .get("recipes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "automation guide payload missing recipes".to_owned())?;
+
+    let mut lines = vec![
+        "Automation guide".to_owned(),
+        String::new(),
+        summary.to_owned(),
+        String::new(),
+        "pick a trigger:".to_owned(),
+    ];
+
+    for trigger_source in trigger_sources {
+        let kind = trigger_source
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide trigger source missing type".to_owned())?;
+        let use_when = trigger_source
+            .get("use_when")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide trigger source missing use_when".to_owned())?;
+        let avoid_when = trigger_source
+            .get("avoid_when")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide trigger source missing avoid_when".to_owned())?;
+        lines.push(format!("- {kind}: {use_when}"));
+        lines.push(format!("  avoid: {avoid_when}"));
+        if let Some(preview_command) = trigger_source
+            .get("preview_command")
+            .and_then(Value::as_str)
+        {
+            lines.push(format!("  preview: {preview_command}"));
+        }
+        if let Some(create_command) = trigger_source.get("create_command").and_then(Value::as_str) {
+            lines.push(format!("  create: {create_command}"));
+        }
+        if let Some(create_commands) = trigger_source
+            .get("create_commands")
+            .and_then(Value::as_array)
+        {
+            for create_command in create_commands {
+                let create_command = create_command.as_str().ok_or_else(|| {
+                    "automation guide create_commands entry must be a string".to_owned()
+                })?;
+                lines.push(format!("  create: {create_command}"));
+            }
+        }
+        if let Some(test_command) = trigger_source.get("test_command").and_then(Value::as_str) {
+            lines.push(format!("  test: {test_command}"));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("operational notes:".to_owned());
+    for note in operational_notes {
+        let note = note
+            .as_str()
+            .ok_or_else(|| "automation guide operational note must be a string".to_owned())?;
+        lines.push(format!("- {note}"));
+    }
+
+    lines.push(String::new());
+    lines.push("recipes:".to_owned());
+    for recipe in recipes {
+        let name = recipe
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide recipe missing name".to_owned())?;
+        let command = recipe
+            .get("command")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide recipe missing command".to_owned())?;
+        let purpose = recipe
+            .get("purpose")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "automation guide recipe missing purpose".to_owned())?;
+        lines.push(format!("- {name}: {purpose}"));
+        lines.push(format!("  {command}"));
+    }
+
     Ok(lines.join("\n"))
 }
 
@@ -2835,12 +3068,19 @@ fn render_cron_preview(payload: &Value) -> CliResult<String> {
         .get("preview")
         .and_then(Value::as_array)
         .ok_or_else(|| "automation cron preview payload missing preview".to_owned())?;
+    let command_name = crate::active_cli_command_name();
+    let next_step = format!(
+        "{command_name} automation create-cron --name <name> --cron '{expression}' --session <session> --task '<task>'"
+    );
 
     let mut lines = vec![
         "Automation cron preview".to_owned(),
         String::new(),
         format!("expression: {expression}"),
         format!("timezone: {timezone}"),
+        "use when: wall-clock recurrence such as weekdays at 09:00 UTC.".to_owned(),
+        "prefer schedule when a one-shot run or a fixed every-N-seconds cadence is enough."
+            .to_owned(),
         String::new(),
         "next fires:".to_owned(),
     ];
@@ -2860,6 +3100,9 @@ fn render_cron_preview(payload: &Value) -> CliResult<String> {
             .unwrap_or("unknown");
         lines.push(format!("- #{ordinal}: {fire_at_rfc3339} ({fire_at_ms})"));
     }
+
+    lines.push(String::new());
+    lines.push(format!("next step: {next_step}"));
 
     Ok(lines.join("\n"))
 }
@@ -3224,6 +3467,58 @@ mod tests {
             .as_i64()
             .expect("first preview fire_at_ms");
         assert!(first_fire_at_ms > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn render_cron_preview_surfaces_guidance_and_next_step() {
+        let payload = execute_cron_preview_command(AutomationCronPreviewCommandOptions {
+            cron: "0 9 * * 1-5".to_owned(),
+            after: None,
+            after_ms: Some(1_700_000_000_000),
+            count: 2,
+        })
+        .expect("preview cron expression");
+
+        let rendered = render_automation_text(&payload).expect("render cron preview");
+
+        assert!(rendered.contains("use when: wall-clock recurrence"));
+        assert!(rendered.contains("prefer schedule when"));
+        assert!(rendered.contains("next step:"));
+        assert!(rendered.contains("automation create-cron"));
+    }
+
+    #[test]
+    fn execute_guide_command_reports_trigger_selection_and_recipes() {
+        let payload =
+            execute_guide_command(AutomationGuideCommandOptions::default()).expect("guide payload");
+
+        assert_eq!(payload["command"], "guide");
+        assert_eq!(payload["trigger_sources"].as_array().map(Vec::len), Some(3));
+        assert!(
+            payload["operational_notes"]
+                .as_array()
+                .is_some_and(|notes| !notes.is_empty())
+        );
+        assert!(
+            payload["recipes"]
+                .as_array()
+                .is_some_and(|recipes| !recipes.is_empty())
+        );
+    }
+
+    #[test]
+    fn render_guide_surfaces_trigger_choice_and_runner_guidance() {
+        let payload =
+            execute_guide_command(AutomationGuideCommandOptions::default()).expect("guide payload");
+
+        let rendered = render_automation_text(&payload).expect("render guide");
+
+        assert!(rendered.contains("Automation guide"));
+        assert!(rendered.contains("- schedule:"));
+        assert!(rendered.contains("- cron:"));
+        assert!(rendered.contains("- event:"));
+        assert!(rendered.contains("automation serve"));
+        assert!(rendered.contains("automation emit"));
     }
 
     #[test]

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -48,6 +48,8 @@ pub enum AutomationCommands {
     Fire(AutomationFireCommandOptions),
     /// Emit one named event to matching triggers
     Emit(AutomationEmitCommandOptions),
+    /// Inspect or manage the internal automation journal
+    Journal(AutomationJournalCommandOptions),
     /// Run the scheduler loop and optional webhook ingress
     Serve(AutomationServeCommandOptions),
 }
@@ -176,6 +178,39 @@ pub struct AutomationServeCommandOptions {
     #[arg(long, default_value_t = AUTOMATION_DEFAULT_POLL_MS)]
     pub poll_ms: u64,
 }
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationJournalCommandOptions {
+    #[command(subcommand)]
+    pub command: AutomationJournalCommands,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum AutomationJournalCommands {
+    /// Inspect the internal automation journal layout and cursor
+    Inspect(AutomationJournalInspectCommandOptions),
+    /// Rotate the active internal automation journal segment
+    Rotate(AutomationJournalRotateCommandOptions),
+    /// Prune sealed internal automation journal segments older than the retained segment
+    Prune(AutomationJournalPruneCommandOptions),
+    /// Repair the internal automation journal state from on-disk layout
+    Repair(AutomationJournalRepairCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationJournalInspectCommandOptions {}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationJournalRotateCommandOptions {}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationJournalPruneCommandOptions {
+    #[arg(long)]
+    pub retain_segment_id: Option<String>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationJournalRepairCommandOptions {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -374,6 +409,9 @@ pub async fn execute_automation_command(options: AutomationCommandOptions) -> Cl
             )
             .await
         }
+        AutomationCommands::Journal(command) => {
+            execute_journal_command(options.config, command).await
+        }
         AutomationCommands::Serve(command) => {
             execute_serve_command(store_path.as_path(), options.config, command).await
         }
@@ -400,6 +438,14 @@ fn automation_event_cursor_path() -> PathBuf {
     crate::mvp::config::default_loong_home()
         .join("automation")
         .join("internal-events.cursor")
+}
+
+fn automation_journal_state_path() -> PathBuf {
+    crate::mvp::internal_events::internal_event_journal_state_path()
+}
+
+fn automation_active_segment_marker_path() -> PathBuf {
+    crate::mvp::internal_events::internal_event_active_segment_id_path()
 }
 
 fn now_ms() -> i64 {
@@ -1035,6 +1081,18 @@ async fn execute_emit_value_command(
     }))
 }
 
+async fn execute_journal_command(
+    config: Option<String>,
+    options: AutomationJournalCommandOptions,
+) -> CliResult<Value> {
+    match options.command {
+        AutomationJournalCommands::Inspect(_command) => execute_journal_inspect_command(),
+        AutomationJournalCommands::Rotate(_command) => execute_journal_rotate_command(config).await,
+        AutomationJournalCommands::Prune(command) => execute_journal_prune_command(command),
+        AutomationJournalCommands::Repair(_command) => execute_journal_repair_command(),
+    }
+}
+
 pub(crate) async fn emit_named_automation_event(
     config: Option<String>,
     event_name: &str,
@@ -1049,6 +1107,74 @@ pub(crate) async fn emit_named_automation_event(
         payload,
     )
     .await
+}
+
+fn execute_journal_inspect_command() -> CliResult<Value> {
+    let cursor_path = automation_event_cursor_path();
+    let cursor = load_internal_event_cursor(cursor_path.as_path())?;
+    let layout = mvp::internal_events::inspect_internal_event_journal_layout()?;
+    Ok(json!({
+        "command": "journal_inspect",
+        "serve_owner_active": automation_serve_owner_is_active(),
+        "cursor_path": cursor_path.display().to_string(),
+        "cursor": cursor,
+        "layout": layout,
+        "state_path": automation_journal_state_path().display().to_string(),
+        "active_marker_path": automation_active_segment_marker_path().display().to_string(),
+    }))
+}
+
+async fn execute_journal_rotate_command(config: Option<String>) -> CliResult<Value> {
+    let next_segment_id = mvp::internal_events::rotate_internal_event_journal_segment()?;
+    let inspection = execute_journal_inspect_command()?;
+    Ok(json!({
+        "command": "journal_rotate",
+        "next_segment_id": next_segment_id,
+        "serve_owner_active": automation_serve_owner_is_active(),
+        "inspection": inspection,
+        "config": config,
+    }))
+}
+
+fn execute_journal_prune_command(
+    options: AutomationJournalPruneCommandOptions,
+) -> CliResult<Value> {
+    let cursor_path = automation_event_cursor_path();
+    let cursor = load_internal_event_cursor(cursor_path.as_path())?;
+    let retain_cursor = if let Some(retain_segment_id) = options.retain_segment_id {
+        mvp::internal_events::InternalEventJournalCursor {
+            segment_id: Some(retain_segment_id),
+            ..mvp::internal_events::InternalEventJournalCursor::default()
+        }
+    } else {
+        cursor.clone()
+    };
+    let pruned_segments =
+        mvp::internal_events::prune_internal_event_journal_segments(&retain_cursor)?;
+    let inspection = execute_journal_inspect_command()?;
+    Ok(json!({
+        "command": "journal_prune",
+        "cursor_path": cursor_path.display().to_string(),
+        "cursor": cursor,
+        "retain_cursor": retain_cursor,
+        "pruned_segments": pruned_segments,
+        "inspection": inspection,
+    }))
+}
+
+fn execute_journal_repair_command() -> CliResult<Value> {
+    let layout = mvp::internal_events::repair_internal_event_journal_state()?;
+    let cursor_path = automation_event_cursor_path();
+    let cursor = load_internal_event_cursor(cursor_path.as_path())?;
+    Ok(json!({
+        "command": "journal_repair",
+        "serve_owner_active": automation_serve_owner_is_active(),
+        "cursor_path": cursor_path.display().to_string(),
+        "cursor": cursor,
+        "layout": layout,
+        "state_path": automation_journal_state_path().display().to_string(),
+        "active_marker_path": automation_active_segment_marker_path().display().to_string(),
+    }))
 }
 
 pub(crate) async fn publish_daemon_internal_event(
@@ -1212,7 +1338,10 @@ async fn process_internal_journal_events(config: Option<&String>) -> CliResult<(
     if changed {
         save_store(store_path.as_path(), &store)?;
     }
-    store_internal_event_cursor(cursor_path.as_path(), next_cursor)?;
+    store_internal_event_cursor(cursor_path.as_path(), next_cursor.clone())?;
+    if next_cursor.segment_id != current_cursor.segment_id {
+        let _ = mvp::internal_events::prune_internal_event_journal_segments(&next_cursor)?;
+    }
     Ok(())
 }
 
@@ -1257,10 +1386,18 @@ fn store_internal_event_cursor(
     }
     let encoded = serde_json::to_string_pretty(&cursor)
         .map_err(|error| format!("serialize automation event cursor failed: {error}"))?;
-    fs::write(path, format!("{encoded}\n")).map_err(|error| {
+    let tmp_path = path.with_extension("cursor.tmp");
+    fs::write(&tmp_path, format!("{encoded}\n")).map_err(|error| {
         format!(
-            "write automation event cursor {} failed: {error}",
-            path.display()
+            "write automation temp event cursor {} failed: {error}",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, path).map_err(|error| {
+        format!(
+            "publish automation event cursor {} from {} failed: {error}",
+            path.display(),
+            tmp_path.display()
         )
     })
 }
@@ -1567,6 +1704,10 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
             render_fire_result(result)
         }
         "emit" => render_emit_result(payload),
+        "journal_inspect" => render_journal_inspect(payload),
+        "journal_rotate" => render_journal_rotate(payload),
+        "journal_prune" => render_journal_prune(payload),
+        "journal_repair" => render_journal_repair(payload),
         "serve" => Ok("Automation runner stopped.".to_owned()),
         other => Err(format!("unsupported automation render command `{other}`")),
     }
@@ -1721,6 +1862,96 @@ fn render_emit_result(payload: &Value) -> CliResult<String> {
         lines.push(render_fire_result(result)?);
     }
     Ok(lines.join("\n"))
+}
+
+fn render_journal_inspect(payload: &Value) -> CliResult<String> {
+    let layout = payload
+        .get("layout")
+        .ok_or_else(|| "automation journal inspect payload missing layout".to_owned())?;
+    let active_segment_id = layout["active_segment_id"]
+        .as_str()
+        .ok_or_else(|| "automation journal inspect payload missing active_segment_id".to_owned())?;
+    let segments = layout["segments"]
+        .as_array()
+        .ok_or_else(|| "automation journal inspect payload missing segments".to_owned())?;
+    let mut lines = vec![
+        "Automation journal".to_owned(),
+        format!("serve_owner_active: {}", payload["serve_owner_active"]),
+        format!("active_segment_id: {active_segment_id}"),
+        format!("cursor: {}", payload["cursor"]),
+        format!(
+            "state_path: {}",
+            payload["state_path"].as_str().unwrap_or("unknown")
+        ),
+        format!(
+            "active_marker_path: {}",
+            payload["active_marker_path"].as_str().unwrap_or("unknown")
+        ),
+        String::new(),
+        "segments:".to_owned(),
+    ];
+    for segment in segments {
+        let segment_id = segment["segment_id"].as_str().unwrap_or("unknown");
+        let status = segment["status"].as_str().unwrap_or("unknown");
+        let path = segment["path"].as_str().unwrap_or("unknown");
+        lines.push(format!("- {segment_id} [{status}] {path}"));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn render_journal_rotate(payload: &Value) -> CliResult<String> {
+    let next_segment_id = payload["next_segment_id"]
+        .as_str()
+        .ok_or_else(|| "automation journal rotate payload missing next_segment_id".to_owned())?;
+    let inspection = payload
+        .get("inspection")
+        .ok_or_else(|| "automation journal rotate payload missing inspection".to_owned())?;
+    Ok(format!(
+        "Rotated automation journal to `{next_segment_id}`.\n\n{}",
+        render_journal_inspect(inspection)?
+    ))
+}
+
+fn render_journal_prune(payload: &Value) -> CliResult<String> {
+    let pruned_segments = payload["pruned_segments"]
+        .as_array()
+        .ok_or_else(|| "automation journal prune payload missing pruned_segments".to_owned())?;
+    let inspection = payload
+        .get("inspection")
+        .ok_or_else(|| "automation journal prune payload missing inspection".to_owned())?;
+    if pruned_segments.is_empty() {
+        return Ok(format!(
+            "No sealed automation journal segments were pruned.\n\n{}",
+            render_journal_inspect(inspection)?
+        ));
+    }
+    let pruned_list = pruned_segments
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(format!(
+        "Pruned automation journal segments: {pruned_list}\n\n{}",
+        render_journal_inspect(inspection)?
+    ))
+}
+
+fn render_journal_repair(payload: &Value) -> CliResult<String> {
+    let layout = payload
+        .get("layout")
+        .ok_or_else(|| "automation journal repair payload missing layout".to_owned())?;
+    Ok(format!(
+        "Repaired automation journal state.\n\n{}",
+        render_journal_inspect(&json!({
+            "command": "journal_inspect",
+            "serve_owner_active": payload["serve_owner_active"],
+            "cursor_path": payload["cursor_path"],
+            "cursor": payload["cursor"],
+            "layout": layout,
+            "state_path": payload["state_path"],
+            "active_marker_path": payload["active_marker_path"],
+        }))?
+    ))
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -189,6 +189,8 @@ pub struct AutomationJournalCommandOptions {
 pub enum AutomationJournalCommands {
     /// Inspect the internal automation journal layout and cursor
     Inspect(AutomationJournalInspectCommandOptions),
+    /// Report automation journal health and drift signals
+    Health(AutomationJournalHealthCommandOptions),
     /// Rotate the active internal automation journal segment
     Rotate(AutomationJournalRotateCommandOptions),
     /// Prune sealed internal automation journal segments older than the retained segment
@@ -199,6 +201,9 @@ pub enum AutomationJournalCommands {
 
 #[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
 pub struct AutomationJournalInspectCommandOptions {}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationJournalHealthCommandOptions {}
 
 #[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
 pub struct AutomationJournalRotateCommandOptions {}
@@ -1087,6 +1092,7 @@ async fn execute_journal_command(
 ) -> CliResult<Value> {
     match options.command {
         AutomationJournalCommands::Inspect(_command) => execute_journal_inspect_command(),
+        AutomationJournalCommands::Health(_command) => execute_journal_health_command(),
         AutomationJournalCommands::Rotate(_command) => execute_journal_rotate_command(config).await,
         AutomationJournalCommands::Prune(command) => execute_journal_prune_command(command),
         AutomationJournalCommands::Repair(_command) => execute_journal_repair_command(),
@@ -1121,6 +1127,64 @@ fn execute_journal_inspect_command() -> CliResult<Value> {
         "layout": layout,
         "state_path": automation_journal_state_path().display().to_string(),
         "active_marker_path": automation_active_segment_marker_path().display().to_string(),
+    }))
+}
+
+fn execute_journal_health_command() -> CliResult<Value> {
+    let inspection = execute_journal_inspect_command()?;
+    let layout = inspection
+        .get("layout")
+        .cloned()
+        .ok_or_else(|| "automation journal inspect payload missing layout".to_owned())?;
+    let cursor = inspection
+        .get("cursor")
+        .cloned()
+        .ok_or_else(|| "automation journal inspect payload missing cursor".to_owned())?;
+    let state_path = automation_journal_state_path();
+    let active_marker_path = automation_active_segment_marker_path();
+    let state_active_segment_id = fs::read_to_string(state_path.as_path())
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(raw.as_str()).ok())
+        .and_then(|value| value.get("active_segment_id").cloned())
+        .unwrap_or(Value::Null);
+    let active_marker_segment_id = fs::read_to_string(active_marker_path.as_path())
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .map(Value::String)
+        .unwrap_or(Value::Null);
+    let cursor_segment_id = cursor.get("segment_id").cloned().unwrap_or(Value::Null);
+    let layout_segments = layout["segments"]
+        .as_array()
+        .ok_or_else(|| "automation journal inspect payload missing segments".to_owned())?;
+    let cursor_segment_exists = cursor_segment_id.as_str().is_some_and(|segment_id| {
+        layout_segments
+            .iter()
+            .any(|segment| segment["segment_id"].as_str() == Some(segment_id))
+    });
+    let active_segment_exists = layout["active_segment_id"]
+        .as_str()
+        .is_some_and(|segment_id| {
+            layout_segments
+                .iter()
+                .any(|segment| segment["segment_id"].as_str() == Some(segment_id))
+        });
+    let active_marker_matches_state = match (
+        active_marker_segment_id.as_str(),
+        state_active_segment_id.as_str(),
+    ) {
+        (Some(marker), Some(state)) => marker == state,
+        _ => false,
+    };
+    Ok(json!({
+        "command": "journal_health",
+        "inspection": inspection,
+        "state_active_segment_id": state_active_segment_id,
+        "active_marker_segment_id": active_marker_segment_id,
+        "cursor_segment_id": cursor_segment_id,
+        "cursor_segment_exists": cursor_segment_exists,
+        "active_segment_exists": active_segment_exists,
+        "active_marker_matches_state": active_marker_matches_state,
     }))
 }
 
@@ -1705,6 +1769,7 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
         }
         "emit" => render_emit_result(payload),
         "journal_inspect" => render_journal_inspect(payload),
+        "journal_health" => render_journal_health(payload),
         "journal_rotate" => render_journal_rotate(payload),
         "journal_prune" => render_journal_prune(payload),
         "journal_repair" => render_journal_repair(payload),
@@ -1896,6 +1961,39 @@ fn render_journal_inspect(payload: &Value) -> CliResult<String> {
         let path = segment["path"].as_str().unwrap_or("unknown");
         lines.push(format!("- {segment_id} [{status}] {path}"));
     }
+    Ok(lines.join("\n"))
+}
+
+fn render_journal_health(payload: &Value) -> CliResult<String> {
+    let inspection = payload
+        .get("inspection")
+        .ok_or_else(|| "automation journal health payload missing inspection".to_owned())?;
+    let lines = vec![
+        "Automation journal health".to_owned(),
+        format!(
+            "active_marker_matches_state: {}",
+            payload["active_marker_matches_state"]
+        ),
+        format!(
+            "active_segment_exists: {}",
+            payload["active_segment_exists"]
+        ),
+        format!(
+            "cursor_segment_exists: {}",
+            payload["cursor_segment_exists"]
+        ),
+        format!(
+            "state_active_segment_id: {}",
+            payload["state_active_segment_id"]
+        ),
+        format!(
+            "active_marker_segment_id: {}",
+            payload["active_marker_segment_id"]
+        ),
+        format!("cursor_segment_id: {}", payload["cursor_segment_id"]),
+        String::new(),
+        render_journal_inspect(inspection)?,
+    ];
     Ok(lines.join("\n"))
 }
 

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -208,6 +208,10 @@ pub struct AutomationServeCommandOptions {
     pub path: String,
     #[arg(long, default_value_t = AUTOMATION_DEFAULT_POLL_MS)]
     pub poll_ms: u64,
+    #[arg(long, default_value_t = 0)]
+    pub retain_last_sealed: usize,
+    #[arg(long)]
+    pub retain_min_age_seconds: Option<u64>,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -408,6 +412,8 @@ struct AutomationRunnerStatus {
     bind_address: Option<String>,
     event_path: Option<String>,
     poll_ms: u64,
+    retain_last_sealed_segments: usize,
+    retain_min_age_ms: Option<u64>,
     lease_timeout_ms: u64,
     lease_expires_at_ms: u64,
     started_at_ms: u64,
@@ -427,6 +433,10 @@ struct PersistedAutomationRunnerState {
     bind_address: Option<String>,
     event_path: Option<String>,
     poll_ms: u64,
+    #[serde(default)]
+    retain_last_sealed_segments: usize,
+    #[serde(default)]
+    retain_min_age_ms: Option<u64>,
     started_at_ms: u64,
     last_heartbeat_at: u64,
     stopped_at_ms: Option<u64>,
@@ -462,6 +472,12 @@ struct AutomationRunnerTracker {
     stop_request_path: PathBuf,
     owner_token: String,
     state: std::sync::Mutex<PersistedAutomationRunnerState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AutomationRunnerRetentionPolicy {
+    retain_last_sealed_segments: usize,
+    retain_min_age_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -611,6 +627,18 @@ fn automation_runner_state_is_stale(
     let lease_expires_at_ms =
         automation_runner_lease_expires_at_ms(persisted_state.last_heartbeat_at);
     now_ms > lease_expires_at_ms
+}
+
+fn automation_runner_retention_policy_from_options(
+    options: &AutomationServeCommandOptions,
+) -> AutomationRunnerRetentionPolicy {
+    let retain_min_age_ms = options
+        .retain_min_age_seconds
+        .map(|seconds| seconds.saturating_mul(1_000));
+    AutomationRunnerRetentionPolicy {
+        retain_last_sealed_segments: options.retain_last_sealed,
+        retain_min_age_ms,
+    }
 }
 
 fn now_ms() -> i64 {
@@ -988,6 +1016,7 @@ impl AutomationRunnerTracker {
 
         let owner_token = new_automation_runner_owner_token(std::process::id());
         let started_at_ms = u64::try_from(now_ms()).unwrap_or_default();
+        let retention_policy = automation_runner_retention_policy_from_options(options);
         let initial_state = PersistedAutomationRunnerState {
             phase: "starting".to_owned(),
             running: true,
@@ -997,6 +1026,8 @@ impl AutomationRunnerTracker {
             bind_address: options.bind.clone(),
             event_path: Some(options.path.clone()),
             poll_ms: options.poll_ms.max(250),
+            retain_last_sealed_segments: retention_policy.retain_last_sealed_segments,
+            retain_min_age_ms: retention_policy.retain_min_age_ms,
             started_at_ms,
             last_heartbeat_at: started_at_ms,
             stopped_at_ms: None,
@@ -1124,6 +1155,8 @@ fn load_automation_runner_status() -> Option<AutomationRunnerStatus> {
         bind_address: persisted_state.bind_address,
         event_path: persisted_state.event_path,
         poll_ms: persisted_state.poll_ms,
+        retain_last_sealed_segments: persisted_state.retain_last_sealed_segments,
+        retain_min_age_ms: persisted_state.retain_min_age_ms,
         lease_timeout_ms: AUTOMATION_RUNTIME_STALE_MS,
         lease_expires_at_ms,
         started_at_ms: persisted_state.started_at_ms,
@@ -1973,6 +2006,7 @@ async fn execute_serve_command(
     config: Option<String>,
     options: AutomationServeCommandOptions,
 ) -> CliResult<Value> {
+    let retention_policy = automation_runner_retention_policy_from_options(&options);
     let runner_tracker = AutomationRunnerTracker::acquire(config.as_deref(), &options)?;
     let poll_ms = options.poll_ms.max(250);
     let stop_requested = Arc::new(AtomicBool::new(false));
@@ -1983,6 +2017,7 @@ async fn execute_serve_command(
     let finalize_owner_token = scheduler_owner_token.clone();
     let scheduler_runner_tracker = Arc::new(runner_tracker);
     let scheduler_runner_tracker_for_loop = scheduler_runner_tracker.clone();
+    let scheduler_retention_policy = retention_policy.clone();
     let scheduler_task = tokio::spawn(async move {
         while !scheduler_stop.load(Ordering::SeqCst) {
             if automation_runner_stop_requested(scheduler_owner_token.as_str()) {
@@ -1998,7 +2033,12 @@ async fn execute_serve_command(
             {
                 eprintln!("automation scheduler error: {error}");
             }
-            if let Err(error) = process_internal_journal_events(scheduler_config.as_ref()).await {
+            if let Err(error) = process_internal_journal_events_with_policy(
+                scheduler_config.as_ref(),
+                &scheduler_retention_policy,
+            )
+            .await
+            {
                 eprintln!("automation internal event journal error: {error}");
             }
             tokio::time::sleep(Duration::from_millis(
@@ -2064,7 +2104,10 @@ async fn execute_serve_command(
     }))
 }
 
-async fn process_internal_journal_events(config: Option<&String>) -> CliResult<()> {
+async fn process_internal_journal_events_with_policy(
+    config: Option<&String>,
+    retention_policy: &AutomationRunnerRetentionPolicy,
+) -> CliResult<()> {
     let cursor_path = automation_event_cursor_path();
     let current_cursor = load_internal_event_cursor(cursor_path.as_path())?;
     let (events, next_cursor) =
@@ -2095,7 +2138,12 @@ async fn process_internal_journal_events(config: Option<&String>) -> CliResult<(
     }
     store_internal_event_cursor(cursor_path.as_path(), next_cursor.clone())?;
     if next_cursor.segment_id != current_cursor.segment_id {
-        let _ = mvp::internal_events::prune_internal_event_journal_segments(&next_cursor)?;
+        let gc_policy = mvp::internal_events::InternalEventJournalGcPolicy {
+            retain_floor_segment_id: next_cursor.segment_id.clone(),
+            retain_last_sealed_segments: retention_policy.retain_last_sealed_segments,
+            retain_min_age_ms: retention_policy.retain_min_age_ms,
+        };
+        let _ = mvp::internal_events::gc_internal_event_journal_segments(&gc_policy)?;
     }
     Ok(())
 }
@@ -2629,6 +2677,15 @@ fn render_runner_inspect(payload: &Value) -> CliResult<String> {
     if let Some(event_path) = json_pointer_str(status, "/event_path") {
         lines.push(format!("event_path: {event_path}"));
     }
+    let retain_last_sealed_segments =
+        json_pointer_u64(status, "/retain_last_sealed_segments").unwrap_or_default();
+    let retain_min_age_ms = json_pointer_value(status, "/retain_min_age_ms")
+        .cloned()
+        .unwrap_or(Value::Null);
+    lines.push(format!(
+        "retain_last_sealed_segments: {retain_last_sealed_segments}"
+    ));
+    lines.push(format!("retain_min_age_ms: {retain_min_age_ms}"));
     if let Some(shutdown_reason) = json_pointer_str(status, "/shutdown_reason") {
         lines.push(format!("shutdown_reason: {shutdown_reason}"));
     }
@@ -2941,6 +2998,8 @@ mod tests {
             bind_address: None,
             event_path: Some("/automation/events".to_owned()),
             poll_ms: 250,
+            retain_last_sealed_segments: 0,
+            retain_min_age_ms: None,
             started_at_ms: last_heartbeat_at.saturating_sub(500),
             last_heartbeat_at,
             stopped_at_ms: None,
@@ -3260,6 +3319,8 @@ mod tests {
             auth_token: None,
             path: AUTOMATION_DEFAULT_EVENT_PATH.to_owned(),
             poll_ms: 250,
+            retain_last_sealed: 0,
+            retain_min_age_seconds: None,
         };
         let tracker = AutomationRunnerTracker::acquire(Some("/tmp/loong.toml"), &options)
             .expect("acquire tracker");

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -204,12 +204,12 @@ pub struct AutomationServeCommandOptions {
     pub bind: Option<String>,
     #[arg(long)]
     pub auth_token: Option<String>,
-    #[arg(long, default_value = AUTOMATION_DEFAULT_EVENT_PATH)]
-    pub path: String,
-    #[arg(long, default_value_t = AUTOMATION_DEFAULT_POLL_MS)]
-    pub poll_ms: u64,
-    #[arg(long, default_value_t = 0)]
-    pub retain_last_sealed: usize,
+    #[arg(long)]
+    pub path: Option<String>,
+    #[arg(long)]
+    pub poll_ms: Option<u64>,
+    #[arg(long)]
+    pub retain_last_sealed: Option<usize>,
     #[arg(long)]
     pub retain_min_age_seconds: Option<u64>,
 }
@@ -272,8 +272,8 @@ pub struct AutomationJournalRotateCommandOptions {}
 pub struct AutomationJournalPruneCommandOptions {
     #[arg(long)]
     pub retain_segment_id: Option<String>,
-    #[arg(long, default_value_t = 0)]
-    pub retain_last_sealed: usize,
+    #[arg(long)]
+    pub retain_last_sealed: Option<usize>,
     #[arg(long)]
     pub retain_min_age_seconds: Option<u64>,
     #[arg(long, default_value_t = false)]
@@ -480,6 +480,19 @@ struct AutomationRunnerRetentionPolicy {
     retain_min_age_ms: Option<u64>,
 }
 
+#[derive(Debug, Clone)]
+struct LoadedAutomationConfig {
+    resolved_path: PathBuf,
+    config: mvp::config::LoongConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedAutomationServeSettings {
+    event_path: String,
+    poll_ms: u64,
+    retention_policy: AutomationRunnerRetentionPolicy,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CronField {
     any: bool,
@@ -636,8 +649,74 @@ fn automation_runner_retention_policy_from_options(
         .retain_min_age_seconds
         .map(|seconds| seconds.saturating_mul(1_000));
     AutomationRunnerRetentionPolicy {
-        retain_last_sealed_segments: options.retain_last_sealed,
+        retain_last_sealed_segments: options.retain_last_sealed.unwrap_or_default(),
         retain_min_age_ms,
+    }
+}
+
+fn load_automation_config(config_path: Option<&str>) -> CliResult<Option<LoadedAutomationConfig>> {
+    if let Some(config_path) = config_path {
+        let (resolved_path, config) = mvp::config::load(Some(config_path))?;
+        return Ok(Some(LoadedAutomationConfig {
+            resolved_path,
+            config,
+        }));
+    }
+
+    let default_config_path = mvp::config::default_config_path();
+    if !default_config_path.is_file() {
+        return Ok(None);
+    }
+
+    let (resolved_path, config) = mvp::config::load(None)?;
+    Ok(Some(LoadedAutomationConfig {
+        resolved_path,
+        config,
+    }))
+}
+
+fn resolved_automation_runner_retention_policy(
+    retain_last_sealed_override: Option<usize>,
+    retain_min_age_seconds_override: Option<u64>,
+    config: Option<&mvp::config::LoongConfig>,
+) -> AutomationRunnerRetentionPolicy {
+    let retain_last_sealed_segments = retain_last_sealed_override.unwrap_or_else(|| {
+        config
+            .map(|config| config.automation.retain_last_sealed_segments)
+            .unwrap_or_default()
+    });
+    let retain_min_age_seconds = retain_min_age_seconds_override
+        .or_else(|| config.and_then(|config| config.automation.retain_min_age_seconds));
+    let retain_min_age_ms = retain_min_age_seconds.map(|seconds| seconds.saturating_mul(1_000));
+    AutomationRunnerRetentionPolicy {
+        retain_last_sealed_segments,
+        retain_min_age_ms,
+    }
+}
+
+fn resolve_automation_serve_settings(
+    options: &AutomationServeCommandOptions,
+    config: Option<&mvp::config::LoongConfig>,
+) -> ResolvedAutomationServeSettings {
+    let event_path = options.path.clone().unwrap_or_else(|| {
+        config
+            .map(|config| config.automation.resolved_event_path())
+            .unwrap_or_else(|| AUTOMATION_DEFAULT_EVENT_PATH.to_owned())
+    });
+    let poll_ms = options.poll_ms.unwrap_or_else(|| {
+        config
+            .map(|config| config.automation.resolved_poll_ms())
+            .unwrap_or(AUTOMATION_DEFAULT_POLL_MS)
+    });
+    let retention_policy = resolved_automation_runner_retention_policy(
+        options.retain_last_sealed,
+        options.retain_min_age_seconds,
+        config,
+    );
+    ResolvedAutomationServeSettings {
+        event_path,
+        poll_ms,
+        retention_policy,
     }
 }
 
@@ -1017,6 +1096,10 @@ impl AutomationRunnerTracker {
         let owner_token = new_automation_runner_owner_token(std::process::id());
         let started_at_ms = u64::try_from(now_ms()).unwrap_or_default();
         let retention_policy = automation_runner_retention_policy_from_options(options);
+        let poll_ms = options
+            .poll_ms
+            .unwrap_or(AUTOMATION_DEFAULT_POLL_MS)
+            .max(250);
         let initial_state = PersistedAutomationRunnerState {
             phase: "starting".to_owned(),
             running: true,
@@ -1024,8 +1107,8 @@ impl AutomationRunnerTracker {
             version: env!("CARGO_PKG_VERSION").to_owned(),
             config_path: config.map(ToOwned::to_owned),
             bind_address: options.bind.clone(),
-            event_path: Some(options.path.clone()),
-            poll_ms: options.poll_ms.max(250),
+            event_path: options.path.clone(),
+            poll_ms,
             retain_last_sealed_segments: retention_policy.retain_last_sealed_segments,
             retain_min_age_ms: retention_policy.retain_min_age_ms,
             started_at_ms,
@@ -1709,7 +1792,9 @@ async fn execute_journal_command(
         AutomationJournalCommands::Inspect(_command) => execute_journal_inspect_command(),
         AutomationJournalCommands::Health(_command) => execute_journal_health_command(),
         AutomationJournalCommands::Rotate(_command) => execute_journal_rotate_command(config).await,
-        AutomationJournalCommands::Prune(command) => execute_journal_prune_command(command),
+        AutomationJournalCommands::Prune(command) => {
+            execute_journal_prune_command(config.as_deref(), command)
+        }
         AutomationJournalCommands::Repair(_command) => execute_journal_repair_command(),
     }
 }
@@ -1826,8 +1911,11 @@ async fn execute_journal_rotate_command(config: Option<String>) -> CliResult<Val
 }
 
 fn execute_journal_prune_command(
+    config_path: Option<&str>,
     options: AutomationJournalPruneCommandOptions,
 ) -> CliResult<Value> {
+    let loaded_config = load_automation_config(config_path)?;
+    let automation_config = loaded_config.as_ref().map(|loaded| &loaded.config);
     let cursor_path = automation_event_cursor_path();
     let cursor = load_internal_event_cursor(cursor_path.as_path())?;
     let retain_floor_segment_id_option = options
@@ -1844,13 +1932,15 @@ fn execute_journal_prune_command(
         segment_id: Some(retain_floor_segment_id.clone()),
         ..mvp::internal_events::InternalEventJournalCursor::default()
     };
-    let retain_min_age_ms = options
-        .retain_min_age_seconds
-        .map(|seconds| seconds.saturating_mul(1_000));
+    let retention_policy = resolved_automation_runner_retention_policy(
+        options.retain_last_sealed,
+        options.retain_min_age_seconds,
+        automation_config,
+    );
     let gc_policy = mvp::internal_events::InternalEventJournalGcPolicy {
         retain_floor_segment_id: Some(retain_floor_segment_id.clone()),
-        retain_last_sealed_segments: options.retain_last_sealed,
-        retain_min_age_ms,
+        retain_last_sealed_segments: retention_policy.retain_last_sealed_segments,
+        retain_min_age_ms: retention_policy.retain_min_age_ms,
     };
     let plan = if options.dry_run {
         mvp::internal_events::plan_internal_event_journal_gc(&gc_policy)?
@@ -1871,8 +1961,8 @@ fn execute_journal_prune_command(
         "cursor": cursor,
         "retain_cursor": retain_cursor,
         "retain_floor_segment_id": retain_floor_segment_id,
-        "retain_last_sealed_segments": options.retain_last_sealed,
-        "retain_min_age_ms": retain_min_age_ms,
+        "retain_last_sealed_segments": retention_policy.retain_last_sealed_segments,
+        "retain_min_age_ms": retention_policy.retain_min_age_ms,
         "pruned_segments": pruned_segments,
         "plan": plan,
         "inspection": inspection,
@@ -2003,16 +2093,36 @@ fn augment_internal_event_payload(
 
 async fn execute_serve_command(
     store_path: &Path,
-    config: Option<String>,
+    config_path: Option<String>,
     options: AutomationServeCommandOptions,
 ) -> CliResult<Value> {
-    let retention_policy = automation_runner_retention_policy_from_options(&options);
-    let runner_tracker = AutomationRunnerTracker::acquire(config.as_deref(), &options)?;
-    let poll_ms = options.poll_ms.max(250);
+    let loaded_config = load_automation_config(config_path.as_deref())?;
+    if let Some(loaded_automation_config) = loaded_config.as_ref() {
+        mvp::runtime_env::initialize_runtime_environment(
+            &loaded_automation_config.config,
+            Some(loaded_automation_config.resolved_path.as_path()),
+        );
+    }
+    let automation_config = loaded_config.as_ref().map(|loaded| &loaded.config);
+    let resolved_settings = resolve_automation_serve_settings(&options, automation_config);
+    let poll_ms = resolved_settings.poll_ms.max(250);
+    let retention_policy = resolved_settings.retention_policy.clone();
+    let retain_min_age_seconds = retention_policy
+        .retain_min_age_ms
+        .map(|retain_min_age_ms| retain_min_age_ms / 1_000);
+    let runner_options = AutomationServeCommandOptions {
+        bind: options.bind.clone(),
+        auth_token: options.auth_token.clone(),
+        path: Some(resolved_settings.event_path.clone()),
+        poll_ms: Some(poll_ms),
+        retain_last_sealed: Some(retention_policy.retain_last_sealed_segments),
+        retain_min_age_seconds,
+    };
+    let runner_tracker = AutomationRunnerTracker::acquire(config_path.as_deref(), &runner_options)?;
     let stop_requested = Arc::new(AtomicBool::new(false));
     let scheduler_stop = stop_requested.clone();
     let scheduler_store_path = store_path.to_path_buf();
-    let scheduler_config = config.clone();
+    let scheduler_config = config_path.clone();
     let scheduler_owner_token = runner_tracker.owner_token().to_owned();
     let finalize_owner_token = scheduler_owner_token.clone();
     let scheduler_runner_tracker = Arc::new(runner_tracker);
@@ -2067,13 +2177,13 @@ async fn execute_serve_command(
     };
 
     if let Some(bind) = options.bind {
-        let normalized_path = normalize_event_path(options.path.as_str())?;
+        let normalized_path = normalize_event_path(resolved_settings.event_path.as_str())?;
         let route_path = format!("{normalized_path}/:event_name");
         let listener = tokio::net::TcpListener::bind(bind.as_str())
             .await
             .map_err(|error| format!("bind automation webhook listener failed: {error}"))?;
         let state = AutomationServeState {
-            config,
+            config: config_path,
             auth_token: options.auth_token,
         };
         let router = Router::new()
@@ -3252,6 +3362,39 @@ mod tests {
     }
 
     #[test]
+    fn resolve_automation_serve_settings_prefers_cli_over_config_defaults() {
+        let mut config = mvp::config::LoongConfig::default();
+        config.automation.event_path = "/automation/from-config".to_owned();
+        config.automation.poll_ms = 900;
+        config.automation.retain_last_sealed_segments = 3;
+        config.automation.retain_min_age_seconds = Some(60);
+
+        let options = AutomationServeCommandOptions {
+            bind: None,
+            auth_token: None,
+            path: Some("/automation/from-cli".to_owned()),
+            poll_ms: Some(250),
+            retain_last_sealed: Some(1),
+            retain_min_age_seconds: Some(5),
+        };
+
+        let resolved_settings = resolve_automation_serve_settings(&options, Some(&config));
+
+        assert_eq!(resolved_settings.event_path, "/automation/from-cli");
+        assert_eq!(resolved_settings.poll_ms, 250);
+        assert_eq!(
+            resolved_settings
+                .retention_policy
+                .retain_last_sealed_segments,
+            1
+        );
+        assert_eq!(
+            resolved_settings.retention_policy.retain_min_age_ms,
+            Some(5_000)
+        );
+    }
+
+    #[test]
     fn automation_runner_status_reports_stale_lease_expiry() {
         let (_env, _temp_home) = isolated_automation_home("loong-automation-runner-status");
         let last_heartbeat_at = 1;
@@ -3317,9 +3460,9 @@ mod tests {
         let options = AutomationServeCommandOptions {
             bind: None,
             auth_token: None,
-            path: AUTOMATION_DEFAULT_EVENT_PATH.to_owned(),
-            poll_ms: 250,
-            retain_last_sealed: 0,
+            path: Some(AUTOMATION_DEFAULT_EVENT_PATH.to_owned()),
+            poll_ms: Some(250),
+            retain_last_sealed: Some(0),
             retain_min_age_seconds: None,
         };
         let tracker = AutomationRunnerTracker::acquire(Some("/tmp/loong.toml"), &options)

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -195,6 +196,8 @@ pub enum AutomationRunnerCommands {
     Inspect(AutomationRunnerInspectCommandOptions),
     /// Request graceful shutdown for the current automation runner owner
     Stop(AutomationRunnerStopCommandOptions),
+    /// Reclaim a stale automation runner owner slot
+    Reclaim(AutomationRunnerReclaimCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
@@ -202,6 +205,9 @@ pub struct AutomationRunnerInspectCommandOptions {}
 
 #[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
 pub struct AutomationRunnerStopCommandOptions {}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationRunnerReclaimCommandOptions {}
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct AutomationJournalCommandOptions {
@@ -370,6 +376,8 @@ struct AutomationRunnerStatus {
     bind_address: Option<String>,
     event_path: Option<String>,
     poll_ms: u64,
+    lease_timeout_ms: u64,
+    lease_expires_at_ms: u64,
     started_at_ms: u64,
     last_heartbeat_at: u64,
     stopped_at_ms: Option<u64>,
@@ -407,6 +415,13 @@ enum AutomationRunnerStopRequestOutcome {
     Requested,
     AlreadyRequested,
     AlreadyStopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutomationRunnerReclaimOutcome {
+    Reclaimed,
+    AlreadyClean,
+    OwnerActive,
 }
 
 struct AutomationRunnerTracker {
@@ -510,7 +525,10 @@ fn automation_serve_lock_path() -> PathBuf {
 }
 
 pub(crate) fn automation_serve_owner_is_active() -> bool {
-    automation_serve_lock_path().exists()
+    let status = load_automation_runner_status();
+    status
+        .as_ref()
+        .is_some_and(|status| status.running && !status.stale)
 }
 
 fn automation_event_cursor_path() -> PathBuf {
@@ -537,6 +555,22 @@ fn automation_journal_state_path() -> PathBuf {
 
 fn automation_active_segment_marker_path() -> PathBuf {
     crate::mvp::internal_events::internal_event_active_segment_id_path()
+}
+
+fn automation_runner_lease_expires_at_ms(last_heartbeat_at: u64) -> u64 {
+    last_heartbeat_at.saturating_add(AUTOMATION_RUNTIME_STALE_MS)
+}
+
+fn automation_runner_state_is_stale(
+    persisted_state: &PersistedAutomationRunnerState,
+    now_ms: u64,
+) -> bool {
+    if !persisted_state.running {
+        return false;
+    }
+    let lease_expires_at_ms =
+        automation_runner_lease_expires_at_ms(persisted_state.last_heartbeat_at);
+    now_ms > lease_expires_at_ms
 }
 
 fn now_ms() -> i64 {
@@ -824,18 +858,27 @@ impl AutomationRunnerTracker {
         let active_owner_path = automation_serve_lock_path();
         let status_snapshot_path = automation_runner_status_snapshot_path();
         let stop_request_path = automation_runner_stop_request_path();
-        if active_owner_path.exists()
-            && let Some(status) = load_automation_runner_status()
-        {
+        if active_owner_path.exists() {
+            let status = load_automation_runner_status();
+            let Some(status) = status else {
+                return Err(format!(
+                    "automation serve owner state at {} is unreadable; reclaim it before starting a new owner",
+                    active_owner_path.display()
+                ));
+            };
             if status.running && !status.stale {
                 return Err(format!(
                     "automation serve owner already active at {}",
                     active_owner_path.display()
                 ));
             }
-            let _ = fs::remove_file(active_owner_path.as_path());
-            let _ = fs::remove_file(status_snapshot_path.as_path());
-            let _ = fs::remove_file(stop_request_path.as_path());
+            let reclaim_outcome = reclaim_stale_automation_runner_owner()?;
+            if reclaim_outcome != AutomationRunnerReclaimOutcome::Reclaimed {
+                return Err(format!(
+                    "automation serve owner slot at {} could not be reclaimed",
+                    active_owner_path.display()
+                ));
+            }
         }
 
         let owner_token = new_automation_runner_owner_token(std::process::id());
@@ -856,7 +899,7 @@ impl AutomationRunnerTracker {
             last_error: None,
             owner_token: owner_token.clone(),
         };
-        write_json_path(
+        create_json_path_exclusive(
             active_owner_path.as_path(),
             &initial_state,
             "automation serve owner",
@@ -887,14 +930,15 @@ impl AutomationRunnerTracker {
             .map_err(|error| format!("automation runner state lock poisoned: {error}"))?;
         state.phase = phase.to_owned();
         state.last_heartbeat_at = u64::try_from(now_ms()).unwrap_or_default();
-        write_json_path(
+        let persisted_state = state.clone();
+        write_automation_runner_active_owner_if_owned(
             self.active_owner_path.as_path(),
-            &*state,
-            "automation serve owner",
+            &persisted_state,
+            self.owner_token.as_str(),
         )?;
         write_json_path(
             self.status_snapshot_path.as_path(),
-            &*state,
+            &persisted_state,
             "automation serve status snapshot",
         )
     }
@@ -909,19 +953,31 @@ impl AutomationRunnerTracker {
             .state
             .lock()
             .map_err(|error| format!("automation runner state lock poisoned: {error}"))?;
+        let current_owner_token =
+            current_automation_runner_owner_token(self.active_owner_path.as_path());
+        if current_owner_token.as_deref() != Some(self.owner_token.as_str()) {
+            return Ok(());
+        }
         state.phase = phase.to_owned();
         state.running = false;
         state.last_heartbeat_at = u64::try_from(now_ms()).unwrap_or_default();
         state.stopped_at_ms = Some(u64::try_from(now_ms()).unwrap_or_default());
         state.shutdown_reason = shutdown_reason.map(ToOwned::to_owned);
         state.last_error = last_error.map(ToOwned::to_owned);
+        let persisted_state = state.clone();
         write_json_path(
             self.status_snapshot_path.as_path(),
-            &*state,
+            &persisted_state,
             "automation serve status snapshot",
         )?;
-        let _ = fs::remove_file(self.active_owner_path.as_path());
-        let _ = fs::remove_file(self.stop_request_path.as_path());
+        remove_automation_runner_active_owner_if_owned(
+            self.active_owner_path.as_path(),
+            self.owner_token.as_str(),
+        )?;
+        remove_automation_runner_stop_request_if_owned(
+            self.stop_request_path.as_path(),
+            self.owner_token.as_str(),
+        )?;
         Ok(())
     }
 }
@@ -946,8 +1002,9 @@ fn load_automation_runner_status() -> Option<AutomationRunnerStatus> {
         (None, None) => return None,
     };
     let now_ms = u64::try_from(now_ms()).unwrap_or_default();
-    let stale = persisted_state.running
-        && now_ms.saturating_sub(persisted_state.last_heartbeat_at) > AUTOMATION_RUNTIME_STALE_MS;
+    let stale = automation_runner_state_is_stale(&persisted_state, now_ms);
+    let lease_expires_at_ms =
+        automation_runner_lease_expires_at_ms(persisted_state.last_heartbeat_at);
     Some(AutomationRunnerStatus {
         runtime_dir: crate::mvp::config::default_loong_home()
             .join("automation")
@@ -962,6 +1019,8 @@ fn load_automation_runner_status() -> Option<AutomationRunnerStatus> {
         bind_address: persisted_state.bind_address,
         event_path: persisted_state.event_path,
         poll_ms: persisted_state.poll_ms,
+        lease_timeout_ms: AUTOMATION_RUNTIME_STALE_MS,
+        lease_expires_at_ms,
         started_at_ms: persisted_state.started_at_ms,
         last_heartbeat_at: persisted_state.last_heartbeat_at,
         stopped_at_ms: persisted_state.stopped_at_ms,
@@ -1012,6 +1071,127 @@ fn automation_runner_stop_requested(owner_token: &str) -> bool {
     request
         .as_ref()
         .is_some_and(|request| request.target_owner_token == owner_token)
+}
+
+fn current_automation_runner_owner_token(path: &Path) -> Option<String> {
+    let persisted_state = read_json_path::<PersistedAutomationRunnerState>(path);
+    persisted_state.map(|persisted_state| persisted_state.owner_token)
+}
+
+fn create_json_path_exclusive<T>(path: &Path, value: &T, label: &str) -> CliResult<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create {label} directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let encoded = serde_json::to_string_pretty(value)
+        .map_err(|error| format!("serialize {label} failed: {error}"))?;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("create {label} {} failed: {error}", path.display()))?;
+    file.write_all(format!("{encoded}\n").as_bytes())
+        .map_err(|error| format!("write {label} {} failed: {error}", path.display()))
+}
+
+fn write_automation_runner_active_owner_if_owned(
+    path: &Path,
+    persisted_state: &PersistedAutomationRunnerState,
+    owner_token: &str,
+) -> CliResult<()> {
+    let current_owner_token = current_automation_runner_owner_token(path);
+    if current_owner_token.as_deref() != Some(owner_token) {
+        return Err(
+            "automation runner ownership changed while the serve loop was still active".to_owned(),
+        );
+    }
+    write_json_path(path, persisted_state, "automation serve owner")
+}
+
+fn remove_automation_runner_active_owner_if_owned(path: &Path, owner_token: &str) -> CliResult<()> {
+    let current_owner_token = current_automation_runner_owner_token(path);
+    if current_owner_token.as_deref() != Some(owner_token) {
+        return Ok(());
+    }
+    fs::remove_file(path).map_err(|error| {
+        format!(
+            "remove automation serve owner {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn remove_automation_runner_stop_request_if_owned(path: &Path, owner_token: &str) -> CliResult<()> {
+    let stop_request = read_json_path::<PersistedAutomationStopRequest>(path);
+    let Some(stop_request) = stop_request else {
+        return Ok(());
+    };
+    if stop_request.target_owner_token != owner_token {
+        return Ok(());
+    }
+    fs::remove_file(path).map_err(|error| {
+        format!(
+            "remove automation serve stop request {} failed: {error}",
+            path.display()
+        )
+    })
+}
+
+fn reclaim_stale_automation_runner_owner() -> CliResult<AutomationRunnerReclaimOutcome> {
+    let active_owner_path = automation_serve_lock_path();
+    let status_snapshot_path = automation_runner_status_snapshot_path();
+    let stop_request_path = automation_runner_stop_request_path();
+    let active_owner =
+        read_json_path::<PersistedAutomationRunnerState>(active_owner_path.as_path());
+    let status = load_automation_runner_status();
+
+    let Some(status) = status else {
+        return Ok(AutomationRunnerReclaimOutcome::AlreadyClean);
+    };
+    if status.running && !status.stale {
+        return Ok(AutomationRunnerReclaimOutcome::OwnerActive);
+    }
+
+    let Some(mut persisted_state) = active_owner.or_else(|| {
+        read_json_path::<PersistedAutomationRunnerState>(status_snapshot_path.as_path())
+    }) else {
+        return Ok(AutomationRunnerReclaimOutcome::AlreadyClean);
+    };
+
+    let reclaimed_at_ms = u64::try_from(now_ms()).unwrap_or_default();
+    persisted_state.phase = "stopped".to_owned();
+    persisted_state.running = false;
+    persisted_state.last_heartbeat_at = reclaimed_at_ms;
+    persisted_state.stopped_at_ms = Some(reclaimed_at_ms);
+    persisted_state.shutdown_reason = Some("stale_reclaimed".to_owned());
+    persisted_state.last_error = None;
+
+    write_json_path(
+        status_snapshot_path.as_path(),
+        &persisted_state,
+        "automation serve status snapshot",
+    )?;
+    remove_automation_runner_active_owner_if_owned(
+        active_owner_path.as_path(),
+        persisted_state.owner_token.as_str(),
+    )?;
+    if stop_request_path.exists() {
+        fs::remove_file(stop_request_path.as_path()).map_err(|error| {
+            format!(
+                "remove stale automation serve stop request {} failed: {error}",
+                stop_request_path.display()
+            )
+        })?;
+    }
+    Ok(AutomationRunnerReclaimOutcome::Reclaimed)
 }
 
 fn read_json_path<T>(path: &Path) -> Option<T>
@@ -1400,6 +1580,7 @@ fn execute_runner_command(options: AutomationRunnerCommandOptions) -> CliResult<
     match options.command {
         AutomationRunnerCommands::Inspect(_command) => execute_runner_inspect_command(),
         AutomationRunnerCommands::Stop(_command) => execute_runner_stop_command(),
+        AutomationRunnerCommands::Reclaim(_command) => execute_runner_reclaim_command(),
     }
 }
 
@@ -1569,6 +1750,23 @@ fn execute_runner_stop_command() -> CliResult<Value> {
             AutomationRunnerStopRequestOutcome::AlreadyStopped => "already_stopped",
         },
         "status": status,
+        "stop_request_path": automation_runner_stop_request_path().display().to_string(),
+    }))
+}
+
+fn execute_runner_reclaim_command() -> CliResult<Value> {
+    let outcome = reclaim_stale_automation_runner_owner()?;
+    let status = load_automation_runner_status();
+    Ok(json!({
+        "command": "runner_reclaim",
+        "outcome": match outcome {
+            AutomationRunnerReclaimOutcome::Reclaimed => "reclaimed",
+            AutomationRunnerReclaimOutcome::AlreadyClean => "already_clean",
+            AutomationRunnerReclaimOutcome::OwnerActive => "owner_active",
+        },
+        "status": status,
+        "active_owner_path": automation_serve_lock_path().display().to_string(),
+        "status_snapshot_path": automation_runner_status_snapshot_path().display().to_string(),
         "stop_request_path": automation_runner_stop_request_path().display().to_string(),
     }))
 }
@@ -2133,6 +2331,9 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
         "journal_rotate" => render_journal_rotate(payload),
         "journal_prune" => render_journal_prune(payload),
         "journal_repair" => render_journal_repair(payload),
+        "runner_inspect" => render_runner_inspect(payload),
+        "runner_stop" => render_runner_stop(payload),
+        "runner_reclaim" => render_runner_reclaim(payload),
         "serve" => Ok("Automation runner stopped.".to_owned()),
         other => Err(format!("unsupported automation render command `{other}`")),
     }
@@ -2254,6 +2455,70 @@ fn render_trigger_detail(trigger: &Value) -> CliResult<String> {
         lines.push(format!("run_history_count: {}", run_history.len()));
     }
     Ok(lines.join("\n"))
+}
+
+fn render_runner_inspect(payload: &Value) -> CliResult<String> {
+    let status = payload
+        .get("status")
+        .ok_or_else(|| "automation runner inspect payload missing status".to_owned())?;
+    if status.is_null() {
+        return Ok("No automation runner owner is active.".to_owned());
+    }
+
+    let phase = json_pointer_str(status, "/phase").unwrap_or("unknown");
+    let running = json_pointer_value(status, "/running")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let stale = json_pointer_value(status, "/stale")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let poll_ms = json_pointer_u64(status, "/poll_ms").unwrap_or_default();
+    let lease_timeout_ms = json_pointer_u64(status, "/lease_timeout_ms").unwrap_or_default();
+    let lease_expires_at_ms = json_pointer_u64(status, "/lease_expires_at_ms").unwrap_or_default();
+    let last_heartbeat_at = json_pointer_u64(status, "/last_heartbeat_at").unwrap_or_default();
+
+    let mut lines = vec![
+        "Automation runner".to_owned(),
+        String::new(),
+        format!("phase: {phase}"),
+        format!("running: {running}"),
+        format!("stale: {stale}"),
+        format!("poll_ms: {poll_ms}"),
+        format!("lease_timeout_ms: {lease_timeout_ms}"),
+        format!("lease_expires_at_ms: {lease_expires_at_ms}"),
+        format!("last_heartbeat_at: {last_heartbeat_at}"),
+    ];
+
+    if let Some(bind_address) = json_pointer_str(status, "/bind_address") {
+        lines.push(format!("bind_address: {bind_address}"));
+    }
+    if let Some(event_path) = json_pointer_str(status, "/event_path") {
+        lines.push(format!("event_path: {event_path}"));
+    }
+    if let Some(shutdown_reason) = json_pointer_str(status, "/shutdown_reason") {
+        lines.push(format!("shutdown_reason: {shutdown_reason}"));
+    }
+    if let Some(last_error) = json_pointer_str(status, "/last_error") {
+        lines.push(format!("last_error: {last_error}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_runner_stop(payload: &Value) -> CliResult<String> {
+    let outcome = payload
+        .get("outcome")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation runner stop payload missing outcome".to_owned())?;
+    Ok(format!("Automation runner stop outcome: {outcome}."))
+}
+
+fn render_runner_reclaim(payload: &Value) -> CliResult<String> {
+    let outcome = payload
+        .get("outcome")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation runner reclaim payload missing outcome".to_owned())?;
+    Ok(format!("Automation runner reclaim outcome: {outcome}."))
 }
 
 fn render_fire_result(result: &Value) -> CliResult<String> {
@@ -2417,6 +2682,69 @@ fn render_journal_repair(payload: &Value) -> CliResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::test_support::ScopedEnv;
+
+    struct TempHomeGuard {
+        path: PathBuf,
+    }
+
+    impl TempHomeGuard {
+        fn new(prefix: &str) -> Self {
+            static NEXT_TEMP_HOME_SEED: AtomicUsize = AtomicUsize::new(1);
+            let seed = NEXT_TEMP_HOME_SEED.fetch_add(1, Ordering::Relaxed);
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            let process_id = std::process::id();
+            let path = std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"));
+            fs::create_dir_all(&path).expect("create temp home");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempHomeGuard {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.path).ok();
+        }
+    }
+
+    fn isolated_automation_home(prefix: &str) -> (ScopedEnv, TempHomeGuard) {
+        let mut env = ScopedEnv::new();
+        let temp_home = TempHomeGuard::new(prefix);
+        env.set("LOONG_HOME", temp_home.path().as_os_str());
+        (env, temp_home)
+    }
+
+    fn sample_runner_state(
+        owner_token: &str,
+        last_heartbeat_at: u64,
+    ) -> PersistedAutomationRunnerState {
+        PersistedAutomationRunnerState {
+            phase: "running".to_owned(),
+            running: true,
+            pid: Some(42),
+            version: "test".to_owned(),
+            config_path: Some("/tmp/loong.toml".to_owned()),
+            bind_address: None,
+            event_path: Some("/automation/events".to_owned()),
+            poll_ms: 250,
+            started_at_ms: last_heartbeat_at.saturating_sub(500),
+            last_heartbeat_at,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            owner_token: owner_token.to_owned(),
+        }
+    }
 
     fn sample_schedule_trigger(interval_ms: Option<u64>) -> AutomationTriggerRecord {
         AutomationTriggerRecord {
@@ -2638,5 +2966,98 @@ mod tests {
     fn normalize_event_path_rejects_root_path() {
         let error = normalize_event_path("/").expect_err("root should fail");
         assert!(error.contains("must not be `/`"));
+    }
+
+    #[test]
+    fn automation_runner_status_reports_stale_lease_expiry() {
+        let (_env, _temp_home) = isolated_automation_home("loong-automation-runner-status");
+        let last_heartbeat_at = 1;
+        let stale_state = sample_runner_state("owner-a", last_heartbeat_at);
+        write_json_path(
+            automation_serve_lock_path().as_path(),
+            &stale_state,
+            "automation serve owner",
+        )
+        .expect("write active owner");
+
+        let status = load_automation_runner_status().expect("load automation runner status");
+        assert!(status.stale);
+        assert_eq!(status.lease_timeout_ms, AUTOMATION_RUNTIME_STALE_MS);
+        assert_eq!(
+            status.lease_expires_at_ms,
+            automation_runner_lease_expires_at_ms(last_heartbeat_at)
+        );
+    }
+
+    #[test]
+    fn automation_runner_reclaim_clears_stale_owner_and_stop_request() {
+        let (_env, _temp_home) = isolated_automation_home("loong-automation-runner-reclaim");
+        let stale_state = sample_runner_state("owner-stale", 1);
+        write_json_path(
+            automation_serve_lock_path().as_path(),
+            &stale_state,
+            "automation serve owner",
+        )
+        .expect("write stale owner");
+        write_json_path(
+            automation_runner_status_snapshot_path().as_path(),
+            &stale_state,
+            "automation serve status snapshot",
+        )
+        .expect("write stale snapshot");
+        let stop_request = PersistedAutomationStopRequest {
+            requested_at_ms: 2,
+            requested_by_pid: 77,
+            target_owner_token: "owner-stale".to_owned(),
+        };
+        write_json_path(
+            automation_runner_stop_request_path().as_path(),
+            &stop_request,
+            "automation serve stop request",
+        )
+        .expect("write stop request");
+
+        let outcome = reclaim_stale_automation_runner_owner().expect("reclaim stale runner");
+        assert_eq!(outcome, AutomationRunnerReclaimOutcome::Reclaimed);
+        assert!(!automation_serve_lock_path().exists());
+        assert!(!automation_runner_stop_request_path().exists());
+
+        let status = load_automation_runner_status().expect("load reclaimed status");
+        assert!(!status.running);
+        assert_eq!(status.shutdown_reason.as_deref(), Some("stale_reclaimed"));
+        assert!(!status.stale);
+    }
+
+    #[test]
+    fn automation_runner_heartbeat_rejects_lost_ownership() {
+        let (_env, _temp_home) = isolated_automation_home("loong-automation-runner-heartbeat");
+        let options = AutomationServeCommandOptions {
+            bind: None,
+            auth_token: None,
+            path: AUTOMATION_DEFAULT_EVENT_PATH.to_owned(),
+            poll_ms: 250,
+        };
+        let tracker = AutomationRunnerTracker::acquire(Some("/tmp/loong.toml"), &options)
+            .expect("acquire tracker");
+
+        let mut foreign_state = {
+            let state_guard = tracker
+                .state
+                .lock()
+                .expect("automation runner state lock should not be poisoned");
+            state_guard.clone()
+        };
+        foreign_state.owner_token = "owner-foreign".to_owned();
+        write_json_path(
+            automation_serve_lock_path().as_path(),
+            &foreign_state,
+            "automation serve owner",
+        )
+        .expect("replace owner slot");
+
+        let error = tracker
+            .heartbeat("running")
+            .expect_err("lost ownership should fail heartbeat");
+        assert!(error.contains("ownership changed"));
     }
 }

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -23,6 +23,8 @@ const AUTOMATION_SCHEMA_VERSION: u32 = 1;
 const AUTOMATION_DEFAULT_POLL_MS: u64 = 1_000;
 const AUTOMATION_DEFAULT_EVENT_PATH: &str = "/automation/events";
 const AUTOMATION_FAILURE_RETRY_MS: i64 = 60_000;
+const AUTOMATION_RUNTIME_HEARTBEAT_MS: u64 = 5_000;
+const AUTOMATION_RUNTIME_STALE_MS: u64 = 15_000;
 
 static AUTOMATION_TRIGGER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -48,6 +50,8 @@ pub enum AutomationCommands {
     Fire(AutomationFireCommandOptions),
     /// Emit one named event to matching triggers
     Emit(AutomationEmitCommandOptions),
+    /// Inspect or manage the automation runner owner lifecycle
+    Runner(AutomationRunnerCommandOptions),
     /// Inspect or manage the internal automation journal
     Journal(AutomationJournalCommandOptions),
     /// Run the scheduler loop and optional webhook ingress
@@ -178,6 +182,26 @@ pub struct AutomationServeCommandOptions {
     #[arg(long, default_value_t = AUTOMATION_DEFAULT_POLL_MS)]
     pub poll_ms: u64,
 }
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationRunnerCommandOptions {
+    #[command(subcommand)]
+    pub command: AutomationRunnerCommands,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum AutomationRunnerCommands {
+    /// Inspect the current automation runner owner state
+    Inspect(AutomationRunnerInspectCommandOptions),
+    /// Request graceful shutdown for the current automation runner owner
+    Stop(AutomationRunnerStopCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationRunnerInspectCommandOptions {}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
+pub struct AutomationRunnerStopCommandOptions {}
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct AutomationJournalCommandOptions {
@@ -334,14 +358,63 @@ struct AutomationServeState {
     auth_token: Option<String>,
 }
 
-struct AutomationServeLock {
-    path: PathBuf,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AutomationRunnerStatus {
+    runtime_dir: String,
+    phase: String,
+    running: bool,
+    stale: bool,
+    pid: Option<u32>,
+    version: String,
+    config_path: Option<String>,
+    bind_address: Option<String>,
+    event_path: Option<String>,
+    poll_ms: u64,
+    started_at_ms: u64,
+    last_heartbeat_at: u64,
+    stopped_at_ms: Option<u64>,
+    shutdown_reason: Option<String>,
+    last_error: Option<String>,
 }
 
-impl Drop for AutomationServeLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedAutomationRunnerState {
+    phase: String,
+    running: bool,
+    pid: Option<u32>,
+    version: String,
+    config_path: Option<String>,
+    bind_address: Option<String>,
+    event_path: Option<String>,
+    poll_ms: u64,
+    started_at_ms: u64,
+    last_heartbeat_at: u64,
+    stopped_at_ms: Option<u64>,
+    shutdown_reason: Option<String>,
+    last_error: Option<String>,
+    owner_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedAutomationStopRequest {
+    requested_at_ms: u64,
+    requested_by_pid: u32,
+    target_owner_token: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutomationRunnerStopRequestOutcome {
+    Requested,
+    AlreadyRequested,
+    AlreadyStopped,
+}
+
+struct AutomationRunnerTracker {
+    active_owner_path: PathBuf,
+    status_snapshot_path: PathBuf,
+    stop_request_path: PathBuf,
+    owner_token: String,
+    state: std::sync::Mutex<PersistedAutomationRunnerState>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -414,6 +487,7 @@ pub async fn execute_automation_command(options: AutomationCommandOptions) -> Cl
             )
             .await
         }
+        AutomationCommands::Runner(command) => execute_runner_command(command),
         AutomationCommands::Journal(command) => {
             execute_journal_command(options.config, command).await
         }
@@ -443,6 +517,18 @@ fn automation_event_cursor_path() -> PathBuf {
     crate::mvp::config::default_loong_home()
         .join("automation")
         .join("internal-events.cursor")
+}
+
+fn automation_runner_status_snapshot_path() -> PathBuf {
+    crate::mvp::config::default_loong_home()
+        .join("automation")
+        .join("serve.status.json")
+}
+
+fn automation_runner_stop_request_path() -> PathBuf {
+    crate::mvp::config::default_loong_home()
+        .join("automation")
+        .join("serve.stop-request.json")
 }
 
 fn automation_journal_state_path() -> PathBuf {
@@ -711,49 +797,238 @@ fn next_cron_fire_at_ms(expression: &str, after_ms: i64) -> CliResult<i64> {
     ))
 }
 
-fn acquire_automation_serve_lock() -> CliResult<AutomationServeLock> {
-    let path = automation_serve_lock_path();
+impl AutomationRunnerTracker {
+    fn acquire(config: Option<&str>, options: &AutomationServeCommandOptions) -> CliResult<Self> {
+        let active_owner_path = automation_serve_lock_path();
+        let status_snapshot_path = automation_runner_status_snapshot_path();
+        let stop_request_path = automation_runner_stop_request_path();
+        if active_owner_path.exists()
+            && let Some(status) = load_automation_runner_status()
+        {
+            if status.running && !status.stale {
+                return Err(format!(
+                    "automation serve owner already active at {}",
+                    active_owner_path.display()
+                ));
+            }
+            let _ = fs::remove_file(active_owner_path.as_path());
+            let _ = fs::remove_file(status_snapshot_path.as_path());
+            let _ = fs::remove_file(stop_request_path.as_path());
+        }
+
+        let owner_token = new_automation_runner_owner_token(std::process::id());
+        let started_at_ms = u64::try_from(now_ms()).unwrap_or_default();
+        let initial_state = PersistedAutomationRunnerState {
+            phase: "starting".to_owned(),
+            running: true,
+            pid: Some(std::process::id()),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            config_path: config.map(ToOwned::to_owned),
+            bind_address: options.bind.clone(),
+            event_path: Some(options.path.clone()),
+            poll_ms: options.poll_ms.max(250),
+            started_at_ms,
+            last_heartbeat_at: started_at_ms,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            owner_token: owner_token.clone(),
+        };
+        write_json_path(
+            active_owner_path.as_path(),
+            &initial_state,
+            "automation serve owner",
+        )?;
+        write_json_path(
+            status_snapshot_path.as_path(),
+            &initial_state,
+            "automation serve status snapshot",
+        )?;
+
+        Ok(Self {
+            active_owner_path,
+            status_snapshot_path,
+            stop_request_path,
+            owner_token,
+            state: std::sync::Mutex::new(initial_state),
+        })
+    }
+
+    fn owner_token(&self) -> &str {
+        self.owner_token.as_str()
+    }
+
+    fn heartbeat(&self, phase: &str) -> CliResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| format!("automation runner state lock poisoned: {error}"))?;
+        state.phase = phase.to_owned();
+        state.last_heartbeat_at = u64::try_from(now_ms()).unwrap_or_default();
+        write_json_path(
+            self.active_owner_path.as_path(),
+            &*state,
+            "automation serve owner",
+        )?;
+        write_json_path(
+            self.status_snapshot_path.as_path(),
+            &*state,
+            "automation serve status snapshot",
+        )
+    }
+
+    fn finalize(
+        &self,
+        phase: &str,
+        shutdown_reason: Option<&str>,
+        last_error: Option<&str>,
+    ) -> CliResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| format!("automation runner state lock poisoned: {error}"))?;
+        state.phase = phase.to_owned();
+        state.running = false;
+        state.last_heartbeat_at = u64::try_from(now_ms()).unwrap_or_default();
+        state.stopped_at_ms = Some(u64::try_from(now_ms()).unwrap_or_default());
+        state.shutdown_reason = shutdown_reason.map(ToOwned::to_owned);
+        state.last_error = last_error.map(ToOwned::to_owned);
+        write_json_path(
+            self.status_snapshot_path.as_path(),
+            &*state,
+            "automation serve status snapshot",
+        )?;
+        let _ = fs::remove_file(self.active_owner_path.as_path());
+        let _ = fs::remove_file(self.stop_request_path.as_path());
+        Ok(())
+    }
+}
+
+fn load_automation_runner_status() -> Option<AutomationRunnerStatus> {
+    let status_snapshot_path = automation_runner_status_snapshot_path();
+    let active_owner_path = automation_serve_lock_path();
+    let status_snapshot =
+        read_json_path::<PersistedAutomationRunnerState>(status_snapshot_path.as_path());
+    let active_owner =
+        read_json_path::<PersistedAutomationRunnerState>(active_owner_path.as_path());
+    let persisted_state = match (status_snapshot, active_owner) {
+        (Some(status_snapshot), Some(active_owner)) => {
+            if active_owner.last_heartbeat_at >= status_snapshot.last_heartbeat_at {
+                active_owner
+            } else {
+                status_snapshot
+            }
+        }
+        (Some(status_snapshot), None) => status_snapshot,
+        (None, Some(active_owner)) => active_owner,
+        (None, None) => return None,
+    };
+    let now_ms = u64::try_from(now_ms()).unwrap_or_default();
+    let stale = persisted_state.running
+        && now_ms.saturating_sub(persisted_state.last_heartbeat_at) > AUTOMATION_RUNTIME_STALE_MS;
+    Some(AutomationRunnerStatus {
+        runtime_dir: crate::mvp::config::default_loong_home()
+            .join("automation")
+            .display()
+            .to_string(),
+        phase: persisted_state.phase,
+        running: persisted_state.running,
+        stale,
+        pid: persisted_state.pid,
+        version: persisted_state.version,
+        config_path: persisted_state.config_path,
+        bind_address: persisted_state.bind_address,
+        event_path: persisted_state.event_path,
+        poll_ms: persisted_state.poll_ms,
+        started_at_ms: persisted_state.started_at_ms,
+        last_heartbeat_at: persisted_state.last_heartbeat_at,
+        stopped_at_ms: persisted_state.stopped_at_ms,
+        shutdown_reason: persisted_state.shutdown_reason,
+        last_error: persisted_state.last_error,
+    })
+}
+
+fn request_automation_runner_stop() -> CliResult<AutomationRunnerStopRequestOutcome> {
+    let active_owner_path = automation_serve_lock_path();
+    let stop_request_path = automation_runner_stop_request_path();
+    let active_owner =
+        read_json_path::<PersistedAutomationRunnerState>(active_owner_path.as_path());
+    let Some(active_owner) = active_owner else {
+        return Ok(AutomationRunnerStopRequestOutcome::AlreadyStopped);
+    };
+    let current_status = load_automation_runner_status();
+    let Some(current_status) = current_status else {
+        return Ok(AutomationRunnerStopRequestOutcome::AlreadyStopped);
+    };
+    if !current_status.running || current_status.stale {
+        return Ok(AutomationRunnerStopRequestOutcome::AlreadyStopped);
+    }
+    let existing_stop_request =
+        read_json_path::<PersistedAutomationStopRequest>(stop_request_path.as_path());
+    if existing_stop_request
+        .as_ref()
+        .is_some_and(|request| request.target_owner_token == active_owner.owner_token)
+    {
+        return Ok(AutomationRunnerStopRequestOutcome::AlreadyRequested);
+    }
+    let stop_request = PersistedAutomationStopRequest {
+        requested_at_ms: u64::try_from(now_ms()).unwrap_or_default(),
+        requested_by_pid: std::process::id(),
+        target_owner_token: active_owner.owner_token,
+    };
+    write_json_path(
+        stop_request_path.as_path(),
+        &stop_request,
+        "automation serve stop request",
+    )?;
+    Ok(AutomationRunnerStopRequestOutcome::Requested)
+}
+
+fn automation_runner_stop_requested(owner_token: &str) -> bool {
+    let stop_request_path = automation_runner_stop_request_path();
+    let request = read_json_path::<PersistedAutomationStopRequest>(stop_request_path.as_path());
+    request
+        .as_ref()
+        .is_some_and(|request| request.target_owner_token == owner_token)
+}
+
+fn read_json_path<T>(path: &Path) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(raw.as_str()).ok()
+}
+
+fn write_json_path<T>(path: &Path, value: &T, label: &str) -> CliResult<()>
+where
+    T: Serialize,
+{
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             format!(
-                "create automation runtime directory {} failed: {error}",
+                "create {label} directory {} failed: {error}",
                 parent.display()
             )
         })?;
     }
+    let encoded = serde_json::to_string_pretty(value)
+        .map_err(|error| format!("serialize {label} failed: {error}"))?;
+    let tmp_path = path.with_extension("tmp");
+    fs::write(tmp_path.as_path(), format!("{encoded}\n"))
+        .map_err(|error| format!("write {label} {} failed: {error}", tmp_path.display()))?;
+    fs::rename(tmp_path.as_path(), path).map_err(|error| {
+        format!(
+            "publish {label} {} from {} failed: {error}",
+            path.display(),
+            tmp_path.display()
+        )
+    })
+}
 
-    let write_lock = |path: &Path| -> CliResult<()> {
-        let payload = json!({
-            "pid": std::process::id(),
-            "started_at_ms": now_ms(),
-        });
-        let bytes = serde_json::to_vec_pretty(&payload)
-            .map_err(|error| format!("serialize automation serve lock failed: {error}"))?;
-        fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(path)
-            .and_then(|mut file| std::io::Write::write_all(&mut file, &bytes))
-            .map_err(|error| {
-                format!(
-                    "write automation serve lock {} failed: {error}",
-                    path.display()
-                )
-            })
-    };
-
-    match write_lock(path.as_path()) {
-        Ok(()) => Ok(AutomationServeLock { path }),
-        Err(error) if error.contains("File exists") || error.contains("file exists") => {
-            Err(format!(
-                "automation serve lock {} already exists; stop the active automation runner or remove the stale lock file manually",
-                path.display()
-            ))
-        }
-        Err(error) => Err(format!(
-            "automation serve is already active or lock acquisition failed: {error}"
-        )),
-    }
+fn new_automation_runner_owner_token(process_id: u32) -> String {
+    let millis = u64::try_from(now_ms()).unwrap_or_default();
+    format!("automation-{process_id:08x}-{millis:016x}")
 }
 
 fn load_store(path: &Path) -> CliResult<AutomationStore> {
@@ -1099,6 +1374,13 @@ async fn execute_journal_command(
     }
 }
 
+fn execute_runner_command(options: AutomationRunnerCommandOptions) -> CliResult<Value> {
+    match options.command {
+        AutomationRunnerCommands::Inspect(_command) => execute_runner_inspect_command(),
+        AutomationRunnerCommands::Stop(_command) => execute_runner_stop_command(),
+    }
+}
+
 pub(crate) async fn emit_named_automation_event(
     config: Option<String>,
     event_name: &str,
@@ -1241,6 +1523,32 @@ fn execute_journal_repair_command() -> CliResult<Value> {
     }))
 }
 
+fn execute_runner_inspect_command() -> CliResult<Value> {
+    let status = load_automation_runner_status();
+    Ok(json!({
+        "command": "runner_inspect",
+        "status": status,
+        "active_owner_path": automation_serve_lock_path().display().to_string(),
+        "status_snapshot_path": automation_runner_status_snapshot_path().display().to_string(),
+        "stop_request_path": automation_runner_stop_request_path().display().to_string(),
+    }))
+}
+
+fn execute_runner_stop_command() -> CliResult<Value> {
+    let outcome = request_automation_runner_stop()?;
+    let status = load_automation_runner_status();
+    Ok(json!({
+        "command": "runner_stop",
+        "outcome": match outcome {
+            AutomationRunnerStopRequestOutcome::Requested => "requested",
+            AutomationRunnerStopRequestOutcome::AlreadyRequested => "already_requested",
+            AutomationRunnerStopRequestOutcome::AlreadyStopped => "already_stopped",
+        },
+        "status": status,
+        "stop_request_path": automation_runner_stop_request_path().display().to_string(),
+    }))
+}
+
 pub(crate) async fn publish_daemon_internal_event(
     config: Option<String>,
     event_name: &str,
@@ -1312,14 +1620,23 @@ async fn execute_serve_command(
     config: Option<String>,
     options: AutomationServeCommandOptions,
 ) -> CliResult<Value> {
-    let _serve_lock = acquire_automation_serve_lock()?;
+    let runner_tracker = AutomationRunnerTracker::acquire(config.as_deref(), &options)?;
     let poll_ms = options.poll_ms.max(250);
     let stop_requested = Arc::new(AtomicBool::new(false));
     let scheduler_stop = stop_requested.clone();
     let scheduler_store_path = store_path.to_path_buf();
     let scheduler_config = config.clone();
+    let scheduler_owner_token = runner_tracker.owner_token().to_owned();
+    let finalize_owner_token = scheduler_owner_token.clone();
+    let scheduler_runner_tracker = Arc::new(runner_tracker);
+    let scheduler_runner_tracker_for_loop = scheduler_runner_tracker.clone();
     let scheduler_task = tokio::spawn(async move {
         while !scheduler_stop.load(Ordering::SeqCst) {
+            if automation_runner_stop_requested(scheduler_owner_token.as_str()) {
+                scheduler_stop.store(true, Ordering::SeqCst);
+                break;
+            }
+            let _ = scheduler_runner_tracker_for_loop.heartbeat("running");
             if let Err(error) = process_due_schedule_triggers(
                 scheduler_store_path.as_path(),
                 scheduler_config.as_ref(),
@@ -1331,14 +1648,29 @@ async fn execute_serve_command(
             if let Err(error) = process_internal_journal_events(scheduler_config.as_ref()).await {
                 eprintln!("automation internal event journal error: {error}");
             }
-            tokio::time::sleep(Duration::from_millis(poll_ms)).await;
+            tokio::time::sleep(Duration::from_millis(
+                poll_ms.min(AUTOMATION_RUNTIME_HEARTBEAT_MS),
+            ))
+            .await;
         }
     });
 
     let shutdown_requested = stop_requested.clone();
     let shutdown_signal = async move {
-        let _ = tokio::signal::ctrl_c().await;
-        shutdown_requested.store(true, Ordering::SeqCst);
+        loop {
+            if shutdown_requested.load(Ordering::SeqCst) {
+                return;
+            }
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    shutdown_requested.store(true, Ordering::SeqCst);
+                    return;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(
+                    poll_ms.min(AUTOMATION_RUNTIME_HEARTBEAT_MS),
+                )) => {}
+            }
+        }
     };
 
     if let Some(bind) = options.bind {
@@ -1364,6 +1696,12 @@ async fn execute_serve_command(
 
     stop_requested.store(true, Ordering::SeqCst);
     let _ = scheduler_task.await;
+    let shutdown_reason = if automation_runner_stop_requested(finalize_owner_token.as_str()) {
+        Some("stop_requested")
+    } else {
+        Some("stopped")
+    };
+    let _ = scheduler_runner_tracker.finalize("stopped", shutdown_reason, None);
 
     Ok(json!({
         "command": "serve",

--- a/crates/daemon/src/automation_cli.rs
+++ b/crates/daemon/src/automation_cli.rs
@@ -35,6 +35,8 @@ pub enum AutomationCommands {
     CreateSchedule(AutomationCreateScheduleCommandOptions),
     /// Create one cron-style automation trigger
     CreateCron(AutomationCreateCronCommandOptions),
+    /// Inspect or preview cron expressions without creating a trigger
+    Cron(AutomationCronCommandOptions),
     /// Create one event-triggered automation rule
     CreateEvent(AutomationCreateEventCommandOptions),
     /// List durable automation triggers
@@ -124,6 +126,30 @@ pub struct AutomationCreateCronCommandOptions {
     pub label: Option<String>,
     #[arg(long)]
     pub timeout_seconds: Option<u64>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationCronCommandOptions {
+    #[command(subcommand)]
+    pub command: AutomationCronCommands,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum AutomationCronCommands {
+    /// Preview the next fire times for one cron expression
+    Preview(AutomationCronPreviewCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct AutomationCronPreviewCommandOptions {
+    #[arg(long)]
+    pub cron: String,
+    #[arg(long)]
+    pub after: Option<String>,
+    #[arg(long)]
+    pub after_ms: Option<i64>,
+    #[arg(long, default_value_t = 5)]
+    pub count: usize,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -242,6 +268,12 @@ pub struct AutomationJournalRotateCommandOptions {}
 pub struct AutomationJournalPruneCommandOptions {
     #[arg(long)]
     pub retain_segment_id: Option<String>,
+    #[arg(long, default_value_t = 0)]
+    pub retain_last_sealed: usize,
+    #[arg(long)]
+    pub retain_min_age_seconds: Option<u64>,
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq, Default)]
@@ -447,6 +479,13 @@ struct CronExpression {
     day_of_week: CronField,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct AutomationCronPreviewEntry {
+    ordinal: usize,
+    fire_at_ms: i64,
+    fire_at_rfc3339: String,
+}
+
 pub async fn run_automation_cli(options: AutomationCommandOptions) -> CliResult<()> {
     let payload = execute_automation_command(options.clone()).await?;
     if options.json {
@@ -470,6 +509,7 @@ pub async fn execute_automation_command(options: AutomationCommandOptions) -> Cl
         AutomationCommands::CreateCron(command) => {
             execute_create_cron_command(store_path.as_path(), command).await
         }
+        AutomationCommands::Cron(command) => execute_cron_command(command),
         AutomationCommands::CreateEvent(command) => {
             execute_create_event_command(store_path.as_path(), command).await
         }
@@ -618,6 +658,25 @@ fn parse_run_at_ms(raw_text: Option<String>, raw_ms: Option<i64>) -> CliResult<i
             let millis = parsed.unix_timestamp_nanos() / 1_000_000;
             let millis = i64::try_from(millis).map_err(|error| {
                 format!("automation --run-at overflowed i64 milliseconds: {error}")
+            })?;
+            Ok(millis)
+        }
+    }
+}
+
+fn parse_cron_preview_after_ms(raw_text: Option<String>, raw_ms: Option<i64>) -> CliResult<i64> {
+    match (raw_text, raw_ms) {
+        (Some(_), Some(_)) => {
+            Err("automation cron preview accepts either --after or --after-ms, not both".to_owned())
+        }
+        (None, None) => Ok(now_ms()),
+        (None, Some(after_ms)) => Ok(after_ms),
+        (Some(text), None) => {
+            let parsed = OffsetDateTime::parse(text.trim(), &Rfc3339)
+                .map_err(|error| format!("parse automation cron --after failed: {error}"))?;
+            let millis = parsed.unix_timestamp_nanos() / 1_000_000;
+            let millis = i64::try_from(millis).map_err(|error| {
+                format!("automation cron --after overflowed i64 milliseconds: {error}")
             })?;
             Ok(millis)
         }
@@ -851,6 +910,52 @@ fn next_cron_fire_at_ms(expression: &str, after_ms: i64) -> CliResult<i64> {
     Err(format!(
         "automation cron expression `{expression}` did not match within the next 366 days"
     ))
+}
+
+fn format_automation_fire_at_rfc3339(fire_at_ms: i64) -> CliResult<String> {
+    let fire_at_ns = i128::from(fire_at_ms).saturating_mul(1_000_000);
+    let fire_at = OffsetDateTime::from_unix_timestamp_nanos(fire_at_ns)
+        .map_err(|error| format!("format automation fire-at timestamp failed: {error}"))?;
+    fire_at
+        .format(&Rfc3339)
+        .map_err(|error| format!("format automation fire-at RFC3339 failed: {error}"))
+}
+
+fn execute_cron_command(options: AutomationCronCommandOptions) -> CliResult<Value> {
+    match options.command {
+        AutomationCronCommands::Preview(command) => execute_cron_preview_command(command),
+    }
+}
+
+fn execute_cron_preview_command(options: AutomationCronPreviewCommandOptions) -> CliResult<Value> {
+    if options.count == 0 {
+        return Err("automation cron preview --count must be greater than zero".to_owned());
+    }
+    if options.count > 20 {
+        return Err("automation cron preview --count must be <= 20".to_owned());
+    }
+
+    let after_ms = parse_cron_preview_after_ms(options.after, options.after_ms)?;
+    let mut preview = Vec::new();
+    let mut anchor_ms = after_ms;
+    for ordinal in 1..=options.count {
+        let fire_at_ms = next_cron_fire_at_ms(options.cron.as_str(), anchor_ms)?;
+        let fire_at_rfc3339 = format_automation_fire_at_rfc3339(fire_at_ms)?;
+        preview.push(AutomationCronPreviewEntry {
+            ordinal,
+            fire_at_ms,
+            fire_at_rfc3339,
+        });
+        anchor_ms = fire_at_ms;
+    }
+
+    Ok(json!({
+        "command": "cron_preview",
+        "expression": options.cron,
+        "timezone": "UTC",
+        "after_ms": after_ms,
+        "preview": preview,
+    }))
 }
 
 impl AutomationRunnerTracker {
@@ -1692,23 +1797,51 @@ fn execute_journal_prune_command(
 ) -> CliResult<Value> {
     let cursor_path = automation_event_cursor_path();
     let cursor = load_internal_event_cursor(cursor_path.as_path())?;
-    let retain_cursor = if let Some(retain_segment_id) = options.retain_segment_id {
-        mvp::internal_events::InternalEventJournalCursor {
-            segment_id: Some(retain_segment_id),
-            ..mvp::internal_events::InternalEventJournalCursor::default()
-        }
-    } else {
-        cursor.clone()
+    let retain_floor_segment_id_option = options
+        .retain_segment_id
+        .clone()
+        .or_else(|| cursor.segment_id.clone());
+    let Some(retain_floor_segment_id) = retain_floor_segment_id_option else {
+        return Err(
+            "automation journal prune requires a retained segment id; use --retain-segment-id when no persisted cursor is available"
+                .to_owned(),
+        );
     };
-    let pruned_segments =
-        mvp::internal_events::prune_internal_event_journal_segments(&retain_cursor)?;
+    let retain_cursor = mvp::internal_events::InternalEventJournalCursor {
+        segment_id: Some(retain_floor_segment_id.clone()),
+        ..mvp::internal_events::InternalEventJournalCursor::default()
+    };
+    let retain_min_age_ms = options
+        .retain_min_age_seconds
+        .map(|seconds| seconds.saturating_mul(1_000));
+    let gc_policy = mvp::internal_events::InternalEventJournalGcPolicy {
+        retain_floor_segment_id: Some(retain_floor_segment_id.clone()),
+        retain_last_sealed_segments: options.retain_last_sealed,
+        retain_min_age_ms,
+    };
+    let plan = if options.dry_run {
+        mvp::internal_events::plan_internal_event_journal_gc(&gc_policy)?
+    } else {
+        mvp::internal_events::gc_internal_event_journal_segments(&gc_policy)?
+    };
+    let pruned_segments = plan
+        .decisions
+        .iter()
+        .filter(|decision| decision.action == "prune")
+        .map(|decision| Value::String(decision.segment_id.clone()))
+        .collect::<Vec<_>>();
     let inspection = execute_journal_inspect_command()?;
     Ok(json!({
         "command": "journal_prune",
+        "dry_run": options.dry_run,
         "cursor_path": cursor_path.display().to_string(),
         "cursor": cursor,
         "retain_cursor": retain_cursor,
+        "retain_floor_segment_id": retain_floor_segment_id,
+        "retain_last_sealed_segments": options.retain_last_sealed,
+        "retain_min_age_ms": retain_min_age_ms,
         "pruned_segments": pruned_segments,
+        "plan": plan,
         "inspection": inspection,
     }))
 }
@@ -2308,6 +2441,7 @@ fn render_automation_text(payload: &Value) -> CliResult<String> {
         .and_then(Value::as_str)
         .ok_or_else(|| "automation payload missing command".to_owned())?;
     match command {
+        "cron_preview" => render_cron_preview(payload),
         "create_schedule" | "create_cron" | "create_event" | "show" | "status_update" => {
             let trigger = payload
                 .get("trigger")
@@ -2521,6 +2655,48 @@ fn render_runner_reclaim(payload: &Value) -> CliResult<String> {
     Ok(format!("Automation runner reclaim outcome: {outcome}."))
 }
 
+fn render_cron_preview(payload: &Value) -> CliResult<String> {
+    let expression = payload
+        .get("expression")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation cron preview payload missing expression".to_owned())?;
+    let timezone = payload
+        .get("timezone")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "automation cron preview payload missing timezone".to_owned())?;
+    let preview = payload
+        .get("preview")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "automation cron preview payload missing preview".to_owned())?;
+
+    let mut lines = vec![
+        "Automation cron preview".to_owned(),
+        String::new(),
+        format!("expression: {expression}"),
+        format!("timezone: {timezone}"),
+        String::new(),
+        "next fires:".to_owned(),
+    ];
+
+    for entry in preview {
+        let ordinal = entry
+            .get("ordinal")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let fire_at_ms = entry
+            .get("fire_at_ms")
+            .and_then(Value::as_i64)
+            .unwrap_or_default();
+        let fire_at_rfc3339 = entry
+            .get("fire_at_rfc3339")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        lines.push(format!("- #{ordinal}: {fire_at_rfc3339} ({fire_at_ms})"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
 fn render_fire_result(result: &Value) -> CliResult<String> {
     let id = result["trigger_id"]
         .as_str()
@@ -2638,27 +2814,55 @@ fn render_journal_rotate(payload: &Value) -> CliResult<String> {
 }
 
 fn render_journal_prune(payload: &Value) -> CliResult<String> {
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let pruned_segments = payload["pruned_segments"]
         .as_array()
         .ok_or_else(|| "automation journal prune payload missing pruned_segments".to_owned())?;
+    let retain_floor_segment_id = payload
+        .get("retain_floor_segment_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let retain_last_sealed_segments = payload
+        .get("retain_last_sealed_segments")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let retain_min_age_ms = payload
+        .get("retain_min_age_ms")
+        .cloned()
+        .unwrap_or(Value::Null);
     let inspection = payload
         .get("inspection")
         .ok_or_else(|| "automation journal prune payload missing inspection".to_owned())?;
+    let mut header_lines = vec![
+        format!("retain_floor_segment_id: {retain_floor_segment_id}"),
+        format!("retain_last_sealed_segments: {retain_last_sealed_segments}"),
+        format!("retain_min_age_ms: {retain_min_age_ms}"),
+        String::new(),
+    ];
     if pruned_segments.is_empty() {
-        return Ok(format!(
-            "No sealed automation journal segments were pruned.\n\n{}",
-            render_journal_inspect(inspection)?
-        ));
+        let prefix = if dry_run {
+            "Automation journal prune dry-run would not remove any sealed segments.".to_owned()
+        } else {
+            "No sealed automation journal segments were pruned.".to_owned()
+        };
+        header_lines.push(render_journal_inspect(inspection)?);
+        return Ok(format!("{prefix}\n\n{}", header_lines.join("\n")));
     }
     let pruned_list = pruned_segments
         .iter()
         .filter_map(Value::as_str)
         .collect::<Vec<_>>()
         .join(", ");
-    Ok(format!(
-        "Pruned automation journal segments: {pruned_list}\n\n{}",
-        render_journal_inspect(inspection)?
-    ))
+    let prefix = if dry_run {
+        format!("Automation journal prune dry-run would remove: {pruned_list}")
+    } else {
+        format!("Pruned automation journal segments: {pruned_list}")
+    };
+    header_lines.push(render_journal_inspect(inspection)?);
+    Ok(format!("{prefix}\n\n{}", header_lines.join("\n")))
 }
 
 fn render_journal_repair(payload: &Value) -> CliResult<String> {
@@ -2831,6 +3035,26 @@ mod tests {
         let next = next_cron_fire_at_ms("0 0 1 1 *", 1_700_000_000_000);
         assert!(next.is_ok());
         assert!(next.unwrap_or_default() > 1_700_000_000_000);
+    }
+
+    #[test]
+    fn execute_cron_preview_command_returns_bounded_future_fire_times() {
+        let payload = execute_cron_preview_command(AutomationCronPreviewCommandOptions {
+            cron: "0 0 * * *".to_owned(),
+            after: None,
+            after_ms: Some(1_700_000_000_000),
+            count: 3,
+        })
+        .expect("preview cron expression");
+
+        assert_eq!(payload["command"], "cron_preview");
+        assert_eq!(payload["expression"], "0 0 * * *");
+        assert_eq!(payload["timezone"], "UTC");
+        assert_eq!(payload["preview"].as_array().map(Vec::len), Some(3));
+        let first_fire_at_ms = payload["preview"][0]["fire_at_ms"]
+            .as_i64()
+            .expect("first preview fire_at_ms");
+        assert!(first_fire_at_ms > 1_700_000_000_000);
     }
 
     #[test]

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -30,6 +30,7 @@ impl Commands {
             Self::Skills { .. } => "skills",
             Self::Status { .. } => "status",
             Self::Tasks { .. } => "tasks",
+            Self::Automation { .. } => "automation",
             Self::DelegateChildRun { .. } => "delegate_child_run",
             Self::Sessions { .. } => "sessions",
             Self::Plugins { .. } => "plugins",
@@ -134,6 +135,20 @@ mod tests {
             }
             .command_kind_for_logging(),
             "status"
+        );
+        assert_eq!(
+            Commands::Automation {
+                config: None,
+                json: false,
+                command: crate::automation_cli::AutomationCommands::List(
+                    crate::automation_cli::AutomationListCommandOptions {
+                        limit: 20,
+                        include_completed: false,
+                    },
+                ),
+            }
+            .command_kind_for_logging(),
+            "automation"
         );
         assert_eq!(
             Commands::WorkUnit {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -112,6 +112,7 @@ pub use {base64, kernel, sha2};
 
 pub mod acp_cli;
 pub mod audit_cli;
+pub mod automation_cli;
 mod browser_companion_diagnostics;
 pub mod browser_preview;
 mod channel_access_policy_render;
@@ -801,6 +802,15 @@ pub enum Commands {
         session: String,
         #[command(subcommand)]
         command: tasks_cli::TasksCommands,
+    },
+    /// Manage schedule and event-driven automation triggers
+    Automation {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[command(subcommand)]
+        command: automation_cli::AutomationCommands,
     },
     #[command(hide = true)]
     DelegateChildRun {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -803,7 +803,10 @@ pub enum Commands {
         #[command(subcommand)]
         command: tasks_cli::TasksCommands,
     },
-    /// Manage schedule and event-driven automation triggers
+    #[command(
+        about = "Manage schedule and event-driven automation triggers",
+        long_about = "Manage schedule and event-driven automation triggers.\n\nUse `loong automation guide` when you need a decision entrypoint instead of remembering every automation subcommand.\n- choose `create-schedule` for one future run or a fixed every-N-seconds cadence\n- choose `cron preview` plus `create-cron` for wall-clock recurrence\n- choose `create-event` when a webhook or runtime event already exists\n- run `automation serve` for durable cron delivery, webhook ingress, and journal-backed internal-event consumption"
+    )]
     Automation {
         #[arg(long, global = true)]
         config: Option<String>,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -480,6 +480,18 @@ async fn run_command(command: Commands) -> CliResult<()> {
             })
             .await
         }
+        Commands::Automation {
+            config,
+            json,
+            command,
+        } => {
+            automation_cli::run_automation_cli(automation_cli::AutomationCommandOptions {
+                config,
+                json,
+                command,
+            })
+            .await
+        }
         Commands::DelegateChildRun {
             config_path,
             payload_file,
@@ -541,7 +553,7 @@ async fn run_command(command: Commands) -> CliResult<()> {
         Commands::RuntimeCapability { command } => {
             runtime_capability_cli::run_runtime_capability_cli(command)
         }
-        Commands::WorkUnit { command } => work_unit_cli::run_work_unit_cli(command),
+        Commands::WorkUnit { command } => work_unit_cli::run_work_unit_cli(command).await,
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -115,6 +115,11 @@ pub async fn execute_sessions_command(
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
     let tool_config = &config.tools;
     let resolved_config_path = resolved_path.display().to_string();
+    if !crate::automation_cli::automation_serve_owner_is_active() {
+        crate::automation_cli::install_daemon_automation_event_sink(Some(
+            resolved_config_path.clone(),
+        ));
+    }
 
     let payload = match command {
         SessionsCommands::List {
@@ -188,45 +193,54 @@ pub async fn execute_sessions_command(
         SessionsCommands::Cancel {
             session_id,
             dry_run,
-        } => execute_mutation_command(
-            "cancel",
-            "session_cancel",
-            "cancel_action",
-            &resolved_config_path,
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &session_id,
-            dry_run,
-        )?,
+        } => {
+            execute_mutation_command(
+                "cancel",
+                "session_cancel",
+                "cancel_action",
+                &resolved_config_path,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+                dry_run,
+            )
+            .await?
+        }
         SessionsCommands::Recover {
             session_id,
             dry_run,
-        } => execute_mutation_command(
-            "recover",
-            "session_recover",
-            "recovery_action",
-            &resolved_config_path,
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &session_id,
-            dry_run,
-        )?,
+        } => {
+            execute_mutation_command(
+                "recover",
+                "session_recover",
+                "recovery_action",
+                &resolved_config_path,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+                dry_run,
+            )
+            .await?
+        }
         SessionsCommands::Archive {
             session_id,
             dry_run,
-        } => execute_mutation_command(
-            "archive",
-            "session_archive",
-            "archive_action",
-            &resolved_config_path,
-            &current_session_id,
-            &memory_config,
-            tool_config,
-            &session_id,
-            dry_run,
-        )?,
+        } => {
+            execute_mutation_command(
+                "archive",
+                "session_archive",
+                "archive_action",
+                &resolved_config_path,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+                dry_run,
+            )
+            .await?
+        }
     };
 
     Ok(SessionsCommandExecution {
@@ -477,7 +491,7 @@ fn execute_history_command(
     }))
 }
 
-fn execute_mutation_command(
+async fn execute_mutation_command(
     command_name: &str,
     tool_name: &str,
     action_field: &str,
@@ -512,7 +526,7 @@ fn execute_mutation_command(
     let inspection = result.get("inspection").cloned().unwrap_or(Value::Null);
     let mutation_result = result.get("result").cloned().unwrap_or(Value::Null);
 
-    Ok(json!({
+    let output = json!({
         "command": command_name,
         "config": resolved_config_path,
         "current_session_id": current_session_id,
@@ -522,7 +536,8 @@ fn execute_mutation_command(
         "message": message,
         "action": action,
         "inspection": inspection,
-    }))
+    });
+    Ok(output)
 }
 
 fn execute_app_tool_request(

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -275,6 +275,13 @@ async fn execute_create_command(
         "recipes": recipes,
         "next_steps": next_steps,
     });
+    let _ = crate::automation_cli::publish_daemon_internal_event(
+        Some(resolved_config_path.to_owned()),
+        "background_task.queued",
+        "tasks_cli",
+        Some(payload.clone()),
+    )
+    .await;
     Ok(payload)
 }
 
@@ -522,6 +529,15 @@ async fn execute_cancel_command(
         "task": task,
         "task_lookup_error": task_lookup_error,
     });
+    if !dry_run && !action.is_null() {
+        let _ = crate::automation_cli::publish_daemon_internal_event(
+            Some(resolved_config_path.to_owned()),
+            "background_task.cancelled",
+            "tasks_cli",
+            Some(output.clone()),
+        )
+        .await;
+    }
     Ok(output)
 }
 
@@ -581,6 +597,15 @@ async fn execute_recover_command(
         "task": task,
         "task_lookup_error": task_lookup_error,
     });
+    if !dry_run && !action.is_null() {
+        let _ = crate::automation_cli::publish_daemon_internal_event(
+            Some(resolved_config_path.to_owned()),
+            "background_task.recovered",
+            "tasks_cli",
+            Some(output.clone()),
+        )
+        .await;
+    }
     Ok(output)
 }
 

--- a/crates/daemon/src/work_unit_cli.rs
+++ b/crates/daemon/src/work_unit_cli.rs
@@ -439,28 +439,28 @@ impl From<WorkUnitDispositionArg> for mvp::work::repository::WorkUnitCompletionD
     }
 }
 
-pub fn run_work_unit_cli(command: WorkUnitCommands) -> CliResult<()> {
+pub async fn run_work_unit_cli(command: WorkUnitCommands) -> CliResult<()> {
     match command {
-        WorkUnitCommands::Create(options) => run_create_command(options),
+        WorkUnitCommands::Create(options) => run_create_command(options).await,
         WorkUnitCommands::Show(options) => run_show_command(options),
         WorkUnitCommands::List(options) => run_list_command(options),
         WorkUnitCommands::Events(options) => run_events_command(options),
-        WorkUnitCommands::Claim(options) => run_claim_command(options),
-        WorkUnitCommands::Start(options) => run_start_command(options),
-        WorkUnitCommands::Heartbeat(options) => run_heartbeat_command(options),
-        WorkUnitCommands::Complete(options) => run_complete_command(options),
-        WorkUnitCommands::Recover(options) => run_recover_command(options),
-        WorkUnitCommands::Archive(options) => run_archive_command(options),
-        WorkUnitCommands::Assign(options) => run_assign_command(options),
-        WorkUnitCommands::Update(options) => run_update_command(options),
-        WorkUnitCommands::Depend(options) => run_depend_command(options),
-        WorkUnitCommands::Undepend(options) => run_undepend_command(options),
-        WorkUnitCommands::Note(options) => run_note_command(options),
+        WorkUnitCommands::Claim(options) => run_claim_command(options).await,
+        WorkUnitCommands::Start(options) => run_start_command(options).await,
+        WorkUnitCommands::Heartbeat(options) => run_heartbeat_command(options).await,
+        WorkUnitCommands::Complete(options) => run_complete_command(options).await,
+        WorkUnitCommands::Recover(options) => run_recover_command(options).await,
+        WorkUnitCommands::Archive(options) => run_archive_command(options).await,
+        WorkUnitCommands::Assign(options) => run_assign_command(options).await,
+        WorkUnitCommands::Update(options) => run_update_command(options).await,
+        WorkUnitCommands::Depend(options) => run_depend_command(options).await,
+        WorkUnitCommands::Undepend(options) => run_undepend_command(options).await,
+        WorkUnitCommands::Note(options) => run_note_command(options).await,
         WorkUnitCommands::Health(options) => run_health_command(options),
     }
 }
 
-fn run_create_command(options: WorkUnitCreateCommandOptions) -> CliResult<()> {
+async fn run_create_command(options: WorkUnitCreateCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let retry_policy = WorkUnitRetryPolicy {
         max_attempts: options.max_attempts,
@@ -522,7 +522,7 @@ fn run_events_command(options: WorkUnitEventsCommandOptions) -> CliResult<()> {
     })
 }
 
-fn run_claim_command(options: WorkUnitClaimCommandOptions) -> CliResult<()> {
+async fn run_claim_command(options: WorkUnitClaimCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::AcquireWorkUnitLeaseRequest {
         owner: options.owner,
@@ -544,7 +544,7 @@ fn run_claim_command(options: WorkUnitClaimCommandOptions) -> CliResult<()> {
     Ok(())
 }
 
-fn run_start_command(options: WorkUnitStartCommandOptions) -> CliResult<()> {
+async fn run_start_command(options: WorkUnitStartCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::StartWorkUnitLeaseRequest {
         work_unit_id: options.id,
@@ -557,7 +557,7 @@ fn run_start_command(options: WorkUnitStartCommandOptions) -> CliResult<()> {
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_heartbeat_command(options: WorkUnitHeartbeatCommandOptions) -> CliResult<()> {
+async fn run_heartbeat_command(options: WorkUnitHeartbeatCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::WorkUnitHeartbeatRequest {
         work_unit_id: options.id,
@@ -571,7 +571,7 @@ fn run_heartbeat_command(options: WorkUnitHeartbeatCommandOptions) -> CliResult<
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_complete_command(options: WorkUnitCompleteCommandOptions) -> CliResult<()> {
+async fn run_complete_command(options: WorkUnitCompleteCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let result_payload_json = options
         .result_payload_json
@@ -593,7 +593,7 @@ fn run_complete_command(options: WorkUnitCompleteCommandOptions) -> CliResult<()
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_recover_command(options: WorkUnitRecoverCommandOptions) -> CliResult<()> {
+async fn run_recover_command(options: WorkUnitRecoverCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let snapshots = repository.recover_expired_leases(options.actor.as_deref(), options.now_ms)?;
     render_json_or_text(&snapshots, options.json, |value| {
@@ -601,7 +601,7 @@ fn run_recover_command(options: WorkUnitRecoverCommandOptions) -> CliResult<()> 
     })
 }
 
-fn run_archive_command(options: WorkUnitArchiveCommandOptions) -> CliResult<()> {
+async fn run_archive_command(options: WorkUnitArchiveCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::ArchiveWorkUnitRequest {
         work_unit_id: options.id,
@@ -614,7 +614,7 @@ fn run_archive_command(options: WorkUnitArchiveCommandOptions) -> CliResult<()> 
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_assign_command(options: WorkUnitAssignCommandOptions) -> CliResult<()> {
+async fn run_assign_command(options: WorkUnitAssignCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::AssignWorkUnitRequest {
         work_unit_id: options.id,
@@ -627,7 +627,7 @@ fn run_assign_command(options: WorkUnitAssignCommandOptions) -> CliResult<()> {
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_update_command(options: WorkUnitUpdateCommandOptions) -> CliResult<()> {
+async fn run_update_command(options: WorkUnitUpdateCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::UpdateWorkUnitRequest {
         work_unit_id: options.id,
@@ -646,7 +646,7 @@ fn run_update_command(options: WorkUnitUpdateCommandOptions) -> CliResult<()> {
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_depend_command(options: WorkUnitDependCommandOptions) -> CliResult<()> {
+async fn run_depend_command(options: WorkUnitDependCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::AddWorkUnitDependencyRequest {
         blocking_work_unit_id: options.blocking_id,
@@ -659,7 +659,7 @@ fn run_depend_command(options: WorkUnitDependCommandOptions) -> CliResult<()> {
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_undepend_command(options: WorkUnitUndependCommandOptions) -> CliResult<()> {
+async fn run_undepend_command(options: WorkUnitUndependCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::RemoveWorkUnitDependencyRequest {
         blocking_work_unit_id: options.blocking_id,
@@ -672,7 +672,7 @@ fn run_undepend_command(options: WorkUnitUndependCommandOptions) -> CliResult<()
     render_optional_snapshot(snapshot, options.json, missing_message)
 }
 
-fn run_note_command(options: WorkUnitNoteCommandOptions) -> CliResult<()> {
+async fn run_note_command(options: WorkUnitNoteCommandOptions) -> CliResult<()> {
     let repository = load_work_unit_repository(options.config.as_deref())?;
     let request = mvp::work::repository::AppendWorkUnitNoteRequest {
         work_unit_id: options.id,
@@ -705,6 +705,11 @@ fn load_work_unit_repository(
     #[cfg(feature = "memory-sqlite")]
     {
         let (_, config) = mvp::config::load(config_path)?;
+        if !crate::automation_cli::automation_serve_owner_is_active() {
+            crate::automation_cli::install_daemon_automation_event_sink(
+                config_path.map(str::to_owned),
+            );
+        }
         let memory_config =
             mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         mvp::work::repository::WorkUnitRepository::new(&memory_config)

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -1,0 +1,1796 @@
+use super::*;
+use loong_app::internal_events::append_internal_event_to_journal;
+use rusqlite::params;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::atomic::{AtomicUsize, Ordering},
+    sync::{Mutex, OnceLock},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn automation_integration_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn lock_automation_integration() -> std::sync::MutexGuard<'static, ()> {
+    automation_integration_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
+    let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let process_id = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"))
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(prefix: &str) -> Self {
+        Self {
+            path: unique_temp_dir(prefix),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path).ok();
+    }
+}
+
+fn write_automation_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongConfig::default();
+    config.memory.sqlite_path = root.join("memory.sqlite3").display().to_string();
+    config.audit.mode = mvp::config::AuditMode::InMemory;
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.sessions.allow_mutation = true;
+
+    let config_path = root.join("loong.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn load_session_repository(config_path: &Path) -> mvp::session::repository::SessionRepository {
+    let (_, config) =
+        mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    mvp::session::repository::SessionRepository::new(&memory_config).expect("session repository")
+}
+
+fn wait_for_session_record(
+    repo: &mvp::session::repository::SessionRepository,
+    session_id: &str,
+) -> mvp::session::repository::SessionRecord {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Some(snapshot) = repo
+            .load_session(session_id)
+            .expect("load queued child session")
+        {
+            return snapshot;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("timed out waiting for queued child session `{session_id}`");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+async fn wait_for_trigger_fire_count(
+    config_path: &Path,
+    trigger_id: &str,
+    expected_fire_count: u64,
+) -> serde_json::Value {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let show_payload = loong_daemon::automation_cli::execute_automation_command(
+            loong_daemon::automation_cli::AutomationCommandOptions {
+                config: Some(config_path.display().to_string()),
+                json: false,
+                command: loong_daemon::automation_cli::AutomationCommands::Show(
+                    loong_daemon::automation_cli::AutomationShowCommandOptions {
+                        id: trigger_id.to_owned(),
+                    },
+                ),
+            },
+        )
+        .await
+        .expect("show automation trigger while waiting");
+        if show_payload["trigger"]["fire_count"].as_u64() == Some(expected_fire_count) {
+            return show_payload;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for trigger `{trigger_id}` fire_count={expected_fire_count}; last payload={show_payload}"
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+fn automation_cursor_path(loong_home: &Path) -> PathBuf {
+    loong_home.join("automation").join("internal-events.cursor")
+}
+
+fn automation_serve_lock_path(loong_home: &Path) -> PathBuf {
+    loong_home.join("automation").join("serve.lock")
+}
+
+fn wait_for_path(path: &Path, description: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        if path.exists() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {description} at {}", path.display());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn wait_for_serve_lock(child: &mut Child, path: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        if path.exists() {
+            return;
+        }
+        if let Some(status) = child.try_wait().expect("poll automation serve child") {
+            let stderr = child
+                .stderr
+                .take()
+                .map(|mut stream| {
+                    let mut output = String::new();
+                    std::io::Read::read_to_string(&mut stream, &mut output)
+                        .expect("read automation serve stderr");
+                    output
+                })
+                .unwrap_or_default();
+            panic!(
+                "automation serve exited before creating lock {}: status={status:?} stderr={stderr}",
+                path.display()
+            );
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for automation serve lock at {}",
+                path.display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn wait_for_cursor_value(path: &Path, expected: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let current = fs::read_to_string(path).ok();
+        let current_line_cursor = current.as_deref().and_then(parse_cursor_line_cursor);
+        if current_line_cursor.as_deref() == Some(expected) {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for automation cursor {expected} at {}; last value={current:?}",
+                path.display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn parse_cursor_line_cursor(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Some("0".to_owned());
+    }
+    if trimmed.chars().all(|ch| ch.is_ascii_digit()) {
+        return Some(trimmed.to_owned());
+    }
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .ok()
+        .and_then(|value| value.get("line_cursor").and_then(serde_json::Value::as_u64))
+        .map(|value| value.to_string())
+}
+
+#[tokio::test]
+async fn automation_cli_show_loads_legacy_store_without_run_history() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-cli-legacy-store");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    let automation_dir = loong_home.join("automation");
+    fs::create_dir_all(&automation_dir).expect("create automation dir");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let raw = json!({
+        "schema_version": 1,
+        "triggers": [
+            {
+                "trigger_id": "atrg-legacy",
+                "name": "Legacy Trigger",
+                "status": "active",
+                "source": {
+                    "type": "event",
+                    "event": {
+                        "event_name": "session.cancelled",
+                        "json_pointer": "/session_id",
+                        "equals_json": "delegate:legacy",
+                        "contains_text": null
+                    }
+                },
+                "action": {
+                    "type": "background_task",
+                    "background_task": {
+                        "session": "ops-root",
+                        "task": "follow up on a legacy trigger",
+                        "label": "Legacy Follow-up",
+                        "timeout_seconds": 30
+                    }
+                },
+                "created_at_ms": 10,
+                "updated_at_ms": 10,
+                "last_fired_at_ms": null,
+                "last_task_id": null,
+                "last_error": null,
+                "fire_count": 0
+            }
+        ]
+    });
+    fs::write(
+        automation_dir.join("triggers.json"),
+        serde_json::to_vec_pretty(&raw).expect("serialize legacy store"),
+    )
+    .expect("write legacy trigger store");
+
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions {
+                    id: "atrg-legacy".to_owned(),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("show legacy automation trigger");
+
+    assert_eq!(show_payload["trigger"]["trigger_id"], "atrg-legacy");
+    assert_eq!(
+        show_payload["trigger"]["source"]["event"]["event_name"],
+        "session.cancelled"
+    );
+    assert_eq!(show_payload["trigger"]["fire_count"], 0);
+    assert_eq!(show_payload["trigger"]["run_history"], json!([]));
+    drop(guard);
+}
+
+fn set_session_event_ts(config_path: &Path, session_id: &str, event_kind: &str, ts: i64) {
+    let (_, config) =
+        mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+    let conn =
+        rusqlite::Connection::open(&config.memory.sqlite_path).expect("open automation sqlite");
+    conn.execute(
+        "UPDATE session_events
+         SET ts = ?3
+         WHERE session_id = ?1 AND event_kind = ?2",
+        params![session_id, event_kind, ts],
+    )
+    .expect("update session event ts");
+}
+
+fn seed_overdue_background_task(config_path: &Path, root_session_id: &str, task_id: &str) {
+    let repo = load_session_repository(config_path);
+    super::tasks_cli::ensure_root_session(&repo, root_session_id);
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: task_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some(root_session_id.to_owned()),
+        label: Some("Recover Me".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create overdue child session");
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: task_id.to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some(root_session_id.to_owned()),
+        payload_json: serde_json::json!({
+            "task": "recover overdue task",
+            "label": "Recover Me",
+            "timeout_seconds": 30
+        }),
+    })
+    .expect("append queued event");
+    let now_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs() as i64;
+    set_session_event_ts(config_path, task_id, "delegate_queued", now_ts - 90);
+}
+
+#[tokio::test]
+async fn automation_cli_emit_matches_event_trigger_and_queues_background_task() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-cli-emit");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Build Ready Follow-up".to_owned(),
+                    event: "build.ready".to_owned(),
+                    json_pointer: None,
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "review the completed build".to_owned(),
+                    label: Some("Automation Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create automation event trigger");
+
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+    assert_eq!(create_payload["command"], "create_event");
+    assert_eq!(
+        create_payload["trigger"]["source"]["event"]["event_name"],
+        "build.ready"
+    );
+
+    let emit_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Emit(
+                loong_daemon::automation_cli::AutomationEmitCommandOptions {
+                    event: "BUILD.READY".to_owned(),
+                    payload_json: Some(r#"{"reason":"ready to ship"}"#.to_owned()),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("emit automation event");
+
+    let queued_task_id = emit_payload["results"][0]["queued_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(emit_payload["command"], "emit");
+    assert_eq!(emit_payload["event_name"], "build.ready");
+    assert_eq!(emit_payload["matched_count"], 1);
+    assert_eq!(emit_payload["payload"]["reason"], "ready to ship");
+    assert!(queued_task_id.starts_with("delegate:"));
+    assert!(emit_payload["results"][0]["error"].is_null());
+
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show automation trigger");
+
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert_eq!(show_payload["trigger"]["last_task_id"], queued_task_id);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["queued_task_id"],
+        queued_task_id
+    );
+
+    let repo = load_session_repository(&config_path);
+    let child_session = wait_for_session_record(&repo, &queued_task_id);
+    assert_eq!(child_session.parent_session_id.as_deref(), Some("ops-root"));
+    assert_eq!(
+        child_session.kind,
+        mvp::session::repository::SessionKind::DelegateChild
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn work_unit_create_emits_automation_event_and_queues_background_task() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-work-unit-automation");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "New Work Unit Follow-up".to_owned(),
+                    event: "work_unit.created".to_owned(),
+                    json_pointer: None,
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "triage the new work unit".to_owned(),
+                    label: Some("Work Unit Automation".to_owned()),
+                    timeout_seconds: Some(45),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create work-unit automation trigger");
+
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let create_output = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "work-unit",
+            "create",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--id",
+            "wu-automation",
+            "--kind",
+            "feature",
+            "--title",
+            "Automation-covered work unit",
+            "--description",
+            "Verify work-unit automation event emission",
+            "--status",
+            "ready",
+            "--priority",
+            "high",
+            "--max-attempts",
+            "3",
+            "--initial-backoff-ms",
+            "1000",
+            "--max-backoff-ms",
+            "60000",
+            "--next-run-at-ms",
+            "1000",
+            "--actor",
+            "operator",
+            "--source-kind",
+            "manual",
+            "--json",
+        ])
+        .output()
+        .expect("spawn work-unit create process");
+    assert!(
+        create_output.status.success(),
+        "create work unit with automation emission: status={:?} stdout={} stderr={}",
+        create_output.status.code(),
+        String::from_utf8_lossy(&create_output.stdout),
+        String::from_utf8_lossy(&create_output.stderr),
+    );
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    let queued_task_id = show_payload["trigger"]["last_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(queued_task_id.starts_with("delegate:"));
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["source_kind"],
+        "event"
+    );
+
+    let work_unit_repo = {
+        let (_, config) =
+            mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        mvp::work::repository::WorkUnitRepository::new(&memory_config)
+            .expect("work unit repository")
+    };
+    let snapshot = work_unit_repo
+        .load_work_unit_snapshot("wu-automation")
+        .expect("load work unit snapshot")
+        .expect("created work unit snapshot");
+    assert_eq!(snapshot.work_unit.work_unit_id, "wu-automation");
+    assert!(queued_task_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn work_unit_create_can_filter_on_app_layer_source_surface_metadata() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-work-unit-source-surface");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Work Unit App Surface Filter".to_owned(),
+                    event: "work_unit.created".to_owned(),
+                    json_pointer: Some("/_automation/source_surface".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("app.work.repository".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on app-layer work unit event".to_owned(),
+                    label: Some("Work Unit App Surface".to_owned()),
+                    timeout_seconds: Some(45),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create work-unit app-surface trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let create_output = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "work-unit",
+            "create",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--id",
+            "wu-app-surface",
+            "--kind",
+            "feature",
+            "--title",
+            "App layer source surface",
+            "--description",
+            "Verify work-unit source surface metadata",
+            "--status",
+            "ready",
+            "--priority",
+            "high",
+            "--max-attempts",
+            "3",
+            "--initial-backoff-ms",
+            "1000",
+            "--max-backoff-ms",
+            "60000",
+            "--next-run-at-ms",
+            "1000",
+            "--actor",
+            "operator",
+            "--source-kind",
+            "manual",
+            "--json",
+        ])
+        .output()
+        .expect("spawn work-unit create process");
+    assert!(
+        create_output.status.success(),
+        "work-unit create app-surface case failed: status={:?} stdout={} stderr={}",
+        create_output.status.code(),
+        String::from_utf8_lossy(&create_output.stdout),
+        String::from_utf8_lossy(&create_output.stderr),
+    );
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["source_kind"],
+        "event"
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_cli_create_cron_persists_next_fire_cursor() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-cli-cron");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let before_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_millis() as i64;
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateCron(
+                loong_daemon::automation_cli::AutomationCreateCronCommandOptions {
+                    name: "Nightly Ops Sweep".to_owned(),
+                    cron: "0 0 * * *".to_owned(),
+                    session: "ops-root".to_owned(),
+                    task: "run nightly ops sweep".to_owned(),
+                    label: Some("Nightly Sweep".to_owned()),
+                    timeout_seconds: Some(60),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create cron automation trigger");
+
+    assert_eq!(create_payload["command"], "create_cron");
+    assert_eq!(create_payload["trigger"]["source"]["type"], "cron");
+    assert_eq!(
+        create_payload["trigger"]["source"]["cron"]["expression"],
+        "0 0 * * *"
+    );
+    let next_fire_at_ms = create_payload["trigger"]["source"]["cron"]["next_fire_at_ms"]
+        .as_i64()
+        .expect("next fire at ms");
+    assert!(
+        next_fire_at_ms > before_ms,
+        "cron cursor should point into the future, got {next_fire_at_ms} <= {before_ms}"
+    );
+
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show cron automation trigger");
+
+    assert_eq!(show_payload["trigger"]["source"]["type"], "cron");
+    assert_eq!(
+        show_payload["trigger"]["source"]["cron"]["next_fire_at_ms"],
+        next_fire_at_ms
+    );
+    assert_eq!(show_payload["trigger"]["fire_count"], 0);
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_cli_event_filter_exists_and_contains_text_gate_delivery() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-cli-filter");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let exists_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Exists Filter".to_owned(),
+                    event: "build.ready".to_owned(),
+                    json_pointer: Some("/reason".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "exists filter fired".to_owned(),
+                    label: Some("Exists Filter".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create exists filter trigger");
+    let exists_trigger_id = exists_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("exists trigger id")
+        .to_owned();
+
+    let contains_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Contains Filter".to_owned(),
+                    event: "build.ready".to_owned(),
+                    json_pointer: Some("/reason".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: Some("ship".to_owned()),
+                    session: "ops-root".to_owned(),
+                    task: "contains filter fired".to_owned(),
+                    label: Some("Contains Filter".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create contains filter trigger");
+    let contains_trigger_id = contains_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("contains trigger id")
+        .to_owned();
+
+    let miss_emit = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Emit(
+                loong_daemon::automation_cli::AutomationEmitCommandOptions {
+                    event: "build.ready".to_owned(),
+                    payload_json: Some(r#"{"other":"value"}"#.to_owned()),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("emit non-matching exists payload");
+    assert_eq!(miss_emit["matched_count"], 0);
+
+    let partial_emit = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Emit(
+                loong_daemon::automation_cli::AutomationEmitCommandOptions {
+                    event: "build.ready".to_owned(),
+                    payload_json: Some(r#"{"reason":"ready to review"}"#.to_owned()),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("emit exists-only matching payload");
+    assert_eq!(partial_emit["matched_count"], 1);
+
+    let full_emit = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Emit(
+                loong_daemon::automation_cli::AutomationEmitCommandOptions {
+                    event: "build.ready".to_owned(),
+                    payload_json: Some(r#"{"reason":"ready to ship"}"#.to_owned()),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("emit full matching payload");
+    assert_eq!(full_emit["matched_count"], 2);
+
+    let exists_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions {
+                    id: exists_trigger_id,
+                },
+            ),
+        },
+    )
+    .await
+    .expect("show exists trigger");
+    assert_eq!(exists_show["trigger"]["fire_count"], 2);
+    assert_eq!(
+        exists_show["trigger"]["source"]["event"]["json_pointer"],
+        "/reason"
+    );
+
+    let contains_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions {
+                    id: contains_trigger_id,
+                },
+            ),
+        },
+    )
+    .await
+    .expect("show contains trigger");
+    assert_eq!(contains_show["trigger"]["fire_count"], 1);
+    assert_eq!(
+        contains_show["trigger"]["source"]["event"]["contains_text"],
+        "ship"
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn background_task_cancel_emits_automation_event_and_queues_followup() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-background-task-cancel-automation");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    super::tasks_cli::seed_background_task(&config_path, "ops-root", "delegate:cancel-me");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Cancelled Follow-up".to_owned(),
+                    event: "background_task.cancelled".to_owned(),
+                    json_pointer: Some("/task/task_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:cancel-me".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on cancelled background task".to_owned(),
+                    label: Some("Cancellation Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create background-task cancelled automation trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let cancel_payload = loong_daemon::tasks_cli::execute_tasks_command(
+        loong_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::tasks_cli::TasksCommands::Cancel {
+                task_id: "delegate:cancel-me".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("cancel background task");
+
+    assert_eq!(cancel_payload.payload["command"], "cancel");
+    assert_eq!(
+        cancel_payload.payload["action"]["kind"],
+        "queued_async_cancelled"
+    );
+
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show cancelled background-task trigger");
+
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    let repo = load_session_repository(&config_path);
+    let sessions = repo
+        .list_sessions()
+        .expect("list sessions after cancellation");
+    let follow_up_sessions = sessions
+        .iter()
+        .filter(|session| {
+            session.parent_session_id.as_deref() == Some("ops-root")
+                && session.kind == mvp::session::repository::SessionKind::DelegateChild
+                && session.session_id != "delegate:cancel-me"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(follow_up_sessions.len(), 1);
+    assert!(follow_up_sessions[0].session_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn background_task_cancel_can_filter_on_internal_source_surface_metadata() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-background-task-cancel-source-surface");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    super::tasks_cli::seed_background_task(&config_path, "ops-root", "delegate:meta-cancel");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Tasks CLI Metadata Filter".to_owned(),
+                    event: "background_task.cancelled".to_owned(),
+                    json_pointer: Some("/_automation/source_surface".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("tasks_cli".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on tasks cli sourced cancellation".to_owned(),
+                    label: Some("Tasks CLI Metadata Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create metadata filtered trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let _cancel_payload = loong_daemon::tasks_cli::execute_tasks_command(
+        loong_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::tasks_cli::TasksCommands::Cancel {
+                task_id: "delegate:meta-cancel".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("cancel metadata-filtered background task");
+
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show metadata filtered trigger");
+
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["source_kind"],
+        "event"
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn background_task_recover_emits_automation_event_and_queues_followup() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-background-task-recover-automation");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    seed_overdue_background_task(&config_path, "ops-root", "delegate:recover-me");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Recovered Follow-up".to_owned(),
+                    event: "background_task.recovered".to_owned(),
+                    json_pointer: Some("/task/task_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:recover-me".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on recovered background task".to_owned(),
+                    label: Some("Recovery Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create background-task recovered automation trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let recover_payload = loong_daemon::tasks_cli::execute_tasks_command(
+        loong_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::tasks_cli::TasksCommands::Recover {
+                task_id: "delegate:recover-me".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("recover background task");
+
+    assert_eq!(recover_payload.payload["command"], "recover");
+    assert_eq!(
+        recover_payload.payload["action"]["kind"],
+        "queued_async_overdue_marked_failed"
+    );
+
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show recovered background-task trigger");
+
+    let queued_task_id = show_payload["trigger"]["last_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert!(queued_task_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn session_cancel_emits_automation_event_and_queues_followup() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-session-cancel-automation");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    super::tasks_cli::seed_background_task(&config_path, "ops-root", "delegate:session-cancel");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Session Cancelled Follow-up".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:session-cancel".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on cancelled session".to_owned(),
+                    label: Some("Session Cancel Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create session cancelled automation trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let cancel_payload = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Cancel {
+                session_id: "delegate:session-cancel".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("cancel session through sessions CLI");
+
+    assert_eq!(cancel_payload.payload["command"], "cancel");
+    assert_eq!(
+        cancel_payload.payload["session_id"],
+        "delegate:session-cancel"
+    );
+    assert_eq!(
+        cancel_payload.payload["action"]["kind"],
+        "queued_async_cancelled"
+    );
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+
+    let queued_task_id = show_payload["trigger"]["last_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["source_kind"],
+        "event"
+    );
+    assert!(queued_task_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn session_cancel_can_filter_on_app_layer_source_surface_metadata() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-session-source-surface");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    super::tasks_cli::seed_background_task(&config_path, "ops-root", "delegate:session-meta");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Session App Surface Filter".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/_automation/source_surface".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("app.tools.session".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on app-layer session event".to_owned(),
+                    label: Some("Session App Surface".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create session app-surface trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let _cancel_payload = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Cancel {
+                session_id: "delegate:session-meta".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("cancel session for app-surface case");
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(
+        show_payload["trigger"]["run_history"][0]["source_kind"],
+        "event"
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn session_archive_emits_automation_event_and_queues_followup() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-session-archive-automation");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "delegate:archive-me".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("ops-root".to_owned()),
+        label: Some("Archive Me".to_owned()),
+        state: mvp::session::repository::SessionState::Running,
+    })
+    .expect("create archivable child session");
+    repo.finalize_session_terminal(
+        "delegate:archive-me",
+        mvp::session::repository::FinalizeSessionTerminalRequest {
+            state: mvp::session::repository::SessionState::Completed,
+            last_error: None,
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("ops-root".to_owned()),
+            event_payload_json: json!({ "result": "ok" }),
+            outcome_status: "ok".to_owned(),
+            outcome_payload_json: json!({
+                "child_session_id": "delegate:archive-me",
+                "result": "ok"
+            }),
+            frozen_result: None,
+        },
+    )
+    .expect("finalize archivable child session");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Session Archived Follow-up".to_owned(),
+                    event: "session.archived".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:archive-me".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on archived session".to_owned(),
+                    label: Some("Session Archive Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create session archived automation trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let archive_payload = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Archive {
+                session_id: "delegate:archive-me".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("archive session through sessions CLI");
+
+    assert_eq!(archive_payload.payload["command"], "archive");
+    assert_eq!(archive_payload.payload["session_id"], "delegate:archive-me");
+    assert_eq!(
+        archive_payload.payload["action"]["kind"],
+        "session_archived"
+    );
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+
+    let queued_task_id = show_payload["trigger"]["last_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert!(queued_task_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn session_recover_emits_automation_event_and_queues_followup() {
+    let guard = lock_automation_integration();
+    let root = super::tasks_cli::TempDirGuard::new("loong-session-recover-automation");
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+    seed_overdue_background_task(&config_path, "ops-root", "delegate:session-recover");
+
+    let create_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Session Recovered Follow-up".to_owned(),
+                    event: "session.recovered".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:session-recover".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on recovered session".to_owned(),
+                    label: Some("Session Recover Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create session recovered automation trigger");
+    let trigger_id = create_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let recover_payload = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Recover {
+                session_id: "delegate:session-recover".to_owned(),
+                dry_run: false,
+            },
+        },
+    )
+    .await
+    .expect("recover session through sessions CLI");
+
+    assert_eq!(recover_payload.payload["command"], "recover");
+    assert_eq!(
+        recover_payload.payload["session_id"],
+        "delegate:session-recover"
+    );
+    assert_eq!(
+        recover_payload.payload["action"]["kind"],
+        "queued_async_overdue_marked_failed"
+    );
+
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    let queued_task_id = show_payload["trigger"]["last_task_id"]
+        .as_str()
+        .expect("queued task id")
+        .to_owned();
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert!(queued_task_id.starts_with("delegate:"));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_processes_internal_journal_once_and_advances_cursor() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-cursor");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Journal Cursor Follow-up".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:cursor-test".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on journal cursor event".to_owned(),
+                    label: Some("Journal Cursor Follow-up".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create journal cursor trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:cursor-test"
+        }),
+    )
+    .expect("append internal journal row");
+
+    let first_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(first_show["trigger"]["last_error"].is_null());
+    wait_for_cursor_value(automation_cursor_path(&loong_home).as_path(), "1");
+    let cursor_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_payload["line_cursor"], 1);
+    assert!(
+        cursor_payload["byte_offset"].as_u64().unwrap_or_default() > 0,
+        "byte_offset should advance after the first consumed journal record"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let second_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show trigger after replay window");
+    assert_eq!(second_show["trigger"]["fire_count"], 1);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_migrates_legacy_numeric_cursor_without_replaying_consumed_rows() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-legacy-cursor");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+    let automation_dir = loong_home.join("automation");
+    fs::create_dir_all(&automation_dir).expect("create automation dir");
+    fs::write(automation_dir.join("internal-events.cursor"), "1\n")
+        .expect("seed legacy numeric cursor");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Legacy Cursor Migration".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: None,
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on migrated cursor event".to_owned(),
+                    label: Some("Legacy Cursor Migration".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create legacy cursor trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:first"
+        }),
+    )
+    .expect("append first journal row");
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:second"
+        }),
+    )
+    .expect("append second journal row");
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+    let show_payload = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(show_payload["trigger"]["last_error"].is_null());
+    assert_eq!(show_payload["trigger"]["fire_count"], 1);
+    let cursor_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_payload["line_cursor"], 2);
+    assert!(
+        cursor_payload["byte_offset"].as_u64().unwrap_or_default() > 0,
+        "migrated cursor should persist a nonzero byte offset"
+    );
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_matches_internal_journal_source_surface_metadata() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-source-surface");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Journal App Surface Filter".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/_automation/source_surface".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("app.tools.session".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on journal source-surface event".to_owned(),
+                    label: Some("Journal App Surface Filter".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create source-surface trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:wrong-surface",
+            "_automation": {
+                "event_name": "session.cancelled",
+                "source_surface": "tasks_cli"
+            }
+        }),
+    )
+    .expect("append non-matching metadata journal row");
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:matched-surface",
+            "_automation": {
+                "event_name": "session.cancelled",
+                "source_surface": "app.tools.session"
+            }
+        }),
+    )
+    .expect("append matching metadata journal row");
+
+    wait_for_cursor_value(automation_cursor_path(&loong_home).as_path(), "2");
+    let cursor_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_payload["line_cursor"], 2);
+    assert!(
+        cursor_payload["byte_offset"].as_u64().unwrap_or_default() > 0,
+        "byte_offset should advance after consuming journal metadata rows"
+    );
+    let show_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show metadata trigger after cursor advance");
+    assert_eq!(
+        show_payload["trigger"]["fire_count"], 1,
+        "journal cursor advanced but metadata-filtered trigger did not fire"
+    );
+    assert!(show_payload["trigger"]["last_error"].is_null());
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -690,6 +690,9 @@ async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
                     command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
                         loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
                             retain_segment_id: None,
+                            retain_last_sealed: 0,
+                            retain_min_age_seconds: None,
+                            dry_run: false,
                         },
                     ),
                 },
@@ -704,6 +707,106 @@ async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
     assert!(!loong_app::internal_events::internal_event_segment_path("segment-000001").exists());
     assert!(loong_app::internal_events::internal_event_segment_path("segment-000002").exists());
     assert!(loong_app::internal_events::internal_event_segment_path("segment-000003").exists());
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_prune_dry_run_reports_policy_without_deleting_segments() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-journal-prune-dry-run");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000004\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":30},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":40},\n",
+            "    {\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            loong_app::internal_events::internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000004\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
+                        loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
+                            retain_segment_id: None,
+                            retain_last_sealed: 1,
+                            retain_min_age_seconds: None,
+                            dry_run: true,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("dry-run journal prune");
+
+    assert_eq!(payload["command"], "journal_prune");
+    assert_eq!(payload["dry_run"], true);
+    assert_eq!(payload["retain_floor_segment_id"], "segment-000004");
+    assert_eq!(payload["retain_last_sealed_segments"], 1);
+    assert_eq!(
+        payload["pruned_segments"],
+        json!(["segment-000001", "segment-000002"])
+    );
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000001").exists());
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000002").exists());
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000003").exists());
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000004").exists());
     drop(guard);
 }
 
@@ -1520,6 +1623,50 @@ async fn automation_cli_create_cron_persists_next_fire_cursor() {
         next_fire_at_ms
     );
     assert_eq!(show_payload["trigger"]["fire_count"], 0);
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_cron_preview_surfaces_future_fire_times_in_utc() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-cron-preview");
+    let config_path = write_automation_config(root.path());
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Cron(
+                loong_daemon::automation_cli::AutomationCronCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationCronCommands::Preview(
+                        loong_daemon::automation_cli::AutomationCronPreviewCommandOptions {
+                            cron: "0 0 * * *".to_owned(),
+                            after: None,
+                            after_ms: Some(1_700_000_000_000),
+                            count: 3,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("preview cron");
+
+    assert_eq!(payload["command"], "cron_preview");
+    assert_eq!(payload["expression"], "0 0 * * *");
+    assert_eq!(payload["timezone"], "UTC");
+    assert_eq!(payload["preview"].as_array().map(Vec::len), Some(3));
+    let first_fire_at_ms = payload["preview"][0]["fire_at_ms"]
+        .as_i64()
+        .expect("first preview fire_at_ms");
+    assert!(first_fire_at_ms > 1_700_000_000_000);
+    assert!(
+        payload["preview"][0]["fire_at_rfc3339"]
+            .as_str()
+            .expect("first preview fire_at_rfc3339")
+            .contains('T')
+    );
     drop(guard);
 }
 

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -293,6 +293,324 @@ async fn automation_cli_show_loads_legacy_store_without_run_history() {
     drop(guard);
 }
 
+#[tokio::test]
+async fn automation_journal_inspect_surfaces_layout_and_cursor() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-inspect");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000002\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"legacy\",\"status\":\"legacy\"},\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000002\",\"status\":\"active\",\"created_at_ms\":30}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000002\",\n",
+            "  \"line_cursor\": 3,\n",
+            "  \"byte_offset\": 120,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationJournalInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation journal");
+
+    assert_eq!(payload["command"], "journal_inspect");
+    assert_eq!(payload["layout"]["active_segment_id"], "segment-000002");
+    assert_eq!(payload["layout"]["segments"][0]["segment_id"], "legacy");
+    assert_eq!(payload["layout"]["segments"][1]["status"], "sealed");
+    assert_eq!(payload["layout"]["segments"][2]["status"], "active");
+    assert_eq!(payload["cursor"]["segment_id"], "segment-000002");
+    assert_eq!(payload["cursor"]["line_cursor"], 3);
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_rotate_updates_active_segment_for_future_appends() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-rotate");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000001\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"active\",\"created_at_ms\":10}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write initial journal state");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Rotate(
+                        loong_daemon::automation_cli::AutomationJournalRotateCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("rotate automation journal");
+
+    assert_eq!(payload["command"], "journal_rotate");
+    assert_eq!(payload["next_segment_id"], "segment-000002");
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:journal-rotate"
+        }),
+    )
+    .expect("append after journal rotate");
+    let active_contents = fs::read_to_string(
+        loong_app::internal_events::internal_event_segment_path("segment-000002"),
+    )
+    .expect("read rotated active segment");
+    assert!(
+        active_contents.contains("delegate:journal-rotate"),
+        "future appends should land in the rotated active segment: {active_contents}"
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-prune");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000003\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\"},\n",
+            "    {\"segment_id\":\"segment-000002\",\"status\":\"sealed\"},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"active\"}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"prune-a\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write first sealed segment");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"prune-b\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write second sealed segment");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"prune-c\"},\"recorded_at_ms\":3}\n",
+    )
+    .expect("write active segment");
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000002\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
+                        loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
+                            retain_segment_id: None,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("prune automation journal");
+
+    assert_eq!(payload["command"], "journal_prune");
+    assert_eq!(payload["pruned_segments"][0], "segment-000001");
+    assert!(!loong_app::internal_events::internal_event_segment_path("segment-000001").exists());
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000002").exists());
+    assert!(loong_app::internal_events::internal_event_segment_path("segment-000003").exists());
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_repair_reconciles_state_and_reports_updated_layout() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-repair");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000003\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":20},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"active\",\"created_at_ms\":30}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write stale journal state");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000004\n",
+    )
+    .expect("write newer active marker");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"sealed\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write sealed segment");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000004"),
+        "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"active\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write recovered active segment");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Repair(
+                        loong_daemon::automation_cli::AutomationJournalRepairCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("repair automation journal");
+
+    assert_eq!(payload["command"], "journal_repair");
+    assert_eq!(payload["layout"]["active_segment_id"], "segment-000004");
+    assert_eq!(
+        payload["layout"]["segments"][0]["segment_id"],
+        "segment-000001"
+    );
+    assert_eq!(payload["layout"]["segments"][0]["status"], "sealed");
+    assert_eq!(
+        payload["layout"]["segments"][1]["segment_id"],
+        "segment-000004"
+    );
+    assert_eq!(payload["layout"]["segments"][1]["status"], "active");
+    drop(guard);
+}
+
 fn set_session_event_ts(config_path: &Path, session_id: &str, event_kind: &str, ts: i64) {
     let (_, config) =
         mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
@@ -1789,6 +2107,411 @@ async fn automation_serve_matches_internal_journal_source_surface_metadata() {
         "journal cursor advanced but metadata-filtered trigger did not fire"
     );
     assert!(show_payload["trigger"]["last_error"].is_null());
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_recovers_after_internal_journal_rotation_and_processes_new_rows_once() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-rotation");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Rotation Recovery".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: Some("rotation".to_owned()),
+                    session: "ops-root".to_owned(),
+                    task: "follow up on rotated journal event".to_owned(),
+                    label: Some("Rotation Recovery".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create rotation recovery trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:rotation-first"
+        }),
+    )
+    .expect("append first rotation row");
+
+    let first_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(first_show["trigger"]["last_error"].is_null());
+
+    let cursor_before_rotation: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    let fingerprint_before_rotation = cursor_before_rotation["journal_fingerprint"].clone();
+
+    let journal_path = loong_app::internal_events::internal_event_journal_path();
+    fs::write(
+        &journal_path,
+        concat!(
+            "{\"event_name\":\"session.archived\",\"payload\":{\"session_id\":\"rotation-ignored-padding-with-longer-content\"},\"recorded_at_ms\":4}\n",
+            "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:rotation-second\"},\"recorded_at_ms\":5}\n"
+        ),
+    )
+    .expect("replace journal with rotated content");
+
+    let second_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 2).await;
+    assert!(second_show["trigger"]["last_error"].is_null());
+    let cursor_after_rotation: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_after_rotation["line_cursor"], 2);
+    assert!(
+        cursor_after_rotation["byte_offset"]
+            .as_u64()
+            .unwrap_or_default()
+            > 0,
+        "rotation recovery should persist a nonzero byte offset"
+    );
+    assert_ne!(
+        cursor_after_rotation["journal_fingerprint"], fingerprint_before_rotation,
+        "rotation recovery should rewrite the cursor fingerprint"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let third_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show trigger after rotation replay window");
+    assert_eq!(third_show["trigger"]["fire_count"], 2);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_processes_segment_rollover_once_without_skipping_or_replaying() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-segment-rollover");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000001\n",
+    )
+    .expect("seed active segment id");
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Segment Rollover".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: Some("segment-rollover".to_owned()),
+                    session: "ops-root".to_owned(),
+                    task: "follow up on segment rollover event".to_owned(),
+                    label: Some("Segment Rollover".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create segment rollover trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:segment-rollover-old"
+        }),
+    )
+    .expect("append first segment row");
+
+    let first_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(first_show["trigger"]["last_error"].is_null());
+
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000002\n",
+    )
+    .expect("promote second segment to active");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:segment-rollover-new\"},\"recorded_at_ms\":9}\n",
+    )
+    .expect("write second segment");
+
+    let second_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 2).await;
+    assert!(second_show["trigger"]["last_error"].is_null());
+    let cursor_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_payload["segment_id"], "segment-000002");
+    assert_eq!(cursor_payload["line_cursor"], 1);
+    assert!(
+        !loong_app::internal_events::internal_event_segment_path("segment-000001").exists(),
+        "serve should prune fully consumed sealed segments once the cursor is persisted on the newer segment"
+    );
+    assert!(
+        loong_app::internal_events::internal_event_segment_path("segment-000002").exists(),
+        "active segment should remain after pruning older sealed segments"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let third_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show trigger after segment replay window");
+    assert_eq!(third_show["trigger"]["fire_count"], 2);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_missing_segment_cursor_skips_older_surviving_segment() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-missing-segment-cursor");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000003\n",
+    )
+    .expect("seed active segment id");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:missing-segment-older\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write older surviving segment");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:missing-segment-newer\"},\"recorded_at_ms\":3}\n",
+    )
+    .expect("write newer surviving segment");
+    fs::write(
+        automation_cursor_path(&loong_home),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "segment_id": "segment-000002",
+            "line_cursor": 5,
+            "byte_offset": 99,
+            "journal_fingerprint": "stale"
+        }))
+        .expect("serialize missing segment cursor"),
+    )
+    .expect("seed missing segment cursor");
+
+    let older_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Older Missing Segment".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:missing-segment-older".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on older missing-segment event".to_owned(),
+                    label: Some("Older Missing Segment".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create older missing segment trigger");
+    let older_trigger_id = older_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("older trigger id")
+        .to_owned();
+
+    let newer_trigger_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Newer Missing Segment".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: Some("delegate:missing-segment-newer".to_owned()),
+                    contains_text: None,
+                    session: "ops-root".to_owned(),
+                    task: "follow up on newer missing-segment event".to_owned(),
+                    label: Some("Newer Missing Segment".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create newer missing segment trigger");
+    let newer_trigger_id = newer_trigger_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("newer trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    let newer_show = wait_for_trigger_fire_count(&config_path, &newer_trigger_id, 1).await;
+    assert!(newer_show["trigger"]["last_error"].is_null());
+    let older_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions {
+                    id: older_trigger_id,
+                },
+            ),
+        },
+    )
+    .await
+    .expect("show older trigger after missing segment normalization");
+    assert_eq!(older_show["trigger"]["fire_count"], 0);
+
+    let cursor_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(automation_cursor_path(&loong_home)).expect("read cursor payload"),
+    )
+    .expect("parse cursor payload");
+    assert_eq!(cursor_payload["segment_id"], "segment-000003");
+    assert_eq!(cursor_payload["line_cursor"], 1);
 
     serve.kill().expect("stop automation serve");
     let _ = serve.wait();

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -150,7 +150,7 @@ fn wait_for_path(path: &Path, description: &str) {
 }
 
 fn wait_for_serve_lock(child: &mut Child, path: &Path) {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
     loop {
         if path.exists() {
             return;
@@ -365,6 +365,95 @@ async fn automation_journal_inspect_surfaces_layout_and_cursor() {
     assert_eq!(payload["layout"]["segments"][2]["status"], "active");
     assert_eq!(payload["cursor"]["segment_id"], "segment-000002");
     assert_eq!(payload["cursor"]["line_cursor"], 3);
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_health_reports_state_marker_drift_and_missing_cursor_segment() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-journal-health");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        concat!(
+            "{\n",
+            "  \"schema_version\": 1,\n",
+            "  \"active_segment_id\": \"segment-000003\",\n",
+            "  \"segments\": [\n",
+            "    {\"segment_id\":\"segment-000001\",\"status\":\"sealed\"},\n",
+            "    {\"segment_id\":\"segment-000003\",\"status\":\"active\"}\n",
+            "  ]\n",
+            "}\n"
+        ),
+    )
+    .expect("write journal state");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000004\n",
+    )
+    .expect("write divergent active marker");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000001"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"health-old\"},\"recorded_at_ms\":1}\n",
+    )
+    .expect("write first segment");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"health-active\"},\"recorded_at_ms\":2}\n",
+    )
+    .expect("write active segment");
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000005\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"missing\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write missing cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Health(
+                        loong_daemon::automation_cli::AutomationJournalHealthCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("journal health");
+
+    assert_eq!(payload["command"], "journal_health");
+    assert_eq!(payload["state_active_segment_id"], "segment-000003");
+    assert_eq!(payload["active_marker_segment_id"], "segment-000004");
+    assert_eq!(payload["cursor_segment_id"], "segment-000005");
+    assert_eq!(payload["active_marker_matches_state"], false);
+    assert_eq!(payload["active_segment_exists"], true);
+    assert_eq!(payload["cursor_segment_exists"], false);
     drop(guard);
 }
 

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -181,6 +181,19 @@ fn wait_for_serve_lock(child: &mut Child, path: &Path) {
     }
 }
 
+fn wait_for_child_exit(child: &mut Child, description: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        if let Some(_status) = child.try_wait().expect("poll child exit") {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {description} to exit");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 fn wait_for_cursor_value(path: &Path, expected: &str) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
     loop {
@@ -697,6 +710,150 @@ async fn automation_journal_repair_reconciles_state_and_reports_updated_layout()
         "segment-000004"
     );
     assert_eq!(payload["layout"]["segments"][1]["status"], "active");
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_runner_inspect_reports_active_owner_status() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-runner-inspect");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner");
+
+    assert_eq!(payload["command"], "runner_inspect");
+    assert_eq!(payload["status"]["running"], true);
+    assert_eq!(payload["status"]["stale"], false);
+    assert_eq!(payload["status"]["poll_ms"], 250);
+    assert_eq!(
+        payload["active_owner_path"],
+        automation_serve_lock_path(&loong_home)
+            .display()
+            .to_string()
+    );
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_runner_stop_requests_shutdown_for_running_owner() {
+    let guard = lock_automation_integration();
+    let root = TempDirGuard::new("loong-automation-runner-stop");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Stop(
+                        loong_daemon::automation_cli::AutomationRunnerStopCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("stop automation runner");
+
+    assert_eq!(payload["command"], "runner_stop");
+    assert_eq!(payload["outcome"], "requested");
+    wait_for_child_exit(&mut serve, "automation serve");
+
+    let status_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner after stop");
+    assert_eq!(status_payload["status"]["running"], false);
+
     drop(guard);
 }
 

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use super::*;
 use loong_app::internal_events::append_internal_event_to_journal;
 use rusqlite::params;
@@ -5,20 +7,18 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
+    sync::OnceLock,
     sync::atomic::{AtomicUsize, Ordering},
-    sync::{Mutex, OnceLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 
-fn automation_integration_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+fn automation_integration_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-fn lock_automation_integration() -> std::sync::MutexGuard<'static, ()> {
-    automation_integration_lock()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+async fn lock_automation_integration() -> tokio::sync::MutexGuard<'static, ()> {
+    automation_integration_lock().lock().await
 }
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
@@ -228,7 +228,7 @@ fn parse_cursor_line_cursor(raw: &str) -> Option<String> {
 
 #[tokio::test]
 async fn automation_cli_show_loads_legacy_store_without_run_history() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-cli-legacy-store");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -308,7 +308,7 @@ async fn automation_cli_show_loads_legacy_store_without_run_history() {
 
 #[tokio::test]
 async fn automation_journal_inspect_surfaces_layout_and_cursor() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-inspect");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -383,7 +383,7 @@ async fn automation_journal_inspect_surfaces_layout_and_cursor() {
 
 #[tokio::test]
 async fn automation_journal_health_reports_state_marker_drift_and_missing_cursor_segment() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-health");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -472,7 +472,7 @@ async fn automation_journal_health_reports_state_marker_drift_and_missing_cursor
 
 #[tokio::test]
 async fn automation_journal_rotate_updates_active_segment_for_future_appends() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-rotate");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -543,7 +543,7 @@ async fn automation_journal_rotate_updates_active_segment_for_future_appends() {
 
 #[tokio::test]
 async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-prune");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -633,7 +633,7 @@ async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
 
 #[tokio::test]
 async fn automation_journal_repair_reconciles_state_and_reports_updated_layout() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-repair");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -715,7 +715,7 @@ async fn automation_journal_repair_reconciles_state_and_reports_updated_layout()
 
 #[tokio::test]
 async fn automation_runner_inspect_reports_active_owner_status() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-runner-inspect");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -783,7 +783,7 @@ async fn automation_runner_inspect_reports_active_owner_status() {
 
 #[tokio::test]
 async fn automation_runner_stop_requests_shutdown_for_running_owner() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-runner-stop");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -902,7 +902,7 @@ fn seed_overdue_background_task(config_path: &Path, root_session_id: &str, task_
 
 #[tokio::test]
 async fn automation_cli_emit_matches_event_trigger_and_queues_background_task() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-cli-emit");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1012,7 +1012,7 @@ async fn automation_cli_emit_matches_event_trigger_and_queues_background_task() 
 
 #[tokio::test]
 async fn work_unit_create_emits_automation_event_and_queues_background_task() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-work-unit-automation");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1129,7 +1129,7 @@ async fn work_unit_create_emits_automation_event_and_queues_background_task() {
 
 #[tokio::test]
 async fn work_unit_create_can_filter_on_app_layer_source_surface_metadata() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-work-unit-source-surface");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1224,7 +1224,7 @@ async fn work_unit_create_can_filter_on_app_layer_source_surface_metadata() {
 
 #[tokio::test]
 async fn automation_cli_create_cron_persists_next_fire_cursor() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-cli-cron");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1302,7 +1302,7 @@ async fn automation_cli_create_cron_persists_next_fire_cursor() {
 
 #[tokio::test]
 async fn automation_cli_event_filter_exists_and_contains_text_gate_delivery() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-cli-filter");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1459,7 +1459,7 @@ async fn automation_cli_event_filter_exists_and_contains_text_gate_delivery() {
 
 #[tokio::test]
 async fn background_task_cancel_emits_automation_event_and_queues_followup() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-background-task-cancel-automation");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1558,7 +1558,7 @@ async fn background_task_cancel_emits_automation_event_and_queues_followup() {
 
 #[tokio::test]
 async fn background_task_cancel_can_filter_on_internal_source_surface_metadata() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-background-task-cancel-source-surface");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1635,7 +1635,7 @@ async fn background_task_cancel_can_filter_on_internal_source_surface_metadata()
 
 #[tokio::test]
 async fn background_task_recover_emits_automation_event_and_queues_followup() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-background-task-recover-automation");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1719,7 +1719,7 @@ async fn background_task_recover_emits_automation_event_and_queues_followup() {
 
 #[tokio::test]
 async fn session_cancel_emits_automation_event_and_queues_followup() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-session-cancel-automation");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1801,7 +1801,7 @@ async fn session_cancel_emits_automation_event_and_queues_followup() {
 
 #[tokio::test]
 async fn session_cancel_can_filter_on_app_layer_source_surface_metadata() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-session-source-surface");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1866,7 +1866,7 @@ async fn session_cancel_can_filter_on_app_layer_source_surface_metadata() {
 
 #[tokio::test]
 async fn session_archive_emits_automation_event_and_queues_followup() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-session-archive-automation");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -1967,7 +1967,7 @@ async fn session_archive_emits_automation_event_and_queues_followup() {
 
 #[tokio::test]
 async fn session_recover_emits_automation_event_and_queues_followup() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = super::tasks_cli::TempDirGuard::new("loong-session-recover-automation");
     let config_path = super::tasks_cli::write_tasks_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2044,7 +2044,7 @@ async fn session_recover_emits_automation_event_and_queues_followup() {
 
 #[tokio::test]
 async fn automation_serve_processes_internal_journal_once_and_advances_cursor() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-cursor");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2147,7 +2147,7 @@ async fn automation_serve_processes_internal_journal_once_and_advances_cursor() 
 
 #[tokio::test]
 async fn automation_serve_migrates_legacy_numeric_cursor_without_replaying_consumed_rows() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-legacy-cursor");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2246,7 +2246,7 @@ async fn automation_serve_migrates_legacy_numeric_cursor_without_replaying_consu
 
 #[tokio::test]
 async fn automation_serve_matches_internal_journal_source_surface_metadata() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-source-surface");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2361,7 +2361,7 @@ async fn automation_serve_matches_internal_journal_source_surface_metadata() {
 
 #[tokio::test]
 async fn automation_serve_recovers_after_internal_journal_rotation_and_processes_new_rows_once() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-journal-rotation");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2489,7 +2489,7 @@ async fn automation_serve_recovers_after_internal_journal_rotation_and_processes
 
 #[tokio::test]
 async fn automation_serve_processes_segment_rollover_once_without_skipping_or_replaying() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-segment-rollover");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");
@@ -2618,7 +2618,7 @@ async fn automation_serve_processes_segment_rollover_once_without_skipping_or_re
 
 #[tokio::test]
 async fn automation_serve_missing_segment_cursor_skips_older_surviving_segment() {
-    let guard = lock_automation_integration();
+    let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-missing-segment-cursor");
     let config_path = write_automation_config(root.path());
     let loong_home = root.path().join("loong-home");

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -2987,6 +2987,193 @@ async fn automation_serve_processes_segment_rollover_once_without_skipping_or_re
 }
 
 #[tokio::test]
+async fn automation_serve_auto_prune_respects_retain_last_sealed_policy() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-segment-retention-policy");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000001\n",
+    )
+    .expect("seed active segment id");
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Segment Retention Policy".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: Some("segment-retention".to_owned()),
+                    session: "ops-root".to_owned(),
+                    task: "follow up on retained segment event".to_owned(),
+                    label: Some("Segment Retention Policy".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create segment retention trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+            "--retain-last-sealed",
+            "1",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:segment-retention-1"
+        }),
+    )
+    .expect("append first segment row");
+    let first_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(first_show["trigger"]["last_error"].is_null());
+
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000002\n",
+    )
+    .expect("promote second segment to active");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:segment-retention-2\"},\"recorded_at_ms\":9}\n",
+    )
+    .expect("write second segment");
+    let second_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 2).await;
+    assert!(second_show["trigger"]["last_error"].is_null());
+
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000003\n",
+    )
+    .expect("promote third segment to active");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:segment-retention-3\"},\"recorded_at_ms\":10}\n",
+    )
+    .expect("write third segment");
+    let third_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 3).await;
+    assert!(third_show["trigger"]["last_error"].is_null());
+
+    assert!(
+        !loong_app::internal_events::internal_event_segment_path("segment-000001").exists(),
+        "oldest sealed segment should be pruned once the cursor reaches segment-000003"
+    );
+    assert!(
+        loong_app::internal_events::internal_event_segment_path("segment-000002").exists(),
+        "newest sealed segment should be retained by the keep-last policy"
+    );
+    assert!(
+        loong_app::internal_events::internal_event_segment_path("segment-000003").exists(),
+        "active segment should remain"
+    );
+
+    let runner_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner retention policy");
+    assert_eq!(runner_payload["status"]["retain_last_sealed_segments"], 1);
+    assert!(runner_payload["status"]["retain_min_age_ms"].is_null());
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+
+    let mut restarted_serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+            "--retain-last-sealed",
+            "1",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("restart automation serve");
+
+    wait_for_serve_lock(
+        &mut restarted_serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let restart_show = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Show(
+                loong_daemon::automation_cli::AutomationShowCommandOptions { id: trigger_id },
+            ),
+        },
+    )
+    .await
+    .expect("show trigger after restart");
+    assert_eq!(restart_show["trigger"]["fire_count"], 3);
+
+    restarted_serve
+        .kill()
+        .expect("stop restarted automation serve");
+    let _ = restarted_serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
 async fn automation_serve_missing_segment_cursor_skips_older_surviving_segment() {
     let guard = lock_automation_integration().await;
     let root = TempDirGuard::new("loong-automation-missing-segment-cursor");

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -69,6 +69,44 @@ fn write_automation_config(root: &Path) -> PathBuf {
     config_path
 }
 
+fn write_automation_config_with(
+    root: &Path,
+    configure: impl FnOnce(&mut mvp::config::LoongConfig),
+) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongConfig::default();
+    config.memory.sqlite_path = root.join("memory.sqlite3").display().to_string();
+    config.audit.mode = mvp::config::AuditMode::InMemory;
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.sessions.allow_mutation = true;
+    configure(&mut config);
+
+    let config_path = root.join("loong.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn write_default_automation_config_with(
+    loong_home: &Path,
+    configure: impl FnOnce(&mut mvp::config::LoongConfig),
+) -> PathBuf {
+    fs::create_dir_all(loong_home).expect("create loong home");
+
+    let mut config = mvp::config::LoongConfig::default();
+    config.memory.sqlite_path = loong_home.join("memory.sqlite3").display().to_string();
+    config.audit.mode = mvp::config::AuditMode::InMemory;
+    config.tools.file_root = Some(loong_home.display().to_string());
+    config.tools.sessions.allow_mutation = true;
+    configure(&mut config);
+
+    let config_path = loong_home.join("config.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write default config fixture");
+    config_path
+}
+
 fn load_session_repository(config_path: &Path) -> mvp::session::repository::SessionRepository {
     let (_, config) =
         mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
@@ -690,7 +728,7 @@ async fn automation_journal_prune_uses_current_cursor_segment_as_floor() {
                     command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
                         loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
                             retain_segment_id: None,
-                            retain_last_sealed: 0,
+                            retain_last_sealed: Some(0),
                             retain_min_age_seconds: None,
                             dry_run: false,
                         },
@@ -783,7 +821,7 @@ async fn automation_journal_prune_dry_run_reports_policy_without_deleting_segmen
                     command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
                         loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
                             retain_segment_id: None,
-                            retain_last_sealed: 1,
+                            retain_last_sealed: Some(1),
                             retain_min_age_seconds: None,
                             dry_run: true,
                         },
@@ -889,6 +927,318 @@ async fn automation_journal_repair_reconciles_state_and_reports_updated_layout()
         "segment-000004"
     );
     assert_eq!(payload["layout"]["segments"][1]["status"], "active");
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_prune_uses_automation_config_defaults_when_flags_are_omitted() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-journal-prune-config-defaults");
+    let config_path = write_automation_config_with(root.path(), |config| {
+        config.automation.retain_last_sealed_segments = 1;
+        config.automation.retain_min_age_seconds = Some(60);
+    });
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        format!(
+            concat!(
+                "{{\n",
+                "  \"schema_version\": 1,\n",
+                "  \"active_segment_id\": \"segment-000004\",\n",
+                "  \"segments\": [\n",
+                "    {{\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":{old_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}}\n",
+                "  ]\n",
+                "}}\n"
+            ),
+            old_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(120))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+            young_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(5))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            loong_app::internal_events::internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000004\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
+                        loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
+                            retain_segment_id: None,
+                            retain_last_sealed: None,
+                            retain_min_age_seconds: None,
+                            dry_run: true,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("dry-run journal prune with config defaults");
+
+    assert_eq!(payload["retain_last_sealed_segments"], 1);
+    assert_eq!(payload["retain_min_age_ms"], 60_000);
+    assert_eq!(payload["pruned_segments"], json!(["segment-000001"]));
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_prune_prefers_cli_policy_over_automation_config_defaults() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-journal-prune-config-override");
+    let config_path = write_automation_config_with(root.path(), |config| {
+        config.automation.retain_last_sealed_segments = 1;
+        config.automation.retain_min_age_seconds = Some(60);
+    });
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        format!(
+            concat!(
+                "{{\n",
+                "  \"schema_version\": 1,\n",
+                "  \"active_segment_id\": \"segment-000004\",\n",
+                "  \"segments\": [\n",
+                "    {{\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":{old_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}}\n",
+                "  ]\n",
+                "}}\n"
+            ),
+            old_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(120))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+            young_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(5))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            loong_app::internal_events::internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000004\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
+                        loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
+                            retain_segment_id: None,
+                            retain_last_sealed: Some(0),
+                            retain_min_age_seconds: Some(0),
+                            dry_run: true,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("dry-run journal prune with explicit override");
+
+    assert_eq!(payload["retain_last_sealed_segments"], 0);
+    assert_eq!(payload["retain_min_age_ms"], 0);
+    assert_eq!(
+        payload["pruned_segments"],
+        json!(["segment-000001", "segment-000002", "segment-000003"])
+    );
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_journal_prune_uses_default_config_path_when_flag_is_omitted() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-journal-prune-default-config-path");
+    let loong_home = root.path().join("loong-home");
+    let config_path = write_default_automation_config_with(&loong_home, |config| {
+        config.automation.retain_last_sealed_segments = 1;
+        config.automation.retain_min_age_seconds = Some(60);
+    });
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(
+        loong_app::internal_events::internal_event_segment_path("segment-000001")
+            .parent()
+            .expect("segment parent"),
+    )
+    .expect("create segment parent");
+    fs::write(
+        loong_app::internal_events::internal_event_journal_state_path(),
+        format!(
+            concat!(
+                "{{\n",
+                "  \"schema_version\": 1,\n",
+                "  \"active_segment_id\": \"segment-000004\",\n",
+                "  \"segments\": [\n",
+                "    {{\"segment_id\":\"segment-000001\",\"status\":\"sealed\",\"created_at_ms\":10,\"sealed_at_ms\":{old_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000002\",\"status\":\"sealed\",\"created_at_ms\":20,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000003\",\"status\":\"sealed\",\"created_at_ms\":30,\"sealed_at_ms\":{young_ms}}},\n",
+                "    {{\"segment_id\":\"segment-000004\",\"status\":\"active\",\"created_at_ms\":50}}\n",
+                "  ]\n",
+                "}}\n"
+            ),
+            old_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(120))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+            young_ms = (time::OffsetDateTime::now_utc() - time::Duration::seconds(5))
+                .unix_timestamp_nanos()
+                / 1_000_000,
+        ),
+    )
+    .expect("write journal state");
+    for segment_id in [
+        "segment-000001",
+        "segment-000002",
+        "segment-000003",
+        "segment-000004",
+    ] {
+        fs::write(
+            loong_app::internal_events::internal_event_segment_path(segment_id),
+            format!(
+                "{{\"event_name\":\"session.cancelled\",\"payload\":{{\"segment_id\":\"{segment_id}\"}},\"recorded_at_ms\":1}}\n"
+            ),
+        )
+        .expect("write segment");
+    }
+    fs::write(
+        automation_cursor_path(&loong_home),
+        concat!(
+            "{\n",
+            "  \"segment_id\": \"segment-000004\",\n",
+            "  \"line_cursor\": 1,\n",
+            "  \"byte_offset\": 10,\n",
+            "  \"journal_fingerprint\": \"abc\"\n",
+            "}\n"
+        ),
+    )
+    .expect("write cursor payload");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: None,
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Journal(
+                loong_daemon::automation_cli::AutomationJournalCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationJournalCommands::Prune(
+                        loong_daemon::automation_cli::AutomationJournalPruneCommandOptions {
+                            retain_segment_id: None,
+                            retain_last_sealed: None,
+                            retain_min_age_seconds: None,
+                            dry_run: true,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("dry-run journal prune with default config path");
+
+    assert_eq!(
+        config_path.file_name().and_then(|value| value.to_str()),
+        Some("config.toml")
+    );
+    assert_eq!(payload["retain_last_sealed_segments"], 1);
+    assert_eq!(payload["retain_min_age_ms"], 60_000);
+    assert_eq!(payload["pruned_segments"], json!(["segment-000001"]));
     drop(guard);
 }
 
@@ -3315,6 +3665,309 @@ async fn automation_serve_missing_segment_cursor_skips_older_surviving_segment()
     .expect("parse cursor payload");
     assert_eq!(cursor_payload["segment_id"], "segment-000003");
     assert_eq!(cursor_payload["line_cursor"], 1);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_uses_automation_config_defaults_for_retention_and_polling() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-serve-config-defaults");
+    let config_path = write_automation_config_with(root.path(), |config| {
+        config.automation.event_path = "/automation/config-defaults".to_owned();
+        config.automation.poll_ms = 250;
+        config.automation.retain_last_sealed_segments = 1;
+    });
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000001\n",
+    )
+    .expect("seed active segment id");
+
+    let create_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::CreateEvent(
+                loong_daemon::automation_cli::AutomationCreateEventCommandOptions {
+                    name: "Segment Retention Config Defaults".to_owned(),
+                    event: "session.cancelled".to_owned(),
+                    json_pointer: Some("/session_id".to_owned()),
+                    equals_json: None,
+                    equals_text: None,
+                    contains_text: Some("segment-config-retention".to_owned()),
+                    session: "ops-root".to_owned(),
+                    task: "follow up on retained segment event".to_owned(),
+                    label: Some("Segment Retention Config Defaults".to_owned()),
+                    timeout_seconds: Some(30),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("create segment retention config-default trigger");
+    let trigger_id = create_payload["trigger"]["trigger_id"]
+        .as_str()
+        .expect("trigger id")
+        .to_owned();
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve with config defaults");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    append_internal_event_to_journal(
+        "session.cancelled",
+        &serde_json::json!({
+            "session_id": "delegate:segment-config-retention-1"
+        }),
+    )
+    .expect("append first segment row");
+    let first_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 1).await;
+    assert!(first_show["trigger"]["last_error"].is_null());
+
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000002\n",
+    )
+    .expect("promote second segment to active");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000002"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:segment-config-retention-2\"},\"recorded_at_ms\":9}\n",
+    )
+    .expect("write second segment");
+    let second_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 2).await;
+    assert!(second_show["trigger"]["last_error"].is_null());
+
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000003\n",
+    )
+    .expect("promote third segment to active");
+    fs::write(
+        loong_app::internal_events::internal_event_segment_path("segment-000003"),
+        "{\"event_name\":\"session.cancelled\",\"payload\":{\"session_id\":\"delegate:segment-config-retention-3\"},\"recorded_at_ms\":10}\n",
+    )
+    .expect("write third segment");
+    let third_show = wait_for_trigger_fire_count(&config_path, &trigger_id, 3).await;
+    assert!(third_show["trigger"]["last_error"].is_null());
+
+    let runner_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner config defaults");
+    assert_eq!(
+        runner_payload["status"]["event_path"],
+        "/automation/config-defaults"
+    );
+    assert_eq!(runner_payload["status"]["poll_ms"], 250);
+    assert_eq!(runner_payload["status"]["retain_last_sealed_segments"], 1);
+
+    assert!(
+        !loong_app::internal_events::internal_event_segment_path("segment-000001").exists(),
+        "oldest sealed segment should be pruned by serve using config-backed defaults"
+    );
+    assert!(
+        loong_app::internal_events::internal_event_segment_path("segment-000002").exists(),
+        "newest sealed segment should be retained by serve using config-backed defaults"
+    );
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_prefers_cli_policy_over_automation_config_defaults() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-serve-config-override");
+    let config_path = write_automation_config_with(root.path(), |config| {
+        config.automation.event_path = "/automation/from-config".to_owned();
+        config.automation.poll_ms = 900;
+        config.automation.retain_last_sealed_segments = 3;
+        config.automation.retain_min_age_seconds = Some(60);
+    });
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000001\n",
+    )
+    .expect("seed active segment id");
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--path",
+            "/automation/from-cli",
+            "--poll-ms",
+            "250",
+            "--retain-last-sealed",
+            "1",
+            "--retain-min-age-seconds",
+            "5",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve with explicit overrides");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    let runner_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner explicit overrides");
+
+    assert_eq!(
+        runner_payload["status"]["event_path"],
+        "/automation/from-cli"
+    );
+    assert_eq!(runner_payload["status"]["poll_ms"], 250);
+    assert_eq!(runner_payload["status"]["retain_last_sealed_segments"], 1);
+    assert_eq!(runner_payload["status"]["retain_min_age_ms"], 5_000);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_uses_default_config_path_when_flag_is_omitted() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-serve-default-config-path");
+    let loong_home = root.path().join("loong-home");
+    let config_path = write_default_automation_config_with(&loong_home, |config| {
+        config.automation.event_path = "/automation/from-default-config".to_owned();
+        config.automation.poll_ms = 250;
+        config.automation.retain_last_sealed_segments = 1;
+        config.automation.retain_min_age_seconds = Some(5);
+    });
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    fs::create_dir_all(loong_app::internal_events::internal_event_segments_dir())
+        .expect("create internal event segments dir");
+    fs::write(
+        loong_app::internal_events::internal_event_active_segment_id_path(),
+        "segment-000001\n",
+    )
+    .expect("seed active segment id");
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args(["automation", "serve"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve with default config path");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+
+    let runner_payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: None,
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner default config path");
+
+    assert_eq!(
+        config_path.file_name().and_then(|value| value.to_str()),
+        Some("config.toml")
+    );
+    assert_eq!(
+        runner_payload["status"]["event_path"],
+        "/automation/from-default-config"
+    );
+    assert_eq!(runner_payload["status"]["poll_ms"], 250);
+    assert_eq!(runner_payload["status"]["retain_last_sealed_segments"], 1);
+    assert_eq!(runner_payload["status"]["retain_min_age_ms"], 5_000);
 
     serve.kill().expect("stop automation serve");
     let _ = serve.wait();

--- a/crates/daemon/tests/integration/automation_cli.rs
+++ b/crates/daemon/tests/integration/automation_cli.rs
@@ -136,6 +136,16 @@ fn automation_serve_lock_path(loong_home: &Path) -> PathBuf {
     loong_home.join("automation").join("serve.lock")
 }
 
+fn automation_runner_status_snapshot_path(loong_home: &Path) -> PathBuf {
+    loong_home.join("automation").join("serve.status.json")
+}
+
+fn automation_runner_stop_request_path(loong_home: &Path) -> PathBuf {
+    loong_home
+        .join("automation")
+        .join("serve.stop-request.json")
+}
+
 fn wait_for_path(path: &Path, description: &str) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
     loop {
@@ -147,6 +157,72 @@ fn wait_for_path(path: &Path, description: &str) {
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
+}
+
+fn wait_for_path_absent(path: &Path, description: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        if !path.exists() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for {description} to disappear at {}",
+                path.display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn seed_stale_automation_runner_state(loong_home: &Path, config_path: &Path, owner_token: &str) {
+    let stale_runner_state = json!({
+        "phase": "running",
+        "running": true,
+        "pid": 4242,
+        "version": "test",
+        "config_path": config_path.display().to_string(),
+        "bind_address": Value::Null,
+        "event_path": "/automation/events",
+        "poll_ms": 250,
+        "started_at_ms": 1,
+        "last_heartbeat_at": 1,
+        "stopped_at_ms": Value::Null,
+        "shutdown_reason": Value::Null,
+        "last_error": Value::Null,
+        "owner_token": owner_token,
+    });
+    let encoded_runner_state =
+        serde_json::to_string_pretty(&stale_runner_state).expect("encode stale runner state");
+    let encoded_runner_state = format!("{encoded_runner_state}\n");
+    let automation_dir = loong_home.join("automation");
+    fs::create_dir_all(&automation_dir).expect("create automation dir");
+    fs::write(
+        automation_serve_lock_path(loong_home).as_path(),
+        encoded_runner_state.as_bytes(),
+    )
+    .expect("write stale serve lock");
+    fs::write(
+        automation_runner_status_snapshot_path(loong_home).as_path(),
+        encoded_runner_state.as_bytes(),
+    )
+    .expect("write stale serve status snapshot");
+}
+
+fn seed_automation_runner_stop_request(loong_home: &Path, owner_token: &str) {
+    let stop_request = json!({
+        "requested_at_ms": 2,
+        "requested_by_pid": 4242,
+        "target_owner_token": owner_token,
+    });
+    let encoded_stop_request =
+        serde_json::to_string_pretty(&stop_request).expect("encode stale stop request");
+    let encoded_stop_request = format!("{encoded_stop_request}\n");
+    fs::write(
+        automation_runner_stop_request_path(loong_home).as_path(),
+        encoded_stop_request.as_bytes(),
+    )
+    .expect("write stale stop request");
 }
 
 fn wait_for_serve_lock(child: &mut Child, path: &Path) {
@@ -854,6 +930,153 @@ async fn automation_runner_stop_requests_shutdown_for_running_owner() {
     .expect("inspect automation runner after stop");
     assert_eq!(status_payload["status"]["running"], false);
 
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_runner_inspect_reports_stale_lease_metadata() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-runner-stale-inspect");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let _env = MigrationEnvironmentGuard::set(&[("LOONG_HOME", Some(loong_home_text.as_str()))]);
+
+    seed_stale_automation_runner_state(&loong_home, &config_path, "owner-stale-inspect");
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect stale automation runner");
+
+    assert_eq!(payload["command"], "runner_inspect");
+    assert_eq!(payload["status"]["running"], true);
+    assert_eq!(payload["status"]["stale"], true);
+    assert_eq!(payload["status"]["lease_timeout_ms"], 15_000);
+    assert_eq!(payload["status"]["lease_expires_at_ms"], 15_001);
+
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_runner_reclaim_marks_stale_owner_stopped_and_clears_slot() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-runner-reclaim");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let _env = MigrationEnvironmentGuard::set(&[("LOONG_HOME", Some(loong_home_text.as_str()))]);
+
+    let owner_token = "owner-stale-reclaim";
+    seed_stale_automation_runner_state(&loong_home, &config_path, owner_token);
+    seed_automation_runner_stop_request(&loong_home, owner_token);
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Reclaim(
+                        loong_daemon::automation_cli::AutomationRunnerReclaimCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("reclaim stale automation runner");
+
+    assert_eq!(payload["command"], "runner_reclaim");
+    assert_eq!(payload["outcome"], "reclaimed");
+    assert_eq!(payload["status"]["running"], false);
+    assert_eq!(payload["status"]["shutdown_reason"], "stale_reclaimed");
+    assert!(!automation_serve_lock_path(&loong_home).exists());
+    assert!(!automation_runner_stop_request_path(&loong_home).exists());
+
+    drop(guard);
+}
+
+#[tokio::test]
+async fn automation_serve_reclaims_stale_owner_slot_before_start() {
+    let guard = lock_automation_integration().await;
+    let root = TempDirGuard::new("loong-automation-runner-stale-start");
+    let config_path = write_automation_config(root.path());
+    let loong_home = root.path().join("loong-home");
+    fs::create_dir_all(&loong_home).expect("create loong home");
+
+    let loong_home_text = loong_home.display().to_string();
+    let detached_binary = env!("CARGO_BIN_EXE_loong").to_owned();
+    let _env = MigrationEnvironmentGuard::set(&[
+        ("LOONG_HOME", Some(loong_home_text.as_str())),
+        ("CARGO_BIN_EXE_loong", Some(detached_binary.as_str())),
+    ]);
+
+    let owner_token = "owner-stale-start";
+    seed_stale_automation_runner_state(&loong_home, &config_path, owner_token);
+    seed_automation_runner_stop_request(&loong_home, owner_token);
+
+    let mut serve = Command::new(env!("CARGO_BIN_EXE_loong"))
+        .env("LOONG_HOME", loong_home_text.as_str())
+        .env("CARGO_BIN_EXE_loong", detached_binary.as_str())
+        .args([
+            "automation",
+            "serve",
+            "--config",
+            config_path.to_string_lossy().as_ref(),
+            "--poll-ms",
+            "250",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn automation serve after stale owner");
+
+    wait_for_serve_lock(
+        &mut serve,
+        automation_serve_lock_path(&loong_home).as_path(),
+    );
+    wait_for_path_absent(
+        automation_runner_stop_request_path(&loong_home).as_path(),
+        "stale automation runner stop request",
+    );
+
+    let payload = loong_daemon::automation_cli::execute_automation_command(
+        loong_daemon::automation_cli::AutomationCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loong_daemon::automation_cli::AutomationCommands::Runner(
+                loong_daemon::automation_cli::AutomationRunnerCommandOptions {
+                    command: loong_daemon::automation_cli::AutomationRunnerCommands::Inspect(
+                        loong_daemon::automation_cli::AutomationRunnerInspectCommandOptions::default(),
+                    ),
+                },
+            ),
+        },
+    )
+    .await
+    .expect("inspect automation runner after stale reclaim");
+
+    assert_eq!(payload["status"]["running"], true);
+    assert_eq!(payload["status"]["stale"], false);
+
+    serve.kill().expect("stop automation serve");
+    let _ = serve.wait();
     drop(guard);
 }
 

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -29,6 +29,46 @@ fn root_help_uses_onboarding_language() {
 }
 
 #[test]
+fn automation_help_mentions_guide_and_trigger_selection() {
+    let help = render_cli_help(["automation"]);
+
+    assert!(
+        help.contains("automation guide"),
+        "automation help should point operators at the guidance entrypoint: {help}"
+    );
+    assert!(
+        help.contains("create-schedule"),
+        "automation help should mention schedule guidance: {help}"
+    );
+    assert!(
+        help.contains("create-cron") && help.contains("cron preview"),
+        "automation help should mention the cron preview and create flow: {help}"
+    );
+    assert!(
+        help.contains("create-event"),
+        "automation help should mention event guidance: {help}"
+    );
+    assert!(
+        help.contains("automation serve"),
+        "automation help should mention the live runner requirement: {help}"
+    );
+}
+
+#[test]
+fn automation_guide_cli_parses() {
+    let cli = try_parse_cli(["loong", "automation", "guide"])
+        .expect("`loong automation guide` should parse");
+
+    match cli.command {
+        Some(Commands::Automation {
+            command: loong_daemon::automation_cli::AutomationCommands::Guide(_),
+            ..
+        }) => {}
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn welcome_subcommand_help_advertises_first_run_shortcuts() {
     let help = render_cli_help(["welcome"]);
 

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -1544,8 +1544,26 @@ fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
     );
 }
 
+fn clear_memory_runtime_env_overrides(env: &mut loong_daemon::test_support::ScopedEnv) {
+    for key in [
+        "LOONG_MEMORY_BACKEND",
+        "LOONG_MEMORY_SYSTEM",
+        "LOONG_MEMORY_PROFILE",
+        "LOONG_MEMORY_FAIL_OPEN",
+        "LOONG_MEMORY_INGEST_MODE",
+        "LOONG_SQLITE_PATH",
+        "LOONG_SLIDING_WINDOW",
+        "LOONG_MEMORY_SUMMARY_MAX_CHARS",
+        "LOONG_MEMORY_PROFILE_NOTE",
+    ] {
+        env.remove(key);
+    }
+}
+
 #[test]
 fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
+    let mut env = loong_daemon::test_support::ScopedEnv::new();
+    clear_memory_runtime_env_overrides(&mut env);
     let config = mvp::config::LoongConfig {
         memory: mvp::config::MemoryConfig {
             profile: mvp::config::MemoryProfile::WindowPlusSummary,
@@ -1603,19 +1621,7 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
 #[test]
 fn render_memory_system_snapshot_text_reports_fail_open_policy() {
     let mut env = loong_daemon::test_support::ScopedEnv::new();
-    for key in [
-        "LOONG_MEMORY_BACKEND",
-        "LOONG_MEMORY_SYSTEM",
-        "LOONG_MEMORY_PROFILE",
-        "LOONG_MEMORY_FAIL_OPEN",
-        "LOONG_MEMORY_INGEST_MODE",
-        "LOONG_SQLITE_PATH",
-        "LOONG_SLIDING_WINDOW",
-        "LOONG_MEMORY_SUMMARY_MAX_CHARS",
-        "LOONG_MEMORY_PROFILE_NOTE",
-    ] {
-        env.remove(key);
-    }
+    clear_memory_runtime_env_overrides(&mut env);
     let config = mvp::config::LoongConfig {
         memory: mvp::config::MemoryConfig {
             profile: mvp::config::MemoryProfile::WindowPlusSummary,

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -125,6 +125,7 @@ fn validation_diagnostic_with_severity(
 mod acp;
 mod architecture;
 mod ask_cli;
+mod automation_cli;
 mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -193,7 +193,7 @@ pub(super) fn write_tasks_config(root: &Path) -> PathBuf {
     write_tasks_config_with(root, |_| {})
 }
 
-fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str) {
+pub(super) fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str) {
     let repo = load_session_repository(config_path);
     seed_background_task_record(&repo, root_session_id, task_id, true);
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Not every file under `docs/` belongs in the normal public reading path.
 | --- | --- | --- |
 | read Loong like a public docs site visitor | [`../site/index.mdx`](../site/index.mdx) | `site/` is the main reader-facing docs surface |
 | understand runtime shape, boundaries, and crate responsibilities | [`design-docs/index.md`](design-docs/index.md) | source-facing architecture references live there |
+| understand how Loong should model scheduled work, webhook ingress, and future hook-triggered automation | [`design-docs/automation-triggering.md`](design-docs/automation-triggering.md) | the trigger model now lives in one source-facing design document |
 | trace how turns enter the runtime from CLI, channels, gateway, control plane, or daemon tasks | [`design-docs/runtime-entrypoint-map.md`](design-docs/runtime-entrypoint-map.md) | this is the fastest repo-native map for bootstrap and handoff differences |
 | edit or review product specs or implementation plans | `eastreams/knowledge-base` | source contracts and plans no longer live in the main repository |
 | check roadmap, reliability, product, or security references from the repository | [`ROADMAP.md`](ROADMAP.md), [`RELIABILITY.md`](RELIABILITY.md), [`PRODUCT_SENSE.md`](PRODUCT_SENSE.md), [`SECURITY.md`](SECURITY.md) | these are the repository-native reference documents |

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -109,6 +109,9 @@ journal:
 - manual journal pruning is now policy-aware instead of purely cursor-floor
   driven: operators can dry-run a prune plan, retain the latest sealed
   segments, and keep recently sealed segments above a minimum age threshold
+- the same retention policy shape now applies to both manual prune and the
+  automatic prune path inside `automation serve`, so operator dry-runs and
+  steady-state runtime behavior no longer diverge
 - `internal-events.state.json` is now the richer layout truth for segmented
   journals, with the legacy `internal-events.active` marker retained as a
   compatibility shadow
@@ -118,6 +121,12 @@ journal:
   segment exceeds the configured byte budget
   (`LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES`), with a conservative built-in
   default
+- automation policy defaults can now be carried through the config surface via
+  `[automation]`; when operators run `automation serve` or
+  `automation journal prune` against a Loong config file, whether by explicit
+  `--config <path>` or the default config path, the loaded config supplies the
+  default event path, poll cadence, retention window, and segment rotation
+  threshold
 
 This is still a transition state rather than the final architecture. Some
 surfaces still retain an immediate compatibility bridge so automation can work
@@ -139,6 +148,8 @@ best-effort background loop.
   after roughly 15 seconds without a heartbeat
 - `automation runner inspect` now surfaces lease timeout and lease expiry so
   operators can see whether a slot is live or stale
+- `automation runner inspect` also surfaces the effective automatic retention
+  settings that the live `automation serve` owner is using
 - `automation runner stop` is for graceful shutdown of a live owner
 - `automation runner reclaim` is for explicitly reclaiming a stale owner slot;
   it marks the snapshot as stopped with a `stale_reclaimed` reason before
@@ -237,6 +248,14 @@ set of sources that proves the model:
 - cron expressions can be previewed without creating a trigger, so operators
   can validate UTC cadence and the next bounded fire times before persisting
   automation state
+- when `automation serve` starts against a Loong config file without explicit
+  retention or poll flags, it now falls back to `[automation]` config defaults
+  instead of only hardcoded CLI defaults
+- when `automation journal prune` runs against a Loong config file and omits
+  explicit keep-last or minimum-age flags, it now uses the same `[automation]`
+  defaults that the live runner uses
+- explicit `automation serve` and `automation journal prune` flags still win
+  over loaded `[automation]` defaults
 - event triggers may optionally require a JSON-pointer payload value match
 - app-owned internal events now preserve `_automation.source_surface`
 - internal journal consumption is a runtime substrate concern only; journal rows
@@ -248,6 +267,8 @@ set of sources that proves the model:
   `automation serve` owner
 - manual journal pruning can now be run as a dry-run policy evaluation before
   any segment is deleted
+- automatic journal pruning now follows the same keep-last / minimum-age policy
+  surface instead of a cursor-floor-only rule
 - failed fires keep their trigger record and retry on a bounded later tick
 - webhook ingress requires an explicit token when configured
 
@@ -263,5 +284,5 @@ The intentionally reserved next steps are:
 - richer retention policy and GC beyond the current cursor floor + keep-last +
   minimum-age policy
 - richer operator-facing journal health and repair/reporting surfaces
-- policy/config hardening around automatic rotation thresholds and retention
-  controls
+- broader validation and operator-facing reporting around automatic rotation
+  thresholds and retention controls

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -52,6 +52,8 @@ Loong now uses a small trigger record with:
 - `cron`
   - 5-field cron expression with a materialized `next_fire_at_ms`
   - current first slice evaluates cron in UTC
+  - operators can preview the next bounded UTC fire times before persisting a
+    trigger through `automation cron preview`
 - `event`
   - exact named event match such as `github.pr.opened` or
     `session.compaction.completed`
@@ -104,6 +106,9 @@ journal:
 - `automation serve` can now prune sealed segments that are strictly older than
   the persisted cursor segment after a successful cursor write, which gives
   Loong a first minimal retention behavior without touching the active segment
+- manual journal pruning is now policy-aware instead of purely cursor-floor
+  driven: operators can dry-run a prune plan, retain the latest sealed
+  segments, and keep recently sealed segments above a minimum age threshold
 - `internal-events.state.json` is now the richer layout truth for segmented
   journals, with the legacy `internal-events.active` marker retained as a
   compatibility shadow
@@ -229,6 +234,9 @@ set of sources that proves the model:
   catch-up bursts
 - cron schedules also persist a materialized next-fire cursor and recompute
   from their expression after each fire
+- cron expressions can be previewed without creating a trigger, so operators
+  can validate UTC cadence and the next bounded fire times before persisting
+  automation state
 - event triggers may optionally require a JSON-pointer payload value match
 - app-owned internal events now preserve `_automation.source_surface`
 - internal journal consumption is a runtime substrate concern only; journal rows
@@ -238,6 +246,8 @@ set of sources that proves the model:
   bridges
 - the immediate callback bridge is only used when there is no live non-stale
   `automation serve` owner
+- manual journal pruning can now be run as a dry-run policy evaluation before
+  any segment is deleted
 - failed fires keep their trigger record and retry on a bounded later tick
 - webhook ingress requires an explicit token when configured
 
@@ -250,8 +260,8 @@ The intentionally reserved next steps are:
 - runtime lifecycle emitters for hook-style events
 - multi-owner scheduling or standby/failover behavior beyond the current leased
   singleton owner model
-- broader retention policy and GC beyond the current minimal “older sealed
-  segments only” pruning rule
+- richer retention policy and GC beyond the current cursor floor + keep-last +
+  minimum-age policy
 - richer operator-facing journal health and repair/reporting surfaces
 - policy/config hardening around automatic rotation thresholds and retention
   controls

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -84,15 +84,35 @@ journal:
 - producers emit named internal events from app/runtime surfaces
 - internal events are appended to `internal-events.jsonl`
 - automation consumers can read from that journal with a persisted cursor
-- the cursor now stores both `line_cursor` and `byte_offset`, so long-running
-  consumers can resume with incremental reads instead of rescanning the whole
-  journal on every poll
+- the cursor now stores `segment_id`, `line_cursor`, and `byte_offset`, so
+  long-running consumers can resume with incremental reads instead of
+  rescanning the whole journal on every poll
 - the cursor also carries a lightweight journal fingerprint so consumers can
   detect file replacement/rotation instead of blindly seeking into a different
   file that happens to be the same size or larger
 - journal appends now take an OS file lock before writing, which makes the
   append path safer under concurrent emitters and gives future rotation work a
   clearer synchronization boundary
+- cursor persistence now follows the same temp-write plus rename pattern as the
+  automation trigger store, so serve-side cursor updates do not rely on
+  truncate-in-place writes
+- the journal can now be read across multiple ordered segments, which is the
+  first step toward safe rotation and retention instead of treating every file
+  replacement as a full replay boundary
+- the active segment marker now acts as writer truth, so future appends can
+  move onto a new segment without relying on “last discovered file” heuristics
+- `automation serve` can now prune sealed segments that are strictly older than
+  the persisted cursor segment after a successful cursor write, which gives
+  Loong a first minimal retention behavior without touching the active segment
+- `internal-events.state.json` is now the richer layout truth for segmented
+  journals, with the legacy `internal-events.active` marker retained as a
+  compatibility shadow
+- operators can now inspect, rotate, and prune the automation journal through
+  the automation CLI surface instead of relying on direct file manipulation
+- append paths can now auto-rotate onto a fresh segment when the active
+  segment exceeds the configured byte budget
+  (`LOONG_INTERNAL_EVENT_SEGMENT_MAX_BYTES`), with a conservative built-in
+  default
 
 This is still a transition state rather than the final architecture. Some
 surfaces still retain an immediate compatibility bridge so automation can work
@@ -201,7 +221,10 @@ The intentionally reserved next steps are:
 
 - move remaining daemon-side bridges onto the same app-owned internal event
   substrate
-- make `automation serve` journal-first so the durable journal becomes the
-  primary consumer path
 - runtime lifecycle emitters for hook-style events
 - singleton ownership and lease-backed serving for multi-process automation
+- broader retention policy and GC beyond the current minimal “older sealed
+  segments only” pruning rule
+- richer operator-facing journal health and repair/reporting surfaces
+- policy/config hardening around automatic rotation thresholds and retention
+  controls

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -63,6 +63,27 @@ Webhook ingress is intentionally modeled as a transport that emits named events
 instead of as a separate trigger type. That keeps external webhooks and future
 internal hooks on the same surface.
 
+### Operator And Agent Guidance
+
+The intended decision order is:
+
+- choose `schedule` when the real intent is one future run or a fixed
+  every-N-seconds cadence
+- choose `cron` when the real intent is wall-clock recurrence such as weekdays
+  at 09:00 UTC
+- choose `event` when a webhook, runtime mutation, or named internal event
+  already exists and time is not the real source of truth
+
+To keep the CLI usable for agents instead of only humans reading docs:
+
+- `automation guide` is the decision entrypoint for picking a trigger type and
+  finding the shortest correct command recipe
+- `automation cron preview` is the review step before persisting a cron trigger
+- trigger detail and preview output now carry “when to use” and “next step”
+  guidance instead of only raw fields
+- `automation serve` remains the live runner for durable cron delivery, webhook
+  ingress, and journal-backed internal-event consumption
+
 ### Actions
 
 The first action type is `background_task`, which queues the existing detached

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -120,6 +120,30 @@ without a long-running `automation serve` owner. The long-term target is
 journal-first consumption, with the callback bridge demoted to compatibility or
 removed entirely.
 
+## Automation Runner Ownership
+
+`automation serve` now operates as a leased singleton owner, not just a
+best-effort background loop.
+
+- the active owner is published through `serve.lock`
+- the latest observable runner state is published through `serve.status.json`
+- cooperative shutdown requests are published through `serve.stop-request.json`
+- runner state is keyed by an `owner_token`, so cleanup only removes lock or
+  stop-request state that still belongs to the same owner
+- the runner emits a heartbeat roughly every 5 seconds and becomes reclaimable
+  after roughly 15 seconds without a heartbeat
+- `automation runner inspect` now surfaces lease timeout and lease expiry so
+  operators can see whether a slot is live or stale
+- `automation runner stop` is for graceful shutdown of a live owner
+- `automation runner reclaim` is for explicitly reclaiming a stale owner slot;
+  it marks the snapshot as stopped with a `stale_reclaimed` reason before
+  clearing the stale owner file
+- startup rejects a live owner, but it may reclaim a stale owner before
+  acquiring the slot for the new serve process
+
+This remains a leased singleton model. Multi-owner scheduling or standby/failover
+coordination is still future work.
+
 ## Why Not Full Cron First
 
 We deliberately did not start with a full cron expression engine in this slice.
@@ -212,6 +236,8 @@ set of sources that proves the model:
   trigger/runtime efficiency without increasing LLM token usage
   provenance so consumers can distinguish app/runtime sources from daemon-side
   bridges
+- the immediate callback bridge is only used when there is no live non-stale
+  `automation serve` owner
 - failed fires keep their trigger record and retry on a bounded later tick
 - webhook ingress requires an explicit token when configured
 
@@ -222,7 +248,8 @@ The intentionally reserved next steps are:
 - move remaining daemon-side bridges onto the same app-owned internal event
   substrate
 - runtime lifecycle emitters for hook-style events
-- singleton ownership and lease-backed serving for multi-process automation
+- multi-owner scheduling or standby/failover behavior beyond the current leased
+  singleton owner model
 - broader retention policy and GC beyond the current minimal “older sealed
   segments only” pruning rule
 - richer operator-facing journal health and repair/reporting surfaces

--- a/docs/design-docs/automation-triggering.md
+++ b/docs/design-docs/automation-triggering.md
@@ -1,0 +1,207 @@
+# Automation Triggering
+
+This document defines the first durable triggering model for Loong automation.
+
+## Problem
+
+Loong already had two important pieces:
+
+- a truthful background-task surface built on detached child sessions
+- inbound webhook/channel runtime paths that can already enter the shared turn runtime
+
+What was missing was a small operator-facing trigger model that could answer
+three different needs without splitting execution ownership:
+
+- schedule work for later
+- trigger work from external events such as webhooks
+- leave room for future lifecycle hooks without creating a third automation
+  state model
+
+## Reference Synthesis
+
+The reference projects split into a few stable patterns:
+
+- `openclaw` treats cron, heartbeat, hooks, and webhooks as one product area,
+  but still routes execution back into task and session surfaces
+- `hermes-agent` uses a dedicated cron subsystem with durable job storage,
+  a daemon tick loop, file locking, and explicit delivery paths
+- `badlogic/pi-mono` emphasizes extension hooks and event-bus style triggering
+  more than scheduler ownership
+- `openai/codex` models hooks as structured runtime events with typed payloads
+  and execution summaries, not as a second agent runtime
+- `paseo` persists schedules as first-class records with cadence, target, and
+  run history
+
+The common lesson is that timing, event ingress, and hook surfaces should be
+different trigger sources that converge on one execution substrate.
+
+## Chosen Model
+
+Loong now uses a small trigger record with:
+
+- one durable trigger id and status
+- one trigger source
+- one action
+- last-fire bookkeeping plus bounded run history
+
+### Trigger Sources
+
+- `schedule`
+  - one-shot via `next_fire_at_ms`
+  - recurring interval via `interval_ms`
+- `cron`
+  - 5-field cron expression with a materialized `next_fire_at_ms`
+  - current first slice evaluates cron in UTC
+- `event`
+  - exact named event match such as `github.pr.opened` or
+    `session.compaction.completed`
+  - optional payload conditions via JSON-pointer `exists`, equality, or text-contains matching
+
+Webhook ingress is intentionally modeled as a transport that emits named events
+instead of as a separate trigger type. That keeps external webhooks and future
+internal hooks on the same surface.
+
+### Actions
+
+The first action type is `background_task`, which queues the existing detached
+delegate/task workflow instead of inventing a second worker runtime.
+
+That choice keeps:
+
+- session lineage
+- approval truth
+- timeout handling
+- task inspection
+- runtime diagnostics
+
+inside the already-shipped task substrate.
+
+## Internal Event Substrate
+
+Loong now has an app-owned internal event publication seam plus a durable
+journal:
+
+- producers emit named internal events from app/runtime surfaces
+- internal events are appended to `internal-events.jsonl`
+- automation consumers can read from that journal with a persisted cursor
+- the cursor now stores both `line_cursor` and `byte_offset`, so long-running
+  consumers can resume with incremental reads instead of rescanning the whole
+  journal on every poll
+- the cursor also carries a lightweight journal fingerprint so consumers can
+  detect file replacement/rotation instead of blindly seeking into a different
+  file that happens to be the same size or larger
+- journal appends now take an OS file lock before writing, which makes the
+  append path safer under concurrent emitters and gives future rotation work a
+  clearer synchronization boundary
+
+This is still a transition state rather than the final architecture. Some
+surfaces still retain an immediate compatibility bridge so automation can work
+without a long-running `automation serve` owner. The long-term target is
+journal-first consumption, with the callback bridge demoted to compatibility or
+removed entirely.
+
+## Why Not Full Cron First
+
+We deliberately did not start with a full cron expression engine in this slice.
+
+Reasons:
+
+- Loong did not already ship a cron parser in the current dependency contract
+- the most important architectural decision was unifying execution, not adding
+  the broadest schedule syntax
+- one-shot and interval scheduling already cover the first useful operator
+  workflows while keeping the surface small and reviewable
+
+Nothing in this model blocks a future upgrade from interval scheduling to
+cron-expression scheduling. That would be a source-shape expansion, not a new
+automation system.
+
+## Hooks Positioning
+
+The current `event` trigger source is the compatibility bridge for future
+hooks.
+
+Near-term meaning:
+
+- operators can emit named events manually
+- HTTP webhook ingress can emit named events
+- automation rules can subscribe to named events
+
+Future meaning:
+
+- runtime lifecycle surfaces can emit the same named events directly
+- provider-native hook bridges can normalize external hook payloads into the
+  same event names
+
+This keeps hook adoption additive instead of forcing a later migration from
+`hooks` to `events`.
+
+## Current Internal Event Sources
+
+The current built-in emitters cover three source families:
+
+- app session mutation surfaces
+- app work-unit repository surfaces
+- daemon-side background-task operator surfaces
+
+Successful mutations now emit named events that can be matched by `event`
+triggers.
+
+Current names:
+
+- `background_task.queued`
+- `background_task.cancelled`
+- `background_task.recovered`
+- `session.cancelled`
+- `session.recovered`
+- `session.archived`
+- `work_unit.created`
+- `work_unit.leased`
+- `work_unit.started`
+- `work_unit.heartbeat`
+- `work_unit.completed`
+- `work_unit.retry_pending`
+- `work_unit.failed_terminal`
+- `work_unit.cancelled`
+- `work_unit.recovered`
+- `work_unit.archived`
+- `work_unit.assigned`
+- `work_unit.updated`
+- `work_unit.dependency_added`
+- `work_unit.dependency_removed`
+- `work_unit.noted`
+
+These are not yet the full Loong hook vocabulary. They are the first stable
+set of sources that proves the model:
+
+`runtime mutation -> named event -> trigger match -> background task`
+
+## Operational Rules
+
+- scheduled and event-driven automation only queue background tasks; they do
+  not run a shadow execution lane
+- one-shot schedules complete after a successful fire
+- recurring schedules reschedule from actual fire time instead of attempting
+  catch-up bursts
+- cron schedules also persist a materialized next-fire cursor and recompute
+  from their expression after each fire
+- event triggers may optionally require a JSON-pointer payload value match
+- app-owned internal events now preserve `_automation.source_surface`
+- internal journal consumption is a runtime substrate concern only; journal rows
+  are not meant to be injected into model prompts, so this design improves
+  trigger/runtime efficiency without increasing LLM token usage
+  provenance so consumers can distinguish app/runtime sources from daemon-side
+  bridges
+- failed fires keep their trigger record and retry on a bounded later tick
+- webhook ingress requires an explicit token when configured
+
+## Follow-on Work
+
+The intentionally reserved next steps are:
+
+- move remaining daemon-side bridges onto the same app-owned internal event
+  substrate
+- make `automation serve` journal-first so the durable journal becomes the
+  primary consumer path
+- runtime lifecycle emitters for hook-style events
+- singleton ownership and lease-backed serving for multi-process automation

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -34,6 +34,7 @@ design backlog artifacts are intentionally out of the public docs flow.
 | [Core Beliefs](core-beliefs.md) | you need the engineering principles that should survive refactors |
 | [Layered Kernel Design](layered-kernel-design.md) | you need the crate and layer boundary model before changing runtime shape |
 | [Runtime Entrypoint and Bootstrap Map](runtime-entrypoint-map.md) | you need the shortest source-facing map of how CLI, channel, gateway, control-plane, and daemon task turns enter the shared runtime |
+| [Automation Triggering](automation-triggering.md) | you are changing schedule, webhook, event-driven, or future hook-triggered automation and need the repository-native trigger model |
 | [Single-Entry Runtime Convergence](single-entry-runtime-convergence.md) | you are working on session-vs-memory ownership or converging host turn seams without breaking the current crate contract |
 | [Harness Engineering](harness-engineering.md) | you are working on the agent-driven development environment itself |
 | [Tool Surface Exposure](tool-surface-exposure.md) | you are changing provider-visible tool exposure, discovery, or hidden-tool progressive disclosure |

--- a/docs/product-specs/background-tasks.md
+++ b/docs/product-specs/background-tasks.md
@@ -1,5 +1,12 @@
 # Background Tasks
 
+This document remains the product contract for the task-shaped async delegate
+surface itself.
+
+Scheduled and event-driven automation now live beside it, not inside it. See
+[`../design-docs/automation-triggering.md`](../design-docs/automation-triggering.md)
+for the newer trigger model that can queue these background tasks.
+
 ## User Story
 
 As a Loong operator, I want a task-shaped background work surface so that I
@@ -44,7 +51,7 @@ The current runtime already ships the substrate for this surface:
 The missing part is the operator-facing product contract that turns those
 session primitives into a coherent task workflow.
 
-## Out of Scope
+## Out of Scope For This Task Surface
 
 - cron
 - heartbeat jobs


### PR DESCRIPTION
## Summary

- Problem:
  Automation triggers had already grown a durable internal event journal, but the journal and its live runner still had soft spots: layout truth was partly heuristic, stale state could be hard to reason about, runner ownership was weaker than the journal-backed trigger path it orchestrated, and policy defaults still lived partly in CLI constants instead of one operator-visible config surface.
- Why it matters:
  Without clearer journal truth, explicit runner ownership semantics, policy-aware retention tooling, and a real config-backed default surface, rotation, retention, recovery, and long-running `automation serve` behavior stay fragile. That increases the chance of replay drift, stale state, divergent operator expectations, and difficult recovery paths.
- What changed:
  - moved the internal event journal to a manifest-backed segmented model centered on `internal-events.state.json`
  - kept segmented cursors, stale-segment normalization, rollover, and minimal safe prune aligned with that manifest truth
  - added operator-facing journal admin commands for inspect / health / rotate / prune / repair
  - added automatic segment rollover on append when the active segment crosses the configured byte budget
  - promoted `automation serve` into a managed runner control plane with inspect / stop / reclaim semantics backed by owner state, heartbeat snapshots, lease expiry, and stop requests
  - hardened the runner owner slot so active-owner detection depends on live non-stale state instead of raw file existence, startup can reclaim stale owners, and heartbeat/finalize paths are ownership-aware
  - added app-owned journal GC planning/apply helpers so retention decisions are manifest-backed instead of daemon-only heuristics
  - extended `automation journal prune` into a policy-aware surface with `--dry-run`, `--retain-last-sealed`, and `--retain-min-age-seconds`
  - aligned `automation serve` auto-prune with that same policy-backed GC model instead of the older cursor-floor-only helper
  - added `automation cron preview` so operators can inspect bounded future UTC fire times before creating a cron trigger
  - introduced an `[automation]` config surface for default event path, poll cadence, retention policy, and internal-event segment rotation threshold
  - taught `automation serve` and `automation journal prune` to honor either an explicit `--config` path or the default config file when present, while preserving config-free behavior when no config file exists
  - kept CLI flags as explicit overrides over loaded `[automation]` defaults and added regression coverage for precedence, default-config-path discovery, config round-tripping, template discoverability, and stale runtime-env clearing
  - added an `automation guide` decision surface plus clearer help / preview / trigger-detail wording so agents can choose schedule vs cron vs event without guessing from scattered subcommands
  - expanded app and daemon coverage around manifest drift, missing segments, rollover, prune, repair, health, runner lifecycle, stale-owner reclaim, GC planning, dry-run retention, serve-side policy retention, cron preview, config fallback, and CLI-over-config precedence
- What did not change (scope boundary):
  - no second automation runtime was introduced
  - no multi-owner or standby/failover scheduling for `automation serve` yet; this is still a leased singleton owner model
  - no full journal compaction; retention is still segment-oriented GC, not a compacted storage format
  - no change to the background-task execution substrate

## Linked Issues

- Closes #1388
- Related #1388

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes the durability and lifecycle semantics of the automation journal and the live automation runner, and it also moves policy defaults into a config-backed operator surface. The execution substrate stays the same, but the internal event log, serve control plane, and operator policy defaults now have stronger state, lease, retention, and discovery semantics.
- Rollout / guardrails:
  Legacy numeric cursors, legacy flat `internal-events.jsonl`, and the legacy `internal-events.active` marker remain compatible. Journal admin and runner admin surfaces are explicit. Automatic rotation is conservative and byte-budget driven. Runner ownership remains singleton even after the new lease/reclaim semantics. Retention GC stays segment-oriented and never prunes the active segment. Config-backed defaults only apply when a Loong config file is present; otherwise automation stays usable with the built-in defaults.
- Rollback path:
  Revert the PR to return to the earlier journal-backed automation substrate and CLI-owned default behavior. Trigger/action semantics remain unchanged, so rollback does not require a migration in the background-task runtime.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test --workspace --all-features`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
  passed

./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
  passed

./scripts/cargo-local-toolchain.sh test --workspace --all-features
  passed

Focused checks also passed for:
- ./scripts/cargo-local-toolchain.sh test -p loong automation_cli -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong-app automation_config_round_trips_policy_defaults -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong-app write_template_includes_automation_policy_notes -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong-app initialize_runtime_environment_ -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong gateway_openai_chat_completion_surfaces_provider_usage_in_non_streaming_response -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong gateway_openai_models_disambiguate_duplicate_model_ids_by_profile -- --nocapture
- ./scripts/cargo-local-toolchain.sh test -p loong gateway_openai_chat_completion_persists_turn_history_through_gateway_runtime -- --nocapture

Updated automation-focused integration coverage now includes:
- automation_journal_prune_prefers_cli_policy_over_automation_config_defaults
- automation_journal_prune_uses_default_config_path_when_flag_is_omitted
- automation_serve_prefers_cli_policy_over_automation_config_defaults
- automation_serve_uses_default_config_path_when_flag_is_omitted
```

## User-visible / Operator-visible Changes

- `automation journal inspect` reports journal layout, active segment, and cursor state.
- `automation journal health` reports journal drift signals such as marker/state disagreement and missing cursor segments.
- `automation journal rotate` rotates the active internal event segment.
- `automation journal prune` supports dry-run retention planning plus keep-last and minimum-age controls, and it now reads `[automation]` defaults when a config file is present and explicit flags are omitted.
- `automation journal repair` reconciles manifest/state with on-disk journal layout.
- `automation runner inspect` reports live owner state, heartbeat timing, lease timeout, lease expiry, and the active automatic retention settings.
- `automation runner stop` requests graceful shutdown for the current live serve owner.
- `automation runner reclaim` explicitly reclaims a stale owner slot and records a `stale_reclaimed` shutdown reason.
- `automation cron preview` shows the next bounded UTC fire times for a cron expression without creating a trigger.
- `automation guide` now acts as the agent/operator decision entrypoint for choosing between schedule, cron, and event triggers, with concrete command recipes.
- Internal event appends can auto-rotate to a new segment once the configured byte budget is exceeded.
- `automation serve` now uses the same policy-backed GC model as manual journal prune after cursor advancement.
- `[automation]` provides one operator-visible place to set default event path, poll cadence, retention policy, and segment rotation threshold. Explicit CLI flags still override those defaults.
- Generated config templates now explain the `[automation]` keys and what they affect.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR. Operators can also keep automation in config-free mode by omitting a config file, or avoid aggressive churn by leaving `internal_event_segment_max_bytes` unset and using explicit `automation journal rotate` only when needed.
- Observable failure symptoms reviewers should watch for:
  - cursor unexpectedly jumping to an older segment
  - sealed segments being pruned too early or contrary to the dry-run plan
  - journal inspect/health/repair disagreeing on active segment
  - post-rotation appends still landing in the old segment
  - runner inspect showing a stale owner that cannot be reclaimed
  - a reclaimed stale owner clobbering a newer live owner slot
  - cron preview disagreeing with stored `next_fire_at_ms`
  - automatic serve-side retention deleting more than the equivalent manual policy would allow
  - explicit `automation serve` / `automation journal prune` flags not winning over loaded `[automation]` defaults

## Reviewer Focus

- `crates/app/src/config/automation.rs`
  Focus on the new config surface, normalization rules, and default semantics.
- `crates/app/src/config/runtime.rs`
  Focus on config round-tripping and template discoverability for `[automation]`.
- `crates/app/src/runtime_env.rs`
  Focus on the segment-threshold export and stale-env clearing behavior.
- `crates/daemon/src/automation_cli.rs`
  Focus on config discovery, CLI-over-config precedence, default-config-path handling, the new automation guidance surface, cron preview guidance, serve-side policy-backed retention, and leased runner ownership.
- `crates/daemon/tests/integration/automation_cli.rs`
  Focus on config fallback, default-config-path coverage, precedence coverage, missing-segment handling, repair/health, runner lifecycle, stale-owner reclaim, dry-run retention, and serve-side retention policy.
- `docs/design-docs/automation-triggering.md`
  Confirm the operator contract around config-backed defaults, CLI precedence, default-config-path behavior, and the current runner lease/reclaim model.
