### PR TITLE
Promote non-terminal tool continuations into runtime follow-up decisions

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -7384,6 +7384,119 @@ async fn handle_turn_with_runtime_tool_search_requests_a_followup_provider_turn(
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_nonterminal_continuation_requests_followup_provider_turn() {
+    let _home =
+        crate::test_support::ScopedLoongHome::new("conversation-continuation-followup-home");
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-continuation-followup", "session-wait")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = session_store_config_from_config(&config);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Running,
+    })
+    .expect("create child session");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "I will keep checking the delegated work.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "session_wait",
+                    json!({
+                        "session_id": "child-session",
+                        "timeout_ms": 1
+                    }),
+                    "root-session",
+                    "turn-continuation-1",
+                    "call-session-wait-1",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text:
+                    "The delegated work is still running, so I should not report completion yet."
+                        .to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "wait for the delegated session to finish and then summarize it",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("continuation followup turn should succeed");
+
+    assert_eq!(
+        reply,
+        "The delegated work is still running, so I should not report completion yet."
+    );
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("user")
+                && content.is_some_and(|content| content.contains("Continuation guidance:"))
+        }),
+        "second provider turn should receive continuation followup guidance: {requested_turn_messages:?}"
+    );
+    assert!(
+        requested_turn_messages[1].iter().any(|message| {
+            let role = message.get("role").and_then(Value::as_str);
+            let content = message.get("content").and_then(Value::as_str);
+            role == Some("user")
+                && content.is_some_and(|content| content.contains("`session_wait`"))
+        }),
+        "second provider turn should receive the recommended wait tool guidance: {requested_turn_messages:?}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn default_runtime_build_context_includes_tool_discovery_delta_from_persisted_state() {
     let mut config = test_config();

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -6013,12 +6013,15 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         });
     let malformed_parse_followup_turn =
         provider_turn_has_malformed_parse_followup_signal(&turn.raw_meta);
+    let runtime_followup_turn = tool_driven_followup_payload(had_tool_intents, &turn_result)
+        .is_some_and(|payload| payload.requests_runtime_followup_chain());
     let preface_signals_provider_turn_followup =
         assistant_preface_signals_provider_turn_followup(assistant_preface.as_str());
     let supports_provider_turn_followup = followup_chain_active
         || discovery_search_turn
         || recovery_followup_turn
         || malformed_parse_followup_turn
+        || runtime_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,

--- a/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
+++ b/crates/app/src/conversation/turn_coordinator/provider_turn_lane.rs
@@ -166,15 +166,13 @@ pub(super) async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         &turn_result,
         fast_lane_tool_batch_trace.as_ref(),
     );
-    let recovery_followup_turn = tool_driven_followup_payload(had_tool_intents, &turn_result)
-        .is_some_and(|payload| {
-            matches!(payload, ToolDrivenFollowupPayload::DiscoveryRecovery { .. })
-        });
+    let runtime_followup_turn = tool_driven_followup_payload(had_tool_intents, &turn_result)
+        .is_some_and(|payload| payload.requests_runtime_followup_chain());
     let preface_signals_provider_turn_followup =
         assistant_preface_signals_provider_turn_followup(assistant_preface.as_str());
     let supports_provider_turn_followup = followup_chain_active
         || discovery_search_turn
-        || recovery_followup_turn
+        || runtime_followup_turn
         || preface_signals_provider_turn_followup;
     ProviderTurnLaneExecution {
         lane,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2439,6 +2439,20 @@ fn compact_continuation_payload_summary(payload: &serde_json::Value) -> Option<s
     let payload_object = payload.as_object()?;
     let continuation_object = payload_object.get("continuation")?.as_object()?;
 
+    let mut compacted = serde_json::Map::new();
+    for key in [
+        "mode",
+        "profile",
+        "label",
+        "state",
+        "wait_status",
+        "task_id",
+    ] {
+        if let Some(value) = payload_object.get(key) {
+            compacted.insert(key.to_owned(), value.clone());
+        }
+    }
+
     let mut compacted_continuation = serde_json::Map::new();
     for key in [
         "state",
@@ -2450,9 +2464,11 @@ fn compact_continuation_payload_summary(payload: &serde_json::Value) -> Option<s
             compacted_continuation.insert(key.to_owned(), value.clone());
         }
     }
-    Some(json!({
-        "continuation": compacted_continuation,
-    }))
+    compacted.insert(
+        "continuation".to_owned(),
+        Value::Object(compacted_continuation),
+    );
+    Some(Value::Object(compacted))
 }
 
 fn summarize_tool_result_payload(
@@ -6941,10 +6957,10 @@ mod tests {
             "session_wait"
         );
         assert!(
-            payload_summary
-                .as_object()
-                .is_some_and(|object| object.len() == 1),
-            "compacted summary should only retain continuation metadata: {payload_summary:?}"
+            payload_summary.as_object().is_some_and(|object| {
+                object.contains_key("continuation") && !object.contains_key("events")
+            }),
+            "compacted summary should keep only compact continuation-safe fields: {payload_summary:?}"
         );
     }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2420,6 +2420,10 @@ fn compact_tool_result_payload_value(
     tool_name: &str,
     payload: &serde_json::Value,
 ) -> serde_json::Value {
+    if let Some(compacted_payload) = compact_continuation_payload_summary(payload) {
+        return compacted_payload;
+    }
+
     if tool_name == "tool.search" {
         let compacted_payload = compact_tool_search_payload_summary(payload);
 
@@ -2429,6 +2433,26 @@ fn compact_tool_result_payload_value(
     }
 
     payload.clone()
+}
+
+fn compact_continuation_payload_summary(payload: &serde_json::Value) -> Option<serde_json::Value> {
+    let payload_object = payload.as_object()?;
+    let continuation_object = payload_object.get("continuation")?.as_object()?;
+
+    let mut compacted_continuation = serde_json::Map::new();
+    for key in [
+        "state",
+        "is_terminal",
+        "recommended_tool",
+        "recommended_payload",
+    ] {
+        if let Some(value) = continuation_object.get(key) {
+            compacted_continuation.insert(key.to_owned(), value.clone());
+        }
+    }
+    Some(json!({
+        "continuation": compacted_continuation,
+    }))
 }
 
 fn summarize_tool_result_payload(
@@ -6864,6 +6888,63 @@ mod tests {
             payload_chars > TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS as u64,
             "expected original payload char count, got {:?}",
             record.outcome.payload
+        );
+    }
+
+    #[test]
+    fn continuation_payload_summary_is_compacted_before_low_limit_truncation() {
+        let intent = provider_app_tool_intent(
+            "session_wait",
+            json!({"session_id": "child-session"}),
+            "session-continuation-payload",
+            "turn-continuation-payload",
+            "call-continuation-payload",
+        );
+        let outcome = ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "session": {
+                    "session_id": "child-session",
+                    "state": "running",
+                    "label": "Child",
+                    "kind": "delegate_child",
+                    "details": "x".repeat(512),
+                },
+                "wait_status": "waiting",
+                "events": [
+                    {
+                        "event_kind": "delegate_result",
+                        "payload": "x".repeat(512),
+                    }
+                ],
+                "continuation": {
+                    "state": "waiting",
+                    "is_terminal": false,
+                    "recommended_tool": "session_wait",
+                    "recommended_payload": {
+                        "session_id": "child-session",
+                        "timeout_ms": 1000,
+                    },
+                    "note": "Keep waiting before presenting final completion.",
+                }
+            }),
+        };
+
+        let envelope = build_tool_result_envelope(&intent, &outcome, 256);
+        let payload_summary =
+            serde_json::from_str::<Value>(envelope.payload_summary.as_str()).expect("payload json");
+
+        assert!(!envelope.payload_truncated, "envelope: {envelope:?}");
+        assert_eq!(payload_summary["continuation"]["state"], "waiting");
+        assert_eq!(
+            payload_summary["continuation"]["recommended_tool"],
+            "session_wait"
+        );
+        assert!(
+            payload_summary
+                .as_object()
+                .is_some_and(|object| object.len() == 1),
+            "compacted summary should only retain continuation metadata: {payload_summary:?}"
         );
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -23,7 +23,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::CliResult;
 
-pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to continue working toward the original user request. If another tool call is needed, make it now. If the request is already complete, answer in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
+pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to continue satisfying the original user request. Prefer the next bounded tool call or completion step over narrating intermediate status. Only stop to answer in natural language when the request is actually complete, blocked on a real approval or input gate, or the available evidence is already sufficient. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
@@ -1541,6 +1541,11 @@ pub fn build_tool_followup_user_prompt_with_context(
     if followup_prompt_needs_truncation_hint(tool_result_text, rendered_tool_result_text) {
         sections.push(TOOL_TRUNCATION_HINT_PROMPT.to_owned());
     }
+    if let Some(continuation_guidance) =
+        proactive_followup_continuation_context(tool_result_text, rendered_tool_result_text)
+    {
+        sections.push(continuation_guidance);
+    }
     if let Some(extra_context) = extra_context {
         sections.push(extra_context.to_owned());
     }
@@ -1556,6 +1561,120 @@ fn combine_followup_extra_context(parts: &[Option<&str>]) -> Option<String> {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>();
     (!joined.is_empty()).then(|| joined.join("\n\n"))
+}
+
+fn proactive_followup_continuation_context(
+    tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
+) -> Option<String> {
+    let primary_context = tool_result_text.and_then(parse_tool_result_followup_context);
+    let fallback_context = rendered_tool_result_text.and_then(parse_tool_result_followup_context);
+    let tool_result_context = primary_context.or(fallback_context)?;
+    let continuation = parse_tool_result_continuation(&tool_result_context.payload_json)?;
+    Some(render_tool_result_continuation_guidance(&continuation))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolResultFollowupContext {
+    payload_json: Value,
+}
+
+fn parse_tool_result_followup_context(tool_result_text: &str) -> Option<ToolResultFollowupContext> {
+    tool_result_text.lines().find_map(|line| {
+        let trimmed_line = line.trim();
+        let tool_result_line = ToolResultLine::parse(trimmed_line)?;
+        let payload_json = tool_result_line.payload_summary_json()?;
+        Some(ToolResultFollowupContext { payload_json })
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolResultContinuation {
+    state: String,
+    is_terminal: bool,
+    recommended_tool: Option<String>,
+    recommended_payload: Option<Value>,
+    note: Option<String>,
+}
+
+fn parse_tool_result_continuation(payload_json: &Value) -> Option<ToolResultContinuation> {
+    let continuation_value = payload_json.get("continuation")?;
+    let continuation_object = continuation_value.as_object()?;
+    let state = continuation_object
+        .get("state")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let is_terminal = continuation_object
+        .get("is_terminal")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let recommended_tool = continuation_object
+        .get("recommended_tool")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let recommended_payload = continuation_object.get("recommended_payload").cloned();
+    let note = continuation_object
+        .get("note")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    Some(ToolResultContinuation {
+        state,
+        is_terminal,
+        recommended_tool,
+        recommended_payload,
+        note,
+    })
+}
+
+fn render_tool_result_continuation_guidance(continuation: &ToolResultContinuation) -> String {
+    let mut lines = vec!["Continuation guidance:".to_owned()];
+    let state_line = if continuation.is_terminal {
+        format!(
+            "The tool reported terminal state `{}`. Finish the request only if the user-facing work is actually complete.",
+            continuation.state
+        )
+    } else {
+        format!(
+            "The tool reported intermediate state `{}`. Do not present this as final completion.",
+            continuation.state
+        )
+    };
+    lines.push(state_line);
+
+    if let Some(note) = continuation.note.as_deref() {
+        lines.push(note.to_owned());
+    }
+
+    if let Some(recommended_tool) = continuation.recommended_tool.as_deref() {
+        let mut recommendation = format!(
+            "If the original request still depends on this work, continue with `{recommended_tool}`"
+        );
+        if let Some(recommended_payload) = continuation.recommended_payload.as_ref() {
+            let payload_text =
+                serde_json::to_string(recommended_payload).unwrap_or_else(|_| "{}".to_owned());
+            recommendation.push_str(" using payload:");
+            recommendation.push('\n');
+            recommendation.push_str(payload_text.as_str());
+            recommendation.push('\n');
+            recommendation.push_str("before answering.");
+        } else {
+            recommendation.push_str(" before answering.");
+        }
+        lines.push(recommendation);
+    } else if !continuation.is_terminal {
+        lines.push(
+            "Keep advancing if you can resolve the gate from available tools; otherwise report the exact blocker instead of a vague progress update."
+                .to_owned(),
+        );
+    }
+
+    lines.join("\n")
 }
 
 pub fn build_discovery_recovery_followup_user_prompt(
@@ -3880,6 +3999,88 @@ mod tests {
 
         assert!(prompt.contains(DISCOVERY_RESULT_FOLLOWUP_PROMPT));
         assert!(prompt.contains("Original request:\nfind the latest ai news and summarize it"));
+    }
+
+    #[test]
+    fn followup_prompt_uses_generic_continuation_metadata_for_delegate_queue() {
+        let payload_summary = json!({
+            "child_session_id": "delegate:child-1",
+            "mode": "async",
+            "state": "queued",
+            "continuation": {
+                "state": "queued",
+                "is_terminal": false,
+                "recommended_tool": "session_wait",
+                "recommended_payload": {
+                    "session_id": "delegate:child-1",
+                    "timeout_ms": 30000
+                },
+                "note": "The delegated child is still running in the background."
+            }
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "delegate_async",
+                "tool_call_id": "call-delegate-1",
+                "payload_summary": payload_summary,
+                "payload_chars": 256,
+                "payload_truncated": false
+            })
+        );
+
+        let prompt = build_tool_followup_user_prompt(
+            "finish the delegated research and summarize the result",
+            None,
+            Some(tool_result.as_str()),
+            None,
+            None,
+        );
+
+        assert!(prompt.contains("Continuation guidance:"));
+        assert!(prompt.contains("intermediate state `queued`"));
+        assert!(prompt.contains("still running in the background"));
+        assert!(prompt.contains("`session_wait`"));
+        assert!(prompt.contains("{\"session_id\":\"delegate:child-1\",\"timeout_ms\":30000}"));
+    }
+
+    #[test]
+    fn followup_prompt_uses_generic_continuation_metadata_for_waiting_task() {
+        let payload_summary = json!({
+            "wait_status": "waiting",
+            "continuation": {
+                "state": "waiting",
+                "is_terminal": false,
+                "note": "The runtime is still waiting on an approval or external completion gate."
+            }
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "task_wait",
+                "tool_call_id": "call-task-wait-1",
+                "payload_summary": payload_summary,
+                "payload_chars": 256,
+                "payload_truncated": false
+            })
+        );
+
+        let prompt = build_tool_followup_user_prompt(
+            "wait until the task is complete and then summarize it",
+            None,
+            Some(tool_result.as_str()),
+            None,
+            None,
+        );
+
+        assert!(prompt.contains("Continuation guidance:"));
+        assert!(prompt.contains("intermediate state `waiting`"));
+        assert!(prompt.contains("approval or external completion gate"));
+        assert!(prompt.contains("exact blocker"));
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -430,6 +430,20 @@ impl ToolDrivenFollowupPayload {
             }
         )
     }
+
+    pub fn requests_runtime_followup_chain(&self) -> bool {
+        match self {
+            Self::DiscoveryRecovery { .. } => true,
+            Self::ToolResult { text } => {
+                let tool_result_context = parse_tool_result_followup_context(text.as_str());
+                let continuation = tool_result_context
+                    .as_ref()
+                    .and_then(|context| parse_tool_result_continuation(&context.payload_json));
+                continuation.is_some_and(|continuation| !continuation.is_terminal)
+            }
+            Self::ToolFailure { .. } => false,
+        }
+    }
 }
 
 pub fn parse_tool_driven_continuation_reply(text: &str) -> ParsedToolDrivenContinuationReply {
@@ -4081,6 +4095,63 @@ mod tests {
         assert!(prompt.contains("intermediate state `waiting`"));
         assert!(prompt.contains("approval or external completion gate"));
         assert!(prompt.contains("exact blocker"));
+    }
+
+    #[test]
+    fn tool_result_payload_requests_runtime_followup_chain_for_nonterminal_continuation() {
+        let payload = ToolDrivenFollowupPayload::ToolResult {
+            text: format!(
+                "[ok] {}",
+                json!({
+                    "status": "ok",
+                    "tool": "session_wait",
+                    "tool_call_id": "call-session-wait",
+                    "payload_summary": json!({
+                        "wait_status": "waiting",
+                        "continuation": {
+                            "state": "waiting",
+                            "is_terminal": false,
+                            "recommended_tool": "session_wait",
+                            "recommended_payload": {
+                                "session_id": "child-session",
+                                "timeout_ms": 1000
+                            }
+                        }
+                    })
+                    .to_string(),
+                    "payload_chars": 256,
+                    "payload_truncated": false
+                })
+            ),
+        };
+
+        assert!(payload.requests_runtime_followup_chain());
+    }
+
+    #[test]
+    fn tool_result_payload_does_not_request_runtime_followup_chain_for_terminal_continuation() {
+        let payload = ToolDrivenFollowupPayload::ToolResult {
+            text: format!(
+                "[ok] {}",
+                json!({
+                    "status": "ok",
+                    "tool": "session_wait",
+                    "tool_call_id": "call-session-wait",
+                    "payload_summary": json!({
+                        "wait_status": "completed",
+                        "continuation": {
+                            "state": "completed",
+                            "is_terminal": true
+                        }
+                    })
+                    .to_string(),
+                    "payload_chars": 256,
+                    "payload_truncated": false
+                })
+            ),
+        };
+
+        assert!(!payload.requests_runtime_followup_chain());
     }
 
     #[test]

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -387,6 +387,8 @@ fn render_execution_discipline_section() -> String {
             .to_owned(),
         "- If one retrieval path returns partial or empty results, retry with a different bounded strategy before asking the user."
             .to_owned(),
+        "- Prefer continuing through bounded intermediate steps over narrating every step to the user."
+            .to_owned(),
         "</tool_persistence>".to_owned(),
         "<mandatory_tool_use>".to_owned(),
         "- Do not answer live system, file-content, git-state, or current-fact questions from memory when runtime retrieval is available."
@@ -399,6 +401,8 @@ fn render_execution_discipline_section() -> String {
             .to_owned(),
         "- Ask only when the missing detail changes the required tool, target, or side effect."
             .to_owned(),
+        "- Do not emit incremental progress chatter after each tool result; keep going until you can deliver a completed result, a concrete blocker, or a real approval request."
+            .to_owned(),
         "</act_dont_ask>".to_owned(),
         "<prerequisite_checks>".to_owned(),
         "- Before a mutating step or a high-confidence claim, check whether discovery, inspection, or preflight lookup is still needed."
@@ -410,6 +414,8 @@ fn render_execution_discipline_section() -> String {
         "- Before finalizing, check correctness, grounding, output shape, and whether a real stop condition has been reached."
             .to_owned(),
         "- A reply is not by itself proof that a long-running task is complete."
+            .to_owned(),
+        "- Queued async work, waiting task handles, blocked task states, and pending approvals are intermediate runtime states, not final completion."
             .to_owned(),
         "</verification>".to_owned(),
         "<missing_context>".to_owned(),
@@ -1096,6 +1102,14 @@ mod tests {
     fn build_system_message_returns_none_when_disabled() {
         let config = LoongConfig::default();
         assert_eq!(build_system_message(&config, false), None);
+    }
+
+    #[test]
+    fn execution_discipline_section_emphasizes_continued_execution_over_progress_chatter() {
+        let section = render_execution_discipline_section();
+        assert!(section.contains("Prefer continuing through bounded intermediate steps"));
+        assert!(section.contains("Do not emit incremental progress chatter"));
+        assert!(section.contains("intermediate runtime states, not final completion"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -216,12 +216,23 @@ pub(crate) fn delegate_async_queued_outcome(
     profile: Option<DelegateBuiltinProfile>,
     timeout_seconds: u64,
 ) -> ToolCoreOutcome {
+    let recommended_payload = json!({
+        "session_id": child_session_id,
+        "timeout_ms": timeout_seconds.saturating_mul(1_000),
+    });
     let mut payload = json!({
         "child_session_id": child_session_id,
         "label": label,
         "mode": "async",
         "state": "queued",
         "timeout_seconds": timeout_seconds,
+        "continuation": {
+            "state": "queued",
+            "is_terminal": false,
+            "recommended_tool": "session_wait",
+            "recommended_payload": recommended_payload,
+            "note": "This queued delegate child is still running in the background. Wait for the child result before presenting final completion if the original request depends on it."
+        }
     });
     if let Some(profile) = profile
         && let Some(object) = payload.as_object_mut()
@@ -519,6 +530,29 @@ mod tests {
         .expect_err("invalid timeout should be rejected");
 
         assert!(error.contains("invalid_timeout_seconds"), "error: {error}");
+    }
+
+    #[test]
+    fn delegate_async_queued_outcome_exposes_generic_continuation_metadata() {
+        let outcome = delegate_async_queued_outcome(
+            "delegate:child-1".to_owned(),
+            None,
+            Some("research-child".to_owned()),
+            None,
+            30,
+        );
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["continuation"]["state"], "queued");
+        assert_eq!(outcome.payload["continuation"]["is_terminal"], false);
+        assert_eq!(
+            outcome.payload["continuation"]["recommended_tool"],
+            "session_wait"
+        );
+        assert_eq!(
+            outcome.payload["continuation"]["recommended_payload"]["session_id"],
+            "delegate:child-1"
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -5283,11 +5283,23 @@ fn wait_payload(
         if wait_status != "completed" {
             let continuation_note =
                 continuation_note_for_wait_status(wait_status, object.get("session"));
+            let session_id = object
+                .get("session")
+                .and_then(|value| value.get("session_id"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let recommended_payload = json!({
+                "session_id": session_id,
+                "timeout_ms": timeout_ms,
+            });
             object.insert(
                 "continuation".to_owned(),
                 json!({
                     "state": wait_status,
                     "is_terminal": false,
+                    "recommended_tool": "session_wait",
+                    "recommended_payload": recommended_payload,
                     "note": continuation_note,
                 }),
             );
@@ -5394,6 +5406,27 @@ fn task_wait_payload(
     let task_state = task_state_from_payload(&payload);
     if let Some(object) = payload.as_object_mut() {
         object.insert("task_events".to_owned(), Value::Array(task_events));
+        if wait_status != "completed" {
+            let task_id = object
+                .get("task_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let recommended_payload = json!({
+                "task_id": task_id,
+                "timeout_ms": timeout_ms,
+            });
+            let continuation_value = object
+                .entry("continuation".to_owned())
+                .or_insert_with(|| json!({}));
+            if let Some(continuation_object) = continuation_value.as_object_mut() {
+                continuation_object.insert(
+                    "recommended_tool".to_owned(),
+                    Value::String("task_wait".to_owned()),
+                );
+                continuation_object.insert("recommended_payload".to_owned(), recommended_payload);
+            }
+        }
     }
     let payload = decorate_task_status_payload(payload, task_state);
     decorate_task_lineage_payload(payload, lineage_records, current_owner_session_id)

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -5280,6 +5280,18 @@ fn wait_payload(
             "wait_status".to_owned(),
             Value::String(wait_status.to_owned()),
         );
+        if wait_status != "completed" {
+            let continuation_note =
+                continuation_note_for_wait_status(wait_status, object.get("session"));
+            object.insert(
+                "continuation".to_owned(),
+                json!({
+                    "state": wait_status,
+                    "is_terminal": false,
+                    "note": continuation_note,
+                }),
+            );
+        }
         object.insert("timeout_ms".to_owned(), Value::from(timeout_ms));
         object.insert(
             "after_id".to_owned(),
@@ -5297,6 +5309,25 @@ fn wait_payload(
         );
     }
     payload
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn continuation_note_for_wait_status(wait_status: &str, session_payload: Option<&Value>) -> String {
+    let session_state = session_payload
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    match wait_status {
+        "waiting" => format!(
+            "The runtime is still waiting on session state `{session_state}`. Treat this as intermediate progress, not final completion."
+        ),
+        "blocked" => format!(
+            "The runtime is blocked while the session state is `{session_state}`. Report the exact blocker or resolve it before presenting final completion."
+        ),
+        other => format!(
+            "The runtime is still in non-terminal wait state `{other}` with session state `{session_state}`."
+        ),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -10496,10 +10527,42 @@ mod tests {
         );
         assert_eq!(outcome.payload["task_state"], "waiting");
         assert_eq!(outcome.payload["task_is_stable"], true);
+        assert_eq!(outcome.payload["continuation"]["state"], "waiting");
+        assert_eq!(outcome.payload["continuation"]["is_terminal"], false);
         assert!(
             started_at.elapsed() < immediate_resolution_budget,
             "waiting task state should resolve without waiting for terminal session state"
         );
+    }
+
+    #[tokio::test]
+    async fn session_wait_waiting_state_exposes_generic_continuation_metadata() {
+        let config = isolated_memory_config("session-wait-continuation");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+
+        let outcome = crate::tools::wait_for_session_with_config(
+            json!({
+                "session_id": "child-session",
+                "timeout_ms": 100
+            }),
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .await
+        .expect("session_wait outcome");
+
+        assert_eq!(outcome.payload["wait_status"], "timeout");
+        assert_eq!(outcome.payload["continuation"]["state"], "timeout");
+        assert_eq!(outcome.payload["continuation"]["is_terminal"], false);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Problem:
  Loong could still narrate intermediate runtime states like queued delegate children or waiting task handles instead of consistently driving the next bounded step.
- Why it matters:
  That made long-running work feel more reactive and step-by-step than the surrounding runtime architecture intended.
- What changed:
  Added a shared continuation contract for non-terminal tool results, taught wait surfaces to emit actionable continuation metadata, and promoted that contract into provider-turn follow-up decisions so runtime-owned continuation can keep the provider chain alive when work is still in progress.
- What did not change (scope boundary):
  This does not introduce a new orchestration subsystem and does not auto-run arbitrary recommended tools inside the coordinator. It keeps the existing provider-turn loop, task/session surfaces, and approval boundaries intact.

## Linked Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes how intermediate tool results participate in runtime follow-up decisions, especially for queued and waiting states.
- Rollout / guardrails:
  The continuation contract is additive, bounded by the existing provider follow-up round budget, and covered by targeted regression tests plus CI-parity validation.
- Rollback path:
  Revert this branch's continuation-runtime commits.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/check_architecture_boundaries.sh
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh test --workspace
./scripts/cargo-local-toolchain.sh test --workspace --all-features

Targeted regressions also passed for:
- delegate_async_queued_outcome_exposes_generic_continuation_metadata
- session_wait_waiting_state_exposes_generic_continuation_metadata
- task_wait_returns_immediately_for_waiting_canonical_task_state
- tool_result_payload_requests_runtime_followup_chain_for_nonterminal_continuation
- tool_result_payload_does_not_request_runtime_followup_chain_for_terminal_continuation
- handle_turn_with_runtime_nonterminal_continuation_requests_followup_provider_turn
