### PR TITLE
Mature agent runtime seams across app-layer turn entrypoints

### DIFF
--- a/crates/app/src/agent_runtime.rs
+++ b/crates/app/src/agent_runtime.rs
@@ -110,10 +110,7 @@ impl AgentRuntime {
         session_hint: Option<&str>,
         request: &AgentTurnRequest,
     ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-
+        require_turn_message(request)?;
         let options = cli_chat_options_for_turn_request(request);
         let runtime = initialize_cli_turn_runtime(
             config_path,
@@ -226,10 +223,7 @@ impl AgentRuntime {
         provider_error_mode: crate::conversation::ProviderErrorMode,
         acp_manager: Option<Arc<crate::acp::AcpSessionManager>>,
     ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-        let message = request.message.as_str();
+        let message = require_turn_message(request)?;
 
         let turn_address = resolved_session_address(runtime, request);
         let explicit_acp_request = runtime.explicit_acp_request
@@ -256,26 +250,22 @@ impl AgentRuntime {
                 acp_manager,
             )
             .await?;
-            let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-            let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
             return match execution.outcome {
                 crate::acp::AcpConversationTurnExecutionOutcome::Succeeded(success) => {
-                    Ok(AgentTurnResult {
-                        session_id: runtime.session_id.clone(),
-                        output_text: success.result.output_text,
-                        turn_mode: request.turn_mode,
-                        governed_session_mode: runtime.conversation_binding().session_mode(),
-                        state: Some(acp_session_state_label(success.result.state).to_owned()),
-                        stop_reason: success
+                    Ok(build_agent_turn_result(
+                        runtime,
+                        request,
+                        success.result.output_text,
+                        Some(acp_session_state_label(success.result.state).to_owned()),
+                        success
                             .result
                             .stop_reason
                             .map(acp_turn_stop_reason_label)
                             .map(ToOwned::to_owned),
-                        usage: success.result.usage,
-                        event_count: success.runtime_events.len(),
-                        prompt_assembly,
-                        prompt_cache,
-                    })
+                        success.result.usage,
+                        success.runtime_events.len(),
+                    )
+                    .await)
                 }
                 crate::acp::AcpConversationTurnExecutionOutcome::Failed(failure) => {
                     Err(failure.error)
@@ -298,21 +288,16 @@ impl AgentRuntime {
                 observer,
             )
             .await?;
-        let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
-        let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
-
-        Ok(AgentTurnResult {
-            session_id: runtime.session_id.clone(),
-            output_text: turn_outcome.reply,
-            turn_mode: request.turn_mode,
-            governed_session_mode: runtime.conversation_binding().session_mode(),
-            state: None,
-            stop_reason: None,
-            usage: turn_outcome.usage,
-            event_count: 0,
-            prompt_assembly,
-            prompt_cache,
-        })
+        Ok(build_agent_turn_result(
+            runtime,
+            request,
+            turn_outcome.reply,
+            None,
+            None,
+            turn_outcome.usage,
+            0,
+        )
+        .await)
     }
 
     pub async fn resume_turn(
@@ -338,19 +323,12 @@ impl AgentRuntime {
         request: &AgentTurnRequest,
         event_sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        require_turn_message(request)?;
+        let runtime = initialize_loaded_config_runtime_for_turn_request(
             resolved_path,
             config,
             session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
+            request,
         )?;
 
         self.run_turn_with_runtime(&runtime, request, event_sink)
@@ -367,19 +345,12 @@ impl AgentRuntime {
         observer: Option<crate::conversation::ConversationTurnObserverHandle>,
         provider_error_mode: crate::conversation::ProviderErrorMode,
     ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        require_turn_message(request)?;
+        let runtime = initialize_loaded_config_runtime_for_turn_request(
             resolved_path,
             config,
             session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
+            request,
         )?;
 
         self.run_turn_with_runtime_and_observer_and_context_and_error_mode(
@@ -409,19 +380,12 @@ impl AgentRuntime {
         event_sink: Option<&dyn AcpTurnEventSink>,
         acp_manager: Arc<crate::acp::AcpSessionManager>,
     ) -> CliResult<AgentTurnResult> {
-        if request.message.trim().is_empty() {
-            return Err("agent runtime message must not be empty".to_owned());
-        }
-
-        let options = cli_chat_options_for_turn_request(request);
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        require_turn_message(request)?;
+        let runtime = initialize_loaded_config_runtime_for_turn_request(
             resolved_path,
             config,
             session_hint,
-            &options,
-            kernel_scope_for_turn_mode(request.turn_mode),
-            crate::chat::CliSessionRequirement::AllowImplicitDefault,
-            false,
+            request,
         )?;
 
         self.run_turn_with_runtime_and_context_and_manager(
@@ -530,6 +494,31 @@ fn cli_chat_options_for_turn_request(request: &AgentTurnRequest) -> CliChatOptio
         acp_bootstrap_mcp_servers: request.acp_bootstrap_mcp_servers.clone(),
         acp_working_directory: normalized_turn_working_directory(request.acp_cwd.as_deref()),
     }
+}
+
+fn require_turn_message(request: &AgentTurnRequest) -> CliResult<&str> {
+    if request.message.trim().is_empty() {
+        return Err("agent runtime message must not be empty".to_owned());
+    }
+    Ok(request.message.as_str())
+}
+
+fn initialize_loaded_config_runtime_for_turn_request(
+    resolved_path: PathBuf,
+    config: crate::config::LoongConfig,
+    session_hint: Option<&str>,
+    request: &AgentTurnRequest,
+) -> CliResult<crate::chat::CliTurnRuntime> {
+    let options = cli_chat_options_for_turn_request(request);
+    initialize_cli_turn_runtime_with_loaded_config(
+        resolved_path,
+        config,
+        session_hint,
+        &options,
+        kernel_scope_for_turn_mode(request.turn_mode),
+        crate::chat::CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
 }
 
 fn normalized_turn_working_directory(value: Option<&str>) -> Option<std::path::PathBuf> {
@@ -649,6 +638,32 @@ async fn load_runtime_prompt_frame_summary(
     {
         let _ = runtime;
         PromptFrameEventSummary::default()
+    }
+}
+
+async fn build_agent_turn_result(
+    runtime: &crate::chat::CliTurnRuntime,
+    request: &AgentTurnRequest,
+    output_text: String,
+    state: Option<String>,
+    stop_reason: Option<String>,
+    usage: Option<Value>,
+    event_count: usize,
+) -> AgentTurnResult {
+    let prompt_frame_summary = load_runtime_prompt_frame_summary(runtime).await;
+    let (prompt_assembly, prompt_cache) = build_prompt_plans(&prompt_frame_summary);
+
+    AgentTurnResult {
+        session_id: runtime.session_id.clone(),
+        output_text,
+        turn_mode: request.turn_mode,
+        governed_session_mode: runtime.conversation_binding().session_mode(),
+        state,
+        stop_reason,
+        usage,
+        event_count,
+        prompt_assembly,
+        prompt_cache,
     }
 }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -941,29 +941,9 @@ async fn process_cli_chat_input(
     }
 
     let agent_runtime = crate::agent_runtime::AgentRuntime::new();
+    let turn_request = build_interactive_agent_turn_request(runtime, input, event_sink);
     let turn_result = agent_runtime
-        .run_turn_with_runtime(
-            runtime,
-            &crate::agent_runtime::AgentTurnRequest {
-                message: input.to_owned(),
-                turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
-                channel_id: runtime.session_address.channel_id.clone(),
-                account_id: runtime.session_address.account_id.clone(),
-                conversation_id: runtime.session_address.conversation_id.clone(),
-                participant_id: runtime.session_address.participant_id.clone(),
-                thread_id: runtime.session_address.thread_id.clone(),
-                metadata: BTreeMap::new(),
-                acp: runtime.explicit_acp_request,
-                acp_event_stream: event_sink.is_some(),
-                acp_bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
-                acp_cwd: runtime
-                    .effective_working_directory
-                    .as_ref()
-                    .map(|path| path.display().to_string()),
-                live_surface_enabled: true,
-            },
-            event_sink,
-        )
+        .run_turn_with_runtime(runtime, &turn_request, event_sink)
         .await?;
 
     Ok(CliChatLoopControl::AssistantText(turn_result.output_text))
@@ -1052,55 +1032,69 @@ pub(crate) async fn run_cli_turn_with_address_and_ingress_and_error_mode_outcome
     observer_override: Option<ConversationTurnObserverHandle>,
 ) -> CliResult<crate::conversation::ConversationTurnOutcome> {
     let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
-    let acp_options = if runtime.explicit_acp_request {
-        AcpConversationTurnOptions::explicit()
-    } else {
-        AcpConversationTurnOptions::automatic()
-    }
-    .with_event_sink(event_sink)
-    .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
-    .with_working_directory(runtime.effective_working_directory.as_deref())
-    .with_metadata(metadata)
-    .with_provenance(provenance);
-    let live_surface_observer = if let Some(observer) = observer_override {
-        Some(observer)
-    } else if live_surface_enabled {
-        let render_width = detect_cli_chat_render_width();
-        Some(build_cli_chat_live_surface_observer(render_width))
-    } else {
-        None
-    };
+    let acp_options = build_cli_turn_acp_options(runtime, event_sink, metadata, provenance);
+    let live_surface_observer = resolve_cli_turn_observer(live_surface_enabled, observer_override);
+    let runtime_binding = runtime.conversation_binding();
+
+    execute_cli_turn_outcome(
+        runtime,
+        &turn_config,
+        address,
+        input,
+        provider_error_mode,
+        &acp_options,
+        runtime_binding,
+        ingress,
+        live_surface_observer,
+    )
+    .await
+}
+
+async fn execute_cli_turn_outcome(
+    runtime: &CliTurnRuntime,
+    turn_config: &LoongConfig,
+    address: &ConversationSessionAddress,
+    input: &str,
+    provider_error_mode: ProviderErrorMode,
+    acp_options: &AcpConversationTurnOptions<'_>,
+    runtime_binding: ConversationRuntimeBinding<'_>,
+    ingress: Option<&ConversationIngressContext>,
+    live_surface_observer: Option<ConversationTurnObserverHandle>,
+) -> CliResult<crate::conversation::ConversationTurnOutcome> {
     if let Some(ingress) = ingress {
-        runtime
+        let reply = runtime
             .turn_coordinator
             .handle_turn_with_address_and_acp_options_and_ingress_and_observer(
-                &turn_config,
+                turn_config,
                 address,
                 input,
                 provider_error_mode,
-                &acp_options,
-                runtime.conversation_binding(),
+                acp_options,
+                runtime_binding,
                 Some(ingress),
                 live_surface_observer,
             )
-            .await
-            .map(|reply| crate::conversation::ConversationTurnOutcome { reply, usage: None })
-    } else {
-        runtime
-            .turn_coordinator
-            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_outcome(
-                &turn_config,
-                address,
-                input,
-                provider_error_mode,
-                &crate::conversation::DefaultConversationRuntime::from_config_or_env(&turn_config)?,
-                &acp_options,
-                runtime.conversation_binding(),
-                None,
-                live_surface_observer,
-            )
-            .await
+            .await?;
+        let outcome = crate::conversation::ConversationTurnOutcome { reply, usage: None };
+        return Ok(outcome);
     }
+
+    let conversation_runtime =
+        crate::conversation::DefaultConversationRuntime::from_config_or_env(turn_config)?;
+    runtime
+        .turn_coordinator
+        .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer_outcome(
+            turn_config,
+            address,
+            input,
+            provider_error_mode,
+            &conversation_runtime,
+            acp_options,
+            runtime_binding,
+            None,
+            live_surface_observer,
+        )
+        .await
 }
 
 fn reload_cli_turn_config(config: &LoongConfig, resolved_path: &Path) -> CliResult<LoongConfig> {
@@ -1108,6 +1102,68 @@ fn reload_cli_turn_config(config: &LoongConfig, resolved_path: &Path) -> CliResu
         return Ok(config.clone());
     }
     config.reload_provider_runtime_state_from_path(resolved_path)
+}
+
+fn build_interactive_agent_turn_request(
+    runtime: &CliTurnRuntime,
+    input: &str,
+    event_sink: Option<&dyn AcpTurnEventSink>,
+) -> crate::agent_runtime::AgentTurnRequest {
+    crate::agent_runtime::AgentTurnRequest {
+        message: input.to_owned(),
+        turn_mode: crate::agent_runtime::AgentTurnMode::Interactive,
+        channel_id: runtime.session_address.channel_id.clone(),
+        account_id: runtime.session_address.account_id.clone(),
+        conversation_id: runtime.session_address.conversation_id.clone(),
+        participant_id: runtime.session_address.participant_id.clone(),
+        thread_id: runtime.session_address.thread_id.clone(),
+        metadata: BTreeMap::new(),
+        acp: runtime.explicit_acp_request,
+        acp_event_stream: event_sink.is_some(),
+        acp_bootstrap_mcp_servers: runtime.effective_bootstrap_mcp_servers.clone(),
+        acp_cwd: runtime
+            .effective_working_directory
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        live_surface_enabled: true,
+    }
+}
+
+fn build_cli_turn_acp_options<'a>(
+    runtime: &'a CliTurnRuntime,
+    event_sink: Option<&'a dyn AcpTurnEventSink>,
+    metadata: Option<&'a BTreeMap<String, String>>,
+    provenance: AcpTurnProvenance<'a>,
+) -> AcpConversationTurnOptions<'a> {
+    let base_options = if runtime.explicit_acp_request {
+        AcpConversationTurnOptions::explicit()
+    } else {
+        AcpConversationTurnOptions::automatic()
+    };
+
+    base_options
+        .with_event_sink(event_sink)
+        .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
+        .with_working_directory(runtime.effective_working_directory.as_deref())
+        .with_metadata(metadata)
+        .with_provenance(provenance)
+}
+
+fn resolve_cli_turn_observer(
+    live_surface_enabled: bool,
+    observer_override: Option<ConversationTurnObserverHandle>,
+) -> Option<ConversationTurnObserverHandle> {
+    if let Some(observer) = observer_override {
+        return Some(observer);
+    }
+
+    if !live_surface_enabled {
+        return None;
+    }
+
+    let render_width = detect_cli_chat_render_width();
+    let observer = build_cli_chat_live_surface_observer(render_width);
+    Some(observer)
 }
 
 fn is_exit_command(config: &LoongConfig, input: &str) -> bool {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -893,6 +893,15 @@ impl ProviderTurnRequestTerminalPhase {
     }
 }
 
+#[cfg(test)]
+fn provider_turn_request_error_text(action: &ProviderTurnRequestAction) -> Option<&str> {
+    match action {
+        ProviderTurnRequestAction::Continue { .. } => None,
+        ProviderTurnRequestAction::FinalizeInlineProviderError { reply } => Some(reply.as_str()),
+        ProviderTurnRequestAction::ReturnError { error } => Some(error.as_str()),
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SafeLaneTurnOutcome {
     result: TurnResult,
@@ -2845,6 +2854,17 @@ fn build_turn_loop_circuit_breaker_resolved_turn(
     ResolvedProviderTurn::persist_reply(reply, None, checkpoint)
 }
 
+fn resolve_followup_persisted_reply(
+    continue_phase: &ProviderTurnContinuePhase,
+    preparation: &ProviderTurnPreparation,
+    user_input: &str,
+    reply: String,
+    usage: Option<Value>,
+) -> ResolvedProviderTurn {
+    let checkpoint = continue_phase.checkpoint(preparation, user_input, reply.as_str());
+    ResolvedProviderTurn::persist_reply(reply, usage, checkpoint)
+}
+
 async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
     config: &LoongConfig,
     runtime: &R,
@@ -3229,19 +3249,16 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 config,
                                 runtime,
                                 session_id,
-                                provider_error_text.as_str(),
+                                &provider_error_text,
                                 binding,
                             )
                             .await;
-                            let checkpoint = current_continue_phase.checkpoint(
+                            return resolve_followup_persisted_reply(
+                                &current_continue_phase,
                                 preparation,
                                 user_input,
-                                raw_reply.as_str(),
-                            );
-                            return ResolvedProviderTurn::persist_reply(
                                 raw_reply,
                                 current_continue_phase.lane_execution.provider_usage.clone(),
-                                checkpoint,
                             );
                         }
                     }
@@ -3255,17 +3272,21 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                         raw_reply.as_str(),
                     )
                     .await;
-                    let checkpoint =
-                        current_continue_phase.checkpoint(preparation, user_input, reply.as_str());
-                    return ResolvedProviderTurn::persist_reply(reply, None, checkpoint);
+                    return resolve_followup_persisted_reply(
+                        &current_continue_phase,
+                        preparation,
+                        user_input,
+                        reply,
+                        None,
+                    );
                 }
 
-                let checkpoint =
-                    current_continue_phase.checkpoint(preparation, user_input, raw_reply.as_str());
-                return ResolvedProviderTurn::persist_reply(
+                return resolve_followup_persisted_reply(
+                    &current_continue_phase,
+                    preparation,
+                    user_input,
                     raw_reply,
                     current_continue_phase.lane_execution.provider_usage.clone(),
-                    checkpoint,
                 );
             }
             ReplyLoopDecision::GuardFollowup {
@@ -9529,6 +9550,17 @@ mod tests {
                 panic!("propagated provider error should resolve to return-error outcome")
             }
         }
+    }
+
+    #[test]
+    fn provider_turn_request_error_text_reads_return_error_text() {
+        let action = ProviderTurnRequestAction::ReturnError {
+            error: "timeout".to_owned(),
+        };
+
+        let error_text = provider_turn_request_error_text(&action);
+
+        assert_eq!(error_text, Some("timeout"));
     }
 
     #[test]

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -361,6 +361,11 @@ pub struct TurnTestHarness {
     pub temp_dir: PathBuf,
 }
 
+pub struct TurnTestHarnessBuilder {
+    capabilities: BTreeSet<Capability>,
+    tool_config_override: ToolRuntimeConfig,
+}
+
 impl TurnTestHarness {
     pub fn new() -> Self {
         Self::with_capabilities(BTreeSet::from([
@@ -374,10 +379,24 @@ impl TurnTestHarness {
         Self::with_tool_config(capabilities, ToolRuntimeConfig::default())
     }
 
+    pub fn builder() -> TurnTestHarnessBuilder {
+        TurnTestHarnessBuilder::new()
+    }
+
     /// Construct a harness with a caller-supplied `ToolRuntimeConfig`.
     /// Use this when a test needs specific allow/deny/approval lists rather
     /// than the generic defaults.
     pub fn with_tool_config(
+        capabilities: BTreeSet<Capability>,
+        tool_config_override: ToolRuntimeConfig,
+    ) -> Self {
+        TurnTestHarnessBuilder::new()
+            .capabilities(capabilities)
+            .tool_config(tool_config_override)
+            .build()
+    }
+
+    fn build_with(
         capabilities: BTreeSet<Capability>,
         tool_config_override: ToolRuntimeConfig,
     ) -> Self {
@@ -386,71 +405,13 @@ impl TurnTestHarness {
             std::env::temp_dir().join(format!("loong-integ-{}-{id}", std::process::id()));
         std::fs::create_dir_all(&temp_dir).expect("create temp dir");
 
-        // Merge the caller's overrides with the unique temp dir as file_root.
-        let tool_config = ToolRuntimeConfig {
-            file_root: Some(temp_dir.clone()),
-            config_path: Some(temp_dir.join("loong.toml")),
-            ..tool_config_override
-        };
-
+        let tool_config = build_harness_tool_config(&temp_dir, tool_config_override);
         let audit = Arc::new(InMemoryAuditSink::default());
-        let clock = Arc::new(FixedClock::new(1_700_000_000));
-        let mut kernel =
-            LoongKernel::with_runtime(StaticPolicyEngine::default(), clock, audit.clone());
-
-        let pack = VerticalPackManifest {
-            pack_id: "test-pack".to_owned(),
-            domain: "testing".to_owned(),
-            version: "0.1.0".to_owned(),
-            default_route: ExecutionRoute {
-                harness_kind: HarnessKind::EmbeddedPi,
-                adapter: None,
-            },
-            allowed_connectors: BTreeSet::new(),
-            granted_capabilities: capabilities,
-            metadata: BTreeMap::new(),
-        };
-        kernel.register_pack(pack).expect("register pack");
-        kernel.register_core_tool_adapter(MvpToolAdapter::with_config(tool_config.clone()));
-        kernel
-            .set_default_core_tool_adapter("mvp-tools")
-            .expect("set default adapter");
-
-        // Register policy extensions for unified security enforcement.
-        // Policy rules come exclusively from the runtime config; no hardcoded
-        // lists are injected here.
-        kernel.register_policy_extension(
-            crate::tools::shell_policy_ext::ToolPolicyExtension::from_config(&tool_config),
-        );
-        kernel.register_policy_extension(crate::tools::file_policy_ext::FilePolicyExtension::new(
-            tool_config.file_root,
-        ));
-
-        #[cfg(feature = "memory-sqlite")]
-        {
-            use crate::memory::runtime_config::MemoryRuntimeConfig;
-            let memory_config =
-                MemoryRuntimeConfig::for_sqlite_path(temp_dir.join("memory.sqlite3"));
-            kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
-                memory_config,
-            ));
-            kernel
-                .set_default_core_memory_adapter("mvp-memory")
-                .expect("set default memory adapter");
-        }
-
-        let token = kernel
-            .issue_token("test-pack", "test-agent", 3600)
-            .expect("issue token");
-
-        let ctx = KernelContext {
-            kernel: Arc::new(kernel),
-            token,
-        };
+        let kernel_ctx = build_harness_kernel_context(capabilities, tool_config, audit.clone());
 
         Self {
             engine: TurnEngine::new(1),
-            kernel_ctx: ctx,
+            kernel_ctx,
             audit,
             temp_dir,
         }
@@ -460,6 +421,125 @@ impl TurnTestHarness {
     #[allow(dead_code)]
     pub async fn execute(&self, turn: &ProviderTurn) -> TurnResult {
         self.engine.execute_turn(turn, &self.kernel_ctx).await
+    }
+}
+
+impl TurnTestHarnessBuilder {
+    pub fn new() -> Self {
+        Self {
+            capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::FilesystemRead,
+                Capability::FilesystemWrite,
+            ]),
+            tool_config_override: ToolRuntimeConfig::default(),
+        }
+    }
+
+    pub fn capabilities(mut self, capabilities: BTreeSet<Capability>) -> Self {
+        self.capabilities = capabilities;
+        self
+    }
+
+    pub fn tool_config(mut self, tool_config_override: ToolRuntimeConfig) -> Self {
+        self.tool_config_override = tool_config_override;
+        self
+    }
+
+    pub fn build(self) -> TurnTestHarness {
+        TurnTestHarness::build_with(self.capabilities, self.tool_config_override)
+    }
+}
+
+fn build_harness_tool_config(
+    temp_dir: &std::path::Path,
+    tool_config_override: ToolRuntimeConfig,
+) -> ToolRuntimeConfig {
+    ToolRuntimeConfig {
+        file_root: Some(temp_dir.to_path_buf()),
+        config_path: Some(temp_dir.join("loong.toml")),
+        ..tool_config_override
+    }
+}
+
+fn build_harness_kernel_context(
+    capabilities: BTreeSet<Capability>,
+    tool_config: ToolRuntimeConfig,
+    audit: Arc<InMemoryAuditSink>,
+) -> KernelContext {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    register_harness_pack(&mut kernel, capabilities);
+    register_harness_tool_adapters(&mut kernel, &tool_config);
+    register_harness_memory_adapters(&mut kernel, &tool_config);
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    }
+}
+
+fn register_harness_pack(
+    kernel: &mut LoongKernel<StaticPolicyEngine>,
+    capabilities: BTreeSet<Capability>,
+) {
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: capabilities,
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+}
+
+fn register_harness_tool_adapters(
+    kernel: &mut LoongKernel<StaticPolicyEngine>,
+    tool_config: &ToolRuntimeConfig,
+) {
+    kernel.register_core_tool_adapter(MvpToolAdapter::with_config(tool_config.clone()));
+    kernel
+        .set_default_core_tool_adapter("mvp-tools")
+        .expect("set default adapter");
+
+    kernel.register_policy_extension(
+        crate::tools::shell_policy_ext::ToolPolicyExtension::from_config(tool_config),
+    );
+    kernel.register_policy_extension(crate::tools::file_policy_ext::FilePolicyExtension::new(
+        tool_config.file_root.clone(),
+    ));
+}
+
+fn register_harness_memory_adapters(
+    kernel: &mut LoongKernel<StaticPolicyEngine>,
+    tool_config: &ToolRuntimeConfig,
+) {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        use crate::memory::runtime_config::MemoryRuntimeConfig;
+
+        let sqlite_path = tool_config
+            .config_path
+            .as_ref()
+            .map(|config_path| config_path.with_file_name("memory.sqlite3"))
+            .expect("test harness should always set config_path");
+        let memory_config = MemoryRuntimeConfig::for_sqlite_path(sqlite_path);
+        kernel.register_core_memory_adapter(crate::memory::MvpMemoryAdapter::with_config(
+            memory_config,
+        ));
+        kernel
+            .set_default_core_memory_adapter("mvp-memory")
+            .expect("set default memory adapter");
     }
 }
 

--- a/crates/app/tests/conversation_integration.rs
+++ b/crates/app/tests/conversation_integration.rs
@@ -61,6 +61,33 @@ fn harness_builds_with_invoke_tool_capability() {
 }
 
 #[test]
+fn harness_builder_preserves_custom_capabilities_and_tool_config() {
+    let harness = TurnTestHarness::builder()
+        .capabilities(BTreeSet::from([Capability::MemoryRead]))
+        .tool_config(ToolRuntimeConfig {
+            shell_allow: BTreeSet::from(["echo".to_owned()]),
+            ..ToolRuntimeConfig::default()
+        })
+        .build();
+
+    assert!(
+        harness
+            .kernel_ctx
+            .token
+            .allowed_capabilities
+            .contains(&Capability::MemoryRead)
+    );
+    assert!(
+        !harness
+            .kernel_ctx
+            .token
+            .allowed_capabilities
+            .contains(&Capability::InvokeTool)
+    );
+    assert!(harness.temp_dir.exists());
+}
+
+#[test]
 fn harness_temp_dirs_are_unique() {
     let h1 = TurnTestHarness::new();
     let h2 = TurnTestHarness::new();


### PR DESCRIPTION
## Summary

- Problem:
  App-layer turn entrypoints repeated bootstrap, request-construction, and provider terminal-action logic across the test harness, `AgentRuntime`, `chat`, `ConversationTurnLoop`, and `ConversationTurnCoordinator`.
- Why it matters:
  The duplication makes behavior drift more likely and raises the cost of verifying runtime changes.
- What changed:
  Refactored the app-layer seams in small passes so harness setup, loaded-config turn bootstrap, interactive CLI turn request construction, and provider terminal-action handling are more localized.
- What did not change (scope boundary):
  No new user-facing workflows, no cross-repo architecture rewrite, and no speculative fallback branches.

## Linked Issues

- Closes #1409
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh check -p loong-app --tests
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh clippy -p loong-app --tests -- -D warnings
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong-app --test conversation_integration -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong-app agent_runtime -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong-app turn_loop -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong-app turn_coordinator -- --nocapture
CARGO_TARGET_DIR=<redacted-target-dir> ./scripts/cargo-local-toolchain.sh test -p loong-app chat -- --nocapture
```

## User-visible / Operator-visible Changes

- None. This pass is intended to keep behavior stable while reducing app-layer runtime duplication.

## Failure Recovery

- Fast rollback or disable path:
  Revert the single refactor commit on this branch.
- Observable failure symptoms reviewers should watch for:
  Entry-point behavior drift between `chat`, `AgentRuntime`, `TurnLoop`, and `TurnCoordinator`, especially around ACP routing or provider terminal handling.

## Reviewer Focus

- `crates/app/src/test_support.rs`: harness bootstrap extraction and builder semantics
- `crates/app/src/agent_runtime.rs`: loaded-config entrypoint consolidation and result assembly
- `crates/app/src/chat.rs`: interactive turn request / ACP option / observer helper seams
- `crates/app/src/conversation/turn_coordinator.rs`: provider terminal/followup persisted-reply helpers
