### PR TITLE
Restore trustworthy cross-platform validation for platform-gated test helpers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,8 +49,8 @@ If Track B, fill these in:
 
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --workspace --locked`
-- [ ] `cargo test --workspace --all-features --locked`
+- [ ] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
+- [ ] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
 - [ ] Relevant architecture / dep-graph / docs checks for touched areas
 - [ ] Additional scenario, benchmark, or manual checks when behavior changed
 - [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,12 @@ source of truth, with a fallback to the full `integration` binary for broad
 harness edits. These fast loops **do not** replace the Track A required checks
 or CI parity.
 
+When you open a pull request, record the exact Rust validation that matches the
+touched package and feature surface. If a known baseline or platform-specific
+repository issue blocks full local parity, document the blocker together with
+the narrower checks you did run instead of checking boxes for commands you
+could not complete.
+
 If `task` or its transitive dependencies are unavailable locally, run at least
 CI parity plus architecture/dep-graph checks directly:
 

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -15,7 +15,7 @@ use crate::process_launch::retry_executable_file_busy_async;
 #[cfg(test)]
 use crate::process_launch::retry_executable_file_busy_blocking as retry_spawn_blocking;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) use super::acpx_mcp::probe_mcp_proxy_support_with_runtime;
 pub(crate) use super::acpx_mcp::{
     AcpxMcpServerEntry, AcpxMcpServerEnvEntry, build_mcp_proxy_agent_command,
@@ -755,6 +755,7 @@ mod tests {
 
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongConfig};
+    #[cfg(unix)]
     use crate::test_support::ScopedEnv;
 
     const ACPX_RUNTIME_TEST_TIMEOUT_SECONDS: f64 = 45.0;

--- a/crates/app/src/chat/cli_input.rs
+++ b/crates/app/src/chat/cli_input.rs
@@ -1,4 +1,6 @@
+#[cfg(unix)]
 use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::io::Read;
 
 #[cfg(unix)]

--- a/crates/app/src/tools/bash.rs
+++ b/crates/app/src/tools/bash.rs
@@ -252,10 +252,12 @@ mod tests {
     };
     use loong_contracts::ToolCoreRequest;
     use serde_json::json;
+    #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[derive(Default)]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -146,7 +146,7 @@ pub use provider_schema::{
     provider_tool_definitions, tool_parameter_schema_types, try_provider_tool_definitions_for_view,
 };
 pub(crate) use routing::hidden_operation_for_tool_name;
-#[cfg(test)]
+#[cfg(all(test, unix, feature = "tool-shell"))]
 pub(crate) use routing::route_direct_tool_name;
 pub use tool_surface::ToolSurfaceState;
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1796,7 +1796,7 @@ fn managed_bridge_runtime_attention_surfaces<'a>(
             continue;
         }
 
-        recent_incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+        recent_incidents.sort_by_key(|incident| std::cmp::Reverse(incident.at_ms));
         recent_incidents.truncate(5);
         surfaces.push(ManagedBridgeRuntimeAttention {
             channel_id: surface.catalog.id,

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1890,7 +1890,7 @@ fn collect_channel_surface_recent_runtime_incidents(
         .flatten()
         .collect::<Vec<_>>();
 
-    incidents.sort_by(|left, right| right.at_ms.cmp(&left.at_ms));
+    incidents.sort_by_key(|incident| std::cmp::Reverse(incident.at_ms));
     incidents.truncate(5);
     incidents
 }


### PR DESCRIPTION
## Summary

- Problem:
  Strict contributor validation could fail on non-Unix or narrower test surfaces because several Unix-only imports and test-only helper re-exports remained visible outside the platform and feature combinations that actually use them.
- Why it matters:
  That creates misleading review feedback, blocks contributors with unrelated baseline failures, and makes the PR template overstate what authors should attest locally.
- What changed:
  Tightened the affected app imports and test-only helper re-exports to the same platform / feature boundaries as their real consumers, and updated contributor-facing validation guidance so PRs can document touched-surface Rust validation plus known baseline blockers honestly.
- What did not change (scope boundary):
  This does not change CI routing, runtime behavior, or test semantics beyond removing the cross-platform visibility drift.

## Linked Issues

- Closes #1393
- Related #1354

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
  PASS

./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
  PASS

./scripts/cargo-local-toolchain.sh test -p loong-app concurrent_cli_input_reader_reads_regular_file_input
  PASS

./scripts/cargo-local-toolchain.sh test -p loong-app probe_mcp_proxy_support_invokes_script_runtime
  PASS

./scripts/cargo-local-toolchain.sh test -p loong-app direct_exec_routes_script_mode_to_bash_exec
  PASS

scripts/check-docs.sh
  PASS (with existing non-blocking release-artifact warnings)

Full workspace / all-features Rust tests were not rerun locally for this PR because the touched
surface is limited to platform-gated app imports plus contributor workflow docs, and the repository's
PR Rust test lanes already narrow by touched package / feature surface.
```

## User-visible / Operator-visible Changes

- None.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous import / template state.
- Observable failure symptoms reviewers should watch for:
  Unexpected non-Unix compile failures in `loong-app` tests or contributor confusion if validation wording still does not match the effective CI scope.

## Reviewer Focus

- Check that each tightened `cfg` matches the only real consumer surface.
- Check that the updated PR template and contributing guide now match the repository's changed-package Rust test routing without weakening the strict clippy requirement.
