### PR TITLE
Add a bounded sessions-heal orchestration surface

### DIFF
--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -3084,6 +3084,8 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         "missing" => session_terminal_outcome_missing_reason(recovery.as_ref()),
         _ => None,
     };
+    let diagnostics =
+        session_diagnostics_json(&snapshot, terminal_outcome_state, recovery.as_ref());
     let subagent_handle = subagent_handle_for_session(
         &snapshot.session,
         snapshot.subagent_contract.as_ref(),
@@ -3108,6 +3110,7 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         "workflow": session_workflow_json(snapshot.workflow),
         "terminal_outcome_state": terminal_outcome_state,
         "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
+        "diagnostics": diagnostics,
         "delegate_lifecycle": delegate_lifecycle
             .map(|lifecycle| session_delegate_lifecycle_json(
                 lifecycle,
@@ -3130,6 +3133,230 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         subagent_handle.as_ref(),
     );
     payload
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_diagnostics_json(
+    snapshot: &SessionInspectionSnapshot,
+    terminal_outcome_state: &str,
+    recovery: Option<&SessionRecoveryRecord>,
+) -> Value {
+    let recent_events = snapshot.recent_events.as_slice();
+    let latest_provider_failover = latest_provider_failover_diagnostic(recent_events);
+    let recommended_action = recommended_session_action(snapshot);
+    let attention_hints = build_session_attention_hints(
+        latest_provider_failover.as_ref(),
+        recommended_action.as_ref(),
+        recovery,
+        terminal_outcome_state,
+    );
+
+    json!({
+        "latest_provider_failover": latest_provider_failover,
+        "recommended_action": recommended_action,
+        "attention_hints": attention_hints,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn latest_provider_failover_diagnostic(recent_events: &[SessionEventRecord]) -> Option<Value> {
+    let matching_event = recent_events
+        .iter()
+        .filter(|event| event.event_kind == "trust_provider_failover")
+        .max_by_key(|event| event.ts)?;
+    let payload_object = matching_event.payload_json.as_object()?;
+    let provider_failover = payload_object.get("provider_failover")?.as_object()?;
+
+    let provider_id = payload_object
+        .get("provider_id")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let binding = payload_object
+        .get("binding")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let reason = provider_failover
+        .get("reason")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let stage = provider_failover
+        .get("stage")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let model = provider_failover
+        .get("model")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let attempt = provider_failover
+        .get("attempt")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let max_attempts = provider_failover
+        .get("max_attempts")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let status_code = provider_failover
+        .get("status_code")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let request_id = provider_failover
+        .get("request_id")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let cf_ray = provider_failover
+        .get("cf_ray")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let auth_error = provider_failover
+        .get("auth_error")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let auth_error_code = provider_failover
+        .get("auth_error_code")
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    Some(json!({
+        "event_id": matching_event.id,
+        "event_kind": matching_event.event_kind,
+        "ts": matching_event.ts,
+        "provider_id": provider_id,
+        "binding": binding,
+        "reason": reason,
+        "stage": stage,
+        "model": model,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "status_code": status_code,
+        "request_id": request_id,
+        "cf_ray": cf_ray,
+        "auth_error": auth_error,
+        "auth_error_code": auth_error_code,
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn recommended_session_action(snapshot: &SessionInspectionSnapshot) -> Option<Value> {
+    let recover_action = recommended_recover_action(snapshot);
+    if recover_action.is_some() {
+        return recover_action;
+    }
+
+    recommended_resume_action(snapshot)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn recommended_recover_action(snapshot: &SessionInspectionSnapshot) -> Option<Value> {
+    let recover_plan = build_session_recover_plan(snapshot, current_unix_ts()).ok()?;
+    let mut recover_action = session_recovery_action_json(&recover_plan);
+    let action_object = recover_action.as_object_mut()?;
+    action_object.insert(
+        "source".to_owned(),
+        Value::String("session_recover_plan".to_owned()),
+    );
+    action_object.insert(
+        "tool_name".to_owned(),
+        Value::String("session_recover".to_owned()),
+    );
+    action_object.insert("requires_mutation".to_owned(), Value::Bool(true));
+    Some(recover_action)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn recommended_resume_action(snapshot: &SessionInspectionSnapshot) -> Option<Value> {
+    let task_progress = snapshot.workflow.task_progress.as_ref()?;
+    let resume_recipe = task_progress.resume_recipe.as_ref()?;
+    let tool_name = resume_recipe.recommended_tool.clone();
+    let session_id = resume_recipe.session_id.clone();
+    let note = resume_recipe.note.clone();
+    let requires_mutation = session_action_requires_mutation(tool_name.as_str());
+    let task_status = task_progress.status.as_str().to_owned();
+
+    Some(json!({
+        "source": "task_progress_resume_recipe",
+        "kind": "follow_resume_recipe",
+        "tool_name": tool_name,
+        "session_id": session_id,
+        "note": note,
+        "task_status": task_status,
+        "requires_mutation": requires_mutation,
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_action_requires_mutation(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "session_archive" | "session_cancel" | "session_continue" | "session_recover"
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_attention_hints(
+    latest_provider_failover: Option<&Value>,
+    recommended_action: Option<&Value>,
+    recovery: Option<&SessionRecoveryRecord>,
+    terminal_outcome_state: &str,
+) -> Vec<String> {
+    let mut hints = Vec::new();
+
+    if let Some(provider_failover) = latest_provider_failover {
+        let reason = provider_failover
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let model = provider_failover
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let stage = provider_failover
+            .get("stage")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let request_id = provider_failover
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let auth_error_code = provider_failover
+            .get("auth_error_code")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        hints.push(format!(
+            "provider_failover_present reason={reason} model={model} stage={stage} request_id={request_id} auth_error_code={auth_error_code}"
+        ));
+    }
+
+    if let Some(action) = recommended_action {
+        let tool_name = action
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let kind = action
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let source = action
+            .get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        hints.push(format!(
+            "recommended_action tool={tool_name} kind={kind} source={source}"
+        ));
+    }
+
+    if terminal_outcome_state == "missing" {
+        let recovery_kind = recovery
+            .map(|record| record.kind.as_str())
+            .unwrap_or("unknown");
+        let recovery_source = recovery
+            .map(|record| record.source.as_str())
+            .unwrap_or("none");
+        hints.push(format!(
+            "terminal_outcome_missing kind={recovery_kind} source={recovery_source}"
+        ));
+    }
+
+    hints
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -8272,6 +8499,219 @@ mod tests {
         assert_eq!(outcome.payload["recovery"]["source"], "none");
         assert!(outcome.payload["recovery"]["recovery_error"].is_null());
         assert!(outcome.payload["recovery"]["event_kind"].is_null());
+    }
+
+    #[test]
+    fn session_status_surfaces_latest_provider_failover_diagnostics() {
+        let config = isolated_memory_config("session-status-provider-failover");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: "trust_provider_failover".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "source": "provider_runtime",
+                "binding": "kernel",
+                "provider_id": "openai",
+                "provider_failover": {
+                    "reason": "rate_limited",
+                    "stage": "status_failure",
+                    "model": "gpt-4o",
+                    "attempt": 2,
+                    "max_attempts": 3,
+                    "status_code": 429,
+                    "request_id": "req-123"
+                }
+            }),
+        })
+        .expect("append provider failover event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "root-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["diagnostics"]["latest_provider_failover"]["provider_id"],
+            "openai"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["latest_provider_failover"]["reason"],
+            "rate_limited"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["latest_provider_failover"]["model"],
+            "gpt-4o"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["latest_provider_failover"]["status_code"],
+            429
+        );
+        let attention_hints = outcome.payload["diagnostics"]["attention_hints"]
+            .as_array()
+            .expect("attention_hints array");
+        assert!(
+            attention_hints.iter().any(|hint| {
+                hint.as_str().is_some_and(|hint| {
+                    hint.contains("provider_failover_present")
+                        && hint.contains("reason=rate_limited")
+                        && hint.contains("request_id=req-123")
+                })
+            }),
+            "expected provider failover attention hint, got: {attention_hints:?}"
+        );
+    }
+
+    #[test]
+    fn session_status_recommends_session_recover_for_overdue_async_child() {
+        let config = isolated_memory_config("session-status-recover-recommendation");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        overwrite_session_event_ts(
+            &config,
+            "child-session",
+            "delegate_queued",
+            super::current_unix_ts() - 90,
+        );
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["tool_name"],
+            "session_recover"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["kind"],
+            "queued_async_overdue_marked_failed"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["source"],
+            "session_recover_plan"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["requires_mutation"],
+            true
+        );
+    }
+
+    #[test]
+    fn session_status_recommends_resume_recipe_when_recover_plan_is_unavailable() {
+        let config = isolated_memory_config("session-status-resume-recipe-recommendation");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: crate::task_progress::TASK_PROGRESS_EVENT_KIND.to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: crate::task_progress::task_progress_event_payload(
+                "unit_test",
+                &crate::task_progress::TaskProgressRecord {
+                    task_id: "root-session".to_owned(),
+                    owner_kind: "conversation_turn".to_owned(),
+                    status: crate::task_progress::TaskProgressStatus::Waiting,
+                    intent_summary: Some("Wait for the durable task to settle".to_owned()),
+                    verification_state: Some(crate::task_progress::TaskVerificationState::Pending),
+                    active_handles: Vec::new(),
+                    resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
+                        recommended_tool: "session_wait".to_owned(),
+                        session_id: "root-session".to_owned(),
+                        note: Some("Wait for the terminal transition.".to_owned()),
+                    }),
+                    updated_at: 123,
+                },
+            ),
+        })
+        .expect("append task progress event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "root-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["tool_name"],
+            "session_wait"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["kind"],
+            "follow_resume_recipe"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["source"],
+            "task_progress_resume_recipe"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["task_status"],
+            "waiting"
+        );
+        assert_eq!(
+            outcome.payload["diagnostics"]["recommended_action"]["requires_mutation"],
+            false
+        );
     }
 
     #[test]

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -808,11 +808,14 @@ fn maybe_build_turn_checkpoint_heal_action(
     session_id: &str,
     detail: &Value,
 ) -> Option<SessionHealAction> {
-    let requires_recovery = detail
-        .pointer("/turn_checkpoint/summary/requires_recovery")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    if !requires_recovery {
+    let summary_value = detail.pointer("/turn_checkpoint/summary")?;
+    let summary = parse_turn_checkpoint_summary(summary_value)?;
+    let repair_plan = mvp::conversation::build_turn_checkpoint_repair_plan(&summary);
+    let action = repair_plan.action();
+    if matches!(
+        action,
+        mvp::conversation::TurnCheckpointRecoveryAction::None
+    ) {
         return None;
     }
 
@@ -820,22 +823,73 @@ fn maybe_build_turn_checkpoint_heal_action(
     let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
     let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
     let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
-    let command = format!(
-        "{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg} --apply"
-    );
-    let description = "Run production turn-checkpoint repair for the selected session.".to_owned();
+    let manual_reason = repair_plan
+        .manual_reason()
+        .map(|reason| reason.as_str().to_owned());
 
-    Some(SessionHealAction {
-        id: "checkpoint:repair".to_owned(),
-        kind: "turn_checkpoint_repair".to_owned(),
-        source: "turn_checkpoint_summary".to_owned(),
-        tool_name: "turn_checkpoint_repair".to_owned(),
-        description,
-        command,
-        can_apply: true,
-        requires_mutation: true,
-        apply_strategy: SessionHealApplyStrategy::TurnCheckpointRepair,
-    })
+    match action {
+        mvp::conversation::TurnCheckpointRecoveryAction::RunAfterTurn
+        | mvp::conversation::TurnCheckpointRecoveryAction::RunCompaction
+        | mvp::conversation::TurnCheckpointRecoveryAction::RunAfterTurnAndCompaction => {
+            let command = format!(
+                "{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg} --apply"
+            );
+            let action_kind = action.as_str().to_owned();
+            let action_description = format!(
+                "Run production turn-checkpoint repair for `{}`.",
+                action.as_str()
+            );
+
+            Some(SessionHealAction {
+                id: "checkpoint:repair".to_owned(),
+                kind: action_kind,
+                source: "turn_checkpoint_summary".to_owned(),
+                tool_name: "turn_checkpoint_repair".to_owned(),
+                description: action_description,
+                command,
+                can_apply: true,
+                requires_mutation: true,
+                apply_strategy: SessionHealApplyStrategy::TurnCheckpointRepair,
+            })
+        }
+        mvp::conversation::TurnCheckpointRecoveryAction::InspectManually => {
+            let command = format!(
+                "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
+            );
+            let reason_text = manual_reason
+                .unwrap_or_else(|| "checkpoint_state_requires_manual_inspection".to_owned());
+            let description =
+                format!("Inspect turn-checkpoint recovery manually because `{reason_text}`.");
+
+            Some(SessionHealAction {
+                id: "checkpoint:manual".to_owned(),
+                kind: "turn_checkpoint_manual_review".to_owned(),
+                source: "turn_checkpoint_summary".to_owned(),
+                tool_name: "session_status".to_owned(),
+                description,
+                command,
+                can_apply: false,
+                requires_mutation: false,
+                apply_strategy: SessionHealApplyStrategy::ObserveOnly,
+            })
+        }
+        mvp::conversation::TurnCheckpointRecoveryAction::None => None,
+    }
+}
+
+fn parse_turn_checkpoint_summary(
+    summary_value: &Value,
+) -> Option<mvp::conversation::TurnCheckpointEventSummary> {
+    let default_summary = mvp::conversation::TurnCheckpointEventSummary::default();
+    let mut merged_summary_value = serde_json::to_value(default_summary).ok()?;
+    let merged_summary_object = merged_summary_value.as_object_mut()?;
+    let summary_object = summary_value.as_object()?;
+
+    for (key, value) in summary_object {
+        merged_summary_object.insert(key.clone(), value.clone());
+    }
+
+    serde_json::from_value(merged_summary_value).ok()
 }
 
 fn build_session_heal_action_command(
@@ -2045,7 +2099,7 @@ mod tests {
     }
 
     #[test]
-    fn build_session_heal_plan_adds_turn_checkpoint_repair_action_when_needed() {
+    fn build_session_heal_plan_marks_manual_checkpoint_recovery_as_observe_only() {
         let detail = json!({
             "diagnostics": {
                 "attention_hints": ["checkpoint attention"]
@@ -2061,12 +2115,44 @@ mod tests {
             .expect("build heal plan");
 
         assert_eq!(plan.actions.len(), 1);
-        assert_eq!(plan.actions[0].tool_name, "turn_checkpoint_repair");
-        assert!(plan.actions[0].can_apply);
+        assert_eq!(plan.actions[0].tool_name, "session_status");
+        assert!(!plan.actions[0].can_apply);
+        assert_eq!(plan.actions[0].kind, "turn_checkpoint_manual_review");
         assert_eq!(
             plan.attention_hints,
             vec!["checkpoint attention".to_owned()]
         );
+    }
+
+    #[test]
+    fn build_session_heal_plan_adds_turn_checkpoint_repair_action_when_runtime_repair_is_possible()
+    {
+        let detail = json!({
+            "diagnostics": {
+                "attention_hints": ["checkpoint attention"]
+            },
+            "turn_checkpoint": {
+                "summary": {
+                    "requires_recovery": true,
+                    "latest_identity_present": true,
+                    "latest_runs_after_turn": true,
+                    "latest_attempts_context_compaction": true,
+                    "latest_after_turn": "completed",
+                    "latest_compaction": "failed",
+                    "session_state": "finalization_failed",
+                    "checkpoint_durable": true,
+                    "reply_durable": true
+                }
+            }
+        });
+
+        let plan = build_session_heal_plan("/tmp/loong.toml", "ops-root", "session-1", &detail)
+            .expect("build heal plan");
+
+        assert_eq!(plan.actions.len(), 1);
+        assert_eq!(plan.actions[0].tool_name, "turn_checkpoint_repair");
+        assert!(plan.actions[0].can_apply);
+        assert_eq!(plan.actions[0].kind, "run_compaction");
     }
 
     #[test]

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -942,7 +942,11 @@ fn build_session_heal_action_command(
                 "task_status" => "status",
                 "task_wait" => "wait",
                 "task_events" | "task_history" => "events",
-                _ => unreachable!(),
+                other => {
+                    return Err(format!(
+                        "sessions heal does not support task command rendering for `{other}`"
+                    ));
+                }
             };
             Ok(format!(
                 "{command_name} tasks {task_command} --config {config_arg} --session {session_arg} {task_arg}"
@@ -2221,7 +2225,7 @@ mod tests {
         assert_eq!(plan.actions[0].tool_name, "task_status");
         assert_eq!(
             plan.actions[0].command,
-            "loong tasks status --config /tmp/loong.toml --session ops-root task-123"
+            "loong tasks status --config '/tmp/loong.toml' --session 'ops-root' 'task-123'"
         );
         assert!(!plan.actions[0].can_apply);
     }

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -66,6 +66,12 @@ pub enum SessionsCommands {
         #[arg(long, default_value_t = false)]
         dry_run: bool,
     },
+    /// Plan or apply bounded self-heal actions for one visible session
+    Heal {
+        session_id: String,
+        #[arg(long, default_value_t = false)]
+        apply: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +87,32 @@ pub struct SessionsCommandExecution {
     pub resolved_config_path: String,
     pub current_session_id: String,
     pub payload: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionHealApplyStrategy {
+    SessionRecover,
+    TurnCheckpointRepair,
+    ObserveOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionHealAction {
+    id: String,
+    kind: String,
+    source: String,
+    tool_name: String,
+    description: String,
+    command: String,
+    can_apply: bool,
+    requires_mutation: bool,
+    apply_strategy: SessionHealApplyStrategy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionHealPlan {
+    actions: Vec<SessionHealAction>,
+    attention_hints: Vec<String>,
 }
 
 pub async fn run_sessions_cli(options: SessionsCommandOptions) -> CliResult<()> {
@@ -227,6 +259,18 @@ pub async fn execute_sessions_command(
             &session_id,
             dry_run,
         )?,
+        SessionsCommands::Heal { session_id, apply } => {
+            execute_heal_command(
+                &resolved_config_path,
+                &config,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+                apply,
+            )
+            .await?
+        }
     };
 
     Ok(SessionsCommandExecution {
@@ -477,6 +521,499 @@ fn execute_history_command(
     }))
 }
 
+async fn execute_heal_command(
+    resolved_config_path: &str,
+    config: &mvp::config::LoongConfig,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    apply: bool,
+) -> CliResult<Value> {
+    let detail_before = load_session_status_payload_with_runtime_summaries(
+        memory_config,
+        tool_config,
+        current_session_id,
+        session_id,
+    )
+    .await?;
+    let plan = build_session_heal_plan(
+        resolved_config_path,
+        current_session_id,
+        session_id,
+        &detail_before,
+    )?;
+    let applied_actions = if apply {
+        execute_session_heal_plan(
+            resolved_config_path,
+            config,
+            current_session_id,
+            memory_config,
+            tool_config,
+            session_id,
+            &plan,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
+    let detail_after = if apply {
+        load_session_status_payload_with_runtime_summaries(
+            memory_config,
+            tool_config,
+            current_session_id,
+            session_id,
+        )
+        .await?
+    } else {
+        detail_before.clone()
+    };
+    let recipes =
+        build_session_heal_recipes(resolved_config_path, current_session_id, session_id, &plan);
+    let next_steps = build_session_heal_next_steps(
+        resolved_config_path,
+        current_session_id,
+        session_id,
+        &plan,
+        apply,
+        applied_actions.as_slice(),
+    );
+    let plan_payload = session_heal_plan_json(&plan);
+
+    Ok(json!({
+        "command": "heal",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "apply": apply,
+        "detail": detail_after,
+        "plan": plan_payload,
+        "applied_actions": applied_actions,
+        "recipes": recipes,
+        "next_steps": next_steps,
+    }))
+}
+
+async fn execute_session_heal_plan(
+    resolved_config_path: &str,
+    config: &mvp::config::LoongConfig,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    plan: &SessionHealPlan,
+) -> CliResult<Vec<Value>> {
+    let mut applied_actions = Vec::new();
+
+    for action in &plan.actions {
+        if !action.can_apply {
+            continue;
+        }
+
+        let applied_action = match action.apply_strategy {
+            SessionHealApplyStrategy::SessionRecover => {
+                let payload = execute_mutation_command(
+                    "recover",
+                    "session_recover",
+                    "recovery_action",
+                    resolved_config_path,
+                    current_session_id,
+                    memory_config,
+                    tool_config,
+                    session_id,
+                    false,
+                )?;
+                json!({
+                    "id": action.id,
+                    "kind": action.kind,
+                    "tool_name": action.tool_name,
+                    "status": "applied",
+                    "result": payload,
+                })
+            }
+            SessionHealApplyStrategy::TurnCheckpointRepair => {
+                let payload = execute_turn_checkpoint_heal_action(config, session_id).await?;
+                let status = payload
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                json!({
+                    "id": action.id,
+                    "kind": action.kind,
+                    "tool_name": action.tool_name,
+                    "status": status,
+                    "result": payload,
+                })
+            }
+            SessionHealApplyStrategy::ObserveOnly => {
+                continue;
+            }
+        };
+
+        applied_actions.push(applied_action);
+    }
+
+    Ok(applied_actions)
+}
+
+async fn execute_turn_checkpoint_heal_action(
+    config: &mvp::config::LoongConfig,
+    session_id: &str,
+) -> CliResult<Value> {
+    let runtime_kernel = bootstrap_sessions_runtime_kernel(config)?;
+    let binding = runtime_kernel.conversation_binding();
+    let coordinator = mvp::conversation::ConversationTurnCoordinator::new();
+    let outcome = coordinator
+        .repair_production_turn_checkpoint_tail(config, session_id, binding)
+        .await?;
+    let source = outcome.source().map(|value| value.as_str()).unwrap_or("-");
+    let after_turn_status = outcome.after_turn_status().unwrap_or("-");
+    let compaction_status = outcome.compaction_status().unwrap_or("-");
+
+    Ok(json!({
+        "status": outcome.status().as_str(),
+        "action": outcome.action().as_str(),
+        "source": source,
+        "reason": outcome.reason().as_str(),
+        "session_state": outcome.session_state().as_str(),
+        "checkpoint_events": outcome.checkpoint_events(),
+        "after_turn_status": after_turn_status,
+        "compaction_status": compaction_status,
+    }))
+}
+
+fn bootstrap_sessions_runtime_kernel(
+    config: &mvp::config::LoongConfig,
+) -> CliResult<mvp::runtime_bridge::RuntimeKernelOwner> {
+    let agent_id = "cli-sessions-heal";
+    let runtime_kernel = mvp::runtime_bridge::RuntimeKernelOwner::bootstrap(agent_id, config)?;
+    Ok(runtime_kernel)
+}
+
+fn build_session_heal_plan(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    detail: &Value,
+) -> CliResult<SessionHealPlan> {
+    let diagnostics = detail.get("diagnostics").cloned().unwrap_or(Value::Null);
+    let attention_hints = diagnostics
+        .get("attention_hints")
+        .and_then(Value::as_array)
+        .map(|hints| {
+            hints
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut actions = Vec::new();
+
+    if let Some(recommended_action) = diagnostics.get("recommended_action") {
+        let mapped_action = map_recommended_action_to_session_heal_action(
+            resolved_config_path,
+            current_session_id,
+            session_id,
+            recommended_action,
+        )?;
+        if let Some(mapped_action) = mapped_action {
+            actions.push(mapped_action);
+        }
+    }
+
+    let checkpoint_action = maybe_build_turn_checkpoint_heal_action(
+        resolved_config_path,
+        current_session_id,
+        session_id,
+        detail,
+    );
+    if let Some(checkpoint_action) = checkpoint_action {
+        actions.push(checkpoint_action);
+    }
+
+    Ok(SessionHealPlan {
+        actions,
+        attention_hints,
+    })
+}
+
+fn map_recommended_action_to_session_heal_action(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    action: &Value,
+) -> CliResult<Option<SessionHealAction>> {
+    let tool_name = action
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_owned();
+    if tool_name.is_empty() {
+        return Ok(None);
+    }
+
+    let kind = action
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    let source = action
+        .get("source")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    let note = action
+        .get("note")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let requires_mutation = action
+        .get("requires_mutation")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let command = build_session_heal_action_command(
+        resolved_config_path,
+        current_session_id,
+        session_id,
+        &tool_name,
+    );
+    let description = build_session_heal_action_description(
+        &tool_name,
+        &kind,
+        note.as_deref(),
+        requires_mutation,
+    );
+    let apply_strategy = session_heal_apply_strategy(tool_name.as_str(), source.as_str());
+    let can_apply = !matches!(apply_strategy, SessionHealApplyStrategy::ObserveOnly);
+    let action_id = format!("recommended:{tool_name}");
+
+    Ok(Some(SessionHealAction {
+        id: action_id,
+        kind,
+        source,
+        tool_name,
+        description,
+        command,
+        can_apply,
+        requires_mutation,
+        apply_strategy,
+    }))
+}
+
+fn maybe_build_turn_checkpoint_heal_action(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    detail: &Value,
+) -> Option<SessionHealAction> {
+    let requires_recovery = detail
+        .pointer("/turn_checkpoint/summary/requires_recovery")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !requires_recovery {
+        return None;
+    }
+
+    let command_name = crate::active_cli_command_name();
+    let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+    let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+    let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+    let command = format!(
+        "{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg} --apply"
+    );
+    let description = "Run production turn-checkpoint repair for the selected session.".to_owned();
+
+    Some(SessionHealAction {
+        id: "checkpoint:repair".to_owned(),
+        kind: "turn_checkpoint_repair".to_owned(),
+        source: "turn_checkpoint_summary".to_owned(),
+        tool_name: "turn_checkpoint_repair".to_owned(),
+        description,
+        command,
+        can_apply: true,
+        requires_mutation: true,
+        apply_strategy: SessionHealApplyStrategy::TurnCheckpointRepair,
+    })
+}
+
+fn build_session_heal_action_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    tool_name: &str,
+) -> String {
+    let command_name = crate::active_cli_command_name();
+    let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+    let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+    let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+
+    match tool_name {
+        "session_recover" => format!(
+            "{command_name} sessions recover --config {config_arg} --session {session_arg} {target_arg}"
+        ),
+        "session_wait" => format!(
+            "{command_name} sessions wait --config {config_arg} --session {session_arg} {target_arg}"
+        ),
+        "session_status" => format!(
+            "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
+        ),
+        _ => format!(
+            "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
+        ),
+    }
+}
+
+fn build_session_heal_action_description(
+    tool_name: &str,
+    kind: &str,
+    note: Option<&str>,
+    requires_mutation: bool,
+) -> String {
+    if let Some(note) = note {
+        let trimmed_note = note.trim();
+        if !trimmed_note.is_empty() {
+            return trimmed_note.to_owned();
+        }
+    }
+
+    match (tool_name, requires_mutation) {
+        ("session_recover", true) => {
+            "Apply the existing overdue async delegate recovery path.".to_owned()
+        }
+        ("session_wait", false) => {
+            "Wait for the current session to reach a newer durable state.".to_owned()
+        }
+        ("session_status", false) => {
+            "Re-read the current session status before choosing a mutation.".to_owned()
+        }
+        _ => {
+            format!("Follow the recommended `{tool_name}` action for `{kind}`.")
+        }
+    }
+}
+
+fn session_heal_apply_strategy(tool_name: &str, source: &str) -> SessionHealApplyStrategy {
+    if tool_name == "session_recover" && source == "session_recover_plan" {
+        return SessionHealApplyStrategy::SessionRecover;
+    }
+
+    SessionHealApplyStrategy::ObserveOnly
+}
+
+fn session_heal_plan_json(plan: &SessionHealPlan) -> Value {
+    let applyable_count = plan
+        .actions
+        .iter()
+        .filter(|action| action.can_apply)
+        .count();
+    let action_count = plan.actions.len();
+    let attention_count = plan.attention_hints.len();
+    let actions = plan
+        .actions
+        .iter()
+        .map(session_heal_action_json)
+        .collect::<Vec<_>>();
+
+    json!({
+        "action_count": action_count,
+        "applyable_count": applyable_count,
+        "attention_count": attention_count,
+        "attention_hints": plan.attention_hints,
+        "actions": actions,
+    })
+}
+
+fn session_heal_action_json(action: &SessionHealAction) -> Value {
+    json!({
+        "id": action.id,
+        "kind": action.kind,
+        "source": action.source,
+        "tool_name": action.tool_name,
+        "description": action.description,
+        "command": action.command,
+        "can_apply": action.can_apply,
+        "requires_mutation": action.requires_mutation,
+    })
+}
+
+fn build_session_heal_recipes(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    plan: &SessionHealPlan,
+) -> Vec<String> {
+    let command_name = crate::active_cli_command_name();
+    let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+    let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+    let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+    let plan_recipe = format!(
+        "{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg}"
+    );
+    let apply_recipe = format!(
+        "{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg} --apply"
+    );
+    let mut recipes = vec![plan_recipe, apply_recipe];
+
+    for action in &plan.actions {
+        recipes.push(action.command.clone());
+    }
+
+    recipes
+}
+
+fn build_session_heal_next_steps(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+    plan: &SessionHealPlan,
+    apply: bool,
+    applied_actions: &[Value],
+) -> Vec<String> {
+    let mut next_steps = Vec::new();
+    let applyable_action_exists = plan.actions.iter().any(|action| action.can_apply);
+
+    if !apply && applyable_action_exists {
+        let command_name = crate::active_cli_command_name();
+        let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+        let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+        let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+        next_steps.push(format!(
+            "Run `{command_name} sessions heal --config {config_arg} --session {session_arg} {target_arg} --apply` to execute the bounded self-heal actions."
+        ));
+    }
+
+    if !apply && !applyable_action_exists && !plan.actions.is_empty() {
+        let first_action = plan.actions.first();
+        if let Some(first_action) = first_action {
+            next_steps.push(format!(
+                "Follow the recommended command for the first action: `{}`.",
+                first_action.command
+            ));
+        }
+    }
+
+    if plan.actions.is_empty() {
+        next_steps.push(
+            "No bounded self-heal action is currently available; inspect `sessions status`, `sessions events`, and `sessions wait` for more evidence."
+                .to_owned(),
+        );
+    }
+
+    if apply && !applied_actions.is_empty() {
+        let command_name = crate::active_cli_command_name();
+        let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+        let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+        let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+        next_steps.push(format!(
+            "Re-run `{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}` to confirm the refreshed durable state."
+        ));
+    }
+
+    next_steps
+}
+
 fn execute_mutation_command(
     command_name: &str,
     tool_name: &str,
@@ -637,6 +1174,7 @@ pub fn render_sessions_cli_text(execution: &SessionsCommandExecution) -> CliResu
     let rendered = match command {
         "list" => render_sessions_list_text(&execution.payload)?,
         "status" => render_sessions_status_text(&execution.payload)?,
+        "heal" => render_sessions_heal_text(&execution.payload)?,
         "events" => render_sessions_events_text(&execution.payload)?,
         "wait" => render_sessions_wait_text(&execution.payload)?,
         "history" => render_sessions_history_text(&execution.payload)?,
@@ -762,6 +1300,151 @@ fn render_sessions_status_text(payload: &Value) -> CliResult<String> {
         sections,
         footer_lines,
     ))
+}
+
+fn render_sessions_heal_text(payload: &Value) -> CliResult<String> {
+    let detail = payload
+        .get("detail")
+        .ok_or_else(|| "sessions heal payload missing detail".to_owned())?;
+    let plan = payload
+        .get("plan")
+        .ok_or_else(|| "sessions heal payload missing plan".to_owned())?;
+    let recipes = payload
+        .get("recipes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions heal payload missing recipes".to_owned())?;
+    let next_steps = payload
+        .get("next_steps")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions heal payload missing next_steps".to_owned())?;
+    let applied_actions = payload
+        .get("applied_actions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions heal payload missing applied_actions".to_owned())?;
+
+    let detail_lines = render_session_inspection_lines(detail)?;
+    let plan_lines = render_session_heal_plan_lines(plan)?;
+    let mut sections = vec![
+        ("self-heal plan", plan_lines),
+        ("session detail", detail_lines),
+    ];
+
+    if !applied_actions.is_empty() {
+        let applied_lines = render_session_heal_applied_lines(applied_actions);
+        sections.insert(1, ("applied actions", applied_lines));
+    }
+
+    let mut recipes_lines = Vec::new();
+    for recipe in recipes {
+        let raw_recipe = recipe.as_str().unwrap_or("");
+        let sanitized_recipe = sanitize_terminal_text(raw_recipe);
+        recipes_lines.push(format!("- {sanitized_recipe}"));
+    }
+    if !recipes_lines.is_empty() {
+        sections.push(("recipes", recipes_lines));
+    }
+
+    let mut next_lines = Vec::new();
+    for step in next_steps {
+        let raw_step = step.as_str().unwrap_or("");
+        let sanitized_step = sanitize_terminal_text(raw_step);
+        next_lines.push(format!("- {sanitized_step}"));
+    }
+    if !next_lines.is_empty() {
+        sections.insert(0, ("next steps", next_lines));
+    }
+
+    Ok(render_sessions_surface(
+        "session self-heal",
+        "session shell",
+        Vec::new(),
+        sections,
+        vec!["Use `sessions heal --apply` only when the surfaced actions match the desired bounded recovery path.".to_owned()],
+    ))
+}
+
+fn render_session_heal_plan_lines(plan: &Value) -> CliResult<Vec<String>> {
+    let action_count = plan
+        .get("action_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let applyable_count = plan
+        .get("applyable_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let attention_count = plan
+        .get("attention_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let actions = plan
+        .get("actions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions heal plan missing actions".to_owned())?;
+    let attention_hints = plan
+        .get("attention_hints")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions heal plan missing attention_hints".to_owned())?;
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "actions={action_count} applyable={applyable_count} attention_hints={attention_count}"
+    ));
+
+    for action in actions {
+        let rendered_action = render_session_heal_action_line(action);
+        lines.push(format!("- {rendered_action}"));
+    }
+
+    for hint in attention_hints {
+        let rendered_hint = hint.as_str().unwrap_or("-");
+        let sanitized_hint = sanitize_terminal_text(rendered_hint);
+        lines.push(format!("- hint {sanitized_hint}"));
+    }
+
+    if actions.is_empty() && attention_hints.is_empty() {
+        lines.push("No bounded self-heal action is currently available.".to_owned());
+    }
+
+    Ok(lines)
+}
+
+fn render_session_heal_action_line(action: &Value) -> String {
+    let id = action.get("id").and_then(Value::as_str).unwrap_or("-");
+    let tool_name = action
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let kind = action.get("kind").and_then(Value::as_str).unwrap_or("-");
+    let source = action.get("source").and_then(Value::as_str).unwrap_or("-");
+    let can_apply = action
+        .get("can_apply")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let apply_flag = if can_apply { "yes" } else { "no" };
+
+    format!("{id} tool={tool_name} kind={kind} source={source} apply={apply_flag}")
+}
+
+fn render_session_heal_applied_lines(applied_actions: &[Value]) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    for applied_action in applied_actions {
+        let id = applied_action
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let tool_name = applied_action
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let status = applied_action
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        lines.push(format!("- {id} tool={tool_name} status={status}"));
+    }
+
+    lines
 }
 
 fn render_sessions_events_text(payload: &Value) -> CliResult<String> {
@@ -1308,7 +1991,9 @@ fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value
 mod tests {
     use serde_json::json;
 
-    use super::render_session_inspection_lines;
+    use super::{
+        build_session_heal_plan, render_session_heal_plan_lines, render_session_inspection_lines,
+    };
 
     #[test]
     fn render_session_inspection_lines_includes_diagnostics_summaries() {
@@ -1356,6 +2041,73 @@ mod tests {
                 line == "recommended_action: tool=session_wait kind=follow_resume_recipe source=task_progress_resume_recipe"
             }),
             "expected recommended_action summary, got: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn build_session_heal_plan_adds_turn_checkpoint_repair_action_when_needed() {
+        let detail = json!({
+            "diagnostics": {
+                "attention_hints": ["checkpoint attention"]
+            },
+            "turn_checkpoint": {
+                "summary": {
+                    "requires_recovery": true
+                }
+            }
+        });
+
+        let plan = build_session_heal_plan("/tmp/loong.toml", "ops-root", "session-1", &detail)
+            .expect("build heal plan");
+
+        assert_eq!(plan.actions.len(), 1);
+        assert_eq!(plan.actions[0].tool_name, "turn_checkpoint_repair");
+        assert!(plan.actions[0].can_apply);
+        assert_eq!(
+            plan.attention_hints,
+            vec!["checkpoint attention".to_owned()]
+        );
+    }
+
+    #[test]
+    fn render_session_heal_plan_lines_surface_actions_and_hints() {
+        let plan = json!({
+            "action_count": 1,
+            "applyable_count": 1,
+            "attention_count": 1,
+            "actions": [{
+                "id": "recommended:session_recover",
+                "tool_name": "session_recover",
+                "kind": "queued_async_overdue_marked_failed",
+                "source": "session_recover_plan",
+                "can_apply": true
+            }],
+            "attention_hints": ["provider_failover_present reason=rate_limited"]
+        });
+
+        let lines = render_session_heal_plan_lines(&plan).expect("render heal plan lines");
+
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("actions=1")
+                    && line.contains("applyable=1")
+                    && line.contains("attention_hints=1")
+            }),
+            "expected heal plan summary, got: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("recommended:session_recover")
+                    && line.contains("tool=session_recover")
+                    && line.contains("apply=yes")
+            }),
+            "expected action line, got: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| { line.contains("hint provider_failover_present") }),
+            "expected attention hint line, got: {lines:#?}"
         );
     }
 }

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -1122,6 +1122,16 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
         detail.get("turn_checkpoint"),
     );
     let turn_checkpoint_summary = sanitize_terminal_text(turn_checkpoint_summary.as_str());
+    let diagnostics = detail.get("diagnostics").cloned().unwrap_or(Value::Null);
+    let diagnostics_latest_provider_failover = render_session_latest_provider_failover_summary(
+        diagnostics.get("latest_provider_failover"),
+    );
+    let diagnostics_latest_provider_failover =
+        sanitize_terminal_text(diagnostics_latest_provider_failover.as_str());
+    let diagnostics_recommended_action =
+        render_session_recommended_action_summary(diagnostics.get("recommended_action"));
+    let diagnostics_recommended_action =
+        sanitize_terminal_text(diagnostics_recommended_action.as_str());
     let delegate_mode = detail
         .get("delegate_lifecycle")
         .and_then(|value| value.get("mode"))
@@ -1208,6 +1218,12 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("prompt_frame: {prompt_frame_summary}"));
     lines.push(format!("safe_lane: {safe_lane_summary}"));
     lines.push(format!("turn_checkpoint: {turn_checkpoint_summary}"));
+    lines.push(format!(
+        "latest_provider_failover: {diagnostics_latest_provider_failover}"
+    ));
+    lines.push(format!(
+        "recommended_action: {diagnostics_recommended_action}"
+    ));
     lines.push(format!("turn_count: {turn_count}"));
     lines.push(format!("last_turn_at: {last_turn_at}"));
     lines.push(format!("last_error: {sanitized_last_error}"));
@@ -1219,6 +1235,46 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
     lines.push(format!("recovery_kind: {recovery_kind}"));
     lines.push(format!("recent_events: {recent_events}"));
     Ok(lines)
+}
+
+fn render_session_latest_provider_failover_summary(diagnostic: Option<&Value>) -> String {
+    let Some(diagnostic) = diagnostic else {
+        return "-".to_owned();
+    };
+
+    let reason = diagnostic
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let model = diagnostic
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let stage = diagnostic
+        .get("stage")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let request_id = diagnostic
+        .get("request_id")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+
+    format!("reason={reason} model={model} stage={stage} request_id={request_id}")
+}
+
+fn render_session_recommended_action_summary(action: Option<&Value>) -> String {
+    let Some(action) = action else {
+        return "-".to_owned();
+    };
+
+    let tool_name = action
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let kind = action.get("kind").and_then(Value::as_str).unwrap_or("-");
+    let source = action.get("source").and_then(Value::as_str).unwrap_or("-");
+
+    format!("tool={tool_name} kind={kind} source={source}")
 }
 
 fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value>) -> String {
@@ -1246,4 +1302,60 @@ fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value
         "present resolved_identity={} session_profile_projection={}",
         resolved_identity_present, session_profile_projection_present
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::render_session_inspection_lines;
+
+    #[test]
+    fn render_session_inspection_lines_includes_diagnostics_summaries() {
+        let detail = json!({
+            "session": {
+                "session_id": "session-1",
+                "kind": "root",
+                "state": "running",
+                "parent_session_id": null,
+                "label": "Root",
+                "turn_count": 3,
+                "last_turn_at": 123,
+                "last_error": "rate_limited"
+            },
+            "workflow": {},
+            "terminal_outcome_state": "not_terminal",
+            "terminal_outcome": null,
+            "recovery": null,
+            "recent_events": [],
+            "diagnostics": {
+                "latest_provider_failover": {
+                    "reason": "rate_limited",
+                    "model": "gpt-4o",
+                    "stage": "status_failure",
+                    "request_id": "req-123"
+                },
+                "recommended_action": {
+                    "tool_name": "session_wait",
+                    "kind": "follow_resume_recipe",
+                    "source": "task_progress_resume_recipe"
+                }
+            }
+        });
+
+        let lines = render_session_inspection_lines(&detail).expect("render lines");
+
+        assert!(
+            lines.iter().any(|line| {
+                line == "latest_provider_failover: reason=rate_limited model=gpt-4o stage=status_failure request_id=req-123"
+            }),
+            "expected latest_provider_failover summary, got: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| {
+                line == "recommended_action: tool=session_wait kind=follow_resume_recipe source=task_progress_resume_recipe"
+            }),
+            "expected recommended_action summary, got: {lines:#?}"
+        );
+    }
 }

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -717,6 +717,7 @@ fn build_session_heal_plan(
             current_session_id,
             session_id,
             recommended_action,
+            detail,
         )?;
         if let Some(mapped_action) = mapped_action {
             actions.push(mapped_action);
@@ -744,6 +745,7 @@ fn map_recommended_action_to_session_heal_action(
     current_session_id: &str,
     session_id: &str,
     action: &Value,
+    detail: &Value,
 ) -> CliResult<Option<SessionHealAction>> {
     let tool_name = action
         .get("tool_name")
@@ -773,12 +775,29 @@ fn map_recommended_action_to_session_heal_action(
         .get("requires_mutation")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let target_session_id = action
+        .get("session_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(session_id);
+    let target_task_id = action
+        .get("task_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            detail
+                .get("task_progress")
+                .and_then(|task_progress| task_progress.get("task_id"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        });
     let command = build_session_heal_action_command(
         resolved_config_path,
         current_session_id,
-        session_id,
+        target_session_id,
+        target_task_id,
         &tool_name,
-    );
+    )?;
     let description = build_session_heal_action_description(
         &tool_name,
         &kind,
@@ -896,26 +915,42 @@ fn build_session_heal_action_command(
     resolved_config_path: &str,
     current_session_id: &str,
     session_id: &str,
+    task_id: Option<&str>,
     tool_name: &str,
-) -> String {
+) -> CliResult<String> {
     let command_name = crate::active_cli_command_name();
     let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
     let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
     let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
 
     match tool_name {
-        "session_recover" => format!(
+        "session_recover" => Ok(format!(
             "{command_name} sessions recover --config {config_arg} --session {session_arg} {target_arg}"
-        ),
-        "session_wait" => format!(
+        )),
+        "session_wait" => Ok(format!(
             "{command_name} sessions wait --config {config_arg} --session {session_arg} {target_arg}"
-        ),
-        "session_status" => format!(
+        )),
+        "session_status" => Ok(format!(
             "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
-        ),
-        _ => format!(
+        )),
+        "task_status" | "task_wait" | "task_events" | "task_history" => {
+            let task_id = task_id.ok_or_else(|| {
+                format!("sessions heal missing task_id for recommended tool `{tool_name}`")
+            })?;
+            let task_arg = crate::cli_handoff::shell_quote_argument(task_id);
+            let task_command = match tool_name {
+                "task_status" => "status",
+                "task_wait" => "wait",
+                "task_events" | "task_history" => "events",
+                _ => unreachable!(),
+            };
+            Ok(format!(
+                "{command_name} tasks {task_command} --config {config_arg} --session {session_arg} {task_arg}"
+            ))
+        }
+        _ => Ok(format!(
             "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
-        ),
+        )),
     }
 }
 
@@ -941,6 +976,12 @@ fn build_session_heal_action_description(
         }
         ("session_status", false) => {
             "Re-read the current session status before choosing a mutation.".to_owned()
+        }
+        ("task_status", false) => {
+            "Inspect durable task progress before choosing a session mutation.".to_owned()
+        }
+        ("task_wait", false) => {
+            "Wait for the current background task to reach a newer durable state.".to_owned()
         }
         _ => {
             format!("Follow the recommended `{tool_name}` action for `{kind}`.")
@@ -2153,6 +2194,36 @@ mod tests {
         assert_eq!(plan.actions[0].tool_name, "turn_checkpoint_repair");
         assert!(plan.actions[0].can_apply);
         assert_eq!(plan.actions[0].kind, "run_compaction");
+    }
+
+    #[test]
+    fn build_session_heal_plan_preserves_task_surface_commands_for_resume_recipes() {
+        let detail = json!({
+            "task_progress": {
+                "task_id": "task-123"
+            },
+            "diagnostics": {
+                "recommended_action": {
+                    "tool_name": "task_status",
+                    "kind": "follow_resume_recipe",
+                    "source": "task_progress_resume_recipe",
+                    "session_id": "task-owner",
+                    "requires_mutation": false
+                },
+                "attention_hints": []
+            }
+        });
+
+        let plan = build_session_heal_plan("/tmp/loong.toml", "ops-root", "session-1", &detail)
+            .expect("build heal plan");
+
+        assert_eq!(plan.actions.len(), 1);
+        assert_eq!(plan.actions[0].tool_name, "task_status");
+        assert_eq!(
+            plan.actions[0].command,
+            "loong tasks status --config /tmp/loong.toml --session ops-root task-123"
+        );
+        assert!(!plan.actions[0].can_apply);
     }
 
     #[test]

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -42,6 +42,33 @@ fn append_session_conversation_event(
     append_session_turn(root, session_id, "assistant", &serialized_payload);
 }
 
+fn overwrite_session_event_ts(
+    root: &super::tasks_cli::TempDirGuard,
+    session_id: &str,
+    event_kind: &str,
+    ts: i64,
+) {
+    let sqlite_path = root.path().join("memory.sqlite3");
+    let connection = rusqlite::Connection::open(sqlite_path).expect("open sqlite db");
+    let updated = connection
+        .execute(
+            "UPDATE session_events
+             SET ts = ?3
+             WHERE session_id = ?1 AND event_kind = ?2",
+            rusqlite::params![session_id, event_kind, ts],
+        )
+        .expect("update session event timestamp");
+    assert!(updated > 0, "expected at least one updated event row");
+}
+
+fn current_unix_ts() -> i64 {
+    let now = std::time::SystemTime::now();
+    let duration = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("current unix timestamp");
+    duration.as_secs() as i64
+}
+
 #[test]
 fn sessions_list_cli_parses_global_flags_after_subcommand() {
     let cli = try_parse_cli([
@@ -114,6 +141,10 @@ fn cli_sessions_help_mentions_operator_facing_session_shell() {
     assert!(
         help.contains("recover"),
         "sessions help should surface recovery actions: {help}"
+    );
+    assert!(
+        help.contains("heal"),
+        "sessions help should surface self-heal actions: {help}"
     );
 }
 
@@ -535,6 +566,141 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
     assert!(
         rendered.contains("compaction=completed"),
         "status render should surface turn-checkpoint compaction detail: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_heal_plans_overdue_session_recovery() {
+    let root = super::tasks_cli::TempDirGuard::new("loong-sessions-cli-heal-plan");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Recovery Child",
+        mvp::session::repository::SessionState::Ready,
+    );
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "recover the child",
+            "timeout_seconds": 30
+        }),
+    })
+    .expect("append queued event");
+    overwrite_session_event_ts(
+        &root,
+        "delegate:session-1",
+        "delegate_queued",
+        current_unix_ts() - 90,
+    );
+
+    let execution = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Heal {
+                session_id: "delegate:session-1".to_owned(),
+                apply: false,
+            },
+        },
+    )
+    .await
+    .expect("sessions heal plan should succeed");
+
+    assert_eq!(execution.payload["command"], "heal");
+    assert_eq!(execution.payload["apply"], false);
+    assert_eq!(execution.payload["plan"]["action_count"], 1);
+    assert_eq!(
+        execution.payload["plan"]["actions"][0]["tool_name"],
+        "session_recover"
+    );
+    assert_eq!(execution.payload["plan"]["actions"][0]["can_apply"], true);
+
+    let rendered = loong_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions heal plan");
+    assert!(
+        rendered.contains("recommended_action: tool=session_recover"),
+        "heal render should surface recommended action: {rendered}"
+    );
+    assert!(
+        rendered.contains("self-heal plan"),
+        "heal render should surface self-heal section: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_heal_apply_runs_session_recover() {
+    let root = super::tasks_cli::TempDirGuard::new("loong-sessions-cli-heal-apply");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Recovery Child",
+        mvp::session::repository::SessionState::Ready,
+    );
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "recover the child",
+            "timeout_seconds": 30
+        }),
+    })
+    .expect("append queued event");
+    overwrite_session_event_ts(
+        &root,
+        "delegate:session-1",
+        "delegate_queued",
+        current_unix_ts() - 90,
+    );
+
+    let execution = loong_daemon::sessions_cli::execute_sessions_command(
+        loong_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loong_daemon::sessions_cli::SessionsCommands::Heal {
+                session_id: "delegate:session-1".to_owned(),
+                apply: true,
+            },
+        },
+    )
+    .await
+    .expect("sessions heal apply should succeed");
+
+    assert_eq!(execution.payload["command"], "heal");
+    assert_eq!(execution.payload["apply"], true);
+    assert_eq!(
+        execution.payload["applied_actions"][0]["tool_name"],
+        "session_recover"
+    );
+    assert_eq!(execution.payload["detail"]["session"]["state"], "failed");
+    assert_eq!(
+        execution.payload["detail"]["terminal_outcome_state"],
+        "present"
+    );
+
+    let rendered = loong_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions heal apply");
+    assert!(
+        rendered.contains("applied actions"),
+        "heal apply render should surface applied actions: {rendered}"
+    );
+    assert!(
+        rendered.contains("status=applied"),
+        "heal apply render should surface applied action status: {rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Problem:
  Loong already persisted session recovery facts, provider failover diagnostics, task resume recipes, and turn-checkpoint recovery state, but operators and agent flows still had to reconstruct the next safe action by hand.
- Why it matters:
  That made bounded self-heal behavior inconsistent, increased repeated diagnosis work, and kept the daemon session shell behind the structured truth already available in app/runtime layers.
- What changed:
  Added a daemon-side `sessions heal` orchestration surface that plans and, when explicitly requested, applies bounded self-heal actions; extended `session_status` diagnostics so they carry typed provider-failover facts plus a recommended action; and mirrored those diagnostics into `sessions status` text output.
- What did not change (scope boundary):
  This does not add a new generic self-heal app tool, does not move turn-checkpoint repair into generic app tools, and does not toolize the future debug-bundle or watch surfaces in this slice.

## Linked Issues

- Closes #1398
- Related #1392

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track B (higher-risk / policy-impacting)

- Risk notes:
  The change adds a new daemon operator surface and extends the structured session-status contract, so the main risk is recommendation drift between the daemon shell and the underlying app/runtime seams.
- Rollout / guardrails:
  The new surface reuses only existing recovery seams, targeted unit and integration coverage now locks the new planning and apply paths, and static checks plus architecture-boundary checks passed for the touched packages.
- Rollback path:
  Revert the `sessions heal` command and the added `session_status` diagnostics fields. Existing `session_status`, `session_recover`, and turn-checkpoint repair behavior remain intact underneath.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh test -p loong-app tools::session::tests::session_status_surfaces_latest_provider_failover_diagnostics -- --exact
./scripts/cargo-local-toolchain.sh test -p loong-app tools::session::tests::session_status_recommends_session_recover_for_overdue_async_child -- --exact
./scripts/cargo-local-toolchain.sh test -p loong-app tools::session::tests::session_status_recommends_resume_recipe_when_recover_plan_is_unavailable -- --exact
./scripts/cargo-local-toolchain.sh test -p loong-app tools::session::tests::session_status_ -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong-app tools::session::tests::session_recover_ -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong --lib sessions_cli::tests:: -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong --test integration sessions_cli:: -- --nocapture
./scripts/cargo-local-toolchain.sh clippy -p loong-app -p loong --all-targets --all-features -- -D warnings
./scripts/check_architecture_boundaries.sh
./scripts/cargo-local-toolchain.sh test --workspace --locked
./scripts/cargo-local-toolchain.sh test --workspace --all-features --locked
```

Result summary:
- All touched self-heal and session-shell tests passed.
- The new daemon unit and integration tests for `sessions heal` passed.
- `clippy` passed for the touched packages.
- Architecture boundary checks passed.
- Workspace-wide test suites are still blocked in this sandbox by existing daemon tests that bind local listeners and fail with `Operation not permitted`; the failure set remained in the same gateway, onboarding, managed-bridge, and update-cli areas before and after this slice.

## User-visible / Operator-visible Changes

- `session_status` now returns a structured diagnostics block with typed provider-failover evidence and a recommended next action.
- `sessions status` now surfaces the same latest-provider-failover and recommended-action summary that agents can consume from JSON.
- `sessions heal` now provides a bounded daemon-side orchestration surface for planning and explicitly applying safe existing recovery seams.

## Failure Recovery

- Fast rollback or disable path:
  Revert the `sessions heal` surface and the additional `session_status` diagnostics fields.
- Observable failure symptoms reviewers should watch for:
  Missing or malformed `diagnostics.recommended_action`, mismatch between `sessions status` and `session_status` JSON, or `sessions heal --apply` attempting an action that was not first surfaced in the plan.

## Reviewer Focus

- `crates/app/src/tools/session.rs`: recommendation precedence between `session_recover`, task resume recipes, and provider-failover diagnostics.
- `crates/daemon/src/sessions_cli.rs`: new plan/apply orchestration, text rendering, and the daemon-only turn-checkpoint repair boundary.
- `crates/daemon/tests/integration/sessions_cli.rs`: operator-facing integration coverage for the new `sessions heal` path.