### PR TITLE
docs(README): call out CN Feishu vs international Lark domain in onboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,19 @@ model = "auto"
 - `api_key = { env = "OPENAI_API_KEY" }` reads the secret from that environment variable. `api_key = "OPENAI_API_KEY"` would instead treat the string as the literal key value — a common pitfall.
 - `model = "auto"` uses provider-side discovery; pin `model = "<id>"` when discovery is unreliable for your region or account.
 
-#### Channels — Lark
+#### Channels — Lark / Feishu
 
 Recommended first-run setup:
 
 ```bash
+# International Lark tenants (open.larksuite.com)
 loong feishu onboard --domain lark
+
+# China Feishu tenants (open.feishu.cn) — the CLI default
+loong feishu onboard --domain feishu
 ```
+
+Pick the `--domain` that matches the tenant you log in to: `lark` hits `open.larksuite.com` (international), `feishu` hits `open.feishu.cn` (China). Running with the wrong domain sends you to the wrong registration endpoint and the QR flow will fail to bind. If you omit `--domain` entirely the CLI defaults to `feishu`.
 
 That flow shows an in-terminal QR code, creates the bot app through the official Lark/Feishu registration API, and writes the generated credentials into `loong.toml`. Manual fallback is still available through `loong feishu onboard --manual --app-id ... --app-secret ...`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,8 +178,14 @@ model = "auto"
 推荐先走命令行二维码接入：
 
 ```bash
-loong feishu onboard
+# 国内飞书租户（open.feishu.cn）—— CLI 默认值
+loong feishu onboard --domain feishu
+
+# 国际版 Lark 租户（open.larksuite.com）
+loong feishu onboard --domain lark
 ```
+
+`--domain` 一定要和你登录的租户类型对上：`feishu` 走国内 `open.feishu.cn`，`lark` 走国际 `open.larksuite.com`。选错端点时二维码扫完也绑不上对应 app。省略 `--domain` 时默认走 `feishu`。
 
 这条命令会在终端里展示二维码，走官方 Feishu/Lark 注册接口创建 bot app，并把生成的凭据写回 `loong.toml`。如果你已经有现成凭据，也可以继续用 `loong feishu onboard --manual --app-id ... --app-secret ...` 手动回填。
 


### PR DESCRIPTION
## Summary

- Document the `--domain feishu` vs `--domain lark` split in the Feishu onboarding section of both `README.md` and `README.zh-CN.md` so CN users do not silently land on `open.larksuite.com`.
- Note that omitting `--domain` falls back to the CLI default (`feishu`), matching `FeishuOnboardDomainArg::Feishu` in `crates/daemon/src/feishu_cli.rs`.

## Why

The prior README only showed `loong feishu onboard --domain lark` with a single toml comment hinting at the CN lane. Tracking eastreams/loong#1348 — CN users reported running the example verbatim and getting routed to the international registration endpoint.

## Test plan

- [x] README renders both command variants
- [x] Diff limited to README.md and README.zh-CN.md — no code paths touched

Refs eastreams/loong#1348