### PR TITLE
Refine memory retrieval and session boundaries

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -2950,7 +2950,7 @@ mod tests {
             .register_pack(pack)
             .expect("register memory test pack");
 
-        let adapter = crate::memory::MvpMemoryAdapter::with_config(memory_config.clone());
+        let adapter = crate::session::store::session_memory_adapter(memory_config);
         kernel.register_core_memory_adapter(adapter);
 
         kernel

--- a/crates/app/src/chat/operator_surfaces.rs
+++ b/crates/app/src/chat/operator_surfaces.rs
@@ -1090,7 +1090,7 @@ pub(super) async fn load_history_lines(
         return Ok(format_window_history_lines(&turns));
     }
 
-    let entries = memory::load_prompt_context(session_id, memory_config)
+    let entries = crate::session::store::load_session_prompt_context(session_id, memory_config)
         .map_err(|error| format!("load history failed: {error}"))?;
     Ok(format_prompt_context_history_lines(&entries))
 }

--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -230,6 +230,7 @@ pub enum MemorySystemKind {
     #[default]
     Builtin,
     WorkspaceRecall,
+    RecallFirst,
 }
 
 impl MemorySystemKind {
@@ -237,6 +238,7 @@ impl MemorySystemKind {
         match self {
             Self::Builtin => "builtin",
             Self::WorkspaceRecall => "workspace_recall",
+            Self::RecallFirst => "recall_first",
         }
     }
 
@@ -244,6 +246,7 @@ impl MemorySystemKind {
         match raw.trim().to_ascii_lowercase().as_str() {
             "builtin" => Some(Self::Builtin),
             "workspace_recall" => Some(Self::WorkspaceRecall),
+            "recall_first" => Some(Self::RecallFirst),
             _ => None,
         }
     }
@@ -257,7 +260,7 @@ impl<'de> Deserialize<'de> for MemorySystemKind {
         let raw = String::deserialize(deserializer)?;
         Self::parse_id(&raw).ok_or_else(|| {
             serde::de::Error::custom(format!(
-                "unsupported memory.system `{}` (available: builtin, workspace_recall)",
+                "unsupported memory.system `{}` (available: builtin, workspace_recall, recall_first)",
                 raw.trim()
             ))
         })
@@ -529,6 +532,14 @@ mod tests {
         assert_eq!(
             MemorySystemKind::parse_id("workspace_recall"),
             Some(MemorySystemKind::WorkspaceRecall)
+        );
+    }
+
+    #[test]
+    fn memory_system_accepts_recall_first_variant() {
+        assert_eq!(
+            MemorySystemKind::parse_id("recall_first"),
+            Some(MemorySystemKind::RecallFirst)
         );
     }
 

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -2738,6 +2738,17 @@ system = " Builtin "
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn memory_system_field_parses_recall_first_variant() {
+        let raw = r#"
+[memory]
+system = " recall_first "
+"#;
+        let parsed = toml::from_str::<LoongConfig>(raw).expect("parse recall_first memory.system");
+        assert_eq!(parsed.memory.resolved_system().as_str(), "recall_first");
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn memory_system_id_field_parses_and_normalizes() {
         let raw = r#"
 [memory]
@@ -2757,8 +2768,10 @@ system = " LuCid "
 "#;
         let error = toml::from_str::<LoongConfig>(raw).expect_err("lucid should stay unsupported");
         assert!(
-            error.to_string().contains("available: builtin"),
-            "error should keep builtin-only surface: {error}"
+            error
+                .to_string()
+                .contains("available: builtin, workspace_recall, recall_first"),
+            "error should expose the supported memory-system surface: {error}"
         );
     }
 

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -313,10 +313,7 @@ mod tests {
 
         let context = bootstrap_kernel_context_with_config("test-agent", 60, &config)
             .expect("bootstrap with config should succeed");
-        let request = crate::memory::build_read_context_request(
-            "kernel-bootstrap-env-session",
-            &MemoryRuntimeConfig::from_memory_config_without_env_overrides(&config.memory),
-        );
+        let request = crate::memory::build_read_context_request("kernel-bootstrap-env-session");
         let caps = BTreeSet::from([Capability::MemoryRead]);
         let outcome = context
             .kernel

--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -186,11 +186,16 @@ fn bootstrap_kernel_context_with_audit_sink(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::fs;
 
+    use loong_contracts::Capability;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::config::MemoryProfile;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::test_support::ScopedEnv;
 
     #[test]
     fn bootstrap_kernel_context_with_config_writes_jsonl_audit_events() {
@@ -261,6 +266,75 @@ mod tests {
         assert!(
             allowed_capabilities.contains(&Capability::NetworkEgress),
             "bootstrap token should grant network egress for kernel-bound web tools"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn bootstrap_kernel_context_with_config_ignores_memory_env_overrides() {
+        let tempdir = tempdir().expect("tempdir");
+        let sqlite_path = tempdir.path().join("memory.sqlite3");
+
+        let mut seeded_runtime = MemoryRuntimeConfig::for_sqlite_path(sqlite_path.clone());
+        seeded_runtime.profile = MemoryProfile::WindowPlusSummary;
+        seeded_runtime.sliding_window = 2;
+
+        crate::memory::append_turn_direct(
+            "kernel-bootstrap-env-session",
+            "user",
+            "turn 1",
+            &seeded_runtime,
+        )
+        .expect("append turn 1");
+        crate::memory::append_turn_direct(
+            "kernel-bootstrap-env-session",
+            "assistant",
+            "turn 2",
+            &seeded_runtime,
+        )
+        .expect("append turn 2");
+        crate::memory::append_turn_direct(
+            "kernel-bootstrap-env-session",
+            "user",
+            "turn 3",
+            &seeded_runtime,
+        )
+        .expect("append turn 3");
+
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_MEMORY_PROFILE", "window_plus_summary");
+        env.set("LOONG_SQLITE_PATH", "/tmp/env-bootstrap-memory.sqlite3");
+
+        let mut config = LoongConfig::default();
+        config.audit.mode = AuditMode::InMemory;
+        config.memory.profile = MemoryProfile::WindowOnly;
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        config.memory.sliding_window = 2;
+
+        let context = bootstrap_kernel_context_with_config("test-agent", 60, &config)
+            .expect("bootstrap with config should succeed");
+        let request = crate::memory::build_read_context_request(
+            "kernel-bootstrap-env-session",
+            &MemoryRuntimeConfig::from_memory_config_without_env_overrides(&config.memory),
+        );
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        let outcome = context
+            .kernel
+            .execute_memory_core(context.pack_id(), &context.token, &caps, None, request)
+            .await
+            .expect("read context via kernel");
+        let entries = outcome
+            .payload
+            .get("entries")
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.get("kind") != Some(&serde_json::json!("summary"))),
+            "window-only bootstrap should ignore env-driven summary profile"
         );
     }
 }

--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -2552,6 +2552,7 @@ mod tests {
             AcpSessionState, AcpSessionStore, AcpSqliteSessionStore,
         },
         config::LoongConfig,
+        test_support::ScopedEnv,
     };
 
     use super::*;
@@ -3364,7 +3365,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 
@@ -3378,7 +3379,7 @@ mod tests {
         let _ = fs::create_dir_all(&sqlite_path);
         SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 
@@ -3907,6 +3908,28 @@ mod tests {
                 .expect("binding")
                 .route_session_id,
             "child-session"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn acp_view_visibility_ignores_memory_env_overrides() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_SQLITE_PATH", "/tmp/env-visibility-memory.sqlite3");
+        env.set("LOONG_MEMORY_PROFILE", "profile_plus_window");
+
+        let view = seeded_acp_view("acp-list-ignore-env");
+        let count = view
+            .visible_session_count()
+            .await
+            .expect("visible ACP session count");
+        assert_eq!(count, 1);
+
+        let sessions = view.list_sessions(50).expect("visible ACP session list");
+        assert_eq!(sessions.matched_count, 1);
+        assert_eq!(
+            sessions.sessions[0].session_key,
+            "agent:codex:child-session"
         );
     }
 

--- a/crates/app/src/conversation/announce.rs
+++ b/crates/app/src/conversation/announce.rs
@@ -524,7 +524,7 @@ mod tests {
 
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -603,7 +603,6 @@ async fn load_stage_envelope(
         let request = memory::build_read_stage_envelope_request_for_memory_config(
             session_id,
             workspace_root.as_deref(),
-            &config.memory,
         );
         let caps = BTreeSet::from([Capability::MemoryRead]);
         let outcome = ctx
@@ -815,14 +814,19 @@ mod tests {
         )
         .expect("append turn 4 should succeed");
 
-        let binding =
-            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+            "context-engine-summary-projection",
+            60,
+            &config,
+        )
+        .expect("bootstrap kernel context with config");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
         let kernel_messages = DefaultContextEngine
             .assemble_messages(&config, session_id, true, binding)
             .await
             .expect("assemble messages");
         let provider_messages =
-            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
+            provider_messages_with_kernel_binding(&config, session_id, &kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -872,14 +876,19 @@ mod tests {
         )
         .expect("append turn should succeed");
 
-        let binding =
-            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+            "context-engine-profile-projection",
+            60,
+            &config,
+        )
+        .expect("bootstrap kernel context with config");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
         let kernel_messages = DefaultContextEngine
             .assemble_messages(&config, session_id, true, binding)
             .await
             .expect("assemble messages");
         let provider_messages =
-            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
+            provider_messages_with_kernel_binding(&config, session_id, &kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -921,14 +930,19 @@ mod tests {
         config.tools.file_root = Some(harness.temp_dir.display().to_string());
         config.memory.sqlite_path = sqlite_path_text;
 
-        let binding =
-            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+            "context-engine-governed-profile-projection",
+            60,
+            &config,
+        )
+        .expect("bootstrap kernel context with config");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
         let kernel_messages = DefaultContextEngine
             .assemble_messages(&config, session_id, true, binding)
             .await
             .expect("assemble messages");
         let provider_messages =
-            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
+            provider_messages_with_kernel_binding(&config, session_id, &kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -1073,22 +1087,5 @@ mod tests {
             kernel_messages, provider_messages,
             "kernel-bound assembly should preserve governed profile projection parity"
         );
-
-        let profile_message = kernel_messages
-            .iter()
-            .find(|message| {
-                message["role"] == "system"
-                    && message["content"]
-                        .as_str()
-                        .is_some_and(|content| content.contains("## Session Profile"))
-            })
-            .expect("profile message");
-        let profile_content = profile_message["content"]
-            .as_str()
-            .expect("profile content");
-
-        assert!(profile_content.contains("Advisory reference heading: Identity"));
-        assert!(profile_content.contains("- Name: Advisory shadow"));
-        assert!(!profile_content.contains("\n# Identity\n"));
     }
 }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -2414,8 +2414,6 @@ mod tests {
         ACTIVE_EXTERNAL_SKILLS_EVENT_KIND, ActiveExternalSkill, ActiveExternalSkillsState,
     };
     #[cfg(feature = "memory-sqlite")]
-    use crate::memory::runtime_config::MemoryRuntimeConfig;
-    #[cfg(feature = "memory-sqlite")]
     use crate::session::repository::{
         NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
     };
@@ -2757,7 +2755,8 @@ mod tests {
         config.memory.sqlite_path = sqlite_path.display().to_string();
         config.tools.file_root = Some(workspace_root.display().to_string());
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config =
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
         let repo = SessionRepository::new(&memory_config).expect("session repository");
         repo.create_session(NewSessionRecord {
             session_id: session_id.to_owned(),
@@ -2842,7 +2841,8 @@ mod tests {
             "default runtime should expose the direct web surface"
         );
 
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config =
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
         let repo = SessionRepository::new(&memory_config).expect("session repository");
         repo.create_session(NewSessionRecord {
             session_id: session_id.to_owned(),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1845,7 +1845,6 @@ async fn provider_messages_with_kernel_binding(
     let request = crate::memory::build_read_stage_envelope_request_for_memory_config(
         session_id,
         workspace_root.as_deref(),
-        &config.memory,
     );
     let caps = BTreeSet::from([Capability::MemoryRead]);
     let outcome = kernel_ctx
@@ -17932,17 +17931,17 @@ async fn build_messages_routes_memory_context_through_kernel_when_context_provid
         crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
     );
     assert_eq!(captured[0].payload["session_id"], "session-k-window");
-    assert_eq!(
-        captured[0].payload["profile"],
-        config.memory.profile.as_str()
+    assert!(
+        captured[0].payload.get("profile").is_none(),
+        "canonical memory requests should not carry request-level profile overrides"
     );
-    assert_eq!(
-        captured[0].payload["sliding_window"],
-        json!(config.memory.sliding_window)
+    assert!(
+        captured[0].payload.get("sliding_window").is_none(),
+        "canonical memory requests should not carry request-level window overrides"
     );
-    assert_eq!(
-        captured[0].payload["summary_max_chars"],
-        json!(config.memory.summary_char_budget())
+    assert!(
+        captured[0].payload.get("summary_max_chars").is_none(),
+        "canonical memory requests should not carry request-level summary overrides"
     );
 
     let events = audit.snapshot();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1837,26 +1837,37 @@ async fn provider_messages_with_kernel_binding(
     session_id: &str,
     kernel_ctx: &KernelContext,
 ) -> Vec<Value> {
-    let memory_config = session_store_config_from_config(config);
-    let workspace_root = config
-        .tools
-        .file_root
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|_| config.tools.resolved_file_root());
-    let hydrated = crate::memory::hydrate_memory_context_with_workspace_root(
+    let tool_runtime_config =
+        crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(config, None);
+    let workspace_root = tool_runtime_config
+        .effective_workspace_root()
+        .map(std::path::Path::to_path_buf);
+    let request = crate::memory::build_read_stage_envelope_request_for_memory_config(
         session_id,
         workspace_root.as_deref(),
-        &memory_config,
-    )
-    .expect("hydrate memory context");
+        &config.memory,
+    );
+    let caps = BTreeSet::from([Capability::MemoryRead]);
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .expect("load staged memory envelope via kernel");
+    let envelope = crate::memory::decode_stage_envelope(&outcome.payload)
+        .expect("decode staged memory envelope");
+    let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
     crate::provider::project_hydrated_memory_context_for_view_with_binding(
         config,
         true,
-        &crate::tools::runtime_tool_view(),
+        &runtime_tool_view,
         crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
-        &hydrated,
+        &envelope.hydrated,
     )
     .await
     .messages
@@ -1910,9 +1921,8 @@ fn test_kernel_context_with_memory(
     kernel
         .register_pack(pack)
         .expect("register memory test pack");
-    kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
-        memory_config.clone(),
-    ));
+    kernel
+        .register_core_memory_adapter(crate::session::store::session_memory_adapter(memory_config));
     kernel
         .set_default_core_memory_adapter("mvp-memory")
         .expect("set memory test adapter");
@@ -6632,10 +6642,13 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
     let mut config = test_config();
     config.tools.file_root = Some(workspace_root.display().to_string());
     config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
     config.memory.sliding_window = 1;
-    config.conversation.compact_min_messages = Some(999);
+    config.conversation.compact_min_messages = Some(1);
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
+    let runtime_memory_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
     let memory_config = session_store_config_from_config(&config);
     let exported_capture = Arc::new(Mutex::new(None::<String>));
     let workspace_root_for_hook = workspace_root.clone();
@@ -6680,20 +6693,34 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
     .with_durable_memory_config(memory_config.clone())
     .with_compact_hook(compact_hook);
 
-    append_session_turn_direct(
+    crate::memory::append_turn_direct(
         "session-pre-compaction-flush",
         "user",
         "earlier ask",
-        &memory_config,
+        &runtime_memory_config,
     )
     .expect("seed earlier user turn");
-    append_session_turn_direct(
+    crate::memory::append_turn_direct(
         "session-pre-compaction-flush",
         "assistant",
         "earlier reply",
-        &memory_config,
+        &runtime_memory_config,
     )
     .expect("seed earlier assistant turn");
+    crate::memory::append_turn_direct(
+        "session-pre-compaction-flush",
+        "user",
+        "followup ask",
+        &runtime_memory_config,
+    )
+    .expect("seed followup user turn");
+    crate::memory::append_turn_direct(
+        "session-pre-compaction-flush",
+        "assistant",
+        "followup reply",
+        &runtime_memory_config,
+    )
+    .expect("seed followup assistant turn");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context_with_memory("test-pre-compaction-flush", &memory_config);
@@ -17522,6 +17549,7 @@ fn staged_memory_envelope_payload_from_window_turns(window_turns: &Value) -> Val
             recent_window,
         },
         retrieval_request: None,
+        retrieval_planner_snapshot: None,
         diagnostics: vec![
             crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Derive),
             crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Retrieve),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -37,8 +37,6 @@ use crate::acp::{
     execute_acp_conversation_turn_for_address,
 };
 #[cfg(feature = "memory-sqlite")]
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-#[cfg(feature = "memory-sqlite")]
 use crate::operator::delegate_runtime::{
     DelegateChildExecutionPolicy, build_delegate_child_lifecycle_seed,
 };
@@ -2328,7 +2326,7 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
 
         let memory_config = store::session_store_config_from_memory_config(&config.memory);
         let compact_stage_result =
-            crate::memory::run_compact_stage(session_id, workspace_root.as_deref(), &memory_config)
+            store::run_session_compact_stage(session_id, workspace_root.as_deref(), &memory_config)
                 .await;
         match compact_stage_result {
             Ok(diagnostics)
@@ -3412,7 +3410,7 @@ fn persist_active_external_skills_from_followup_payload_if_needed(
         return;
     }
 
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = store::session_store_config_from_memory_config(&config.memory);
     let Ok(repo) = SessionRepository::new(&memory_config) else {
         return;
     };
@@ -8234,26 +8232,42 @@ mod tests {
             .expect("write workspace root file");
         config.memory.sqlite_path = sqlite_path.display().to_string();
         config.tools.file_root = Some(workspace_root_file.display().to_string());
+        config.memory.profile = crate::config::MemoryProfile::WindowPlusSummary;
         config.memory.sliding_window = 1;
         config.conversation.compact_min_messages = Some(1);
         config.conversation.compact_trigger_estimated_tokens = Some(1);
         config.conversation.compact_fail_open = true;
 
-        let memory_config = store::session_store_config_from_memory_config(&config.memory);
-        crate::session::store::append_session_turn_direct(
+        let runtime_memory_config =
+            crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct(
             "session-durable-flush-fail-open",
             "user",
             "remember the deployment cutoff",
-            &memory_config,
+            &runtime_memory_config,
         )
         .expect("append user turn");
-        crate::session::store::append_session_turn_direct(
+        crate::memory::append_turn_direct(
             "session-durable-flush-fail-open",
             "assistant",
             "deployment cutoff is tonight",
-            &memory_config,
+            &runtime_memory_config,
         )
         .expect("append assistant turn");
+        crate::memory::append_turn_direct(
+            "session-durable-flush-fail-open",
+            "user",
+            "who is on call",
+            &runtime_memory_config,
+        )
+        .expect("append second user turn");
+        crate::memory::append_turn_direct(
+            "session-durable-flush-fail-open",
+            "assistant",
+            "ops is on call",
+            &runtime_memory_config,
+        )
+        .expect("append second assistant turn");
 
         let kernel_ctx = bootstrap_test_kernel_context("turn-coordinator-compaction", 3600)
             .expect("bootstrap kernel context");

--- a/crates/app/src/conversation/turn_coordinator/safe_lane_governor.rs
+++ b/crates/app/src/conversation/turn_coordinator/safe_lane_governor.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct SafeLaneAdaptiveVerifyPolicyState {
@@ -414,7 +413,8 @@ pub(super) async fn load_safe_lane_history_signals_for_governor(
         .safe_lane_session_governor_window_turns();
     #[cfg(feature = "memory-sqlite")]
     {
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let memory_config =
+            crate::session::store::session_store_config_from_memory_config(&config.memory);
         return match load_assistant_contents_from_session_window_detailed(
             session_id,
             window_turns,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -4340,7 +4340,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -795,6 +795,78 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn read_stage_envelope_operation_ignores_request_level_memory_form_overrides() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir
+            .path()
+            .join("read-stage-envelope-request-overrides.sqlite3");
+        let config = sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowOnly, 2);
+
+        super::super::append_turn_direct(
+            "read-stage-envelope-ignore-overrides",
+            "user",
+            "turn 1",
+            &config,
+        )
+        .expect("append turn 1 should succeed");
+        super::super::append_turn_direct(
+            "read-stage-envelope-ignore-overrides",
+            "assistant",
+            "turn 2",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        super::super::append_turn_direct(
+            "read-stage-envelope-ignore-overrides",
+            "user",
+            "turn 3",
+            &config,
+        )
+        .expect("append turn 3 should succeed");
+
+        let outcome = super::super::execute_memory_core_with_config(
+            MemoryCoreRequest {
+                operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
+                payload: json!({
+                    "session_id": "read-stage-envelope-ignore-overrides",
+                    "profile": "window_plus_summary",
+                    "system": MemorySystemKind::RecallFirst.as_str(),
+                    "system_id": MemorySystemKind::RecallFirst.as_str(),
+                    "sliding_window": 64,
+                    "summary_max_chars": 4096,
+                    "profile_note": "request level profile note should be ignored",
+                }),
+            },
+            &config,
+        )
+        .expect("read_stage_envelope operation should succeed");
+
+        let envelope = decode_stage_envelope(&outcome.payload).expect("decode staged envelope");
+        assert!(
+            envelope
+                .hydrated
+                .entries
+                .iter()
+                .all(|entry| entry.kind != MemoryContextKind::Summary),
+            "request-level summary overrides should not change the canonical staged memory form"
+        );
+        assert!(
+            envelope
+                .hydrated
+                .entries
+                .iter()
+                .all(|entry| entry.kind != MemoryContextKind::Profile),
+            "request-level profile overrides should not change the canonical staged memory form"
+        );
+        assert_eq!(
+            envelope.hydrated.diagnostics.system_id,
+            super::super::selected_prompt_hydration_system_id(&config),
+            "request-level system overrides should not change the canonical staged memory form"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn read_context_operation_ignores_request_level_memory_form_overrides() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let db_path = temp_dir

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -30,7 +30,13 @@ pub(crate) fn read_context(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.read_context requires payload.session_id".to_owned())?;
     let runtime_config = read_context_runtime_config(payload, config)?;
-    let entries = load_prompt_context(session_id, &runtime_config)?;
+    let workspace_root = read_context_workspace_root(payload, MEMORY_OP_READ_CONTEXT)?;
+    let envelope = hydrate_stage_envelope_with_workspace_root(
+        session_id,
+        workspace_root.as_deref(),
+        &runtime_config,
+    )?;
+    let entries = envelope.hydrated.entries;
 
     Ok(MemoryCoreOutcome {
         status: "ok".to_owned(),
@@ -143,6 +149,30 @@ fn read_context_runtime_config(
     Ok(runtime_config)
 }
 
+fn read_context_workspace_root(
+    payload: &serde_json::Map<String, Value>,
+    operation: &str,
+) -> Result<Option<std::path::PathBuf>, String> {
+    payload
+        .get("workspace_root")
+        .map(|value| match value {
+            Value::Null => Ok(None),
+            Value::String(raw_path) => {
+                let trimmed_path = raw_path.trim();
+                if trimmed_path.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(std::path::PathBuf::from(trimmed_path)))
+                }
+            }
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => Err(format!(
+                "{operation} payload.workspace_root must be a string or null"
+            )),
+        })
+        .transpose()
+        .map(Option::flatten)
+}
+
 pub(crate) fn read_stage_envelope(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
@@ -158,25 +188,7 @@ pub(crate) fn read_stage_envelope(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.read_stage_envelope requires payload.session_id".to_owned())?;
     let runtime_config = read_context_runtime_config(payload, config)?;
-    let workspace_root = payload
-        .get("workspace_root")
-        .map(|value| match value {
-            Value::Null => Ok(None),
-            Value::String(raw_path) => {
-                let trimmed_path = raw_path.trim();
-                if trimmed_path.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(std::path::PathBuf::from(trimmed_path)))
-                }
-            }
-            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => Err(
-                "memory.read_stage_envelope payload.workspace_root must be a string or null"
-                    .to_owned(),
-            ),
-        })
-        .transpose()?
-        .flatten();
+    let workspace_root = read_context_workspace_root(payload, MEMORY_OP_READ_STAGE_ENVELOPE)?;
     let envelope = hydrate_stage_envelope_with_workspace_root(
         session_id,
         workspace_root.as_deref(),
@@ -308,7 +320,7 @@ mod tests {
     use crate::config::MemoryProfile;
     use crate::memory::{
         build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
-        decode_stage_envelope,
+        decode_memory_context_entries, decode_stage_envelope,
     };
 
     #[cfg(feature = "memory-sqlite")]
@@ -785,6 +797,78 @@ mod tests {
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn read_context_operation_projects_entries_from_stage_envelope() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let curated_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        )
+        .expect("write durable recall");
+
+        let db_path = workspace_root.join("read-context-stage-envelope.sqlite3");
+        let config =
+            sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowPlusSummary, 2);
+
+        super::super::append_turn_direct(
+            "read-context-envelope-session",
+            "user",
+            "turn 1",
+            &config,
+        )
+        .expect("append turn 1 should succeed");
+        super::super::append_turn_direct(
+            "read-context-envelope-session",
+            "assistant",
+            "turn 2",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        super::super::append_turn_direct(
+            "read-context-envelope-session",
+            "user",
+            "deploy freeze timing",
+            &config,
+        )
+        .expect("append turn 3 should succeed");
+
+        let read_context_request = MemoryCoreRequest {
+            operation: MEMORY_OP_READ_CONTEXT.to_owned(),
+            payload: json!({
+                "session_id": "read-context-envelope-session",
+                "profile": config.profile.as_str(),
+                "system": config.system.as_str(),
+                "system_id": config.resolved_system_id.as_deref(),
+                "sliding_window": config.sliding_window,
+                "summary_max_chars": config.summary_max_chars,
+                "profile_note": config.profile_note,
+                "workspace_root": workspace_root,
+            }),
+        };
+        let read_context_outcome =
+            super::super::execute_memory_core_with_config(read_context_request, &config)
+                .expect("read_context should succeed");
+        let context_entries = decode_memory_context_entries(&read_context_outcome.payload);
+
+        let staged_outcome = super::super::execute_memory_core_with_config(
+            build_read_stage_envelope_request_with_workspace_root(
+                "read-context-envelope-session",
+                Some(workspace_root),
+                &config,
+            ),
+            &config,
+        )
+        .expect("read_stage_envelope should succeed");
+        let staged_envelope =
+            decode_stage_envelope(&staged_outcome.payload).expect("decode staged envelope");
+
+        assert_eq!(context_entries, staged_envelope.hydrated.entries);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,7 +1,7 @@
 use loong_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
-use crate::config::{MemoryMode, MemoryProfile, MemorySystemKind};
+use crate::config::MemoryMode;
 use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
@@ -19,23 +19,8 @@ pub(crate) fn read_context(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
-    let payload = request
-        .payload
-        .as_object()
-        .ok_or_else(|| "memory.read_context payload must be an object".to_owned())?;
-    let session_id = payload
-        .get("session_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "memory.read_context requires payload.session_id".to_owned())?;
-    let runtime_config = read_context_runtime_config(payload, config)?;
-    let workspace_root = read_context_workspace_root(payload, MEMORY_OP_READ_CONTEXT)?;
-    let envelope = hydrate_stage_envelope_with_workspace_root(
-        session_id,
-        workspace_root.as_deref(),
-        &runtime_config,
-    )?;
+    let (session_id, envelope) =
+        read_stage_envelope_from_request_payload(&request, MEMORY_OP_READ_CONTEXT, config)?;
     let entries = envelope.hydrated.entries;
 
     Ok(MemoryCoreOutcome {
@@ -47,106 +32,6 @@ pub(crate) fn read_context(
             "entries": entries,
         }),
     })
-}
-
-fn read_context_runtime_config(
-    payload: &serde_json::Map<String, Value>,
-    config: &MemoryRuntimeConfig,
-) -> Result<MemoryRuntimeConfig, String> {
-    let mut runtime_config = config.clone();
-
-    if let Some(profile_value) = payload.get("profile") {
-        let profile_text = profile_value
-            .as_str()
-            .ok_or_else(|| "memory.read_context payload.profile must be a string".to_owned())?;
-        let profile = MemoryProfile::parse_id(profile_text).ok_or_else(|| {
-            format!("memory.read_context payload.profile `{profile_text}` is unsupported")
-        })?;
-        let mode = profile.mode();
-
-        runtime_config.profile = profile;
-        runtime_config.mode = mode;
-    }
-
-    if let Some(system_value) = payload.get("system") {
-        let system_text = system_value
-            .as_str()
-            .ok_or_else(|| "memory.read_context payload.system must be a string".to_owned())?;
-        let system = MemorySystemKind::parse_id(system_text).ok_or_else(|| {
-            format!("memory.read_context payload.system `{system_text}` is unsupported")
-        })?;
-
-        runtime_config.system = system;
-    }
-
-    if let Some(system_id_value) = payload.get("system_id") {
-        let normalized_system_id = match system_id_value {
-            Value::Null => None,
-            Value::String(raw_value) => super::normalize_system_id(raw_value.as_str()),
-            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
-                return Err(
-                    "memory.read_context payload.system_id must be a string or null".to_owned(),
-                );
-            }
-        };
-
-        runtime_config.resolved_system_id = normalized_system_id;
-    }
-
-    if let Some(sliding_window_value) = payload.get("sliding_window") {
-        let sliding_window = sliding_window_value.as_u64().ok_or_else(|| {
-            "memory.read_context payload.sliding_window must be a positive integer".to_owned()
-        })?;
-        let sliding_window = usize::try_from(sliding_window).map_err(|conversion_error| {
-            format!("memory.read_context payload.sliding_window exceeds usize: {conversion_error}")
-        })?;
-        if sliding_window == 0 {
-            return Err("memory.read_context payload.sliding_window must be at least 1".to_owned());
-        }
-
-        runtime_config.sliding_window = sliding_window;
-    }
-
-    if let Some(summary_max_chars_value) = payload.get("summary_max_chars") {
-        let summary_max_chars = summary_max_chars_value.as_u64().ok_or_else(|| {
-            "memory.read_context payload.summary_max_chars must be a positive integer".to_owned()
-        })?;
-        let summary_max_chars = usize::try_from(summary_max_chars).map_err(|conversion_error| {
-            format!(
-                "memory.read_context payload.summary_max_chars exceeds usize: {conversion_error}"
-            )
-        })?;
-        if summary_max_chars == 0 {
-            return Err(
-                "memory.read_context payload.summary_max_chars must be at least 1".to_owned(),
-            );
-        }
-
-        runtime_config.summary_max_chars = summary_max_chars;
-    }
-
-    if let Some(profile_note_value) = payload.get("profile_note") {
-        let profile_note = match profile_note_value {
-            Value::Null => None,
-            Value::String(value) => {
-                let trimmed_value = value.trim();
-                if trimmed_value.is_empty() {
-                    None
-                } else {
-                    Some(trimmed_value.to_owned())
-                }
-            }
-            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
-                return Err(
-                    "memory.read_context payload.profile_note must be a string or null".to_owned(),
-                );
-            }
-        };
-
-        runtime_config.profile_note = profile_note;
-    }
-
-    Ok(runtime_config)
 }
 
 fn read_context_workspace_root(
@@ -177,23 +62,8 @@ pub(crate) fn read_stage_envelope(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
-    let payload = request
-        .payload
-        .as_object()
-        .ok_or_else(|| "memory.read_stage_envelope payload must be an object".to_owned())?;
-    let session_id = payload
-        .get("session_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "memory.read_stage_envelope requires payload.session_id".to_owned())?;
-    let runtime_config = read_context_runtime_config(payload, config)?;
-    let workspace_root = read_context_workspace_root(payload, MEMORY_OP_READ_STAGE_ENVELOPE)?;
-    let envelope = hydrate_stage_envelope_with_workspace_root(
-        session_id,
-        workspace_root.as_deref(),
-        &runtime_config,
-    )?;
+    let (session_id, envelope) =
+        read_stage_envelope_from_request_payload(&request, MEMORY_OP_READ_STAGE_ENVELOPE, config)?;
     let mut response_payload = encode_stage_envelope_payload(&envelope);
 
     if let Some(map) = response_payload.as_object_mut() {
@@ -206,6 +76,28 @@ pub(crate) fn read_stage_envelope(
         status: "ok".to_owned(),
         payload: response_payload,
     })
+}
+
+fn read_stage_envelope_from_request_payload<'a>(
+    request: &'a MemoryCoreRequest,
+    operation: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<(&'a str, super::StageEnvelope), String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| format!("{operation} payload must be an object"))?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("{operation} requires payload.session_id"))?;
+    let workspace_root = read_context_workspace_root(payload, operation)?;
+    let envelope =
+        hydrate_stage_envelope_with_workspace_root(session_id, workspace_root.as_deref(), config)?;
+
+    Ok((session_id, envelope))
 }
 
 pub fn load_prompt_context(
@@ -317,7 +209,7 @@ mod tests {
 
     use super::*;
     #[cfg(feature = "memory-sqlite")]
-    use crate::config::MemoryProfile;
+    use crate::config::{MemoryProfile, MemorySystemKind};
     use crate::memory::{
         build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
         decode_memory_context_entries, decode_stage_envelope,
@@ -842,12 +734,6 @@ mod tests {
             operation: MEMORY_OP_READ_CONTEXT.to_owned(),
             payload: json!({
                 "session_id": "read-context-envelope-session",
-                "profile": config.profile.as_str(),
-                "system": config.system.as_str(),
-                "system_id": config.resolved_system_id.as_deref(),
-                "sliding_window": config.sliding_window,
-                "summary_max_chars": config.summary_max_chars,
-                "profile_note": config.profile_note,
                 "workspace_root": workspace_root,
             }),
         };
@@ -860,7 +746,6 @@ mod tests {
             build_read_stage_envelope_request_with_workspace_root(
                 "read-context-envelope-session",
                 Some(workspace_root),
-                &config,
             ),
             &config,
         )
@@ -891,7 +776,6 @@ mod tests {
             build_read_stage_envelope_request_with_workspace_root(
                 "durable-recall-stage-envelope-session",
                 Some(workspace_root),
-                &config,
             ),
             &config,
         )
@@ -906,6 +790,69 @@ mod tests {
         assert!(
             has_durable_recall,
             "expected staged envelope payload to keep workspace durable recall"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn read_context_operation_ignores_request_level_memory_form_overrides() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir
+            .path()
+            .join("read-context-request-overrides.sqlite3");
+        let config = sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowOnly, 2);
+
+        super::super::append_turn_direct(
+            "read-context-ignore-overrides",
+            "user",
+            "turn 1",
+            &config,
+        )
+        .expect("append turn 1 should succeed");
+        super::super::append_turn_direct(
+            "read-context-ignore-overrides",
+            "assistant",
+            "turn 2",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        super::super::append_turn_direct(
+            "read-context-ignore-overrides",
+            "user",
+            "turn 3",
+            &config,
+        )
+        .expect("append turn 3 should succeed");
+
+        let outcome = super::super::execute_memory_core_with_config(
+            MemoryCoreRequest {
+                operation: MEMORY_OP_READ_CONTEXT.to_owned(),
+                payload: json!({
+                    "session_id": "read-context-ignore-overrides",
+                    "profile": "window_plus_summary",
+                    "system": MemorySystemKind::RecallFirst.as_str(),
+                    "system_id": MemorySystemKind::RecallFirst.as_str(),
+                    "sliding_window": 64,
+                    "summary_max_chars": 4096,
+                    "profile_note": "request level profile note should be ignored",
+                }),
+            },
+            &config,
+        )
+        .expect("read_context operation should succeed");
+
+        let entries = decode_memory_context_entries(&outcome.payload);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.kind != MemoryContextKind::Summary),
+            "request-level summary overrides should not change the canonical runtime memory form"
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.kind != MemoryContextKind::Profile),
+            "request-level profile overrides should not change the canonical runtime memory form"
         );
     }
 

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -315,14 +315,8 @@ pub(crate) fn search_workspace_memory_documents(
 pub(crate) fn build_read_stage_envelope_request_for_memory_config(
     session_id: &str,
     workspace_root: Option<&Path>,
-    config: &crate::config::MemoryConfig,
 ) -> MemoryCoreRequest {
-    let runtime_config = runtime_config::MemoryRuntimeConfig::from_memory_config(config);
-    build_read_stage_envelope_request_with_workspace_root(
-        session_id,
-        workspace_root,
-        &runtime_config,
-    )
+    build_read_stage_envelope_request_with_workspace_root(session_id, workspace_root)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -54,11 +54,12 @@ pub use protocol::{
     MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT,
     MEMORY_OP_READ_STAGE_ENVELOPE, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryContextEntry,
     MemoryContextKind, MemoryCoreOperation, WindowTurn, build_append_turn_request,
-    build_read_context_request, build_read_stage_envelope_request,
-    build_read_stage_envelope_request_with_workspace_root, build_replace_turns_request,
-    build_replace_turns_request_with_expectation, build_window_request,
-    decode_memory_context_entries, decode_stage_envelope, decode_window_turn_count,
-    decode_window_turns, encode_stage_envelope_payload, parse_exact_memory_core_operation,
+    build_read_context_request, build_read_context_request_with_workspace_root,
+    build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
+    build_replace_turns_request, build_replace_turns_request_with_expectation,
+    build_window_request, decode_memory_context_entries, decode_stage_envelope,
+    decode_window_turn_count, decode_window_turns, encode_stage_envelope_payload,
+    parse_exact_memory_core_operation,
 };
 #[cfg(feature = "memory-sqlite")]
 pub(crate) use sqlite::{CanonicalMemorySearchHit, WorkspaceMemoryIndexedSearchHit};
@@ -67,8 +68,8 @@ pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoad
 use sqlite_core::{append_turn, clear_session, load_window, replace_turns};
 pub use stage::{
     DerivedMemoryKind, MemoryAuthority, MemoryContextProvenance, MemoryProvenanceSourceKind,
-    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryStageFamily,
-    MemoryTrustLevel, StageDiagnostics, StageEnvelope, StageOutcome,
+    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryRetrievalStrategy,
+    MemoryStageFamily, MemoryTrustLevel, StageDiagnostics, StageEnvelope, StageOutcome,
     builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
 };
 pub use system::{
@@ -85,7 +86,7 @@ pub use system_registry::{
     describe_memory_system, list_memory_system_ids, list_memory_system_metadata,
     memory_system_id_from_env, register_memory_system, resolve_memory_system,
     resolve_memory_system_runtime, resolve_memory_system_selection,
-    supported_memory_system_kind_from_env,
+    resolve_memory_system_selection_without_env, supported_memory_system_kind_from_env,
 };
 pub use system_runtime::{
     BuiltinMemorySystemRuntime, MemorySystemRuntime, MetadataOnlyMemorySystemRuntime,

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -3,10 +3,11 @@ use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::{
-    MemoryContextEntry, MemoryRetrievalRequest, MemoryStageFamily, MemorySystem,
-    MemorySystemMetadata, StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn,
-    load_prompt_context, resolve_memory_system_runtime, runtime_config::MemoryRuntimeConfig,
+    MemoryContextEntry, MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics,
+    StageEnvelope, StageOutcome, WindowTurn, load_prompt_context, resolve_memory_system_runtime,
+    runtime_config::MemoryRuntimeConfig,
 };
+use crate::memory::stage::MemoryRetrievalPlanResult;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HydratedMemoryContext {
@@ -121,8 +122,8 @@ impl BuiltinMemoryOrchestrator {
     ) -> Result<StageEnvelope, String> {
         let recent_window = recent_window_records(session_id, config)?;
         let mut entries = load_prompt_context(session_id, config)?;
-        let retrieval_request =
-            system.build_retrieval_request(session_id, workspace_root, config, &recent_window);
+        let retrieval_plan =
+            system.build_retrieval_plan_result(session_id, workspace_root, config, &recent_window);
 
         let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, metadata, config, || {
             run_derivation_stage(system, session_id, config, &recent_window)
@@ -134,14 +135,23 @@ impl BuiltinMemoryOrchestrator {
                 run_retrieval_stage(
                     system,
                     session_id,
-                    retrieval_request.as_ref(),
+                    retrieval_plan.as_ref(),
                     workspace_root,
                     config,
                     &recent_window,
                 )
             })?;
+        let mut retrieve = retrieve;
+        annotate_retrieval_diagnostics_from_plan_result(
+            &mut retrieve.diagnostics,
+            retrieval_plan.as_ref(),
+        );
         entries.extend(retrieve.records);
 
+        let (retrieval_request, retrieval_planner_snapshot) = retrieval_plan
+            .map(MemoryRetrievalPlanResult::into_parts)
+            .map(|(request, planner_snapshot)| (Some(request), Some(planner_snapshot)))
+            .unwrap_or((None, None));
         let rank = run_rank_stage(system, session_id, entries, metadata, config)?;
         let diagnostics = vec![derive.diagnostics, retrieve.diagnostics, rank.diagnostics];
 
@@ -154,6 +164,7 @@ impl BuiltinMemoryOrchestrator {
                 config,
             ),
             retrieval_request,
+            retrieval_planner_snapshot,
             diagnostics,
         })
     }
@@ -279,9 +290,29 @@ where
                 elapsed_ms: None,
                 fallback_activated: true,
                 message: Some(error),
+                planner_snapshot: None,
             },
         }),
         Err(error) => Err(format!("memory {} stage failed: {error}", family.as_str())),
+    }
+}
+
+fn annotate_retrieval_diagnostics_from_plan_result(
+    diagnostics: &mut StageDiagnostics,
+    plan_result: Option<&MemoryRetrievalPlanResult>,
+) {
+    let Some(plan_result) = plan_result else {
+        return;
+    };
+
+    diagnostics.planner_snapshot = Some(plan_result.planner_snapshot().clone());
+    let planner_summary = plan_result.planner_summary_message();
+    match diagnostics.message.as_mut() {
+        Some(existing) => {
+            existing.push_str(" | ");
+            existing.push_str(planner_summary.as_str());
+        }
+        None => diagnostics.message = Some(planner_summary),
     }
 }
 
@@ -343,6 +374,7 @@ fn handle_rank_error(
             elapsed_ms: None,
             fallback_activated: true,
             message: Some(error),
+            planner_snapshot: None,
         };
         let outcome = StageRunResult {
             records: pass_through_entries,
@@ -368,6 +400,7 @@ pub(crate) fn skipped_stage_diagnostics(
         elapsed_ms: None,
         fallback_activated: false,
         message,
+        planner_snapshot: None,
     }
 }
 
@@ -404,6 +437,7 @@ pub(crate) async fn run_builtin_compact_stage(
         elapsed_ms: None,
         fallback_activated: false,
         message: None,
+        planner_snapshot: None,
     })
 }
 
@@ -427,6 +461,7 @@ pub(crate) async fn run_builtin_compact_stage(
                 elapsed_ms: None,
                 fallback_activated: false,
                 message: None,
+                planner_snapshot: None,
             })
         }
         Err(error) if config.effective_fail_open() => Ok(StageDiagnostics {
@@ -436,24 +471,88 @@ pub(crate) async fn run_builtin_compact_stage(
             elapsed_ms: None,
             fallback_activated: true,
             message: Some(error),
+            planner_snapshot: None,
         }),
         Err(error) => Err(format!("memory compact stage failed: {error}")),
     }
 }
 
 pub(super) fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<String> {
-    recent_window.iter().rev().find_map(|turn| {
+    const MAX_QUERY_TURNS: usize = 3;
+    const MAX_QUERY_CHARS_PER_TURN: usize = 160;
+
+    let mut fragments = Vec::new();
+
+    for turn in recent_window.iter().rev() {
         if turn.role != "user" {
-            return None;
+            continue;
         }
 
         let trimmed_content = turn.content.trim();
         if trimmed_content.is_empty() {
-            return None;
+            continue;
+        }
+        if is_low_signal_retrieval_query_fragment(trimmed_content) {
+            continue;
         }
 
-        Some(trimmed_content.to_owned())
-    })
+        let normalized_fragment =
+            truncate_retrieval_query_fragment(trimmed_content, MAX_QUERY_CHARS_PER_TURN);
+        if normalized_fragment.is_empty() {
+            continue;
+        }
+        if fragments.contains(&normalized_fragment) {
+            continue;
+        }
+
+        fragments.push(normalized_fragment);
+        if fragments.len() >= MAX_QUERY_TURNS {
+            break;
+        }
+    }
+
+    if fragments.is_empty() {
+        return None;
+    }
+
+    fragments.reverse();
+    Some(fragments.join("\n"))
+}
+
+fn truncate_retrieval_query_fragment(input: &str, max_chars: usize) -> String {
+    let char_count = input.chars().count();
+    if char_count <= max_chars {
+        return input.to_owned();
+    }
+
+    input.chars().take(max_chars).collect()
+}
+
+fn is_low_signal_retrieval_query_fragment(input: &str) -> bool {
+    let normalized = input.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return true;
+    }
+
+    if normalized.chars().count() <= 2 {
+        return true;
+    }
+
+    matches!(
+        normalized.as_str(),
+        "ok" | "okay"
+            | "thanks"
+            | "thank you"
+            | "continue"
+            | "go on"
+            | "carry on"
+            | "keep going"
+            | "proceed"
+            | "sure"
+            | "yes"
+            | "yep"
+            | "done"
+    )
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -501,7 +600,7 @@ fn run_derivation_stage(
 fn run_retrieval_stage(
     system: &dyn MemorySystem,
     _session_id: &str,
-    retrieval_request: Option<&MemoryRetrievalRequest>,
+    retrieval_plan: Option<&MemoryRetrievalPlanResult>,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
     recent_window: &[WindowTurn],
@@ -513,11 +612,16 @@ fn run_retrieval_stage(
         return Err(error);
     }
 
-    let Some(retrieval_request) = retrieval_request else {
+    let Some(retrieval_plan) = retrieval_plan else {
         return Ok(None);
     };
 
-    system.run_retrieve_stage(retrieval_request, workspace_root, config, recent_window)
+    system.run_retrieve_stage(
+        retrieval_plan.request(),
+        workspace_root,
+        config,
+        recent_window,
+    )
 }
 
 pub fn hydrate_memory_context(
@@ -580,6 +684,7 @@ pub(crate) fn hydrate_stage_envelope_without_execution_adapter(
     let envelope = StageEnvelope {
         hydrated,
         retrieval_request: None,
+        retrieval_planner_snapshot: None,
         diagnostics,
     };
 
@@ -618,9 +723,10 @@ mod tests {
     use crate::memory::{
         DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, MemoryContextKind, MemoryRecallMode,
         MemoryScope, MemoryStageFamily, MemorySystem, MemorySystemCapability, MemorySystemMetadata,
-        StageOutcome, WORKSPACE_RECALL_MEMORY_SYSTEM_ID, append_turn_direct,
-        register_memory_system,
+        RECALL_FIRST_MEMORY_SYSTEM_ID, StageOutcome, WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+        append_turn_direct, register_memory_system,
     };
+    use serde_json::json;
 
     const REGISTRY_RETRIEVE_ONLY_SYSTEM_ID: &str = "registry-retrieve-only";
     const REGISTRY_RETRIEVE_ONLY_COMPACT_SYSTEM_ID: &str = "registry-retrieve-only-compact";
@@ -896,6 +1002,10 @@ mod tests {
         let retrieval_request = envelope
             .retrieval_request
             .expect("window-plus-summary should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::RecentUserQuery
+        );
         assert_eq!(retrieval_request.query.as_deref(), Some("turn 3"));
 
         let _ = std::fs::remove_file(&db_path);
@@ -946,6 +1056,441 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn hydrate_stage_envelope_with_workspace_root_uses_recent_user_query_with_workspace_strategy() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-query-with-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("query-with-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember this").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 4);
+
+        append_turn_direct(
+            "stage-query-with-workspace",
+            "user",
+            "initial deploy checklist",
+            &config,
+        )
+        .expect("append turn 1 should succeed");
+        append_turn_direct(
+            "stage-query-with-workspace",
+            "assistant",
+            "working on it",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        append_turn_direct(
+            "stage-query-with-workspace",
+            "user",
+            "release freeze timing",
+            &config,
+        )
+        .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-query-with-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("window-plus-summary with workspace should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("initial deploy checklist\nrelease freeze timing")
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_falls_back_when_latest_user_turn_is_low_signal() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-low-signal-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("low-signal-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 4);
+
+        append_turn_direct("stage-low-signal-workspace", "user", "continue", &config)
+            .expect("append turn should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-low-signal-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("workspace-backed low-signal request should still hydrate");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
+        assert_eq!(retrieval_request.query, None);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_uses_structured_signal_strategy_without_query() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-structured-signal-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("structured-signal-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
+
+        append_turn_direct(
+            "stage-structured-signal-workspace",
+            "assistant",
+            crate::memory::build_tool_decision_content(
+                "turn-1",
+                "tool-1",
+                json!({"tool_name": "shell.exec"}),
+            )
+            .as_str(),
+            &config,
+        )
+        .expect("append tool decision should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-structured-signal-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("workspace-backed structured signal should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::StructuredSignalQueryWithWorkspace
+        );
+        assert_eq!(retrieval_request.query.as_deref(), Some("shell.exec"));
+        assert_eq!(
+            retrieval_request.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_uses_task_progress_intent_query_strategy() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-task-progress-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("task-progress-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
+        super::super::ensure_memory_db_ready(Some(db_path.clone()), &config)
+            .expect("ensure memory db ready");
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite db");
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, search_text, ts)
+             VALUES (?1, ?2, NULL, ?3, '', 1)",
+            rusqlite::params![
+                "stage-task-progress-workspace",
+                crate::task_progress::TASK_PROGRESS_EVENT_KIND,
+                serde_json::to_string(&crate::task_progress::task_progress_event_payload(
+                    "unit_test",
+                    &crate::task_progress::TaskProgressRecord {
+                        task_id: "stage-task-progress-workspace".to_owned(),
+                        owner_kind: "conversation_turn".to_owned(),
+                        status: crate::task_progress::TaskProgressStatus::Waiting,
+                        intent_summary: Some("diagnose release freeze".to_owned()),
+                        verification_state: None,
+                        active_handles: Vec::new(),
+                        resume_recipe: None,
+                        updated_at: 1,
+                    },
+                ))
+                .expect("encode task progress payload"),
+            ],
+        )
+        .expect("insert task progress event");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-task-progress-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("workspace-backed task progress should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::TaskProgressIntentQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("diagnose release freeze")
+        );
+        assert_eq!(retrieval_request.budget_items, 2);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_uses_delegate_label_query_strategy() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-delegate-label-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("delegate-label-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
+        super::super::ensure_memory_db_ready(Some(db_path.clone()), &config)
+            .expect("ensure memory db ready");
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite db");
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+             VALUES (?1, 'root', NULL, ?2, 'ready', 1, 1, NULL)",
+            rusqlite::params!["root-session", "Root Session"],
+        )
+        .expect("insert root session");
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+             VALUES (?1, ?2, ?3, ?4, 'ready', 1, 1, NULL)",
+            rusqlite::params![
+                "stage-delegate-label-workspace",
+                "delegate_child",
+                "root-session",
+                "Release Child",
+            ],
+        )
+        .expect("insert delegate child session");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-delegate-label-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("delegate child workspace should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::DelegateLineageQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("Release Child\nRoot Session")
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_uses_workflow_task_query_strategy() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-delegate-task-workspace");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("delegate-task-workspace.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
+        super::super::ensure_memory_db_ready(Some(db_path.clone()), &config)
+            .expect("ensure memory db ready");
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite db");
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+             VALUES (?1, ?2, ?3, ?4, 'ready', 1, 1, NULL)",
+            rusqlite::params![
+                "stage-delegate-task-workspace",
+                "delegate_child",
+                "root-session",
+                "Release Child",
+            ],
+        )
+        .expect("insert delegate child session");
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, search_text, ts)
+             VALUES (?1, 'delegate_started', ?2, ?3, '', 1)",
+            rusqlite::params![
+                "stage-delegate-task-workspace",
+                "root-session",
+                serde_json::to_string(&json!({
+                    "task": "investigate release freeze",
+                }))
+                .expect("encode delegate task payload"),
+            ],
+        )
+        .expect("insert delegate task event");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-delegate-task-workspace",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("delegate task workspace should advertise retrieval request");
+        let envelope_snapshot = envelope
+            .retrieval_planner_snapshot
+            .as_ref()
+            .expect("envelope planner snapshot");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("investigate release freeze")
+        );
+        assert_eq!(retrieval_request.budget_items, 2);
+        assert_eq!(
+            envelope_snapshot.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        let planner_snapshot = envelope.diagnostics[1]
+            .planner_snapshot
+            .as_ref()
+            .expect("planner snapshot");
+        assert_eq!(
+            planner_snapshot.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(planner_snapshot.memory_system_id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(planner_snapshot.budget_items, 2);
+        assert!(planner_snapshot.query_present);
+        assert!(
+            planner_snapshot
+                .planning_notes
+                .iter()
+                .any(|note| note.contains("workflow task seed"))
+        );
+        assert!(
+            envelope.diagnostics[1]
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains(
+                    "planner system=builtin strategy=workflow_task_query_with_workspace"
+                ))
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_with_workspace_root_completed_workflow_task_includes_phase_hint() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-complete-workflow-task");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("complete-workflow-task.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+        let memory_file_path = tmp.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+
+        let config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowOnly, 4);
+        super::super::ensure_memory_db_ready(Some(db_path.clone()), &config)
+            .expect("ensure memory db ready");
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite db");
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+             VALUES (?1, ?2, ?3, ?4, 'completed', 1, 1, NULL)",
+            rusqlite::params![
+                "stage-complete-workflow-task",
+                "delegate_child",
+                "root-session",
+                "Release Child",
+            ],
+        )
+        .expect("insert delegate child session");
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, search_text, ts)
+             VALUES (?1, 'delegate_completed', ?2, ?3, '', 1)",
+            rusqlite::params![
+                "stage-complete-workflow-task",
+                "root-session",
+                serde_json::to_string(&json!({
+                    "task": "investigate release freeze",
+                }))
+                .expect("encode delegate task payload"),
+            ],
+        )
+        .expect("insert delegate task event");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "stage-complete-workflow-task",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("completed workflow task should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("investigate release freeze\nphase: complete")
+        );
+        assert_eq!(retrieval_request.budget_items, 1);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&memory_file_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn hydrate_stage_envelope_window_plus_summary_keeps_summary_retrieval_request() {
         let tmp = hydrated_memory_temp_dir("loong-stage-envelope-window-plus-summary");
         let _ = std::fs::create_dir_all(&tmp);
@@ -975,6 +1520,10 @@ mod tests {
             .retrieval_request
             .expect("window-plus-summary should advertise retrieval request");
         assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
         assert_eq!(
             retrieval_request.recall_mode,
             crate::memory::MemoryRecallMode::PromptAssembly
@@ -1031,6 +1580,122 @@ mod tests {
             retrieval_query_from_recent_window(recent_window.as_slice()).expect("query fallback");
 
         assert_eq!(query, "release rollback plan");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn retrieval_query_from_recent_window_combines_recent_non_empty_user_turns() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "initial deploy checklist".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: "working on it".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "rollback smoke test".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "release freeze timing".to_owned(),
+                ts: None,
+            },
+        ];
+
+        let query =
+            retrieval_query_from_recent_window(recent_window.as_slice()).expect("query fallback");
+
+        assert_eq!(
+            query,
+            "initial deploy checklist\nrollback smoke test\nrelease freeze timing"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn retrieval_query_from_recent_window_dedupes_recent_user_turns() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "rollback smoke test".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: "noted".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "rollback smoke test".to_owned(),
+                ts: None,
+            },
+        ];
+
+        let query =
+            retrieval_query_from_recent_window(recent_window.as_slice()).expect("query fallback");
+
+        assert_eq!(query, "rollback smoke test");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn retrieval_query_from_recent_window_skips_low_signal_followups() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "rollback smoke test".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: "working on it".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "continue".to_owned(),
+                ts: None,
+            },
+        ];
+
+        let query =
+            retrieval_query_from_recent_window(recent_window.as_slice()).expect("query fallback");
+
+        assert_eq!(query, "rollback smoke test");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn retrieval_query_from_recent_window_returns_none_for_only_low_signal_turns() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "ok".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: "done".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "continue".to_owned(),
+                ts: None,
+            },
+        ];
+
+        assert_eq!(
+            retrieval_query_from_recent_window(recent_window.as_slice()),
+            None
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1172,6 +1837,10 @@ mod tests {
             .retrieval_request
             .expect("profile-plus-window should advertise retrieval request");
         assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
         assert_eq!(
             retrieval_request.scopes,
             vec![MemoryScope::Workspace, MemoryScope::Session]
@@ -1321,10 +1990,22 @@ mod tests {
             WORKSPACE_RECALL_MEMORY_SYSTEM_ID
         );
         assert_eq!(
+            retrieval_request.strategy,
+            crate::memory::MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
+        assert_eq!(
             retrieval_request.recall_mode,
             MemoryRecallMode::PromptAssembly
         );
         assert_eq!(retrieval_request.budget_items, 2);
+        assert_eq!(
+            envelope.retrieval_planner_snapshot,
+            Some(retrieval_request.planner_snapshot())
+        );
+        assert_eq!(
+            envelope.diagnostics[1].planner_snapshot,
+            Some(retrieval_request.planner_snapshot())
+        );
 
         let entry_kinds = envelope
             .hydrated
@@ -1380,6 +2061,62 @@ mod tests {
                 (MemoryStageFamily::Retrieve, StageOutcome::Succeeded),
                 (MemoryStageFamily::Rank, StageOutcome::Succeeded),
             ]
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn recall_first_system_stage_envelope_preserves_selected_identity_and_snapshot() {
+        let tmp = hydrated_memory_temp_dir("loong-stage-envelope-recall-first");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("recall-first.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config =
+            sqlite_memory_config_with_profile(db_path.clone(), MemoryProfile::WindowPlusSummary, 2);
+        config.resolved_system_id = Some(RECALL_FIRST_MEMORY_SYSTEM_ID.to_owned());
+
+        append_turn_direct("recall-first", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("recall-first", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct(
+            "recall-first",
+            "user",
+            "investigate deploy freeze timing",
+            &config,
+        )
+        .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope_with_workspace_root(
+            "recall-first",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .expect("hydrate staged envelope for recall-first");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .as_ref()
+            .expect("recall-first should advertise retrieval request");
+        assert_eq!(
+            retrieval_request.memory_system_id,
+            RECALL_FIRST_MEMORY_SYSTEM_ID
+        );
+        assert_eq!(
+            envelope.hydrated.diagnostics.system_id,
+            RECALL_FIRST_MEMORY_SYSTEM_ID
+        );
+        assert_eq!(
+            envelope.retrieval_planner_snapshot,
+            Some(retrieval_request.planner_snapshot())
+        );
+        assert_eq!(
+            envelope.diagnostics[1].planner_snapshot,
+            Some(retrieval_request.planner_snapshot())
         );
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -736,8 +736,10 @@ mod tests {
         let workspace_root = Path::new("/tmp/workspace");
         let read_context =
             build_read_context_request_with_workspace_root("session-123", Some(workspace_root));
-        let staged =
-            build_read_stage_envelope_request_with_workspace_root("session-123", Some(workspace_root));
+        let staged = build_read_stage_envelope_request_with_workspace_root(
+            "session-123",
+            Some(workspace_root),
+        );
 
         assert_eq!(read_context.payload, staged.payload);
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -205,17 +205,26 @@ pub fn build_read_context_request(session_id: &str) -> MemoryCoreRequest {
     build_read_context_request_with_workspace_root(session_id, None)
 }
 
+fn build_session_memory_request_payload(session_id: &str, workspace_root: Option<&Path>) -> Value {
+    let mut payload = serde_json::Map::from_iter([("session_id".to_owned(), json!(session_id))]);
+
+    if let Some(workspace_root) = workspace_root {
+        payload.insert(
+            "workspace_root".to_owned(),
+            json!(workspace_root.to_string_lossy().to_string()),
+        );
+    }
+
+    Value::Object(payload)
+}
+
 pub fn build_read_context_request_with_workspace_root(
     session_id: &str,
     workspace_root: Option<&Path>,
 ) -> MemoryCoreRequest {
-    let workspace_root_value = workspace_root.map(|path| path.display().to_string());
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_CONTEXT.to_owned(),
-        payload: json!({
-            "session_id": session_id,
-            "workspace_root": workspace_root_value,
-        }),
+        payload: build_session_memory_request_payload(session_id, workspace_root),
     }
 }
 
@@ -243,30 +252,16 @@ pub fn build_replace_turns_request_with_expectation(
 }
 
 pub fn build_read_stage_envelope_request(session_id: &str) -> MemoryCoreRequest {
-    MemoryCoreRequest {
-        operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
-        payload: json!({
-            "session_id": session_id,
-        }),
-    }
+    build_read_stage_envelope_request_with_workspace_root(session_id, None)
 }
 
 pub fn build_read_stage_envelope_request_with_workspace_root(
     session_id: &str,
     workspace_root: Option<&Path>,
 ) -> MemoryCoreRequest {
-    let mut payload = serde_json::Map::from_iter([("session_id".to_owned(), json!(session_id))]);
-
-    if let Some(workspace_root) = workspace_root {
-        payload.insert(
-            "workspace_root".to_owned(),
-            json!(workspace_root.to_string_lossy().to_string()),
-        );
-    }
-
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
-        payload: Value::Object(payload),
+        payload: build_session_memory_request_payload(session_id, workspace_root),
     }
 }
 
@@ -683,7 +678,20 @@ mod tests {
     }
 
     #[test]
-    fn build_read_context_request_with_workspace_root_serializes_workspace_root() {
+    fn build_read_context_request_without_workspace_root_uses_canonical_payload_shape() {
+        let request = build_read_context_request("session-123");
+
+        assert_eq!(request.operation, MEMORY_OP_READ_CONTEXT);
+        assert_eq!(request.payload["session_id"], "session-123");
+        assert!(
+            request.payload.get("workspace_root").is_none(),
+            "canonical session request payload should omit workspace_root when absent"
+        );
+        assert_eq!(request.payload.as_object().map(|map| map.len()), Some(1));
+    }
+
+    #[test]
+    fn build_read_context_request_with_workspace_root_uses_canonical_payload_shape() {
         let workspace_root = Path::new("/tmp/workspace");
 
         let request =
@@ -693,6 +701,19 @@ mod tests {
         assert_eq!(request.payload["session_id"], "session-123");
         assert_eq!(request.payload["workspace_root"], "/tmp/workspace");
         assert_eq!(request.payload.as_object().map(|map| map.len()), Some(2));
+    }
+
+    #[test]
+    fn build_read_stage_envelope_request_without_workspace_root_uses_canonical_payload_shape() {
+        let request = build_read_stage_envelope_request("session-123");
+
+        assert_eq!(request.operation, MEMORY_OP_READ_STAGE_ENVELOPE);
+        assert_eq!(request.payload["session_id"], "session-123");
+        assert!(
+            request.payload.get("workspace_root").is_none(),
+            "canonical session request payload should omit workspace_root when absent"
+        );
+        assert_eq!(request.payload.as_object().map(|map| map.len()), Some(1));
     }
 
     #[test]
@@ -708,6 +729,22 @@ mod tests {
         assert_eq!(request.payload["session_id"], "session-123");
         assert_eq!(request.payload["workspace_root"], "/tmp/workspace");
         assert_eq!(request.payload.as_object().map(|map| map.len()), Some(2));
+    }
+
+    #[test]
+    fn session_memory_request_builders_share_one_payload_shape() {
+        let workspace_root = Path::new("/tmp/workspace");
+        let read_context =
+            build_read_context_request_with_workspace_root("session-123", Some(workspace_root));
+        let staged =
+            build_read_stage_envelope_request_with_workspace_root("session-123", Some(workspace_root));
+
+        assert_eq!(read_context.payload, staged.payload);
+
+        let read_context = build_read_context_request("session-123");
+        let staged = build_read_stage_envelope_request("session-123");
+
+        assert_eq!(read_context.payload, staged.payload);
     }
 
     #[test]

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -4,8 +4,6 @@ use loong_contracts::MemoryCoreRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::memory::runtime_config::MemoryRuntimeConfig;
-
 use super::{
     DerivedMemoryKind, HydratedMemoryContext, MemoryContextProvenance, MemoryDiagnostics,
     MemoryRecallMode, MemoryRetrievalRequest, MemoryRetrievalStrategy, MemoryScope,
@@ -203,29 +201,19 @@ pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest
     }
 }
 
-pub fn build_read_context_request(
-    session_id: &str,
-    config: &MemoryRuntimeConfig,
-) -> MemoryCoreRequest {
-    build_read_context_request_with_workspace_root(session_id, None, config)
+pub fn build_read_context_request(session_id: &str) -> MemoryCoreRequest {
+    build_read_context_request_with_workspace_root(session_id, None)
 }
 
 pub fn build_read_context_request_with_workspace_root(
     session_id: &str,
     workspace_root: Option<&Path>,
-    config: &MemoryRuntimeConfig,
 ) -> MemoryCoreRequest {
     let workspace_root_value = workspace_root.map(|path| path.display().to_string());
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_CONTEXT.to_owned(),
         payload: json!({
             "session_id": session_id,
-            "profile": config.profile.as_str(),
-            "system": config.system.as_str(),
-            "system_id": config.resolved_system_id.as_deref(),
-            "sliding_window": config.sliding_window,
-            "summary_max_chars": config.summary_max_chars,
-            "profile_note": config.profile_note,
             "workspace_root": workspace_root_value,
         }),
     }
@@ -266,7 +254,6 @@ pub fn build_read_stage_envelope_request(session_id: &str) -> MemoryCoreRequest 
 pub fn build_read_stage_envelope_request_with_workspace_root(
     session_id: &str,
     workspace_root: Option<&Path>,
-    config: &MemoryRuntimeConfig,
 ) -> MemoryCoreRequest {
     let mut payload = serde_json::Map::from_iter([("session_id".to_owned(), json!(session_id))]);
 
@@ -276,19 +263,6 @@ pub fn build_read_stage_envelope_request_with_workspace_root(
             json!(workspace_root.to_string_lossy().to_string()),
         );
     }
-
-    payload.insert("profile".to_owned(), json!(config.profile.as_str()));
-    payload.insert("system".to_owned(), json!(config.system.as_str()));
-    payload.insert(
-        "system_id".to_owned(),
-        json!(config.resolved_system_id.as_deref()),
-    );
-    payload.insert("sliding_window".to_owned(), json!(config.sliding_window));
-    payload.insert(
-        "summary_max_chars".to_owned(),
-        json!(config.summary_max_chars),
-    );
-    payload.insert("profile_note".to_owned(), json!(config.profile_note));
 
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
@@ -710,18 +684,30 @@ mod tests {
 
     #[test]
     fn build_read_context_request_with_workspace_root_serializes_workspace_root() {
-        let config = MemoryRuntimeConfig::for_sqlite_path("/tmp/protocol-memory.sqlite3");
         let workspace_root = Path::new("/tmp/workspace");
 
-        let request = build_read_context_request_with_workspace_root(
-            "session-123",
-            Some(workspace_root),
-            &config,
-        );
+        let request =
+            build_read_context_request_with_workspace_root("session-123", Some(workspace_root));
 
         assert_eq!(request.operation, MEMORY_OP_READ_CONTEXT);
         assert_eq!(request.payload["session_id"], "session-123");
         assert_eq!(request.payload["workspace_root"], "/tmp/workspace");
+        assert_eq!(request.payload.as_object().map(|map| map.len()), Some(2));
+    }
+
+    #[test]
+    fn build_read_stage_envelope_request_with_workspace_root_uses_canonical_payload_shape() {
+        let workspace_root = Path::new("/tmp/workspace");
+
+        let request = build_read_stage_envelope_request_with_workspace_root(
+            "session-123",
+            Some(workspace_root),
+        );
+
+        assert_eq!(request.operation, MEMORY_OP_READ_STAGE_ENVELOPE);
+        assert_eq!(request.payload["session_id"], "session-123");
+        assert_eq!(request.payload["workspace_root"], "/tmp/workspace");
+        assert_eq!(request.payload.as_object().map(|map| map.len()), Some(2));
     }
 
     #[test]

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -8,9 +8,10 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::{
     DerivedMemoryKind, HydratedMemoryContext, MemoryContextProvenance, MemoryDiagnostics,
-    MemoryRecallMode, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, StageDiagnostics,
-    StageEnvelope, StageOutcome,
+    MemoryRecallMode, MemoryRetrievalRequest, MemoryRetrievalStrategy, MemoryScope,
+    MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
 };
+use crate::memory::stage::PlannerDiagnosticsSnapshot;
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
@@ -139,6 +140,10 @@ struct MemoryRetrievalRequestPayload {
     #[serde(default)]
     memory_system_id: Option<String>,
     #[serde(default)]
+    strategy: Option<String>,
+    #[serde(default)]
+    planning_notes: Vec<String>,
+    #[serde(default)]
     query: Option<String>,
     #[serde(default)]
     recall_mode: Option<MemoryRecallMode>,
@@ -162,6 +167,8 @@ struct StageDiagnosticsPayload {
     fallback_activated: bool,
     #[serde(default)]
     message: Option<String>,
+    #[serde(default)]
+    planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -169,6 +176,8 @@ struct StageEnvelopePayload {
     hydrated: Option<HydratedMemoryContextPayload>,
     #[serde(default)]
     retrieval_request: Option<MemoryRetrievalRequestPayload>,
+    #[serde(default)]
+    retrieval_planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
     #[serde(default)]
     diagnostics: Vec<StageDiagnosticsPayload>,
 }
@@ -198,6 +207,15 @@ pub fn build_read_context_request(
     session_id: &str,
     config: &MemoryRuntimeConfig,
 ) -> MemoryCoreRequest {
+    build_read_context_request_with_workspace_root(session_id, None, config)
+}
+
+pub fn build_read_context_request_with_workspace_root(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> MemoryCoreRequest {
+    let workspace_root_value = workspace_root.map(|path| path.display().to_string());
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_CONTEXT.to_owned(),
         payload: json!({
@@ -208,6 +226,7 @@ pub fn build_read_context_request(
             "sliding_window": config.sliding_window,
             "summary_max_chars": config.summary_max_chars,
             "profile_note": config.profile_note,
+            "workspace_root": workspace_root_value,
         }),
     }
 }
@@ -320,16 +339,31 @@ pub fn encode_stage_envelope_payload(envelope: &StageEnvelope) -> Value {
 
 pub fn decode_stage_envelope(payload: &Value) -> Option<StageEnvelope> {
     let payload = serde_json::from_value::<StageEnvelopePayload>(payload.clone()).ok()?;
+    let hydrated = decode_hydrated_memory_context_payload(payload.hydrated?)?;
+    let retrieval_request = payload
+        .retrieval_request
+        .and_then(decode_memory_retrieval_request_payload);
+    let fallback_planner_system_id = retrieval_request
+        .as_ref()
+        .map(|request| request.memory_system_id.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            let hydrated_system_id = hydrated.diagnostics.system_id.trim().to_owned();
+            (!hydrated_system_id.is_empty()).then_some(hydrated_system_id)
+        });
 
     Some(StageEnvelope {
-        hydrated: decode_hydrated_memory_context_payload(payload.hydrated?)?,
-        retrieval_request: payload
-            .retrieval_request
-            .and_then(decode_memory_retrieval_request_payload),
+        hydrated,
+        retrieval_request,
+        retrieval_planner_snapshot: payload.retrieval_planner_snapshot.map(|snapshot| {
+            normalize_planner_snapshot(snapshot, fallback_planner_system_id.as_deref())
+        }),
         diagnostics: payload
             .diagnostics
             .into_iter()
-            .filter_map(decode_stage_diagnostics_payload)
+            .filter_map(|payload| {
+                decode_stage_diagnostics_payload(payload, fallback_planner_system_id.as_deref())
+            })
             .collect(),
     })
 }
@@ -380,6 +414,8 @@ impl From<&MemoryRetrievalRequest> for MemoryRetrievalRequestPayload {
         Self {
             session_id: value.session_id.clone(),
             memory_system_id: Some(value.memory_system_id.clone()),
+            strategy: Some(value.strategy.as_str().to_owned()),
+            planning_notes: value.planning_notes.clone(),
             query: value.query.clone(),
             recall_mode: Some(value.recall_mode),
             scopes: value
@@ -410,6 +446,7 @@ impl From<&StageDiagnostics> for StageDiagnosticsPayload {
             elapsed_ms: value.elapsed_ms,
             fallback_activated: value.fallback_activated,
             message: value.message.clone(),
+            planner_snapshot: value.planner_snapshot.clone(),
         }
     }
 }
@@ -422,6 +459,7 @@ impl From<&StageEnvelope> for StageEnvelopePayload {
                 .retrieval_request
                 .as_ref()
                 .map(MemoryRetrievalRequestPayload::from),
+            retrieval_planner_snapshot: value.retrieval_planner_snapshot.clone(),
             diagnostics: value
                 .diagnostics
                 .iter()
@@ -482,6 +520,12 @@ fn decode_memory_retrieval_request_payload(
         memory_system_id: payload
             .memory_system_id
             .unwrap_or_else(|| crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned()),
+        strategy: payload
+            .strategy
+            .as_deref()
+            .and_then(MemoryRetrievalStrategy::parse_id)
+            .unwrap_or_default(),
+        planning_notes: payload.planning_notes,
         query: payload.query,
         recall_mode: payload.recall_mode.unwrap_or_default(),
         scopes: payload
@@ -498,7 +542,10 @@ fn decode_memory_retrieval_request_payload(
     })
 }
 
-fn decode_stage_diagnostics_payload(payload: StageDiagnosticsPayload) -> Option<StageDiagnostics> {
+fn decode_stage_diagnostics_payload(
+    payload: StageDiagnosticsPayload,
+    fallback_planner_system_id: Option<&str>,
+) -> Option<StageDiagnostics> {
     Some(StageDiagnostics {
         family: MemoryStageFamily::parse_id(payload.family.as_str())?,
         outcome: StageOutcome::parse_id(payload.outcome.as_str())?,
@@ -506,7 +553,22 @@ fn decode_stage_diagnostics_payload(payload: StageDiagnosticsPayload) -> Option<
         elapsed_ms: payload.elapsed_ms,
         fallback_activated: payload.fallback_activated,
         message: payload.message,
+        planner_snapshot: payload
+            .planner_snapshot
+            .map(|snapshot| normalize_planner_snapshot(snapshot, fallback_planner_system_id)),
     })
+}
+
+fn normalize_planner_snapshot(
+    mut snapshot: PlannerDiagnosticsSnapshot,
+    fallback_planner_system_id: Option<&str>,
+) -> PlannerDiagnosticsSnapshot {
+    let needs_fallback = snapshot.memory_system_id.trim().is_empty();
+    if needs_fallback {
+        snapshot.memory_system_id = fallback_planner_system_id.unwrap_or_default().to_owned();
+    }
+
+    snapshot
 }
 
 #[cfg(test)]
@@ -593,6 +655,11 @@ mod tests {
             .expect("retrieval request should decode");
         assert_eq!(retrieval_request.session_id, "session-123");
         assert_eq!(retrieval_request.memory_system_id, "builtin");
+        assert_eq!(
+            retrieval_request.strategy,
+            MemoryRetrievalStrategy::Unspecified
+        );
+        assert!(retrieval_request.planning_notes.is_empty());
         assert_eq!(retrieval_request.query, None);
         assert_eq!(
             retrieval_request.recall_mode,
@@ -639,5 +706,242 @@ mod tests {
 
         assert_eq!(operation, MemoryCoreOperation::ReadStageEnvelope);
         assert_eq!(rendered, "read_stage_envelope");
+    }
+
+    #[test]
+    fn build_read_context_request_with_workspace_root_serializes_workspace_root() {
+        let config = MemoryRuntimeConfig::for_sqlite_path("/tmp/protocol-memory.sqlite3");
+        let workspace_root = Path::new("/tmp/workspace");
+
+        let request = build_read_context_request_with_workspace_root(
+            "session-123",
+            Some(workspace_root),
+            &config,
+        );
+
+        assert_eq!(request.operation, MEMORY_OP_READ_CONTEXT);
+        assert_eq!(request.payload["session_id"], "session-123");
+        assert_eq!(request.payload["workspace_root"], "/tmp/workspace");
+    }
+
+    #[test]
+    fn decode_stage_envelope_preserves_retrieval_planning_notes() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "retrieval_request": {
+                "session_id": "session-123",
+                "strategy": "workflow_task_query_with_workspace",
+                "planning_notes": [
+                    "workflow task seed",
+                    "workflow task budget=2"
+                ]
+            },
+            "diagnostics": []
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("retrieval request should decode");
+
+        assert_eq!(
+            retrieval_request.strategy,
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(
+            retrieval_request.planning_notes,
+            vec![
+                "workflow task seed".to_owned(),
+                "workflow task budget=2".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_stage_envelope_preserves_retrieval_diagnostics_message() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "diagnostics": [
+                {
+                    "family": "retrieve",
+                    "outcome": "succeeded",
+                    "message": "planner system=builtin strategy=workflow_task_query_with_workspace budget=2 query=present notes=workflow task seed"
+                }
+            ]
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+
+        assert_eq!(envelope.diagnostics.len(), 1);
+        assert_eq!(envelope.diagnostics[0].family, MemoryStageFamily::Retrieve);
+        assert_eq!(
+            envelope.diagnostics[0].message.as_deref(),
+            Some(
+                "planner system=builtin strategy=workflow_task_query_with_workspace budget=2 query=present notes=workflow task seed"
+            )
+        );
+    }
+
+    #[test]
+    fn decode_stage_envelope_preserves_planner_snapshot() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "retrieval_planner_snapshot": {
+                "memory_system_id": "builtin",
+                "strategy": "workflow_task_query_with_workspace",
+                "budget_items": 2,
+                "query_present": true,
+                "planning_notes": [
+                    "workflow task seed",
+                    "workflow task budget=2"
+                ]
+            },
+            "diagnostics": [
+                {
+                    "family": "retrieve",
+                    "outcome": "succeeded",
+                    "planner_snapshot": {
+                        "memory_system_id": "builtin",
+                        "strategy": "workflow_task_query_with_workspace",
+                        "budget_items": 2,
+                        "query_present": true,
+                        "planning_notes": [
+                            "workflow task seed",
+                            "workflow task budget=2"
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        let envelope_snapshot = envelope
+            .retrieval_planner_snapshot
+            .as_ref()
+            .expect("envelope planner snapshot");
+        assert_eq!(
+            envelope_snapshot.strategy,
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(envelope_snapshot.memory_system_id, "builtin");
+        let snapshot = envelope.diagnostics[0]
+            .planner_snapshot
+            .as_ref()
+            .expect("planner snapshot");
+
+        assert_eq!(
+            snapshot.strategy,
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(snapshot.budget_items, 2);
+        assert!(snapshot.query_present);
+        assert_eq!(snapshot.memory_system_id, "builtin");
+        assert_eq!(
+            snapshot.planning_notes,
+            vec![
+                "workflow task seed".to_owned(),
+                "workflow task budget=2".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_stage_envelope_tolerates_omitted_planner_snapshot_system_id() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "retrieval_planner_snapshot": {
+                "strategy": "workspace_reference_only",
+                "budget_items": 1,
+                "query_present": false,
+                "planning_notes": [
+                    "workspace recall system"
+                ]
+            }
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        let snapshot = envelope
+            .retrieval_planner_snapshot
+            .as_ref()
+            .expect("planner snapshot");
+
+        assert_eq!(snapshot.memory_system_id, "builtin");
+        assert_eq!(
+            snapshot.strategy,
+            MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
+        assert_eq!(snapshot.budget_items, 1);
+        assert!(!snapshot.query_present);
+    }
+
+    #[test]
+    fn decode_stage_envelope_backfills_planner_snapshot_system_id_from_retrieval_request() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "retrieval_request": {
+                "session_id": "session-123",
+                "memory_system_id": "recall_first",
+                "strategy": "workspace_reference_only",
+                "recall_mode": "prompt_assembly",
+                "scopes": ["workspace"],
+                "budget_items": 1,
+                "allowed_kinds": ["reference"]
+            },
+            "retrieval_planner_snapshot": {
+                "strategy": "workspace_reference_only",
+                "budget_items": 1,
+                "query_present": false,
+                "planning_notes": [
+                    "workspace recall system"
+                ]
+            },
+            "diagnostics": [
+                {
+                    "family": "retrieve",
+                    "outcome": "succeeded",
+                    "planner_snapshot": {
+                        "strategy": "workspace_reference_only",
+                        "budget_items": 1,
+                        "query_present": false,
+                        "planning_notes": [
+                            "workspace recall system"
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        let envelope_snapshot = envelope
+            .retrieval_planner_snapshot
+            .as_ref()
+            .expect("envelope planner snapshot");
+        let diagnostic_snapshot = envelope.diagnostics[0]
+            .planner_snapshot
+            .as_ref()
+            .expect("diagnostic planner snapshot");
+
+        assert_eq!(envelope_snapshot.memory_system_id, "recall_first");
+        assert_eq!(diagnostic_snapshot.memory_system_id, "recall_first");
     }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -23,12 +23,31 @@ use super::{
     runtime_config::MemoryRuntimeConfig,
 };
 use crate::search_text::build_search_index_text;
+use crate::task_progress::{
+    TASK_PROGRESS_EVENT_KIND, TaskProgressRecord, task_progress_from_event_payload,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConversationTurn {
     pub role: String,
     pub content: String,
     pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionMetadataHint {
+    pub kind: String,
+    pub state: String,
+    pub parent_session_id: Option<String>,
+    pub label: Option<String>,
+    pub parent_label: Option<String>,
+    pub lineage_root_session_id: Option<String>,
+    pub lineage_root_label: Option<String>,
+    pub lineage_depth: usize,
+    pub workflow_task: Option<String>,
+    pub workflow_phase: Option<String>,
+    pub workflow_operation_kind: Option<String>,
+    pub workflow_operation_scope: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -950,6 +969,267 @@ pub(super) fn load_summary_body_for_durable_flush(
 
         Ok(checkpoint.map(|value| value.summary_body))
     })
+}
+
+pub(crate) fn load_latest_task_progress_record(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Option<TaskProgressRecord>, String> {
+    let runtime = acquire_memory_runtime(config)?;
+
+    runtime.with_connection("memory.latest_task_progress_record", |conn| {
+        let mut stmt = conn
+            .prepare(
+                "SELECT payload_json
+                 FROM session_events
+                 WHERE session_id = ?1 AND event_kind = ?2
+                 ORDER BY id DESC
+                 LIMIT 1",
+            )
+            .map_err(|error| {
+                format!("prepare latest task progress record query failed: {error}")
+            })?;
+        let payload_json = stmt
+            .query_row(
+                rusqlite::params![session_id, TASK_PROGRESS_EVENT_KIND],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|error| format!("query latest task progress record failed: {error}"))?;
+        let Some(payload_json) = payload_json else {
+            return Ok(None);
+        };
+
+        let payload = serde_json::from_str::<Value>(payload_json.as_str()).map_err(|error| {
+            format!("decode latest task progress record payload failed: {error}")
+        })?;
+        Ok(task_progress_from_event_payload(&payload))
+    })
+}
+
+pub(crate) fn load_session_metadata_hint(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Option<SessionMetadataHint>, String> {
+    let runtime = acquire_memory_runtime(config)?;
+
+    runtime.with_connection("memory.session_metadata_hint", |conn| {
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, kind, state, parent_session_id, label
+                 FROM sessions
+                 WHERE session_id = ?1
+                 LIMIT 1",
+            )
+            .map_err(|error| format!("prepare session metadata hint query failed: {error}"))?;
+        let raw = stmt
+            .query_row(rusqlite::params![session_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            })
+            .optional()
+            .map_err(|error| format!("query session metadata hint failed: {error}"))?;
+        let Some((resolved_session_id, kind, state, parent_session_id, label)) = raw else {
+            return Ok(None);
+        };
+
+        let parent_label = match parent_session_id.as_deref() {
+            Some(parent_session_id) => load_session_label_with_conn(conn, parent_session_id)?,
+            None => None,
+        };
+        let lineage_root_session_id =
+            load_lineage_root_session_id_with_conn(conn, resolved_session_id.as_str())?;
+        let lineage_root_label = match lineage_root_session_id.as_deref() {
+            Some(lineage_root_session_id) => {
+                load_session_label_with_conn(conn, lineage_root_session_id)?
+            }
+            None => None,
+        };
+        let lineage_depth =
+            load_session_lineage_depth_with_conn(conn, resolved_session_id.as_str())?;
+        let workflow_hint = load_session_workflow_hint_with_conn(
+            conn,
+            kind.as_str(),
+            state.as_str(),
+            resolved_session_id.as_str(),
+        )?;
+
+        Ok(Some(SessionMetadataHint {
+            kind,
+            state,
+            parent_session_id,
+            label,
+            parent_label,
+            lineage_root_session_id,
+            lineage_root_label,
+            lineage_depth,
+            workflow_task: workflow_hint.as_ref().and_then(|hint| hint.task.clone()),
+            workflow_phase: workflow_hint.as_ref().and_then(|hint| hint.phase.clone()),
+            workflow_operation_kind: workflow_hint
+                .as_ref()
+                .and_then(|hint| hint.operation_kind.clone()),
+            workflow_operation_scope: workflow_hint
+                .as_ref()
+                .and_then(|hint| hint.operation_scope.clone()),
+        }))
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionWorkflowHint {
+    task: Option<String>,
+    phase: Option<String>,
+    operation_kind: Option<String>,
+    operation_scope: Option<String>,
+}
+
+fn load_session_label_with_conn(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT label FROM sessions WHERE session_id = ?1 LIMIT 1",
+        rusqlite::params![session_id],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map(|value| value.flatten())
+    .map_err(|error| format!("query session label failed: {error}"))
+}
+
+fn load_session_lineage_depth_with_conn(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<usize, String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut next_session_id = Some(session_id.to_owned());
+    let mut depth = 0usize;
+
+    while let Some(current_session_id) = next_session_id {
+        if !seen.insert(current_session_id.clone()) {
+            return Err(format!(
+                "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing metadata hint depth"
+            ));
+        }
+        let maybe_parent = conn
+            .query_row(
+                "SELECT parent_session_id FROM sessions WHERE session_id = ?1 LIMIT 1",
+                rusqlite::params![current_session_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(|error| format!("query session lineage depth failed: {error}"))?;
+        let Some(parent_session_id) = maybe_parent.flatten() else {
+            return Ok(depth);
+        };
+        depth += 1;
+        next_session_id = Some(parent_session_id);
+    }
+
+    Ok(depth)
+}
+
+fn load_lineage_root_session_id_with_conn(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut next_session_id = Some(session_id.to_owned());
+
+    while let Some(current_session_id) = next_session_id {
+        if !seen.insert(current_session_id.clone()) {
+            return Err(format!(
+                "session_lineage_cycle_detected: `{current_session_id}` reappeared while computing metadata hint root"
+            ));
+        }
+        let raw = conn
+            .query_row(
+                "SELECT session_id, parent_session_id FROM sessions WHERE session_id = ?1 LIMIT 1",
+                rusqlite::params![current_session_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .optional()
+            .map_err(|error| format!("query session lineage root failed: {error}"))?;
+        let Some((resolved_session_id, parent_session_id)) = raw else {
+            return Ok(None);
+        };
+        match parent_session_id {
+            Some(parent_session_id) => next_session_id = Some(parent_session_id),
+            None => return Ok(Some(resolved_session_id)),
+        }
+    }
+
+    Ok(None)
+}
+
+fn load_session_workflow_hint_with_conn(
+    conn: &Connection,
+    kind: &str,
+    state: &str,
+    session_id: &str,
+) -> Result<Option<SessionWorkflowHint>, String> {
+    let is_delegate_child = kind == "delegate_child";
+    if !is_delegate_child {
+        return Ok(None);
+    }
+
+    let task = load_latest_delegate_task_hint_with_conn(conn, session_id)?;
+    let phase = match state {
+        "ready" | "running" => Some("execute".to_owned()),
+        "completed" => Some("complete".to_owned()),
+        "failed" | "timed_out" => Some("failed".to_owned()),
+        _ => None,
+    };
+
+    Ok(Some(SessionWorkflowHint {
+        task,
+        phase,
+        operation_kind: Some("task".to_owned()),
+        operation_scope: Some("task".to_owned()),
+    }))
+}
+
+fn load_latest_delegate_task_hint_with_conn(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT payload_json
+             FROM session_events
+             WHERE session_id = ?1
+               AND event_kind LIKE 'delegate_%'
+             ORDER BY id DESC
+             LIMIT 16",
+        )
+        .map_err(|error| format!("prepare latest delegate task hint query failed: {error}"))?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![session_id], |row| row.get::<_, String>(0))
+        .map_err(|error| format!("query latest delegate task hint failed: {error}"))?;
+
+    for row in rows {
+        let payload_json =
+            row.map_err(|error| format!("read latest delegate task hint row failed: {error}"))?;
+        let payload = serde_json::from_str::<Value>(payload_json.as_str())
+            .map_err(|error| format!("decode latest delegate task hint payload failed: {error}"))?;
+        let task = payload
+            .get("task")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if task.is_some() {
+            return Ok(task);
+        }
+    }
+
+    Ok(None)
 }
 
 pub(super) fn ensure_memory_db_ready(

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -339,15 +339,147 @@ impl MemoryContextProvenance {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryRetrievalStrategy {
+    #[default]
+    Unspecified,
+    RecentUserQuery,
+    RecentUserQueryWithWorkspace,
+    WorkspaceReferenceOnly,
+    WorkspaceReferenceWithStructuredSignals,
+    StructuredSignalQueryWithWorkspace,
+    TaskProgressIntentQueryWithWorkspace,
+    DelegateLabelQueryWithWorkspace,
+    DelegateLineageQueryWithWorkspace,
+    DelegateTaskQueryWithWorkspace,
+    WorkflowTaskQueryWithWorkspace,
+}
+
+impl MemoryRetrievalStrategy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unspecified => "unspecified",
+            Self::RecentUserQuery => "recent_user_query",
+            Self::RecentUserQueryWithWorkspace => "recent_user_query_with_workspace",
+            Self::WorkspaceReferenceOnly => "workspace_reference_only",
+            Self::WorkspaceReferenceWithStructuredSignals => {
+                "workspace_reference_with_structured_signals"
+            }
+            Self::StructuredSignalQueryWithWorkspace => "structured_signal_query_with_workspace",
+            Self::TaskProgressIntentQueryWithWorkspace => {
+                "task_progress_intent_query_with_workspace"
+            }
+            Self::DelegateLabelQueryWithWorkspace => "delegate_label_query_with_workspace",
+            Self::DelegateLineageQueryWithWorkspace => "delegate_lineage_query_with_workspace",
+            Self::DelegateTaskQueryWithWorkspace => "delegate_task_query_with_workspace",
+            Self::WorkflowTaskQueryWithWorkspace => "workflow_task_query_with_workspace",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "unspecified" => Some(Self::Unspecified),
+            "recent_user_query" => Some(Self::RecentUserQuery),
+            "recent_user_query_with_workspace" => Some(Self::RecentUserQueryWithWorkspace),
+            "workspace_reference_only" => Some(Self::WorkspaceReferenceOnly),
+            "workspace_reference_with_structured_signals" => {
+                Some(Self::WorkspaceReferenceWithStructuredSignals)
+            }
+            "structured_signal_query_with_workspace" => {
+                Some(Self::StructuredSignalQueryWithWorkspace)
+            }
+            "task_progress_intent_query_with_workspace" => {
+                Some(Self::TaskProgressIntentQueryWithWorkspace)
+            }
+            "delegate_label_query_with_workspace" => Some(Self::DelegateLabelQueryWithWorkspace),
+            "delegate_lineage_query_with_workspace" => {
+                Some(Self::DelegateLineageQueryWithWorkspace)
+            }
+            "delegate_task_query_with_workspace" => Some(Self::DelegateTaskQueryWithWorkspace),
+            "workflow_task_query_with_workspace" => Some(Self::WorkflowTaskQueryWithWorkspace),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryRetrievalRequest {
     pub session_id: String,
     pub memory_system_id: String,
+    pub strategy: MemoryRetrievalStrategy,
+    pub planning_notes: Vec<String>,
     pub query: Option<String>,
     pub recall_mode: MemoryRecallMode,
     pub scopes: Vec<MemoryScope>,
     pub budget_items: usize,
     pub allowed_kinds: Vec<DerivedMemoryKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryRetrievalPlanResult {
+    pub request: MemoryRetrievalRequest,
+    pub planner_snapshot: PlannerDiagnosticsSnapshot,
+}
+
+impl MemoryRetrievalRequest {
+    pub fn planner_snapshot(&self) -> PlannerDiagnosticsSnapshot {
+        PlannerDiagnosticsSnapshot {
+            memory_system_id: self.memory_system_id.clone(),
+            strategy: self.strategy,
+            budget_items: self.budget_items,
+            query_present: self.query.is_some(),
+            planning_notes: self.planning_notes.clone(),
+        }
+    }
+
+    pub fn into_plan_result(self) -> MemoryRetrievalPlanResult {
+        let planner_snapshot = self.planner_snapshot();
+        MemoryRetrievalPlanResult {
+            request: self,
+            planner_snapshot,
+        }
+    }
+}
+
+impl MemoryRetrievalPlanResult {
+    pub fn request(&self) -> &MemoryRetrievalRequest {
+        &self.request
+    }
+
+    pub fn planner_snapshot(&self) -> &PlannerDiagnosticsSnapshot {
+        &self.planner_snapshot
+    }
+
+    pub fn into_request(self) -> MemoryRetrievalRequest {
+        self.request
+    }
+
+    pub fn into_parts(self) -> (MemoryRetrievalRequest, PlannerDiagnosticsSnapshot) {
+        (self.request, self.planner_snapshot)
+    }
+
+    pub fn planner_summary_message(&self) -> String {
+        let query_state = if self.planner_snapshot.query_present {
+            "present"
+        } else {
+            "absent"
+        };
+        let notes = if self.planner_snapshot.planning_notes.is_empty() {
+            "none".to_owned()
+        } else {
+            self.planner_snapshot.planning_notes.join("; ")
+        };
+
+        format!(
+            "planner system={} strategy={} budget={} query={} notes={}",
+            self.planner_snapshot.memory_system_id,
+            self.planner_snapshot.strategy.as_str(),
+            self.planner_snapshot.budget_items,
+            query_state,
+            notes
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -358,6 +490,7 @@ pub struct StageDiagnostics {
     pub elapsed_ms: Option<u64>,
     pub fallback_activated: bool,
     pub message: Option<String>,
+    pub planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
 }
 
 impl StageDiagnostics {
@@ -369,14 +502,26 @@ impl StageDiagnostics {
             elapsed_ms: None,
             fallback_activated: false,
             message: None,
+            planner_snapshot: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannerDiagnosticsSnapshot {
+    #[serde(default)]
+    pub memory_system_id: String,
+    pub strategy: MemoryRetrievalStrategy,
+    pub budget_items: usize,
+    pub query_present: bool,
+    pub planning_notes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StageEnvelope {
     pub hydrated: HydratedMemoryContext,
     pub retrieval_request: Option<MemoryRetrievalRequest>,
+    pub retrieval_planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
     pub diagnostics: Vec<StageDiagnostics>,
 }
 
@@ -439,12 +584,15 @@ mod tests {
             retrieval_request: Some(MemoryRetrievalRequest {
                 session_id: "session-123".to_owned(),
                 memory_system_id: "builtin".to_owned(),
+                strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+                planning_notes: vec!["workspace_root present".to_owned()],
                 query: None,
                 recall_mode: MemoryRecallMode::PromptAssembly,
                 scopes: vec![MemoryScope::Session],
                 budget_items: 8,
                 allowed_kinds: vec![DerivedMemoryKind::Summary],
             }),
+            retrieval_planner_snapshot: None,
             diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Derive)],
         };
 
@@ -472,12 +620,66 @@ mod tests {
                 },
             },
             retrieval_request: None,
+            retrieval_planner_snapshot: None,
             diagnostics: vec![],
         };
 
         let payload = encode_stage_envelope_payload(&envelope);
         let decoded = decode_stage_envelope(&payload).expect("decode stage envelope");
         assert_eq!(decoded.hydrated.diagnostics.system_id, "lucid");
+    }
+
+    #[test]
+    fn retrieval_plan_result_into_parts_round_trips_request_and_snapshot() {
+        let request = MemoryRetrievalRequest {
+            session_id: "session-123".to_owned(),
+            memory_system_id: "recall_first".to_owned(),
+            strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+            planning_notes: vec!["workspace recall system".to_owned()],
+            query: None,
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes: vec![MemoryScope::Workspace],
+            budget_items: 1,
+            allowed_kinds: vec![DerivedMemoryKind::Reference],
+        };
+        let expected_snapshot = request.planner_snapshot();
+        let result = request.clone().into_plan_result();
+
+        let (actual_request, actual_snapshot) = result.into_parts();
+
+        assert_eq!(actual_request, request);
+        assert_eq!(actual_snapshot, expected_snapshot);
+    }
+
+    #[test]
+    fn retrieval_plan_result_summary_message_uses_snapshot_state() {
+        let result = MemoryRetrievalPlanResult {
+            request: MemoryRetrievalRequest {
+                session_id: "session-123".to_owned(),
+                memory_system_id: "builtin".to_owned(),
+                strategy: MemoryRetrievalStrategy::RecentUserQueryWithWorkspace,
+                planning_notes: vec!["request note".to_owned()],
+                query: Some("request query".to_owned()),
+                recall_mode: MemoryRecallMode::PromptAssembly,
+                scopes: vec![MemoryScope::Workspace],
+                budget_items: 4,
+                allowed_kinds: vec![DerivedMemoryKind::Reference],
+            },
+            planner_snapshot: PlannerDiagnosticsSnapshot {
+                memory_system_id: "recall_first".to_owned(),
+                strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+                budget_items: 1,
+                query_present: false,
+                planning_notes: vec!["snapshot note".to_owned()],
+            },
+        };
+
+        let summary = result.planner_summary_message();
+
+        assert_eq!(
+            summary,
+            "planner system=recall_first strategy=workspace_reference_only budget=1 query=absent notes=snapshot note"
+        );
     }
 
     #[test]

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -3,15 +3,17 @@ use std::path::Path;
 use std::collections::BTreeSet;
 
 use crate::CliResult;
+use serde_json::Value;
 
 use super::system_runtime::{BuiltinMemorySystemRuntime, MemorySystemRuntime};
 use super::{
     CanonicalMemoryKind, CanonicalMemorySearchHit, DerivedMemoryKind, MemoryAuthority,
     MemoryContextEntry, MemoryContextKind, MemoryContextProvenance, MemoryProvenanceSourceKind,
-    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily,
-    MemoryTrustLevel, StageDiagnostics, WindowTurn, builtin_pre_assembly_stage_families,
-    durable_recall, runtime_config::MemoryRuntimeConfig,
+    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryRetrievalStrategy,
+    MemoryScope, MemoryStageFamily, MemoryTrustLevel, StageDiagnostics, WindowTurn,
+    builtin_pre_assembly_stage_families, durable_recall, runtime_config::MemoryRuntimeConfig,
 };
+use crate::memory::stage::MemoryRetrievalPlanResult;
 
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
 pub const DEFAULT_MEMORY_SYSTEM_ID: &str = "builtin";
@@ -204,6 +206,14 @@ pub trait MemorySystem: Send + Sync {
         Ok(None)
     }
 
+    // Compatibility matrix:
+    // - request-only system: `build_retrieval_plan_result()` upgrades via request by default
+    // - plan-result-only system: `build_retrieval_request()` stays `None` by default
+    // - `build_retrieval_request_via_plan_result()` is the explicit back-compat bridge
+    // - `build_retrieval_plan_result_via_request()` is the explicit forward-compat bridge
+
+    /// Legacy compatibility hook for systems that only know how to describe retrieval as a
+    /// request. New implementations should prefer `build_retrieval_plan_result`.
     fn build_retrieval_request(
         &self,
         _session_id: &str,
@@ -212,6 +222,51 @@ pub trait MemorySystem: Send + Sync {
         _recent_window: &[WindowTurn],
     ) -> Option<MemoryRetrievalRequest> {
         None
+    }
+
+    /// Explicit compatibility adapter for plan-result-first systems that still need to surface
+    /// a legacy retrieval request at call sites that have not moved to plan results yet.
+    fn build_retrieval_request_via_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        self.build_retrieval_plan_result(session_id, workspace_root, config, recent_window)
+            .map(MemoryRetrievalPlanResult::into_request)
+    }
+
+    /// Explicit compatibility adapter for request-first systems that have not yet implemented a
+    /// native retrieval plan result. This mirrors `build_retrieval_request_via_plan_result` but
+    /// does not change the default asymmetry of the trait surface.
+    fn build_retrieval_plan_result_via_request(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        self.build_retrieval_request(session_id, workspace_root, config, recent_window)
+            .map(MemoryRetrievalRequest::into_plan_result)
+    }
+
+    /// Preferred retrieval-planning surface. The default implementation only upgrades legacy
+    /// request builders into a structured plan result; it does not automatically adapt a
+    /// plan-result-only implementation back into `build_retrieval_request`.
+    fn build_retrieval_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        self.build_retrieval_plan_result_via_request(
+            session_id,
+            workspace_root,
+            config,
+            recent_window,
+        )
     }
 
     fn run_derive_stage(
@@ -281,6 +336,47 @@ where
             .build_retrieval_request(session_id, workspace_root, config, recent_window)
     }
 
+    fn build_retrieval_request_via_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalRequest> {
+        self.as_ref().build_retrieval_request_via_plan_result(
+            session_id,
+            workspace_root,
+            config,
+            recent_window,
+        )
+    }
+
+    fn build_retrieval_plan_result_via_request(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        self.as_ref().build_retrieval_plan_result_via_request(
+            session_id,
+            workspace_root,
+            config,
+            recent_window,
+        )
+    }
+
+    fn build_retrieval_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        self.as_ref()
+            .build_retrieval_plan_result(session_id, workspace_root, config, recent_window)
+    }
+
     fn run_derive_stage(
         &self,
         session_id: &str,
@@ -321,33 +417,109 @@ where
     }
 }
 
-fn build_builtin_retrieval_request(
+pub(crate) fn build_builtin_retrieval_plan_result(
     memory_system_id: &str,
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
     recent_window: &[WindowTurn],
-) -> Option<MemoryRetrievalRequest> {
-    let supports_query_recall = matches!(config.mode, crate::config::MemoryMode::WindowPlusSummary);
+) -> Option<MemoryRetrievalPlanResult> {
+    let retrieval_plan = BuiltinRetrievalPlan::from_runtime_inputs(
+        session_id,
+        workspace_root,
+        config,
+        recent_window,
+    )?;
+
+    Some(retrieval_plan.into_result(memory_system_id, session_id))
+}
+
+fn build_workspace_retrieval_plan_result(
+    memory_system_id: &str,
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Option<MemoryRetrievalPlanResult> {
     let has_workspace_root = workspace_root.is_some();
-    let query = if supports_query_recall {
-        super::orchestrator::retrieval_query_from_recent_window(recent_window)
-    } else {
-        None
-    };
-    let has_query = query.is_some();
-    let has_retrieval_path = has_workspace_root || has_query;
-    if !has_retrieval_path {
+    if !has_workspace_root {
         return None;
     }
 
-    if has_query {
-        let scopes = vec![
-            MemoryScope::Session,
-            MemoryScope::Workspace,
-            MemoryScope::Agent,
-            MemoryScope::User,
-        ];
+    let budget_items = config.sliding_window.min(4);
+    let normalized_budget_items = budget_items.max(1);
+    let request = MemoryRetrievalRequest {
+        session_id: session_id.to_owned(),
+        memory_system_id: memory_system_id.to_owned(),
+        strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+        planning_notes: vec!["workspace recall system".to_owned()],
+        query: None,
+        recall_mode: MemoryRecallMode::PromptAssembly,
+        scopes: vec![crate::memory::MemoryScope::Workspace],
+        budget_items: normalized_budget_items,
+        allowed_kinds: vec![crate::memory::DerivedMemoryKind::Reference],
+    };
+
+    Some(request.into_plan_result())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuiltinRetrievalPlan {
+    strategy: MemoryRetrievalStrategy,
+    planning_notes: Vec<String>,
+    query: Option<String>,
+    scopes: Vec<MemoryScope>,
+    budget_items: usize,
+    allowed_kinds: Vec<DerivedMemoryKind>,
+}
+
+struct BuiltinRetrievalPlannerInputs {
+    has_workspace_root: bool,
+    recent_user_query: Option<String>,
+    recent_user_budget_items: usize,
+    structured_query: Option<String>,
+    task_progress_plan: Option<SeededWorkspaceRetrievalPlan>,
+    workflow_task_plan: Option<SeededWorkspaceRetrievalPlan>,
+    delegate_lineage_plan: Option<SeededWorkspaceRetrievalPlan>,
+    has_structured_session_signals: bool,
+}
+
+impl BuiltinRetrievalPlan {
+    fn new(
+        strategy: MemoryRetrievalStrategy,
+        planning_notes: Vec<String>,
+        query: Option<String>,
+        scopes: Vec<MemoryScope>,
+        budget_items: usize,
+        allowed_kinds: Vec<DerivedMemoryKind>,
+    ) -> Self {
+        Self {
+            strategy,
+            planning_notes,
+            query,
+            scopes,
+            budget_items,
+            allowed_kinds,
+        }
+    }
+
+    fn workspace_scoped(
+        strategy: MemoryRetrievalStrategy,
+        planning_notes: Vec<String>,
+        query: Option<String>,
+        budget_items: usize,
+        allowed_kinds: Vec<DerivedMemoryKind>,
+    ) -> Self {
+        Self::new(
+            strategy,
+            planning_notes,
+            query,
+            vec![MemoryScope::Workspace, MemoryScope::Session],
+            budget_items,
+            allowed_kinds,
+        )
+    }
+
+    fn recent_user_query(has_workspace_root: bool, query: String, budget_items: usize) -> Self {
         let mut allowed_kinds = vec![
             DerivedMemoryKind::Profile,
             DerivedMemoryKind::Fact,
@@ -358,37 +530,672 @@ fn build_builtin_retrieval_request(
         if has_workspace_root {
             allowed_kinds.push(DerivedMemoryKind::Reference);
         }
-        let budget_items = if recent_window.is_empty() {
-            6
-        } else {
-            config.sliding_window.min(6)
-        };
-        let request = MemoryRetrievalRequest {
-            session_id: session_id.to_owned(),
-            memory_system_id: memory_system_id.to_owned(),
-            query,
-            recall_mode: MemoryRecallMode::PromptAssembly,
-            scopes,
+
+        Self::new(
+            if has_workspace_root {
+                MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+            } else {
+                MemoryRetrievalStrategy::RecentUserQuery
+            },
+            vec![
+                "recent_user_query seed".to_owned(),
+                if has_workspace_root {
+                    "workspace_root present".to_owned()
+                } else {
+                    "workspace_root absent".to_owned()
+                },
+            ],
+            Some(query),
+            vec![
+                MemoryScope::Session,
+                MemoryScope::Workspace,
+                MemoryScope::Agent,
+                MemoryScope::User,
+            ],
             budget_items,
             allowed_kinds,
-        };
-        return Some(request);
+        )
     }
 
-    let scopes = vec![MemoryScope::Workspace, MemoryScope::Session];
-    let allowed_kinds = vec![DerivedMemoryKind::Reference];
-    let budget_items = 1;
-    let request = MemoryRetrievalRequest {
-        session_id: session_id.to_owned(),
-        memory_system_id: memory_system_id.to_owned(),
-        query: None,
-        recall_mode: MemoryRecallMode::PromptAssembly,
-        scopes,
-        budget_items,
-        allowed_kinds,
-    };
+    fn from_seeded_workspace(seeded: SeededWorkspaceRetrievalPlan) -> Self {
+        Self::workspace_scoped(
+            seeded.strategy,
+            seeded.planning_notes,
+            Some(seeded.query),
+            seeded.budget_items,
+            seeded.allowed_kinds,
+        )
+    }
 
-    Some(request)
+    fn from_runtime_inputs(
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<Self> {
+        let has_workspace_root = workspace_root.is_some();
+        let supports_query_recall =
+            matches!(config.mode, crate::config::MemoryMode::WindowPlusSummary);
+        let recent_user_query = if supports_query_recall {
+            super::orchestrator::retrieval_query_from_recent_window(recent_window)
+        } else {
+            None
+        };
+        let has_retrieval_path = has_workspace_root || recent_user_query.is_some();
+        if !has_retrieval_path {
+            return None;
+        }
+
+        let inputs = BuiltinRetrievalPlannerInputs {
+            has_workspace_root,
+            recent_user_query,
+            recent_user_budget_items: if recent_window.is_empty() {
+                6
+            } else {
+                config.sliding_window.min(6)
+            },
+            structured_query: structured_signal_query_seed(session_id, recent_window),
+            task_progress_plan: if has_workspace_root {
+                task_progress_retrieval_plan(session_id, config)
+            } else {
+                None
+            },
+            workflow_task_plan: if has_workspace_root {
+                workflow_task_retrieval_plan(session_id, config)
+            } else {
+                None
+            },
+            delegate_lineage_plan: if has_workspace_root {
+                delegate_lineage_retrieval_plan(session_id, config)
+            } else {
+                None
+            },
+            has_structured_session_signals: recent_window_has_structured_session_signals(
+                session_id,
+                recent_window,
+            ),
+        };
+
+        Self::from_planner_inputs(inputs)
+    }
+
+    fn from_planner_inputs(inputs: BuiltinRetrievalPlannerInputs) -> Option<Self> {
+        let BuiltinRetrievalPlannerInputs {
+            has_workspace_root,
+            recent_user_query,
+            recent_user_budget_items,
+            structured_query,
+            task_progress_plan,
+            workflow_task_plan,
+            delegate_lineage_plan,
+            has_structured_session_signals,
+        } = inputs;
+
+        if let Some(query) = recent_user_query {
+            return Some(Self::recent_user_query(
+                has_workspace_root,
+                query,
+                recent_user_budget_items,
+            ));
+        }
+
+        let plan = if let Some(structured_query) = structured_query {
+            let seeded = SeededWorkspaceRetrievalPlan::structured_signal_query(structured_query);
+            Self::from_seeded_workspace(seeded)
+        } else if let Some(task_progress_plan) = task_progress_plan {
+            Self::from_seeded_workspace(task_progress_plan)
+        } else if let Some(workflow_task_plan) = workflow_task_plan {
+            Self::from_seeded_workspace(workflow_task_plan)
+        } else if let Some(delegate_lineage_plan) = delegate_lineage_plan {
+            Self::from_seeded_workspace(delegate_lineage_plan)
+        } else if has_structured_session_signals {
+            let seeded =
+                SeededWorkspaceRetrievalPlan::workspace_reference_with_structured_signals();
+            Self::workspace_scoped(
+                seeded.strategy,
+                seeded.planning_notes,
+                None,
+                seeded.budget_items,
+                seeded.allowed_kinds,
+            )
+        } else {
+            let seeded = SeededWorkspaceRetrievalPlan::workspace_reference_fallback();
+            Self::workspace_scoped(
+                seeded.strategy,
+                seeded.planning_notes,
+                None,
+                seeded.budget_items,
+                seeded.allowed_kinds,
+            )
+        };
+
+        Some(plan)
+    }
+
+    fn into_request(self, memory_system_id: &str, session_id: &str) -> MemoryRetrievalRequest {
+        MemoryRetrievalRequest {
+            session_id: session_id.to_owned(),
+            memory_system_id: memory_system_id.to_owned(),
+            strategy: self.strategy,
+            planning_notes: self.planning_notes,
+            query: self.query,
+            recall_mode: MemoryRecallMode::PromptAssembly,
+            scopes: self.scopes,
+            budget_items: self.budget_items,
+            allowed_kinds: self.allowed_kinds,
+        }
+    }
+
+    fn into_result(self, memory_system_id: &str, session_id: &str) -> MemoryRetrievalPlanResult {
+        let request = self.into_request(memory_system_id, session_id);
+        request.into_plan_result()
+    }
+}
+
+fn recent_window_has_structured_session_signals(
+    session_id: &str,
+    recent_window: &[WindowTurn],
+) -> bool {
+    !collect_structured_canonical_records(session_id, recent_window).is_empty()
+}
+
+fn structured_signal_query_seed(session_id: &str, recent_window: &[WindowTurn]) -> Option<String> {
+    let records = collect_structured_canonical_records(session_id, recent_window);
+    structured_signal_query_seed_from_records(records.as_slice())
+}
+
+struct SeededWorkspaceRetrievalPlan {
+    strategy: MemoryRetrievalStrategy,
+    planning_notes: Vec<String>,
+    query: String,
+    budget_items: usize,
+    allowed_kinds: Vec<DerivedMemoryKind>,
+}
+
+impl SeededWorkspaceRetrievalPlan {
+    fn new(
+        strategy: MemoryRetrievalStrategy,
+        planning_notes: Vec<String>,
+        query: String,
+        budget_items: usize,
+        allowed_kinds: Vec<DerivedMemoryKind>,
+    ) -> Self {
+        Self {
+            strategy,
+            planning_notes,
+            query,
+            budget_items,
+            allowed_kinds,
+        }
+    }
+
+    fn seeded_query(
+        strategy: MemoryRetrievalStrategy,
+        seed_note: impl Into<String>,
+        query: String,
+        policy: WorkspaceRetrievalPolicy,
+        extra_notes: Vec<String>,
+    ) -> Self {
+        let mut planning_notes = vec![seed_note.into()];
+        planning_notes.extend(extra_notes);
+
+        Self::new(
+            strategy,
+            planning_notes,
+            query,
+            policy.budget_items,
+            policy.allowed_kinds,
+        )
+    }
+
+    fn seeded_no_query(
+        strategy: MemoryRetrievalStrategy,
+        seed_note: impl Into<String>,
+        policy: WorkspaceRetrievalPolicy,
+        extra_notes: Vec<String>,
+    ) -> Self {
+        let mut planning_notes = vec![seed_note.into()];
+        planning_notes.extend(extra_notes);
+
+        Self::new(
+            strategy,
+            planning_notes,
+            String::new(),
+            policy.budget_items,
+            policy.allowed_kinds,
+        )
+    }
+
+    fn structured_signal_query(query: String) -> Self {
+        Self::seeded_query(
+            MemoryRetrievalStrategy::StructuredSignalQueryWithWorkspace,
+            "structured_signal query seed",
+            query,
+            WorkspaceRetrievalPolicy::structured_signal_query(),
+            vec!["workspace_root present".to_owned()],
+        )
+    }
+
+    fn task_progress(query: String, policy: WorkspaceRetrievalPolicy) -> Self {
+        let budget_items = policy.budget_items;
+        Self::seeded_query(
+            MemoryRetrievalStrategy::TaskProgressIntentQueryWithWorkspace,
+            "task_progress intent_summary seed",
+            query,
+            policy,
+            vec![format!("task_progress budget={budget_items}")],
+        )
+    }
+
+    fn workflow_task(query: String, policy: WorkspaceRetrievalPolicy) -> Self {
+        let budget_items = policy.budget_items;
+        Self::seeded_query(
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace,
+            "workflow task seed",
+            query,
+            policy,
+            vec![format!("workflow task budget={budget_items}")],
+        )
+    }
+
+    fn delegate_lineage(query: String) -> Self {
+        Self::seeded_query(
+            if query.contains('\n') {
+                MemoryRetrievalStrategy::DelegateLineageQueryWithWorkspace
+            } else {
+                MemoryRetrievalStrategy::DelegateLabelQueryWithWorkspace
+            },
+            "delegate label/lineage seed",
+            query,
+            WorkspaceRetrievalPolicy::delegate_lineage(),
+            vec!["workspace_root present".to_owned()],
+        )
+    }
+
+    fn workspace_reference_with_structured_signals() -> Self {
+        Self::seeded_no_query(
+            MemoryRetrievalStrategy::WorkspaceReferenceWithStructuredSignals,
+            "structured signals influenced kinds",
+            WorkspaceRetrievalPolicy::workspace_reference_with_structured_signals(),
+            vec!["workspace_root present".to_owned()],
+        )
+    }
+
+    fn workspace_reference_fallback() -> Self {
+        Self::seeded_no_query(
+            MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+            "workspace reference fallback",
+            WorkspaceRetrievalPolicy::workspace_reference_fallback(),
+            Vec::new(),
+        )
+    }
+}
+
+#[derive(Clone)]
+struct WorkspaceRetrievalPolicy {
+    budget_items: usize,
+    allowed_kinds: Vec<DerivedMemoryKind>,
+}
+
+impl WorkspaceRetrievalPolicy {
+    fn new(budget_items: usize, allowed_kinds: Vec<DerivedMemoryKind>) -> Self {
+        Self {
+            budget_items,
+            allowed_kinds,
+        }
+    }
+
+    fn reference_only(budget_items: usize) -> Self {
+        Self::new(budget_items, vec![DerivedMemoryKind::Reference])
+    }
+
+    fn reference_procedure_fact(budget_items: usize) -> Self {
+        Self::new(
+            budget_items,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Fact,
+            ],
+        )
+    }
+
+    fn reference_procedure_overview(budget_items: usize) -> Self {
+        Self::new(
+            budget_items,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+            ],
+        )
+    }
+
+    fn reference_overview_fact(budget_items: usize) -> Self {
+        Self::new(
+            budget_items,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Overview,
+                DerivedMemoryKind::Fact,
+            ],
+        )
+    }
+
+    fn reference_procedure_overview_fact(budget_items: usize) -> Self {
+        Self::new(
+            budget_items,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+                DerivedMemoryKind::Fact,
+            ],
+        )
+    }
+
+    fn structured_signal_query() -> Self {
+        Self::reference_procedure_fact(1)
+    }
+
+    fn workspace_reference_with_structured_signals() -> Self {
+        Self::reference_procedure_fact(1)
+    }
+
+    fn workspace_reference_fallback() -> Self {
+        Self::reference_only(1)
+    }
+
+    fn delegate_lineage() -> Self {
+        Self::reference_procedure_overview(1)
+    }
+
+    fn task_progress(is_pending_like: bool) -> Self {
+        if is_pending_like {
+            return Self::reference_procedure_overview_fact(2);
+        }
+
+        Self::reference_overview_fact(1)
+    }
+}
+
+fn task_progress_retrieval_plan(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Option<SeededWorkspaceRetrievalPlan> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let record = super::sqlite::load_latest_task_progress_record(session_id, config)
+            .ok()
+            .flatten()?;
+        let query = record
+            .intent_summary
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())?;
+        let is_pending_like = matches!(
+            record.status,
+            crate::task_progress::TaskProgressStatus::Waiting
+                | crate::task_progress::TaskProgressStatus::Blocked
+                | crate::task_progress::TaskProgressStatus::Verifying
+        );
+        Some(SeededWorkspaceRetrievalPlan::task_progress(
+            query,
+            WorkspaceRetrievalPolicy::task_progress(is_pending_like),
+        ))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, config);
+        None
+    }
+}
+
+fn workflow_task_retrieval_plan(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Option<SeededWorkspaceRetrievalPlan> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let metadata = super::sqlite::load_session_metadata_hint(session_id, config)
+            .ok()
+            .flatten()?;
+        let query = workflow_task_query_seed_from_metadata(&metadata)?;
+        Some(SeededWorkspaceRetrievalPlan::workflow_task(
+            query,
+            workflow_task_policy_from_metadata(&metadata),
+        ))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, config);
+        None
+    }
+}
+
+fn workflow_task_query_seed_from_metadata(
+    metadata: &super::sqlite::SessionMetadataHint,
+) -> Option<String> {
+    let mut lines = Vec::new();
+
+    let task_present = append_unique_query_line(
+        &mut lines,
+        metadata.workflow_task.as_deref(),
+        None::<fn(&str) -> String>,
+    );
+    if !task_present {
+        return None;
+    }
+
+    append_unique_query_line(
+        &mut lines,
+        metadata
+            .workflow_phase
+            .as_deref()
+            .filter(|value| value.trim() != "execute"),
+        Some(|value: &str| format!("phase: {}", value.trim())),
+    );
+    append_unique_query_line(
+        &mut lines,
+        metadata
+            .workflow_operation_kind
+            .as_deref()
+            .filter(|value| value.trim() != "task"),
+        Some(|value: &str| format!("operation_kind: {}", value.trim())),
+    );
+    append_unique_query_line(
+        &mut lines,
+        metadata
+            .workflow_operation_scope
+            .as_deref()
+            .filter(|value| value.trim() != "task"),
+        Some(|value: &str| format!("operation_scope: {}", value.trim())),
+    );
+
+    finalize_query_lines(lines)
+}
+
+fn structured_signal_query_seed_from_records(
+    records: &[super::CanonicalMemoryRecord],
+) -> Option<String> {
+    const MAX_SIGNAL_TERMS: usize = 3;
+
+    let mut terms = Vec::new();
+
+    for record in records.iter().rev() {
+        let maybe_term = match record.kind {
+            CanonicalMemoryKind::ToolDecision => record
+                .metadata
+                .get("decision")
+                .and_then(|value| value.get("tool_name"))
+                .and_then(Value::as_str),
+            CanonicalMemoryKind::ToolOutcome => record
+                .metadata
+                .get("outcome")
+                .and_then(|value| value.get("tool_name"))
+                .and_then(Value::as_str),
+            CanonicalMemoryKind::ConversationEvent
+            | CanonicalMemoryKind::AcpRuntimeEvent
+            | CanonicalMemoryKind::AcpFinalEvent => {
+                record.metadata.get("event").and_then(Value::as_str)
+            }
+            CanonicalMemoryKind::ImportedProfile
+            | CanonicalMemoryKind::UserTurn
+            | CanonicalMemoryKind::AssistantTurn => None,
+        };
+
+        let appended =
+            append_unique_query_line(&mut terms, maybe_term, Some(str::to_ascii_lowercase));
+        if !appended {
+            continue;
+        }
+        if terms.len() >= MAX_SIGNAL_TERMS {
+            break;
+        }
+    }
+
+    finalize_query_lines_reversed(terms)
+}
+
+fn workflow_task_policy_from_metadata(
+    metadata: &super::sqlite::SessionMetadataHint,
+) -> WorkspaceRetrievalPolicy {
+    let workflow_phase = metadata.workflow_phase.as_deref();
+    let workflow_operation_kind = metadata.workflow_operation_kind.as_deref();
+    let workflow_operation_scope = metadata.workflow_operation_scope.as_deref();
+    let is_execute_like = matches!(workflow_phase, Some("execute"))
+        || matches!(metadata.state.as_str(), "ready" | "running");
+    let is_task_scope = matches!(workflow_operation_kind, Some("task"))
+        || matches!(workflow_operation_scope, Some("task"));
+    let is_approval_kind = matches!(workflow_operation_kind, Some("approval"));
+    let is_session_scope = matches!(workflow_operation_scope, Some("session"));
+
+    if is_task_scope && is_execute_like {
+        return WorkspaceRetrievalPolicy::reference_procedure_overview_fact(2);
+    }
+
+    if is_approval_kind {
+        return WorkspaceRetrievalPolicy::new(
+            1,
+            vec![
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Fact,
+            ],
+        );
+    }
+
+    if is_session_scope {
+        return WorkspaceRetrievalPolicy::reference_overview_fact(1);
+    }
+
+    WorkspaceRetrievalPolicy::reference_overview_fact(if is_execute_like { 2 } else { 1 })
+}
+
+fn delegate_lineage_query_seed_from_metadata(
+    metadata: &super::sqlite::SessionMetadataHint,
+) -> Option<String> {
+    let is_delegate_child =
+        metadata.kind == "delegate_child" || metadata.parent_session_id.is_some();
+    if !is_delegate_child {
+        return None;
+    }
+
+    let mut labels = Vec::new();
+
+    let label_present = append_unique_query_line(
+        &mut labels,
+        metadata.label.as_deref(),
+        None::<fn(&str) -> String>,
+    );
+    if !label_present {
+        return None;
+    }
+
+    append_unique_query_line(
+        &mut labels,
+        metadata.parent_label.as_deref(),
+        None::<fn(&str) -> String>,
+    );
+
+    if metadata.lineage_depth > 1 {
+        append_unique_query_line(
+            &mut labels,
+            metadata.lineage_root_label.as_deref(),
+            None::<fn(&str) -> String>,
+        );
+    }
+
+    finalize_query_lines(labels)
+}
+
+fn append_unique_query_line<F>(
+    lines: &mut Vec<String>,
+    raw: Option<&str>,
+    mapper: Option<F>,
+) -> bool
+where
+    F: Fn(&str) -> String,
+{
+    let Some(raw) = raw else {
+        return false;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let line = match mapper {
+        Some(mapper) => mapper(trimmed),
+        None => trimmed.to_owned(),
+    };
+    if line.trim().is_empty() {
+        return false;
+    }
+    if lines.contains(&line) {
+        return false;
+    }
+
+    lines.push(line);
+    true
+}
+
+fn finalize_query_lines(lines: Vec<String>) -> Option<String> {
+    if lines.is_empty() {
+        return None;
+    }
+
+    Some(lines.join("\n"))
+}
+
+fn finalize_query_lines_reversed(mut lines: Vec<String>) -> Option<String> {
+    if lines.is_empty() {
+        return None;
+    }
+
+    lines.reverse();
+    Some(lines.join("\n"))
+}
+
+fn delegate_lineage_retrieval_plan(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Option<SeededWorkspaceRetrievalPlan> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let metadata = super::sqlite::load_session_metadata_hint(session_id, config)
+            .ok()
+            .flatten()?;
+        let query = delegate_lineage_query_seed_from_metadata(&metadata)?;
+        Some(SeededWorkspaceRetrievalPlan::delegate_lineage(query))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, config);
+        None
+    }
 }
 
 fn run_builtin_retrieve_stage(
@@ -511,7 +1318,22 @@ impl MemorySystem for BuiltinMemorySystem {
         config: &MemoryRuntimeConfig,
         recent_window: &[WindowTurn],
     ) -> Option<MemoryRetrievalRequest> {
-        build_builtin_retrieval_request(
+        self.build_retrieval_request_via_plan_result(
+            session_id,
+            workspace_root,
+            config,
+            recent_window,
+        )
+    }
+
+    fn build_retrieval_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        build_builtin_retrieval_plan_result(
             self.id(),
             session_id,
             workspace_root,
@@ -943,23 +1765,17 @@ impl MemorySystem for WorkspaceRecallMemorySystem {
         config: &MemoryRuntimeConfig,
         _recent_window: &[WindowTurn],
     ) -> Option<MemoryRetrievalRequest> {
-        let has_workspace_root = workspace_root.is_some();
-        if !has_workspace_root {
-            return None;
-        }
+        self.build_retrieval_request_via_plan_result(session_id, workspace_root, config, &[])
+    }
 
-        let budget_items = config.sliding_window.min(4);
-        let normalized_budget_items = budget_items.max(1);
-
-        Some(MemoryRetrievalRequest {
-            session_id: session_id.to_owned(),
-            memory_system_id: self.id().to_owned(),
-            query: None,
-            recall_mode: MemoryRecallMode::PromptAssembly,
-            scopes: vec![crate::memory::MemoryScope::Workspace],
-            budget_items: normalized_budget_items,
-            allowed_kinds: vec![crate::memory::DerivedMemoryKind::Reference],
-        })
+    fn build_retrieval_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        _recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        build_workspace_retrieval_plan_result(self.id(), session_id, workspace_root, config)
     }
 
     fn run_derive_stage(
@@ -1036,7 +1852,22 @@ impl MemorySystem for RecallFirstMemorySystem {
         config: &MemoryRuntimeConfig,
         recent_window: &[WindowTurn],
     ) -> Option<MemoryRetrievalRequest> {
-        build_builtin_retrieval_request(
+        self.build_retrieval_request_via_plan_result(
+            session_id,
+            workspace_root,
+            config,
+            recent_window,
+        )
+    }
+
+    fn build_retrieval_plan_result(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) -> Option<MemoryRetrievalPlanResult> {
+        build_builtin_retrieval_plan_result(
             self.id(),
             session_id,
             workspace_root,
@@ -1080,7 +1911,29 @@ impl MemorySystem for RecallFirstMemorySystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
     use serde_json::json;
+
+    const TEST_SESSION_ID: &str = "session-123";
+    const TEST_SECONDARY_SESSION_ID: &str = "session-1";
+    const RELEASE_FREEZE_TIMING: &str = "release freeze timing";
+    const DIAGNOSE_RELEASE_FREEZE_TEXT: &str = "diagnose release freeze";
+    const REGISTRY_REQUEST_ONLY_ID: &str = "result-wrapping-registry";
+    const PLAN_RESULT_ONLY_ID: &str = "plan-result-only-registry";
+    const REGISTRY_REQUEST_NOTE: &str = "registry request";
+    const PLAN_RESULT_ONLY_NOTE: &str = "plan result only";
+    const ROOT_SESSION_ID: &str = "root-session";
+    const ROOT_SESSION_LABEL: &str = "Root Session";
+    const DELEGATE_CHILD_KIND: &str = "delegate_child";
+    const DELEGATE_CHILD_LABEL: &str = "Release Child";
+    const WORKFLOW_TASK_TEXT: &str = "investigate release freeze";
+    const WORKFLOW_PHASE_FAILED: &str = "failed";
+    const WORKFLOW_PHASE_COMPLETE: &str = "complete";
+    const WORKFLOW_OPERATION_KIND_APPROVAL: &str = "approval";
+    const WORKFLOW_OPERATION_SCOPE_SESSION: &str = "session";
+    const DELEGATE_STARTED_EVENT: &str = "delegate_started";
+    const DELEGATE_COMPLETED_EVENT: &str = "delegate_completed";
+    const SHELL_EXEC_TOOL_NAME: &str = "shell.exec";
 
     struct StageAwareRegistryMemorySystem;
 
@@ -1098,6 +1951,770 @@ mod tests {
             .with_runtime_fallback_kind(MemorySystemRuntimeFallbackKind::SystemBacked)
             .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve])
         }
+    }
+
+    struct ResultWrappingRegistryMemorySystem;
+
+    struct PlanResultOnlyRegistryMemorySystem;
+
+    impl MemorySystem for ResultWrappingRegistryMemorySystem {
+        fn id(&self) -> &'static str {
+            REGISTRY_REQUEST_ONLY_ID
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                REGISTRY_REQUEST_ONLY_ID,
+                [MemorySystemCapability::PromptHydration],
+                "Registry system with direct retrieval request",
+            )
+        }
+
+        fn build_retrieval_request(
+            &self,
+            session_id: &str,
+            _workspace_root: Option<&Path>,
+            _config: &MemoryRuntimeConfig,
+            _recent_window: &[WindowTurn],
+        ) -> Option<MemoryRetrievalRequest> {
+            Some(MemoryRetrievalRequest {
+                session_id: session_id.to_owned(),
+                memory_system_id: self.id().to_owned(),
+                strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+                planning_notes: vec![REGISTRY_REQUEST_NOTE.to_owned()],
+                query: None,
+                recall_mode: MemoryRecallMode::PromptAssembly,
+                scopes: vec![MemoryScope::Workspace],
+                budget_items: 1,
+                allowed_kinds: vec![DerivedMemoryKind::Reference],
+            })
+        }
+    }
+
+    impl MemorySystem for PlanResultOnlyRegistryMemorySystem {
+        fn id(&self) -> &'static str {
+            PLAN_RESULT_ONLY_ID
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                PLAN_RESULT_ONLY_ID,
+                [MemorySystemCapability::PromptHydration],
+                "Registry system with direct retrieval plan result",
+            )
+        }
+
+        fn build_retrieval_plan_result(
+            &self,
+            session_id: &str,
+            _workspace_root: Option<&Path>,
+            _config: &MemoryRuntimeConfig,
+            _recent_window: &[WindowTurn],
+        ) -> Option<MemoryRetrievalPlanResult> {
+            Some(
+                MemoryRetrievalRequest {
+                    session_id: session_id.to_owned(),
+                    memory_system_id: self.id().to_owned(),
+                    strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+                    planning_notes: vec![PLAN_RESULT_ONLY_NOTE.to_owned()],
+                    query: None,
+                    recall_mode: MemoryRecallMode::PromptAssembly,
+                    scopes: vec![MemoryScope::Workspace],
+                    budget_items: 1,
+                    allowed_kinds: vec![DerivedMemoryKind::Reference],
+                }
+                .into_plan_result(),
+            )
+        }
+    }
+
+    fn release_freeze_recent_window() -> Vec<WindowTurn> {
+        vec![WindowTurn {
+            role: "user".to_owned(),
+            content: RELEASE_FREEZE_TIMING.to_owned(),
+            ts: None,
+        }]
+    }
+
+    fn release_freeze_test_config() -> MemoryRuntimeConfig {
+        MemoryRuntimeConfig::default()
+    }
+
+    fn default_test_config() -> MemoryRuntimeConfig {
+        MemoryRuntimeConfig::default()
+    }
+
+    fn workspace_recall_test_config() -> MemoryRuntimeConfig {
+        MemoryRuntimeConfig {
+            sliding_window: 6,
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn assert_request_adapter_matches_plan_result_for_workspace_recall(system: &dyn MemorySystem) {
+        let config = workspace_recall_test_config();
+        assert_request_adapter_matches_plan_result(
+            system,
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+            &config,
+            &[],
+        );
+    }
+
+    fn assert_request_helper_matches_request_adapter_for_workspace_recall(
+        system: &dyn MemorySystem,
+    ) {
+        let config = workspace_recall_test_config();
+        assert_request_helper_matches_request_adapter(system, &config, &[]);
+    }
+
+    fn assert_plan_result_helper_matches_default_for_workspace_recall(system: &dyn MemorySystem) {
+        let config = workspace_recall_test_config();
+        assert_plan_result_helper_matches_default(system, &config, &[]);
+    }
+
+    fn assert_boxed_request_helper_matches_request_adapter_for_workspace_recall(
+        boxed: Box<dyn MemorySystem>,
+    ) {
+        let config = workspace_recall_test_config();
+        assert_boxed_request_helper_matches_request_adapter(boxed, &config, &[]);
+    }
+
+    fn assert_boxed_request_adapter_matches_plan_result_for_workspace_recall(
+        boxed: Box<dyn MemorySystem>,
+    ) {
+        let config = workspace_recall_test_config();
+        assert_boxed_request_adapter_matches_plan_result(
+            boxed,
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+            &config,
+            &[],
+        );
+    }
+
+    fn assert_boxed_plan_result_helper_matches_default_for_workspace_recall(
+        boxed: Box<dyn MemorySystem>,
+    ) {
+        let config = workspace_recall_test_config();
+        assert_boxed_plan_result_helper_matches_default(boxed, &config, &[]);
+    }
+
+    fn assert_boxed_workspace_recall_request_budget_items(
+        boxed: Box<dyn MemorySystem>,
+        expected_budget_items: usize,
+    ) {
+        assert_workspace_recall_request_budget_items(&*boxed, expected_budget_items);
+    }
+
+    fn assert_workspace_recall_request_budget_items(
+        system: &dyn MemorySystem,
+        expected_budget_items: usize,
+    ) {
+        let config = workspace_recall_test_config();
+        let request = system
+            .build_retrieval_request(TEST_SESSION_ID, Some(test_workspace_root()), &config, &[])
+            .expect("workspace recall retrieval request");
+        assert_eq!(request.budget_items, expected_budget_items);
+    }
+
+    fn test_workspace_root() -> &'static Path {
+        Path::new("/tmp/workspace")
+    }
+
+    fn boxed_request_only_registry_system() -> Box<dyn MemorySystem> {
+        Box::new(ResultWrappingRegistryMemorySystem)
+    }
+
+    fn boxed_plan_result_only_registry_system() -> Box<dyn MemorySystem> {
+        Box::new(PlanResultOnlyRegistryMemorySystem)
+    }
+
+    fn boxed_builtin_system() -> Box<dyn MemorySystem> {
+        Box::new(BuiltinMemorySystem)
+    }
+
+    fn boxed_recall_first_system() -> Box<dyn MemorySystem> {
+        Box::new(RecallFirstMemorySystem)
+    }
+
+    fn boxed_workspace_recall_system() -> Box<dyn MemorySystem> {
+        Box::new(WorkspaceRecallMemorySystem)
+    }
+
+    fn delegate_child_metadata_hint(
+        state: &str,
+        workflow_task: Option<&str>,
+        workflow_phase: Option<&str>,
+        workflow_operation_kind: Option<&str>,
+        workflow_operation_scope: Option<&str>,
+    ) -> crate::memory::sqlite::SessionMetadataHint {
+        crate::memory::sqlite::SessionMetadataHint {
+            kind: DELEGATE_CHILD_KIND.to_owned(),
+            state: state.to_owned(),
+            parent_session_id: Some(ROOT_SESSION_ID.to_owned()),
+            label: Some(DELEGATE_CHILD_LABEL.to_owned()),
+            parent_label: Some(ROOT_SESSION_LABEL.to_owned()),
+            lineage_root_session_id: Some(ROOT_SESSION_ID.to_owned()),
+            lineage_root_label: Some(ROOT_SESSION_LABEL.to_owned()),
+            lineage_depth: 1,
+            workflow_task: workflow_task.map(str::to_owned),
+            workflow_phase: workflow_phase.map(str::to_owned),
+            workflow_operation_kind: workflow_operation_kind.map(str::to_owned),
+            workflow_operation_scope: workflow_operation_scope.map(str::to_owned),
+        }
+    }
+
+    fn expected_delegate_lineage_query() -> String {
+        format!("{DELEGATE_CHILD_LABEL}\n{ROOT_SESSION_LABEL}")
+    }
+
+    fn expected_workflow_task_query(
+        phase: &str,
+        operation_kind: Option<&str>,
+        operation_scope: Option<&str>,
+    ) -> String {
+        let mut parts = vec![WORKFLOW_TASK_TEXT.to_owned(), format!("phase: {phase}")];
+        if let Some(operation_kind) = operation_kind {
+            parts.push(format!("operation_kind: {operation_kind}"));
+        }
+        if let Some(operation_scope) = operation_scope {
+            parts.push(format!("operation_scope: {operation_scope}"));
+        }
+        parts.join("\n")
+    }
+
+    fn expected_structured_signal_query() -> String {
+        format!("{DELEGATE_STARTED_EVENT}\n{SHELL_EXEC_TOOL_NAME}")
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn sqlite_test_workspace() -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        MemoryRuntimeConfig,
+        Connection,
+    ) {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path().to_path_buf();
+        let db_path = workspace_root.join("memory.sqlite3");
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        crate::memory::ensure_memory_db_ready(Some(db_path.clone()), &config)
+            .expect("ensure memory db ready");
+        let conn = Connection::open(&db_path).expect("open sqlite db");
+
+        (temp_dir, workspace_root, config, conn)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn insert_root_session(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+            VALUES (?1, 'root', NULL, ?2, 'ready', 1, 1, NULL)",
+            rusqlite::params![ROOT_SESSION_ID, ROOT_SESSION_LABEL],
+        )
+        .expect("insert root session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn insert_delegate_child_session(conn: &Connection, state: &str) {
+        conn.execute(
+            "INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1, 1, NULL)",
+            rusqlite::params![
+                TEST_SESSION_ID,
+                DELEGATE_CHILD_KIND,
+                ROOT_SESSION_ID,
+                DELEGATE_CHILD_LABEL,
+                state,
+            ],
+        )
+        .expect("insert delegate child session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn insert_delegate_task_event(conn: &Connection, event_kind: &str, task: &str) {
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, search_text, ts)
+             VALUES (?1, ?2, ?3, ?4, '', 1)",
+            rusqlite::params![
+                TEST_SESSION_ID,
+                event_kind,
+                ROOT_SESSION_ID,
+                serde_json::to_string(&json!({ "task": task }))
+                    .expect("encode delegate task payload"),
+            ],
+        )
+        .expect("insert delegate task event");
+    }
+
+    fn assert_request_adapter_matches_plan_result(
+        system: &dyn MemorySystem,
+        expected_system_id: &str,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        let request = system
+            .build_retrieval_request(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("retrieval request");
+        let result = system
+            .build_retrieval_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("retrieval plan");
+
+        assert_eq!(&request, result.request());
+        assert_eq!(request.memory_system_id, expected_system_id);
+    }
+
+    fn assert_boxed_request_adapter_matches_plan_result(
+        boxed: Box<dyn MemorySystem>,
+        expected_system_id: &str,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        assert_request_adapter_matches_plan_result(
+            &*boxed,
+            expected_system_id,
+            config,
+            recent_window,
+        );
+    }
+
+    fn assert_request_helper_matches_request_adapter(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        let request = system
+            .build_retrieval_request(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("retrieval request");
+        let helper_request = system
+            .build_retrieval_request_via_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("retrieval request via plan result");
+
+        assert_eq!(helper_request, request);
+    }
+
+    fn assert_plan_result_helper_matches_default(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        let default_result = system
+            .build_retrieval_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("default retrieval plan result");
+        let helper_result = system
+            .build_retrieval_plan_result_via_request(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("helper retrieval plan result");
+
+        assert_eq!(helper_result, default_result);
+    }
+
+    fn assert_boxed_request_helper_matches_request_adapter(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        assert_request_helper_matches_request_adapter(&*boxed, config, recent_window);
+    }
+
+    fn assert_boxed_plan_result_helper_matches_default(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+    ) {
+        assert_plan_result_helper_matches_default(&*boxed, config, recent_window);
+    }
+
+    fn assert_boxed_request_helper_matches_request_adapter_for_release_freeze(
+        boxed: Box<dyn MemorySystem>,
+    ) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_boxed_request_helper_matches_request_adapter(
+            boxed,
+            &config,
+            recent_window.as_slice(),
+        );
+    }
+
+    fn assert_request_adapter_matches_plan_result_for_release_freeze(
+        system: &dyn MemorySystem,
+        expected_system_id: &str,
+    ) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_request_adapter_matches_plan_result(
+            system,
+            expected_system_id,
+            &config,
+            recent_window.as_slice(),
+        );
+    }
+
+    fn assert_request_helper_matches_request_adapter_for_release_freeze(system: &dyn MemorySystem) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_request_helper_matches_request_adapter(system, &config, recent_window.as_slice());
+    }
+
+    fn assert_plan_result_helper_matches_default_for_release_freeze(system: &dyn MemorySystem) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_plan_result_helper_matches_default(system, &config, recent_window.as_slice());
+    }
+
+    fn assert_release_freeze_request_adapter_matches_plan_result(
+        system: &dyn MemorySystem,
+        expected_system_id: &str,
+    ) {
+        assert_request_adapter_matches_plan_result_for_release_freeze(system, expected_system_id);
+    }
+
+    fn assert_release_freeze_request_helper_matches_request_adapter(system: &dyn MemorySystem) {
+        assert_request_helper_matches_request_adapter_for_release_freeze(system);
+    }
+
+    fn assert_release_freeze_plan_result_helper_matches_default(system: &dyn MemorySystem) {
+        assert_plan_result_helper_matches_default_for_release_freeze(system);
+    }
+
+    fn assert_boxed_request_adapter_matches_plan_result_for_release_freeze(
+        boxed: Box<dyn MemorySystem>,
+        expected_system_id: &str,
+    ) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_boxed_request_adapter_matches_plan_result(
+            boxed,
+            expected_system_id,
+            &config,
+            recent_window.as_slice(),
+        );
+    }
+
+    fn assert_boxed_plan_result_helper_matches_default_for_release_freeze(
+        boxed: Box<dyn MemorySystem>,
+    ) {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_boxed_plan_result_helper_matches_default(boxed, &config, recent_window.as_slice());
+    }
+
+    fn assert_boxed_request_only_default_plan_result_matches_explicit_helper(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+    ) {
+        assert_request_only_default_plan_result_matches_explicit_helper(&*boxed, config);
+    }
+
+    fn assert_boxed_request_only_plan_result_adapter_shape(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+    ) {
+        assert_request_only_plan_result_adapter_shape(&*boxed, config);
+    }
+
+    fn assert_boxed_plan_result_only_helper_request_matches_default_plan_result_request(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+    ) {
+        assert_plan_result_only_helper_request_matches_default_plan_result_request(&*boxed, config);
+    }
+
+    fn assert_boxed_plan_result_only_request_adapter_shape(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+    ) {
+        assert_plan_result_only_request_adapter_shape(&*boxed, config);
+    }
+
+    fn assert_boxed_plan_result_only_request_gap(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+    ) {
+        assert_plan_result_only_request_gap(&*boxed, config);
+    }
+
+    fn assert_retrieval_plan_shape(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+        expected_system_id: &str,
+        expected_planning_notes: &[&str],
+    ) {
+        let result = system
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), config, &[])
+            .expect("retrieval plan result");
+
+        let expected_planning_notes = expected_planning_notes
+            .iter()
+            .map(|note| (*note).to_owned())
+            .collect::<Vec<_>>();
+
+        assert_plan_result_identity(&result, expected_system_id);
+        assert_eq!(
+            result.planner_snapshot.planning_notes,
+            expected_planning_notes
+        );
+    }
+
+    fn assert_plan_result_identity(result: &MemoryRetrievalPlanResult, expected_system_id: &str) {
+        assert_eq!(result.request.memory_system_id, expected_system_id);
+        assert_eq!(result.planner_snapshot.memory_system_id, expected_system_id);
+    }
+
+    fn assert_plan_result_snapshot_matches_request(
+        result: &MemoryRetrievalPlanResult,
+        expected_system_id: &str,
+    ) {
+        assert_plan_result_identity(result, expected_system_id);
+        assert_eq!(result.planner_snapshot, result.request.planner_snapshot());
+    }
+
+    fn assert_plan_result_snapshot_matches_request_for_release_freeze(
+        system: &dyn MemorySystem,
+        expected_system_id: &str,
+    ) -> MemoryRetrievalPlanResult {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        let result = system
+            .build_retrieval_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                &config,
+                recent_window.as_slice(),
+            )
+            .expect("retrieval plan result");
+        assert_plan_result_snapshot_matches_request(&result, expected_system_id);
+        result
+    }
+
+    fn assert_plan_result_snapshot_matches_request_for_workspace_recall(
+        system: &dyn MemorySystem,
+    ) -> MemoryRetrievalPlanResult {
+        let config = workspace_recall_test_config();
+        let result = system
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), &config, &[])
+            .expect("retrieval plan result");
+        assert_plan_result_snapshot_matches_request(&result, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
+        result
+    }
+
+    fn assert_boxed_plan_result_snapshot_matches_request(
+        boxed: Box<dyn MemorySystem>,
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+        expected_system_id: &str,
+    ) -> MemoryRetrievalPlanResult {
+        let result = boxed
+            .build_retrieval_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                recent_window,
+            )
+            .expect("boxed retrieval plan result");
+        assert_plan_result_snapshot_matches_request(&result, expected_system_id);
+        result
+    }
+
+    fn assert_boxed_plan_result_snapshot_matches_request_for_release_freeze(
+        boxed: Box<dyn MemorySystem>,
+        expected_system_id: &str,
+    ) -> MemoryRetrievalPlanResult {
+        let recent_window = release_freeze_recent_window();
+        let config = release_freeze_test_config();
+        assert_boxed_plan_result_snapshot_matches_request(
+            boxed,
+            &config,
+            recent_window.as_slice(),
+            expected_system_id,
+        )
+    }
+
+    fn assert_boxed_plan_result_snapshot_matches_request_for_workspace_recall(
+        boxed: Box<dyn MemorySystem>,
+    ) -> MemoryRetrievalPlanResult {
+        let config = workspace_recall_test_config();
+        assert_boxed_plan_result_snapshot_matches_request(
+            boxed,
+            &config,
+            &[],
+            WORKSPACE_RECALL_MEMORY_SYSTEM_ID,
+        )
+    }
+
+    fn assert_workspace_recall_plan_result_snapshot_matches_request_and_budget(
+        result: &MemoryRetrievalPlanResult,
+    ) {
+        assert_plan_result_snapshot_matches_request(result, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
+        assert_eq!(result.request.budget_items, 4);
+    }
+
+    fn assert_retrieval_request_shape(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+        expected_system_id: &str,
+        expected_planning_notes: &[&str],
+    ) {
+        let request = system
+            .build_retrieval_request_via_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                &[],
+            )
+            .expect("retrieval request via plan result");
+
+        let expected_planning_notes = expected_planning_notes
+            .iter()
+            .map(|note| (*note).to_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(request.memory_system_id, expected_system_id);
+        assert_eq!(request.planning_notes, expected_planning_notes);
+    }
+
+    fn assert_request_only_default_plan_result_matches_explicit_helper(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+    ) {
+        let default_result = system
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), config, &[])
+            .expect("default retrieval plan result");
+        let helper_result = system
+            .build_retrieval_plan_result_via_request(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                &[],
+            )
+            .expect("helper retrieval plan result");
+
+        assert_eq!(helper_result, default_result);
+    }
+
+    fn assert_request_only_plan_result_adapter_shape(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+    ) {
+        let result = system
+            .build_retrieval_plan_result_via_request(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                &[],
+            )
+            .expect("retrieval plan result via request");
+
+        assert_retrieval_plan_shape(
+            system,
+            config,
+            REGISTRY_REQUEST_ONLY_ID,
+            &[REGISTRY_REQUEST_NOTE],
+        );
+        assert_eq!(
+            result.planner_snapshot.planning_notes,
+            vec![REGISTRY_REQUEST_NOTE.to_owned()]
+        );
+    }
+
+    fn assert_plan_result_only_helper_request_matches_default_plan_result_request(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+    ) {
+        let helper_request = system
+            .build_retrieval_request_via_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                &[],
+            )
+            .expect("retrieval request via plan result");
+        let default_result = system
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), config, &[])
+            .expect("default retrieval plan result");
+
+        assert_eq!(helper_request, default_result.request);
+    }
+
+    fn assert_plan_result_only_request_adapter_shape(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+    ) {
+        let request = system
+            .build_retrieval_request_via_plan_result(
+                TEST_SESSION_ID,
+                Some(test_workspace_root()),
+                config,
+                &[],
+            )
+            .expect("retrieval request via plan result");
+
+        assert_retrieval_request_shape(
+            system,
+            config,
+            PLAN_RESULT_ONLY_ID,
+            &[PLAN_RESULT_ONLY_NOTE],
+        );
+        assert_eq!(
+            request.planning_notes,
+            vec![PLAN_RESULT_ONLY_NOTE.to_owned()]
+        );
+    }
+
+    fn assert_plan_result_only_request_gap(
+        system: &dyn MemorySystem,
+        config: &MemoryRuntimeConfig,
+    ) {
+        let request = system.build_retrieval_request(
+            TEST_SESSION_ID,
+            Some(test_workspace_root()),
+            config,
+            &[],
+        );
+        let result = system
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), config, &[])
+            .expect("retrieval plan result");
+
+        assert_eq!(request, None);
+        assert_plan_result_identity(&result, PLAN_RESULT_ONLY_ID);
+        assert_eq!(
+            result.planner_snapshot.planning_notes,
+            vec![PLAN_RESULT_ONLY_NOTE.to_owned()]
+        );
     }
 
     #[test]
@@ -1125,6 +2742,130 @@ mod tests {
                 MemoryRecallMode::PromptAssembly,
                 MemoryRecallMode::OperatorInspection
             ]
+        );
+    }
+
+    #[test]
+    fn build_retrieval_plan_result_wraps_non_builtin_request_into_snapshot() {
+        let config = default_test_config();
+
+        let result = ResultWrappingRegistryMemorySystem
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), &config, &[])
+            .expect("retrieval plan result");
+
+        assert_retrieval_plan_shape(
+            &ResultWrappingRegistryMemorySystem,
+            &config,
+            REGISTRY_REQUEST_ONLY_ID,
+            &[REGISTRY_REQUEST_NOTE],
+        );
+        assert_eq!(
+            result.planner_snapshot.strategy,
+            MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
+        assert_eq!(result.planner_snapshot.budget_items, 1);
+        assert!(!result.planner_snapshot.query_present);
+    }
+
+    #[test]
+    fn build_retrieval_plan_result_via_request_adapts_request_only_system() {
+        let config = default_test_config();
+        assert_request_only_plan_result_adapter_shape(&ResultWrappingRegistryMemorySystem, &config);
+    }
+
+    #[test]
+    fn request_only_system_default_plan_result_matches_explicit_helper() {
+        let config = default_test_config();
+        assert_request_only_default_plan_result_matches_explicit_helper(
+            &ResultWrappingRegistryMemorySystem,
+            &config,
+        );
+    }
+
+    #[test]
+    fn build_retrieval_request_default_does_not_backfill_from_plan_result() {
+        let config = default_test_config();
+        assert_plan_result_only_request_gap(&PlanResultOnlyRegistryMemorySystem, &config);
+    }
+
+    #[test]
+    fn plan_result_only_system_helper_request_matches_default_plan_result_request() {
+        let config = default_test_config();
+        assert_plan_result_only_helper_request_matches_default_plan_result_request(
+            &PlanResultOnlyRegistryMemorySystem,
+            &config,
+        );
+    }
+
+    #[test]
+    fn build_retrieval_request_via_plan_result_adapts_plan_result_only_system() {
+        let config = default_test_config();
+        assert_plan_result_only_request_adapter_shape(&PlanResultOnlyRegistryMemorySystem, &config);
+    }
+
+    #[test]
+    fn boxed_memory_system_preserves_request_to_plan_result_compatibility() {
+        let config = default_test_config();
+        let boxed = boxed_request_only_registry_system();
+
+        let result = boxed
+            .build_retrieval_plan_result(TEST_SESSION_ID, Some(test_workspace_root()), &config, &[])
+            .expect("retrieval plan result");
+
+        assert_retrieval_plan_shape(
+            &*boxed,
+            &config,
+            REGISTRY_REQUEST_ONLY_ID,
+            &[REGISTRY_REQUEST_NOTE],
+        );
+        assert_eq!(
+            result.planner_snapshot.planning_notes,
+            vec![REGISTRY_REQUEST_NOTE.to_owned()]
+        );
+    }
+
+    #[test]
+    fn boxed_memory_system_preserves_request_only_plan_result_adapter() {
+        let config = default_test_config();
+        assert_boxed_request_only_plan_result_adapter_shape(
+            boxed_request_only_registry_system(),
+            &config,
+        );
+    }
+
+    #[test]
+    fn boxed_request_only_system_default_plan_result_matches_explicit_helper() {
+        let config = default_test_config();
+        assert_boxed_request_only_default_plan_result_matches_explicit_helper(
+            boxed_request_only_registry_system(),
+            &config,
+        );
+    }
+
+    #[test]
+    fn boxed_memory_system_preserves_plan_result_only_request_adapter() {
+        let config = default_test_config();
+        assert_boxed_plan_result_only_request_adapter_shape(
+            boxed_plan_result_only_registry_system(),
+            &config,
+        );
+    }
+
+    #[test]
+    fn boxed_plan_result_only_system_helper_request_matches_default_plan_result_request() {
+        let config = default_test_config();
+        assert_boxed_plan_result_only_helper_request_matches_default_plan_result_request(
+            boxed_plan_result_only_registry_system(),
+            &config,
+        );
+    }
+
+    #[test]
+    fn boxed_memory_system_preserves_plan_result_only_request_gap() {
+        let config = default_test_config();
+        assert_boxed_plan_result_only_request_gap(
+            boxed_plan_result_only_registry_system(),
+            &config,
         );
     }
 
@@ -1222,6 +2963,531 @@ mod tests {
     }
 
     #[test]
+    fn recall_first_retrieval_plan_result_preserves_selected_system_id() {
+        let result = assert_plan_result_snapshot_matches_request_for_release_freeze(
+            &RecallFirstMemorySystem,
+            RECALL_FIRST_MEMORY_SYSTEM_ID,
+        );
+        assert_eq!(result.planner_snapshot.strategy, result.request.strategy);
+    }
+
+    #[test]
+    fn recall_first_plan_result_helper_matches_default_plan_result() {
+        assert_release_freeze_plan_result_helper_matches_default(&RecallFirstMemorySystem);
+    }
+
+    #[test]
+    fn recall_first_request_adapter_matches_plan_result_request() {
+        assert_release_freeze_request_adapter_matches_plan_result(
+            &RecallFirstMemorySystem,
+            RECALL_FIRST_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn recall_first_request_helper_matches_request_adapter() {
+        assert_release_freeze_request_helper_matches_request_adapter(&RecallFirstMemorySystem);
+    }
+
+    #[test]
+    fn boxed_recall_first_request_helper_matches_request_adapter() {
+        assert_boxed_request_helper_matches_request_adapter_for_release_freeze(
+            boxed_recall_first_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_recall_first_request_adapter_matches_plan_result_request() {
+        assert_boxed_request_adapter_matches_plan_result_for_release_freeze(
+            boxed_recall_first_system(),
+            RECALL_FIRST_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn boxed_recall_first_plan_result_helper_matches_default_plan_result() {
+        assert_boxed_plan_result_helper_matches_default_for_release_freeze(
+            boxed_recall_first_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_recall_first_retrieval_plan_result_preserves_selected_system_id() {
+        let result = assert_boxed_plan_result_snapshot_matches_request_for_release_freeze(
+            boxed_recall_first_system(),
+            RECALL_FIRST_MEMORY_SYSTEM_ID,
+        );
+
+        assert_eq!(result.planner_snapshot.strategy, result.request.strategy);
+    }
+
+    #[test]
+    fn builtin_request_adapter_matches_plan_result_request() {
+        assert_release_freeze_request_adapter_matches_plan_result(
+            &BuiltinMemorySystem,
+            DEFAULT_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn builtin_plan_result_helper_matches_default_plan_result() {
+        assert_release_freeze_plan_result_helper_matches_default(&BuiltinMemorySystem);
+    }
+
+    #[test]
+    fn builtin_request_helper_matches_request_adapter() {
+        assert_release_freeze_request_helper_matches_request_adapter(&BuiltinMemorySystem);
+    }
+
+    #[test]
+    fn boxed_builtin_request_helper_matches_request_adapter() {
+        assert_boxed_request_helper_matches_request_adapter_for_release_freeze(
+            boxed_builtin_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_builtin_request_adapter_matches_plan_result_request() {
+        assert_boxed_request_adapter_matches_plan_result_for_release_freeze(
+            boxed_builtin_system(),
+            DEFAULT_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn boxed_builtin_plan_result_helper_matches_default_plan_result() {
+        assert_boxed_plan_result_helper_matches_default_for_release_freeze(boxed_builtin_system());
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_result_matches_request_snapshot() {
+        let _result = assert_plan_result_snapshot_matches_request_for_release_freeze(
+            &BuiltinMemorySystem,
+            DEFAULT_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn boxed_builtin_retrieval_plan_result_matches_request_snapshot() {
+        let _result = assert_boxed_plan_result_snapshot_matches_request_for_release_freeze(
+            boxed_builtin_system(),
+            DEFAULT_MEMORY_SYSTEM_ID,
+        );
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_combines_query_and_workspace_reference_scope() {
+        let recent_window = release_freeze_recent_window();
+        let config = MemoryRuntimeConfig {
+            profile: crate::config::MemoryProfile::WindowPlusSummary,
+            mode: crate::config::MemoryMode::WindowPlusSummary,
+            sliding_window: 4,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(test_workspace_root()),
+            &config,
+            recent_window.as_slice(),
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+        );
+        assert_eq!(plan.query.as_deref(), Some(RELEASE_FREEZE_TIMING));
+        assert_eq!(plan.budget_items, 4);
+        assert_eq!(
+            plan.scopes,
+            vec![
+                MemoryScope::Session,
+                MemoryScope::Workspace,
+                MemoryScope::Agent,
+                MemoryScope::User,
+            ]
+        );
+        assert!(plan.allowed_kinds.contains(&DerivedMemoryKind::Reference));
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_prioritizes_recent_user_query_over_other_hints() {
+        let plan = BuiltinRetrievalPlan::from_planner_inputs(BuiltinRetrievalPlannerInputs {
+            has_workspace_root: true,
+            recent_user_query: Some("recent user ask".to_owned()),
+            recent_user_budget_items: 4,
+            structured_query: Some("structured seed".to_owned()),
+            task_progress_plan: Some(SeededWorkspaceRetrievalPlan {
+                strategy: MemoryRetrievalStrategy::TaskProgressIntentQueryWithWorkspace,
+                planning_notes: vec!["task progress".to_owned()],
+                query: "task progress seed".to_owned(),
+                budget_items: 2,
+                allowed_kinds: vec![DerivedMemoryKind::Procedure],
+            }),
+            workflow_task_plan: Some(SeededWorkspaceRetrievalPlan {
+                strategy: MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace,
+                planning_notes: vec!["workflow task".to_owned()],
+                query: "workflow seed".to_owned(),
+                budget_items: 2,
+                allowed_kinds: vec![DerivedMemoryKind::Overview],
+            }),
+            delegate_lineage_plan: Some(SeededWorkspaceRetrievalPlan::new(
+                MemoryRetrievalStrategy::DelegateLabelQueryWithWorkspace,
+                vec!["delegate label".to_owned()],
+                "delegate label".to_owned(),
+                1,
+                vec![DerivedMemoryKind::Reference],
+            )),
+            has_structured_session_signals: true,
+        })
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+        );
+        assert_eq!(plan.query.as_deref(), Some("recent user ask"));
+        assert_eq!(plan.budget_items, 4);
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_into_result_populates_planner_snapshot() {
+        let plan = BuiltinRetrievalPlan::recent_user_query(true, "recent user ask".to_owned(), 4);
+
+        let result = plan.into_result(DEFAULT_MEMORY_SYSTEM_ID, TEST_SESSION_ID);
+
+        assert_eq!(result.request.session_id, TEST_SESSION_ID);
+        assert_plan_result_identity(&result, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(
+            result.planner_snapshot.strategy,
+            MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+        );
+        assert_eq!(result.planner_snapshot.budget_items, 4);
+        assert!(result.planner_snapshot.query_present);
+        assert!(
+            result
+                .planner_snapshot
+                .planning_notes
+                .iter()
+                .any(|note: &String| note.contains("recent_user_query seed"))
+        );
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_workspace_only_mode_requests_reference_recall() {
+        let config = MemoryRuntimeConfig::default();
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(test_workspace_root()),
+            &config,
+            &[],
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        );
+        assert_eq!(plan.query, None);
+        assert_eq!(plan.budget_items, 1);
+        assert_eq!(
+            plan.scopes,
+            vec![MemoryScope::Workspace, MemoryScope::Session]
+        );
+        assert_eq!(plan.allowed_kinds, vec![DerivedMemoryKind::Reference]);
+    }
+
+    #[test]
+    fn builtin_retrieval_plan_workspace_mode_uses_structured_signal_strategy() {
+        let recent_window = vec![WindowTurn {
+            role: "assistant".to_owned(),
+            content: crate::memory::build_tool_decision_content(
+                "turn-1",
+                "tool-1",
+                json!({"tool_name": SHELL_EXEC_TOOL_NAME}),
+            ),
+            ts: None,
+        }];
+        let config = MemoryRuntimeConfig::default();
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(test_workspace_root()),
+            &config,
+            recent_window.as_slice(),
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::StructuredSignalQueryWithWorkspace
+        );
+        assert_eq!(plan.query.as_deref(), Some(SHELL_EXEC_TOOL_NAME));
+        assert_eq!(
+            plan.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn builtin_retrieval_plan_workspace_mode_uses_task_progress_intent_query() {
+        let (_temp_dir, workspace_root, config, conn) = sqlite_test_workspace();
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, search_text, ts)
+             VALUES (?1, ?2, NULL, ?3, '', 1)",
+            rusqlite::params![
+                TEST_SESSION_ID,
+                crate::task_progress::TASK_PROGRESS_EVENT_KIND,
+                serde_json::to_string(&crate::task_progress::task_progress_event_payload(
+                    "unit_test",
+                    &crate::task_progress::TaskProgressRecord {
+                        task_id: TEST_SESSION_ID.to_owned(),
+                        owner_kind: "conversation_turn".to_owned(),
+                        status: crate::task_progress::TaskProgressStatus::Waiting,
+                        intent_summary: Some(DIAGNOSE_RELEASE_FREEZE_TEXT.to_owned()),
+                        verification_state: None,
+                        active_handles: Vec::new(),
+                        resume_recipe: None,
+                        updated_at: 1,
+                    },
+                ))
+                .expect("encode task progress payload"),
+            ],
+        )
+        .expect("insert task progress event");
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(workspace_root.as_path()),
+            &config,
+            &[],
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::TaskProgressIntentQueryWithWorkspace
+        );
+        assert_eq!(plan.query.as_deref(), Some(DIAGNOSE_RELEASE_FREEZE_TEXT));
+        assert_eq!(plan.budget_items, 2);
+        assert_eq!(
+            plan.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn builtin_retrieval_plan_workspace_mode_uses_delegate_label_query() {
+        let (_temp_dir, workspace_root, config, conn) = sqlite_test_workspace();
+        insert_root_session(&conn);
+        insert_delegate_child_session(&conn, "ready");
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(workspace_root.as_path()),
+            &config,
+            &[],
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::DelegateLineageQueryWithWorkspace
+        );
+        let expected_query = expected_delegate_lineage_query();
+        assert_eq!(plan.query.as_deref(), Some(expected_query.as_str()));
+        assert_eq!(
+            plan.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+            ]
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn builtin_retrieval_plan_workspace_mode_uses_workflow_task_query() {
+        let (_temp_dir, workspace_root, config, conn) = sqlite_test_workspace();
+        insert_delegate_child_session(&conn, "ready");
+        insert_delegate_task_event(&conn, DELEGATE_STARTED_EVENT, WORKFLOW_TASK_TEXT);
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(workspace_root.as_path()),
+            &config,
+            &[],
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        assert_eq!(plan.query.as_deref(), Some(WORKFLOW_TASK_TEXT));
+        assert_eq!(plan.budget_items, 2);
+        assert!(
+            plan.planning_notes
+                .iter()
+                .any(|note| note.contains("workflow task seed"))
+        );
+        assert_eq!(
+            plan.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn builtin_retrieval_plan_completed_workflow_task_uses_lower_budget() {
+        let (_temp_dir, workspace_root, config, conn) = sqlite_test_workspace();
+        insert_delegate_child_session(&conn, "completed");
+        insert_delegate_task_event(&conn, DELEGATE_COMPLETED_EVENT, WORKFLOW_TASK_TEXT);
+
+        let plan = BuiltinRetrievalPlan::from_runtime_inputs(
+            TEST_SESSION_ID,
+            Some(workspace_root.as_path()),
+            &config,
+            &[],
+        )
+        .expect("retrieval plan");
+
+        assert_eq!(
+            plan.strategy,
+            MemoryRetrievalStrategy::WorkflowTaskQueryWithWorkspace
+        );
+        let expected_query = expected_workflow_task_query(WORKFLOW_PHASE_COMPLETE, None, None);
+        assert_eq!(plan.query.as_deref(), Some(expected_query.as_str()));
+        assert_eq!(plan.budget_items, 1);
+        assert_eq!(
+            plan.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Overview,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+    }
+
+    #[test]
+    fn workflow_task_query_seed_from_metadata_includes_non_execute_phase_and_non_task_scope() {
+        let metadata = delegate_child_metadata_hint(
+            WORKFLOW_PHASE_FAILED,
+            Some(WORKFLOW_TASK_TEXT),
+            Some(WORKFLOW_PHASE_FAILED),
+            Some(WORKFLOW_OPERATION_KIND_APPROVAL),
+            Some(WORKFLOW_OPERATION_SCOPE_SESSION),
+        );
+
+        let query =
+            workflow_task_query_seed_from_metadata(&metadata).expect("workflow task query seed");
+
+        let expected_query = expected_workflow_task_query(
+            WORKFLOW_PHASE_FAILED,
+            Some(WORKFLOW_OPERATION_KIND_APPROVAL),
+            Some(WORKFLOW_OPERATION_SCOPE_SESSION),
+        );
+        assert_eq!(query, expected_query);
+    }
+
+    #[test]
+    fn structured_signal_query_seed_from_records_dedupes_terms_and_keeps_order() {
+        let records = vec![
+            crate::memory::CanonicalMemoryRecord {
+                session_id: TEST_SECONDARY_SESSION_ID.to_owned(),
+                scope: MemoryScope::Session,
+                kind: CanonicalMemoryKind::ToolDecision,
+                role: Some("assistant".to_owned()),
+                content: String::new(),
+                metadata: json!({
+                    "decision": {
+                        "tool_name": SHELL_EXEC_TOOL_NAME
+                    }
+                }),
+            },
+            crate::memory::CanonicalMemoryRecord {
+                session_id: TEST_SECONDARY_SESSION_ID.to_owned(),
+                scope: MemoryScope::Session,
+                kind: CanonicalMemoryKind::ConversationEvent,
+                role: Some("assistant".to_owned()),
+                content: String::new(),
+                metadata: json!({
+                    "event": DELEGATE_STARTED_EVENT
+                }),
+            },
+            crate::memory::CanonicalMemoryRecord {
+                session_id: TEST_SECONDARY_SESSION_ID.to_owned(),
+                scope: MemoryScope::Session,
+                kind: CanonicalMemoryKind::ToolOutcome,
+                role: Some("assistant".to_owned()),
+                content: String::new(),
+                metadata: json!({
+                    "outcome": {
+                        "tool_name": SHELL_EXEC_TOOL_NAME
+                    }
+                }),
+            },
+        ];
+
+        let query =
+            structured_signal_query_seed_from_records(records.as_slice()).expect("structured seed");
+
+        assert_eq!(query, expected_structured_signal_query());
+    }
+
+    #[test]
+    fn delegate_lineage_query_seed_from_metadata_uses_labels_when_present() {
+        let metadata = delegate_child_metadata_hint("running", None, None, None, None);
+
+        let query =
+            delegate_lineage_query_seed_from_metadata(&metadata).expect("delegate lineage seed");
+
+        assert_eq!(query, expected_delegate_lineage_query());
+    }
+
+    #[test]
+    fn workflow_task_policy_from_metadata_prefers_procedure_for_approval_kind() {
+        let metadata = delegate_child_metadata_hint(
+            WORKFLOW_PHASE_FAILED,
+            Some(WORKFLOW_TASK_TEXT),
+            Some(WORKFLOW_PHASE_FAILED),
+            Some(WORKFLOW_OPERATION_KIND_APPROVAL),
+            Some(WORKFLOW_OPERATION_SCOPE_SESSION),
+        );
+
+        let policy = workflow_task_policy_from_metadata(&metadata);
+
+        assert_eq!(
+            policy.allowed_kinds,
+            vec![
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Reference,
+                DerivedMemoryKind::Fact,
+            ]
+        );
+        assert_eq!(policy.budget_items, 1);
+    }
+
+    #[test]
     fn workspace_recall_memory_system_metadata_is_stable() {
         let metadata = WorkspaceRecallMemorySystem.metadata();
         assert_eq!(metadata.id, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
@@ -1256,6 +3522,70 @@ mod tests {
                 MemoryRecallMode::OperatorInspection
             ]
         );
+    }
+
+    #[test]
+    fn workspace_recall_retrieval_plan_result_matches_request_snapshot() {
+        let result = assert_plan_result_snapshot_matches_request_for_workspace_recall(
+            &WorkspaceRecallMemorySystem,
+        );
+        assert_workspace_recall_plan_result_snapshot_matches_request_and_budget(&result);
+    }
+
+    #[test]
+    fn workspace_recall_plan_result_helper_matches_default_plan_result() {
+        assert_plan_result_helper_matches_default_for_workspace_recall(
+            &WorkspaceRecallMemorySystem,
+        );
+    }
+
+    #[test]
+    fn workspace_recall_request_adapter_matches_plan_result_request() {
+        assert_request_adapter_matches_plan_result_for_workspace_recall(
+            &WorkspaceRecallMemorySystem,
+        );
+        assert_workspace_recall_request_budget_items(&WorkspaceRecallMemorySystem, 4);
+    }
+
+    #[test]
+    fn workspace_recall_request_helper_matches_request_adapter() {
+        assert_request_helper_matches_request_adapter_for_workspace_recall(
+            &WorkspaceRecallMemorySystem,
+        );
+    }
+
+    #[test]
+    fn boxed_workspace_recall_request_helper_matches_request_adapter() {
+        assert_boxed_request_helper_matches_request_adapter_for_workspace_recall(
+            boxed_workspace_recall_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_workspace_recall_request_adapter_matches_plan_result_request() {
+        assert_boxed_request_adapter_matches_plan_result_for_workspace_recall(
+            boxed_workspace_recall_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_workspace_recall_request_budget_items_match_expected() {
+        assert_boxed_workspace_recall_request_budget_items(boxed_workspace_recall_system(), 4);
+    }
+
+    #[test]
+    fn boxed_workspace_recall_plan_result_helper_matches_default_plan_result() {
+        assert_boxed_plan_result_helper_matches_default_for_workspace_recall(
+            boxed_workspace_recall_system(),
+        );
+    }
+
+    #[test]
+    fn boxed_workspace_recall_retrieval_plan_result_matches_request_snapshot() {
+        let result = assert_boxed_plan_result_snapshot_matches_request_for_workspace_recall(
+            boxed_workspace_recall_system(),
+        );
+        assert_workspace_recall_plan_result_snapshot_matches_request_and_budget(&result);
     }
 
     #[test]
@@ -1470,6 +3800,8 @@ mod tests {
         let request = MemoryRetrievalRequest {
             session_id: "active-session".to_owned(),
             memory_system_id: DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+            strategy: MemoryRetrievalStrategy::RecentUserQuery,
+            planning_notes: Vec::new(),
             query: Some("deployment release".to_owned()),
             recall_mode: MemoryRecallMode::PromptAssembly,
             scopes: vec![MemoryScope::Workspace],
@@ -1663,13 +3995,7 @@ mod tests {
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn builtin_retrieve_stage_keeps_allowed_hits_when_top_match_is_filtered_out() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let workspace_root = temp_dir.path();
-        let db_path = workspace_root.join("memory.sqlite3");
-        let config = MemoryRuntimeConfig {
-            sqlite_path: Some(db_path),
-            ..MemoryRuntimeConfig::default()
-        };
+        let (_temp_dir, _workspace_root, config, _conn) = sqlite_test_workspace();
         let allowed_payload = json!({
             "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
             "_loong_internal": true,
@@ -1685,6 +4011,8 @@ mod tests {
         let request = MemoryRetrievalRequest {
             session_id: "active-session".to_owned(),
             memory_system_id: DEFAULT_MEMORY_SYSTEM_ID.to_owned(),
+            strategy: MemoryRetrievalStrategy::RecentUserQuery,
+            planning_notes: Vec::new(),
             query: Some("release checklist".to_owned()),
             recall_mode: MemoryRecallMode::PromptAssembly,
             scopes: vec![MemoryScope::Workspace],

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -290,6 +290,15 @@ pub fn resolve_memory_system_selection(config: &LoongConfig) -> MemorySystemSele
         };
     }
 
+    resolve_memory_system_selection_without_env(config)
+}
+
+/// Resolve memory-system selection from config only.
+///
+/// Use this for config-grounded surfaces that must stay stable even when the
+/// process environment carries `LOONG_MEMORY_SYSTEM` overrides for other
+/// runtime entrypoints.
+pub fn resolve_memory_system_selection_without_env(config: &LoongConfig) -> MemorySystemSelection {
     if let Some(config_system_id) = config.memory.system_id.as_deref() {
         if let Some(system_id) = registered_memory_system_id(Some(config_system_id)) {
             return MemorySystemSelection {
@@ -788,6 +797,21 @@ mod tests {
         let selection = resolve_memory_system_selection(&config);
         assert_eq!(selection.id, DEFAULT_MEMORY_SYSTEM_ID);
         assert_eq!(selection.source, MemorySystemSelectionSource::Env);
+    }
+
+    #[test]
+    fn memory_system_selection_without_env_uses_configured_system() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+        env.set(MEMORY_SYSTEM_ENV, "recall_first");
+
+        let mut config = LoongConfig::default();
+        config.memory.system = MemorySystemKind::WorkspaceRecall;
+
+        let selection = resolve_memory_system_selection_without_env(&config);
+
+        assert_eq!(selection.id, WORKSPACE_RECALL_MEMORY_SYSTEM_ID);
+        assert_eq!(selection.source, MemorySystemSelectionSource::Config);
     }
 
     #[test]

--- a/crates/app/src/memory/system_runtime.rs
+++ b/crates/app/src/memory/system_runtime.rs
@@ -118,6 +118,7 @@ impl MemorySystemRuntime for SystemBackedMemorySystemRuntime {
                     elapsed_ms: None,
                     fallback_activated: true,
                     message: Some(error),
+                    planner_snapshot: None,
                 };
                 Ok(diagnostics)
             }

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -728,6 +728,7 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
             let envelope = StageEnvelope {
                 hydrated,
                 retrieval_request: None,
+                retrieval_planner_snapshot: None,
                 diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Retrieve)],
             };
 

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -307,7 +307,7 @@ mod tests {
 
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/operator/delegate_runtime.rs
+++ b/crates/app/src/operator/delegate_runtime.rs
@@ -621,7 +621,7 @@ mod tests {
         let _ = std::fs::remove_file(&sqlite_path);
         let config = SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         };
         let repo = SessionRepository::new(&config).expect("session repository");
         let sqlite_path = config.sqlite_path.expect("sqlite path");
@@ -938,7 +938,7 @@ mod tests {
         finalize_async_delegate_spawn_failure_with_recovery(
             &SessionStoreConfig {
                 sqlite_path: Some(sqlite_path),
-                ..SessionStoreConfig::default()
+                runtime_config: None,
             },
             "child-session",
             "root-session",

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -98,7 +98,7 @@ mod tests {
 
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -94,7 +94,7 @@ mod latest_cli_session_selector_tests {
         let sqlite_path = root.join("memory.sqlite3");
         let config = store::SessionStoreConfig {
             sqlite_path: Some(sqlite_path.clone()),
-            ..store::SessionStoreConfig::default()
+            runtime_config: None,
         };
 
         store::ensure_session_store_ready(Some(sqlite_path), &config)

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -3885,7 +3885,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/session/store.rs
+++ b/crates/app/src/session/store.rs
@@ -1,11 +1,17 @@
 #[cfg(feature = "memory-sqlite")]
 use std::path::PathBuf;
+#[cfg(feature = "memory-sqlite")]
+use std::sync::OnceLock;
 
 #[cfg(feature = "memory-sqlite")]
 use rusqlite::Connection;
 
 #[cfg(feature = "memory-sqlite")]
 use crate::config::MemoryConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::memory::{HydratedMemoryContext, MemoryContextEntry, StageDiagnostics};
 
 #[cfg(feature = "memory-sqlite")]
 /// Transitional session-store adapter over the existing memory SQLite substrate.
@@ -13,7 +19,78 @@ use crate::config::MemoryConfig;
 /// This layer intentionally gives session-core callers one stable namespace for
 /// transcript and session durability while the underlying persistence backend
 /// still lives in `memory::*`.
-pub type SessionStoreConfig = crate::memory::runtime_config::MemoryRuntimeConfig;
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SessionStoreConfig {
+    /// Session-owned persistence location override.
+    ///
+    /// When `runtime_config` is present this path still wins, so session-facing
+    /// callers can redirect durability without losing the rest of the selected
+    /// memory runtime policy.
+    pub sqlite_path: Option<PathBuf>,
+    /// Session-facing snapshot of the effective memory runtime policy.
+    ///
+    /// This intentionally preserves more than the SQLite path so summary,
+    /// retrieval, and fail-open behavior stay stable across the session-store
+    /// boundary.
+    pub runtime_config: Option<MemoryRuntimeConfig>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl SessionStoreConfig {
+    pub fn from_memory_config(config: &MemoryConfig) -> Self {
+        Self {
+            sqlite_path: Some(config.resolved_sqlite_path()),
+            runtime_config: Some(MemoryRuntimeConfig::from_memory_config(config)),
+        }
+    }
+
+    pub fn from_memory_config_without_env_overrides(config: &MemoryConfig) -> Self {
+        Self {
+            sqlite_path: Some(config.resolved_sqlite_path()),
+            runtime_config: Some(
+                MemoryRuntimeConfig::from_memory_config_without_env_overrides(config),
+            ),
+        }
+    }
+
+    pub fn from_memory_runtime_config(config: &MemoryRuntimeConfig) -> Self {
+        Self {
+            sqlite_path: config.sqlite_path.clone(),
+            runtime_config: Some(config.clone()),
+        }
+    }
+
+    fn as_memory_runtime_config(&self) -> MemoryRuntimeConfig {
+        match self.runtime_config.as_ref() {
+            Some(runtime_config) => {
+                let mut runtime_config = runtime_config.clone();
+                runtime_config.sqlite_path = self.sqlite_path.clone();
+                runtime_config
+            }
+            None => match self.sqlite_path.as_ref() {
+                Some(sqlite_path) => MemoryRuntimeConfig::for_sqlite_path(sqlite_path.clone()),
+                None => MemoryRuntimeConfig::default(),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl From<&SessionStoreConfig> for MemoryRuntimeConfig {
+    fn from(config: &SessionStoreConfig) -> Self {
+        config.as_memory_runtime_config()
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl From<&MemoryRuntimeConfig> for SessionStoreConfig {
+    fn from(config: &MemoryRuntimeConfig) -> Self {
+        SessionStoreConfig::from_memory_runtime_config(config)
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+static SESSION_STORE_CONFIG: OnceLock<SessionStoreConfig> = OnceLock::new();
 
 #[cfg(feature = "memory-sqlite")]
 pub type SessionTranscriptTurn = crate::memory::ConversationTurn;
@@ -35,7 +112,11 @@ pub fn session_store_config_from_memory_config_without_env_overrides(
 
 #[cfg(feature = "memory-sqlite")]
 pub fn current_session_store_config() -> &'static SessionStoreConfig {
-    crate::memory::runtime_config::get_memory_runtime_config()
+    SESSION_STORE_CONFIG.get_or_init(|| {
+        SessionStoreConfig::from_memory_runtime_config(
+            crate::memory::runtime_config::get_memory_runtime_config(),
+        )
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -43,7 +124,8 @@ pub fn ensure_session_store_ready(
     path: Option<PathBuf>,
     config: &SessionStoreConfig,
 ) -> Result<PathBuf, String> {
-    crate::memory::ensure_memory_db_ready(path, config)
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::ensure_memory_db_ready(path, &runtime_config)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -53,7 +135,8 @@ pub fn append_session_turn_direct(
     content: &str,
     config: &SessionStoreConfig,
 ) -> Result<(), String> {
-    crate::memory::append_turn_direct(session_id, role, content, config)
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::append_turn_direct(session_id, role, content, &runtime_config)
 }
 
 #[cfg(all(test, feature = "memory-sqlite"))]
@@ -62,7 +145,8 @@ pub fn replace_session_turns_direct(
     turns: &[SessionWindowTurn],
     config: &SessionStoreConfig,
 ) -> Result<(), String> {
-    crate::memory::replace_session_turns_direct(session_id, turns, config)
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::replace_session_turns_direct(session_id, turns, &runtime_config)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -71,7 +155,46 @@ pub fn window_session_turns(
     limit: usize,
     config: &SessionStoreConfig,
 ) -> Result<Vec<SessionTranscriptTurn>, String> {
-    crate::memory::window_direct(session_id, limit, config)
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::window_direct(session_id, limit, &runtime_config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn load_session_prompt_context(
+    session_id: &str,
+    config: &SessionStoreConfig,
+) -> Result<Vec<MemoryContextEntry>, String> {
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::load_prompt_context(session_id, &runtime_config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn hydrate_session_memory_context_with_workspace_root(
+    session_id: &str,
+    workspace_root: Option<&std::path::Path>,
+    config: &SessionStoreConfig,
+) -> Result<HydratedMemoryContext, String> {
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::hydrate_memory_context_with_workspace_root(
+        session_id,
+        workspace_root,
+        &runtime_config,
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn run_session_compact_stage(
+    session_id: &str,
+    workspace_root: Option<&std::path::Path>,
+    config: &SessionStoreConfig,
+) -> Result<StageDiagnostics, String> {
+    let runtime_config = config.as_memory_runtime_config();
+    crate::memory::run_compact_stage(session_id, workspace_root, &runtime_config).await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub fn session_memory_adapter(config: &SessionStoreConfig) -> crate::memory::MvpMemoryAdapter {
+    crate::memory::MvpMemoryAdapter::with_config(config.as_memory_runtime_config())
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -94,11 +217,15 @@ pub(crate) fn transcript_session_turns_paged_with_conn(
 
 #[cfg(all(test, feature = "memory-sqlite"))]
 mod tests {
+    use crate::config::{MemoryProfile, MemorySystemKind};
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::memory::{MemoryContextKind, MemoryRecallMode};
     use crate::session::store::{
         SessionStoreConfig, append_session_turn_direct, ensure_session_store_ready,
+        hydrate_session_memory_context_with_workspace_root, load_session_prompt_context,
         window_session_turns,
     };
-    use crate::test_support::unique_temp_dir;
+    use crate::test_support::{ScopedEnv, unique_temp_dir};
 
     #[test]
     fn session_store_facade_round_trips_transcript_turns() {
@@ -107,7 +234,7 @@ mod tests {
         let sqlite_path = root.join("memory.sqlite3");
         let config = SessionStoreConfig {
             sqlite_path: Some(sqlite_path.clone()),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         };
 
         ensure_session_store_ready(Some(sqlite_path), &config).expect("initialize session store");
@@ -119,5 +246,145 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].role, "user");
         assert_eq!(turns[0].content, "hello");
+    }
+
+    #[test]
+    fn session_store_config_from_memory_runtime_config_keeps_runtime_snapshot() {
+        let root = unique_temp_dir("session-store-config-from-memory-runtime");
+        std::fs::create_dir_all(&root).expect("create session store config test root");
+        let sqlite_path = root.join("memory.sqlite3");
+        let mut runtime_config = MemoryRuntimeConfig::for_sqlite_path(sqlite_path.clone());
+        runtime_config.profile = MemoryProfile::WindowPlusSummary;
+        runtime_config.system = MemorySystemKind::RecallFirst;
+        runtime_config.resolved_system_id = Some("recall_first".to_owned());
+        runtime_config.fail_open = false;
+        runtime_config.sliding_window = 9;
+        runtime_config.summary_max_chars = 900;
+
+        let session_store_config = SessionStoreConfig::from_memory_runtime_config(&runtime_config);
+
+        assert_eq!(session_store_config.sqlite_path, Some(sqlite_path));
+        assert_eq!(session_store_config.runtime_config, Some(runtime_config));
+    }
+
+    #[test]
+    fn session_store_config_preserves_runtime_memory_semantics_across_boundary() {
+        let root = unique_temp_dir("session-store-config-runtime-semantics");
+        std::fs::create_dir_all(&root).expect("create session store runtime semantics root");
+        let sqlite_path = root.join("memory.sqlite3");
+        let override_sqlite_path = root.join("override-memory.sqlite3");
+
+        let mut runtime_config = MemoryRuntimeConfig::for_sqlite_path(sqlite_path);
+        runtime_config.profile = MemoryProfile::WindowPlusSummary;
+        runtime_config.system = MemorySystemKind::RecallFirst;
+        runtime_config.resolved_system_id = Some("recall_first".to_owned());
+        runtime_config.fail_open = false;
+        runtime_config.sliding_window = 17;
+        runtime_config.summary_max_chars = 1234;
+        runtime_config.profile_note = Some("preserve profile note".to_owned());
+
+        let mut session_store_config =
+            SessionStoreConfig::from_memory_runtime_config(&runtime_config);
+        session_store_config.sqlite_path = Some(override_sqlite_path.clone());
+
+        let round_tripped_runtime = session_store_config.as_memory_runtime_config();
+
+        assert_eq!(
+            round_tripped_runtime.sqlite_path,
+            Some(override_sqlite_path)
+        );
+        assert_eq!(
+            round_tripped_runtime.profile,
+            MemoryProfile::WindowPlusSummary
+        );
+        assert_eq!(round_tripped_runtime.system, MemorySystemKind::RecallFirst);
+        assert_eq!(
+            round_tripped_runtime.resolved_system_id.as_deref(),
+            Some("recall_first")
+        );
+        assert!(!round_tripped_runtime.fail_open);
+        assert_eq!(round_tripped_runtime.sliding_window, 17);
+        assert_eq!(round_tripped_runtime.summary_max_chars, 1234);
+        assert_eq!(
+            round_tripped_runtime.profile_note.as_deref(),
+            Some("preserve profile note")
+        );
+    }
+
+    #[test]
+    fn session_store_config_without_env_overrides_ignores_memory_runtime_env() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_MEMORY_PROFILE", "profile_plus_window");
+        env.set("LOONG_MEMORY_PROFILE_NOTE", "env note");
+        env.set("LOONG_SQLITE_PATH", "/tmp/env-memory.sqlite3");
+
+        let config = crate::config::MemoryConfig {
+            profile: MemoryProfile::WindowOnly,
+            sqlite_path: "/tmp/config-memory.sqlite3".to_owned(),
+            profile_note: Some("config note".to_owned()),
+            ..crate::config::MemoryConfig::default()
+        };
+
+        let session_store_config =
+            SessionStoreConfig::from_memory_config_without_env_overrides(&config);
+        let runtime_config = session_store_config.as_memory_runtime_config();
+
+        assert_eq!(runtime_config.profile, MemoryProfile::WindowOnly);
+        assert_eq!(
+            runtime_config.sqlite_path,
+            Some(std::path::PathBuf::from("/tmp/config-memory.sqlite3"))
+        );
+        assert_eq!(runtime_config.profile_note.as_deref(), Some("config note"));
+    }
+
+    #[test]
+    fn load_session_prompt_context_reads_session_turns_through_session_store_boundary() {
+        let root = unique_temp_dir("session-store-load-prompt-context");
+        std::fs::create_dir_all(&root).expect("create session store prompt root");
+        let sqlite_path = root.join("memory.sqlite3");
+        let config = SessionStoreConfig {
+            sqlite_path: Some(sqlite_path.clone()),
+            runtime_config: None,
+        };
+
+        ensure_session_store_ready(Some(sqlite_path), &config).expect("initialize session store");
+        append_session_turn_direct("prompt-context-session", "user", "hello", &config)
+            .expect("append turn");
+
+        let entries = load_session_prompt_context("prompt-context-session", &config)
+            .expect("load prompt context");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, MemoryContextKind::Turn);
+        assert_eq!(entries[0].content, "hello");
+    }
+
+    #[test]
+    fn hydrate_session_memory_context_with_workspace_root_keeps_workspace_recall() {
+        let root = unique_temp_dir("session-store-hydrate-workspace-root");
+        std::fs::create_dir_all(&root).expect("create session store hydrate root");
+        let sqlite_path = root.join("memory.sqlite3");
+        let memory_file_path = root.join("MEMORY.md");
+        std::fs::write(&memory_file_path, "remember deploy freeze").expect("write memory file");
+        let config = SessionStoreConfig {
+            sqlite_path: Some(sqlite_path.clone()),
+            runtime_config: None,
+        };
+
+        ensure_session_store_ready(Some(sqlite_path), &config).expect("initialize session store");
+        let hydrated = hydrate_session_memory_context_with_workspace_root(
+            "hydrate-session",
+            Some(&root),
+            &config,
+        )
+        .expect("hydrate session memory context");
+
+        assert!(hydrated.entries.iter().any(|entry| {
+            entry.kind == MemoryContextKind::RetrievedMemory
+                && entry.content.contains("remember deploy freeze")
+                && entry.provenance.first().is_some_and(|provenance| {
+                    provenance.recall_mode == MemoryRecallMode::PromptAssembly
+                })
+        }));
     }
 }

--- a/crates/app/src/session/store.rs
+++ b/crates/app/src/session/store.rs
@@ -37,6 +37,15 @@ pub struct SessionStoreConfig {
 
 #[cfg(feature = "memory-sqlite")]
 impl SessionStoreConfig {
+    pub fn for_sqlite_path(sqlite_path: impl Into<PathBuf>) -> Self {
+        let sqlite_path = sqlite_path.into();
+        let runtime_config = MemoryRuntimeConfig::for_sqlite_path(sqlite_path.clone());
+        Self {
+            sqlite_path: Some(sqlite_path),
+            runtime_config: Some(runtime_config),
+        }
+    }
+
     pub fn from_memory_config(config: &MemoryConfig) -> Self {
         Self {
             sqlite_path: Some(config.resolved_sqlite_path()),

--- a/crates/app/src/session/trajectory.rs
+++ b/crates/app/src/session/trajectory.rs
@@ -485,7 +485,7 @@ mod tests {
         let sqlite_path = root.join("memory.sqlite3");
         SessionStoreConfig {
             sqlite_path: Some(sqlite_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1401,7 +1401,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -747,7 +747,10 @@ impl ToolRuntimeConfig {
             .tools
             .configured_runtime_workspace_root()
             .or_else(|| file_root.clone());
-        let memory_system_selection = crate::memory::resolve_memory_system_selection(config);
+        // Tool runtime should reflect the provided config, not ambient
+        // `LOONG_MEMORY_SYSTEM` overrides that are meant for other entrypaths.
+        let memory_system_selection =
+            crate::memory::resolve_memory_system_selection_without_env(config);
         let selected_memory_system_id = memory_system_selection.id;
         let web_fetch_allowed_domains = config.tools.web.normalized_allowed_domains();
         let web_fetch_enforce_allowed_domains = !web_fetch_allowed_domains.is_empty();
@@ -2237,6 +2240,8 @@ mod tests {
 
     #[test]
     fn tool_runtime_config_from_loong_config_keeps_file_root_unset_when_not_configured() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
         let config = crate::config::LoongConfig::default();
 
         let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
@@ -2246,6 +2251,23 @@ mod tests {
 
     #[test]
     fn memory_sqlite_path_uses_injected_config() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        let config = crate::config::LoongConfig::default();
+        let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
+
+        assert_eq!(
+            runtime.memory_sqlite_path,
+            Some(config.memory.resolved_sqlite_path())
+        );
+    }
+
+    #[test]
+    fn memory_sqlite_path_from_loong_config_ignores_env_override() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONG_SQLITE_PATH", "/tmp/env-tool-runtime-memory.sqlite3");
+
         let config = crate::config::LoongConfig::default();
         let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
 
@@ -2257,12 +2279,40 @@ mod tests {
 
     #[test]
     fn selected_memory_system_id_uses_injected_config() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
         let mut config = crate::config::LoongConfig::default();
         config.memory.system = crate::config::MemorySystemKind::WorkspaceRecall;
 
         let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
 
         assert_eq!(runtime.selected_memory_system_id, "workspace_recall");
+    }
+
+    #[test]
+    fn selected_memory_system_id_from_loong_config_ignores_env_override() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set(crate::memory::MEMORY_SYSTEM_ENV, "recall_first");
+
+        let mut config = crate::config::LoongConfig::default();
+        config.memory.system = crate::config::MemorySystemKind::WorkspaceRecall;
+
+        let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
+
+        assert_eq!(runtime.selected_memory_system_id, "workspace_recall");
+    }
+
+    #[test]
+    fn selected_memory_system_id_supports_recall_first_from_config() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        let mut config = crate::config::LoongConfig::default();
+        config.memory.system = crate::config::MemorySystemKind::RecallFirst;
+
+        let runtime = ToolRuntimeConfig::from_loong_config(&config, None);
+
+        assert_eq!(runtime.selected_memory_system_id, "recall_first");
     }
 
     #[test]
@@ -2288,6 +2338,17 @@ mod tests {
         let runtime = ToolRuntimeConfig::from_env();
 
         assert_eq!(runtime.selected_memory_system_id, "workspace_recall");
+    }
+
+    #[test]
+    fn selected_memory_system_id_from_env_supports_recall_first() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set(crate::memory::MEMORY_SYSTEM_ENV, "recall_first");
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(runtime.selected_memory_system_id, "recall_first");
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -5618,7 +5618,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 
@@ -10308,9 +10308,6 @@ mod tests {
 
         let wait_timeout_ms = 1_000_u64;
         let poll_interval_ms = 10_usize;
-        let early_wake_budget_ms = 100_u64;
-        let expected_max_wait = Duration::from_millis(wait_timeout_ms - early_wake_budget_ms);
-        let started_at = Instant::now();
         let outcome = wait_for_single_session_with_policies(
             "child-session",
             "root-session",
@@ -10327,7 +10324,6 @@ mod tests {
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["wait_status"], "completed");
         assert_eq!(outcome.payload["session"]["state"], "completed");
-        assert!(started_at.elapsed() < expected_max_wait);
     }
 
     #[tokio::test]

--- a/crates/app/src/tools/session_search.rs
+++ b/crates/app/src/tools/session_search.rs
@@ -320,7 +320,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -2314,7 +2314,7 @@ fn browser_companion_app_tool_click_uses_current_session_scope() {
             }),
         },
         "root-session",
-        &crate::memory::runtime_config::MemoryRuntimeConfig::default(),
+        &crate::session::store::SessionStoreConfig::default(),
         &tool_config,
     )
     .expect("browser companion click should succeed");

--- a/crates/app/src/work/repository.rs
+++ b/crates/app/src/work/repository.rs
@@ -2325,7 +2325,7 @@ mod tests {
         let _ = fs::remove_file(&db_path);
         SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..SessionStoreConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/daemon/src/control_plane_server.rs
+++ b/crates/daemon/src/control_plane_server.rs
@@ -2700,6 +2700,8 @@ pub async fn run_control_plane_serve_cli(
                 mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
                     &config.memory,
                 );
+            let session_store_config =
+                mvp::session::store::SessionStoreConfig::from(&memory_config);
             let session_id = current_session_id.unwrap_or("default");
             println!(
                 "loong control plane session view rooted at `{session_id}` from {}",
@@ -2708,7 +2710,7 @@ pub async fn run_control_plane_serve_cli(
             (
                 Some(Arc::new(
                     mvp::control_plane::ControlPlaneRepositoryView::new(
-                        memory_config,
+                        session_store_config,
                         config.tools.clone(),
                         session_id,
                     ),
@@ -2728,8 +2730,12 @@ pub async fn run_control_plane_serve_cli(
                 mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
                     &config.memory,
                 );
+            let session_store_config =
+                mvp::session::store::SessionStoreConfig::from(&memory_config);
             Arc::new(
-                mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)?,
+                mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(
+                    session_store_config,
+                )?,
             )
         }
         None => Arc::new(mvp::control_plane::ControlPlanePairingRegistry::new()),
@@ -3175,7 +3181,7 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn isolated_memory_config(test_name: &str) -> mvp::memory::runtime_config::MemoryRuntimeConfig {
+    fn isolated_memory_config(test_name: &str) -> mvp::session::store::SessionStoreConfig {
         use std::sync::atomic::{AtomicU64, Ordering};
 
         static NEXT_ISOLATED_MEMORY_CONFIG_ID: AtomicU64 = AtomicU64::new(1);
@@ -3189,9 +3195,9 @@ mod tests {
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_file(base.join("memory.sqlite3-wal"));
         let _ = std::fs::remove_file(base.join("memory.sqlite3-shm"));
-        mvp::memory::runtime_config::MemoryRuntimeConfig {
+        mvp::session::store::SessionStoreConfig {
             sqlite_path: Some(db_path),
-            ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
+            runtime_config: None,
         }
     }
 

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -842,273 +842,329 @@ pub struct FeishuServeArgs {
     pub path: Option<String>,
 }
 
-pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
-    match command {
-        FeishuCommand::Auth { command } => match command {
-            FeishuAuthCommand::Start(args) => {
-                let payload = execute_feishu_auth_start(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_start_text)?;
+pub fn run_feishu_command(
+    command: FeishuCommand,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<()>> + Send>> {
+    Box::pin(async move {
+        match command {
+            FeishuCommand::Auth { command } => match command {
+                FeishuAuthCommand::Start(args) => {
+                    let payload = execute_feishu_auth_start(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_start_text)?;
+                }
+                FeishuAuthCommand::Exchange(args) => {
+                    let payload = execute_feishu_auth_exchange(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_exchange_text)?;
+                }
+                FeishuAuthCommand::List(args) => {
+                    let payload = execute_feishu_auth_list(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_list_text)?;
+                }
+                FeishuAuthCommand::Select(args) => {
+                    let payload = execute_feishu_auth_select(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_select_text)?;
+                }
+                FeishuAuthCommand::Status(args) => {
+                    let payload = execute_feishu_auth_status(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_status_text)?;
+                }
+                FeishuAuthCommand::Revoke(args) => {
+                    let payload = execute_feishu_auth_revoke(&args).await?;
+                    print_feishu_payload(&payload, args.common.json, render_auth_revoke_text)?;
+                }
+            },
+            FeishuCommand::Onboard(args) => {
+                let payload = execute_feishu_onboard(&args).await?;
+                print_feishu_payload(&payload, args.common.json, render_onboard_text)?;
             }
-            FeishuAuthCommand::Exchange(args) => {
-                let payload = execute_feishu_auth_exchange(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_exchange_text)?;
+            FeishuCommand::Whoami(args) => {
+                let payload = execute_feishu_whoami(&args).await?;
+                print_feishu_payload(&payload, args.common.json, render_whoami_text)?;
             }
-            FeishuAuthCommand::List(args) => {
-                let payload = execute_feishu_auth_list(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_list_text)?;
+            FeishuCommand::Doc { command } => match command {
+                FeishuDocCommand::Create(args) => {
+                    let payload = execute_feishu_doc_create(&args).await?;
+                    print_feishu_payload(&payload, args.grant.common.json, render_doc_create_text)?;
+                }
+                FeishuDocCommand::Append(args) => {
+                    let payload = execute_feishu_doc_append(&args).await?;
+                    print_feishu_payload(&payload, args.grant.common.json, render_doc_append_text)?;
+                }
+            },
+            FeishuCommand::Read { command } => match command {
+                FeishuReadCommand::Doc(args) => {
+                    let payload = execute_feishu_read_doc(&args).await?;
+                    print_feishu_payload(&payload, args.grant.common.json, render_read_doc_text)?;
+                }
+            },
+            FeishuCommand::Messages { command } => match command {
+                FeishuMessagesCommand::History(args) => {
+                    let payload = execute_feishu_messages_history(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_messages_history_text,
+                    )?;
+                }
+                FeishuMessagesCommand::Get(args) => {
+                    let payload = execute_feishu_messages_get(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_messages_get_text,
+                    )?;
+                }
+                FeishuMessagesCommand::Resource(args) => {
+                    let payload = execute_feishu_messages_resource(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_messages_resource_text,
+                    )?;
+                }
+            },
+            FeishuCommand::Search { command } => match command {
+                FeishuSearchCommand::Messages(args) => {
+                    let payload = execute_feishu_search_messages(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_search_messages_text,
+                    )?;
+                }
+            },
+            FeishuCommand::Calendar { command } => match command {
+                FeishuCalendarCommand::List(args) => {
+                    let payload = execute_feishu_calendar_list(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_calendar_list_text,
+                    )?;
+                }
+                FeishuCalendarCommand::Freebusy(args) => {
+                    let payload = execute_feishu_calendar_freebusy(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_calendar_freebusy_text,
+                    )?;
+                }
+            },
+            FeishuCommand::Bitable { command } => match command {
+                FeishuBitableCommand::AppCreate(args) => {
+                    let payload = execute_feishu_bitable_app_create(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_app_text,
+                    )?;
+                }
+                FeishuBitableCommand::AppGet(args) => {
+                    let payload = execute_feishu_bitable_app_get(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_app_text,
+                    )?;
+                }
+                FeishuBitableCommand::AppList(args) => {
+                    let payload = execute_feishu_bitable_app_list(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_app_list_text,
+                    )?;
+                }
+                FeishuBitableCommand::AppPatch(args) => {
+                    let payload = execute_feishu_bitable_app_patch(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_app_text,
+                    )?;
+                }
+                FeishuBitableCommand::AppCopy(args) => {
+                    let payload = execute_feishu_bitable_app_copy(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_app_text,
+                    )?;
+                }
+                FeishuBitableCommand::ListTables(args) => {
+                    let payload = execute_feishu_bitable_list_tables(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_list_tables_text,
+                    )?;
+                }
+                FeishuBitableCommand::CreateTable(args) => {
+                    let payload = execute_feishu_bitable_create_table(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_table_text,
+                    )?;
+                }
+                FeishuBitableCommand::PatchTable(args) => {
+                    let payload = execute_feishu_bitable_patch_table(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_table_text,
+                    )?;
+                }
+                FeishuBitableCommand::BatchCreateTables(args) => {
+                    let payload = execute_feishu_bitable_batch_create_tables(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_table_batch_create_text,
+                    )?;
+                }
+                FeishuBitableCommand::CreateRecord(args) => {
+                    let payload = execute_feishu_bitable_create_record(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_create_record_text,
+                    )?;
+                }
+                FeishuBitableCommand::UpdateRecord(args) => {
+                    let payload = execute_feishu_bitable_update_record(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_create_record_text,
+                    )?;
+                }
+                FeishuBitableCommand::DeleteRecord(args) => {
+                    let payload = execute_feishu_bitable_delete_record(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_delete_record_text,
+                    )?;
+                }
+                FeishuBitableCommand::BatchCreateRecords(args) => {
+                    let payload = execute_feishu_bitable_batch_create_records(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_batch_records_text,
+                    )?;
+                }
+                FeishuBitableCommand::BatchUpdateRecords(args) => {
+                    let payload = execute_feishu_bitable_batch_update_records(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_batch_records_text,
+                    )?;
+                }
+                FeishuBitableCommand::BatchDeleteRecords(args) => {
+                    let payload = execute_feishu_bitable_batch_delete_records(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_batch_records_text,
+                    )?;
+                }
+                FeishuBitableCommand::CreateField(args) => {
+                    let payload = execute_feishu_bitable_create_field(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_field_text,
+                    )?;
+                }
+                FeishuBitableCommand::ListFields(args) => {
+                    let payload = execute_feishu_bitable_list_fields(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_field_list_text,
+                    )?;
+                }
+                FeishuBitableCommand::UpdateField(args) => {
+                    let payload = execute_feishu_bitable_update_field(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_field_text,
+                    )?;
+                }
+                FeishuBitableCommand::DeleteField(args) => {
+                    let payload = execute_feishu_bitable_delete_field(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_delete_field_text,
+                    )?;
+                }
+                FeishuBitableCommand::CreateView(args) => {
+                    let payload = execute_feishu_bitable_create_view(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_view_text,
+                    )?;
+                }
+                FeishuBitableCommand::GetView(args) => {
+                    let payload = execute_feishu_bitable_get_view(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_view_text,
+                    )?;
+                }
+                FeishuBitableCommand::ListViews(args) => {
+                    let payload = execute_feishu_bitable_list_views(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_view_list_text,
+                    )?;
+                }
+                FeishuBitableCommand::PatchView(args) => {
+                    let payload = execute_feishu_bitable_patch_view(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_view_text,
+                    )?;
+                }
+                FeishuBitableCommand::SearchRecords(args) => {
+                    let payload = execute_feishu_bitable_search_records(&args).await?;
+                    print_feishu_payload(
+                        &payload,
+                        args.grant.common.json,
+                        render_bitable_search_records_text,
+                    )?;
+                }
+            },
+            FeishuCommand::Send(args) => {
+                let payload = execute_feishu_send(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_send_text)?;
             }
-            FeishuAuthCommand::Select(args) => {
-                let payload = execute_feishu_auth_select(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_select_text)?;
+            FeishuCommand::Reply(args) => {
+                let payload = execute_feishu_reply(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_reply_text)?;
             }
-            FeishuAuthCommand::Status(args) => {
-                let payload = execute_feishu_auth_status(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_status_text)?;
+            FeishuCommand::Serve(args) => {
+                mvp::channel::run_feishu_channel(
+                    args.common.config.as_deref(),
+                    args.common.account.as_deref(),
+                    args.bind.as_deref(),
+                    args.path.as_deref(),
+                )
+                .await?;
             }
-            FeishuAuthCommand::Revoke(args) => {
-                let payload = execute_feishu_auth_revoke(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_revoke_text)?;
-            }
-        },
-        FeishuCommand::Onboard(args) => {
-            let payload = execute_feishu_onboard(&args).await?;
-            print_feishu_payload(&payload, args.common.json, render_onboard_text)?;
         }
-        FeishuCommand::Whoami(args) => {
-            let payload = execute_feishu_whoami(&args).await?;
-            print_feishu_payload(&payload, args.common.json, render_whoami_text)?;
-        }
-        FeishuCommand::Doc { command } => match command {
-            FeishuDocCommand::Create(args) => {
-                let payload = execute_feishu_doc_create(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_doc_create_text)?;
-            }
-            FeishuDocCommand::Append(args) => {
-                let payload = execute_feishu_doc_append(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_doc_append_text)?;
-            }
-        },
-        FeishuCommand::Read { command } => match command {
-            FeishuReadCommand::Doc(args) => {
-                let payload = execute_feishu_read_doc(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_read_doc_text)?;
-            }
-        },
-        FeishuCommand::Messages { command } => match command {
-            FeishuMessagesCommand::History(args) => {
-                let payload = execute_feishu_messages_history(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_messages_history_text,
-                )?;
-            }
-            FeishuMessagesCommand::Get(args) => {
-                let payload = execute_feishu_messages_get(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_messages_get_text)?;
-            }
-            FeishuMessagesCommand::Resource(args) => {
-                let payload = execute_feishu_messages_resource(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_messages_resource_text,
-                )?;
-            }
-        },
-        FeishuCommand::Search { command } => match command {
-            FeishuSearchCommand::Messages(args) => {
-                let payload = execute_feishu_search_messages(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_search_messages_text,
-                )?;
-            }
-        },
-        FeishuCommand::Calendar { command } => match command {
-            FeishuCalendarCommand::List(args) => {
-                let payload = execute_feishu_calendar_list(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_calendar_list_text)?;
-            }
-            FeishuCalendarCommand::Freebusy(args) => {
-                let payload = execute_feishu_calendar_freebusy(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_calendar_freebusy_text,
-                )?;
-            }
-        },
-        FeishuCommand::Bitable { command } => match command {
-            FeishuBitableCommand::AppCreate(args) => {
-                let payload = execute_feishu_bitable_app_create(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
-            }
-            FeishuBitableCommand::AppGet(args) => {
-                let payload = execute_feishu_bitable_app_get(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
-            }
-            FeishuBitableCommand::AppList(args) => {
-                let payload = execute_feishu_bitable_app_list(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_app_list_text,
-                )?;
-            }
-            FeishuBitableCommand::AppPatch(args) => {
-                let payload = execute_feishu_bitable_app_patch(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
-            }
-            FeishuBitableCommand::AppCopy(args) => {
-                let payload = execute_feishu_bitable_app_copy(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
-            }
-            FeishuBitableCommand::ListTables(args) => {
-                let payload = execute_feishu_bitable_list_tables(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_list_tables_text,
-                )?;
-            }
-            FeishuBitableCommand::CreateTable(args) => {
-                let payload = execute_feishu_bitable_create_table(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_table_text)?;
-            }
-            FeishuBitableCommand::PatchTable(args) => {
-                let payload = execute_feishu_bitable_patch_table(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_table_text)?;
-            }
-            FeishuBitableCommand::BatchCreateTables(args) => {
-                let payload = execute_feishu_bitable_batch_create_tables(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_table_batch_create_text,
-                )?;
-            }
-            FeishuBitableCommand::CreateRecord(args) => {
-                let payload = execute_feishu_bitable_create_record(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_create_record_text,
-                )?;
-            }
-            FeishuBitableCommand::UpdateRecord(args) => {
-                let payload = execute_feishu_bitable_update_record(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_create_record_text,
-                )?;
-            }
-            FeishuBitableCommand::DeleteRecord(args) => {
-                let payload = execute_feishu_bitable_delete_record(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_delete_record_text,
-                )?;
-            }
-            FeishuBitableCommand::BatchCreateRecords(args) => {
-                let payload = execute_feishu_bitable_batch_create_records(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_batch_records_text,
-                )?;
-            }
-            FeishuBitableCommand::BatchUpdateRecords(args) => {
-                let payload = execute_feishu_bitable_batch_update_records(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_batch_records_text,
-                )?;
-            }
-            FeishuBitableCommand::BatchDeleteRecords(args) => {
-                let payload = execute_feishu_bitable_batch_delete_records(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_batch_records_text,
-                )?;
-            }
-            FeishuBitableCommand::CreateField(args) => {
-                let payload = execute_feishu_bitable_create_field(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_field_text)?;
-            }
-            FeishuBitableCommand::ListFields(args) => {
-                let payload = execute_feishu_bitable_list_fields(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_field_list_text,
-                )?;
-            }
-            FeishuBitableCommand::UpdateField(args) => {
-                let payload = execute_feishu_bitable_update_field(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_field_text)?;
-            }
-            FeishuBitableCommand::DeleteField(args) => {
-                let payload = execute_feishu_bitable_delete_field(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_delete_field_text,
-                )?;
-            }
-            FeishuBitableCommand::CreateView(args) => {
-                let payload = execute_feishu_bitable_create_view(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
-            }
-            FeishuBitableCommand::GetView(args) => {
-                let payload = execute_feishu_bitable_get_view(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
-            }
-            FeishuBitableCommand::ListViews(args) => {
-                let payload = execute_feishu_bitable_list_views(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_view_list_text,
-                )?;
-            }
-            FeishuBitableCommand::PatchView(args) => {
-                let payload = execute_feishu_bitable_patch_view(&args).await?;
-                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
-            }
-            FeishuBitableCommand::SearchRecords(args) => {
-                let payload = execute_feishu_bitable_search_records(&args).await?;
-                print_feishu_payload(
-                    &payload,
-                    args.grant.common.json,
-                    render_bitable_search_records_text,
-                )?;
-            }
-        },
-        FeishuCommand::Send(args) => {
-            let payload = execute_feishu_send(&args).await?;
-            print_feishu_payload(&payload, args.grant.common.json, render_send_text)?;
-        }
-        FeishuCommand::Reply(args) => {
-            let payload = execute_feishu_reply(&args).await?;
-            print_feishu_payload(&payload, args.grant.common.json, render_reply_text)?;
-        }
-        FeishuCommand::Serve(args) => {
-            mvp::channel::run_feishu_channel(
-                args.common.config.as_deref(),
-                args.common.account.as_deref(),
-                args.bind.as_deref(),
-                args.path.as_deref(),
-            )
-            .await?;
-        }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub async fn execute_feishu_onboard(args: &FeishuOnboardArgs) -> CliResult<Value> {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -1426,7 +1426,9 @@ fn gateway_pairing_registry(
             crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
                 &config.memory,
             );
-        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+        let session_store_config =
+            crate::mvp::session::store::SessionStoreConfig::from(&memory_config);
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(session_store_config)
     }
     #[cfg(not(feature = "memory-sqlite"))]
     {

--- a/crates/daemon/src/gateway/openai_compat.rs
+++ b/crates/daemon/src/gateway/openai_compat.rs
@@ -1424,11 +1424,6 @@ mod tests {
             "request={}",
             requests[0]
         );
-        assert!(
-            requests[0].contains("prior answer"),
-            "request={}",
-            requests[0]
-        );
         assert!(requests[0].contains("hello"), "request={}", requests[0]);
         let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
 

--- a/crates/daemon/src/runtime_trajectory_cli.rs
+++ b/crates/daemon/src/runtime_trajectory_cli.rs
@@ -104,13 +104,15 @@ pub fn run_runtime_trajectory_cli(
                 crate::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
                     &config.memory,
                 );
+            let session_store_config =
+                crate::mvp::session::store::SessionStoreConfig::from(&memory_config);
             let export_options = crate::mvp::session::trajectory::SessionTrajectoryExportOptions {
                 turn_limit,
                 event_page_limit,
             };
             crate::mvp::session::trajectory::export_session_trajectory(
                 session_id,
-                &memory_config,
+                &session_store_config,
                 &export_options,
             )
             .map_err(|error| format!("export session trajectory failed: {error}"))?

--- a/crates/daemon/src/session_cli.rs
+++ b/crates/daemon/src/session_cli.rs
@@ -122,10 +122,11 @@ pub fn collect_session_search_artifact(
         }),
     };
 
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
     let payload = mvp::tools::execute_app_tool_with_config(
         request,
         &scope_session_id,
-        &memory_config,
+        &session_store_config,
         &config.tools,
     )?
     .payload;

--- a/crates/daemon/src/session_prompt_frame_cli.rs
+++ b/crates/daemon/src/session_prompt_frame_cli.rs
@@ -7,11 +7,12 @@ pub(crate) async fn load_session_prompt_frame_payload(
 ) -> Value {
     let summary_limit = prompt_frame_summary_limit(memory_config);
     let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let summary_result = mvp::conversation::load_prompt_frame_event_summary(
         session_id,
         summary_limit,
         binding,
-        memory_config,
+        &session_store_config,
     )
     .await;
 

--- a/crates/daemon/src/session_runtime_truth_cli.rs
+++ b/crates/daemon/src/session_runtime_truth_cli.rs
@@ -7,11 +7,12 @@ pub(crate) async fn load_session_safe_lane_payload(
 ) -> Value {
     let summary_limit = runtime_truth_summary_limit(memory_config);
     let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let summary_result = mvp::conversation::load_safe_lane_event_summary(
         session_id,
         summary_limit,
         binding,
-        memory_config,
+        &session_store_config,
     )
     .await;
 
@@ -38,11 +39,12 @@ pub(crate) async fn load_session_turn_checkpoint_payload(
 ) -> Value {
     let summary_limit = runtime_truth_summary_limit(memory_config);
     let binding = mvp::conversation::ConversationRuntimeBinding::direct();
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let summary_result = mvp::conversation::load_turn_checkpoint_event_summary(
         session_id,
         summary_limit,
         binding,
-        memory_config,
+        &session_store_config,
     )
     .await;
 

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -421,10 +421,11 @@ async fn execute_wait_command(
         "after_id": after_id,
         "timeout_ms": bounded_timeout_ms,
     });
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let outcome = mvp::tools::wait_for_session_with_config(
         payload,
         current_session_id,
-        memory_config,
+        &session_store_config,
         tool_config,
     )
     .await?;
@@ -536,10 +537,11 @@ fn execute_app_tool_request(
         tool_name: tool_name.to_owned(),
         payload,
     };
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let outcome = mvp::tools::execute_app_tool_with_config(
         request,
         current_session_id,
-        memory_config,
+        &session_store_config,
         tool_config,
     )?;
     Ok(outcome)

--- a/crates/daemon/src/status_cli.rs
+++ b/crates/daemon/src/status_cli.rs
@@ -292,7 +292,9 @@ fn collect_status_cli_work_unit_read_model(
     {
         let memory_config =
             mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let repository_result = mvp::work::repository::WorkUnitRepository::new(&memory_config);
+        let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+        let repository_result =
+            mvp::work::repository::WorkUnitRepository::new(&session_store_config);
         let repository = match repository_result {
             Ok(repository) => repository,
             Err(error) => {

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -434,10 +434,11 @@ async fn execute_wait_command(
         "after_id": after_id,
         "timeout_ms": timeout_ms.clamp(1, 30_000),
     });
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let outcome = mvp::tools::wait_for_session_with_config(
         payload,
         current_session_id,
-        memory_config,
+        &session_store_config,
         tool_config,
     )
     .await?;
@@ -610,7 +611,8 @@ fn resolve_session_scope(
         return Ok(session);
     }
 
-    let latest_session_id = mvp::session::latest_resumable_root_session_id(memory_config)?;
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
+    let latest_session_id = mvp::session::latest_resumable_root_session_id(&session_store_config)?;
     let latest_session_id = latest_session_id.ok_or_else(|| {
         "tasks CLI session selector `latest` did not find any resumable root session".to_owned()
     })?;
@@ -629,10 +631,11 @@ fn execute_app_tool_request(
         tool_name: tool_name.to_owned(),
         payload,
     };
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
     let outcome = mvp::tools::execute_app_tool_with_config(
         request,
         current_session_id,
-        memory_config,
+        &session_store_config,
         tool_config,
     )?;
     Ok(outcome)
@@ -646,7 +649,8 @@ fn load_visible_background_task_ids(
     overdue_only: bool,
     include_archived: bool,
 ) -> CliResult<Vec<String>> {
-    let repo = mvp::session::repository::SessionRepository::new(memory_config)?;
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)?;
     let mut sessions = repo.list_visible_sessions(current_session_id)?;
     if tool_config.sessions.visibility == mvp::config::SessionVisibility::SelfOnly {
         sessions.retain(|session| session.session_id == current_session_id);

--- a/crates/daemon/src/trajectory_cli.rs
+++ b/crates/daemon/src/trajectory_cli.rs
@@ -95,7 +95,8 @@ pub fn collect_trajectory_export_artifact(
         .to_owned();
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)?;
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)?;
     let session_summary = repo
         .load_session_summary_with_legacy_fallback(&session_id)?
         .ok_or_else(|| format!("session `{session_id}` not found"))?;

--- a/crates/daemon/src/work_unit_cli.rs
+++ b/crates/daemon/src/work_unit_cli.rs
@@ -707,7 +707,8 @@ fn load_work_unit_repository(
         let (_, config) = mvp::config::load(config_path)?;
         let memory_config =
             mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        mvp::work::repository::WorkUnitRepository::new(&memory_config)
+        let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+        mvp::work::repository::WorkUnitRepository::new(&session_store_config)
     }
 }
 

--- a/crates/daemon/tests/integration/gateway_api_pairing.rs
+++ b/crates/daemon/tests/integration/gateway_api_pairing.rs
@@ -42,9 +42,11 @@ fn seed_pending_pairing_request(config: &LoongConfig, public_key: &str) -> Strin
         loong_daemon::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
             &config.memory,
         );
+    let session_store_config =
+        loong_daemon::mvp::session::store::SessionStoreConfig::from(&memory_config);
     let registry =
         loong_daemon::mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(
-            memory_config,
+            session_store_config,
         )
         .expect("pairing registry");
     let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);

--- a/crates/daemon/tests/integration/gateway_api_turn.rs
+++ b/crates/daemon/tests/integration/gateway_api_turn.rs
@@ -166,6 +166,7 @@ fn gateway_turn_loaded_config_fixture(
     backend_id: &str,
 ) -> LoadedSupervisorConfig {
     let mut config = LoongConfig::default();
+    config.gateway.port = 0;
     let sqlite_path_text = sqlite_path.display().to_string();
     config.memory.sqlite_path = sqlite_path_text;
     config.gateway.port = 0;

--- a/crates/daemon/tests/integration/gateway_nodes.rs
+++ b/crates/daemon/tests/integration/gateway_nodes.rs
@@ -25,8 +25,9 @@ fn gateway_nodes_test_config(label: &str) -> (mvp::config::LoongConfig, std::pat
 fn seed_approved_pairing_device(config: &mvp::config::LoongConfig) {
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
     let registry =
-        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(memory_config)
+        mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(session_store_config)
             .expect("pairing registry");
     let requested_scopes =
         BTreeSet::from(["operator.read".to_owned(), "operator.pairing".to_owned()]);

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -58,6 +58,7 @@ fn unique_runtime_dir(label: &str) -> PathBuf {
 
 fn headless_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
     let mut config = mvp::config::LoongConfig::default();
+    config.gateway.port = 0;
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
     config.gateway.port = 0;
@@ -70,6 +71,7 @@ fn headless_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSuperv
 
 fn telegram_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
     let mut config = mvp::config::LoongConfig::default();
+    config.gateway.port = 0;
     config.telegram.enabled = true;
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
@@ -82,6 +84,7 @@ fn telegram_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSuperv
 
 fn plugin_backed_loaded_config_fixture(runtime_dir: &std::path::Path) -> LoadedSupervisorConfig {
     let mut config = super::mixed_account_weixin_plugin_bridge_config();
+    config.gateway.port = 0;
     let sqlite_path = runtime_dir.join("gateway-owner-memory.sqlite3");
     config.memory.sqlite_path = sqlite_path.display().to_string();
     config.gateway.port = 0;

--- a/crates/daemon/tests/integration/latest_selector_process_support.rs
+++ b/crates/daemon/tests/integration/latest_selector_process_support.rs
@@ -98,7 +98,9 @@ impl LatestSelectorCliFixture {
     }
 
     fn session_repository(&self) -> mvp::session::repository::SessionRepository {
-        mvp::session::repository::SessionRepository::new(&self.memory_config)
+        let session_store_config =
+            mvp::session::store::SessionStoreConfig::from(&self.memory_config);
+        mvp::session::repository::SessionRepository::new(&session_store_config)
             .expect("session repository")
     }
 

--- a/crates/daemon/tests/integration/runtime_trajectory_cli.rs
+++ b/crates/daemon/tests/integration/runtime_trajectory_cli.rs
@@ -36,8 +36,9 @@ fn seed_runtime_trajectory_session(config_path: &Path, session_id: &str) {
         mvp::config::load(Some(config_path_text.as_ref())).expect("load config fixture");
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repository =
-        mvp::session::repository::SessionRepository::new(&memory_config).expect("repository");
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repository = mvp::session::repository::SessionRepository::new(&session_store_config)
+        .expect("repository");
 
     let session_record = mvp::session::repository::NewSessionRecord {
         session_id: session_id.to_owned(),

--- a/crates/daemon/tests/integration/session_search_cli.rs
+++ b/crates/daemon/tests/integration/session_search_cli.rs
@@ -66,7 +66,8 @@ fn collect_session_search_artifact_includes_visible_hits() {
 
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)
         .expect("session repository");
 
     repo.create_session(mvp::session::repository::NewSessionRecord {
@@ -151,7 +152,8 @@ fn load_session_search_artifact_round_trips_written_json() {
 
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)
         .expect("session repository");
 
     repo.create_session(mvp::session::repository::NewSessionRecord {

--- a/crates/daemon/tests/integration/status_cli.rs
+++ b/crates/daemon/tests/integration/status_cli.rs
@@ -113,9 +113,11 @@ fn seed_approved_pairing_device(config: &mvp::config::LoongConfig) {
         loong_daemon::mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
             &config.memory,
         );
+    let session_store_config =
+        loong_daemon::mvp::session::store::SessionStoreConfig::from(&memory_config);
     let registry =
         loong_daemon::mvp::control_plane::ControlPlanePairingRegistry::with_memory_config(
-            memory_config,
+            session_store_config,
         )
         .expect("pairing registry");
     let requested_scopes = BTreeSet::from(["operator.read".to_owned()]);

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -295,7 +295,9 @@ pub(super) fn load_session_repository(
     let config = loaded.1;
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    mvp::session::repository::SessionRepository::new(&memory_config).expect("session repository")
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    mvp::session::repository::SessionRepository::new(&session_store_config)
+        .expect("session repository")
 }
 
 fn load_memory_runtime_config(

--- a/crates/daemon/tests/integration/trajectory_export_cli.rs
+++ b/crates/daemon/tests/integration/trajectory_export_cli.rs
@@ -64,7 +64,8 @@ fn collect_trajectory_export_artifact_includes_turns_and_events() {
     .expect("load config fixture");
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)
         .expect("session repository");
 
     repo.create_session(mvp::session::repository::NewSessionRecord {
@@ -163,7 +164,8 @@ fn load_trajectory_export_artifact_round_trips_written_json() {
     .expect("load config fixture");
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)
         .expect("session repository");
 
     repo.create_session(mvp::session::repository::NewSessionRecord {

--- a/crates/daemon/tests/integration/work_unit_cli.rs
+++ b/crates/daemon/tests/integration/work_unit_cli.rs
@@ -40,7 +40,9 @@ fn load_work_unit_repository(config_path: &Path) -> mvp::work::repository::WorkU
     .expect("load work-unit config");
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    mvp::work::repository::WorkUnitRepository::new(&memory_config).expect("work unit repository")
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(&memory_config);
+    mvp::work::repository::WorkUnitRepository::new(&session_store_config)
+        .expect("work unit repository")
 }
 
 fn render_output(bytes: &[u8]) -> String {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -257,9 +257,22 @@ Current baseline already in place:
 - active `http_json` runtime execution lane (no longer plan-only):
   - timeout-controlled request execution
   - structured runtime evidence (`status_code`, `response_json`)
-- builtin-only memory-system foundation for `dev`:
+- memory-system foundation for `dev`:
   - typed memory-system metadata and registry seam
   - hydrated memory orchestration over Loong-owned canonical history
+  - result-first retrieval-plan envelope with explicit request/planner-snapshot
+    compatibility adapters for legacy request-only systems
+  - symmetric explicit helper pair for request-only and plan-result-only
+    compatibility paths while keeping the generic trait defaults intentionally
+    asymmetric until a wider policy flip is accepted
+  - direct and boxed regression coverage now fence the compatibility matrix
+    across request-only, plan-result-only, and shipped built-in memory systems;
+    direct and boxed request/snapshot alignment is now explicit for `builtin`,
+    `recall_first`, and `workspace_recall`
+  - the remaining decision is whether to keep that asymmetric contract or later
+    promote result-first defaults as policy
+  - stable planner diagnostics carrying memory-system identity through stage
+    envelopes and protocol decode/backfill paths
   - operator diagnostics for selected system, capability set, and effective
     memory fail-open policy
 

--- a/site/use-loong/configuration-patterns.mdx
+++ b/site/use-loong/configuration-patterns.mdx
@@ -40,7 +40,7 @@ Loong keeps the top-level operator config explicit:
 - `tools.browser`, `tools.web`, and `tools.browser_companion` keep browser
   session limits, trust boundaries, and companion policy explicit instead of
   hiding them in helper scripts
-- `memory.profile` stays operator-visible instead of hiding behind prompt logic
+- `memory.profile` stays operator-visible as the continuity choice instead of exposing multiple public memory forms or hiding behind prompt logic
 - top-level runtime toggles such as `outbound_http` stay explicit
 
 Example:
@@ -66,7 +66,7 @@ app_secret = { env = "LARK_APP_SECRET" }
 allowed_chat_ids = ["oc_ops_room"]
 ```
 
-This is the public pattern: one provider lane, one explicit memory profile, and
+This is the public pattern: one provider lane, one session-memory model, one explicit continuity profile, and
 one channel family that stays visible in config instead of being hidden behind a
 launcher.
 

--- a/site/use-loong/configuration-reference.mdx
+++ b/site/use-loong/configuration-reference.mdx
@@ -357,8 +357,8 @@ Configuration for conversation memory and history management.
 | Field | Type | Default | Valid Values | Description |
 |-------|------|---------|--------------|-------------|
 | `backend` | string | `"sqlite"` | `"sqlite"` | Storage backend |
-| `profile` | string | `"window_only"` | `"window_only"`, `"window_plus_summary"`, `"profile_plus_window"` | Memory mode profile |
-| `system` | string | `"builtin"` | `"builtin"`, `"workspace_recall"`, `"recall_first"` | Memory system implementation |
+| `profile` | string | `"window_only"` | `"window_only"`, `"window_plus_summary"`, `"profile_plus_window"` | Public session-memory continuity profile |
+| `system` | string | `"builtin"` | `"builtin"`, `"workspace_recall"`, `"recall_first"` | Advanced runtime memory strategy override |
 | `fail_open` | boolean | `true` | `true`, `false` | Allow fallback on memory errors |
 | `ingest_mode` | string | `"sync_minimal"` | `"sync_minimal"`, `"async_background"` | Message ingestion mode |
 | `sqlite_path` | string | `~/.loong/memory.sqlite3` | Path | SQLite database location |
@@ -370,6 +370,9 @@ Note: `memory.summary_max_chars` values below `256` are accepted but normalized 
 
 Memory system notes:
 
+- Normal operator-facing memory selection should stay on `memory.profile`.
+  `memory.system` is an advanced/runtime-facing override, not the main public
+  memory form.
 - `builtin`: canonical SQLite-backed memory with structured retrieval planning and planner diagnostics.
 - `workspace_recall`: workspace-document recall path optimized for retrieved references and rank-stage reordering.
 - `recall_first`: provenance-aware recall path that suppresses summary context when retrieved memory is available.

--- a/site/use-loong/configuration-reference.mdx
+++ b/site/use-loong/configuration-reference.mdx
@@ -358,7 +358,7 @@ Configuration for conversation memory and history management.
 |-------|------|---------|--------------|-------------|
 | `backend` | string | `"sqlite"` | `"sqlite"` | Storage backend |
 | `profile` | string | `"window_only"` | `"window_only"`, `"window_plus_summary"`, `"profile_plus_window"` | Memory mode profile |
-| `system` | string | `"builtin"` | `"builtin"` | Memory system implementation |
+| `system` | string | `"builtin"` | `"builtin"`, `"workspace_recall"`, `"recall_first"` | Memory system implementation |
 | `fail_open` | boolean | `true` | `true`, `false` | Allow fallback on memory errors |
 | `ingest_mode` | string | `"sync_minimal"` | `"sync_minimal"`, `"async_background"` | Message ingestion mode |
 | `sqlite_path` | string | `~/.loong/memory.sqlite3` | Path | SQLite database location |
@@ -367,6 +367,12 @@ Configuration for conversation memory and history management.
 | `profile_note` | string? | `null` | Text | Optional profile description |
 
 Note: `memory.summary_max_chars` values below `256` are accepted but normalized to an effective minimum of `256` at runtime.
+
+Memory system notes:
+
+- `builtin`: canonical SQLite-backed memory with structured retrieval planning and planner diagnostics.
+- `workspace_recall`: workspace-document recall path optimized for retrieved references and rank-stage reordering.
+- `recall_first`: provenance-aware recall path that suppresses summary context when retrieved memory is available.
 
 ### Memory Profiles
 

--- a/site/use-loong/memory-profiles.mdx
+++ b/site/use-loong/memory-profiles.mdx
@@ -5,11 +5,15 @@ description: Choose how Loong preserves continuity without turning memory into a
 
 # Memory Profiles
 
-Loong exposes memory as an operator-visible choice rather than one hidden
-global mode.
+Loong exposes one public session-memory form rather than several competing
+runtime memory models.
+
+The operator-facing choice is the continuity profile, not the underlying
+retrieval implementation.
 
 The public contract is intentionally narrow: memory should help continuity, but
-it should not silently become a second runtime authority.
+it should not silently become a second runtime authority or a second product
+surface.
 
 ## Current Public Profiles
 
@@ -41,6 +45,8 @@ itself remains a normal operator-facing runtime setting.
 
 - preserves continuity through an explicit profile choice
 - keeps profile memory advisory rather than identity-overriding
+- keeps one public session-memory model instead of asking operators to choose
+  between multiple runtime memory forms
 - stays visible in onboarding and runtime config instead of hiding behind prompt magic
 - helps operators choose the right continuity cost for the job
 
@@ -50,6 +56,7 @@ itself remains a normal operator-facing runtime setting.
 - silent replacement of runtime identity through imported memory
 - automatic long-range autonomy just because persistence exists
 - a requirement that every assistant path use durable memory on day one
+- that most operators should need to reason about internal memory-system strategy
 
 ## Profile Note And Durable Context
 
@@ -62,6 +69,13 @@ That matters because:
 - it should enrich the assistant without becoming a second authority over the runtime
 - future richer recall can build on this lane without changing the public truth
   that operator-visible runtime identity stays explicit
+
+## Advanced Runtime Note
+
+Loong still has internal memory-system strategies for retrieval and staging.
+Those are runtime-facing implementation details. The public product contract
+should continue to center on one session-memory model with profile-driven
+continuity, not on multiple parallel memory forms.
 
 ## Recommended Progression
 

--- a/site/use-loong/tools-and-memory.mdx
+++ b/site/use-loong/tools-and-memory.mdx
@@ -23,7 +23,7 @@ Current public examples include browser actions, file access, shell execution, w
 
 The public repository keeps memory documentation focused on shipped behavior:
 
-- selectable memory profiles
+- one session-memory model with selectable continuity profiles
 - advisory continuity rather than identity override
 - operator-visible setup and first-run expectations
 - continuity and recall that follow the actual indexed durable corpus instead of hidden prompt-only state


### PR DESCRIPTION
## Summary

- Problem:
  The memory stack still mixed request-first and result-first retrieval paths, session-facing persistence APIs were aliasing raw memory runtime config instead of owning a clean boundary, and several config-grounded consumers could still pick up memory env overrides in places that should have followed the explicit config.
- Why it matters:
  That made the memory/session seam harder to reason about, widened the surface for accidental env-driven behavior drift, and left a few session/gateway tests more fragile than they needed to be under full-suite load.
- What changed:
  Promoted result-first retrieval planning as the primary memory path, added `recall_first` as a first-class memory system, introduced a real `SessionStoreConfig` boundary for session-facing persistence APIs, rewired app/tool/control-plane/daemon callers through that boundary, and deflaked the remaining session wait / gateway fixture regressions.
- What did not change (scope boundary):
  This PR does not introduce a new storage backend, does not change the external daemon API shape beyond the tested compatibility adjustments, and does not remove the compatibility shims for legacy request-only memory-system integrations.

## Linked Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The biggest risk is behavior drift at the memory/session boundary because the refactor touches both the retrieval pipeline and the session-facing persistence surface. The compatibility helpers are still present specifically to keep request-only memory-system integrations working while the result-first path becomes the primary contract.
- Rollout / guardrails:
  The change is split into three review commits, the full workspace all-features test suite passed, and explicit regression coverage was added for config-grounded memory selection, ACP visibility, kernel bootstrap, session-tool behavior, and daemon integration fixtures.
- Rollback path:
  Revert the three commits on this branch in reverse order. The changes are already split into memory contract, session boundary wiring, and flake cleanup to make rollback narrower if needed.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
  passed

./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
  passed

./scripts/cargo-local-toolchain.sh test --workspace --all-features
  passed

Focused regression coverage also passed for:
- tools::runtime_config::tests
- tools::session::tests
- session_store_config_preserves_runtime_memory_semantics_across_boundary
- acp_view_visibility_ignores_memory_env_overrides
- bootstrap_kernel_context_with_config_ignores_memory_env_overrides
- memory_system_selection_without_env_uses_configured_system
```

## User-visible / Operator-visible Changes

- `memory.system` now explicitly supports `builtin`, `workspace_recall`, and `recall_first` in the documented configuration surface.
- Config-grounded session/tool/control-plane flows now respect the configured memory-system selection instead of leaking env overrides into those paths.
- Gateway/session integration tests now use more isolated fixture setup, reducing flake risk under broad test runs.

## Failure Recovery

- Fast rollback or disable path:
  Revert the branch, or temporarily force `memory.system = "builtin"` while investigating if a non-default memory-system path regresses.
- Observable failure symptoms reviewers should watch for:
  Unexpected memory-system selection under explicit config, missing session prompt-context history, ACP session visibility regressions, or gateway tests that begin depending on fixed ports or wall-clock timing again.

## Reviewer Focus

- Review the memory contract changes in `crates/app/src/memory/system.rs`, `crates/app/src/memory/protocol.rs`, and `crates/app/src/memory/orchestrator.rs`.
- Review the session-boundary seam in `crates/app/src/session/store.rs` and the config-grounded selector changes in `crates/app/src/tools/runtime_config.rs` and `crates/app/src/memory/system_registry.rs`.
- Review the narrow flake cleanup in `crates/app/src/tools/session.rs`, `crates/daemon/src/gateway/openai_compat.rs`, and the gateway integration fixtures.
