### PR TITLE
Align runtime policy and standard turn harness across execution paths

### DIFF
--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -191,36 +191,23 @@ impl<'a> RuntimeTurnExecutionService<'a> {
                     acp_manager,
                 )
                 .await?;
-                let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-                let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
-
-                let governed_session_mode = runtime.conversation_binding().session_mode();
-
                 return crate::acp::consume_finalized_acp_conversation_turn(
                     execution,
                     |success| async move {
                         let result = success.result;
-                        let output_text = result.output_text;
-                        let state = Some(acp_session_state_label(result.state).to_owned());
-                        let stop_reason = result
-                            .stop_reason
-                            .map(acp_turn_stop_reason_label)
-                            .map(ToOwned::to_owned);
-                        let usage = result.usage;
-                        let event_count = success.runtime_events.len();
-
-                        Ok(AgentTurnResult {
-                            session_id: runtime.session_id.clone(),
-                            output_text,
-                            turn_mode: request.turn_mode,
-                            governed_session_mode,
-                            state,
-                            stop_reason,
-                            usage,
-                            event_count,
-                            prompt_assembly,
-                            prompt_cache,
-                        })
+                        build_agent_turn_result(
+                            runtime,
+                            request,
+                            result.output_text,
+                            Some(acp_session_state_label(result.state).to_owned()),
+                            result
+                                .stop_reason
+                                .map(acp_turn_stop_reason_label)
+                                .map(ToOwned::to_owned),
+                            result.usage,
+                            success.runtime_events.len(),
+                        )
+                        .await
                     },
                     |failure| async move { Err(failure.error) },
                 )
@@ -229,37 +216,20 @@ impl<'a> RuntimeTurnExecutionService<'a> {
 
             let (effective_ingress, effective_provenance) =
                 effective_turn_context(ingress, provenance);
-            let turn_outcome =
-                crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
-                    runtime,
-                    &turn_address,
-                    message,
-                    event_sink,
-                    request.live_surface_enabled,
-                    Some(&request.metadata),
-                    effective_ingress,
-                    effective_provenance,
-                    provider_error_mode,
-                    observer,
-                    retry_progress,
-                    acp_manager,
-                )
-                .await?;
-            let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-            let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
-
-            Ok(AgentTurnResult {
-                session_id: runtime.session_id.clone(),
-                output_text: turn_outcome.reply,
-                turn_mode: request.turn_mode,
-                governed_session_mode: runtime.conversation_binding().session_mode(),
-                state: None,
-                stop_reason: None,
-                usage: turn_outcome.usage,
-                event_count: 0,
-                prompt_assembly,
-                prompt_cache,
-            })
+            run_standard_turn_with_runtime(
+                runtime,
+                request,
+                &turn_address,
+                message,
+                event_sink,
+                observer,
+                effective_ingress,
+                effective_provenance,
+                provider_error_mode,
+                retry_progress,
+                acp_manager,
+            )
+            .await
         })
     }
 }
@@ -843,6 +813,73 @@ async fn load_runtime_prompt_frame_summary(
         let _ = runtime;
         PromptFrameEventSummary::default()
     }
+}
+
+async fn build_agent_turn_result(
+    runtime: &crate::chat::CliTurnRuntime,
+    request: &AgentTurnRequest,
+    output_text: String,
+    state: Option<String>,
+    stop_reason: Option<String>,
+    usage: Option<Value>,
+    event_count: usize,
+) -> CliResult<AgentTurnResult> {
+    let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+    let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+
+    Ok(AgentTurnResult {
+        session_id: runtime.session_id.clone(),
+        output_text,
+        turn_mode: request.turn_mode,
+        governed_session_mode: runtime.conversation_binding().session_mode(),
+        state,
+        stop_reason,
+        usage,
+        event_count,
+        prompt_assembly,
+        prompt_cache,
+    })
+}
+
+async fn run_standard_turn_with_runtime(
+    runtime: &crate::chat::CliTurnRuntime,
+    request: &AgentTurnRequest,
+    turn_address: &ConversationSessionAddress,
+    message: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+    observer: Option<crate::conversation::ConversationTurnObserverHandle>,
+    ingress: Option<&ConversationIngressContext>,
+    provenance: AcpTurnProvenance<'_>,
+    provider_error_mode: crate::conversation::ProviderErrorMode,
+    retry_progress: crate::provider::ProviderRetryProgressCallback,
+    acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
+) -> CliResult<AgentTurnResult> {
+    let turn_outcome = crate::chat::run_cli_turn_with_address_and_ingress_and_error_mode_outcome(
+        runtime,
+        turn_address,
+        message,
+        event_sink,
+        request.live_surface_enabled,
+        Some(&request.metadata),
+        ingress,
+        provenance,
+        provider_error_mode,
+        observer,
+        retry_progress,
+        acp_manager,
+    )
+    .await?;
+
+    build_agent_turn_result(
+        runtime,
+        request,
+        turn_outcome.reply,
+        None,
+        None,
+        turn_outcome.usage,
+        0,
+    )
+    .await
 }
 
 /// Refresh provider-facing runtime state from disk when a concrete config path

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -13,7 +13,7 @@ use crate::operator::delegate_runtime::{
     derive_subagent_profile_from_lineage, resolve_delegate_child_contract,
 };
 use crate::runtime_self_continuity::{self, RuntimeSelfContinuity};
-use crate::tools::runtime_config::ToolRuntimeNarrowing;
+use crate::tools::runtime_config::{SessionToolRuntimePolicy, ToolRuntimeNarrowing};
 use crate::tools::{ToolView, delegate_child_tool_view_for_contract};
 
 use super::super::memory;
@@ -386,32 +386,20 @@ fn load_session_tool_policy(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn apply_session_tool_policy_to_tool_view(
-    base_tool_view: ToolView,
+fn session_tool_runtime_policy(
     session_tool_policy: Option<&SessionToolPolicyRecord>,
-) -> ToolView {
-    let Some(session_tool_policy) = session_tool_policy else {
-        return base_tool_view;
-    };
-    if session_tool_policy.requested_tool_ids.is_empty() {
-        return base_tool_view;
-    }
-
-    let policy_tool_view = ToolView::from_tool_names(session_tool_policy.requested_tool_ids.iter());
-    base_tool_view.intersect(&policy_tool_view)
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn merge_effective_runtime_narrowing(
     delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
-    session_tool_policy: Option<&SessionToolPolicyRecord>,
-) -> Option<ToolRuntimeNarrowing> {
-    let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
+) -> SessionToolRuntimePolicy {
+    let requested_tool_ids = session_tool_policy
+        .map(|policy| policy.requested_tool_ids.clone())
+        .unwrap_or_default();
+    let requested_runtime_narrowing = session_tool_policy.and_then(|policy| {
         (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
     });
-    crate::tools::runtime_config::merge_runtime_narrowing_sources(
+    SessionToolRuntimePolicy::new(
+        requested_tool_ids,
+        requested_runtime_narrowing,
         delegate_runtime_narrowing,
-        policy_runtime_narrowing,
     )
 }
 
@@ -772,17 +760,16 @@ fn build_session_context_from_snapshot(
     snapshot: PersistedSessionSnapshot,
 ) -> CliResult<SessionContext> {
     let visible_external_skill_roots = model_visible_external_skill_roots_from_config(config);
+    let session_tool_policy = session_tool_runtime_policy(
+        snapshot.session_tool_policy.as_ref(),
+        snapshot.delegate_runtime_narrowing.clone(),
+    );
+    let requested_tool_view = session_tool_policy.apply_to_tool_view(&base_tool_view);
     let tool_view = apply_active_external_skill_blocked_tools_to_tool_view(
-        apply_session_tool_policy_to_tool_view(
-            base_tool_view,
-            snapshot.session_tool_policy.as_ref(),
-        ),
+        requested_tool_view,
         snapshot.active_external_skills.as_ref(),
     );
-    let runtime_narrowing = merge_effective_runtime_narrowing(
-        snapshot.delegate_runtime_narrowing.clone(),
-        snapshot.session_tool_policy.as_ref(),
-    );
+    let runtime_narrowing = session_tool_policy.effective_runtime_narrowing();
     let mut session_context = match snapshot.parent_session_id.clone() {
         Some(parent_session_id) => {
             SessionContext::child(snapshot.session_id.clone(), parent_session_id, tool_view)
@@ -2002,12 +1989,13 @@ where
             let snapshot = load_persisted_session_snapshot(&repo, session_id)?;
             let base_tool_view =
                 build_base_tool_view_from_snapshot(config, &repo, session_id, snapshot.as_ref())?;
-            let tool_view = apply_session_tool_policy_to_tool_view(
-                base_tool_view,
+            let session_tool_policy = session_tool_runtime_policy(
                 snapshot
                     .as_ref()
                     .and_then(|snapshot| snapshot.session_tool_policy.as_ref()),
+                None,
             );
+            let tool_view = session_tool_policy.apply_to_tool_view(&base_tool_view);
             Ok(apply_active_external_skill_blocked_tools_to_tool_view(
                 tool_view,
                 snapshot

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use loong_contracts::{ExecutionSecurityTier, SecretRef};
 use serde::{Deserialize, Serialize};
 
-use super::{bash_rules, shell_policy_ext::ShellPolicyDefault};
+use super::{ToolView, bash_rules, shell_policy_ext::ShellPolicyDefault};
 use crate::config::{AutonomyProfile, LoongConfig};
 #[cfg(feature = "feishu-integration")]
 use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
@@ -205,6 +205,48 @@ pub(crate) fn merge_runtime_narrowing_sources(
         (Some(primary_runtime_narrowing), None) => Some(primary_runtime_narrowing),
         (None, Some(secondary_runtime_narrowing)) => Some(secondary_runtime_narrowing),
         (None, None) => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct SessionToolRuntimePolicy {
+    pub requested_tool_ids: Vec<String>,
+    pub requested_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    pub delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+}
+
+impl SessionToolRuntimePolicy {
+    #[must_use]
+    pub fn new(
+        requested_tool_ids: Vec<String>,
+        requested_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+        delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    ) -> Self {
+        Self {
+            requested_tool_ids,
+            requested_runtime_narrowing: requested_runtime_narrowing
+                .filter(|runtime_narrowing| !runtime_narrowing.is_empty()),
+            delegate_runtime_narrowing: delegate_runtime_narrowing
+                .filter(|runtime_narrowing| !runtime_narrowing.is_empty()),
+        }
+    }
+
+    #[must_use]
+    pub fn apply_to_tool_view(&self, base_tool_view: &ToolView) -> ToolView {
+        if self.requested_tool_ids.is_empty() {
+            return base_tool_view.clone();
+        }
+
+        let requested_tool_view = ToolView::from_tool_names(self.requested_tool_ids.iter());
+        base_tool_view.intersect(&requested_tool_view)
+    }
+
+    #[must_use]
+    pub fn effective_runtime_narrowing(&self) -> Option<ToolRuntimeNarrowing> {
+        merge_runtime_narrowing_sources(
+            self.delegate_runtime_narrowing.clone(),
+            self.requested_runtime_narrowing.clone(),
+        )
     }
 }
 
@@ -3351,6 +3393,68 @@ mod tests {
             empty_primary_with_secondary_result,
             Some(primary_runtime_narrowing)
         );
+    }
+
+    #[test]
+    fn session_tool_runtime_policy_applies_requested_tool_ids_and_effective_narrowing() {
+        let policy = SessionToolRuntimePolicy::new(
+            vec!["browser.open".to_owned(), "web.search".to_owned()],
+            Some(ToolRuntimeNarrowing {
+                browser: BrowserRuntimeNarrowing {
+                    max_sessions: Some(3),
+                    ..BrowserRuntimeNarrowing::default()
+                },
+                web_fetch: WebFetchRuntimeNarrowing {
+                    blocked_domains: BTreeSet::from(["deny-right.example.com".to_owned()]),
+                    ..WebFetchRuntimeNarrowing::default()
+                },
+            }),
+            Some(ToolRuntimeNarrowing {
+                browser: BrowserRuntimeNarrowing {
+                    max_sessions: Some(1),
+                    ..BrowserRuntimeNarrowing::default()
+                },
+                web_fetch: WebFetchRuntimeNarrowing {
+                    blocked_domains: BTreeSet::from(["deny-left.example.com".to_owned()]),
+                    ..WebFetchRuntimeNarrowing::default()
+                },
+            }),
+        );
+
+        let effective_tool_view = policy.apply_to_tool_view(&ToolView::from_tool_names([
+            "browser.open",
+            "web.search",
+            "shell.exec",
+        ]));
+        let effective_runtime_narrowing = policy
+            .effective_runtime_narrowing()
+            .expect("effective runtime narrowing");
+
+        assert_eq!(
+            effective_tool_view.tool_names().collect::<Vec<_>>(),
+            vec!["browser.open", "web.search"]
+        );
+        assert_eq!(effective_runtime_narrowing.browser.max_sessions, Some(1));
+        assert_eq!(
+            effective_runtime_narrowing.web_fetch.blocked_domains,
+            BTreeSet::from([
+                "deny-left.example.com".to_owned(),
+                "deny-right.example.com".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
+    fn session_tool_runtime_policy_ignores_empty_policy_inputs() {
+        let policy = SessionToolRuntimePolicy::new(
+            Vec::new(),
+            Some(ToolRuntimeNarrowing::default()),
+            Some(ToolRuntimeNarrowing::default()),
+        );
+        let base_tool_view = ToolView::from_tool_names(["browser.open", "shell.exec"]);
+
+        assert_eq!(policy.apply_to_tool_view(&base_tool_view), base_tool_view);
+        assert!(policy.effective_runtime_narrowing().is_none());
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -50,7 +50,7 @@ use crate::task_progress::{
 #[cfg(feature = "memory-sqlite")]
 use crate::tools::ToolView;
 #[cfg(feature = "memory-sqlite")]
-use crate::tools::runtime_config::ToolRuntimeNarrowing;
+use crate::tools::runtime_config::{SessionToolRuntimePolicy, ToolRuntimeNarrowing};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
@@ -4990,23 +4990,6 @@ fn session_tool_policy_base_tool_view(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn apply_session_tool_policy_to_tool_view(
-    base_tool_view: &ToolView,
-    session_tool_policy: Option<&SessionToolPolicyRecord>,
-) -> ToolView {
-    let Some(session_tool_policy) = session_tool_policy else {
-        return base_tool_view.clone();
-    };
-    if session_tool_policy.requested_tool_ids.is_empty() {
-        return base_tool_view.clone();
-    }
-
-    let requested_tool_view =
-        ToolView::from_tool_names(session_tool_policy.requested_tool_ids.iter());
-    base_tool_view.intersect(&requested_tool_view)
-}
-
-#[cfg(feature = "memory-sqlite")]
 fn load_session_delegate_runtime_narrowing(
     repo: &SessionRepository,
     session_id: &str,
@@ -5026,16 +5009,20 @@ fn load_session_delegate_runtime_narrowing(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn merge_session_tool_policy_runtime_narrowing(
-    delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+fn session_tool_runtime_policy(
     session_tool_policy: Option<&SessionToolPolicyRecord>,
-) -> Option<ToolRuntimeNarrowing> {
-    let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
+    delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+) -> SessionToolRuntimePolicy {
+    let requested_tool_ids = session_tool_policy
+        .map(|policy| policy.requested_tool_ids.clone())
+        .unwrap_or_default();
+    let requested_runtime_narrowing = session_tool_policy.and_then(|policy| {
         (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
     });
-    super::runtime_config::merge_runtime_narrowing_sources(
+    SessionToolRuntimePolicy::new(
+        requested_tool_ids,
+        requested_runtime_narrowing,
         delegate_runtime_narrowing,
-        policy_runtime_narrowing,
     )
 }
 
@@ -5074,21 +5061,17 @@ pub(crate) fn build_session_tool_policy_status_payload(
 ) -> Result<Value, String> {
     let session_tool_policy = repo.load_session_tool_policy(target_session_id)?;
     let base_tool_view = session_tool_policy_base_tool_view(repo, target_session_id, tool_config)?;
-    let effective_tool_view =
-        apply_session_tool_policy_to_tool_view(&base_tool_view, session_tool_policy.as_ref());
     let delegate_runtime_narrowing =
         load_session_delegate_runtime_narrowing(repo, target_session_id)?;
-    let effective_runtime_narrowing = merge_session_tool_policy_runtime_narrowing(
-        delegate_runtime_narrowing.clone(),
-        session_tool_policy.as_ref(),
-    );
-    let requested_tool_ids = session_tool_policy
-        .as_ref()
-        .map(|policy| policy.requested_tool_ids.clone())
-        .unwrap_or_default();
-    let requested_runtime_narrowing = session_tool_policy.as_ref().and_then(|policy| {
-        (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
-    });
+    let session_tool_runtime_policy =
+        session_tool_runtime_policy(session_tool_policy.as_ref(), delegate_runtime_narrowing);
+    let effective_tool_view = session_tool_runtime_policy.apply_to_tool_view(&base_tool_view);
+    let effective_runtime_narrowing = session_tool_runtime_policy.effective_runtime_narrowing();
+    let SessionToolRuntimePolicy {
+        requested_tool_ids,
+        requested_runtime_narrowing,
+        delegate_runtime_narrowing,
+    } = session_tool_runtime_policy;
     let updated_at = session_tool_policy.as_ref().map(|policy| policy.updated_at);
     let base_tool_ids = tool_view_names(&base_tool_view);
     let effective_tool_ids = tool_view_names(&effective_tool_view);

--- a/crates/daemon/src/session_runtime_truth_cli.rs
+++ b/crates/daemon/src/session_runtime_truth_cli.rs
@@ -196,3 +196,43 @@ fn runtime_truth_summary_limit(
     let scaled_limit = memory_config.sliding_window.saturating_mul(4);
     scaled_limit.clamp(16, 128)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_turn_checkpoint_summary_reports_checkpoint_fields() {
+        let turn_checkpoint = json!({
+            "available": true,
+            "summary": {
+                "session_state": "recovery_ready",
+                "checkpoint_durable": true,
+                "reply_durable": false,
+                "requires_recovery": true,
+                "latest_stage": "finalized",
+                "latest_after_turn": "completed",
+                "latest_compaction": "failed"
+            }
+        });
+
+        let rendered = render_turn_checkpoint_summary(Some(&turn_checkpoint));
+
+        assert_eq!(
+            rendered,
+            "session_state=recovery_ready durable=yes reply_durable=no requires_recovery=yes stage=finalized after_turn=completed compaction=failed"
+        );
+    }
+
+    #[test]
+    fn render_turn_checkpoint_summary_reports_unavailable_errors() {
+        let turn_checkpoint = json!({
+            "available": false,
+            "error": "kernel window unavailable"
+        });
+
+        let rendered = render_turn_checkpoint_summary(Some(&turn_checkpoint));
+
+        assert_eq!(rendered, "unavailable error=kernel window unavailable");
+    }
+}


### PR DESCRIPTION
## Summary

- Problem:
  Runtime-scoped tool policy and standard turn execution had drifted across multiple surfaces, which made autonomy behavior harder to reason about and increased the risk of per-surface divergence.
- Why it matters:
  The runtime should stay governed and flexible through one coherent policy path, and operator/runtime-truth surfaces need direct coverage when they summarize checkpoint state.
- What changed:
  Introduced a typed `SessionToolRuntimePolicy`, reused it across conversation bootstrap and session status/runtime surfaces, refactored standard non-ACP `agent_runtime` result shaping through shared helpers, and added explicit turn-checkpoint renderer tests in `session_runtime_truth_cli.rs`.
- What did not change (scope boundary):
  No broad turn-loop / turn-coordinator redesign, no new config knobs, and no unrelated channel/provider/browser work.

## Linked Issues

- Closes #1407
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [ ] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
rustfmt --check crates/app/src/tools/runtime_config.rs crates/app/src/conversation/runtime.rs crates/app/src/tools/session.rs crates/app/src/agent_runtime.rs crates/daemon/src/session_runtime_truth_cli.rs
./scripts/cargo-local-toolchain.sh test -p loong-app session_tool_runtime_policy -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong render_turn_checkpoint_summary --lib
./scripts/cargo-local-toolchain.sh check -p loong-app --lib
./scripts/cargo-local-toolchain.sh clippy -p loong-app --lib -- -D warnings
```

Results:
- `session_tool_runtime_policy` tests passed in the clean isolated worktree.
- `render_turn_checkpoint_summary` daemon tests passed in the clean isolated worktree.
- `loong-app` library `check` passed.
- `loong-app` library `clippy -D warnings` passed.
- I did not run full workspace/all-features verification on this machine because isolated builds hit disk exhaustion under `/private/tmp`; this PR intentionally stays on the touched runtime seam.

## User-visible / Operator-visible Changes

- Session-scoped tool/runtime policy is now represented through a typed runtime policy path.
- Standard non-ACP runtime turns reuse shared result-shaping helpers instead of per-path duplication.
- Turn-checkpoint runtime-truth summaries now have explicit daemon unit coverage.

## Failure Recovery

- Fast rollback or disable path:
  Revert this commit if session-policy overlay or runtime-truth summary behavior regresses.
- Observable failure symptoms reviewers should watch for:
  Session tool policy status diverging from conversation bootstrap behavior, or checkpoint runtime-truth summaries changing unexpectedly.

## Reviewer Focus

- `crates/app/src/tools/runtime_config.rs`: `SessionToolRuntimePolicy` shape and semantics.
- `crates/app/src/conversation/runtime.rs` and `crates/app/src/tools/session.rs`: shared session-policy overlay application.
- `crates/app/src/agent_runtime.rs`: standard non-ACP turn helper/result-shaping consolidation.
- `crates/daemon/src/session_runtime_truth_cli.rs`: turn-checkpoint renderer coverage and behavior.
