### PR TITLE
Add QR onboarding for the Weixin bridge surface

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -6374,8 +6374,17 @@ mod tests {
 
         assert_eq!(weixin.onboarding.strategy.as_str(), "plugin_bridge");
         assert_eq!(weixin.onboarding.status_command, "loong doctor");
-        assert_eq!(weixin.onboarding.repair_command, None);
+        assert_eq!(
+            weixin.onboarding.repair_command,
+            Some("loong weixin onboard")
+        );
         assert!(weixin.onboarding.setup_hint.contains("ClawBot"));
+        assert!(
+            weixin
+                .onboarding
+                .setup_hint
+                .contains("loong weixin onboard")
+        );
 
         assert_eq!(qqbot.onboarding.strategy.as_str(), "manual_config");
         assert_eq!(qqbot.onboarding.status_command, "loong doctor");

--- a/crates/app/src/channel/registry_bridge.rs
+++ b/crates/app/src/channel/registry_bridge.rs
@@ -145,9 +145,9 @@ const WEIXIN_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
 
 const WEIXIN_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
     strategy: ChannelOnboardingStrategy::PluginBridge,
-    setup_hint: "plugin-bridge weixin surface; connect a compatible WeChat ClawBot or iLink bridge under weixin or weixin.accounts.<account> and let that bridge own the upstream login flow until a native Loong adapter exists",
+    setup_hint: "plugin-bridge weixin surface; run `loong weixin onboard` to provision bridge_url and bridge_access_token through the WeChat ClawBot / iLink QR flow, then let the external bridge or managed plugin keep owning the upstream listener lifecycle",
     status_command: "loong doctor",
-    repair_command: None,
+    repair_command: Some("loong weixin onboard"),
 };
 
 const ONEBOT_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -45,7 +45,7 @@ use account_resolution::*;
 mod validation_support;
 
 use self::validation_support::*;
-pub(crate) use account_resolution::normalize_channel_account_id;
+pub use account_resolution::normalize_channel_account_id;
 #[allow(unused_imports)]
 pub use bridge::{
     OnebotAccountConfig, OnebotChannelConfig, ResolvedOnebotChannelConfig,

--- a/crates/app/src/config/channels_account_resolution.rs
+++ b/crates/app/src/config/channels_account_resolution.rs
@@ -102,7 +102,7 @@ fn parse_env_string_list(raw: &str) -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn normalize_channel_account_id(raw: &str) -> String {
+pub fn normalize_channel_account_id(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return "default".to_owned();

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -51,7 +51,7 @@ pub use channels::{
     TeamsChannelConfig, TelegramAccountConfig, TelegramChannelConfig, TelegramStreamingMode,
     TlonAccountConfig, TlonChannelConfig, TwitchAccountConfig, TwitchChannelConfig,
     WebhookAccountConfig, WebhookChannelConfig, WebhookPayloadFormat, WecomAccountConfig,
-    WecomChannelConfig, WhatsappAccountConfig, WhatsappChannelConfig,
+    WecomChannelConfig, WhatsappAccountConfig, WhatsappChannelConfig, normalize_channel_account_id,
 };
 #[allow(unused_imports)]
 pub(crate) use channels::{
@@ -70,8 +70,7 @@ pub(crate) use channels::{
     WEBHOOK_ENDPOINT_URL_ENV, WEBHOOK_SIGNING_SECRET_ENV, WECOM_BOT_ID_ENV, WECOM_SECRET_ENV,
     WEIXIN_BRIDGE_ACCESS_TOKEN_ENV, WEIXIN_BRIDGE_URL_ENV, WHATSAPP_ACCESS_TOKEN_ENV,
     WHATSAPP_APP_SECRET_ENV, WHATSAPP_PHONE_NUMBER_ID_ENV, WHATSAPP_VERIFY_TOKEN_ENV,
-    normalize_channel_account_id, parse_email_smtp_endpoint, parse_nostr_private_key_hex,
-    parse_nostr_public_key_hex,
+    parse_email_smtp_endpoint, parse_nostr_private_key_hex, parse_nostr_public_key_hex,
 };
 #[allow(unused_imports)]
 pub use conversation::{ConversationConfig, ConversationTurnLoopConfig};

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -40,6 +40,7 @@ impl Commands {
             Self::Chat { .. } => "chat",
             Self::Gateway { .. } => "gateway",
             Self::Feishu { .. } => "feishu",
+            Self::Weixin { .. } => "weixin",
             Self::Completions { .. } => "completions",
         }
     }
@@ -105,6 +106,22 @@ mod tests {
             }
             .command_kind_for_logging(),
             "runtime"
+        );
+        assert_eq!(
+            Commands::Weixin {
+                command: crate::weixin_cli::WeixinCommand::Onboard(
+                    crate::weixin_cli::WeixinOnboardArgs {
+                        common: crate::weixin_cli::WeixinCommonArgs {
+                            config: None,
+                            account: None,
+                            json: false,
+                        },
+                        timeout_s: None,
+                    }
+                )
+            }
+            .command_kind_for_logging(),
+            "weixin"
         );
     }
 }

--- a/crates/daemon/src/configured_account_keys.rs
+++ b/crates/daemon/src/configured_account_keys.rs
@@ -1,0 +1,47 @@
+pub(crate) fn resolve_raw_configured_account_key<'a>(
+    keys: impl IntoIterator<Item = &'a String>,
+    configured_account_id: &str,
+) -> Option<String> {
+    let requested_account_id = configured_account_id.trim();
+    if requested_account_id.is_empty() {
+        return None;
+    }
+
+    let normalized_requested_account_id =
+        crate::mvp::config::normalize_channel_account_id(requested_account_id);
+
+    keys.into_iter().find_map(|raw_key| {
+        let normalized_key = crate::mvp::config::normalize_channel_account_id(raw_key.as_str());
+        if normalized_key == normalized_requested_account_id {
+            return Some(raw_key.clone());
+        }
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn resolve_raw_configured_account_key_matches_display_label_account() {
+        let mut accounts = BTreeMap::new();
+        accounts.insert("Ops Team".to_owned(), 1_u8);
+
+        let resolved = resolve_raw_configured_account_key(accounts.keys(), "ops-team");
+
+        assert_eq!(resolved.as_deref(), Some("Ops Team"));
+    }
+
+    #[test]
+    fn resolve_raw_configured_account_key_returns_none_for_missing_account() {
+        let mut accounts = BTreeMap::new();
+        accounts.insert("Ops Team".to_owned(), 1_u8);
+
+        let resolved = resolve_raw_configured_account_key(accounts.keys(), "alerts");
+
+        assert_eq!(resolved, None);
+    }
+}

--- a/crates/daemon/src/feishu_onboarding.rs
+++ b/crates/daemon/src/feishu_onboarding.rs
@@ -7,6 +7,7 @@ use qrcode::render::unicode;
 use serde_json::Value;
 
 use crate::CliResult;
+use crate::configured_account_keys::resolve_raw_configured_account_key;
 use crate::feishu_support::load_feishu_daemon_context;
 use crate::mvp;
 
@@ -252,8 +253,11 @@ fn apply_credentials_to_selected_account(
     credentials: &FeishuOnboardCredentials,
     options: FeishuOnboardApplyOptions,
 ) {
-    let account_override = channel.accounts.get_mut(configured_account_id);
-    if let Some(account) = account_override {
+    let raw_account_key =
+        resolve_raw_configured_account_key(channel.accounts.keys(), configured_account_id);
+    if let Some(raw_account_key) = raw_account_key.as_deref()
+        && let Some(account) = channel.accounts.get_mut(raw_account_key)
+    {
         account.enabled = Some(true);
         account.app_id = Some(SecretRef::Inline(credentials.app_id.clone()));
         account.app_secret = Some(SecretRef::Inline(credentials.app_secret.clone()));
@@ -307,8 +311,11 @@ fn apply_owner_bootstrap_access(
         return false;
     };
 
-    let account_override = channel.accounts.get_mut(configured_account_id);
-    if let Some(account) = account_override {
+    let raw_account_key =
+        resolve_raw_configured_account_key(channel.accounts.keys(), configured_account_id);
+    if let Some(raw_account_key) = raw_account_key.as_deref()
+        && let Some(account) = channel.accounts.get_mut(raw_account_key)
+    {
         let chats_unset = account
             .allowed_chat_ids
             .as_ref()
@@ -877,6 +884,78 @@ mod tests {
 
         assert!(applied);
         let account = config.accounts.get("work").expect("named account");
+        assert_eq!(
+            account.allowed_chat_ids.clone().unwrap_or_default(),
+            vec!["*".to_owned()]
+        );
+        assert_eq!(
+            account.allowed_sender_ids.clone().unwrap_or_default(),
+            vec!["ou_owner_1".to_owned()]
+        );
+    }
+
+    #[test]
+    fn apply_credentials_to_selected_account_updates_display_label_named_account() {
+        let mut config = mvp::config::FeishuChannelConfig {
+            accounts: BTreeMap::from([(
+                "Work Bot".to_owned(),
+                mvp::config::FeishuAccountConfig::default(),
+            )]),
+            ..mvp::config::FeishuChannelConfig::default()
+        };
+
+        apply_credentials_to_selected_account(
+            &mut config,
+            "work-bot",
+            &FeishuOnboardCredentials {
+                app_id: "cli_work_123".to_owned(),
+                app_secret: "work_secret_123".to_owned(),
+                verification_token: None,
+                encrypt_key: None,
+            },
+            FeishuOnboardApplyOptions {
+                domain: mvp::config::FeishuDomain::Feishu,
+                mode: mvp::config::FeishuChannelServeMode::Websocket,
+            },
+        );
+
+        let account = config.accounts.get("Work Bot").expect("named account");
+        assert_eq!(account.enabled, Some(true));
+        assert_eq!(
+            account
+                .app_id
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("cli_work_123")
+        );
+        assert_eq!(
+            account
+                .app_secret
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("work_secret_123")
+        );
+    }
+
+    #[test]
+    fn apply_owner_bootstrap_access_updates_display_label_named_account() {
+        let mut config = mvp::config::FeishuChannelConfig {
+            accounts: BTreeMap::from([(
+                "Work Bot".to_owned(),
+                mvp::config::FeishuAccountConfig::default(),
+            )]),
+            ..mvp::config::FeishuChannelConfig::default()
+        };
+
+        let applied = apply_owner_bootstrap_access(
+            &mut config,
+            "work-bot",
+            FeishuOnboardCredentialSource::QrRegistration,
+            Some("ou_owner_1"),
+        );
+
+        assert!(applied);
+        let account = config.accounts.get("Work Bot").expect("named account");
         assert_eq!(
             account.allowed_chat_ids.clone().unwrap_or_default(),
             vec!["*".to_owned()]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -128,6 +128,7 @@ mod cli_handoff;
 mod cli_json;
 mod command_kind;
 pub mod completions_cli;
+mod configured_account_keys;
 mod control_plane_server;
 mod copilot_onboarding;
 pub mod debug_cli;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -187,6 +187,8 @@ mod tool_calling_readiness;
 pub mod trajectory_cli;
 mod turn_cli;
 pub mod update_cli;
+pub mod weixin_cli;
+mod weixin_onboarding;
 pub mod work_unit_cli;
 pub use self::acp_cli::{
     acp_backend_metadata_json, acp_binding_scope_json, acp_control_plane_json,
@@ -942,6 +944,11 @@ pub enum Commands {
     Feishu {
         #[command(subcommand)]
         command: feishu_cli::FeishuCommand,
+    },
+    /// Run the Weixin bridge onboarding namespace
+    Weixin {
+        #[command(subcommand)]
+        command: weixin_cli::WeixinCommand,
     },
     /// Print a shell completion script to stdout
     Completions {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -547,6 +547,7 @@ async fn run_command(command: Commands) -> CliResult<()> {
         }
         Commands::Gateway { command } => gateway::service::run_gateway_cli(command).await,
         Commands::Feishu { command } => feishu_cli::run_feishu_command(command).await,
+        Commands::Weixin { command } => weixin_cli::run_weixin_command(command).await,
         Commands::Completions { shell } => {
             completions_cli::run_completions_cli(completions_cli::CompletionsCommandOptions {
                 shell,

--- a/crates/daemon/src/weixin_cli.rs
+++ b/crates/daemon/src/weixin_cli.rs
@@ -1,0 +1,240 @@
+use std::path::{Path, PathBuf};
+
+use clap::{Args, Subcommand};
+use loong_spec::CliResult;
+use serde_json::{Value, json};
+
+use crate::mvp;
+use crate::weixin_onboarding::onboard_via_qr_registration;
+
+#[derive(Subcommand, Debug)]
+pub enum WeixinCommand {
+    /// Start the Weixin / iLink QR onboarding flow and save the resulting bridge contract
+    Onboard(WeixinOnboardArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct WeixinCommonArgs {
+    #[arg(long)]
+    pub config: Option<String>,
+    #[arg(long)]
+    pub account: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct WeixinOnboardArgs {
+    #[command(flatten)]
+    pub common: WeixinCommonArgs,
+    #[arg(long)]
+    pub timeout_s: Option<u64>,
+}
+
+pub fn run_weixin_command(
+    command: WeixinCommand,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = CliResult<()>> + Send>> {
+    Box::pin(async move {
+        match command {
+            WeixinCommand::Onboard(args) => {
+                let payload = execute_weixin_onboard(&args).await?;
+                print_weixin_payload(&payload, args.common.json, render_onboard_text)?;
+            }
+        }
+        Ok(())
+    })
+}
+
+pub async fn execute_weixin_onboard(args: &WeixinOnboardArgs) -> CliResult<Value> {
+    ensure_weixin_onboard_config_exists(args.common.config.as_deref())?;
+
+    let result = onboard_via_qr_registration(
+        args.common.config.as_deref(),
+        args.common.account.as_deref(),
+        args.timeout_s,
+    )
+    .await?;
+
+    let serve_command = if result.configured_account_id == "default" {
+        "loong channels serve weixin".to_owned()
+    } else {
+        format!(
+            "loong channels serve weixin --account {}",
+            result.configured_account_id
+        )
+    };
+    let mut notes = vec![
+        "run `loong doctor` to verify the saved Weixin bridge contract and managed bridge discovery"
+            .to_owned(),
+        "QR onboarding writes the iLink bridge_url and bot_token directly into loong.toml; the long-lived reply loop still stays in the external bridge or managed plugin"
+            .to_owned(),
+    ];
+    if result.owner_contact_bootstrap_applied {
+        if let Some(user_id) = result.user_id.as_deref() {
+            notes.push(format!(
+                "defaulted `allowed_contact_ids = [\"{user_id}\"]` so the onboarding account can start a direct chat immediately"
+            ));
+        }
+    } else {
+        notes.push(
+            "keep `allowed_contact_ids` explicit before running the long-lived bridge reply loop in production"
+                .to_owned(),
+        );
+    }
+    notes.push(
+        "if several compatible managed bridges are installed, pin `weixin.managed_bridge_plugin_id` before production serve"
+            .to_owned(),
+    );
+
+    Ok(json!({
+        "account_id": result.runtime_account_id,
+        "configured_account": result.configured_account_label,
+        "configured_account_id": result.configured_account_id,
+        "config": result.config_path,
+        "credential_source": "qr_registration",
+        "bridge_url": result.bridge_url,
+        "bot_id": result.bot_id,
+        "user_id": result.user_id,
+        "qr_url": result.qr_url,
+        "qr_rendered": result.qr_rendered,
+        "owner_contact_bootstrap_applied": result.owner_contact_bootstrap_applied,
+        "serve_command": serve_command,
+        "status_command": "loong doctor",
+        "notes": notes,
+    }))
+}
+
+#[allow(clippy::print_stdout)]
+fn print_weixin_payload(
+    payload: &Value,
+    as_json: bool,
+    render_text: fn(&Value) -> CliResult<String>,
+) -> CliResult<()> {
+    if as_json {
+        let encoded = serde_json::to_string_pretty(payload)
+            .map_err(|error| format!("serialize weixin command output failed: {error}"))?;
+        println!("{encoded}");
+        return Ok(());
+    }
+    println!("{}", render_text(payload)?);
+    Ok(())
+}
+
+fn render_onboard_text(payload: &Value) -> CliResult<String> {
+    let mut lines = vec![
+        "weixin onboard".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!("config: {}", required_json_string(payload, "config")?),
+        format!(
+            "credential_source: {}",
+            required_json_string(payload, "credential_source")?
+        ),
+        format!(
+            "bridge_url: {}",
+            required_json_string(payload, "bridge_url")?
+        ),
+    ]);
+    if let Some(bot_id) = payload.get("bot_id").and_then(Value::as_str) {
+        lines.push(format!("bot_id: {bot_id}"));
+    }
+    if let Some(user_id) = payload.get("user_id").and_then(Value::as_str) {
+        lines.push(format!("user_id: {user_id}"));
+    }
+    if let Some(qr_url) = payload.get("qr_url").and_then(Value::as_str) {
+        lines.push(format!("qr_url: {qr_url}"));
+    }
+    lines.push(format!(
+        "serve_command: {}",
+        required_json_string(payload, "serve_command")?
+    ));
+    lines.push(format!(
+        "status_command: {}",
+        required_json_string(payload, "status_command")?
+    ));
+    if let Some(notes) = payload.get("notes").and_then(Value::as_array) {
+        for note in notes.iter().filter_map(Value::as_str) {
+            lines.push(format!("note: {note}"));
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+fn required_json_string<'a>(payload: &'a Value, key: &str) -> CliResult<&'a str> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("weixin command output missing `{key}`"))
+}
+
+fn active_cli_command_name() -> &'static str {
+    mvp::config::active_cli_command_name()
+}
+
+fn ensure_weixin_onboard_config_exists(raw: Option<&str>) -> CliResult<PathBuf> {
+    let path = raw
+        .map(PathBuf::from)
+        .unwrap_or_else(mvp::config::default_config_path);
+    verify_weixin_onboard_config_exists(&path)
+}
+
+fn verify_weixin_onboard_config_exists(path: &Path) -> CliResult<PathBuf> {
+    if path.exists() {
+        return Ok(path.to_path_buf());
+    }
+
+    let cli = active_cli_command_name();
+    Err(format!(
+        "config file {} not found; run `{cli} onboard` to complete initial configuration before running `{cli} weixin onboard`",
+        path.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_onboard_text_includes_qr_registration_summary() {
+        let payload = json!({
+            "account_id": "bot-ops",
+            "configured_account": "ops",
+            "config": "/tmp/loong.toml",
+            "credential_source": "qr_registration",
+            "bridge_url": "https://bridge.example.test",
+            "bot_id": "bot-ops",
+            "user_id": "wxid-ops",
+            "qr_url": "https://scan.example/qr",
+            "serve_command": "loong channels serve weixin --account ops",
+            "status_command": "loong doctor",
+            "notes": [
+                "run `loong doctor`",
+                "defaulted `allowed_contact_ids`"
+            ]
+        });
+
+        let rendered = render_onboard_text(&payload).expect("render onboard text");
+
+        assert!(rendered.contains("weixin onboard"));
+        assert!(rendered.contains("account: bot-ops"));
+        assert!(rendered.contains("bridge_url: https://bridge.example.test"));
+        assert!(rendered.contains("serve_command: loong channels serve weixin --account ops"));
+        assert!(rendered.contains("note: run `loong doctor`"));
+    }
+
+    #[test]
+    fn verify_weixin_onboard_config_exists_reports_bootstrap_hint() {
+        let missing = PathBuf::from("/tmp/loong-weixin-missing.toml");
+        let error =
+            verify_weixin_onboard_config_exists(&missing).expect_err("missing config should fail");
+
+        assert!(error.contains("loong onboard"));
+        assert!(error.contains("loong weixin onboard"));
+    }
+}

--- a/crates/daemon/src/weixin_onboarding.rs
+++ b/crates/daemon/src/weixin_onboarding.rs
@@ -1,0 +1,835 @@
+use std::time::Duration;
+
+use loong_contracts::SecretRef;
+use qrcode::QrCode;
+use qrcode::render::unicode;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde_json::Value;
+
+use crate::CliResult;
+use crate::mvp;
+
+const DEFAULT_WEIXIN_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
+const DEFAULT_ONBOARD_TIMEOUT_S: u64 = 600;
+const DEFAULT_ONBOARD_REQUEST_TIMEOUT_S: u64 = 10;
+const DEFAULT_POLL_INTERVAL_S: u64 = 1;
+const MAX_QR_REFRESH_COUNT: u8 = 3;
+const WEIXIN_CHANNEL_VERSION: &str = "2.1.1";
+const ILINK_APP_ID: &str = "bot";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeixinQrRegistrationResult {
+    pub bridge_url: String,
+    pub bot_token: String,
+    pub bot_id: Option<String>,
+    pub user_id: Option<String>,
+    pub qr_url: String,
+    pub qr_rendered: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeixinOnboardResult {
+    pub config_path: String,
+    pub configured_account_id: String,
+    pub configured_account_label: String,
+    pub runtime_account_id: String,
+    pub bridge_url: String,
+    pub bot_id: Option<String>,
+    pub user_id: Option<String>,
+    pub qr_url: String,
+    pub qr_rendered: bool,
+    pub owner_contact_bootstrap_applied: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WeixinQrCode {
+    id: String,
+    scan_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WeixinQrPollStatus {
+    status: String,
+    bot_token: Option<String>,
+    bot_id: Option<String>,
+    user_id: Option<String>,
+    bridge_url: Option<String>,
+    redirect_host: Option<String>,
+}
+
+pub async fn onboard_via_qr_registration(
+    config_path: Option<&str>,
+    account: Option<&str>,
+    timeout_s: Option<u64>,
+) -> CliResult<WeixinOnboardResult> {
+    let result = qr_register(
+        DEFAULT_WEIXIN_BASE_URL,
+        timeout_s.unwrap_or(DEFAULT_ONBOARD_TIMEOUT_S),
+    )
+    .await?
+    .ok_or_else(|| "Weixin / iLink QR registration did not complete".to_owned())?;
+
+    apply_onboard_result_to_config(config_path, account, &result)
+}
+
+pub fn render_qr_instructions(url: &str, qr_rendered: bool) -> Vec<String> {
+    if qr_rendered {
+        return vec![
+            "Scan the QR code above with WeChat on your phone.".to_owned(),
+            format!("If the terminal QR is unreadable, open this scan URL instead: {url}"),
+            "Loong will keep polling until iLink returns the bridge token and runtime base URL."
+                .to_owned(),
+        ];
+    }
+
+    vec![format!(
+        "Open or scan this WeChat / iLink QR URL to activate the bridge: {url}"
+    )]
+}
+
+fn apply_onboard_result_to_config(
+    config_path: Option<&str>,
+    account: Option<&str>,
+    result: &WeixinQrRegistrationResult,
+) -> CliResult<WeixinOnboardResult> {
+    let (config_path, mut config) = mvp::config::load(config_path)?;
+    let configured_account_id = ensure_selected_account_exists(&mut config.weixin, account)?;
+    let owner_contact_bootstrap_applied =
+        apply_registration_to_selected_account(&mut config.weixin, &configured_account_id, result);
+    let resolved = config
+        .weixin
+        .resolve_account(Some(configured_account_id.as_str()))?;
+
+    let config_path_string = config_path.display().to_string();
+    let saved_path = mvp::config::write(Some(config_path_string.as_str()), &config, true)?;
+
+    Ok(WeixinOnboardResult {
+        config_path: saved_path.display().to_string(),
+        configured_account_id: resolved.configured_account_id,
+        configured_account_label: resolved.configured_account_label,
+        runtime_account_id: resolved.account.id,
+        bridge_url: result.bridge_url.clone(),
+        bot_id: result.bot_id.clone(),
+        user_id: result.user_id.clone(),
+        qr_url: result.qr_url.clone(),
+        qr_rendered: result.qr_rendered,
+        owner_contact_bootstrap_applied,
+    })
+}
+
+fn ensure_selected_account_exists(
+    channel: &mut mvp::config::WeixinChannelConfig,
+    account: Option<&str>,
+) -> CliResult<String> {
+    let Some(configured_account_id) = trimmed_opt(account).map(str::to_owned) else {
+        return Ok(channel.default_configured_account_id());
+    };
+
+    if channel
+        .accounts
+        .contains_key(configured_account_id.as_str())
+    {
+        return Ok(configured_account_id);
+    }
+
+    let should_promote_to_default = channel.accounts.is_empty()
+        && channel.default_account.is_none()
+        && !root_weixin_account_is_materially_configured(channel);
+    channel.accounts.insert(
+        configured_account_id.clone(),
+        mvp::config::WeixinAccountConfig::default(),
+    );
+    if should_promote_to_default {
+        channel.default_account = Some(configured_account_id.clone());
+    }
+
+    Ok(configured_account_id)
+}
+
+fn apply_registration_to_selected_account(
+    channel: &mut mvp::config::WeixinChannelConfig,
+    configured_account_id: &str,
+    result: &WeixinQrRegistrationResult,
+) -> bool {
+    let preferred_runtime_account_id = preferred_runtime_account_id(result);
+
+    if let Some(account) = channel.accounts.get_mut(configured_account_id) {
+        account.enabled = Some(true);
+        account.bridge_url = Some(result.bridge_url.clone());
+        account.bridge_url_env = None;
+        account.bridge_access_token = Some(SecretRef::Inline(result.bot_token.clone()));
+        account.bridge_access_token_env = None;
+        if account.account_id.as_deref().is_none_or(is_blank)
+            && let Some(runtime_account_id) = preferred_runtime_account_id.as_deref()
+        {
+            account.account_id = Some(runtime_account_id.to_owned());
+        }
+        return apply_user_bootstrap_to_account(account, result.user_id.as_deref());
+    }
+
+    channel.enabled = true;
+    channel.bridge_url = Some(result.bridge_url.clone());
+    channel.bridge_url_env = None;
+    channel.bridge_access_token = Some(SecretRef::Inline(result.bot_token.clone()));
+    channel.bridge_access_token_env = None;
+    if channel.account_id.as_deref().is_none_or(is_blank)
+        && let Some(runtime_account_id) = preferred_runtime_account_id.as_deref()
+    {
+        channel.account_id = Some(runtime_account_id.to_owned());
+    }
+    apply_user_bootstrap_to_root(channel, result.user_id.as_deref())
+}
+
+fn apply_user_bootstrap_to_account(
+    account: &mut mvp::config::WeixinAccountConfig,
+    user_id: Option<&str>,
+) -> bool {
+    let Some(user_id) = user_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let ids_unset = account
+        .allowed_contact_ids
+        .as_ref()
+        .is_none_or(|values| values.is_empty());
+    if !ids_unset {
+        return false;
+    }
+    account.allowed_contact_ids = Some(vec![user_id.to_owned()]);
+    true
+}
+
+fn apply_user_bootstrap_to_root(
+    channel: &mut mvp::config::WeixinChannelConfig,
+    user_id: Option<&str>,
+) -> bool {
+    let Some(user_id) = user_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    if !channel.allowed_contact_ids.is_empty() {
+        return false;
+    }
+    channel.allowed_contact_ids = vec![user_id.to_owned()];
+    true
+}
+
+fn root_weixin_account_is_materially_configured(
+    channel: &mvp::config::WeixinChannelConfig,
+) -> bool {
+    channel.enabled
+        || channel
+            .account_id
+            .as_deref()
+            .is_some_and(|value| !is_blank(value))
+        || channel
+            .bridge_url
+            .as_deref()
+            .is_some_and(|value| !is_blank(value))
+        || channel.bridge_access_token.is_some()
+        || !channel.allowed_contact_ids.is_empty()
+}
+
+fn preferred_runtime_account_id(result: &WeixinQrRegistrationResult) -> Option<String> {
+    result
+        .bot_id
+        .as_deref()
+        .and_then(|value| trimmed_opt(Some(value)))
+        .or_else(|| {
+            result
+                .user_id
+                .as_deref()
+                .and_then(|value| trimmed_opt(Some(value)))
+        })
+        .map(str::to_owned)
+}
+
+async fn qr_register(
+    initial_base_url: &str,
+    timeout_s: u64,
+) -> CliResult<Option<WeixinQrRegistrationResult>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_ONBOARD_REQUEST_TIMEOUT_S))
+        .build()
+        .map_err(|error| format!("build Weixin / iLink onboarding client failed: {error}"))?;
+
+    print!("  Requesting Weixin / iLink QR code...");
+    let mut qr_code = fetch_qr_code(&client, initial_base_url).await?;
+    println!(" done.");
+    println!();
+
+    let qr_rendered = render_terminal_qr(qr_code.scan_url.as_str());
+    for line in render_qr_instructions(qr_code.scan_url.as_str(), qr_rendered) {
+        println!("  {line}");
+    }
+    println!();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_s.max(1));
+    let mut current_poll_base_url = initial_base_url.to_owned();
+    let mut refresh_count = 0_u8;
+    let mut poll_count = 0_u64;
+
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            if poll_count > 0 {
+                println!();
+            }
+            return Ok(None);
+        }
+
+        let poll_result =
+            poll_qr_status(&client, current_poll_base_url.as_str(), qr_code.id.as_str()).await;
+        let status = match poll_result {
+            Ok(status) => status,
+            Err(QrPollError::Retryable(_)) => {
+                tokio::time::sleep(Duration::from_secs(DEFAULT_POLL_INTERVAL_S)).await;
+                continue;
+            }
+            Err(QrPollError::Fatal(message)) => return Err(message),
+        };
+
+        poll_count = poll_count.saturating_add(1);
+        if poll_count == 1 {
+            print!("  Waiting for QR confirmation...");
+        } else if poll_count.is_multiple_of(6) {
+            print!(".");
+        }
+
+        match status.status.as_str() {
+            "confirmed" => {
+                let bot_token = status
+                    .bot_token
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| {
+                        "Weixin / iLink confirmed the QR scan but did not return `bot_token`"
+                            .to_owned()
+                    })?;
+                let bridge_url = status
+                    .bridge_url
+                    .as_deref()
+                    .and_then(normalize_base_url)
+                    .unwrap_or_else(|| current_poll_base_url.clone());
+                println!();
+                return Ok(Some(WeixinQrRegistrationResult {
+                    bridge_url,
+                    bot_token,
+                    bot_id: status
+                        .bot_id
+                        .and_then(|value| trimmed_opt(Some(value.as_str())).map(str::to_owned)),
+                    user_id: status
+                        .user_id
+                        .and_then(|value| trimmed_opt(Some(value.as_str())).map(str::to_owned)),
+                    qr_url: qr_code.scan_url,
+                    qr_rendered,
+                }));
+            }
+            "scaned_but_redirect" => {
+                if let Some(redirected) =
+                    status.redirect_host.as_deref().and_then(normalize_base_url)
+                    && redirected != current_poll_base_url
+                {
+                    current_poll_base_url = redirected;
+                }
+            }
+            "expired" => {
+                refresh_count = refresh_count.saturating_add(1);
+                if refresh_count > MAX_QR_REFRESH_COUNT {
+                    println!();
+                    return Ok(None);
+                }
+                println!();
+                qr_code = fetch_qr_code(&client, initial_base_url).await?;
+                current_poll_base_url = initial_base_url.to_owned();
+                let _ = render_terminal_qr(qr_code.scan_url.as_str());
+                for line in render_qr_instructions(qr_code.scan_url.as_str(), qr_rendered) {
+                    println!("  {line}");
+                }
+            }
+            _ => {}
+        }
+
+        tokio::time::sleep(Duration::from_secs(DEFAULT_POLL_INTERVAL_S)).await;
+    }
+}
+
+async fn fetch_qr_code(client: &reqwest::Client, base_url: &str) -> CliResult<WeixinQrCode> {
+    let payload = api_get_json(
+        client,
+        base_url,
+        "ilink/bot/get_bot_qrcode",
+        &[("bot_type".to_owned(), "3".to_owned())],
+    )
+    .await?;
+    let qrcode = required_string(&payload, "qrcode", "Weixin / iLink QR response")?;
+    let scan_url =
+        optional_string(&payload, "qrcode_img_content").unwrap_or_else(|| qrcode.clone());
+
+    Ok(WeixinQrCode {
+        id: qrcode,
+        scan_url,
+    })
+}
+
+async fn poll_qr_status(
+    client: &reqwest::Client,
+    base_url: &str,
+    qr_code: &str,
+) -> Result<WeixinQrPollStatus, QrPollError> {
+    let payload = api_get_json_with_retry(
+        client,
+        base_url,
+        "ilink/bot/get_qrcode_status",
+        &[("qrcode".to_owned(), qr_code.to_owned())],
+    )
+    .await?;
+
+    Ok(WeixinQrPollStatus {
+        status: optional_string(&payload, "status").unwrap_or_default(),
+        bot_token: optional_string(&payload, "bot_token"),
+        bot_id: optional_string(&payload, "ilink_bot_id"),
+        user_id: optional_string(&payload, "ilink_user_id"),
+        bridge_url: optional_string(&payload, "baseurl"),
+        redirect_host: optional_string(&payload, "redirect_host"),
+    })
+}
+
+async fn api_get_json(
+    client: &reqwest::Client,
+    base_url: &str,
+    endpoint: &str,
+    query: &[(String, String)],
+) -> CliResult<Value> {
+    let url = build_endpoint_url(base_url, endpoint)?;
+    let response = client
+        .get(url.clone())
+        .query(query)
+        .headers(build_ilink_headers(None)?)
+        .send()
+        .await
+        .map_err(|error| format!("Weixin / iLink request to {endpoint} failed: {error}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("read Weixin / iLink response for {endpoint} failed: {error}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "Weixin / iLink request to {endpoint} failed with {status}: {body}"
+        ));
+    }
+    serde_json::from_str(&body)
+        .map_err(|error| format!("decode Weixin / iLink response for {endpoint} failed: {error}"))
+}
+
+async fn api_get_json_with_retry(
+    client: &reqwest::Client,
+    base_url: &str,
+    endpoint: &str,
+    query: &[(String, String)],
+) -> Result<Value, QrPollError> {
+    let url = build_endpoint_url(base_url, endpoint).map_err(QrPollError::Fatal)?;
+    let response = client
+        .get(url.clone())
+        .query(query)
+        .headers(build_ilink_headers(None).map_err(QrPollError::Fatal)?)
+        .send()
+        .await
+        .map_err(|error| {
+            if error.is_timeout() || error.is_connect() || error.is_request() || error.is_body() {
+                QrPollError::Retryable(format!(
+                    "Weixin / iLink polling request to {endpoint} failed: {error}"
+                ))
+            } else {
+                QrPollError::Fatal(format!(
+                    "Weixin / iLink polling request to {endpoint} failed: {error}"
+                ))
+            }
+        })?;
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        QrPollError::Fatal(format!(
+            "read Weixin / iLink polling response for {endpoint} failed: {error}"
+        ))
+    })?;
+    if status.is_server_error() {
+        return Err(QrPollError::Retryable(format!(
+            "Weixin / iLink polling request to {endpoint} returned {status}: {body}"
+        )));
+    }
+    if !status.is_success() {
+        return Err(QrPollError::Fatal(format!(
+            "Weixin / iLink polling request to {endpoint} failed with {status}: {body}"
+        )));
+    }
+    serde_json::from_str(&body).map_err(|error| {
+        QrPollError::Fatal(format!(
+            "decode Weixin / iLink polling response for {endpoint} failed: {error}"
+        ))
+    })
+}
+
+fn build_endpoint_url(base_url: &str, endpoint: &str) -> CliResult<String> {
+    let normalized_base_url = normalize_base_url(base_url)
+        .ok_or_else(|| format!("invalid Weixin / iLink base url `{base_url}`"))?;
+    Ok(format!(
+        "{}/{}",
+        normalized_base_url.trim_end_matches('/'),
+        endpoint.trim_start_matches('/'),
+    ))
+}
+
+fn build_ilink_headers(auth_token: Option<&str>) -> CliResult<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "X-WECHAT-UIN",
+        HeaderValue::from_str(random_wechat_uin().as_str())
+            .map_err(|error| format!("build Weixin / iLink X-WECHAT-UIN header failed: {error}"))?,
+    );
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        "AuthorizationType",
+        HeaderValue::from_static("ilink_bot_token"),
+    );
+    headers.insert("iLink-App-Id", HeaderValue::from_static(ILINK_APP_ID));
+    let client_version = build_client_version(WEIXIN_CHANNEL_VERSION).to_string();
+    headers.insert(
+        "iLink-App-ClientVersion",
+        HeaderValue::from_str(client_version.as_str()).map_err(|error| {
+            format!("build Weixin / iLink client version header failed: {error}")
+        })?,
+    );
+    if let Some(auth_token) = auth_token.map(str::trim).filter(|value| !value.is_empty()) {
+        let value = format!("Bearer {auth_token}");
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(value.as_str()).map_err(|error| {
+                format!("build Weixin / iLink Authorization header failed: {error}")
+            })?,
+        );
+    }
+    Ok(headers)
+}
+
+fn build_client_version(version: &str) -> u32 {
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or_default();
+    let minor = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or_default();
+    let patch = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or_default();
+    ((major & 0xFF) << 16) | ((minor & 0xFF) << 8) | (patch & 0xFF)
+}
+
+fn random_wechat_uin() -> String {
+    use base64::Engine as _;
+
+    let raw = u32::from_be_bytes(rand::random::<[u8; 4]>());
+    base64::engine::general_purpose::STANDARD.encode(raw.to_string())
+}
+
+fn render_terminal_qr(url: &str) -> bool {
+    let Some(rendered) = encode_terminal_qr(url) else {
+        return false;
+    };
+    println!("{rendered}");
+    true
+}
+
+fn encode_terminal_qr(url: &str) -> Option<String> {
+    let code = QrCode::new(url.as_bytes()).ok()?;
+    let rendered = code
+        .render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .quiet_zone(true)
+        .build();
+    let trimmed = rendered.trim().to_owned();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn normalize_base_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let candidate = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_owned()
+    } else {
+        format!("https://{trimmed}")
+    };
+    let parsed = reqwest::Url::parse(candidate.as_str()).ok()?;
+    let mut normalized = format!("{}://{}", parsed.scheme(), parsed.host_str()?);
+    if let Some(port) = parsed.port() {
+        normalized.push(':');
+        normalized.push_str(port.to_string().as_str());
+    }
+    Some(normalized)
+}
+
+fn required_string(payload: &Value, field: &str, context: &str) -> CliResult<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| format!("{context} missing `{field}`"))
+}
+
+fn optional_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn trimmed_opt(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn is_blank(raw: &str) -> bool {
+    raw.trim().is_empty()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QrPollError {
+    Retryable(String),
+    Fatal(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::extract::{Query, State};
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Default)]
+    struct QrServerState {
+        status_responses: Arc<Mutex<Vec<Value>>>,
+        status_hosts: Arc<Mutex<Vec<String>>>,
+        qr_requests: Arc<Mutex<u32>>,
+    }
+
+    #[tokio::test]
+    async fn qr_register_handles_redirect_then_confirmation() {
+        let redirect_server = spawn_static_json_server(json!({
+            "status": "confirmed",
+            "bot_token": "token-2",
+            "ilink_bot_id": "bot-2",
+            "ilink_user_id": "wxid-owner",
+            "baseurl": "https://bridge.redirect.test"
+        }))
+        .await;
+        let state = QrServerState {
+            status_responses: Arc::new(Mutex::new(vec![json!({
+                "status": "scaned_but_redirect",
+                "redirect_host": redirect_server
+            })])),
+            ..QrServerState::default()
+        };
+        let base_url = spawn_qr_server(state.clone()).await;
+
+        let result = qr_register(base_url.as_str(), 5)
+            .await
+            .expect("qr register");
+        let result = result.expect("registration result");
+
+        assert_eq!(result.bot_id.as_deref(), Some("bot-2"));
+        assert_eq!(result.user_id.as_deref(), Some("wxid-owner"));
+        assert_eq!(result.bot_token, "token-2");
+        assert_eq!(result.bridge_url, "https://bridge.redirect.test");
+        assert!(!result.qr_url.is_empty());
+
+        let hosts = state.status_hosts.lock().await.clone();
+        assert!(hosts.iter().any(|host| host.contains("127.0.0.1")));
+    }
+
+    #[tokio::test]
+    async fn apply_registration_updates_root_channel_and_bootstraps_owner() {
+        let temp = tempdir().expect("tempdir");
+        let config_path = temp.path().join("loong.toml");
+        mvp::config::write_template(Some(config_path.to_string_lossy().as_ref()), true)
+            .expect("write template");
+
+        let result = apply_onboard_result_to_config(
+            Some(config_path.to_string_lossy().as_ref()),
+            None,
+            &WeixinQrRegistrationResult {
+                bridge_url: "https://bridge.example.test".to_owned(),
+                bot_token: "token-root".to_owned(),
+                bot_id: Some("bot-root".to_owned()),
+                user_id: Some("wxid-root".to_owned()),
+                qr_url: "https://scan.example/qr".to_owned(),
+                qr_rendered: true,
+            },
+        )
+        .expect("apply onboarding");
+
+        let (_, config) =
+            mvp::config::load(Some(result.config_path.as_str())).expect("load config");
+        assert!(config.weixin.enabled);
+        assert_eq!(
+            config.weixin.bridge_url.as_deref(),
+            Some("https://bridge.example.test")
+        );
+        assert_eq!(
+            config
+                .weixin
+                .bridge_access_token
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("token-root")
+        );
+        assert_eq!(config.weixin.account_id.as_deref(), Some("bot-root"));
+        assert_eq!(
+            config.weixin.allowed_contact_ids,
+            vec!["wxid-root".to_owned()]
+        );
+        assert!(result.owner_contact_bootstrap_applied);
+        assert_eq!(result.runtime_account_id, "bot-root");
+    }
+
+    #[test]
+    fn apply_registration_updates_named_account_and_sets_first_default_account() {
+        let mut channel = mvp::config::WeixinChannelConfig::default();
+        let configured_account_id =
+            ensure_selected_account_exists(&mut channel, Some("ops")).expect("account selection");
+        assert_eq!(configured_account_id, "ops");
+        assert_eq!(channel.default_account.as_deref(), Some("ops"));
+
+        let applied = apply_registration_to_selected_account(
+            &mut channel,
+            "ops",
+            &WeixinQrRegistrationResult {
+                bridge_url: "https://bridge.example.test".to_owned(),
+                bot_token: "token-ops".to_owned(),
+                bot_id: Some("bot-ops".to_owned()),
+                user_id: Some("wxid-ops".to_owned()),
+                qr_url: "https://scan.example/qr".to_owned(),
+                qr_rendered: false,
+            },
+        );
+
+        let account = channel.accounts.get("ops").expect("named account");
+        assert_eq!(account.enabled, Some(true));
+        assert_eq!(
+            account.bridge_url.as_deref(),
+            Some("https://bridge.example.test")
+        );
+        assert_eq!(
+            account
+                .bridge_access_token
+                .as_ref()
+                .and_then(SecretRef::inline_literal_value),
+            Some("token-ops")
+        );
+        assert_eq!(account.account_id.as_deref(), Some("bot-ops"));
+        assert_eq!(
+            account.allowed_contact_ids.clone().unwrap_or_default(),
+            vec!["wxid-ops".to_owned()]
+        );
+        assert!(applied);
+    }
+
+    #[test]
+    fn render_qr_instructions_mentions_scan_url_when_qr_is_rendered() {
+        let rendered = render_qr_instructions("https://scan.example/qr", true).join("\n");
+        assert!(rendered.contains("Scan the QR code above"));
+        assert!(rendered.contains("https://scan.example/qr"));
+    }
+
+    #[test]
+    fn encode_terminal_qr_returns_non_empty_unicode_art() {
+        let rendered =
+            encode_terminal_qr("https://scan.example/qr?device=1").expect("qr should render");
+        assert!(!rendered.is_empty());
+        assert!(rendered.lines().count() >= 10);
+    }
+
+    #[test]
+    fn build_client_version_encodes_semver_components() {
+        assert_eq!(build_client_version("2.1.1"), 0x0002_0101);
+        assert_eq!(build_client_version("2.1.0"), 0x0002_0100);
+    }
+
+    async fn spawn_qr_server(state: QrServerState) -> String {
+        async fn handle_qr(
+            State(state): State<QrServerState>,
+            Query(_query): Query<HashMap<String, String>>,
+        ) -> Json<Value> {
+            let mut qr_requests = state.qr_requests.lock().await;
+            *qr_requests += 1;
+            let qr_id = format!("qr-{}", *qr_requests);
+            Json(json!({
+                "qrcode": qr_id,
+                "qrcode_img_content": "https://scan.example/activate"
+            }))
+        }
+
+        async fn handle_status(
+            State(state): State<QrServerState>,
+            Query(_query): Query<HashMap<String, String>>,
+            request: axum::extract::Request,
+        ) -> Json<Value> {
+            let host = request
+                .headers()
+                .get("host")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            state.status_hosts.lock().await.push(host);
+            let mut responses = state.status_responses.lock().await;
+            let response = if responses.is_empty() {
+                json!({"status": "wait"})
+            } else {
+                responses.remove(0)
+            };
+            Json(response)
+        }
+
+        let app = Router::new()
+            .route("/ilink/bot/get_bot_qrcode", get(handle_qr))
+            .route("/ilink/bot/get_qrcode_status", get(handle_status))
+            .with_state(state);
+        spawn_router(app).await
+    }
+
+    async fn spawn_static_json_server(payload: Value) -> String {
+        let app = Router::new().route(
+            "/ilink/bot/get_qrcode_status",
+            get(move || {
+                let payload = payload.clone();
+                async move { Json(payload) }
+            }),
+        );
+        spawn_router(app).await
+    }
+
+    async fn spawn_router(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        format!("http://{}", addr)
+    }
+}

--- a/crates/daemon/src/weixin_onboarding.rs
+++ b/crates/daemon/src/weixin_onboarding.rs
@@ -7,6 +7,7 @@ use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde_json::Value;
 
 use crate::CliResult;
+use crate::configured_account_keys::resolve_raw_configured_account_key;
 use crate::mvp;
 
 const DEFAULT_WEIXIN_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
@@ -121,14 +122,14 @@ fn ensure_selected_account_exists(
     channel: &mut mvp::config::WeixinChannelConfig,
     account: Option<&str>,
 ) -> CliResult<String> {
-    let Some(configured_account_id) = trimmed_opt(account).map(str::to_owned) else {
+    let Some(requested_account_label) = trimmed_opt(account) else {
         return Ok(channel.default_configured_account_id());
     };
 
-    if channel
-        .accounts
-        .contains_key(configured_account_id.as_str())
-    {
+    let configured_account_id = mvp::config::normalize_channel_account_id(requested_account_label);
+    let existing_raw_account_key =
+        resolve_raw_configured_account_key(channel.accounts.keys(), configured_account_id.as_str());
+    if existing_raw_account_key.is_some() {
         return Ok(configured_account_id);
     }
 
@@ -136,11 +137,11 @@ fn ensure_selected_account_exists(
         && channel.default_account.is_none()
         && !root_weixin_account_is_materially_configured(channel);
     channel.accounts.insert(
-        configured_account_id.clone(),
+        requested_account_label.to_owned(),
         mvp::config::WeixinAccountConfig::default(),
     );
     if should_promote_to_default {
-        channel.default_account = Some(configured_account_id.clone());
+        channel.default_account = Some(requested_account_label.to_owned());
     }
 
     Ok(configured_account_id)
@@ -152,8 +153,12 @@ fn apply_registration_to_selected_account(
     result: &WeixinQrRegistrationResult,
 ) -> bool {
     let preferred_runtime_account_id = preferred_runtime_account_id(result);
+    let raw_account_key =
+        resolve_raw_configured_account_key(channel.accounts.keys(), configured_account_id);
 
-    if let Some(account) = channel.accounts.get_mut(configured_account_id) {
+    if let Some(raw_account_key) = raw_account_key.as_deref()
+        && let Some(account) = channel.accounts.get_mut(raw_account_key)
+    {
         account.enabled = Some(true);
         account.bridge_url = Some(result.bridge_url.clone());
         account.bridge_url_env = None;
@@ -742,6 +747,53 @@ mod tests {
                 .and_then(SecretRef::inline_literal_value),
             Some("token-ops")
         );
+        assert_eq!(account.account_id.as_deref(), Some("bot-ops"));
+        assert_eq!(
+            account.allowed_contact_ids.clone().unwrap_or_default(),
+            vec!["wxid-ops".to_owned()]
+        );
+        assert!(applied);
+    }
+
+    #[test]
+    fn ensure_selected_account_exists_reuses_existing_display_label_account() {
+        let mut channel = mvp::config::WeixinChannelConfig::default();
+        channel.accounts.insert(
+            "Ops Team".to_owned(),
+            mvp::config::WeixinAccountConfig::default(),
+        );
+
+        let configured_account_id = ensure_selected_account_exists(&mut channel, Some("ops-team"))
+            .expect("account selection");
+
+        assert_eq!(configured_account_id, "ops-team");
+        assert_eq!(channel.accounts.len(), 1);
+        assert!(channel.accounts.contains_key("Ops Team"));
+    }
+
+    #[test]
+    fn apply_registration_updates_display_label_named_account() {
+        let mut channel = mvp::config::WeixinChannelConfig::default();
+        channel.accounts.insert(
+            "Ops Team".to_owned(),
+            mvp::config::WeixinAccountConfig::default(),
+        );
+
+        let applied = apply_registration_to_selected_account(
+            &mut channel,
+            "ops-team",
+            &WeixinQrRegistrationResult {
+                bridge_url: "https://bridge.example.test".to_owned(),
+                bot_token: "token-ops".to_owned(),
+                bot_id: Some("bot-ops".to_owned()),
+                user_id: Some("wxid-ops".to_owned()),
+                qr_url: "https://scan.example/qr".to_owned(),
+                qr_rendered: false,
+            },
+        );
+
+        let account = channel.accounts.get("Ops Team").expect("named account");
+        assert_eq!(account.enabled, Some(true));
         assert_eq!(account.account_id.as_deref(), Some("bot-ops"));
         assert_eq!(
             account.allowed_contact_ids.clone().unwrap_or_default(),

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -9031,6 +9031,12 @@ fn build_channel_onboarding_follow_up_lines_reports_manual_and_planned_channels(
             && line.contains("repair_command=\"loong feishu onboard\"")
     }));
     assert!(lines.iter().any(|line| {
+        line.contains("Weixin [weixin]")
+            && line.contains("strategy=plugin_bridge")
+            && line.contains("repair_command=\"loong weixin onboard\"")
+            && line.contains("ClawBot")
+    }));
+    assert!(lines.iter().any(|line| {
         line.contains("Discord [discord]")
             && line.contains("selection_order=40")
             && line.contains("selection_label=\"community server bot\"")

--- a/site/use-loong/channel-guides/index.mdx
+++ b/site/use-loong/channel-guides/index.mdx
@@ -51,7 +51,7 @@ These surfaces are already real Loong channel contracts, but the active runtime 
 
 | Surface | Transport | Current operator path | Runtime owner |
 | --- | --- | --- | --- |
-| [Weixin](/use-loong/channel-guides/weixin) | wechat_clawbot_ilink_bridge | configure bridge contract + run `loong doctor` / `loong channels` | external plugin |
+| [Weixin](/use-loong/channel-guides/weixin) | wechat_clawbot_ilink_bridge | run `loong weixin onboard`, then verify with `loong doctor` / `loong channels` | external plugin |
 | [QQ Bot](/use-loong/channel-guides/qqbot) | qq_official_bot_gateway_or_plugin_bridge | configure bridge contract + run `loong doctor` / `loong channels` | external plugin |
 | [OneBot](/use-loong/channel-guides/onebot) | onebot_v11_bridge | configure bridge contract + run `loong doctor` / `loong channels` | external plugin |
 

--- a/site/use-loong/channel-guides/weixin.mdx
+++ b/site/use-loong/channel-guides/weixin.mdx
@@ -5,7 +5,23 @@ description: Configure the Weixin plugin-backed bridge surface in Loong.
 
 # Weixin
 
-This is a shipped plugin-backed bridge surface. The channel contract is real and operator-visible, but the active listener and login lifecycle stay in an external bridge or managed plugin rather than a built-in Loong `*-serve` runtime.
+This is a shipped plugin-backed bridge surface. The channel contract is real and operator-visible, and Loong now ships a QR bootstrap flow for provisioning the sanctioned iLink bridge token and base URL. The long-lived listener still stays in an external bridge or managed plugin rather than a built-in Loong `*-serve` runtime.
+
+## Recommended First Run
+
+```bash
+loong weixin onboard
+```
+
+What this does:
+
+- requests a fresh WeChat / iLink QR code
+- renders the QR directly in the terminal when possible
+- polls until iLink returns the `bot_token`, `baseurl`, and bound bot or user ids
+- writes `weixin.bridge_url` plus `weixin.bridge_access_token` into `loong.toml`
+- bootstraps `allowed_contact_ids = ["<ilink_user_id>"]` when that trust boundary is still empty
+
+Use `loong weixin onboard --account ops` when you want the credentials written into `weixin.accounts.ops`.
 
 ## At A Glance
 
@@ -43,6 +59,7 @@ allowed_contact_ids = ["wxid_ops"]
 ## Smoke Test
 
 ```bash
+loong weixin onboard
 loong channels
 loong channels --json
 loong doctor
@@ -51,6 +68,7 @@ loong doctor
 What success looks like:
 
 - `loong channels` lists `Weixin [weixin]` under the plugin-backed section
+- `loong weixin onboard` prints the saved bridge url plus the next `channels serve weixin` command
 - the managed bridge discovery line selects one compatible plugin or explains exactly why discovery is incomplete or ambiguous
 - `loong doctor` reports the bridge contract as ready, or gives a bounded remediation path
 
@@ -58,6 +76,7 @@ What success looks like:
 
 | Operation | Current path | Usage or status |
 | --- | --- | --- |
+| QR bridge bootstrap | `weixin onboard` | provisions `bridge_url` and `bridge_access_token` through the sanctioned iLink QR flow |
 | managed bridge contract check | `loong doctor` | current readiness and remediation surface |
 | inventory + discovery inspection | `loong channels` | current operator inventory surface |
 | bridge-backed send | `channels send weixin` | executes through the selected managed bridge runtime; target contract stays `weixin:<account>:contact:<id>` or `weixin:<account>:room:<id>` |
@@ -111,12 +130,15 @@ Use Loong here for:
 ## Operator Notes
 
 - Keep `allowed_contact_ids` tight. Treat it as the trust boundary, not a convenience list.
+- `loong weixin onboard` is the recommended first-run path because it provisions the sanctioned `bridge_url` and `bridge_access_token` pair without asking operators to copy the raw iLink response by hand.
 - Loong validates `allowed_contact_ids` locally before forwarding a contact send through the managed bridge runtime.
+- If `allowed_contact_ids` is still empty during QR onboarding, Loong bootstraps it with the scanned `ilink_user_id` so the onboarding account can validate the lane immediately.
 - `channels serve weixin` retries transient managed bridge runtime failures with bounded backoff; repeated failures still surface as a hard error so the bridge can be inspected.
 - `channels serve weixin --stop` requests a cooperative shutdown for the currently selected managed bridge runtime owner.
 - When duplicate runtime owners appear, Loong automatically keeps the preferred live runtime owner and requests cooperative shutdown for the older duplicates when the winner is clear.
 - `channels serve weixin --stop-duplicates` remains the operator fallback when duplicate runtime owners persist and you want Loong to keep the preferred live runtime owner while draining the others.
 - While it is retrying, `loong doctor` and `loong channels` surface the current failure count and last bridge error.
+- QR onboarding does not install the bridge plugin for you. Managed bridge execution still needs `[runtime_plugins].enabled = true`, one or more `runtime_plugins.roots`, and either one compatible bridge or an explicit `managed_bridge_plugin_id`.
 - Prefer one explicit managed bridge per environment. If discovery is ambiguous, fix the ambiguity instead of relying on accidental selection.
 - If you need multiple bridge identities, move to `default_account` plus `accounts.<id>` before inventing ad-hoc routes.
 

--- a/site/use-loong/channel-setup.mdx
+++ b/site/use-loong/channel-setup.mdx
@@ -93,7 +93,7 @@ and upstream session lifecycle stay in an external bridge or managed plugin.
 
 | Surface | What you configure first | Current operator path |
 | --- | --- | --- |
-| Weixin | `weixin.enabled`, `bridge_url`, `bridge_access_token`, `allowed_contact_ids` | `loong doctor`, `loong channels`, `loong channels send weixin`, `loong channels serve weixin`, managed bridge discovery |
+| Weixin | `weixin.enabled`, `bridge_url`, `bridge_access_token`, `allowed_contact_ids` | `loong weixin onboard`, `loong doctor`, `loong channels`, `loong channels send weixin`, `loong channels serve weixin`, managed bridge discovery |
 | QQ Bot | `qqbot.enabled`, `app_id`, `client_secret`, `allowed_peer_ids` | `loong doctor`, `loong channels`, `loong channels send qqbot`, `loong channels serve qqbot`, managed bridge discovery |
 | OneBot | `onebot.enabled`, `websocket_url`, `access_token`, `allowed_group_ids` | `loong doctor`, `loong channels`, `loong channels send onebot`, `loong channels serve onebot`, managed bridge discovery |
 
@@ -174,6 +174,7 @@ same shipped contract.
 
 Weixin is a bridge-first surface:
 
+- start with `loong weixin onboard` when you want Loong to request the iLink QR code and save the resulting `bridge_url` plus `bridge_access_token` for you
 - configure `bridge_url` plus `bridge_access_token`
 - keep `allowed_contact_ids` explicit because the bridge contract should stay narrow
 - optional `managed_bridge_plugin_id` is the tie-breaker when several compatible managed bridges are installed


### PR DESCRIPTION
## Summary

- Problem:
  - The shipped Weixin bridge surface still required operators to manually copy raw iLink QR login results into `loong.toml` before the managed bridge send/serve path became usable.
- Why it matters:
  - That manual handoff made the WeChat / ClawBot / iLink lane look less mature than it really is and left the first-run path inconsistent with Loong's other guided onboarding surfaces.
- What changed:
  - Added `loong weixin onboard` as a first-run QR onboarding flow for the Weixin bridge surface.
  - The CLI now requests a fresh iLink QR code, renders it in the terminal, follows redirect-based polling, captures `bot_token` plus `baseurl`, and writes the sanctioned `weixin.bridge_url` / `weixin.bridge_access_token` contract into `loong.toml`.
  - When the trust boundary is still empty, onboarding bootstraps `allowed_contact_ids` with the scanned `ilink_user_id` so the operator can validate the lane immediately.
  - For named accounts, onboarding creates or updates `weixin.accounts.<account>`, promotes the first named account to `default_account` when appropriate, and fills the runtime `account_id` from the scanned bot/user identity.
  - Updated channel onboarding metadata and docs so the operator-facing repair/setup path points at `loong weixin onboard` instead of a generic plugin-bridge hint.
- What did not change (scope boundary):
  - This does not add a native Loong Weixin long-poll runtime. The long-lived listener and reply loop still belong to the external bridge or managed plugin.

## Linked Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh test -p loong weixin_onboarding -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong weixin_cli -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong-app resolve_channel_catalog_entry_exposes_onboarding_contracts -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong build_channel_onboarding_follow_up_lines_reports_manual_and_planned_channels -- --nocapture
./scripts/cargo-local-toolchain.sh test -p loong command_kind_for_logging_uses_stable_variant_names -- --nocapture
./scripts/cargo-local-toolchain.sh test --workspace
./scripts/cargo-local-toolchain.sh test --workspace --all-features

All commands passed locally.

Additional behavior checks:
- unit coverage exercises QR redirect handling, QR confirmation, root-account writeback, named-account writeback, default-account promotion, QR rendering, and onboarding text rendering
- onboarding metadata follow-up coverage now asserts that Weixin advertises `repair_command="loong weixin onboard"`
- the full workspace/all-features runs also covered completion output and command-tree parsing, which now include the new `weixin` namespace

Before / after behavior:
- Before: operators had to obtain the iLink QR result externally and copy `bridge_url` / `bridge_access_token` into `loong.toml` by hand; Weixin onboarding metadata exposed no direct repair command
- After: `loong weixin onboard` performs the QR flow, persists the sanctioned bridge contract, bootstraps the first allowed contact when unset, and is surfaced as the repair/setup command in catalog and onboarding summaries

Process-global env handling:
- tests that mutate environment reuse the repo's scoped env helpers and restore state through the existing serialized test support path
```

## User-visible / Operator-visible Changes

- Weixin now has a real first-run command: `loong weixin onboard`
- The command prints the QR scan URL, saves the selected bridge contract, and points the operator at the next `loong channels serve weixin` step
- Channel inventory/onboarding surfaces now direct operators to `loong weixin onboard` instead of a generic plugin-bridge hint
- Public docs now describe the Weixin lane as QR-bootstrapped and bridge-first instead of implying that only a manual config handoff exists

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR, or remove the persisted `weixin.bridge_url` / `weixin.bridge_access_token` values and fall back to manual config entry
- Observable failure symptoms reviewers should watch for:
  - `loong weixin onboard` fails to parse iLink QR responses
  - named-account onboarding writes the credentials into the wrong scope
  - onboarding over-widens `allowed_contact_ids` instead of keeping it pinned to the scanned user when previously empty

## Reviewer Focus

- `crates/daemon/src/weixin_onboarding.rs`
  - QR polling, redirect handling, config writeback, allowlist bootstrap, and named-account/default-account behavior
- `crates/daemon/src/weixin_cli.rs`
  - operator payload/rendering and config existence guardrails
- `crates/app/src/channel/registry_bridge.rs` and `crates/app/src/channel/registry.rs`
  - onboarding metadata now points at the real repair/setup flow
- `site/use-loong/channel-guides/weixin.mdx`
  - public docs should match the shipped command surface exactly without implying a native listener runtime
