### PR TITLE
Keep bridge-backed serve surfaces discoverable through the grouped CLI

### DIFF
--- a/crates/app/src/channel/sdk.rs
+++ b/crates/app/src/channel/sdk.rs
@@ -484,9 +484,7 @@ fn channel_operational_model(
 fn channel_serve_subcommand(channel_id: &str) -> Option<&'static str> {
     let family_descriptor = resolve_channel_catalog_command_family_descriptor(channel_id)?;
     let serve_operation = family_descriptor.serve;
-    if serve_operation.availability
-        != super::catalog::ChannelCatalogOperationAvailability::Implemented
-    {
+    if !serve_operation.availability.is_runnable() {
         return None;
     }
 
@@ -1083,7 +1081,7 @@ mod tests {
             weixin.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(weixin.serve_subcommand, None);
+        assert_eq!(weixin.serve_subcommand, Some("channels serve weixin"));
 
         let qqbot = channel_descriptor("qq").expect("qq alias should resolve");
         assert_eq!(qqbot.id, "qqbot");
@@ -1094,7 +1092,7 @@ mod tests {
             qqbot.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(qqbot.serve_subcommand, None);
+        assert_eq!(qqbot.serve_subcommand, Some("channels serve qqbot"));
 
         let onebot = channel_descriptor("onebot-v11").expect("onebot alias should resolve");
         assert_eq!(onebot.id, "onebot");
@@ -1105,7 +1103,7 @@ mod tests {
             onebot.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(onebot.serve_subcommand, None);
+        assert_eq!(onebot.serve_subcommand, Some("channels serve onebot"));
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -282,7 +282,7 @@ mod tests {
             weixin.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(weixin.serve_subcommand, None);
+        assert_eq!(weixin.serve_subcommand, Some("channels serve weixin"));
 
         let qqbot = channel_descriptor("qq").expect("qqbot descriptor");
         assert_eq!(qqbot.id, "qqbot");
@@ -292,7 +292,7 @@ mod tests {
             qqbot.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(qqbot.serve_subcommand, None);
+        assert_eq!(qqbot.serve_subcommand, Some("channels serve qqbot"));
 
         let onebot = channel_descriptor("onebot-v11").expect("onebot descriptor");
         assert_eq!(onebot.id, "onebot");
@@ -302,7 +302,7 @@ mod tests {
             onebot.operational_model,
             ChannelOperationalModel::PluginBacked
         );
-        assert_eq!(onebot.serve_subcommand, None);
+        assert_eq!(onebot.serve_subcommand, Some("channels serve onebot"));
 
         let discord = channel_descriptor("discord").expect("discord descriptor");
         assert_eq!(discord.id, "discord");

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1796,7 +1796,7 @@ fn managed_bridge_runtime_attention_surfaces<'a>(
             continue;
         }
 
-        recent_incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+        recent_incidents.sort_by_key(|incident| std::cmp::Reverse(incident.at_ms));
         recent_incidents.truncate(5);
         surfaces.push(ManagedBridgeRuntimeAttention {
             channel_id: surface.catalog.id,

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1890,7 +1890,7 @@ fn collect_channel_surface_recent_runtime_incidents(
         .flatten()
         .collect::<Vec<_>>();
 
-    incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+    incidents.sort_by_key(|incident| std::cmp::Reverse(incident.at_ms));
     incidents.truncate(5);
     incidents
 }

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1,4 +1,34 @@
 use super::*;
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_TEMP_DIR_SEED: AtomicUsize = AtomicUsize::new(1);
+    let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let process_id = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{process_id}-{seed}-{nanos}"))
+}
+
+fn render_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn write_empty_config(prefix: &str) -> PathBuf {
+    let root = unique_temp_dir(prefix);
+    fs::create_dir_all(&root).expect("create fixture root");
+    let config_path = root.join("loong.toml");
+    fs::write(&config_path, "").expect("write empty config fixture");
+    config_path
+}
 
 fn try_parse_cli_slice(args: &[&str]) -> Result<Cli, clap::Error> {
     let owned_args = args
@@ -259,6 +289,70 @@ fn grouped_channels_serve_accepts_a_canonical_shape() {
             "--stop",
         ],
     ]);
+}
+
+#[test]
+fn grouped_channels_serve_accepts_bridge_backed_shapes() {
+    for channel in ["qqbot", "onebot", "weixin"] {
+        let _cli = parse_first_candidate(&[
+            &["loong", "channels", "serve", channel, "--stop"],
+            &["loong", "channels", "serve", "--channel", channel, "--stop"],
+        ]);
+    }
+}
+
+#[test]
+fn grouped_channels_serve_native_surfaces_fail_with_account_configuration_errors() {
+    let config_path = write_empty_config("loong-cli-native-serve-empty");
+    let config_path_text = config_path.to_str().expect("config path should be utf-8");
+
+    for channel in ["telegram", "matrix", "whatsapp", "wecom", "line", "webhook"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_loong"))
+            .arg("channels")
+            .arg("serve")
+            .arg(channel)
+            .arg("--config")
+            .arg(config_path_text)
+            .output()
+            .expect("run grouped native serve command");
+        let stderr = render_output(&output.stderr);
+
+        assert!(
+            !output.status.success(),
+            "empty config should not start `{channel}` serve successfully: {stderr}"
+        );
+        assert!(
+            stderr.contains("account `default` is disabled by configuration"),
+            "`{channel}` serve should reach the native runtime-backed config gate, stderr={stderr:?}"
+        );
+    }
+}
+
+#[test]
+fn grouped_channels_serve_bridge_surfaces_fail_with_managed_runtime_errors() {
+    let config_path = write_empty_config("loong-cli-bridge-serve-empty");
+    let config_path_text = config_path.to_str().expect("config path should be utf-8");
+
+    for channel in ["qqbot", "onebot", "weixin"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_loong"))
+            .arg("channels")
+            .arg("serve")
+            .arg(channel)
+            .arg("--config")
+            .arg(config_path_text)
+            .output()
+            .expect("run grouped bridge serve command");
+        let stderr = render_output(&output.stderr);
+
+        assert!(
+            !output.status.success(),
+            "empty config should not start bridge-backed `{channel}` serve successfully: {stderr}"
+        );
+        assert!(
+            stderr.contains("managed bridge runtime is disabled"),
+            "`{channel}` serve should reach the managed bridge runtime gate, stderr={stderr:?}"
+        );
+    }
 }
 
 #[test]

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -95,9 +95,11 @@ The current product surface is intentionally legible:
 - first-run path: `onboard`, `ask`, `chat`, `doctor`
 - operator runtime controls: `audit`, `migrate`, and related support commands
 - longer-lived service ownership: `gateway run`, `gateway status`, `gateway stop`
-- shipped service-channel runtimes: `channels serve telegram`,
-  `channels serve matrix`, `channels serve wecom`, and the dedicated
-  provider-owned serve surfaces such as `feishu serve`
+- gateway-supervised service-channel runtimes: `channels serve telegram`,
+  `channels serve matrix`, `channels serve wecom`, `channels serve whatsapp`,
+  and the dedicated provider-owned serve surfaces such as `feishu serve`
+- standalone native-serve runtimes: `channels serve line` and
+  `channels serve webhook`
 - outbound delivery: grouped `channels send <channel>` commands plus the
   dedicated provider-owned send surfaces for the shipped outbound inventory
 


### PR DESCRIPTION
## Summary

- keep bridge-backed `serve` surfaces discoverable through the same grouped CLI metadata used by the native channel lanes
- add regression coverage that distinguishes native grouped serve failures from managed-bridge grouped serve failures
- tighten the support story for `qqbot`, `onebot`, and `weixin` so internal descriptor layers no longer contradict the public CLI and docs

## What Changed

- treat managed-bridge `serve` operations as runnable when deriving `serve_subcommand` metadata
- align `weixin`, `qqbot`, and `onebot` descriptor/config expectations with the shipped grouped `channels serve ...` surface
- add grouped CLI integration smoke tests for:
  - bridge-backed `channels serve <id>` parsing
  - native serve failure shape on empty config
  - managed-bridge serve failure shape on empty config

## Why This Matters

A developer reported that they were trying to reference other channel serve implementations while preparing a dedicated `qqbot` command and concluded the grouped serve surface was unusable.

The deeper audit showed two separate realities:

- on current source, grouped `channels serve ...` parsing and routing are present
- but internal descriptor metadata still implied that bridge-backed lanes such as `qqbot`, `onebot`, and `weixin` had no serve subcommand at all

That mismatch made the support story look more broken than it really was and made bridge-backed lanes harder to reason about than native runtime-backed lanes.

## Validation

- `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- `cargo test -p loong-app --lib channel::sdk::tests::channel_descriptor_lookup_normalizes_plugin_backed_aliases -- --exact --nocapture`
- `cargo test -p loong-app --lib channel_descriptor_lookup_reports_shared_metadata -- --nocapture`
- `./scripts/cargo-local-toolchain.sh test -p loong --test integration 'integration::cli_tests::grouped_channels_serve_accepts_bridge_backed_shapes' -- --exact --nocapture`
- `./scripts/cargo-local-toolchain.sh test -p loong --test integration 'integration::cli_tests::grouped_channels_serve_native_surfaces_fail_with_account_configuration_errors' -- --exact --nocapture`
- `./scripts/cargo-local-toolchain.sh test -p loong --test integration 'integration::cli_tests::grouped_channels_serve_bridge_surfaces_fail_with_managed_runtime_errors' -- --exact --nocapture`

## Scope Notes

This PR does not turn `qqbot`, `onebot`, or `weixin` into native runtime-backed channels.
They remain managed-bridge surfaces; this change only makes the grouped serve support story internally consistent and regression-tested.
