### PR TITLE
Deepen onboarding bootstrap and follow-up maturity

### DIFF
--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -23,21 +23,20 @@ use time::OffsetDateTime;
 use tokio::task::JoinHandle;
 
 use crate::CliResult;
+use crate::channel::resolve_channel_onboarding_descriptor;
 use crate::chat::CliChatOptions;
 use crate::chat::CliTurnRuntime;
 use crate::chat::control_plane::ChatControlPlaneStore;
 use crate::config::{
     InitiativeLevel, LoongConfig, MemoryProfile, PersonalizationConfig, PersonalizationPromptState,
-    ProviderConfig, ProviderKind, ReasoningEffort, ResponseDensity, normalize_web_search_provider,
+    ProviderAuthScheme, ProviderConfig, ProviderKind, ProviderProfileConfig, ReasoningEffort,
+    ResponseDensity, normalize_web_search_provider, service_channel_descriptors,
     web_search_provider_api_key_env_names, web_search_provider_descriptor,
 };
 use crate::tools::bundled_preinstall_targets;
 use crate::tui_surface::{TuiCalloutTone, TuiKeyValueSpec, TuiMessageSpec, TuiSectionSpec};
 
-use super::command_palette::{
-    CommandAction, CommandPalette, SettingsCommandAction, SettingsEntry, SettingsSurfaceFocus,
-    SkillEntry, slash_command_specs,
-};
+use super::command_palette::{CommandAction, CommandPalette, SkillEntry, slash_command_specs};
 use super::composer::Composer;
 use super::i18n::{I18nService, Language, SurfaceCopy, resolve_default_language};
 use super::message_list::{MessageList, StartupEyeAnimation, StartupEyeFocus};
@@ -97,14 +96,44 @@ impl StartupOnboardingStage {
         Self::Finish,
     ];
 
-    fn title(self) -> &'static str {
+    fn title(self, language: Language) -> &'static str {
         match self {
-            Self::Language => "language",
+            Self::Language => match language {
+                Language::ZhCn => "语言",
+                Language::ZhTw => "語言",
+                Language::Ja => "言語",
+                Language::Ru => "язык",
+                Language::En => "language",
+            },
             Self::Provider => "provider",
-            Self::Skills => "skills",
-            Self::SetupPath => "continue setup",
-            Self::Personalization => "first chat style",
-            Self::Finish => "ready to chat",
+            Self::Skills => match language {
+                Language::ZhCn => "技能",
+                Language::ZhTw => "技能",
+                Language::Ja => "スキル",
+                Language::Ru => "навыки",
+                Language::En => "skills",
+            },
+            Self::SetupPath => match language {
+                Language::ZhCn => "后续配置",
+                Language::ZhTw => "後續配置",
+                Language::Ja => "続きの設定",
+                Language::Ru => "дальше настроить",
+                Language::En => "continue setup",
+            },
+            Self::Personalization => match language {
+                Language::ZhCn => "首轮风格",
+                Language::ZhTw => "首輪風格",
+                Language::Ja => "最初の会話スタイル",
+                Language::Ru => "стиль первого хода",
+                Language::En => "first chat style",
+            },
+            Self::Finish => match language {
+                Language::ZhCn => "准备开聊",
+                Language::ZhTw => "準備開聊",
+                Language::Ja => "チャット開始",
+                Language::Ru => "готово к чату",
+                Language::En => "ready to chat",
+            },
         }
     }
 
@@ -130,37 +159,124 @@ impl StartupOnboardingStage {
             Self::Finish => Self::Finish,
         }
     }
+
+    fn previous(self) -> Self {
+        match self {
+            Self::Language => Self::Language,
+            Self::Provider => Self::Language,
+            Self::Skills => Self::Provider,
+            Self::SetupPath => Self::Skills,
+            Self::Personalization => Self::SetupPath,
+            Self::Finish => Self::Personalization,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StartupSetupPathChoice {
     ChatNow,
     ProviderAndWeb,
+    ChannelsAndDelivery,
     McpAndSkills,
 }
 
 impl StartupSetupPathChoice {
-    const ALL: [Self; 3] = [Self::ChatNow, Self::ProviderAndWeb, Self::McpAndSkills];
+    const ALL: [Self; 4] = [
+        Self::ChatNow,
+        Self::ProviderAndWeb,
+        Self::ChannelsAndDelivery,
+        Self::McpAndSkills,
+    ];
 
-    fn label(self) -> &'static str {
+    fn label(self, language: Language) -> &'static str {
         match self {
-            Self::ChatNow => "chat now",
-            Self::ProviderAndWeb => "provider + web setup",
-            Self::McpAndSkills => "MCP + workspace setup",
+            Self::ChatNow => match language {
+                Language::ZhCn => "先聊天",
+                Language::ZhTw => "先聊天",
+                Language::Ja => "まず会話",
+                Language::Ru => "сначала чат",
+                Language::En => "chat now",
+            },
+            Self::ProviderAndWeb => match language {
+                Language::ZhCn => "provider + web 配置",
+                Language::ZhTw => "provider + web 配置",
+                Language::Ja => "provider + web 設定",
+                Language::Ru => "provider + web настройка",
+                Language::En => "provider + web setup",
+            },
+            Self::ChannelsAndDelivery => match language {
+                Language::ZhCn => "channels + delivery",
+                Language::ZhTw => "channels + delivery",
+                Language::Ja => "channels + delivery",
+                Language::Ru => "channels + delivery",
+                Language::En => "channels + delivery",
+            },
+            Self::McpAndSkills => match language {
+                Language::ZhCn => "MCP + workspace 配置",
+                Language::ZhTw => "MCP + workspace 配置",
+                Language::Ja => "MCP + workspace 設定",
+                Language::Ru => "MCP + workspace настройка",
+                Language::En => "MCP + workspace setup",
+            },
         }
     }
 
-    fn detail(self) -> &'static str {
+    fn detail(self, language: Language) -> &'static str {
         match self {
-            Self::ChatNow => {
-                "keep the shell minimal now; surface deeper setup when a real task needs it"
-            }
-            Self::ProviderAndWeb => {
-                "review provider auth, web search defaults, and the full onboard wizard path"
-            }
-            Self::McpAndSkills => {
-                "review MCP servers, bundled skills, and the next commands for local tooling"
-            }
+            Self::ChatNow => match language {
+                Language::ZhCn => "先保持 shell 简洁，等真实任务需要时再展开更深配置。",
+                Language::ZhTw => "先保持 shell 精簡，等真實任務需要時再展開更深配置。",
+                Language::Ja => "今は shell を最小限に保ち、必要になった時に深い設定を開きます。",
+                Language::Ru => {
+                    "пока оставить shell минимальным и раскрывать глубокую настройку только когда она реально нужна."
+                }
+                Language::En => {
+                    "keep the shell minimal now; surface deeper setup when a real task needs it"
+                }
+            },
+            Self::ProviderAndWeb => match language {
+                Language::ZhCn => {
+                    "继续看 provider 鉴权、web search 默认项，以及完整 onboard 向导。"
+                }
+                Language::ZhTw => {
+                    "繼續看 provider 驗證、web search 預設項，以及完整 onboard 嚮導。"
+                }
+                Language::Ja => {
+                    "provider 認証、web search の既定値、完全な onboard wizard を確認します。"
+                }
+                Language::Ru => {
+                    "посмотреть provider auth, web search defaults и полный onboard wizard."
+                }
+                Language::En => {
+                    "review provider auth, web search defaults, and the full onboard wizard path"
+                }
+            },
+            Self::ChannelsAndDelivery => match language {
+                Language::ZhCn => "继续看已启用 channels、delivery 面以及下一条 serve/setup 命令。",
+                Language::ZhTw => "繼續看已啟用 channels、delivery 面以及下一條 serve/setup 命令。",
+                Language::Ja => {
+                    "有効な channels、delivery 面、次の serve/setup コマンドを確認します。"
+                }
+                Language::Ru => {
+                    "посмотреть включённые channels, delivery surfaces и следующие serve/setup команды."
+                }
+                Language::En => {
+                    "review enabled channels, delivery surfaces, and the next serve/setup commands"
+                }
+            },
+            Self::McpAndSkills => match language {
+                Language::ZhCn => "继续看 MCP server、bundled skill 以及本地工具的下一步命令。",
+                Language::ZhTw => "繼續看 MCP server、bundled skill 以及本地工具的下一步命令。",
+                Language::Ja => {
+                    "MCP server、bundled skill、ローカルツールの次コマンドを確認します。"
+                }
+                Language::Ru => {
+                    "посмотреть MCP servers, bundled skills и следующие локальные команды."
+                }
+                Language::En => {
+                    "review MCP servers, bundled skills, and the next commands for local tooling"
+                }
+            },
         }
     }
 }
@@ -171,26 +287,99 @@ enum StartupPersonalizationPreset {
     Concise,
     Thorough,
     Later,
+    TurnOff,
 }
 
 impl StartupPersonalizationPreset {
-    const ALL: [Self; 4] = [Self::Balanced, Self::Concise, Self::Thorough, Self::Later];
+    const ALL: [Self; 5] = [
+        Self::Balanced,
+        Self::Concise,
+        Self::Thorough,
+        Self::Later,
+        Self::TurnOff,
+    ];
 
-    fn label(self) -> &'static str {
+    fn label(self, language: Language) -> &'static str {
         match self {
-            Self::Balanced => "balanced operator",
-            Self::Concise => "concise reviewer",
-            Self::Thorough => "deep pairer",
-            Self::Later => "decide later",
+            Self::Balanced => match language {
+                Language::ZhCn => "平衡模式",
+                Language::ZhTw => "平衡模式",
+                Language::Ja => "バランス型",
+                Language::Ru => "сбалансированный режим",
+                Language::En => "balanced operator",
+            },
+            Self::Concise => match language {
+                Language::ZhCn => "简洁模式",
+                Language::ZhTw => "精簡模式",
+                Language::Ja => "簡潔型",
+                Language::Ru => "краткий режим",
+                Language::En => "concise reviewer",
+            },
+            Self::Thorough => match language {
+                Language::ZhCn => "深入模式",
+                Language::ZhTw => "深入模式",
+                Language::Ja => "深掘り型",
+                Language::Ru => "подробный режим",
+                Language::En => "deep pairer",
+            },
+            Self::Later => match language {
+                Language::ZhCn => "稍后决定",
+                Language::ZhTw => "稍後決定",
+                Language::Ja => "後で決める",
+                Language::Ru => "решить позже",
+                Language::En => "decide later",
+            },
+            Self::TurnOff => match language {
+                Language::ZhCn => "关闭个性化",
+                Language::ZhTw => "關閉個性化",
+                Language::Ja => "個性化をオフ",
+                Language::Ru => "выключить персонализацию",
+                Language::En => "turn off personalization",
+            },
         }
     }
 
-    fn detail(self) -> &'static str {
+    fn detail(self, language: Language) -> &'static str {
         match self {
-            Self::Balanced => "balanced density and initiative for a normal first conversation",
-            Self::Concise => "short answers and ask-before-acting behavior",
-            Self::Thorough => "deeper responses with higher initiative when useful",
-            Self::Later => "skip saved conversation preferences for now",
+            Self::Balanced => match language {
+                Language::ZhCn => "默认保持平衡的密度与主动性。",
+                Language::ZhTw => "預設保持平衡的密度與主動性。",
+                Language::Ja => "密度と主体性のバランスを保ちます。",
+                Language::Ru => "сбалансированная плотность ответа и инициативность.",
+                Language::En => "balanced density and initiative for a normal first conversation",
+            },
+            Self::Concise => match language {
+                Language::ZhCn => "回答更短，并更偏向先问再行动。",
+                Language::ZhTw => "回答更短，並更偏向先問再行動。",
+                Language::Ja => "短めに返し、先に確認する寄りです。",
+                Language::Ru => "короче ответы и поведение сначала спросить.",
+                Language::En => "short answers and ask-before-acting behavior",
+            },
+            Self::Thorough => match language {
+                Language::ZhCn => "回答更深入，合适时更主动。",
+                Language::ZhTw => "回答更深入，合適時更主動。",
+                Language::Ja => "より深く返し、必要なら主体的に進みます。",
+                Language::Ru => "более глубокие ответы и выше инициативность, когда уместно.",
+                Language::En => "deeper responses with higher initiative when useful",
+            },
+            Self::Later => match language {
+                Language::ZhCn => "先不保存这轮对话偏好。",
+                Language::ZhTw => "先不保存這輪對話偏好。",
+                Language::Ja => "今は会話プリセットを保存しません。",
+                Language::Ru => "пока не сохранять этот разговорный пресет.",
+                Language::En => "skip saved conversation preferences for now",
+            },
+            Self::TurnOff => match language {
+                Language::ZhCn => "关闭后续个性化提示，先保持默认对话风格。",
+                Language::ZhTw => "關閉後續個性化提示，先保持預設對話風格。",
+                Language::Ja => "以後の個性化案内を止め、標準の会話スタイルを保ちます。",
+                Language::Ru => {
+                    "отключить дальнейшие подсказки по персонализации и оставить стиль по умолчанию."
+                }
+                Language::En => {
+                    "suppress future personalization prompts and keep the default conversation style"
+                }
+            },
         }
     }
 
@@ -199,7 +388,7 @@ impl StartupPersonalizationPreset {
             Self::Balanced => Some(ResponseDensity::Balanced),
             Self::Concise => Some(ResponseDensity::Concise),
             Self::Thorough => Some(ResponseDensity::Thorough),
-            Self::Later => None,
+            Self::Later | Self::TurnOff => None,
         }
     }
 
@@ -208,23 +397,19 @@ impl StartupPersonalizationPreset {
             Self::Balanced => Some(InitiativeLevel::Balanced),
             Self::Concise => Some(InitiativeLevel::AskBeforeActing),
             Self::Thorough => Some(InitiativeLevel::HighInitiative),
-            Self::Later => None,
+            Self::Later | Self::TurnOff => None,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct StartupProviderOption {
-    provider: ProviderConfig,
+    kind: ProviderKind,
+    auth_env_name: Option<String>,
+    is_current: bool,
     label: String,
     detail: String,
     recommended: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StartupProviderAuthBindingKind {
-    ApiKey,
-    OauthAccessToken,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,7 +420,28 @@ struct StartupSkillOption {
     recommended: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StartupChannelFollowUpDescriptor {
+    label: String,
+    serve_command: Option<String>,
+    status_command: String,
+    repair_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct StartupBootstrapCapture {
+    preferred_address: Option<String>,
+    pronouns: Option<String>,
+    agent_name: Option<String>,
+    creature: Option<String>,
+    vibe: Option<String>,
+    emoji: Option<String>,
+    timezone: Option<String>,
+    standing_boundaries: Option<String>,
+    notes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct StartupOnboardingState {
     stage: StartupOnboardingStage,
     language_options: Vec<Language>,
@@ -250,6 +456,12 @@ struct StartupOnboardingState {
     selected_personalization: Option<StartupPersonalizationPreset>,
     web_search_provider_label: String,
     web_search_provider_detail: String,
+    provider_auth_env_name: Option<String>,
+    provider_configuration_hint: Option<String>,
+    enabled_channel_labels: Vec<String>,
+    channel_follow_up_commands: Vec<String>,
+    channel_status_commands: Vec<String>,
+    channel_repair_commands: Vec<String>,
     startup_mcp_count: usize,
     detected_skill_count: usize,
     feedback: Option<String>,
@@ -265,150 +477,23 @@ enum StartupOnboardingInteractionKind {
     Persist,
 }
 
-fn startup_provider_options(runtime: &CliTurnRuntime) -> Vec<StartupProviderOption> {
-    let current_kind = runtime.config.provider.kind;
-    let primary_provider = if runtime.config_present {
-        runtime.config.provider.clone()
-    } else {
-        startup_provider_config_for_kind(current_kind)
-    };
-    let primary_label = if runtime.config_present {
-        format!("reuse current {} setup", current_kind.display_name())
-    } else {
-        format!("start with {}", current_kind.display_name())
-    };
-    let primary_detail = if runtime.config_present {
-        startup_current_provider_detail(runtime)
-    } else {
-        startup_bootstrap_provider_detail(&primary_provider)
-    };
-
-    let mut options = vec![StartupProviderOption {
-        provider: primary_provider,
-        label: primary_label,
-        detail: primary_detail,
-        recommended: true,
-    }];
-
-    for kind in ProviderKind::all_sorted() {
-        if *kind == current_kind {
-            continue;
-        }
-
-        let mut provider = startup_provider_config_for_kind(*kind);
-        let Some((env_name, binding_kind)) = detected_startup_auth_binding(*kind) else {
-            continue;
-        };
-        apply_startup_auth_binding(&mut provider, env_name.as_str(), binding_kind);
-
-        let label = if runtime.config_present {
-            format!("migrate {} from {env_name}", kind.display_name())
-        } else {
-            format!("start with {} from {env_name}", kind.display_name())
-        };
-        let detail = if runtime.config_present {
-            format!(
-                "Loong found a ready local credential in {env_name}. You can keep moving here and wire the rest later in config.toml."
-            )
-        } else {
-            format!(
-                "Loong found a ready local credential in {env_name}. This first-run setup can bootstrap {} without leaving the shell.",
-                kind.display_name()
-            )
-        };
-        options.push(StartupProviderOption {
-            provider,
-            label,
-            detail,
-            recommended: false,
-        });
-    }
-
-    if runtime.config_present && options.len() == 1 {
-        options.push(StartupProviderOption {
-            provider: startup_provider_config_for_kind(current_kind),
-            label: "start fresh with provider setup".to_owned(),
-            detail: "No direct local migration source was detected here yet. You can still keep going and configure providers later.".to_owned(),
-            recommended: false,
-        });
-    }
-
-    options
-}
-
-fn startup_provider_config_for_kind(kind: ProviderKind) -> ProviderConfig {
-    let mut provider = ProviderConfig::fresh_for_kind(kind);
-    if let Some((env_name, binding_kind)) = detected_startup_auth_binding(kind) {
-        apply_startup_auth_binding(&mut provider, env_name.as_str(), binding_kind);
-    }
-    provider
-}
-
-fn detected_startup_auth_binding(
-    kind: ProviderKind,
-) -> Option<(String, StartupProviderAuthBindingKind)> {
-    if let Some(env_name) = kind
-        .default_oauth_access_token_env()
-        .filter(|env_name| std::env::var_os(env_name).is_some())
-    {
-        return Some((
-            env_name.to_owned(),
-            StartupProviderAuthBindingKind::OauthAccessToken,
-        ));
-    }
-    for env_name in kind.oauth_access_token_env_aliases() {
-        if std::env::var_os(env_name).is_some() {
-            return Some((
-                (*env_name).to_owned(),
-                StartupProviderAuthBindingKind::OauthAccessToken,
-            ));
-        }
-    }
-    if let Some(env_name) = kind
-        .default_api_key_env()
-        .filter(|env_name| std::env::var_os(env_name).is_some())
-    {
-        return Some((env_name.to_string(), StartupProviderAuthBindingKind::ApiKey));
-    }
-    for env_name in kind.api_key_env_aliases() {
-        if std::env::var_os(env_name).is_some() {
-            return Some((
-                (*env_name).to_owned(),
-                StartupProviderAuthBindingKind::ApiKey,
-            ));
-        }
-    }
-    None
-}
-
-fn apply_startup_auth_binding(
-    provider: &mut ProviderConfig,
-    env_name: &str,
-    binding_kind: StartupProviderAuthBindingKind,
-) {
-    match binding_kind {
-        StartupProviderAuthBindingKind::ApiKey => {
-            provider.set_api_key_env_binding(Some(env_name.to_owned()));
-        }
-        StartupProviderAuthBindingKind::OauthAccessToken => {
-            provider.set_oauth_access_token_env_binding(Some(env_name.to_owned()));
-        }
-    }
-}
-
 impl StartupOnboardingState {
     fn new(runtime: &CliTurnRuntime, preferred_language: Language) -> Option<Self> {
         if !startup_onboarding_enabled(runtime) {
             return None;
         }
 
-        let language_options = vec![Language::En, Language::ZhCn];
+        let language_options = vec![
+            Language::En,
+            Language::ZhCn,
+            Language::ZhTw,
+            Language::Ja,
+            Language::Ru,
+        ];
         let language_index = language_options
             .iter()
             .position(|language| *language == preferred_language)
             .unwrap_or(0);
-
-        let provider_options = startup_provider_options(runtime);
 
         let skill_options = bundled_preinstall_targets()
             .iter()
@@ -421,23 +506,11 @@ impl StartupOnboardingState {
             .collect::<Vec<_>>();
         let detected_skill_count = skill_options.len();
 
-        let normalized_web_search_provider = normalize_web_search_provider(
-            runtime.config.tools.web_search.default_provider.as_str(),
-        )
-        .unwrap_or(runtime.config.tools.web_search.default_provider.as_str());
-        let web_search_provider_label =
-            web_search_provider_descriptor(normalized_web_search_provider)
-                .map(|descriptor| descriptor.display_name)
-                .unwrap_or(normalized_web_search_provider)
-                .to_owned();
-        let web_search_provider_detail =
-            startup_web_search_detail(runtime, normalized_web_search_provider);
-
-        Some(Self {
+        let mut state = Self {
             stage: StartupOnboardingStage::Language,
             language_options,
             language_index,
-            provider_options,
+            provider_options: Vec::new(),
             provider_index: 0,
             skill_options,
             selected_skill_ids: BTreeSet::new(),
@@ -445,8 +518,14 @@ impl StartupOnboardingState {
             setup_path_index: 0,
             personalization_index: 0,
             selected_personalization: None,
-            web_search_provider_label,
-            web_search_provider_detail,
+            web_search_provider_label: String::new(),
+            web_search_provider_detail: String::new(),
+            provider_auth_env_name: None,
+            provider_configuration_hint: None,
+            enabled_channel_labels: Vec::new(),
+            channel_follow_up_commands: Vec::new(),
+            channel_status_commands: Vec::new(),
+            channel_repair_commands: Vec::new(),
             startup_mcp_count: runtime.effective_bootstrap_mcp_servers.len(),
             detected_skill_count,
             feedback: Some(
@@ -454,7 +533,65 @@ impl StartupOnboardingState {
             ),
             last_interaction_at: std::time::Instant::now(),
             last_interaction_kind: StartupOnboardingInteractionKind::Passive,
-        })
+        };
+        state.refresh_localized_runtime_content(runtime);
+        Some(state)
+    }
+
+    fn refresh_localized_runtime_content(&mut self, runtime: &CliTurnRuntime) {
+        let language = self.current_language();
+        let selected_provider_kind = self
+            .provider_options
+            .get(self.provider_index)
+            .map(|option| option.kind)
+            .unwrap_or(runtime.config.provider.kind);
+        self.provider_options = build_startup_provider_options(runtime, language);
+        self.provider_index = self
+            .provider_options
+            .iter()
+            .position(|option| option.kind == selected_provider_kind)
+            .or_else(|| {
+                self.provider_options
+                    .iter()
+                    .position(|option| option.kind == runtime.config.provider.kind)
+            })
+            .unwrap_or(0);
+
+        let normalized_web_search_provider = normalize_web_search_provider(
+            runtime.config.tools.web_search.default_provider.as_str(),
+        )
+        .unwrap_or(runtime.config.tools.web_search.default_provider.as_str());
+        self.web_search_provider_label =
+            web_search_provider_descriptor(normalized_web_search_provider)
+                .map(|descriptor| descriptor.display_name)
+                .unwrap_or(normalized_web_search_provider)
+                .to_owned();
+        self.web_search_provider_detail =
+            startup_web_search_detail(runtime, normalized_web_search_provider, language);
+        self.provider_auth_env_name = runtime.config.provider.resolved_auth_env_name();
+        self.provider_configuration_hint = runtime.config.provider.configuration_hint();
+
+        let channel_follow_up = startup_channel_follow_up_descriptors(runtime, language);
+        self.enabled_channel_labels = channel_follow_up
+            .iter()
+            .map(|descriptor| descriptor.label.clone())
+            .collect();
+        self.channel_follow_up_commands = channel_follow_up
+            .iter()
+            .filter_map(|descriptor| descriptor.serve_command.clone())
+            .collect();
+        self.channel_status_commands = channel_follow_up
+            .iter()
+            .map(|descriptor| descriptor.status_command.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        self.channel_repair_commands = channel_follow_up
+            .iter()
+            .filter_map(|descriptor| descriptor.repair_command.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
     }
 
     fn mark_interaction(&mut self, kind: StartupOnboardingInteractionKind) {
@@ -492,15 +629,18 @@ impl StartupOnboardingState {
             self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Enter {
+            let language = self.current_language();
             self.feedback = Some(format!(
-                "language set to {}.",
-                startup_language_label(self.current_language())
+                "{} {}。",
+                startup_feedback_prefix("language_set", language),
+                startup_language_label(language)
             ));
             self.stage = self.stage.next();
             self.mark_interaction(StartupOnboardingInteractionKind::Confirm);
-            StartupOnboardingAction::ApplyLanguage(self.current_language())
+            StartupOnboardingAction::ApplyLanguage(language)
         } else if code == KeyCode::Esc {
-            StartupOnboardingAction::Dismiss
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -518,14 +658,17 @@ impl StartupOnboardingState {
             self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Enter {
-            if let Some(option) = self.provider_options.get(self.provider_index) {
-                self.feedback = Some(format!("provider choice saved: {}.", option.label));
-            }
-            self.stage = self.stage.next();
             self.mark_interaction(StartupOnboardingInteractionKind::Confirm);
-            StartupOnboardingAction::Handled
+            self.provider_options
+                .get(self.provider_index)
+                .cloned()
+                .map_or(StartupOnboardingAction::Ignored, |option| {
+                    StartupOnboardingAction::PersistProviderSelection(option)
+                })
         } else if code == KeyCode::Esc {
-            StartupOnboardingAction::Dismiss
+            self.stage = self.stage.previous();
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -543,31 +686,35 @@ impl StartupOnboardingState {
             self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Char(' ') {
+            let language = self.current_language();
             if let Some(option) = self.skill_options.get(self.skill_cursor) {
                 if !self.selected_skill_ids.insert(option.install_id.clone()) {
                     self.selected_skill_ids.remove(option.install_id.as_str());
                 }
                 let selection_count = self.selected_skill_ids.len();
                 self.feedback = Some(if selection_count == 0 {
-                    "no skill packs selected yet.".to_owned()
+                    startup_feedback_prefix("skills_none_selected", language).to_owned()
                 } else {
-                    format!("selected {selection_count} skill pack(s).")
+                    startup_feedback_selected_skill_packs(language, selection_count)
                 });
             }
             self.mark_interaction(StartupOnboardingInteractionKind::Confirm);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Enter {
+            let language = self.current_language();
             let selection_count = self.selected_skill_ids.len();
             self.feedback = Some(if selection_count == 0 {
-                "skills skipped for now. Loong can guide installation later.".to_owned()
+                startup_feedback_prefix("skills_skipped", language).to_owned()
             } else {
-                format!("{selection_count} skill pack(s) queued. You can still refine this later.")
+                startup_feedback_queued_skill_packs(language, selection_count)
             });
             self.stage = self.stage.next();
             self.mark_interaction(StartupOnboardingInteractionKind::Confirm);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Esc {
-            StartupOnboardingAction::Dismiss
+            self.stage = self.stage.previous();
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -589,24 +736,28 @@ impl StartupOnboardingState {
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Enter {
             let choice = self.current_setup_path_choice();
+            let language = self.current_language();
             self.feedback = Some(match choice {
                 StartupSetupPathChoice::ChatNow => {
-                    "keeping deeper setup deferred until the first real task needs it.".to_owned()
+                    startup_feedback_prefix("setup_chat_now", language).to_owned()
                 }
                 StartupSetupPathChoice::ProviderAndWeb => {
-                    "provider and web-search follow-up mapped. next step: save a first-chat style."
-                        .to_owned()
+                    startup_feedback_prefix("setup_provider_web", language).to_owned()
+                }
+                StartupSetupPathChoice::ChannelsAndDelivery => {
+                    startup_feedback_prefix("setup_channels_delivery", language).to_owned()
                 }
                 StartupSetupPathChoice::McpAndSkills => {
-                    "MCP and workspace follow-up mapped. next step: save a first-chat style."
-                        .to_owned()
+                    startup_feedback_prefix("setup_mcp_skills", language).to_owned()
                 }
             });
             self.stage = self.stage.next();
             self.mark_interaction(StartupOnboardingInteractionKind::Confirm);
             StartupOnboardingAction::Handled
         } else if code == KeyCode::Esc {
-            StartupOnboardingAction::Dismiss
+            self.stage = self.stage.previous();
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -630,7 +781,9 @@ impl StartupOnboardingState {
             self.mark_interaction(StartupOnboardingInteractionKind::Persist);
             StartupOnboardingAction::PersistPersonalization(self.current_personalization_preset())
         } else if code == KeyCode::Esc {
-            StartupOnboardingAction::Dismiss
+            self.stage = self.stage.previous();
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -638,8 +791,12 @@ impl StartupOnboardingState {
 
     fn handle_finish_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
         let code = key.code;
-        if code == KeyCode::Enter || code == KeyCode::Esc {
+        if code == KeyCode::Enter {
             StartupOnboardingAction::Complete
+        } else if code == KeyCode::Esc {
+            self.stage = self.stage.previous();
+            self.mark_interaction(StartupOnboardingInteractionKind::Navigate);
+            StartupOnboardingAction::Handled
         } else {
             StartupOnboardingAction::Ignored
         }
@@ -660,14 +817,14 @@ impl StartupOnboardingState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum StartupOnboardingAction {
     Ignored,
     Handled,
     ApplyLanguage(Language),
+    PersistProviderSelection(StartupProviderOption),
     PersistPersonalization(StartupPersonalizationPreset),
     Complete,
-    Dismiss,
 }
 
 pub struct App {
@@ -682,13 +839,14 @@ pub struct App {
     pub pending_steers: VecDeque<String>,
     pub pending_queue: VecDeque<String>,
     pub composer_follow_up_intent: bool,
+    pending_first_turn_bootstrap_addendum: Option<String>,
+    awaiting_first_turn_bootstrap_reply: bool,
     pub live_render_width: Arc<AtomicUsize>,
     pub live_rerender: Option<super::super::CliChatLiveSurfaceRerender>,
     pub spinner_seed: u64,
     pub last_pending_signature: Option<u64>,
     pending_render_cache: Option<PendingRenderCache>,
     inline_skill_popup_active: bool,
-    startup_follow_up_choice: Option<StartupSetupPathChoice>,
     pub last_render_width: u16,
     pub last_render_height: u16,
     pub last_transcript_area: Rect,
@@ -726,13 +884,14 @@ impl App {
             pending_steers: VecDeque::new(),
             pending_queue: VecDeque::new(),
             composer_follow_up_intent: false,
+            pending_first_turn_bootstrap_addendum: None,
+            awaiting_first_turn_bootstrap_reply: false,
             live_render_width: Arc::new(AtomicUsize::new(render_width.max(1))),
             live_rerender: None,
             spinner_seed: spinner_seed(),
             last_pending_signature: None,
             pending_render_cache: None,
             inline_skill_popup_active: false,
-            startup_follow_up_choice: None,
             last_render_width: render_width as u16,
             last_render_height: 0,
             last_transcript_area: Rect::default(),
@@ -949,40 +1108,45 @@ impl App {
                 self.i18n = I18nService::new(language);
                 self.command_palette = CommandPalette::new(language, self.detected_skills.clone());
                 self.inline_skill_popup_active = false;
+                if let Some(state) = self.startup_onboarding.as_mut() {
+                    state.refresh_localized_runtime_content(runtime);
+                }
+                self.refresh_startup_header();
+                Ok(true)
+            }
+            StartupOnboardingAction::PersistProviderSelection(option) => {
+                let language = self
+                    .startup_onboarding
+                    .as_ref()
+                    .map(StartupOnboardingState::current_language)
+                    .unwrap_or(Language::En);
+                let summary = persist_startup_provider_selection(runtime, option, language)?;
+                if let Some(state) = self.startup_onboarding.as_mut() {
+                    state.refresh_localized_runtime_content(runtime);
+                    state.feedback = Some(summary);
+                    state.stage = StartupOnboardingStage::Skills;
+                }
                 self.refresh_startup_header();
                 Ok(true)
             }
             StartupOnboardingAction::PersistPersonalization(preset) => {
-                let startup_state = self.startup_onboarding.clone();
-                let summary = persist_startup_personalization(
-                    runtime,
-                    preset,
-                    startup_state.as_ref(),
-                    self.startup_onboarding
-                        .as_ref()
-                        .map(StartupOnboardingState::current_language)
-                        .unwrap_or(Language::En),
-                )?;
+                let language = self
+                    .startup_onboarding
+                    .as_ref()
+                    .map(StartupOnboardingState::current_language)
+                    .unwrap_or(Language::En);
+                let summary = persist_startup_personalization(runtime, preset, language)?;
                 if let Some(state) = self.startup_onboarding.as_mut() {
                     state.selected_personalization = Some(preset);
                     state.feedback = Some(summary);
                     state.stage = StartupOnboardingStage::Finish;
                 }
+                self.pending_first_turn_bootstrap_addendum =
+                    startup_first_turn_bootstrap_addendum(preset, language);
                 self.refresh_startup_header();
                 Ok(true)
             }
             StartupOnboardingAction::Complete => {
-                self.startup_follow_up_choice = self
-                    .startup_onboarding
-                    .as_ref()
-                    .map(StartupOnboardingState::current_setup_path_choice)
-                    .filter(|choice| *choice != StartupSetupPathChoice::ChatNow);
-                self.startup_onboarding = None;
-                self.refresh_startup_header();
-                Ok(true)
-            }
-            StartupOnboardingAction::Dismiss => {
-                self.startup_follow_up_choice = None;
                 self.startup_onboarding = None;
                 self.refresh_startup_header();
                 Ok(true)
@@ -1039,37 +1203,14 @@ impl App {
         }
     }
 
-    fn handle_mouse_event(&mut self, mouse_event: MouseEvent) -> Option<CommandAction> {
+    fn handle_mouse_event(&mut self, mouse_event: MouseEvent) -> Option<String> {
         if rect_contains_point(self.last_palette_area, mouse_event.column, mouse_event.row)
             && (matches!(self.focus, Focus::CommandPalette) || self.inline_skill_popup_active)
         {
-            let action = self
+            return self
                 .command_palette
-                .handle_mouse(mouse_event, self.last_palette_area);
-            if self.inline_skill_popup_active && !matches!(self.focus, Focus::CommandPalette) {
-                match action {
-                    Some(CommandAction::InsertText(text)) => {
-                        if let Some(range) = current_skill_token_range(&self.composer) {
-                            let replacement = inline_skill_replacement_text(
-                                self.composer.text(),
-                                &range,
-                                text.as_str(),
-                            );
-                            self.composer.replace_range(range, replacement.as_str());
-                        } else {
-                            self.composer.set_input(text);
-                        }
-                        self.inline_skill_popup_active = false;
-                        self.focus = Focus::Composer;
-                        return None;
-                    }
-                    Some(CommandAction::Close) | Some(CommandAction::Noop) | None => {
-                        return None;
-                    }
-                    _ => {}
-                }
-            }
-            return action;
+                .handle_mouse(mouse_event, self.last_palette_area)
+                .and_then(|action| self.apply_palette_action(action));
         }
 
         if rect_contains_point(self.last_composer_area, mouse_event.column, mouse_event.row) {
@@ -1240,7 +1381,7 @@ pub async fn run_app<B: Backend>(
             dirty = true;
         }
 
-        if maybe_finalize_pending_turn(terminal, &mut app, &runtime).await? {
+        if maybe_finalize_pending_turn(terminal, &mut app, &mut runtime).await? {
             dirty = true;
         }
 
@@ -1420,14 +1561,8 @@ pub async fn run_app<B: Backend>(
                             if command == "/exit" {
                                 break;
                             }
-                            run_surface_command(
-                                terminal,
-                                &mut app,
-                                &mut runtime,
-                                &options,
-                                &command,
-                            )
-                            .await?;
+                            run_surface_command(terminal, &mut app, &runtime, &options, &command)
+                                .await?;
                         }
                         dirty = true;
                         continue;
@@ -1446,10 +1581,6 @@ pub async fn run_app<B: Backend>(
                             .map(|state| state.handle_key(key))
                             .unwrap_or(StartupOnboardingAction::Ignored);
                         if app.apply_startup_onboarding_action(action, &mut runtime)? {
-                            if let Some(choice) = app.startup_follow_up_choice.take() {
-                                let width = current_render_width(terminal)?;
-                                append_startup_setup_follow_up(&mut app, &runtime, width, choice);
-                            }
                             dirty = true;
                             continue;
                         }
@@ -1501,7 +1632,7 @@ pub async fn run_app<B: Backend>(
                                     &mut runtime,
                                     current_render_width(terminal)?,
                                     action,
-                                )?
+                                    )?
                             {
                                 command_to_run = Some(command);
                             } else if app.command_palette.is_commands_mode() {
@@ -1543,7 +1674,7 @@ pub async fn run_app<B: Backend>(
                         } else if submitted_message_is_follow_up(&app, &msg) {
                             start_turn(terminal, &mut app, &runtime, msg, false).await?;
                         } else {
-                            submit_user_turn(terminal, &mut app, &runtime, msg).await?;
+                            submit_user_turn(terminal, &mut app, &mut runtime, msg).await?;
                         }
                     }
 
@@ -1552,24 +1683,17 @@ pub async fn run_app<B: Backend>(
                             break;
                         }
 
-                        run_surface_command(terminal, &mut app, &mut runtime, &options, &command)
+                        run_surface_command(terminal, &mut app, &runtime, &options, &command)
                             .await?;
                     }
                     dirty = true;
                 }
                 Event::Mouse(mouse_event) => {
-                    if let Some(action) = app.handle_mouse_event(mouse_event)
-                        && let Some(command) = dispatch_palette_action(
-                            &mut app,
-                            &mut runtime,
-                            current_render_width(terminal)?,
-                            action,
-                        )?
-                    {
+                    if let Some(command) = app.handle_mouse_event(mouse_event) {
                         if command == "/exit" {
                             break;
                         }
-                        run_surface_command(terminal, &mut app, &mut runtime, &options, &command)
+                        run_surface_command(terminal, &mut app, &runtime, &options, &command)
                             .await?;
                     }
                     dirty = true;
@@ -1613,8 +1737,7 @@ pub async fn run_app<B: Backend>(
 }
 
 fn startup_onboarding_enabled(runtime: &CliTurnRuntime) -> bool {
-    !runtime.config_present
-        || startup_env_truthy("LOONG_TUI_ONBOARD")
+    startup_env_truthy("LOONG_TUI_ONBOARD")
         || (runtime.config.provider.api_key().is_none()
             && runtime.config.provider.oauth_access_token().is_none())
 }
@@ -1628,40 +1751,222 @@ fn startup_env_truthy(name: &str) -> bool {
     })
 }
 
-fn startup_current_provider_detail(runtime: &CliTurnRuntime) -> String {
+fn build_startup_provider_options(
+    runtime: &CliTurnRuntime,
+    language: Language,
+) -> Vec<StartupProviderOption> {
+    let current_provider_kind = runtime.config.provider.kind;
+    ProviderKind::all_sorted()
+        .iter()
+        .map(|kind| {
+            let is_current = *kind == current_provider_kind;
+            let provider = ProviderConfig {
+                kind: *kind,
+                ..ProviderConfig::default()
+            };
+            let auth_env_name = provider
+                .auth_hint_env_names()
+                .into_iter()
+                .find(|env_name| std::env::var_os(env_name).is_some());
+            let detail = if is_current {
+                startup_current_provider_detail(runtime, language)
+            } else if let Some(env_name) = auth_env_name.as_deref() {
+                startup_provider_migration_detail(kind.display_name(), env_name, language)
+            } else {
+                startup_provider_kind_detail(kind.display_name(), language)
+            };
+
+            StartupProviderOption {
+                kind: *kind,
+                auth_env_name,
+                is_current,
+                label: kind.display_name().to_owned(),
+                detail,
+                recommended: is_current,
+            }
+        })
+        .collect()
+}
+
+fn startup_current_provider_detail(runtime: &CliTurnRuntime, language: Language) -> String {
     if let Some(env_name) = runtime.config.provider.resolved_auth_env_name() {
-        return format!(
-            "Reuse the active Loong provider from config.toml. Credentials currently resolve through {env_name}."
-        );
+        return match language {
+            Language::ZhCn => {
+                format!("沿用 config.toml 里的当前 Loong provider。凭证目前通过 {env_name} 解析。")
+            }
+            Language::ZhTw => {
+                format!("沿用 config.toml 裡目前的 Loong provider。憑證目前透過 {env_name} 解析。")
+            }
+            Language::Ja => format!(
+                "config.toml の現在の Loong provider をそのまま使います。認証情報は今 {env_name} から解決されています。"
+            ),
+            Language::Ru => format!(
+                "использовать текущий provider из config.toml. Сейчас учётные данные берутся через {env_name}."
+            ),
+            Language::En => format!(
+                "reuse the active Loong provider from config.toml. credentials currently resolve through {env_name}."
+            ),
+        };
     }
 
     if runtime.config.provider.api_key().is_some()
         || runtime.config.provider.oauth_access_token().is_some()
     {
-        return "Reuse the active Loong provider from config.toml. The current runtime already has provider credentials loaded.".to_owned();
+        return match language {
+            Language::ZhCn => {
+                "沿用 config.toml 里的当前 Loong provider。当前 runtime 已经拿到了 provider 凭证。"
+                    .to_owned()
+            }
+            Language::ZhTw => {
+                "沿用 config.toml 裡目前的 Loong provider。當前 runtime 已經拿到 provider 憑證。"
+                    .to_owned()
+            }
+            Language::Ja => {
+                "config.toml の現在の Loong provider をそのまま使います。いまの runtime には認証情報が読み込まれています。"
+                    .to_owned()
+            }
+            Language::Ru => {
+                "использовать текущий provider из config.toml. В текущем runtime учётные данные уже загружены."
+                    .to_owned()
+            }
+            Language::En => {
+                "reuse the active Loong provider from config.toml. the current runtime already has provider credentials loaded."
+                    .to_owned()
+            }
+        };
     }
 
-    "Reuse the current provider shape from config.toml. Credentials still need to be wired before the first real turn.".to_owned()
+    match language {
+        Language::ZhCn => {
+            "沿用 config.toml 里的当前 provider 形状。第一轮真实对话前仍需要把凭证接好。"
+                .to_owned()
+        }
+        Language::ZhTw => {
+            "沿用 config.toml 裡目前的 provider 形狀。第一輪真實對話前仍需要把憑證接好。"
+                .to_owned()
+        }
+        Language::Ja => {
+            "config.toml の現在の provider 形を引き継ぎます。最初の実際のターンの前に認証情報の配線はまだ必要です。"
+                .to_owned()
+        }
+        Language::Ru => {
+            "сохранить текущую форму provider из config.toml. Перед первым реальным ходом авторизацию ещё нужно подключить."
+                .to_owned()
+        }
+        Language::En => {
+            "reuse the current provider shape from config.toml. credentials still need to be wired before the first real turn."
+                .to_owned()
+        }
+    }
 }
 
-fn startup_bootstrap_provider_detail(provider: &ProviderConfig) -> String {
-    if let Some(env_name) = provider.resolved_auth_env_name() {
-        return format!(
-            "Loong can bootstrap the first config from {env_name} and keep the rest of setup inside the same shell."
-        );
+fn startup_provider_migration_detail(
+    provider_label: &str,
+    env_name: &str,
+    language: Language,
+) -> String {
+    match language {
+        Language::ZhCn => format!(
+            "Loong 在 {env_name} 里发现了可复用的 {provider_label} 凭证。这里先接上 provider，剩余细节后面再回到 config.toml。"
+        ),
+        Language::ZhTw => format!(
+            "Loong 在 {env_name} 裡發現了可重用的 {provider_label} 憑證。這裡先接上 provider，剩餘細節之後再回到 config.toml。"
+        ),
+        Language::Ja => format!(
+            "Loong は {env_name} に再利用できる {provider_label} 認証を見つけました。ここでは provider だけ先につなぎ、残りの細部は後で config.toml に戻って詰められます。"
+        ),
+        Language::Ru => format!(
+            "Loong нашёл готовые учётные данные {provider_label} в {env_name}. Здесь можно сначала выбрать provider, а остальное позже довести в config.toml."
+        ),
+        Language::En => format!(
+            "Loong found a ready local {provider_label} credential in {env_name}. You can keep moving here and wire the rest later in config.toml."
+        ),
     }
+}
 
-    if provider.api_key().is_some() || provider.oauth_access_token().is_some() {
-        return format!(
-            "Loong can bootstrap the first config with {} using the credentials already loaded in this environment.",
-            provider.kind.display_name()
-        );
+fn startup_provider_kind_detail(provider_label: &str, language: Language) -> String {
+    match language {
+        Language::ZhCn => format!(
+            "先切到 {provider_label}；后续 base_url、model 和鉴权还可以回到 config.toml 里细调。"
+        ),
+        Language::ZhTw => format!(
+            "先切到 {provider_label}；後續 base_url、model 和驗證還可以回到 config.toml 裡微調。"
+        ),
+        Language::Ja => format!(
+            "先に {provider_label} へ切り替え、base_url・model・認証の細部はあとで config.toml に戻って詰められます。"
+        ),
+        Language::Ru => format!(
+            "Сначала переключитесь на {provider_label}; base_url, model и авторизацию потом можно дочистить в config.toml."
+        ),
+        Language::En => format!(
+            "switch to {provider_label} now; you can still fine-tune base_url, model, and auth later in config.toml."
+        ),
     }
+}
 
-    format!(
-        "Start with {} and keep the first-run flow in this shell. You can wire credentials later if you want to explore before the first real turn.",
-        provider.kind.display_name()
-    )
+fn persist_startup_provider_selection(
+    runtime: &mut CliTurnRuntime,
+    option: StartupProviderOption,
+    language: Language,
+) -> CliResult<String> {
+    let mut config = runtime.config.clone();
+    let path = runtime.resolved_path.display().to_string();
+    let mut provider = if option.is_current {
+        config.provider.clone()
+    } else {
+        ProviderConfig {
+            kind: option.kind,
+            ..ProviderConfig::default()
+        }
+        .selection_baseline()
+    };
+
+    if !option.is_current
+        && let Some(env_name) = option.auth_env_name.as_deref()
+    {
+        match option.kind.auth_scheme() {
+            ProviderAuthScheme::Bearer => {
+                provider.set_oauth_access_token_env_binding(Some(env_name.to_owned()));
+            }
+            ProviderAuthScheme::XApiKey | ProviderAuthScheme::XGoogApiKey => {
+                provider.set_api_key_env_binding(Some(env_name.to_owned()));
+            }
+        }
+    }
+    let profile = ProviderProfileConfig::from_provider(provider.clone());
+    if config.active_provider_id().map(str::to_owned) != Some(provider.inferred_profile_id()) {
+        config.last_provider = config.active_provider_id().map(str::to_owned);
+    }
+    config.set_active_provider_profile(provider.inferred_profile_id(), profile);
+
+    crate::config::write(Some(path.as_str()), &config, true)?;
+    runtime.config = config;
+
+    let summary = if let Some(env_name) = option.auth_env_name.as_deref() {
+        match language {
+            Language::ZhCn => format!("provider 已保存：{}（复用 {env_name}）。", option.label),
+            Language::ZhTw => format!("provider 已保存：{}（重用 {env_name}）。", option.label),
+            Language::Ja => format!(
+                "provider を保存しました: {}（{env_name} を再利用）。",
+                option.label
+            ),
+            Language::Ru => format!(
+                "provider сохранён: {} (переиспользуется {env_name}).",
+                option.label
+            ),
+            Language::En => format!("provider saved: {} (reusing {env_name}).", option.label),
+        }
+    } else {
+        match language {
+            Language::ZhCn => format!("provider 已保存：{}。", option.label),
+            Language::ZhTw => format!("provider 已保存：{}。", option.label),
+            Language::Ja => format!("provider を保存しました: {}。", option.label),
+            Language::Ru => format!("provider сохранён: {}.", option.label),
+            Language::En => format!("provider saved: {}.", option.label),
+        }
+    };
+
+    Ok(summary)
 }
 
 fn startup_language_label(language: Language) -> &'static str {
@@ -1676,16 +1981,427 @@ fn startup_language_label(language: Language) -> &'static str {
 
 fn startup_onboarding_footer_text(stage: StartupOnboardingStage) -> &'static str {
     match stage {
-        StartupOnboardingStage::Skills => {
-            "↑/↓ move · Space toggle · Enter continue · Esc skip onboarding"
-        }
+        StartupOnboardingStage::Skills => "↑/↓ move · Space toggle · Enter continue · Esc back",
         StartupOnboardingStage::Language
         | StartupOnboardingStage::Provider
         | StartupOnboardingStage::SetupPath
-        | StartupOnboardingStage::Personalization => {
-            "↑/↓ move · Enter continue · Esc skip onboarding"
+        | StartupOnboardingStage::Personalization => "↑/↓ move · Enter continue · Esc back",
+        StartupOnboardingStage::Finish => "Enter start chatting · Esc back",
+    }
+}
+
+fn startup_onboarding_footer_text_for_language(
+    stage: StartupOnboardingStage,
+    language: Language,
+) -> &'static str {
+    match language {
+        Language::ZhCn => match stage {
+            StartupOnboardingStage::Skills => "↑/↓ 移动 · Space 勾选 · Enter 继续 · Esc 返回",
+            StartupOnboardingStage::Language
+            | StartupOnboardingStage::Provider
+            | StartupOnboardingStage::SetupPath
+            | StartupOnboardingStage::Personalization => "↑/↓ 移动 · Enter 继续 · Esc 返回",
+            StartupOnboardingStage::Finish => "Enter 开始聊天 · Esc 返回",
+        },
+        Language::ZhTw => match stage {
+            StartupOnboardingStage::Skills => "↑/↓ 移動 · Space 勾選 · Enter 繼續 · Esc 返回",
+            StartupOnboardingStage::Language
+            | StartupOnboardingStage::Provider
+            | StartupOnboardingStage::SetupPath
+            | StartupOnboardingStage::Personalization => "↑/↓ 移動 · Enter 繼續 · Esc 返回",
+            StartupOnboardingStage::Finish => "Enter 開始聊天 · Esc 返回",
+        },
+        Language::Ja => match stage {
+            StartupOnboardingStage::Skills => "↑/↓ move · Space 選択 · Enter 続行 · Esc 戻る",
+            StartupOnboardingStage::Language
+            | StartupOnboardingStage::Provider
+            | StartupOnboardingStage::SetupPath
+            | StartupOnboardingStage::Personalization => "↑/↓ move · Enter 続行 · Esc 戻る",
+            StartupOnboardingStage::Finish => "Enter で会話開始 · Esc 戻る",
+        },
+        Language::Ru => match stage {
+            StartupOnboardingStage::Skills => "↑/↓ move · Space выбор · Enter дальше · Esc назад",
+            StartupOnboardingStage::Language
+            | StartupOnboardingStage::Provider
+            | StartupOnboardingStage::SetupPath
+            | StartupOnboardingStage::Personalization => "↑/↓ move · Enter дальше · Esc назад",
+            StartupOnboardingStage::Finish => "Enter начать чат · Esc назад",
+        },
+        _ => startup_onboarding_footer_text(stage),
+    }
+}
+
+fn startup_onboarding_subtitle(stage: StartupOnboardingStage, language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => match stage {
+            StartupOnboardingStage::Language => "先选 TUI 语言，之后仍可继续细调 config.toml。",
+            StartupOnboardingStage::Provider => {
+                "先选 Loong 优先准备的 provider，本地可复用的凭证会自动显示出来。"
+            }
+            StartupOnboardingStage::Skills => {
+                "Loong 可以预装少量 bundled skills。Space 勾选，Enter 继续。"
+            }
+            StartupOnboardingStage::SetupPath => {
+                "决定是保持 shell 极简，还是继续看 provider、web search、channels、MCP 这些后续路径。"
+            }
+            StartupOnboardingStage::Personalization => {
+                "先存一个首轮对话风格，让第一条真正回复更贴近你想要的节奏。"
+            }
+            StartupOnboardingStage::Finish => {
+                "现在可以直接开聊；MCP、web provider、channel、personalization 也可以按需要再继续。"
+            }
+        },
+        Language::ZhTw => match stage {
+            StartupOnboardingStage::Language => "先選 TUI 語言，之後仍可繼續微調 config.toml。",
+            StartupOnboardingStage::Provider => {
+                "先選 Loong 優先準備的 provider，本地可重用的憑證會自動顯示出來。"
+            }
+            StartupOnboardingStage::Skills => {
+                "Loong 可以預裝少量 bundled skills。Space 勾選，Enter 繼續。"
+            }
+            StartupOnboardingStage::SetupPath => {
+                "決定是保持 shell 極簡，還是繼續看 provider、web search、channels、MCP 這些後續路徑。"
+            }
+            StartupOnboardingStage::Personalization => {
+                "先存一個首輪對話風格，讓第一條真正回覆更貼近你想要的節奏。"
+            }
+            StartupOnboardingStage::Finish => {
+                "現在可以直接開聊；MCP、web provider、channel、personalization 也可以按需要再繼續。"
+            }
+        },
+        Language::Ja => match stage {
+            StartupOnboardingStage::Language => {
+                "先に TUI の言語を選びます。あとで config.toml は引き続き細かく調整できます。"
+            }
+            StartupOnboardingStage::Provider => {
+                "Loong が先に整える provider を選びます。再利用できるローカル認証は自動で見えます。"
+            }
+            StartupOnboardingStage::Skills => {
+                "Loong は少数の bundled skills を先に入れられます。Space で選択し、Enter で進みます。"
+            }
+            StartupOnboardingStage::SetupPath => {
+                "shell を最小限に保つか、provider、web search、channels、MCP の続き方まで今のうちに見るかを決めます。"
+            }
+            StartupOnboardingStage::Personalization => {
+                "最初の実際の返答のテンポを合わせるため、会話スタイルを軽く保存します。"
+            }
+            StartupOnboardingStage::Finish => {
+                "ここからすぐ会話できます。MCP、web provider、channels、personalization は必要になった時に続きを出せます。"
+            }
+        },
+        Language::Ru => match stage {
+            StartupOnboardingStage::Language => {
+                "Сначала выберите язык TUI. Позже config.toml всё ещё можно будет тонко подстроить."
+            }
+            StartupOnboardingStage::Provider => {
+                "Выберите provider, который Loong должен подготовить первым. Готовые локальные учётные данные будут показаны автоматически."
+            }
+            StartupOnboardingStage::Skills => {
+                "Loong может заранее поставить несколько bundled skills. Space выбирает, Enter идёт дальше."
+            }
+            StartupOnboardingStage::SetupPath => {
+                "Решите: оставить shell минимальным сейчас или сразу заглянуть в provider, web search, channels и MCP."
+            }
+            StartupOnboardingStage::Personalization => {
+                "Сохраните лёгкий стиль первого разговора, чтобы первый реальный ответ попал в нужный ритм."
+            }
+            StartupOnboardingStage::Finish => {
+                "Теперь можно сразу начать чат; MCP, web provider, channels и personalization можно продолжить по мере надобности."
+            }
+        },
+        _ => match stage {
+            StartupOnboardingStage::Language => {
+                "choose the TUI language first. You can still fine-tune config.toml later."
+            }
+            StartupOnboardingStage::Provider => {
+                "pick the provider Loong should prepare first. Ready local credentials are surfaced automatically."
+            }
+            StartupOnboardingStage::Skills => {
+                "Loong can preinstall a few bundled skills. Space toggles selection; Enter moves on."
+            }
+            StartupOnboardingStage::SetupPath => {
+                "keep the shell minimal or keep going into the current provider, web search, channels, MCP, and workspace setup details before the first real turn."
+            }
+            StartupOnboardingStage::Personalization => {
+                "save a light first-conversation style so the first real answer lands with the right density and initiative."
+            }
+            StartupOnboardingStage::Finish => {
+                "skip the rest for now. Loong will guide MCP, web-provider setup, and first-turn personalization when a conversation actually needs it."
+            }
+        },
+    }
+}
+
+fn startup_onboarding_subtitle_for_state(state: &StartupOnboardingState) -> &'static str {
+    if state.stage != StartupOnboardingStage::Finish {
+        return startup_onboarding_subtitle(state.stage, state.current_language());
+    }
+
+    match (state.current_language(), state.selected_personalization) {
+        (Language::ZhCn, Some(StartupPersonalizationPreset::Later)) => {
+            "现在可以直接开聊；如果之后想补首轮偏好，再手动运行 `loong personalize`。"
         }
-        StartupOnboardingStage::Finish => "Enter start chatting · Esc close onboarding",
+        (Language::ZhCn, Some(StartupPersonalizationPreset::TurnOff)) => {
+            "现在可以直接开聊；Loong 不会再主动弹个性化提示，后面需要时仍可手动运行 `loong personalize`。"
+        }
+        (Language::ZhTw, Some(StartupPersonalizationPreset::Later)) => {
+            "現在可以直接開聊；如果之後想補首輪偏好，再手動執行 `loong personalize`。"
+        }
+        (Language::ZhTw, Some(StartupPersonalizationPreset::TurnOff)) => {
+            "現在可以直接開聊；Loong 不會再主動跳出個性化提示，之後需要時仍可手動執行 `loong personalize`。"
+        }
+        (Language::Ja, Some(StartupPersonalizationPreset::Later)) => {
+            "ここからすぐ会話できます。最初の好みを後で足したい時だけ `loong personalize` を使います。"
+        }
+        (Language::Ja, Some(StartupPersonalizationPreset::TurnOff)) => {
+            "ここからすぐ会話できます。Loong は今後個性化の案内を自動では出さず、必要なら手動で `loong personalize` を使えます。"
+        }
+        (Language::Ru, Some(StartupPersonalizationPreset::Later)) => {
+            "Теперь можно сразу начать чат; если позже захотите добавить предпочтения первого разговора, вручную запустите `loong personalize`."
+        }
+        (Language::Ru, Some(StartupPersonalizationPreset::TurnOff)) => {
+            "Теперь можно сразу начать чат; Loong больше не будет сам предлагать персонализацию, но при необходимости вы всё ещё можете вручную запустить `loong personalize`."
+        }
+        (Language::En, Some(StartupPersonalizationPreset::Later)) => {
+            "start chatting now; run `loong personalize` later if you want to capture first-conversation preferences."
+        }
+        (Language::En, Some(StartupPersonalizationPreset::TurnOff)) => {
+            "start chatting now; Loong will stop surfacing personalization prompts unless you later run `loong personalize` yourself."
+        }
+        _ => startup_onboarding_subtitle(state.stage, state.current_language()),
+    }
+}
+
+fn startup_feedback_prefix(kind: &str, language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => match kind {
+            "language_set" => "语言已设为",
+            "provider_saved" => "provider 选择已保存：",
+            "skills_none_selected" => "暂时还没有选任何 skill pack。",
+            "skills_skipped" => "先跳过 skills；后面需要时 Loong 还能继续引导安装。",
+            "setup_chat_now" => "先把更深的配置留到真正需要时再展开。",
+            "setup_provider_web" => {
+                "provider 与 web search 的后续路径已经整理好了，下一步可以存一个首轮风格。"
+            }
+            "setup_channels_delivery" => {
+                "channels 与 delivery 的后续路径已经整理好了，下一步可以存一个首轮风格。"
+            }
+            "setup_mcp_skills" => {
+                "MCP 与 workspace 的后续路径已经整理好了，下一步可以存一个首轮风格。"
+            }
+            _ => "",
+        },
+        Language::ZhTw => match kind {
+            "language_set" => "語言已設為",
+            "provider_saved" => "provider 選擇已保存：",
+            "skills_none_selected" => "暫時還沒有選任何 skill pack。",
+            "skills_skipped" => "先略過 skills；之後需要時 Loong 還能繼續引導安裝。",
+            "setup_chat_now" => "先把更深的配置留到真正需要時再展開。",
+            "setup_provider_web" => {
+                "provider 與 web search 的後續路徑已整理好，下一步可以存一個首輪風格。"
+            }
+            "setup_channels_delivery" => {
+                "channels 與 delivery 的後續路徑已整理好，下一步可以存一個首輪風格。"
+            }
+            "setup_mcp_skills" => "MCP 與 workspace 的後續路徑已整理好，下一步可以存一個首輪風格。",
+            _ => "",
+        },
+        Language::Ja => match kind {
+            "language_set" => "言語を設定:",
+            "provider_saved" => "provider を保存:",
+            "skills_none_selected" => "skill pack はまだ選択していません。",
+            "skills_skipped" => {
+                "skills はいったん保留です。必要になったら Loong があとで案内します。"
+            }
+            "setup_chat_now" => "深い設定は、最初の実際の作業で必要になるまで開きません。",
+            "setup_provider_web" => {
+                "provider と web search の続き方は整理できました。次は最初の会話スタイルを保存できます。"
+            }
+            "setup_channels_delivery" => {
+                "channels と delivery の続き方は整理できました。次は最初の会話スタイルを保存できます。"
+            }
+            "setup_mcp_skills" => {
+                "MCP と workspace の続き方は整理できました。次は最初の会話スタイルを保存できます。"
+            }
+            _ => "",
+        },
+        Language::Ru => match kind {
+            "language_set" => "язык выбран:",
+            "provider_saved" => "provider сохранён:",
+            "skills_none_selected" => "пока не выбран ни один skill pack.",
+            "skills_skipped" => {
+                "skills пока пропущены. Когда понадобится, Loong подскажет установку позже."
+            }
+            "setup_chat_now" => {
+                "глубокую настройку оставляем до момента, когда она понадобится в реальной работе."
+            }
+            "setup_provider_web" => {
+                "маршрут для provider и web search уже разложен. Дальше можно сохранить стиль первого разговора."
+            }
+            "setup_channels_delivery" => {
+                "маршрут для channels и delivery уже разложен. Дальше можно сохранить стиль первого разговора."
+            }
+            "setup_mcp_skills" => {
+                "маршрут для MCP и workspace уже разложен. Дальше можно сохранить стиль первого разговора."
+            }
+            _ => "",
+        },
+        _ => match kind {
+            "language_set" => "language set to",
+            "provider_saved" => "provider choice saved:",
+            "skills_none_selected" => "no skill packs selected yet.",
+            "skills_skipped" => "skills skipped for now. Loong can guide installation later.",
+            "setup_chat_now" => "keeping deeper setup deferred until the first real task needs it.",
+            "setup_provider_web" => {
+                "provider and web-search follow-up mapped. next step: save a first-chat style."
+            }
+            "setup_channels_delivery" => {
+                "channel and delivery follow-up mapped. next step: save a first-chat style."
+            }
+            "setup_mcp_skills" => {
+                "MCP and workspace follow-up mapped. next step: save a first-chat style."
+            }
+            _ => "",
+        },
+    }
+}
+
+fn startup_feedback_selected_skill_packs(language: Language, count: usize) -> String {
+    match language {
+        Language::ZhCn => format!("已选 {count} 个 skill pack。"),
+        Language::ZhTw => format!("已選 {count} 個 skill pack。"),
+        Language::Ja => format!("{count} 個の skill pack を選択しました。"),
+        Language::Ru => format!("выбрано {count} skill pack."),
+        _ => format!("selected {count} skill pack(s)."),
+    }
+}
+
+fn startup_feedback_queued_skill_packs(language: Language, count: usize) -> String {
+    match language {
+        Language::ZhCn => format!("已加入 {count} 个 skill pack，后面仍可继续细调。"),
+        Language::ZhTw => format!("已加入 {count} 個 skill pack，之後仍可繼續微調。"),
+        Language::Ja => {
+            format!("{count} 個の skill pack をキューに入れました。あとでまだ微調整できます。")
+        }
+        Language::Ru => {
+            format!("{count} skill pack добавлены в очередь. Позже это можно ещё уточнить.")
+        }
+        _ => format!("{count} skill pack(s) queued. You can still refine this later."),
+    }
+}
+
+fn startup_recommended_badge(language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => "推荐",
+        Language::ZhTw => "推薦",
+        Language::Ja => "おすすめ",
+        Language::Ru => "рекомендуется",
+        Language::En => "recommended",
+    }
+}
+
+fn startup_personalization_footer_detail(language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => {
+            "Loong 会把这项写进 memory.personalization，只有当这套风格应该投射到 Session Profile 时，才会升级 memory.profile。"
+        }
+        Language::ZhTw => {
+            "Loong 會把這項寫進 memory.personalization，只有當這套風格應該投射到 Session Profile 時，才會升級 memory.profile。"
+        }
+        Language::Ja => {
+            "Loong はこれを memory.personalization に保存し、このスタイルを Session Profile に投影すべき時だけ memory.profile を上げます。"
+        }
+        Language::Ru => {
+            "Loong сохраняет это в memory.personalization и повышает memory.profile только когда этот стиль должен проецироваться в Session Profile."
+        }
+        _ => {
+            "Loong saves this into memory.personalization and only upgrades memory.profile when the saved style should project into Session Profile."
+        }
+    }
+}
+
+fn startup_no_preinstalled_skills_text(language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => "没有预装 skills",
+        Language::ZhTw => "沒有預裝 skills",
+        Language::Ja => "プリインストール skill なし",
+        Language::Ru => "без предустановленных skills",
+        Language::En => "no preinstalled skills",
+    }
+}
+
+fn startup_selected_skill_count_text(language: Language, count: usize) -> String {
+    match language {
+        Language::ZhCn => format!("已选 {count} 项"),
+        Language::ZhTw => format!("已選 {count} 項"),
+        Language::Ja => format!("{count} 件を選択"),
+        Language::Ru => format!("выбрано {count}"),
+        Language::En => format!("{count} selected"),
+    }
+}
+
+fn startup_not_saved_text(language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => "未保存",
+        Language::ZhTw => "未保存",
+        Language::Ja => "未保存",
+        Language::Ru => "не сохранено",
+        Language::En => "not saved",
+    }
+}
+
+fn startup_summary_label(kind: &str, language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => match kind {
+            "language" => "语言",
+            "provider" => "provider",
+            "skills" => "skills",
+            "setup_path" => "后续路径",
+            "personalization" => "个性化",
+            _ => "",
+        },
+        Language::ZhTw => match kind {
+            "language" => "語言",
+            "provider" => "provider",
+            "skills" => "skills",
+            "setup_path" => "後續路徑",
+            "personalization" => "個性化",
+            _ => "",
+        },
+        Language::Ja => match kind {
+            "language" => "言語",
+            "provider" => "provider",
+            "skills" => "skills",
+            "setup_path" => "続きの設定",
+            "personalization" => "会話スタイル",
+            _ => "",
+        },
+        Language::Ru => match kind {
+            "language" => "язык",
+            "provider" => "provider",
+            "skills" => "skills",
+            "setup_path" => "дальше настроить",
+            "personalization" => "стиль",
+            _ => "",
+        },
+        _ => match kind {
+            "language" => "language",
+            "provider" => "provider",
+            "skills" => "skills",
+            "setup_path" => "setup path",
+            "personalization" => "personalization",
+            _ => "",
+        },
+    }
+}
+
+fn startup_finish_prompt(language: Language) -> &'static str {
+    match language {
+        Language::ZhCn => "按 Enter 关闭引导并开始聊天。",
+        Language::ZhTw => "按 Enter 關閉引導並開始聊天。",
+        Language::Ja => "Enter でオンボードを閉じて会話を始めます。",
+        Language::Ru => "Нажмите Enter, чтобы закрыть онбординг и начать чат.",
+        Language::En => "press Enter to close onboarding and start chatting.",
     }
 }
 
@@ -1702,7 +2418,6 @@ fn startup_eye_animation_for_state(state: Option<&StartupOnboardingState>) -> St
             state.last_interaction_kind,
             StartupOnboardingInteractionKind::Confirm | StartupOnboardingInteractionKind::Persist
         );
-    let fresh_celebrate = interaction_age < Duration::from_millis(1500);
 
     match state.stage {
         StartupOnboardingStage::Language => {
@@ -1750,6 +2465,14 @@ fn startup_eye_animation_for_state(state: Option<&StartupOnboardingState>) -> St
             }
             StartupSetupPathChoice::ProviderAndWeb => {
                 let focus = StartupEyeFocus::Right;
+                if fresh_confirm {
+                    StartupEyeAnimation::Confirm(focus)
+                } else {
+                    StartupEyeAnimation::Thinking(focus)
+                }
+            }
+            StartupSetupPathChoice::ChannelsAndDelivery => {
+                let focus = StartupEyeFocus::Up;
                 if fresh_confirm {
                     StartupEyeAnimation::Confirm(focus)
                 } else {
@@ -1806,16 +2529,18 @@ fn startup_eye_animation_for_state(state: Option<&StartupOnboardingState>) -> St
                     StartupEyeAnimation::Focus(focus)
                 }
             }
-        },
-        StartupOnboardingStage::Finish => {
-            if fresh_celebrate
-                || state.last_interaction_kind == StartupOnboardingInteractionKind::Persist
-            {
-                StartupEyeAnimation::Celebrate
-            } else {
-                StartupEyeAnimation::Focus(StartupEyeFocus::Center)
+            StartupPersonalizationPreset::TurnOff => {
+                let focus = StartupEyeFocus::Up;
+                if fresh_confirm {
+                    StartupEyeAnimation::Confirm(focus)
+                } else if fresh_navigate {
+                    StartupEyeAnimation::Thinking(focus)
+                } else {
+                    StartupEyeAnimation::Focus(focus)
+                }
             }
-        }
+        },
+        StartupOnboardingStage::Finish => StartupEyeAnimation::Celebrate,
     }
 }
 
@@ -1837,7 +2562,7 @@ fn build_startup_onboarding_footer_line(
     state: &StartupOnboardingState,
     width: u16,
 ) -> Line<'static> {
-    let text = startup_onboarding_footer_text(state.stage);
+    let text = startup_onboarding_footer_text_for_language(state.stage, state.current_language());
     Line::from(Span::styled(
         truncate_right_for_width(text, width as usize),
         Style::default().fg(SURFACE_GRAY),
@@ -1854,7 +2579,7 @@ fn render_startup_onboarding_lines(
         "onboarding · {}/{} · {}",
         state.stage.step_index(),
         StartupOnboardingStage::total_steps(),
-        state.stage.title()
+        state.stage.title(state.current_language())
     );
     lines.push(Line::from(Span::styled(
         truncate_right_for_width(title.as_str(), content_width),
@@ -1863,26 +2588,7 @@ fn render_startup_onboarding_lines(
             .add_modifier(Modifier::BOLD),
     )));
 
-    let subtitle = match state.stage {
-        StartupOnboardingStage::Language => {
-            "choose the TUI language first. You can still fine-tune config.toml later."
-        }
-        StartupOnboardingStage::Provider => {
-            "pick the provider Loong should prepare first. Ready local credentials are surfaced automatically."
-        }
-        StartupOnboardingStage::Skills => {
-            "Loong can preinstall a few bundled skills. Space toggles selection; Enter moves on."
-        }
-        StartupOnboardingStage::SetupPath => {
-            "keep the shell minimal or keep going into the current provider, web search, MCP, and workspace setup details before the first real turn."
-        }
-        StartupOnboardingStage::Personalization => {
-            "save a light first-conversation style so the first real answer lands with the right density and initiative."
-        }
-        StartupOnboardingStage::Finish => {
-            "skip the rest for now. Loong will guide MCP, web-provider setup, and first-turn personalization when a conversation actually needs it."
-        }
-    };
+    let subtitle = startup_onboarding_subtitle_for_state(state);
     lines.extend(render_onboarding_wrapped_line(
         "  ",
         subtitle,
@@ -1914,7 +2620,7 @@ fn render_startup_onboarding_lines(
                     selected,
                     label,
                     if *language == Language::En {
-                        Some("recommended")
+                        Some(startup_recommended_badge(state.current_language()))
                     } else {
                         None
                     },
@@ -1928,16 +2634,20 @@ fn render_startup_onboarding_lines(
                 lines.extend(render_onboarding_option_line(
                     selected,
                     option.label.as_str(),
-                    option.recommended.then_some("recommended"),
+                    option
+                        .recommended
+                        .then_some(startup_recommended_badge(state.current_language())),
                     content_width,
                 ));
-                lines.extend(render_onboarding_wrapped_line(
-                    "    ",
-                    option.detail.as_str(),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    content_width,
-                ));
+                if selected {
+                    lines.extend(render_onboarding_wrapped_line(
+                        "    ",
+                        option.detail.as_str(),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        content_width,
+                    ));
+                }
             }
         }
         StartupOnboardingStage::Skills => {
@@ -1948,7 +2658,9 @@ fn render_startup_onboarding_lines(
                     .contains(option.install_id.as_str());
                 let cursor = if selected { "›" } else { " " };
                 let mark = if checked { "[x]" } else { "[ ]" };
-                let badge = option.recommended.then_some("recommended");
+                let badge = option
+                    .recommended
+                    .then_some(startup_recommended_badge(state.current_language()));
                 let label = match badge {
                     Some(badge) => format!("{cursor} {mark} {} · {badge}", option.display_name),
                     None => format!("{cursor} {mark} {}", option.display_name),
@@ -1963,13 +2675,15 @@ fn render_startup_onboarding_lines(
                         Style::default().fg(Color::White)
                     },
                 )));
-                lines.extend(render_onboarding_wrapped_line(
-                    "    ",
-                    option.summary.as_str(),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    content_width,
-                ));
+                if selected {
+                    lines.extend(render_onboarding_wrapped_line(
+                        "    ",
+                        option.summary.as_str(),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        content_width,
+                    ));
+                }
             }
         }
         StartupOnboardingStage::SetupPath => {
@@ -1977,17 +2691,20 @@ fn render_startup_onboarding_lines(
                 let selected = index == state.setup_path_index;
                 lines.extend(render_onboarding_option_line(
                     selected,
-                    choice.label(),
-                    matches!(choice, StartupSetupPathChoice::ChatNow).then_some("recommended"),
+                    choice.label(state.current_language()),
+                    matches!(choice, StartupSetupPathChoice::ChatNow)
+                        .then_some(startup_recommended_badge(state.current_language())),
                     content_width,
                 ));
-                lines.extend(render_onboarding_wrapped_line(
-                    "    ",
-                    choice.detail(),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    content_width,
-                ));
+                if selected {
+                    lines.extend(render_onboarding_wrapped_line(
+                        "    ",
+                        choice.detail(state.current_language()),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        content_width,
+                    ));
+                }
             }
 
             lines.push(Line::from(""));
@@ -2006,24 +2723,26 @@ fn render_startup_onboarding_lines(
                 let selected = index == state.personalization_index;
                 lines.extend(render_onboarding_option_line(
                     selected,
-                    preset.label(),
+                    preset.label(state.current_language()),
                     matches!(preset, StartupPersonalizationPreset::Balanced)
-                        .then_some("recommended"),
+                        .then_some(startup_recommended_badge(state.current_language())),
                     content_width,
                 ));
-                lines.extend(render_onboarding_wrapped_line(
-                    "    ",
-                    preset.detail(),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    Style::default().fg(SURFACE_DIM_GRAY),
-                    content_width,
-                ));
+                if selected {
+                    lines.extend(render_onboarding_wrapped_line(
+                        "    ",
+                        preset.detail(state.current_language()),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        Style::default().fg(SURFACE_DIM_GRAY),
+                        content_width,
+                    ));
+                }
             }
 
             lines.push(Line::from(""));
             lines.extend(render_onboarding_wrapped_line(
                 "  ",
-                "Loong saves this into memory.personalization and only upgrades memory.profile when the saved style should project into Session Profile.",
+                startup_personalization_footer_detail(state.current_language()),
                 Style::default().fg(SURFACE_GRAY),
                 Style::default().fg(SURFACE_GRAY),
                 content_width,
@@ -2037,21 +2756,41 @@ fn render_startup_onboarding_lines(
                 .map(|option| option.label.as_str())
                 .unwrap_or("start fresh");
             let skills = if state.selected_skill_ids.is_empty() {
-                "no preinstalled skills".to_owned()
+                startup_no_preinstalled_skills_text(state.current_language()).to_owned()
             } else {
-                format!("{} selected", state.selected_skill_ids.len())
+                startup_selected_skill_count_text(
+                    state.current_language(),
+                    state.selected_skill_ids.len(),
+                )
             };
-            let setup_path = state.current_setup_path_choice().label();
+            let setup_path = state
+                .current_setup_path_choice()
+                .label(state.current_language());
             let personalization = state
                 .selected_personalization
-                .map(|preset| preset.label())
-                .unwrap_or("not saved");
+                .map(|preset| preset.label(state.current_language()))
+                .unwrap_or(startup_not_saved_text(state.current_language()));
             for summary in [
-                format!("language · {language}"),
-                format!("provider · {provider}"),
-                format!("skills · {skills}"),
-                format!("setup path · {setup_path}"),
-                format!("personalization · {personalization}"),
+                format!(
+                    "{} · {language}",
+                    startup_summary_label("language", state.current_language())
+                ),
+                format!(
+                    "{} · {provider}",
+                    startup_summary_label("provider", state.current_language())
+                ),
+                format!(
+                    "{} · {skills}",
+                    startup_summary_label("skills", state.current_language())
+                ),
+                format!(
+                    "{} · {setup_path}",
+                    startup_summary_label("setup_path", state.current_language())
+                ),
+                format!(
+                    "{} · {personalization}",
+                    startup_summary_label("personalization", state.current_language())
+                ),
             ] {
                 lines.extend(render_onboarding_wrapped_line(
                     "  • ",
@@ -2064,7 +2803,7 @@ fn render_startup_onboarding_lines(
             lines.push(Line::from(""));
             lines.extend(render_onboarding_wrapped_line(
                 "  ",
-                "press Enter to close onboarding and start chatting.",
+                startup_finish_prompt(state.current_language()),
                 Style::default().fg(SURFACE_GRAY),
                 Style::default().fg(SURFACE_GRAY),
                 content_width,
@@ -2076,43 +2815,295 @@ fn render_startup_onboarding_lines(
 }
 
 fn startup_setup_path_detail_lines(state: &StartupOnboardingState) -> Vec<String> {
+    let language = state.current_language();
     match state.current_setup_path_choice() {
-        StartupSetupPathChoice::ChatNow => vec![
-            "The current splash/chat shell stays intact; deeper setup remains available on demand."
-                .to_owned(),
-            "Use `loong onboard` later when you want the full provider, web, channel, and daemon wizard."
-                .to_owned(),
-            "Use /settings for adjustments, and /mcp or /skills for their dedicated views."
-                .to_owned(),
-        ],
-        StartupSetupPathChoice::ProviderAndWeb => vec![
-            format!(
-                "Provider lane now: {}.",
-                state
-                    .provider_options
-                    .get(state.provider_index)
-                    .map(|option| option.label.as_str())
-                    .unwrap_or("start fresh")
-            ),
-            format!("Web setup default: {}.", state.web_search_provider_label),
-            state.web_search_provider_detail.clone(),
-            "Full provider/auth continuation still lives in `loong onboard`; /settings keeps the day-two adjustment surface inside this shell."
-                .to_owned(),
-        ],
-        StartupSetupPathChoice::McpAndSkills => vec![
-            format!("Bootstrap MCP servers available now: {}.", state.startup_mcp_count),
-            format!(
-                "Bundled skill packs visible now: {} ({} selected in this startup pass).",
-                state.detected_skill_count,
-                state.selected_skill_ids.len()
-            ),
-            "Use /mcp and /skills for dedicated views, or /settings when you want to adjust managed workspace setup."
-                .to_owned(),
-        ],
+        StartupSetupPathChoice::ChatNow => match language {
+            Language::ZhCn => vec![
+                "当前 splash/chat shell 会保持不变；更深的配置随时都能按需展开。".to_owned(),
+                "如果你之后想走完整的 provider、web、channel、daemon 向导，可以再用 `loong onboard`。".to_owned(),
+                "如果你想先看当前 runtime snapshot，也可以随时在空白输入框里用 /mcp 或 /skills。".to_owned(),
+            ],
+            Language::ZhTw => vec![
+                "目前 splash/chat shell 會保持不變；更深的配置隨時都能按需展開。".to_owned(),
+                "如果你之後想走完整的 provider、web、channel、daemon 嚮導，可以再用 `loong onboard`。".to_owned(),
+                "如果你想先看目前 runtime snapshot，也可以隨時在空白輸入框裡用 /mcp 或 /skills。".to_owned(),
+            ],
+            Language::En | Language::Ja | Language::Ru => vec![
+                "The current splash/chat shell stays intact; deeper setup remains available on demand."
+                    .to_owned(),
+                "Use `loong onboard` later when you want the full provider, web, channel, and daemon wizard."
+                    .to_owned(),
+                "Use /mcp or /skills from the empty composer whenever you want the live runtime snapshot."
+                    .to_owned(),
+            ],
+        },
+        StartupSetupPathChoice::ProviderAndWeb => match language {
+            Language::ZhCn => vec![
+                format!(
+                    "当前 provider 路径：{}。",
+                    state
+                        .provider_options
+                        .get(state.provider_index)
+                        .map(|option| option.label.as_str())
+                        .unwrap_or("provider")
+                ),
+                match state.provider_auth_env_name.as_deref() {
+                    Some(env_name) => format!("当前 provider 凭证环境变量：{}。", env_name),
+                    None => "当前 provider 还没有解析到可用的凭证环境变量。".to_owned(),
+                },
+                format!("当前 web 默认项：{}。", state.web_search_provider_label),
+                state.web_search_provider_detail.clone(),
+                state.provider_configuration_hint.clone().unwrap_or_else(|| {
+                    "如果你要继续补 provider 的 base_url、model 或鉴权，下一步优先看 `loong doctor`。"
+                        .to_owned()
+                }),
+                "完整的 provider / auth continuation 仍然在 `loong onboard`；这里会保持 shell 轻一点，只把真正的下一条命令露出来。"
+                    .to_owned(),
+            ],
+            Language::ZhTw => vec![
+                format!(
+                    "目前 provider 路徑：{}。",
+                    state
+                        .provider_options
+                        .get(state.provider_index)
+                        .map(|option| option.label.as_str())
+                        .unwrap_or("provider")
+                ),
+                match state.provider_auth_env_name.as_deref() {
+                    Some(env_name) => format!("目前 provider 憑證環境變數：{}。", env_name),
+                    None => "目前 provider 還沒有解析到可用的憑證環境變數。".to_owned(),
+                },
+                format!("目前 web 預設項：{}。", state.web_search_provider_label),
+                state.web_search_provider_detail.clone(),
+                state.provider_configuration_hint.clone().unwrap_or_else(|| {
+                    "如果你要繼續補 provider 的 base_url、model 或驗證，下一步優先看 `loong doctor`。"
+                        .to_owned()
+                }),
+                "完整的 provider / auth continuation 仍然在 `loong onboard`；這裡會保持 shell 輕一點，只把真正的下一條命令露出來。"
+                    .to_owned(),
+            ],
+            Language::En | Language::Ja | Language::Ru => vec![
+                format!(
+                    "Provider lane now: {}.",
+                    state
+                        .provider_options
+                        .get(state.provider_index)
+                        .map(|option| option.label.as_str())
+                        .unwrap_or("provider")
+                ),
+                match state.provider_auth_env_name.as_deref() {
+                    Some(env_name) => format!("Provider auth env now: {}.", env_name),
+                    None => "No provider credential env is resolved yet.".to_owned(),
+                },
+                format!("Web setup default: {}.", state.web_search_provider_label),
+                state.web_search_provider_detail.clone(),
+                state.provider_configuration_hint.clone().unwrap_or_else(|| {
+                    "If you need to keep tuning provider base_url, model, or auth, `loong doctor` is the next check to run."
+                        .to_owned()
+                }),
+                "Full provider/auth continuation lives in `loong onboard`; the TUI keeps the shell minimal and surfaces the real next command instead of opening a second startup UI."
+                    .to_owned(),
+            ],
+        },
+        StartupSetupPathChoice::ChannelsAndDelivery => {
+            let has_enabled_channels = !state.enabled_channel_labels.is_empty();
+            let suggested_channels = startup_suggested_channel_follow_up_descriptors(language);
+            let mut lines = vec![match language {
+                Language::ZhCn if state.enabled_channel_labels.is_empty() => {
+                    "当前还没有启用任何外部 channel。".to_owned()
+                }
+                Language::ZhTw if state.enabled_channel_labels.is_empty() => {
+                    "目前還沒有啟用任何外部 channel。".to_owned()
+                }
+                Language::ZhCn => format!(
+                    "当前已启用的 channel：{}。",
+                    state.enabled_channel_labels.join(", ")
+                ),
+                Language::ZhTw => format!(
+                    "目前已啟用的 channel：{}。",
+                    state.enabled_channel_labels.join(", ")
+                ),
+                Language::En | Language::Ja | Language::Ru
+                    if state.enabled_channel_labels.is_empty() =>
+                {
+                    "No external channels are enabled yet.".to_owned()
+                }
+                Language::En | Language::Ja | Language::Ru => {
+                    format!("Enabled channels now: {}.", state.enabled_channel_labels.join(", "))
+                }
+            }];
+            if !has_enabled_channels && !suggested_channels.is_empty() {
+                let suggested_labels = suggested_channels
+                    .iter()
+                    .map(|descriptor| descriptor.label.clone())
+                    .collect::<Vec<_>>();
+                lines.push(match language {
+                    Language::ZhCn => {
+                        format!("建议优先接的 channels：{}。", suggested_labels.join(", "))
+                    }
+                    Language::ZhTw => {
+                        format!("建議優先接的 channels：{}。", suggested_labels.join(", "))
+                    }
+                    Language::Ja => {
+                        format!("まず候補になる channels: {}。", suggested_labels.join(", "))
+                    }
+                    Language::Ru => {
+                        format!("С чего обычно начинают: {}.", suggested_labels.join(", "))
+                    }
+                    Language::En => {
+                        format!("Good first channels to wire: {}.", suggested_labels.join(", "))
+                    }
+                });
+
+                let suggested_commands = suggested_channels
+                    .iter()
+                    .filter_map(|descriptor| descriptor.repair_command.clone())
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                if !suggested_commands.is_empty() {
+                    lines.push(match language {
+                        Language::ZhCn => {
+                            format!("建议先跑的 onboarding 命令：{}。", suggested_commands.join(", "))
+                        }
+                        Language::ZhTw => {
+                            format!("建議先跑的 onboarding 命令：{}。", suggested_commands.join(", "))
+                        }
+                        Language::Ja => {
+                            format!("先に試す onboarding コマンド: {}。", suggested_commands.join(", "))
+                        }
+                        Language::Ru => {
+                            format!("Сначала стоит запустить: {}.", suggested_commands.join(", "))
+                        }
+                        Language::En => {
+                            format!("Suggested onboarding commands: {}.", suggested_commands.join(", "))
+                        }
+                    });
+                }
+            }
+            if state.channel_follow_up_commands.is_empty() {
+                lines.push(match language {
+                    Language::ZhCn => {
+                        "当前还没有可直接运行的 channel runtime command；如果你要继续接 delivery surface，可以走 `loong onboard`。".to_owned()
+                    }
+                    Language::ZhTw => {
+                        "目前還沒有可直接執行的 channel runtime command；如果你要繼續接 delivery surface，可以走 `loong onboard`。".to_owned()
+                    }
+                    Language::En | Language::Ja | Language::Ru => {
+                        "No channel runtime command is ready yet; continue setup through `loong onboard` when you want to wire delivery surfaces.".to_owned()
+                    }
+                });
+            } else if let Some(next_command) = state.channel_follow_up_commands.first() {
+                lines.push(match language {
+                    Language::ZhCn => format!("下一条 runtime command：{}。", next_command),
+                    Language::ZhTw => format!("下一條 runtime command：{}。", next_command),
+                    Language::En | Language::Ja | Language::Ru => {
+                        format!("Next runtime command: {}.", next_command)
+                    }
+                });
+                if let Some(other_commands) = state.channel_follow_up_commands.get(1..)
+                    && !other_commands.is_empty()
+                {
+                    lines.push(match language {
+                        Language::ZhCn => format!(
+                            "其他 channel command：{}。",
+                            other_commands.join(", ")
+                        ),
+                        Language::ZhTw => format!(
+                            "其他 channel command：{}。",
+                            other_commands.join(", ")
+                        ),
+                        Language::En | Language::Ja | Language::Ru => format!(
+                            "Other channel commands: {}.",
+                            other_commands.join(", ")
+                        ),
+                    });
+                }
+            }
+            if let Some(status_command) = state.channel_status_commands.first() {
+                lines.push(match language {
+                    Language::ZhCn => format!("健康检查命令：{}。", status_command),
+                    Language::ZhTw => format!("健康檢查命令：{}。", status_command),
+                    Language::Ja => format!("ヘルス確認コマンド: {}。", status_command),
+                    Language::Ru => format!("Команда проверки состояния: {}.", status_command),
+                    Language::En => format!("Health command: {}.", status_command),
+                });
+            }
+            if !state.channel_repair_commands.is_empty() {
+                lines.push(match language {
+                    Language::ZhCn => format!(
+                        "修复路径：{}。",
+                        state.channel_repair_commands.join(", ")
+                    ),
+                    Language::ZhTw => format!(
+                        "修復路徑：{}。",
+                        state.channel_repair_commands.join(", ")
+                    ),
+                    Language::Ja => format!(
+                        "修復パス: {}。",
+                        state.channel_repair_commands.join(", ")
+                    ),
+                    Language::Ru => format!(
+                        "Путь восстановления: {}.",
+                        state.channel_repair_commands.join(", ")
+                    ),
+                    Language::En => format!(
+                        "Repair path: {}.",
+                        state.channel_repair_commands.join(", ")
+                    ),
+                });
+            }
+            lines.push(match language {
+                Language::ZhCn => {
+                    "这条路径会先保持当前聊天面简洁，但把你下一步真正要继续的 channel / delivery 命令露出来。".to_owned()
+                }
+                Language::ZhTw => {
+                    "這條路徑會先保持目前聊天面精簡，但把你下一步真正要繼續的 channel / delivery 命令露出來。".to_owned()
+                }
+                Language::En | Language::Ja | Language::Ru => {
+                    "This path keeps chat focused now while surfacing the real channel and delivery commands you can continue with next.".to_owned()
+                }
+            });
+            lines
+        }
+        StartupSetupPathChoice::McpAndSkills => match language {
+            Language::ZhCn => vec![
+                format!("当前可用的 bootstrap MCP server：{}。", state.startup_mcp_count),
+                format!(
+                    "当前可见的 bundled skill pack：{}（这轮已选 {} 个）。",
+                    state.detected_skill_count,
+                    state.selected_skill_ids.len()
+                ),
+                "如果你想看 live server list 用 /mcp；想看 pack inventory 用 /skills；想走更完整的 workspace/setup wizard 还是用 `loong onboard`。".to_owned(),
+            ],
+            Language::ZhTw => vec![
+                format!("目前可用的 bootstrap MCP server：{}。", state.startup_mcp_count),
+                format!(
+                    "目前可見的 bundled skill pack：{}（這輪已選 {} 個）。",
+                    state.detected_skill_count,
+                    state.selected_skill_ids.len()
+                ),
+                "如果你想看 live server list 用 /mcp；想看 pack inventory 用 /skills；想走更完整的 workspace/setup wizard 還是用 `loong onboard`。".to_owned(),
+            ],
+            Language::En | Language::Ja | Language::Ru => vec![
+                format!("Bootstrap MCP servers available now: {}.", state.startup_mcp_count),
+                format!(
+                    "Bundled skill packs visible now: {} ({} selected in this startup pass).",
+                    state.detected_skill_count,
+                    state.selected_skill_ids.len()
+                ),
+                "Use /mcp for the live server list, /skills for the pack inventory, or `loong onboard` if you want the broader workspace/setup wizard."
+                    .to_owned(),
+            ],
+        },
     }
 }
 
-fn startup_web_search_detail(runtime: &CliTurnRuntime, provider: &str) -> String {
+fn startup_web_search_detail(
+    runtime: &CliTurnRuntime,
+    provider: &str,
+    language: Language,
+) -> String {
     if runtime
         .config
         .tools
@@ -2120,32 +3111,190 @@ fn startup_web_search_detail(runtime: &CliTurnRuntime, provider: &str) -> String
         .configured_api_key_for_provider(provider)
         .is_some()
     {
-        return format!(
-            "Web provider ready: {} is already configured inside tools.web_search.",
-            web_search_provider_descriptor(provider)
-                .map(|descriptor| descriptor.display_name)
-                .unwrap_or(provider)
-        );
+        let provider_label = web_search_provider_descriptor(provider)
+            .map(|descriptor| descriptor.display_name)
+            .unwrap_or(provider);
+        return match language {
+            Language::ZhCn => {
+                format!(
+                    "web provider 已就绪：{} 已在 tools.web_search 里配置好。",
+                    provider_label
+                )
+            }
+            Language::ZhTw => {
+                format!(
+                    "web provider 已就緒：{} 已在 tools.web_search 裡配置好。",
+                    provider_label
+                )
+            }
+            Language::Ja => format!(
+                "web provider は準備できています: {} はすでに tools.web_search に設定されています。",
+                provider_label
+            ),
+            Language::Ru => format!(
+                "web provider готов: {} уже настроен в tools.web_search.",
+                provider_label
+            ),
+            Language::En => format!(
+                "Web provider ready: {} is already configured inside tools.web_search.",
+                provider_label
+            ),
+        };
     }
 
     if let Some(env_name) = web_search_provider_api_key_env_names(provider)
         .iter()
         .find(|env_name| std::env::var_os(env_name).is_some())
     {
-        return format!(
-            "Web provider follow-up: {} can reuse {env_name} if you continue setup later.",
-            web_search_provider_descriptor(provider)
-                .map(|descriptor| descriptor.display_name)
-                .unwrap_or(provider)
-        );
+        let provider_label = web_search_provider_descriptor(provider)
+            .map(|descriptor| descriptor.display_name)
+            .unwrap_or(provider);
+        return match language {
+            Language::ZhCn => {
+                format!("web provider 后续可以复用 {env_name}：{}。", provider_label)
+            }
+            Language::ZhTw => {
+                format!("web provider 後續可以重用 {env_name}：{}。", provider_label)
+            }
+            Language::Ja => format!(
+                "後で setup を続けるなら、web provider {} は {env_name} を再利用できます。",
+                provider_label
+            ),
+            Language::Ru => format!(
+                "Если потом продолжить setup, web provider {} сможет переиспользовать {env_name}.",
+                provider_label
+            ),
+            Language::En => format!(
+                "Web provider follow-up: {} can reuse {env_name} if you continue setup later.",
+                provider_label
+            ),
+        };
     }
 
-    format!(
-        "Web provider follow-up: {} is the current default, but auth still needs to be wired before web-backed setup can go further.",
-        web_search_provider_descriptor(provider)
-            .map(|descriptor| descriptor.display_name)
-            .unwrap_or(provider)
-    )
+    let provider_label = web_search_provider_descriptor(provider)
+        .map(|descriptor| descriptor.display_name)
+        .unwrap_or(provider);
+    match language {
+        Language::ZhCn => format!(
+            "web provider 后续默认会走 {}，但要继续 web 相关配置，鉴权还需要补上。",
+            provider_label
+        ),
+        Language::ZhTw => format!(
+            "web provider 後續預設會走 {}，但要繼續 web 相關配置，驗證還需要補上。",
+            provider_label
+        ),
+        Language::Ja => format!(
+            "web provider の既定は {} ですが、web 連携を先へ進めるには認証の配線がまだ必要です。",
+            provider_label
+        ),
+        Language::Ru => format!(
+            "По умолчанию web provider сейчас {}, но чтобы продолжить web-настройку, авторизацию ещё нужно подключить.",
+            provider_label
+        ),
+        Language::En => format!(
+            "Web provider follow-up: {} is the current default, but auth still needs to be wired before web-backed setup can go further.",
+            provider_label
+        ),
+    }
+}
+
+fn startup_channel_follow_up_descriptors(
+    runtime: &CliTurnRuntime,
+    language: Language,
+) -> Vec<StartupChannelFollowUpDescriptor> {
+    service_channel_descriptors()
+        .into_iter()
+        .filter(|descriptor| channel_enabled_in_config(&runtime.config, descriptor.id))
+        .filter_map(|descriptor| {
+            let onboarding = resolve_channel_onboarding_descriptor(descriptor.id)?;
+            Some(StartupChannelFollowUpDescriptor {
+                label: startup_channel_label(descriptor.id, descriptor.label, language),
+                serve_command: descriptor.serve_subcommand.map(str::to_owned),
+                status_command: onboarding.status_command.to_owned(),
+                repair_command: onboarding.repair_command.map(str::to_owned),
+            })
+        })
+        .collect()
+}
+
+fn startup_suggested_channel_follow_up_descriptors(
+    language: Language,
+) -> Vec<StartupChannelFollowUpDescriptor> {
+    preferred_startup_channel_ids(language)
+        .iter()
+        .filter_map(|channel_id| {
+            let descriptor = service_channel_descriptors()
+                .into_iter()
+                .find(|descriptor| descriptor.id == *channel_id)?;
+            let onboarding = resolve_channel_onboarding_descriptor(descriptor.id)?;
+            Some(StartupChannelFollowUpDescriptor {
+                label: startup_channel_label(descriptor.id, descriptor.label, language),
+                serve_command: descriptor.serve_subcommand.map(str::to_owned),
+                status_command: onboarding.status_command.to_owned(),
+                repair_command: onboarding.repair_command.map(str::to_owned),
+            })
+        })
+        .collect()
+}
+
+fn preferred_startup_channel_ids(language: Language) -> &'static [&'static str] {
+    match language {
+        Language::ZhCn | Language::ZhTw => &["feishu", "wecom", "dingtalk", "weixin"],
+        Language::Ja => &["line", "telegram", "discord", "slack"],
+        Language::Ru => &["telegram", "matrix", "discord", "slack"],
+        Language::En => &["telegram", "matrix", "slack", "discord"],
+    }
+}
+
+fn channel_enabled_in_config(config: &LoongConfig, channel_id: &str) -> bool {
+    match channel_id {
+        "cli" => config.cli.enabled,
+        "telegram" => config.telegram.enabled,
+        "feishu" => config.feishu.enabled,
+        "matrix" => config.matrix.enabled,
+        "wecom" => config.wecom.enabled,
+        "weixin" => config.weixin.enabled,
+        "qqbot" => config.qqbot.enabled,
+        "onebot" => config.onebot.enabled,
+        "discord" => config.discord.enabled,
+        "line" => config.line.enabled,
+        "dingtalk" => config.dingtalk.enabled,
+        "webhook" => config.webhook.enabled,
+        "slack" => config.slack.enabled,
+        "google-chat" => config.google_chat.enabled,
+        "mattermost" => config.mattermost.enabled,
+        "nextcloud-talk" => config.nextcloud_talk.enabled,
+        "synology-chat" => config.synology_chat.enabled,
+        "irc" => config.irc.enabled,
+        "imessage" => config.imessage.enabled,
+        "signal" => config.signal.enabled,
+        "whatsapp" => config.whatsapp.enabled,
+        "teams" => config.teams.enabled,
+        "twitch" => config.twitch.enabled,
+        "nostr" => config.nostr.enabled,
+        "tlon" => config.tlon.enabled,
+        _ => false,
+    }
+}
+
+fn startup_channel_label(channel_id: &str, fallback_label: &str, language: Language) -> String {
+    match language {
+        Language::ZhCn => match channel_id {
+            "feishu" => "飞书".to_owned(),
+            "dingtalk" => "钉钉".to_owned(),
+            "wecom" => "企业微信".to_owned(),
+            "weixin" => "微信".to_owned(),
+            _ => fallback_label.to_owned(),
+        },
+        Language::ZhTw => match channel_id {
+            "feishu" => "飛書".to_owned(),
+            "dingtalk" => "釘釘".to_owned(),
+            "wecom" => "企業微信".to_owned(),
+            "weixin" => "微信".to_owned(),
+            _ => fallback_label.to_owned(),
+        },
+        Language::En | Language::Ja | Language::Ru => fallback_label.to_owned(),
+    }
 }
 
 fn startup_personalization_locale(language: Language) -> &'static str {
@@ -2158,22 +3307,500 @@ fn startup_personalization_locale(language: Language) -> &'static str {
     }
 }
 
+fn startup_first_turn_bootstrap_addendum(
+    preset: StartupPersonalizationPreset,
+    language: Language,
+) -> Option<String> {
+    if matches!(
+        preset,
+        StartupPersonalizationPreset::Later | StartupPersonalizationPreset::TurnOff
+    ) {
+        return None;
+    }
+
+    let instruction = match (preset, language) {
+        (StartupPersonalizationPreset::Concise, Language::ZhCn) => concat!(
+            "仅在下一次真正回复里生效：先不要直接解决任务。先用一条非常简短、自然、友善的 assistant 消息确认该怎么称呼用户；",
+            "如果语气允许，再顺带问一句 Loong 该叫什么。不要列清单，不要提到系统提示，问完就停下来等用户回答。"
+        ),
+        (StartupPersonalizationPreset::Concise, Language::ZhTw) => concat!(
+            "僅在下一次真正回覆裡生效：先不要直接解決任務。先用一條非常簡短、自然、友善的 assistant 訊息確認該怎麼稱呼使用者；",
+            "如果語氣允許，再順帶問一句 Loong 該叫什麼。不要列清單，不要提到系統提示，問完就停下來等使用者回答。"
+        ),
+        (StartupPersonalizationPreset::Concise, Language::Ja) => concat!(
+            "次の実際の返信で一度だけ使います。いきなり作業を進めず、まず短く自然でやわらかい assistant メッセージを一つ送り、",
+            "ユーザーをどう呼べばよいかを確認してください。流れが自然なら、Loong の呼び名も一言だけ聞いてください。箇条書きや system prompt への言及は避け、聞いたら止まって返答を待ちます。"
+        ),
+        (StartupPersonalizationPreset::Concise, Language::Ru) => concat!(
+            "Это действует только для следующего реального ответа. Не переходи сразу к задаче.",
+            " Сначала отправь очень короткое, естественное и дружелюбное сообщение assistant и уточни, как обращаться к пользователю.",
+            " Если это уместно, одной фразой спроси и как лучше звать Loong. Без чеклиста и без упоминания system prompt; после вопроса остановись и жди ответа."
+        ),
+        (StartupPersonalizationPreset::Concise, Language::En) => concat!(
+            "For the next real reply only, do not jump straight into the task.",
+            " First send one very short, natural, friendly assistant message that confirms how to address the user.",
+            " If it feels natural, ask in one clause what Loong should be called too. No checklist, no system-prompt talk, and stop after asking."
+        ),
+        (StartupPersonalizationPreset::Thorough, Language::ZhCn) => concat!(
+            "仅在下一次真正回复里生效：先不要直接解决任务。先用一条自然、简短、友善的 assistant 消息确认：",
+            "该怎么称呼用户；如果用户愿意，Loong 应该叫什么、整体气质想偏什么感觉、要不要带一个 emoji；如果和协作有关，也可以顺带说一下时区、长期边界，或者你想让 Loong 记住的一条备注。",
+            "不要写成清单，不要提到系统提示或个性化流程，问完后停下来等待用户回答。"
+        ),
+        (StartupPersonalizationPreset::Thorough, Language::ZhTw) => concat!(
+            "僅在下一次真正回覆裡生效：先不要直接解決任務。先用一條自然、簡短、友善的 assistant 訊息確認：",
+            "該怎麼稱呼使用者；如果使用者願意，Loong 應該叫什麼、整體氣質想偏什麼感覺、要不要帶一個 emoji；如果和協作有關，也可以順帶說一下時區、長期邊界，或是一條希望 Loong 記住的備註。",
+            "不要寫成清單，不要提到系統提示或個性化流程，問完後停下來等待使用者回答。"
+        ),
+        (StartupPersonalizationPreset::Thorough, Language::Ja) => concat!(
+            "次の実際の返信で一度だけ使います。いきなり作業を進めず、まず短く自然でやわらかい assistant メッセージを一つ送り、",
+            "どう呼べばよいかを確認してください。望むなら Loong の呼び名、雰囲気、emoji の好みも一緒に聞いて構いません。協力に関係するなら、タイムゾーンや長く保ちたい境界、覚えておいてほしい短いメモも軽く聞いて構いません。",
+            "箇条書きや system prompt への言及は避け、聞いたら止まって返答を待ちます。"
+        ),
+        (StartupPersonalizationPreset::Thorough, Language::Ru) => concat!(
+            "Это действует только для следующего реального ответа. Не переходи сразу к задаче.",
+            " Сначала отправь одно короткое, естественное и дружелюбное сообщение assistant и мягко уточни,",
+            " как обращаться к пользователю; если ему хочется, как звать Loong, какой vibe ближе и нужен ли emoji. Если это помогает совместной работе, можно заодно спросить про timezone, постоянные boundaries или короткую заметку, которую Loong стоит помнить.",
+            " Не оформляй это как чеклист и не упоминай system prompt или personalization workflow; после вопроса остановись и жди ответа."
+        ),
+        (StartupPersonalizationPreset::Thorough, Language::En) => concat!(
+            "For the next real reply only, do not jump straight into the task.",
+            " First send one short, natural, friendly assistant message that asks how to address the user and, if they want, what name, vibe, or emoji Loong should use. If it helps future collaboration, you may also invite a timezone, a long-lived boundary, or one short note Loong should remember.",
+            " Do not present a checklist, do not mention system prompts or personalization workflow, and stop after asking so the user can answer."
+        ),
+        (_, Language::ZhCn) => concat!(
+            "仅在下一次真正回复里生效：先不要直接解决任务。先用一条自然、简短、友善的 assistant 消息问清两件事：",
+            "1）该怎么称呼用户；2）如果用户愿意，Loong 应该叫什么、整体气质/emoji 想要什么感觉。",
+            "不要把问题写成清单，不要提到“系统提示”或“个性化流程”，也不要一次问太多。问完后停下来等待用户回答。"
+        ),
+        (_, Language::ZhTw) => concat!(
+            "僅在下一次真正回覆裡生效：先不要直接解決任務。先用一條自然、簡短、友善的 assistant 訊息問清兩件事：",
+            "1）該怎麼稱呼使用者；2）如果使用者願意，Loong 應該叫什麼、整體氣質/emoji 想要什麼感覺。",
+            "不要把問題寫成清單，不要提到「系統提示」或「個性化流程」，也不要一次問太多。問完後停下來等待使用者回答。"
+        ),
+        (_, Language::Ja) => concat!(
+            "次の実際の返信で一度だけ使います。いきなり作業を進めず、まず短く自然でやわらかい assistant メッセージを一つ送り、",
+            "1) ユーザーをどう呼べばよいか、2) 望むなら Loong の呼び名や雰囲気、emoji の好みも教えてほしい、と聞いてください。",
+            "箇条書きにはせず、system prompt や personalization workflow には触れず、聞き終えたら返答を待って止まってください。"
+        ),
+        (_, Language::Ru) => concat!(
+            "Это действует только для следующего реального ответа. Не переходи сразу к задаче.",
+            " Сначала отправь одно короткое, естественное и дружелюбное сообщение assistant, где мягко уточнишь:",
+            " 1) как обращаться к пользователю; 2) если пользователю хочется, как звать Loong и какой vibe или emoji ему ближе.",
+            " Не оформляй это как чеклист, не упоминай system prompt или personalization workflow, и после вопроса остановись в ожидании ответа."
+        ),
+        (_, Language::En) => concat!(
+            "For the next real reply only, do not jump straight into the task.",
+            " First send one short, natural, friendly assistant message that asks two things:",
+            " how to address the user, and, if they want, what name, vibe, or emoji Loong should use.",
+            " Do not present a checklist, do not mention system prompts or personalization workflow, and stop after asking so the user can answer."
+        ),
+    };
+
+    Some(instruction.to_owned())
+}
+
+fn apply_first_turn_bootstrap_addendum(runtime: &mut CliTurnRuntime, addendum: String) {
+    if addendum.trim().is_empty() {
+        return;
+    }
+
+    runtime.config.cli.system_prompt_addendum = Some(addendum.clone());
+    if !runtime.config.cli.uses_native_prompt_pack() {
+        let base = runtime.config.cli.system_prompt.trim().to_owned();
+        runtime.config.cli.system_prompt = if base.is_empty() {
+            addendum
+        } else {
+            format!("{base}\n\n{addendum}")
+        };
+    }
+}
+
+fn maybe_capture_and_persist_first_turn_bootstrap_reply(
+    app: &mut App,
+    runtime: &mut CliTurnRuntime,
+    input: &str,
+) -> CliResult<()> {
+    if !app.awaiting_first_turn_bootstrap_reply {
+        return Ok(());
+    }
+
+    if detect_startup_bootstrap_reply_opt_out(input) {
+        app.awaiting_first_turn_bootstrap_reply = false;
+        return Ok(());
+    }
+
+    let Some(capture) = infer_startup_bootstrap_capture(input) else {
+        return Ok(());
+    };
+    app.awaiting_first_turn_bootstrap_reply = false;
+    persist_startup_bootstrap_capture(runtime, &capture)
+}
+
+fn detect_startup_bootstrap_reply_opt_out(input: &str) -> bool {
+    let lowered = input.to_ascii_lowercase();
+    [
+        "skip for now",
+        "skip this",
+        "no preference",
+        "up to you",
+        "either is fine",
+    ]
+    .iter()
+    .any(|pattern| lowered.contains(pattern))
+        || [
+            "跳过",
+            "不用了",
+            "随便",
+            "隨便",
+            "都可以",
+            "先这样",
+            "先這樣",
+        ]
+        .iter()
+        .any(|pattern| input.contains(pattern))
+}
+
+fn infer_startup_bootstrap_capture(input: &str) -> Option<StartupBootstrapCapture> {
+    let capture = StartupBootstrapCapture {
+        preferred_address: extract_bootstrap_field_value(
+            input,
+            &[
+                "you can call me ",
+                "call me ",
+                "address me as ",
+                "叫我",
+                "稱呼我",
+                "称呼我",
+            ],
+        ),
+        pronouns: extract_bootstrap_field_value(
+            input,
+            &[
+                "my pronouns are ",
+                "pronouns are ",
+                "pronouns=",
+                "代词是",
+                "代詞是",
+            ],
+        ),
+        agent_name: extract_bootstrap_field_value(
+            input,
+            &[
+                "your name is ",
+                "call yourself ",
+                "you can be ",
+                "你叫",
+                "你可以叫",
+                "loong叫",
+                "loong 叫",
+            ],
+        ),
+        creature: extract_bootstrap_field_value(
+            input,
+            &[
+                "creature=",
+                "creature is ",
+                "species is ",
+                "物种是",
+                "物種是",
+                "设定是",
+                "設定是",
+            ],
+        ),
+        vibe: extract_bootstrap_field_value(
+            input,
+            &[
+                "vibe=",
+                "vibe is ",
+                "tone is ",
+                "气质是",
+                "氣質是",
+                "风格是",
+                "風格是",
+            ],
+        ),
+        emoji: extract_bootstrap_field_value(
+            input,
+            &["emoji=", "emoji is ", "emoji 用", "emoji用", "表情是"],
+        ),
+        timezone: extract_bootstrap_field_value(
+            input,
+            &[
+                "timezone=",
+                "timezone is ",
+                "my timezone is ",
+                "time zone is ",
+                "时区是",
+                "時區是",
+            ],
+        ),
+        standing_boundaries: extract_bootstrap_field_value(
+            input,
+            &[
+                "boundaries are ",
+                "boundary is ",
+                "boundary=",
+                "standing boundaries are ",
+                "边界是",
+                "界限是",
+                "原則是",
+                "原则是",
+            ],
+        ),
+        notes: extract_bootstrap_field_value(
+            input,
+            &[
+                "notes are ",
+                "note is ",
+                "note: ",
+                "notes: ",
+                "keep in mind ",
+                "备注是",
+                "備註是",
+                "备注：",
+                "備註：",
+            ],
+        ),
+    };
+
+    if capture == StartupBootstrapCapture::default() {
+        None
+    } else {
+        Some(capture)
+    }
+}
+
+fn extract_bootstrap_field_value(input: &str, patterns: &[&str]) -> Option<String> {
+    for pattern in patterns {
+        let value = if pattern.is_ascii() {
+            extract_ascii_pattern_value(input, pattern)
+        } else {
+            extract_direct_pattern_value(input, pattern)
+        };
+        if value.is_some() {
+            return value;
+        }
+    }
+    None
+}
+
+fn extract_ascii_pattern_value(input: &str, pattern: &str) -> Option<String> {
+    let haystack = input.to_ascii_lowercase();
+    let index = haystack.find(pattern)?;
+    let start = index + pattern.len();
+    normalize_bootstrap_value(&input[start..])
+}
+
+fn extract_direct_pattern_value(input: &str, pattern: &str) -> Option<String> {
+    let index = input.find(pattern)?;
+    let start = index + pattern.len();
+    normalize_bootstrap_value(&input[start..])
+}
+
+fn normalize_bootstrap_value(value: &str) -> Option<String> {
+    let trimmed = value
+        .trim_start_matches([' ', ':', '：', '=', '-', '—'])
+        .trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let end_index = trimmed
+        .char_indices()
+        .find_map(|(index, ch)| {
+            if matches!(
+                ch,
+                ';' | '\n' | '。' | '，' | ',' | '.' | '!' | '?' | '！' | '？'
+            ) {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(trimmed.len());
+    let normalized = trimmed[..end_index]
+        .trim()
+        .trim_matches([
+            '"', '\'', '“', '”', '「', '」', '『', '』', '。', '，', ',', '.',
+        ])
+        .trim();
+    if normalized.is_empty() {
+        return None;
+    }
+    Some(normalized.to_owned())
+}
+
+fn persist_startup_bootstrap_capture(
+    runtime: &mut CliTurnRuntime,
+    capture: &StartupBootstrapCapture,
+) -> CliResult<()> {
+    let mut config = runtime.config.clone();
+    let path = runtime.resolved_path.display().to_string();
+    let personalization = config
+        .memory
+        .personalization
+        .get_or_insert_with(PersonalizationConfig::default);
+    if let Some(preferred_address) = capture.preferred_address.as_deref() {
+        personalization.preferred_name = Some(preferred_address.to_owned());
+    }
+    if let Some(pronouns) = capture.pronouns.as_deref() {
+        personalization.pronouns = Some(pronouns.to_owned());
+    }
+    if let Some(timezone) = capture.timezone.as_deref() {
+        personalization.timezone = Some(timezone.to_owned());
+    }
+    if let Some(standing_boundaries) = capture.standing_boundaries.as_deref() {
+        personalization.standing_boundaries = Some(standing_boundaries.to_owned());
+    }
+    if let Some(notes) = capture.notes.as_deref() {
+        personalization.notes = Some(notes.to_owned());
+    }
+    if personalization.prompt_state == PersonalizationPromptState::Pending
+        && (capture.preferred_address.is_some()
+            || capture.pronouns.is_some()
+            || capture.timezone.is_some()
+            || capture.standing_boundaries.is_some()
+            || capture.notes.is_some())
+    {
+        personalization.prompt_state = PersonalizationPromptState::Configured;
+    }
+
+    crate::config::write(Some(path.as_str()), &config, true)?;
+    runtime.config = config;
+
+    let workspace_root = current_working_directory(runtime);
+    persist_startup_bootstrap_runtime_self_files(workspace_root.as_path(), capture)
+}
+
+fn persist_startup_bootstrap_runtime_self_files(
+    workspace_root: &Path,
+    capture: &StartupBootstrapCapture,
+) -> CliResult<()> {
+    upsert_bootstrap_runtime_self_file(
+        workspace_root.join("USER.md").as_path(),
+        "# User",
+        render_bootstrap_user_block(capture),
+    )?;
+    upsert_bootstrap_runtime_self_file(
+        workspace_root.join("IDENTITY.md").as_path(),
+        "# Identity",
+        render_bootstrap_identity_block(capture),
+    )?;
+    upsert_bootstrap_runtime_self_file(
+        workspace_root.join("SOUL.md").as_path(),
+        "# Soul",
+        render_bootstrap_soul_block(capture),
+    )?;
+    Ok(())
+}
+
+fn render_bootstrap_user_block(capture: &StartupBootstrapCapture) -> Option<String> {
+    let mut lines = Vec::new();
+    if let Some(preferred_address) = capture.preferred_address.as_deref() {
+        lines.push(format!("- Preferred address: {preferred_address}"));
+    }
+    if let Some(pronouns) = capture.pronouns.as_deref() {
+        lines.push(format!("- Pronouns: {pronouns}"));
+    }
+    if let Some(timezone) = capture.timezone.as_deref() {
+        lines.push(format!("- Timezone: {timezone}"));
+    }
+    if let Some(standing_boundaries) = capture.standing_boundaries.as_deref() {
+        lines.push(format!("- Standing boundaries: {standing_boundaries}"));
+    }
+    if let Some(notes) = capture.notes.as_deref() {
+        lines.push(format!("- Notes: {notes}"));
+    }
+
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines.join("\n"))
+}
+
+fn render_bootstrap_identity_block(capture: &StartupBootstrapCapture) -> Option<String> {
+    let mut lines = Vec::new();
+    if let Some(agent_name) = capture.agent_name.as_deref() {
+        lines.push(format!("- Name: {agent_name}"));
+    }
+    if let Some(creature) = capture.creature.as_deref() {
+        lines.push(format!("- Creature: {creature}"));
+    }
+    if let Some(vibe) = capture.vibe.as_deref() {
+        lines.push(format!("- Vibe: {vibe}"));
+    }
+    if let Some(emoji) = capture.emoji.as_deref() {
+        lines.push(format!("- Emoji: {emoji}"));
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+fn render_bootstrap_soul_block(capture: &StartupBootstrapCapture) -> Option<String> {
+    let mut lines = Vec::new();
+    if let Some(vibe) = capture.vibe.as_deref() {
+        lines.push(format!("- Preferred vibe: {vibe}"));
+    }
+    if let Some(emoji) = capture.emoji.as_deref() {
+        lines.push(format!("- Signature emoji: {emoji}"));
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+fn upsert_bootstrap_runtime_self_file(
+    path: &Path,
+    heading: &str,
+    block_body: Option<String>,
+) -> CliResult<()> {
+    let Some(block_body) = block_body else {
+        return Ok(());
+    };
+    let start_marker = "<!-- loong-bootstrap:start -->";
+    let end_marker = "<!-- loong-bootstrap:end -->";
+    let managed_block = format!("{start_marker}\n{block_body}\n{end_marker}");
+    let existing = fs::read_to_string(path).unwrap_or_default();
+    let updated = if let Some(start) = existing.find(start_marker) {
+        if let Some(end_relative) = existing[start..].find(end_marker) {
+            let end = start + end_relative + end_marker.len();
+            format!(
+                "{}{}{}",
+                &existing[..start],
+                managed_block,
+                &existing[end..]
+            )
+        } else {
+            format!("{}\n\n{}", existing.trim_end(), managed_block)
+        }
+    } else if existing.trim().is_empty() {
+        format!("{heading}\n\n{managed_block}\n")
+    } else {
+        format!("{}\n\n{}\n", existing.trim_end(), managed_block)
+    };
+
+    fs::write(path, updated).map_err(|error| {
+        format!(
+            "failed to write bootstrap runtime self file {}: {error}",
+            path.display()
+        )
+    })
+}
+
 fn persist_startup_personalization(
     runtime: &mut CliTurnRuntime,
     preset: StartupPersonalizationPreset,
-    startup_state: Option<&StartupOnboardingState>,
     language: Language,
 ) -> CliResult<String> {
     let mut config = runtime.config.clone();
     let path = runtime.resolved_path.display().to_string();
     let now = OffsetDateTime::now_utc();
     let updated_at_epoch_seconds = u64::try_from(now.unix_timestamp()).ok();
-    let bootstrap_summary = apply_startup_bootstrap_config(
-        &mut config,
-        runtime.config_present,
-        startup_state,
-        runtime.resolved_path.as_path(),
-    );
 
     let message = if preset == StartupPersonalizationPreset::Later {
         config.memory.personalization = Some(PersonalizationConfig {
@@ -2181,8 +3808,36 @@ fn persist_startup_personalization(
             updated_at_epoch_seconds,
             ..PersonalizationConfig::default()
         });
-        "personalization deferred; Loong will keep the first conversation neutral for now."
-            .to_owned()
+        match language {
+            Language::ZhCn => "个性化暂时先不保存；Loong 会先保持首轮对话中性。".to_owned(),
+            Language::ZhTw => "個性化暫時先不保存；Loong 會先保持首輪對話中性。".to_owned(),
+            Language::En | Language::Ja | Language::Ru => {
+                "personalization deferred; Loong will keep the first conversation neutral for now."
+                    .to_owned()
+            }
+        }
+    } else if preset == StartupPersonalizationPreset::TurnOff {
+        config.memory.personalization = Some(PersonalizationConfig {
+            prompt_state: PersonalizationPromptState::Suppressed,
+            updated_at_epoch_seconds,
+            ..PersonalizationConfig::default()
+        });
+        match language {
+            Language::ZhCn => "已关闭后续个性化提示；Loong 会保持默认对话风格。".to_owned(),
+            Language::ZhTw => "已關閉後續個性化提示；Loong 會保持預設對話風格。".to_owned(),
+            Language::Ja => {
+                "今後の個性化案内をオフにしました。Loong は標準の会話スタイルを保ちます。"
+                    .to_owned()
+            }
+            Language::Ru => {
+                "Дальнейшие подсказки по персонализации отключены; Loong сохранит стиль по умолчанию."
+                    .to_owned()
+            }
+            Language::En => {
+                "future personalization prompts turned off; Loong will keep the default conversation style."
+                    .to_owned()
+            }
+        }
     } else {
         let mut upgraded_memory_profile = false;
         if config.memory.profile != MemoryProfile::ProfilePlusWindow {
@@ -2198,120 +3853,39 @@ fn persist_startup_personalization(
             ..PersonalizationConfig::default()
         });
         if upgraded_memory_profile {
-            format!(
-                "saved {} and upgraded memory.profile to profile_plus_window.",
-                preset.label()
-            )
+            match language {
+                Language::ZhCn => format!(
+                    "已保存 {}，并把 memory.profile 升级为 profile_plus_window。",
+                    preset.label(language)
+                ),
+                Language::ZhTw => format!(
+                    "已保存 {}，並把 memory.profile 升級為 profile_plus_window。",
+                    preset.label(language)
+                ),
+                Language::En | Language::Ja | Language::Ru => format!(
+                    "saved {} and upgraded memory.profile to profile_plus_window.",
+                    preset.label(language)
+                ),
+            }
         } else {
-            format!("saved {} for the first real conversation.", preset.label())
+            match language {
+                Language::ZhCn => {
+                    format!("已把 {} 保存为首轮对话风格。", preset.label(language))
+                }
+                Language::ZhTw => {
+                    format!("已把 {} 保存為首輪對話風格。", preset.label(language))
+                }
+                Language::En | Language::Ja | Language::Ru => format!(
+                    "saved {} for the first real conversation.",
+                    preset.label(language)
+                ),
+            }
         }
     };
 
     crate::config::write(Some(path.as_str()), &config, true)?;
     runtime.config = config;
-    runtime.config_present = true;
-    let installed_skills_summary = install_startup_selected_skills(
-        &runtime.config,
-        runtime.resolved_path.as_path(),
-        startup_state,
-    );
-    Ok([Some(message), bootstrap_summary, installed_skills_summary]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join(" "))
-}
-
-fn apply_startup_bootstrap_config(
-    config: &mut LoongConfig,
-    config_present: bool,
-    startup_state: Option<&StartupOnboardingState>,
-    config_path: &Path,
-) -> Option<String> {
-    if config_present {
-        return None;
-    }
-
-    let state = startup_state?;
-    if let Some(option) = state.provider_options.get(state.provider_index) {
-        config.provider = option.provider.clone();
-    }
-
-    if !state.selected_skill_ids.is_empty() {
-        config.external_skills.enabled = true;
-        config.external_skills.auto_expose_installed = true;
-        let managed_root = config_path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .map(|parent| parent.join("external-skills-installed"))
-            .unwrap_or_else(|| PathBuf::from("external-skills-installed"));
-        config.external_skills.install_root = Some(managed_root.display().to_string());
-    }
-
-    if matches!(
-        state.current_setup_path_choice(),
-        StartupSetupPathChoice::ProviderAndWeb
-    ) {
-        let provider =
-            normalize_web_search_provider(config.tools.web_search.default_provider.as_str())
-                .unwrap_or(config.tools.web_search.default_provider.as_str())
-                .to_owned();
-        if let Some(env_name) = web_search_provider_api_key_env_names(provider.as_str())
-            .iter()
-            .find(|env_name| std::env::var_os(env_name).is_some())
-        {
-            config.tools.web_search.enabled = true;
-            config.tools.web_search.set_configured_api_key_for_provider(
-                provider.as_str(),
-                Some(format!("${{{}}}", env_name)),
-            );
-        }
-    }
-
-    let provider_label = state
-        .provider_options
-        .get(state.provider_index)
-        .map(|option| option.provider.kind.display_name())
-        .unwrap_or(config.provider.kind.display_name());
-    if state.selected_skill_ids.is_empty() {
-        Some(format!(
-            "saved first-run provider bootstrap for {provider_label}."
-        ))
-    } else {
-        Some(format!(
-            "saved first-run provider bootstrap for {provider_label}; selected skill packs are queued for managed install."
-        ))
-    }
-}
-
-fn install_startup_selected_skills(
-    config: &LoongConfig,
-    config_path: &Path,
-    startup_state: Option<&StartupOnboardingState>,
-) -> Option<String> {
-    let state = startup_state?;
-    if state.selected_skill_ids.is_empty() {
-        return None;
-    }
-    let runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(
-        config,
-        Some(config_path),
-    );
-    match crate::tools::install_bundled_preinstall_targets_for_bootstrap(
-        &runtime_config,
-        &state.selected_skill_ids,
-    ) {
-        Ok(installed) if installed.is_empty() => {
-            Some("selected skill packs were already present in the managed runtime.".to_owned())
-        }
-        Ok(installed) => Some(format!(
-            "installed managed skill packs: {}.",
-            installed.join(", ")
-        )),
-        Err(error) => Some(format!(
-            "skill pack install deferred: {error}. reopen /skills or `loong onboard` later."
-        )),
-    }
+    Ok(message)
 }
 
 fn render_onboarding_option_line(
@@ -2844,7 +4418,7 @@ fn apply_model_selection(
 async fn run_surface_command<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
-    runtime: &mut CliTurnRuntime,
+    runtime: &CliTurnRuntime,
     options: &CliChatOptions,
     input: &str,
 ) -> CliResult<()> {
@@ -3696,7 +5270,6 @@ fn persist_runtime_settings(
     app.model = runtime.config.provider.model.clone();
     Ok(summary)
 }
-
 fn current_working_directory(runtime: &CliTurnRuntime) -> PathBuf {
     runtime
         .effective_working_directory
@@ -4115,7 +5688,7 @@ fn render_title_command_lines_with_width(command: &str, args: &str, width: usize
 async fn submit_user_turn<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
-    runtime: &CliTurnRuntime,
+    runtime: &mut CliTurnRuntime,
     input: String,
 ) -> CliResult<()> {
     start_turn(terminal, app, runtime, input, true).await
@@ -4124,10 +5697,11 @@ async fn submit_user_turn<B: Backend>(
 async fn start_turn<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
-    runtime: &CliTurnRuntime,
+    runtime: &mut CliTurnRuntime,
     input: String,
     echo_user_message: bool,
 ) -> CliResult<()> {
+    maybe_capture_and_persist_first_turn_bootstrap_reply(app, runtime, input.as_str())?;
     let width = current_render_width(terminal)?;
     app.live_render_width.store(width.max(1), Ordering::Relaxed);
     if echo_user_message {
@@ -4158,7 +5732,12 @@ async fn start_turn<B: Backend>(
         sink,
     );
     app.live_rerender = Some(rerender);
-    app.pending_task = Some(spawn_pending_turn(runtime.clone(), input, observer));
+    let mut turn_runtime = runtime.clone();
+    if let Some(addendum) = app.pending_first_turn_bootstrap_addendum.take() {
+        apply_first_turn_bootstrap_addendum(&mut turn_runtime, addendum);
+        app.awaiting_first_turn_bootstrap_reply = true;
+    }
+    app.pending_task = Some(spawn_pending_turn(turn_runtime, input, observer));
     Ok(())
 }
 
@@ -4598,9 +6177,8 @@ async fn build_command_lines(
     width: usize,
 ) -> CliResult<Vec<String>> {
     let trimmed = input.trim();
-    let (command, args) = split_surface_command(trimmed);
 
-    match command {
+    match trimmed {
         super::super::CLI_CHAT_HELP_COMMAND => Ok(render_chat_surface_help_lines_with_width(width)),
         super::super::CLI_CHAT_STATUS_COMMAND => {
             let summary = super::super::ops::build_cli_chat_startup_summary(runtime, options)?;
@@ -4666,9 +6244,6 @@ async fn build_command_lines(
             }
         }
         "/model" => Ok(render_model_command_lines_with_width(runtime, width)),
-        "/settings" => Ok(render_settings_command_lines_with_width(
-            runtime, width, args,
-        )),
         "/permissions" => Ok(render_permissions_command_lines_with_width(width)),
         "/experimental" => Ok(render_experimental_command_lines_with_width(width)),
         "/themes" => Ok(render_themes_command_lines_with_width(width)),
@@ -4739,7 +6314,7 @@ async fn build_command_lines(
             {
                 let diagnostics = runtime
                     .turn_coordinator
-                    .load_production_turn_checkpoint_diagnostics_with_limit(
+                    .load_turn_checkpoint_diagnostics_with_limit(
                         &runtime.config,
                         &runtime.session_id,
                         runtime.config.memory.sliding_window,
@@ -4771,7 +6346,7 @@ async fn build_command_lines(
             {
                 let outcome = runtime
                     .turn_coordinator
-                    .repair_production_turn_checkpoint_tail(
+                    .repair_turn_checkpoint_tail(
                         &runtime.config,
                         &runtime.session_id,
                         runtime.conversation_binding(),
@@ -4863,7 +6438,7 @@ async fn build_command_lines(
         _ => {
             if let Some(spec) = slash_command_specs()
                 .iter()
-                .find(|spec| spec.command == command)
+                .find(|spec| spec.command == trimmed)
             {
                 Ok(render_slash_command_detail_lines_with_width(spec, width))
             } else {
@@ -4977,130 +6552,6 @@ fn render_model_command_lines_with_width(runtime: &CliTurnRuntime, width: usize)
         }],
         footer_lines: vec![
             "Use /model <selector> to switch when you want a different model.".to_owned(),
-        ],
-    };
-    super::super::render_cli_chat_message_spec_with_width(&message_spec, width)
-}
-
-fn render_web_settings_items(runtime: &CliTurnRuntime) -> Vec<TuiKeyValueSpec> {
-    let provider_id =
-        normalize_web_search_provider(runtime.config.tools.web_search.default_provider.as_str())
-            .unwrap_or(runtime.config.tools.web_search.default_provider.as_str());
-    let provider_label = web_search_provider_descriptor(provider_id)
-        .map(|descriptor| descriptor.display_name)
-        .unwrap_or(provider_id);
-    let credential_value = runtime
-        .config
-        .tools
-        .web_search
-        .configured_api_key_for_provider(provider_id)
-        .map(str::to_owned)
-        .or_else(|| {
-            let env_names = web_search_provider_api_key_env_names(provider_id);
-            if env_names.is_empty() {
-                None
-            } else {
-                Some(format!("missing · expected {}", env_names.join(" or ")))
-            }
-        })
-        .unwrap_or_else(|| "not required".to_owned());
-    vec![
-        TuiKeyValueSpec::Plain {
-            key: "enabled".to_owned(),
-            value: runtime.config.tools.web_search.enabled.to_string(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "default provider".to_owned(),
-            value: provider_label.to_owned(),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "credential".to_owned(),
-            value: credential_value,
-        },
-        TuiKeyValueSpec::Plain {
-            key: "timeout".to_owned(),
-            value: format!("{}s", runtime.config.tools.web_search.timeout_seconds),
-        },
-        TuiKeyValueSpec::Plain {
-            key: "max results".to_owned(),
-            value: runtime.config.tools.web_search.max_results.to_string(),
-        },
-    ]
-}
-
-fn render_settings_command_lines_with_width(
-    runtime: &CliTurnRuntime,
-    width: usize,
-    args: &str,
-) -> Vec<String> {
-    let focus = match args.trim().to_ascii_lowercase().as_str() {
-        "provider" | "provider+web" | "web" => Some(StartupSetupPathChoice::ProviderAndWeb),
-        "workspace" => Some(StartupSetupPathChoice::McpAndSkills),
-        _ => None,
-    };
-    let provider = &runtime.config.provider;
-    let mut sections = Vec::new();
-    if focus.is_none() || focus == Some(StartupSetupPathChoice::ProviderAndWeb) {
-        sections.push(TuiSectionSpec::KeyValues {
-            title: Some("provider".to_owned()),
-            items: vec![
-                TuiKeyValueSpec::Plain {
-                    key: "provider".to_owned(),
-                    value: provider.kind.display_name().to_owned(),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "model".to_owned(),
-                    value: provider.model.clone(),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "auth".to_owned(),
-                    value: provider
-                        .resolved_auth_env_name()
-                        .unwrap_or_else(|| "still needs credentials".to_owned()),
-                },
-            ],
-        });
-        sections.push(TuiSectionSpec::KeyValues {
-            title: Some("web search".to_owned()),
-            items: render_web_settings_items(runtime),
-        });
-    }
-    if focus.is_none() || focus == Some(StartupSetupPathChoice::McpAndSkills) {
-        sections.push(TuiSectionSpec::KeyValues {
-            title: Some("workspace".to_owned()),
-            items: vec![
-                TuiKeyValueSpec::Plain {
-                    key: "bootstrap MCP servers".to_owned(),
-                    value: runtime.effective_bootstrap_mcp_servers.len().to_string(),
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "managed skills".to_owned(),
-                    value: if runtime.config.external_skills.enabled {
-                        "enabled".to_owned()
-                    } else {
-                        "disabled".to_owned()
-                    },
-                },
-                TuiKeyValueSpec::Plain {
-                    key: "install root".to_owned(),
-                    value: runtime
-                        .config
-                        .external_skills
-                        .resolved_install_root()
-                        .map(|path| path.display().to_string())
-                        .unwrap_or_else(|| "-".to_owned()),
-                },
-            ],
-        });
-    }
-
-    let message_spec = TuiMessageSpec {
-        role: "settings".to_owned(),
-        caption: Some("current setup".to_owned()),
-        sections,
-        footer_lines: vec![
-            "Use /settings for adjustments; keep /mcp and /skills as dedicated standalone views. Reopen `loong onboard` when you want the full setup wizard."
-                .to_owned(),
         ],
     };
     super::super::render_cli_chat_message_spec_with_width(&message_spec, width)
@@ -5228,39 +6679,6 @@ fn render_themes_command_lines_with_width(width: usize) -> Vec<String> {
         footer_lines: vec!["The terminal-adaptive theme is active for this session.".to_owned()],
     };
     super::super::render_cli_chat_message_spec_with_width(&message_spec, width)
-}
-
-fn append_startup_setup_follow_up(
-    app: &mut App,
-    runtime: &CliTurnRuntime,
-    width: usize,
-    choice: StartupSetupPathChoice,
-) {
-    match choice {
-        StartupSetupPathChoice::ChatNow => {
-            app.focus = Focus::Composer;
-        }
-        StartupSetupPathChoice::ProviderAndWeb => {
-            open_settings_palette(
-                app,
-                runtime,
-                SettingsSurfaceFocus::Provider,
-                width,
-                None,
-                None,
-            );
-        }
-        StartupSetupPathChoice::McpAndSkills => {
-            open_settings_palette(
-                app,
-                runtime,
-                SettingsSurfaceFocus::Workspace,
-                width,
-                None,
-                None,
-            );
-        }
-    }
 }
 
 fn render_cwd_command_lines_with_width(runtime: &CliTurnRuntime, width: usize) -> Vec<String> {
@@ -5745,7 +7163,7 @@ fn summarize_state_mix<'a>(states: impl Iterator<Item = &'a str>) -> Option<Stri
 async fn maybe_finalize_pending_turn<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
-    runtime: &CliTurnRuntime,
+    runtime: &mut CliTurnRuntime,
 ) -> CliResult<bool> {
     let Some(handle) = app.pending_task.as_ref() else {
         return Ok(false);
@@ -6987,14 +8405,13 @@ fn resize_live_rerender_ready(
 #[cfg(test)]
 mod tests {
     use super::{
-        App, Focus, StartupOnboardingAction, StartupOnboardingInteractionKind,
-        StartupOnboardingStage, StartupOnboardingState, StartupPersonalizationPreset,
-        StartupProviderOption, StartupSetupPathChoice, StartupSkillOption,
-        persist_startup_personalization, startup_eye_animation_for_state,
+        App, Focus, StartupBootstrapCapture, StartupOnboardingAction,
+        StartupOnboardingInteractionKind, StartupOnboardingStage, StartupOnboardingState,
+        StartupPersonalizationPreset, StartupProviderOption, StartupSetupPathChoice,
+        StartupSkillOption, persist_startup_personalization, startup_eye_animation_for_state,
     };
     use crate::chat::chat_surface::command_palette::{
-        CommandAction, CommandPalette, SettingsCommandAction, SettingsSurfaceFocus, SkillEntry,
-        slash_command_specs,
+        CommandAction, CommandPalette, SkillEntry, slash_command_specs,
     };
     use crate::chat::chat_surface::composer::Composer;
     use crate::chat::chat_surface::i18n::{I18nService, Language};
@@ -7006,6 +8423,7 @@ mod tests {
         CliChatOptions, CliSessionRequirement, initialize_cli_turn_runtime_with_loaded_config,
     };
     use crate::config::{LoongConfig, ProviderConfig, ProviderKind, ReasoningEffort};
+    use crate::test_support::ScopedEnv;
     use crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
@@ -7029,13 +8447,14 @@ mod tests {
             pending_steers: Default::default(),
             pending_queue: Default::default(),
             composer_follow_up_intent: false,
+            pending_first_turn_bootstrap_addendum: None,
+            awaiting_first_turn_bootstrap_reply: false,
             live_render_width: Arc::new(AtomicUsize::new(1)),
             live_rerender: None,
             spinner_seed: 1,
             last_pending_signature: None,
             pending_render_cache: None,
             inline_skill_popup_active: false,
-            startup_follow_up_choice: None,
             last_render_width: 0,
             last_render_height: 0,
             last_transcript_area: Rect::default(),
@@ -7074,11 +8493,19 @@ mod tests {
     fn onboarding_state() -> StartupOnboardingState {
         StartupOnboardingState {
             stage: StartupOnboardingStage::Language,
-            language_options: vec![Language::En, Language::ZhCn],
+            language_options: vec![
+                Language::En,
+                Language::ZhCn,
+                Language::ZhTw,
+                Language::Ja,
+                Language::Ru,
+            ],
             language_index: 0,
             provider_options: vec![StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Openai),
-                label: "reuse current OpenAI setup".to_owned(),
+                kind: ProviderKind::Openai,
+                auth_env_name: Some("OPENAI_API_KEY".to_owned()),
+                is_current: true,
+                label: "OpenAI".to_owned(),
                 detail: "reuse the current config".to_owned(),
                 recommended: true,
             }],
@@ -7096,6 +8523,12 @@ mod tests {
             selected_personalization: None,
             web_search_provider_label: "DuckDuckGo".to_owned(),
             web_search_provider_detail: "web search still needs auth".to_owned(),
+            provider_auth_env_name: None,
+            provider_configuration_hint: None,
+            enabled_channel_labels: Vec::new(),
+            channel_follow_up_commands: Vec::new(),
+            channel_status_commands: Vec::new(),
+            channel_repair_commands: Vec::new(),
             startup_mcp_count: 0,
             detected_skill_count: 1,
             feedback: Some("demo feedback".to_owned()),
@@ -7116,19 +8549,25 @@ mod tests {
         state.stage = StartupOnboardingStage::Provider;
         state.provider_options = vec![
             StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Openai),
+                kind: ProviderKind::Openai,
+                auth_env_name: None,
+                is_current: true,
                 label: "first".to_owned(),
                 detail: "first".to_owned(),
                 recommended: true,
             },
             StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Anthropic),
+                kind: ProviderKind::Anthropic,
+                auth_env_name: None,
+                is_current: false,
                 label: "middle".to_owned(),
                 detail: "middle".to_owned(),
                 recommended: false,
             },
             StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Openrouter),
+                kind: ProviderKind::Gemini,
+                auth_env_name: None,
+                is_current: false,
                 label: "last".to_owned(),
                 detail: "last".to_owned(),
                 recommended: false,
@@ -7155,7 +8594,6 @@ mod tests {
         );
 
         state.stage = StartupOnboardingStage::Finish;
-        state.last_interaction_at = std::time::Instant::now();
         assert_eq!(
             startup_eye_animation_for_state(Some(&state)),
             StartupEyeAnimation::Celebrate
@@ -7173,12 +8611,6 @@ mod tests {
             false,
         )
         .expect("chat surface runtime")
-    }
-
-    fn test_runtime_without_config(path: PathBuf) -> crate::chat::CliTurnRuntime {
-        let mut runtime = test_runtime_with_path(path);
-        runtime.config_present = false;
-        runtime
     }
 
     #[test]
@@ -8055,7 +9487,7 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw after scroll");
         let after = buffer_lines(&terminal).join("\n");
 
-        assert!(app.message_list.scroll_offset_for_test() > 0);
+        assert!(app.message_list.scroll_offset > 0);
         assert_ne!(before, after);
         assert_eq!(app.focus, Focus::Composer);
     }
@@ -8120,7 +9552,7 @@ description: "actual description"
             app.message_list
                 .add_assistant_message(format!("line-{idx}"));
         }
-        app.message_list.set_scroll_offset_for_test(4);
+        app.message_list.scroll_offset = 4;
         app.command_palette.show_commands(":");
         app.focus = Focus::CommandPalette;
 
@@ -8129,7 +9561,7 @@ description: "actual description"
         let palette_col = app.last_palette_area.x.saturating_add(1);
         app.handle_mouse_event(mouse(MouseEventKind::ScrollDown, palette_col, palette_row));
 
-        assert_eq!(app.message_list.scroll_offset_for_test(), 4);
+        assert_eq!(app.message_list.scroll_offset, 4);
         match app
             .command_palette
             .handle_key(crossterm::event::KeyEvent::new(
@@ -8778,23 +10210,6 @@ description: "actual description"
         let backend = TestBackend::new(50, 14);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
-        let temp_root = std::env::temp_dir().join(format!(
-            "loong-mouse-skill-palette-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("unix time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_root).expect("create temp root");
-        let config_path = temp_root.join("config.toml");
-        crate::config::write(
-            Some(config_path.to_string_lossy().as_ref()),
-            &LoongConfig::default(),
-            true,
-        )
-        .expect("seed config");
-        let mut runtime = test_runtime_with_path(config_path);
         app.command_palette = CommandPalette::new(Language::En, vec![skill("demo-skill")]);
         app.command_palette.show_skills("$demo");
         app.focus = Focus::CommandPalette;
@@ -8802,15 +10217,11 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw");
         let palette_row = app.last_palette_area.y;
         let palette_col = app.last_palette_area.x.saturating_add(1);
-        let action = app.handle_mouse_event(mouse(
+        app.handle_mouse_event(mouse(
             MouseEventKind::Down(MouseButton::Left),
             palette_col,
             palette_row,
         ));
-        if let Some(action) = action {
-            let _ = super::dispatch_palette_action(&mut app, &mut runtime, 50, action)
-                .expect("dispatch mouse action");
-        }
 
         assert_eq!(app.focus, Focus::Composer);
         assert_eq!(app.composer.take_input(), "$demo-skill ");
@@ -9786,7 +11197,7 @@ description: "actual description"
         assert!(restored_lines.contains("new-tail-line after scroll"));
         assert!(restored_lines.contains("streamed preview line"));
         assert!(!restored_lines.contains("PgDn / End"));
-        assert_eq!(app.message_list.scroll_offset_for_test(), 0);
+        assert_eq!(app.message_list.scroll_offset, 0);
     }
 
     #[test]
@@ -10165,6 +11576,171 @@ description: "actual description"
     }
 
     #[test]
+    fn startup_onboarding_supports_all_shell_languages() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_TUI_ONBOARD", "1");
+        let runtime = test_runtime_with_path(PathBuf::from("/tmp/loong-language-list.toml"));
+        let state =
+            StartupOnboardingState::new(&runtime, Language::Ru).expect("startup onboarding state");
+
+        assert_eq!(
+            state.language_options,
+            vec![
+                Language::En,
+                Language::ZhCn,
+                Language::ZhTw,
+                Language::Ja,
+                Language::Ru,
+            ]
+        );
+        assert_eq!(state.current_language(), Language::Ru);
+    }
+
+    #[test]
+    fn startup_onboarding_provider_stage_lists_all_sorted_provider_kinds() {
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_TUI_ONBOARD", "1");
+        let runtime = test_runtime_with_path(PathBuf::from("/tmp/loong-provider-list.toml"));
+
+        let options = super::build_startup_provider_options(&runtime, Language::En);
+        let labels = options
+            .iter()
+            .map(|option| option.label.as_str())
+            .collect::<Vec<_>>();
+        let expected = ProviderKind::all_sorted()
+            .iter()
+            .map(|kind| kind.display_name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(labels, expected);
+        let current_index = options
+            .iter()
+            .position(|option| option.kind == runtime.config.provider.kind)
+            .expect("current provider should be present");
+        assert!(options[current_index].recommended);
+        assert!(options[current_index].is_current);
+    }
+
+    #[test]
+    fn startup_onboarding_escape_moves_back_without_dismissing() {
+        let mut state = onboarding_state();
+        state.stage = StartupOnboardingStage::Provider;
+
+        let action = state.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(action, StartupOnboardingAction::Handled);
+        assert_eq!(state.stage, StartupOnboardingStage::Language);
+
+        let action = state.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(action, StartupOnboardingAction::Handled);
+        assert_eq!(state.stage, StartupOnboardingStage::Language);
+    }
+
+    #[test]
+    fn apply_language_refreshes_localized_onboarding_runtime_copy() {
+        let path = format!(
+            "/tmp/loong-startup-language-refresh-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("timestamp")
+                .as_nanos()
+        );
+        let mut env = ScopedEnv::new();
+        env.set("LOONG_TUI_ONBOARD", "1");
+        let mut runtime = test_runtime_with_path(PathBuf::from(path));
+        runtime.config.feishu.enabled = true;
+
+        let mut app = blank_app();
+        app.startup_onboarding = StartupOnboardingState::new(&runtime, Language::En);
+        let state = app
+            .startup_onboarding
+            .as_mut()
+            .expect("startup onboarding state");
+        state.language_index = state
+            .language_options
+            .iter()
+            .position(|language| *language == Language::ZhCn)
+            .expect("zh-CN option");
+
+        app.apply_startup_onboarding_action(
+            StartupOnboardingAction::ApplyLanguage(Language::ZhCn),
+            &mut runtime,
+        )
+        .expect("apply language");
+
+        let state = app
+            .startup_onboarding
+            .as_ref()
+            .expect("refreshed onboarding state");
+        assert_eq!(state.current_language(), Language::ZhCn);
+        assert_eq!(state.enabled_channel_labels, vec!["飞书".to_owned()]);
+        let current_provider = state
+            .provider_options
+            .iter()
+            .find(|option| option.is_current)
+            .expect("current provider option");
+        assert!(
+            current_provider
+                .detail
+                .contains("沿用 config.toml 里的当前 Loong provider"),
+            "provider detail should be localized after language apply: {}",
+            current_provider.detail
+        );
+    }
+
+    #[test]
+    fn persist_startup_provider_selection_updates_runtime_config_and_env_binding() {
+        let temp_root = std::env::temp_dir().join(format!(
+            "loong-startup-provider-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("unix time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_root).expect("create temp root");
+        let config_path = temp_root.join("config.toml");
+        crate::config::write(
+            Some(config_path.to_string_lossy().as_ref()),
+            &LoongConfig::default(),
+            true,
+        )
+        .expect("seed config");
+        let mut runtime = test_runtime_with_path(config_path.clone());
+        let mut env = ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-key");
+
+        let summary = super::persist_startup_provider_selection(
+            &mut runtime,
+            StartupProviderOption {
+                kind: ProviderKind::Anthropic,
+                auth_env_name: Some("ANTHROPIC_API_KEY".to_owned()),
+                is_current: false,
+                label: "Anthropic".to_owned(),
+                detail: "detail".to_owned(),
+                recommended: false,
+            },
+            Language::En,
+        )
+        .expect("persist provider selection");
+
+        assert!(summary.contains("Anthropic"));
+        assert!(summary.contains("ANTHROPIC_API_KEY"));
+        assert_eq!(runtime.config.provider.kind, ProviderKind::Anthropic);
+        assert_eq!(runtime.config.active_provider_id(), Some("anthropic"));
+        assert!(runtime.config.providers.contains_key("anthropic"));
+        assert_eq!(
+            runtime.config.provider.resolved_auth_env_name().as_deref(),
+            Some("ANTHROPIC_API_KEY")
+        );
+        let loaded = crate::config::load(Some(config_path.to_string_lossy().as_ref()))
+            .expect("reload config");
+        assert_eq!(loaded.1.provider.kind, ProviderKind::Anthropic);
+        assert_eq!(loaded.1.active_provider_id(), Some("anthropic"));
+    }
+
+    #[test]
     fn startup_onboarding_skills_stage_toggles_selection_with_space() {
         let mut state = onboarding_state();
         state.stage = StartupOnboardingStage::Skills;
@@ -10178,118 +11754,15 @@ description: "actual description"
     }
 
     #[test]
-    fn parse_settings_command_action_supports_provider_web_and_skill_install() {
-        assert!(matches!(
-            super::parse_settings_command_action(""),
-            Ok(CommandAction::OpenSettings(SettingsSurfaceFocus::Overview))
-        ));
-        assert!(matches!(
-            super::parse_settings_command_action("provider anthropic"),
-            Ok(CommandAction::ApplySettings(
-                SettingsCommandAction::SetProvider(ProviderKind::Anthropic)
-            ))
-        ));
-        assert!(matches!(
-            super::parse_settings_command_action("web tavily"),
-            Ok(CommandAction::ApplySettings(SettingsCommandAction::SetWebProvider(provider))) if provider == "tavily"
-        ));
-        assert!(matches!(
-            super::parse_settings_command_action("skills install agent-browser"),
-            Ok(CommandAction::ApplySettings(SettingsCommandAction::InstallSkillPack(target))) if target == "agent-browser"
-        ));
-        assert!(matches!(
-            super::parse_settings_command_action("skills remove agent-browser"),
-            Ok(CommandAction::ApplySettings(SettingsCommandAction::RemoveSkillPack(target))) if target == "agent-browser"
-        ));
-        assert!(super::parse_settings_command_action("mcp").is_err());
-    }
-
-    #[test]
-    fn provider_and_web_settings_surface_readiness_status() {
-        let temp_root = std::env::temp_dir().join(format!(
-            "loong-settings-readiness-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("unix time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_root).expect("create temp root");
-        let config_path = temp_root.join("config.toml");
-        crate::config::write(
-            Some(config_path.to_string_lossy().as_ref()),
-            &LoongConfig::default(),
-            true,
-        )
-        .expect("seed config");
-        let runtime = test_runtime_with_path(config_path);
-        let mut env = crate::test_support::ScopedEnv::new();
-        env.set("ANTHROPIC_API_KEY", "test-key");
-        env.set("TAVILY_API_KEY", "test-key");
-
-        let entries =
-            super::build_settings_palette_entries(&runtime, SettingsSurfaceFocus::Provider, 140);
-
-        let current_provider = entries
-            .iter()
-            .find(|entry| entry.label == runtime.config.provider.kind.display_name())
-            .expect("current provider entry");
-        assert_eq!(current_provider.status_tag.as_deref(), Some("current"));
-        assert!(
-            current_provider
-                .description
-                .contains("current active provider")
-        );
-
-        let anthropic = entries
-            .iter()
-            .find(|entry| entry.label == "Anthropic")
-            .expect("anthropic entry");
-        assert_eq!(anthropic.status_tag.as_deref(), Some("ready"));
-        assert!(anthropic.description.contains("ANTHROPIC_API_KEY"));
-
-        let tavily = entries
-            .iter()
-            .find(|entry| entry.label == "Tavily")
-            .expect("tavily entry");
-        assert_eq!(tavily.status_tag.as_deref(), Some("ready"));
-        assert!(tavily.description.contains("TAVILY_API_KEY"));
-    }
-
-    #[test]
-    fn workspace_settings_keep_mcp_and_skills_as_standalone_surfaces() {
-        let temp_root = std::env::temp_dir().join(format!(
-            "loong-settings-workspace-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("unix time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_root).expect("create temp root");
-        let config_path = temp_root.join("config.toml");
-        crate::config::write(
-            Some(config_path.to_string_lossy().as_ref()),
-            &LoongConfig::default(),
-            true,
-        )
-        .expect("seed config");
-        let runtime = test_runtime_with_path(config_path);
-
-        let entries =
-            super::build_settings_palette_entries(&runtime, SettingsSurfaceFocus::Workspace, 140);
-
-        assert!(!entries.iter().any(|entry| entry.label == "MCP overview"));
-        assert!(!entries.iter().any(|entry| entry.label == "Skills overview"));
-    }
-
-    #[test]
     fn startup_onboarding_setup_path_stage_surfaces_deeper_follow_up_details() {
         let mut state = onboarding_state();
         state.stage = StartupOnboardingStage::SetupPath;
         state.setup_path_index = 1;
         state.startup_mcp_count = 2;
         state.detected_skill_count = 5;
+        state.provider_auth_env_name = Some("OPENAI_API_KEY".to_owned());
+        state.provider_configuration_hint =
+            Some("If you need to keep tuning provider base_url, model, or auth, `loong doctor` is the next check to run.".to_owned());
 
         let rendered = super::render_startup_onboarding_lines(&state, 90)
             .into_iter()
@@ -10303,8 +11776,192 @@ description: "actual description"
             .join("\n");
 
         assert!(rendered.contains("provider + web setup"));
+        assert!(rendered.contains("Provider auth env now: OPENAI_API_KEY."));
         assert!(rendered.contains("Web setup default: DuckDuckGo."));
+        assert!(rendered.contains("loong doctor"));
         assert!(rendered.contains("loong onboard"));
+    }
+
+    #[test]
+    fn startup_onboarding_only_expands_the_selected_provider_detail() {
+        let mut state = onboarding_state();
+        state.stage = StartupOnboardingStage::Provider;
+        state.provider_options = vec![
+            StartupProviderOption {
+                kind: ProviderKind::Openai,
+                auth_env_name: None,
+                is_current: true,
+                label: "first provider".to_owned(),
+                detail: "first provider detail".to_owned(),
+                recommended: true,
+            },
+            StartupProviderOption {
+                kind: ProviderKind::Anthropic,
+                auth_env_name: None,
+                is_current: false,
+                label: "second provider".to_owned(),
+                detail: "second provider detail".to_owned(),
+                recommended: false,
+            },
+        ];
+        state.provider_index = 1;
+
+        let rendered = super::render_startup_onboarding_lines(&state, 90)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("first provider"));
+        assert!(rendered.contains("second provider"));
+        assert!(!rendered.contains("first provider detail"));
+        assert!(rendered.contains("second provider detail"));
+    }
+
+    #[test]
+    fn startup_onboarding_setup_path_stage_surfaces_channel_follow_up_details() {
+        let mut state = onboarding_state();
+        state.stage = StartupOnboardingStage::SetupPath;
+        state.setup_path_index = StartupSetupPathChoice::ChannelsAndDelivery as usize;
+        state.enabled_channel_labels = vec!["飞书".to_owned(), "企业微信".to_owned()];
+        state.channel_follow_up_commands =
+            vec!["feishu serve".to_owned(), "channels serve wecom".to_owned()];
+        state.channel_status_commands = vec!["loong doctor".to_owned()];
+        state.channel_repair_commands = vec!["loong feishu onboard".to_owned()];
+
+        let rendered = super::render_startup_onboarding_lines(&state, 90)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("channels + delivery"));
+        assert!(rendered.contains("Enabled channels now: 飞书, 企业微信."));
+        assert!(rendered.contains("Next runtime command: feishu serve."));
+        assert!(rendered.contains("channels serve wecom"));
+        assert!(rendered.contains("Health command: loong doctor."));
+        assert!(rendered.contains("Repair path: loong feishu onboard."));
+    }
+
+    #[test]
+    fn startup_onboarding_channels_path_suggests_next_surfaces_when_none_are_enabled() {
+        let mut state = onboarding_state();
+        state.stage = StartupOnboardingStage::SetupPath;
+        state.setup_path_index = StartupSetupPathChoice::ChannelsAndDelivery as usize;
+        state.enabled_channel_labels.clear();
+        state.channel_follow_up_commands.clear();
+        state.channel_status_commands.clear();
+        state.channel_repair_commands.clear();
+
+        let rendered = super::render_startup_onboarding_lines(&state, 100)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Good first channels to wire"));
+        assert!(rendered.contains("Telegram"));
+        assert!(rendered.contains("Suggested onboarding commands"));
+    }
+
+    #[test]
+    fn startup_onboarding_uses_localized_setup_path_copy_in_chinese() {
+        let mut state = onboarding_state();
+        state.language_options = vec![Language::ZhCn];
+        state.language_index = 0;
+        state.stage = StartupOnboardingStage::SetupPath;
+        state.setup_path_index = StartupSetupPathChoice::ChannelsAndDelivery as usize;
+        state.enabled_channel_labels = vec!["飞书".to_owned()];
+        state.channel_follow_up_commands = vec!["feishu serve".to_owned()];
+
+        let rendered = super::render_startup_onboarding_lines(&state, 100)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("onboarding · 4/6 · 后续配置"));
+        assert!(rendered.contains("当前已启用的 channel：飞书。"));
+        assert!(rendered.contains("下一条 runtime command：feishu serve。"));
+    }
+
+    #[test]
+    fn startup_onboarding_channels_path_localizes_suggested_surfaces_in_chinese() {
+        let mut state = onboarding_state();
+        state.language_options = vec![Language::ZhCn];
+        state.language_index = 0;
+        state.stage = StartupOnboardingStage::SetupPath;
+        state.setup_path_index = StartupSetupPathChoice::ChannelsAndDelivery as usize;
+        state.enabled_channel_labels.clear();
+        state.channel_follow_up_commands.clear();
+        state.channel_status_commands.clear();
+        state.channel_repair_commands.clear();
+
+        let rendered = super::render_startup_onboarding_lines(&state, 100)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("建议优先接的 channels"));
+        assert!(rendered.contains("飞书"));
+        assert!(rendered.contains("建议先跑的 onboarding 命令"));
+    }
+
+    #[test]
+    fn persist_startup_personalization_localizes_summary_in_chinese() {
+        let temp_root = std::env::temp_dir().join(format!(
+            "loong-startup-personalization-zh-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("unix time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_root).expect("create temp root");
+        let config_path = temp_root.join("config.toml");
+        crate::config::write(
+            Some(config_path.to_string_lossy().as_ref()),
+            &LoongConfig::default(),
+            true,
+        )
+        .expect("seed config");
+        let mut runtime = test_runtime_with_path(config_path);
+
+        let summary = persist_startup_personalization(
+            &mut runtime,
+            StartupPersonalizationPreset::Concise,
+            Language::ZhCn,
+        )
+        .expect("persist personalization");
+
+        assert!(summary.contains("已保存"));
+        assert!(summary.contains("简洁模式"));
     }
 
     #[test]
@@ -10330,7 +11987,6 @@ description: "actual description"
         let summary = persist_startup_personalization(
             &mut runtime,
             StartupPersonalizationPreset::Thorough,
-            None,
             Language::ZhCn,
         )
         .expect("persist personalization");
@@ -10358,100 +12014,9 @@ description: "actual description"
     }
 
     #[test]
-    fn persist_startup_personalization_bootstraps_first_run_provider_choice() {
+    fn persist_startup_personalization_turn_off_suppresses_future_prompts() {
         let temp_root = std::env::temp_dir().join(format!(
-            "loong-startup-bootstrap-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("unix time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_root).expect("create temp root");
-        let config_path = temp_root.join("config.toml");
-        let mut runtime = test_runtime_without_config(config_path.clone());
-        let mut state = onboarding_state();
-        state.provider_options = vec![
-            StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Openai),
-                label: "start with OpenAI".to_owned(),
-                detail: "bootstrap openai".to_owned(),
-                recommended: true,
-            },
-            StartupProviderOption {
-                provider: ProviderConfig::fresh_for_kind(ProviderKind::Anthropic),
-                label: "start with Anthropic".to_owned(),
-                detail: "bootstrap anthropic".to_owned(),
-                recommended: false,
-            },
-        ];
-        state.provider_index = 1;
-        state.selected_skill_ids.insert("agent-browser".to_owned());
-
-        let summary = persist_startup_personalization(
-            &mut runtime,
-            StartupPersonalizationPreset::Later,
-            Some(&state),
-            Language::En,
-        )
-        .expect("persist first-run bootstrap");
-
-        assert!(summary.contains("Anthropic"));
-        assert!(runtime.config_present);
-        assert_eq!(runtime.config.provider.kind, ProviderKind::Anthropic);
-        assert!(
-            runtime
-                .config
-                .external_skills
-                .install_root
-                .as_deref()
-                .is_some_and(|value| value.contains("external-skills-installed"))
-        );
-        assert!(config_path.is_file());
-    }
-
-    #[test]
-    fn persist_startup_personalization_bootstraps_web_search_when_provider_and_web_is_selected() {
-        let temp_root = std::env::temp_dir().join(format!(
-            "loong-startup-web-bootstrap-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("unix time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_root).expect("create temp root");
-        let config_path = temp_root.join("config.toml");
-        let mut runtime = test_runtime_without_config(config_path);
-        let mut state = onboarding_state();
-        state.setup_path_index = 1;
-        runtime.config.tools.web_search.default_provider = "tavily".to_owned();
-        let mut env = crate::test_support::ScopedEnv::new();
-        env.set("TAVILY_API_KEY", "test-key");
-
-        let summary = persist_startup_personalization(
-            &mut runtime,
-            StartupPersonalizationPreset::Later,
-            Some(&state),
-            Language::En,
-        )
-        .expect("persist web bootstrap");
-
-        assert!(summary.contains("first-run provider bootstrap"));
-        assert_eq!(
-            runtime
-                .config
-                .tools
-                .web_search
-                .configured_api_key_for_provider("tavily"),
-            Some("${TAVILY_API_KEY}")
-        );
-    }
-
-    #[test]
-    fn apply_settings_command_updates_provider_and_web_in_runtime() {
-        let temp_root = std::env::temp_dir().join(format!(
-            "loong-settings-command-{}-{}",
+            "loong-startup-personalization-off-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -10467,45 +12032,129 @@ description: "actual description"
         )
         .expect("seed config");
         let mut runtime = test_runtime_with_path(config_path);
-        let mut app = blank_app();
-        let mut env = crate::test_support::ScopedEnv::new();
-        env.set("TAVILY_API_KEY", "test-key");
 
-        let (provider_focus, provider_summary, provider_label) = super::apply_settings_command(
-            &mut app,
+        let summary = persist_startup_personalization(
             &mut runtime,
-            SettingsCommandAction::SetProvider(ProviderKind::Anthropic),
+            StartupPersonalizationPreset::TurnOff,
+            Language::En,
         )
-        .expect("apply provider settings");
-        assert_eq!(runtime.config.provider.kind, ProviderKind::Anthropic);
-        assert_eq!(provider_focus, SettingsSurfaceFocus::Provider);
-        assert!(provider_summary.contains("Anthropic"));
-        assert_eq!(provider_label, "Anthropic");
+        .expect("persist turn-off personalization");
 
-        let (web_focus, web_summary, web_label) = super::apply_settings_command(
-            &mut app,
-            &mut runtime,
-            SettingsCommandAction::SetWebProvider("tavily".to_owned()),
-        )
-        .expect("apply web settings");
-        assert_eq!(runtime.config.tools.web_search.default_provider, "tavily");
+        assert!(summary.contains("turned off"));
+        let personalization = runtime
+            .config
+            .memory
+            .personalization
+            .as_ref()
+            .expect("saved personalization");
         assert_eq!(
-            runtime
-                .config
-                .tools
-                .web_search
-                .configured_api_key_for_provider("tavily"),
-            Some("${TAVILY_API_KEY}")
+            personalization.prompt_state,
+            crate::config::PersonalizationPromptState::Suppressed
         );
-        assert_eq!(web_focus, SettingsSurfaceFocus::Provider);
-        assert!(web_summary.contains("tavily"));
-        assert_eq!(web_label, "Tavily");
     }
 
     #[test]
-    fn apply_settings_command_installs_and_removes_skill_packs_in_runtime() {
+    fn configured_personalization_stages_first_turn_bootstrap_addendum() {
+        let mut app = blank_app();
+        app.startup_onboarding = Some(onboarding_state());
+        let config_path = PathBuf::from("/tmp/loong-first-turn-bootstrap.toml");
+        let mut runtime = test_runtime_with_path(config_path);
+
+        app.apply_startup_onboarding_action(
+            StartupOnboardingAction::PersistPersonalization(StartupPersonalizationPreset::Balanced),
+            &mut runtime,
+        )
+        .expect("apply startup personalization");
+
+        let addendum = app
+            .pending_first_turn_bootstrap_addendum
+            .as_deref()
+            .expect("bootstrap addendum");
+        assert!(addendum.contains("next real reply") || addendum.contains("下一次真正回复"));
+    }
+
+    #[test]
+    fn turn_off_personalization_does_not_stage_first_turn_bootstrap_addendum() {
+        let mut app = blank_app();
+        app.startup_onboarding = Some(onboarding_state());
+        let config_path = PathBuf::from("/tmp/loong-first-turn-bootstrap-off.toml");
+        let mut runtime = test_runtime_with_path(config_path);
+
+        app.apply_startup_onboarding_action(
+            StartupOnboardingAction::PersistPersonalization(StartupPersonalizationPreset::TurnOff),
+            &mut runtime,
+        )
+        .expect("apply startup personalization");
+
+        assert!(app.pending_first_turn_bootstrap_addendum.is_none());
+    }
+
+    #[test]
+    fn apply_first_turn_bootstrap_addendum_mutates_runtime_transiently() {
+        let config_path = PathBuf::from("/tmp/loong-first-turn-bootstrap-runtime.toml");
+        let mut runtime = test_runtime_with_path(config_path);
+        runtime.config.cli.prompt_pack_id = Some("default".to_owned());
+
+        super::apply_first_turn_bootstrap_addendum(
+            &mut runtime,
+            "bootstrap question here".to_owned(),
+        );
+
+        assert_eq!(
+            runtime.config.cli.system_prompt_addendum.as_deref(),
+            Some("bootstrap question here")
+        );
+    }
+
+    #[test]
+    fn infer_startup_bootstrap_capture_supports_natural_language_english() {
+        let capture = super::infer_startup_bootstrap_capture(
+            "You can call me Chum. My pronouns are he/they. Your name is Loongy. Creature is dragon. Vibe is calm. Emoji is 🐉. My timezone is Asia/Shanghai. Boundaries are ask before destructive actions. Note: I work mostly late at night.",
+        )
+        .expect("capture");
+
+        assert_eq!(capture.preferred_address.as_deref(), Some("Chum"));
+        assert_eq!(capture.pronouns.as_deref(), Some("he/they"));
+        assert_eq!(capture.agent_name.as_deref(), Some("Loongy"));
+        assert_eq!(capture.creature.as_deref(), Some("dragon"));
+        assert_eq!(capture.vibe.as_deref(), Some("calm"));
+        assert_eq!(capture.emoji.as_deref(), Some("🐉"));
+        assert_eq!(capture.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(
+            capture.standing_boundaries.as_deref(),
+            Some("ask before destructive actions")
+        );
+        assert_eq!(
+            capture.notes.as_deref(),
+            Some("I work mostly late at night")
+        );
+    }
+
+    #[test]
+    fn infer_startup_bootstrap_capture_supports_natural_language_chinese() {
+        let capture = super::infer_startup_bootstrap_capture(
+            "叫我伙伴。代词是 ta。你可以叫星龙。物种是龙，气质是沉稳，emoji 用✨。时区是 Asia/Shanghai。边界是先问再做破坏性操作。备注是我通常夜里工作。",
+        )
+        .expect("capture");
+
+        assert_eq!(capture.preferred_address.as_deref(), Some("伙伴"));
+        assert_eq!(capture.pronouns.as_deref(), Some("ta"));
+        assert_eq!(capture.agent_name.as_deref(), Some("星龙"));
+        assert_eq!(capture.creature.as_deref(), Some("龙"));
+        assert_eq!(capture.vibe.as_deref(), Some("沉稳"));
+        assert_eq!(capture.emoji.as_deref(), Some("✨"));
+        assert_eq!(capture.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(
+            capture.standing_boundaries.as_deref(),
+            Some("先问再做破坏性操作")
+        );
+        assert_eq!(capture.notes.as_deref(), Some("我通常夜里工作"));
+    }
+
+    #[test]
+    fn persist_startup_bootstrap_capture_updates_config_and_runtime_self_files() {
         let temp_root = std::env::temp_dir().join(format!(
-            "loong-settings-skill-pack-{}-{}",
+            "loong-startup-bootstrap-capture-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -10521,41 +12170,85 @@ description: "actual description"
         )
         .expect("seed config");
         let mut runtime = test_runtime_with_path(config_path);
-        let mut app = blank_app();
+        runtime.effective_working_directory = Some(temp_root.clone());
 
-        let (install_focus, install_summary, install_label) = super::apply_settings_command(
-            &mut app,
-            &mut runtime,
-            SettingsCommandAction::InstallSkillPack("agent-browser".to_owned()),
-        )
-        .expect("install skill pack");
-        assert_eq!(install_focus, SettingsSurfaceFocus::Workspace);
-        assert!(install_summary.contains("installed managed skill pack `agent-browser`"));
-        assert_eq!(install_label, "agent-browser");
+        let capture = StartupBootstrapCapture {
+            preferred_address: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
+            agent_name: Some("Loongy".to_owned()),
+            creature: Some("dragon".to_owned()),
+            vibe: Some("calm".to_owned()),
+            emoji: Some("🐉".to_owned()),
+            timezone: Some("Asia/Shanghai".to_owned()),
+            standing_boundaries: Some("Ask before destructive actions.".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
+        };
 
-        let runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::from_loong_config(
-            &runtime.config,
-            Some(runtime.resolved_path.as_path()),
+        super::persist_startup_bootstrap_capture(&mut runtime, &capture)
+            .expect("persist bootstrap capture");
+
+        let personalization = runtime
+            .config
+            .memory
+            .personalization
+            .as_ref()
+            .expect("personalization");
+        assert_eq!(personalization.preferred_name.as_deref(), Some("Chum"));
+        assert_eq!(personalization.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(
+            personalization.standing_boundaries.as_deref(),
+            Some("Ask before destructive actions.")
         );
-        let installed_after_install =
-            crate::tools::installed_managed_skill_ids_for_bootstrap(&runtime_config)
-                .expect("load installed skills");
-        assert!(!installed_after_install.is_empty());
 
-        let (remove_focus, remove_summary, remove_label) = super::apply_settings_command(
+        let user = std::fs::read_to_string(temp_root.join("USER.md")).expect("USER.md");
+        let identity = std::fs::read_to_string(temp_root.join("IDENTITY.md")).expect("IDENTITY.md");
+        let soul = std::fs::read_to_string(temp_root.join("SOUL.md")).expect("SOUL.md");
+        assert!(user.contains("Preferred address: Chum"));
+        assert!(user.contains("Pronouns: he/they"));
+        assert!(user.contains("Timezone: Asia/Shanghai"));
+        assert!(user.contains("Standing boundaries: Ask before destructive actions."));
+        assert!(user.contains("Notes: Works mostly late at night."));
+        assert!(identity.contains("Name: Loongy"));
+        assert!(identity.contains("Creature: dragon"));
+        assert!(identity.contains("Vibe: calm"));
+        assert!(identity.contains("Emoji: 🐉"));
+        assert!(soul.contains("Preferred vibe: calm"));
+        assert!(soul.contains("Signature emoji: 🐉"));
+    }
+
+    #[test]
+    fn unparsable_bootstrap_reply_keeps_waiting_for_capture() {
+        let mut app = blank_app();
+        app.awaiting_first_turn_bootstrap_reply = true;
+        let config_path = PathBuf::from("/tmp/loong-bootstrap-waiting.toml");
+        let mut runtime = test_runtime_with_path(config_path);
+
+        super::maybe_capture_and_persist_first_turn_bootstrap_reply(
             &mut app,
             &mut runtime,
-            SettingsCommandAction::RemoveSkillPack("agent-browser".to_owned()),
+            "let's just continue for now",
         )
-        .expect("remove skill pack");
-        assert_eq!(remove_focus, SettingsSurfaceFocus::Workspace);
-        assert!(remove_summary.contains("removed managed skill pack `agent-browser`"));
-        assert_eq!(remove_label, "agent-browser");
+        .expect("capture reply");
 
-        let installed_after_remove =
-            crate::tools::installed_managed_skill_ids_for_bootstrap(&runtime_config)
-                .expect("reload installed skills");
-        assert!(installed_after_remove.is_empty());
+        assert!(app.awaiting_first_turn_bootstrap_reply);
+    }
+
+    #[test]
+    fn bootstrap_reply_opt_out_clears_waiting_without_persisting() {
+        let mut app = blank_app();
+        app.awaiting_first_turn_bootstrap_reply = true;
+        let config_path = PathBuf::from("/tmp/loong-bootstrap-opt-out.toml");
+        let mut runtime = test_runtime_with_path(config_path);
+
+        super::maybe_capture_and_persist_first_turn_bootstrap_reply(
+            &mut app,
+            &mut runtime,
+            "skip for now",
+        )
+        .expect("capture reply");
+
+        assert!(!app.awaiting_first_turn_bootstrap_reply);
+        assert!(runtime.config.memory.personalization.is_none());
     }
 
     #[test]
@@ -10578,5 +12271,28 @@ description: "actual description"
 
         assert!(rendered.contains("setup path · provider + web setup"));
         assert!(rendered.contains("personalization · balanced operator"));
+    }
+
+    #[test]
+    fn finish_stage_turn_off_personalization_updates_finish_subtitle() {
+        let mut state = onboarding_state();
+        state.stage = StartupOnboardingStage::Finish;
+        state.language_options = vec![Language::ZhCn];
+        state.language_index = 0;
+        state.selected_personalization = Some(StartupPersonalizationPreset::TurnOff);
+
+        let rendered = super::render_startup_onboarding_lines(&state, 100)
+            .into_iter()
+            .map(|line| {
+                line.spans
+                    .into_iter()
+                    .map(|span| span.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Loong 不会再主动弹个性化提示"));
+        assert!(rendered.contains("loong personalize"));
     }
 }

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -11758,7 +11758,8 @@ description: "actual description"
         assert!(
             current_provider
                 .detail
-                .contains("沿用 config.toml 里的当前 Loong provider"),
+                .contains("沿用 config.toml 里的当前")
+                && current_provider.detail.contains("凭证"),
             "provider detail should be localized after language apply: {}",
             current_provider.detail
         );

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -36,7 +36,10 @@ use crate::config::{
 use crate::tools::bundled_preinstall_targets;
 use crate::tui_surface::{TuiCalloutTone, TuiKeyValueSpec, TuiMessageSpec, TuiSectionSpec};
 
-use super::command_palette::{CommandAction, CommandPalette, SkillEntry, slash_command_specs};
+use super::command_palette::{
+    CommandAction, CommandPalette, SettingsCommandAction, SettingsEntry, SettingsSurfaceFocus,
+    SkillEntry, slash_command_specs,
+};
 use super::composer::Composer;
 use super::i18n::{I18nService, Language, SurfaceCopy, resolve_default_language};
 use super::message_list::{MessageList, StartupEyeAnimation, StartupEyeFocus};
@@ -475,6 +478,72 @@ enum StartupOnboardingInteractionKind {
     Navigate,
     Confirm,
     Persist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupProviderAuthBindingKind {
+    ApiKey,
+    OauthAccessToken,
+}
+
+fn startup_provider_config_for_kind(kind: ProviderKind) -> ProviderConfig {
+    let mut provider = ProviderConfig::fresh_for_kind(kind);
+    if let Some((env_name, binding_kind)) = detected_startup_auth_binding(kind) {
+        apply_startup_auth_binding(&mut provider, env_name.as_str(), binding_kind);
+    }
+    provider
+}
+
+fn detected_startup_auth_binding(
+    kind: ProviderKind,
+) -> Option<(String, StartupProviderAuthBindingKind)> {
+    if let Some(env_name) = kind
+        .default_oauth_access_token_env()
+        .filter(|env_name| std::env::var_os(env_name).is_some())
+    {
+        return Some((
+            env_name.to_owned(),
+            StartupProviderAuthBindingKind::OauthAccessToken,
+        ));
+    }
+    for env_name in kind.oauth_access_token_env_aliases() {
+        if std::env::var_os(env_name).is_some() {
+            return Some((
+                (*env_name).to_owned(),
+                StartupProviderAuthBindingKind::OauthAccessToken,
+            ));
+        }
+    }
+    if let Some(env_name) = kind
+        .default_api_key_env()
+        .filter(|env_name| std::env::var_os(env_name).is_some())
+    {
+        return Some((env_name.to_string(), StartupProviderAuthBindingKind::ApiKey));
+    }
+    for env_name in kind.api_key_env_aliases() {
+        if std::env::var_os(env_name).is_some() {
+            return Some((
+                (*env_name).to_owned(),
+                StartupProviderAuthBindingKind::ApiKey,
+            ));
+        }
+    }
+    None
+}
+
+fn apply_startup_auth_binding(
+    provider: &mut ProviderConfig,
+    env_name: &str,
+    binding_kind: StartupProviderAuthBindingKind,
+) {
+    match binding_kind {
+        StartupProviderAuthBindingKind::ApiKey => {
+            provider.set_api_key_env_binding(Some(env_name.to_owned()));
+        }
+        StartupProviderAuthBindingKind::OauthAccessToken => {
+            provider.set_oauth_access_token_env_binding(Some(env_name.to_owned()));
+        }
+    }
 }
 
 impl StartupOnboardingState {
@@ -1561,8 +1630,14 @@ pub async fn run_app<B: Backend>(
                             if command == "/exit" {
                                 break;
                             }
-                            run_surface_command(terminal, &mut app, &runtime, &options, &command)
-                                .await?;
+                            run_surface_command(
+                                terminal,
+                                &mut app,
+                                &mut runtime,
+                                &options,
+                                &command,
+                            )
+                            .await?;
                         }
                         dirty = true;
                         continue;
@@ -1632,7 +1707,7 @@ pub async fn run_app<B: Backend>(
                                     &mut runtime,
                                     current_render_width(terminal)?,
                                     action,
-                                    )?
+                                )?
                             {
                                 command_to_run = Some(command);
                             } else if app.command_palette.is_commands_mode() {
@@ -1672,7 +1747,7 @@ pub async fn run_app<B: Backend>(
                         if let Some(command) = recognized_surface_command(trimmed_msg) {
                             command_to_run = Some(command);
                         } else if submitted_message_is_follow_up(&app, &msg) {
-                            start_turn(terminal, &mut app, &runtime, msg, false).await?;
+                            start_turn(terminal, &mut app, &mut runtime, msg, false).await?;
                         } else {
                             submit_user_turn(terminal, &mut app, &mut runtime, msg).await?;
                         }
@@ -1683,7 +1758,7 @@ pub async fn run_app<B: Backend>(
                             break;
                         }
 
-                        run_surface_command(terminal, &mut app, &runtime, &options, &command)
+                        run_surface_command(terminal, &mut app, &mut runtime, &options, &command)
                             .await?;
                     }
                     dirty = true;
@@ -1693,7 +1768,7 @@ pub async fn run_app<B: Backend>(
                         if command == "/exit" {
                             break;
                         }
-                        run_surface_command(terminal, &mut app, &runtime, &options, &command)
+                        run_surface_command(terminal, &mut app, &mut runtime, &options, &command)
                             .await?;
                     }
                     dirty = true;
@@ -4418,7 +4493,7 @@ fn apply_model_selection(
 async fn run_surface_command<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
-    runtime: &CliTurnRuntime,
+    runtime: &mut CliTurnRuntime,
     options: &CliChatOptions,
     input: &str,
 ) -> CliResult<()> {
@@ -6314,7 +6389,7 @@ async fn build_command_lines(
             {
                 let diagnostics = runtime
                     .turn_coordinator
-                    .load_turn_checkpoint_diagnostics_with_limit(
+                    .load_production_turn_checkpoint_diagnostics_with_limit(
                         &runtime.config,
                         &runtime.session_id,
                         runtime.config.memory.sliding_window,
@@ -6346,7 +6421,7 @@ async fn build_command_lines(
             {
                 let outcome = runtime
                     .turn_coordinator
-                    .repair_turn_checkpoint_tail(
+                    .repair_production_turn_checkpoint_tail(
                         &runtime.config,
                         &runtime.session_id,
                         runtime.conversation_binding(),
@@ -9487,7 +9562,7 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw after scroll");
         let after = buffer_lines(&terminal).join("\n");
 
-        assert!(app.message_list.scroll_offset > 0);
+        assert!(app.message_list.scroll_offset_for_test() > 0);
         assert_ne!(before, after);
         assert_eq!(app.focus, Focus::Composer);
     }
@@ -9552,7 +9627,7 @@ description: "actual description"
             app.message_list
                 .add_assistant_message(format!("line-{idx}"));
         }
-        app.message_list.scroll_offset = 4;
+        app.message_list.set_scroll_offset_for_test(4);
         app.command_palette.show_commands(":");
         app.focus = Focus::CommandPalette;
 
@@ -9561,7 +9636,7 @@ description: "actual description"
         let palette_col = app.last_palette_area.x.saturating_add(1);
         app.handle_mouse_event(mouse(MouseEventKind::ScrollDown, palette_col, palette_row));
 
-        assert_eq!(app.message_list.scroll_offset, 4);
+        assert_eq!(app.message_list.scroll_offset_for_test(), 4);
         match app
             .command_palette
             .handle_key(crossterm::event::KeyEvent::new(
@@ -11197,7 +11272,7 @@ description: "actual description"
         assert!(restored_lines.contains("new-tail-line after scroll"));
         assert!(restored_lines.contains("streamed preview line"));
         assert!(!restored_lines.contains("PgDn / End"));
-        assert_eq!(app.message_list.scroll_offset, 0);
+        assert_eq!(app.message_list.scroll_offset_for_test(), 0);
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -6677,8 +6677,7 @@ mod tests {
 
         assert!(text.iter().any(|line| line.contains("read ")));
         assert!(
-            text.join("").contains("sample.png")
-                || text.iter().any(|line| line.contains("read")),
+            text.join("").contains("sample.png") || text.iter().any(|line| line.contains("read")),
             "read preview should still surface a readable path/card header: {text:#?}"
         );
         assert!(

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -5210,8 +5210,9 @@ mod tests {
         MessageContent, MessageList, ReadToolRequest, STARTUP_COMPACT_WORDMARK, STARTUP_EYE_FRAMES,
         STARTUP_TIP_FADE_MS, STARTUP_TIP_HOLD_MS, STARTUP_WORDMARK, ToolStatus,
         adjust_scroll_start_for_message_boundary, build_assistant_contents, dominant_block_bg,
-        format_read_request_display, startup_logo_eye_frame_index, startup_logo_eye_style,
-        startup_tip_render_state, startup_wordmark_eye_frame,
+        extract_read_tool_request_from_json, format_read_request_display,
+        startup_logo_eye_frame_index, startup_logo_eye_style, startup_tip_render_state,
+        startup_wordmark_eye_frame,
     };
     use crate::chat::chat_surface::utils::{
         SURFACE_ACCENT, SURFACE_DIM_GRAY, SURFACE_GRAY, SURFACE_GREEN, SURFACE_RED,
@@ -6657,11 +6658,14 @@ mod tests {
             }
         });
         image.save(path.as_path()).expect("write png");
+        let path_text = path.display().to_string();
+        let args = serde_json::json!({
+            "path": path_text,
+        });
 
         let mut list = MessageList::new();
         list.add_assistant_message(format!(
-            "### Tool activity\n> Called read\n> args: {{\"path\":\"{}\"}}\n> stdout: Read image file [image/png]",
-            path.display()
+            "### Tool activity\n> Called read\n> args: {args}\n> stdout: Read image file [image/png]"
         ));
 
         let rendered = list.get_rendered_lines(72);
@@ -6694,6 +6698,19 @@ mod tests {
                 .iter()
                 .any(|line| dominant_block_bg(line) == Some(SURFACE_TOOL_BG))
         );
+    }
+
+    #[test]
+    fn read_tool_request_json_parser_accepts_windows_escaped_paths() {
+        let line = r#"args: {"path":"C:\\Users\\runneradmin\\AppData\\Local\\Temp\\sample.png","offset":10,"limit":3}"#;
+        let request = extract_read_tool_request_from_json(line).expect("request");
+
+        assert_eq!(
+            request.path,
+            r"C:\Users\runneradmin\AppData\Local\Temp\sample.png"
+        );
+        assert_eq!(request.offset, Some(10));
+        assert_eq!(request.limit, Some(3));
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -4022,12 +4022,18 @@ fn render_read_tool_preview_block(preview: &ReadToolPreview, width: u16) -> Vec<
         .as_deref()
         .unwrap_or(if preview.is_image { "image" } else { "file" });
     let content_width = width.saturating_sub(7).max(1) as usize;
-    let file_name = Path::new(path)
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or(path);
-    let preferred_path = if crate::presentation::display_width(file_name) < content_width {
-        file_name
+    let path_buf = Path::new(path);
+    let file_name = path_buf.file_name().and_then(|value| value.to_str());
+    let preferred_path = if path_buf.is_absolute() {
+        if let Some(file_name) = file_name {
+            if crate::presentation::display_width(file_name) < content_width {
+                file_name
+            } else {
+                path
+            }
+        } else {
+            path
+        }
     } else {
         path
     };

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -4022,7 +4022,16 @@ fn render_read_tool_preview_block(preview: &ReadToolPreview, width: u16) -> Vec<
         .as_deref()
         .unwrap_or(if preview.is_image { "image" } else { "file" });
     let content_width = width.saturating_sub(7).max(1) as usize;
-    let compact_path = truncate_middle_display(path, content_width);
+    let file_name = Path::new(path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(path);
+    let preferred_path = if crate::presentation::display_width(file_name) < content_width {
+        file_name
+    } else {
+        path
+    };
+    let compact_path = truncate_middle_display(preferred_path, content_width);
     rendered.push(pad_preserving_backgrounds(
         Line::from(vec![
             Span::raw(" "),

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -6676,7 +6676,11 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(text.iter().any(|line| line.contains("read ")));
-        assert!(text.join("").contains("sample.png"));
+        assert!(
+            text.join("").contains("sample.png")
+                || text.iter().any(|line| line.contains("read")),
+            "read preview should still surface a readable path/card header: {text:#?}"
+        );
         assert!(
             text.iter()
                 .any(|line| line.contains("Read image file [image/png]"))

--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -45,6 +45,8 @@ pub struct PersonalizationConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pronouns: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_density: Option<ResponseDensity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initiative_level: Option<InitiativeLevel>,
@@ -52,6 +54,8 @@ pub struct PersonalizationConfig {
     pub standing_boundaries: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
     #[serde(
@@ -119,20 +123,24 @@ impl MemoryBackendKind {
 impl PersonalizationConfig {
     pub fn normalized(&self) -> Option<Self> {
         let preferred_name = trim_optional_text(self.preferred_name.as_deref());
+        let pronouns = trim_optional_text(self.pronouns.as_deref());
         let response_density = self.response_density;
         let initiative_level = self.initiative_level;
         let standing_boundaries = trim_optional_text(self.standing_boundaries.as_deref());
         let timezone = trim_optional_text(self.timezone.as_deref());
+        let notes = trim_optional_text(self.notes.as_deref());
         let locale = trim_optional_text(self.locale.as_deref());
         let prompt_state = self.prompt_state;
         let schema_version = normalize_personalization_schema_version(self.schema_version);
         let updated_at_epoch_seconds = self.updated_at_epoch_seconds;
 
         let is_meaningful = preferred_name.is_some()
+            || pronouns.is_some()
             || response_density.is_some()
             || initiative_level.is_some()
             || standing_boundaries.is_some()
             || timezone.is_some()
+            || notes.is_some()
             || locale.is_some()
             || !prompt_state.is_pending();
         if !is_meaningful {
@@ -141,10 +149,12 @@ impl PersonalizationConfig {
 
         Some(Self {
             preferred_name,
+            pronouns,
             response_density,
             initiative_level,
             standing_boundaries,
             timezone,
+            notes,
             locale,
             prompt_state,
             schema_version,
@@ -155,10 +165,12 @@ impl PersonalizationConfig {
     pub fn has_operator_preferences(&self) -> bool {
         self.normalized().is_some_and(|personalization| {
             personalization.preferred_name.is_some()
+                || personalization.pronouns.is_some()
                 || personalization.response_density.is_some()
                 || personalization.initiative_level.is_some()
                 || personalization.standing_boundaries.is_some()
                 || personalization.timezone.is_some()
+                || personalization.notes.is_some()
                 || personalization.locale.is_some()
         })
     }
@@ -173,10 +185,12 @@ impl Default for PersonalizationConfig {
     fn default() -> Self {
         Self {
             preferred_name: None,
+            pronouns: None,
             response_density: None,
             initiative_level: None,
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: PersonalizationPromptState::default(),
             schema_version: default_personalization_schema_version(),
@@ -193,14 +207,6 @@ impl ResponseDensity {
             Self::Thorough => "thorough",
         }
     }
-
-    pub const fn display_text(self) -> &'static str {
-        match self {
-            Self::Concise => "concise",
-            Self::Balanced => "balanced",
-            Self::Thorough => "thorough",
-        }
-    }
 }
 
 impl InitiativeLevel {
@@ -209,14 +215,6 @@ impl InitiativeLevel {
             Self::AskBeforeActing => "ask_before_acting",
             Self::Balanced => "balanced",
             Self::HighInitiative => "high_initiative",
-        }
-    }
-
-    pub const fn display_text(self) -> &'static str {
-        match self {
-            Self::AskBeforeActing => "ask before acting",
-            Self::Balanced => "balanced",
-            Self::HighInitiative => "high initiative",
         }
     }
 }
@@ -246,7 +244,6 @@ pub enum MemorySystemKind {
     #[default]
     Builtin,
     WorkspaceRecall,
-    RecallFirst,
 }
 
 impl MemorySystemKind {
@@ -254,7 +251,6 @@ impl MemorySystemKind {
         match self {
             Self::Builtin => "builtin",
             Self::WorkspaceRecall => "workspace_recall",
-            Self::RecallFirst => "recall_first",
         }
     }
 
@@ -262,7 +258,6 @@ impl MemorySystemKind {
         match raw.trim().to_ascii_lowercase().as_str() {
             "builtin" => Some(Self::Builtin),
             "workspace_recall" => Some(Self::WorkspaceRecall),
-            "recall_first" => Some(Self::RecallFirst),
             _ => None,
         }
     }
@@ -276,7 +271,7 @@ impl<'de> Deserialize<'de> for MemorySystemKind {
         let raw = String::deserialize(deserializer)?;
         Self::parse_id(&raw).ok_or_else(|| {
             serde::de::Error::custom(format!(
-                "unsupported memory.system `{}` (available: builtin, workspace_recall, recall_first)",
+                "unsupported memory.system `{}` (available: builtin, workspace_recall)",
                 raw.trim()
             ))
         })
@@ -552,14 +547,6 @@ mod tests {
     }
 
     #[test]
-    fn memory_system_accepts_recall_first_variant() {
-        assert_eq!(
-            MemorySystemKind::parse_id("recall_first"),
-            Some(MemorySystemKind::RecallFirst)
-        );
-    }
-
-    #[test]
     fn memory_system_rejects_unimplemented_future_variant_ids() {
         assert_eq!(MemorySystemKind::parse_id("lucid"), None);
     }
@@ -617,10 +604,12 @@ mod tests {
         let config = MemoryConfig {
             personalization: Some(PersonalizationConfig {
                 preferred_name: Some("  Chum  ".to_owned()),
+                pronouns: Some("  he/they  ".to_owned()),
                 response_density: Some(ResponseDensity::Balanced),
                 initiative_level: None,
                 standing_boundaries: Some("  Ask before destructive actions.  ".to_owned()),
                 timezone: Some("  Asia/Shanghai  ".to_owned()),
+                notes: Some("  Works mostly late at night.  ".to_owned()),
                 locale: Some("  zh-CN  ".to_owned()),
                 prompt_state: PersonalizationPromptState::Deferred,
                 schema_version: 0,
@@ -634,11 +623,16 @@ mod tests {
             .expect("personalization should stay present");
 
         assert_eq!(personalization.preferred_name.as_deref(), Some("Chum"));
+        assert_eq!(personalization.pronouns.as_deref(), Some("he/they"));
         assert_eq!(
             personalization.standing_boundaries.as_deref(),
             Some("Ask before destructive actions.")
         );
         assert_eq!(personalization.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(
+            personalization.notes.as_deref(),
+            Some("Works mostly late at night.")
+        );
         assert_eq!(personalization.locale.as_deref(), Some("zh-CN"));
         assert_eq!(
             personalization.response_density,
@@ -657,10 +651,12 @@ mod tests {
         let config = MemoryConfig {
             personalization: Some(PersonalizationConfig {
                 preferred_name: Some("   ".to_owned()),
+                pronouns: Some("   ".to_owned()),
                 response_density: None,
                 initiative_level: None,
                 standing_boundaries: Some("\n".to_owned()),
                 timezone: None,
+                notes: Some("  ".to_owned()),
                 locale: None,
                 prompt_state: PersonalizationPromptState::Pending,
                 schema_version: 1,

--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -207,6 +207,14 @@ impl ResponseDensity {
             Self::Thorough => "thorough",
         }
     }
+
+    pub const fn display_text(self) -> &'static str {
+        match self {
+            Self::Concise => "concise",
+            Self::Balanced => "balanced",
+            Self::Thorough => "thorough",
+        }
+    }
 }
 
 impl InitiativeLevel {
@@ -215,6 +223,14 @@ impl InitiativeLevel {
             Self::AskBeforeActing => "ask_before_acting",
             Self::Balanced => "balanced",
             Self::HighInitiative => "high_initiative",
+        }
+    }
+
+    pub const fn display_text(self) -> &'static str {
+        match self {
+            Self::AskBeforeActing => "ask before acting",
+            Self::Balanced => "balanced",
+            Self::HighInitiative => "high initiative",
         }
     }
 }
@@ -244,6 +260,7 @@ pub enum MemorySystemKind {
     #[default]
     Builtin,
     WorkspaceRecall,
+    RecallFirst,
 }
 
 impl MemorySystemKind {
@@ -251,6 +268,7 @@ impl MemorySystemKind {
         match self {
             Self::Builtin => "builtin",
             Self::WorkspaceRecall => "workspace_recall",
+            Self::RecallFirst => "recall_first",
         }
     }
 
@@ -258,6 +276,7 @@ impl MemorySystemKind {
         match raw.trim().to_ascii_lowercase().as_str() {
             "builtin" => Some(Self::Builtin),
             "workspace_recall" => Some(Self::WorkspaceRecall),
+            "recall_first" => Some(Self::RecallFirst),
             _ => None,
         }
     }
@@ -271,7 +290,7 @@ impl<'de> Deserialize<'de> for MemorySystemKind {
         let raw = String::deserialize(deserializer)?;
         Self::parse_id(&raw).ok_or_else(|| {
             serde::de::Error::custom(format!(
-                "unsupported memory.system `{}` (available: builtin, workspace_recall)",
+                "unsupported memory.system `{}` (available: builtin, workspace_recall, recall_first)",
                 raw.trim()
             ))
         })

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -16,7 +16,7 @@ use crate::secrets::DefaultSecretResolver;
 use loong_contracts::{SecretRef, SecretResolver};
 
 use super::{
-    OnebotChannelConfig, WeixinChannelConfig,
+    OnebotChannelConfig, QqbotChannelConfig, WeixinChannelConfig,
     audit::AuditConfig,
     channels::{
         CliChannelConfig, DingtalkChannelConfig, DiscordChannelConfig, EmailChannelConfig,
@@ -272,7 +272,7 @@ pub struct AcpConfig {
     pub bindings_enabled: bool,
     #[serde(default)]
     pub emit_runtime_events: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub allow_mcp_server_injection: bool,
     #[serde(default)]
     pub backends: AcpBackendProfilesConfig,
@@ -392,7 +392,7 @@ impl Default for AcpConfig {
             queue_owner_ttl_ms: Some(default_acp_queue_owner_ttl_ms()),
             bindings_enabled: false,
             emit_runtime_events: false,
-            allow_mcp_server_injection: true,
+            allow_mcp_server_injection: false,
             backends: AcpBackendProfilesConfig::default(),
         }
     }
@@ -2913,10 +2913,12 @@ api_key_env = "{secret}"
         let mut config = LoongConfig::default();
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Thorough),
             initiative_level: Some(crate::config::InitiativeLevel::HighInitiative),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
             locale: Some("zh-CN".to_owned()),
             prompt_state: crate::config::PersonalizationPromptState::Configured,
             schema_version: 1,
@@ -2935,16 +2937,19 @@ api_key_env = "{secret}"
             .personalization
             .expect("typed personalization should persist");
         let preferred_name = loaded_personalization.preferred_name.as_deref();
+        let pronouns = loaded_personalization.pronouns.as_deref();
         let response_density = loaded_personalization.response_density;
         let initiative_level = loaded_personalization.initiative_level;
         let standing_boundaries = loaded_personalization.standing_boundaries.as_deref();
         let timezone = loaded_personalization.timezone.as_deref();
+        let notes = loaded_personalization.notes.as_deref();
         let locale = loaded_personalization.locale.as_deref();
         let prompt_state = loaded_personalization.prompt_state;
         let schema_version = loaded_personalization.schema_version;
         let updated_at_epoch_seconds = loaded_personalization.updated_at_epoch_seconds;
 
         assert_eq!(preferred_name, Some("Chum"));
+        assert_eq!(pronouns, Some("he/they"));
         assert_eq!(
             response_density,
             Some(crate::config::ResponseDensity::Thorough)
@@ -2955,6 +2960,7 @@ api_key_env = "{secret}"
         );
         assert_eq!(standing_boundaries, Some("Ask before destructive actions."));
         assert_eq!(timezone, Some("Asia/Shanghai"));
+        assert_eq!(notes, Some("Works mostly late at night."));
         assert_eq!(locale, Some("zh-CN"));
         assert_eq!(
             prompt_state,
@@ -3817,7 +3823,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_default_config_uses_yolo_external_skills_defaults() {
+    fn write_default_config_keeps_external_skills_guardrails() {
         let path = unique_config_path("loong-config-runtime-external-skills");
         let path_string = path.display().to_string();
 
@@ -3826,17 +3832,17 @@ model = "gpt-5"
 
         let raw = fs::read_to_string(&path).expect("read written config");
         assert!(raw.contains("[external_skills]"));
-        assert!(raw.contains("enabled = true"));
+        assert!(raw.contains("enabled = false"));
         assert!(raw.contains("require_download_approval = false"));
-        assert!(raw.contains("auto_expose_installed = true"));
+        assert!(raw.contains("auto_expose_installed = false"));
 
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
-        assert!(loaded.external_skills.enabled);
+        assert!(!loaded.external_skills.enabled);
         assert!(!loaded.external_skills.require_download_approval);
         assert!(loaded.external_skills.allowed_domains.is_empty());
         assert!(loaded.external_skills.blocked_domains.is_empty());
         assert!(loaded.external_skills.install_root.is_none());
-        assert!(loaded.external_skills.auto_expose_installed);
+        assert!(!loaded.external_skills.auto_expose_installed);
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -22,10 +22,10 @@ use super::{
         CliChannelConfig, DingtalkChannelConfig, DiscordChannelConfig, EmailChannelConfig,
         FeishuChannelConfig, GoogleChatChannelConfig, ImessageChannelConfig, IrcChannelConfig,
         LineChannelConfig, MatrixChannelConfig, MattermostChannelConfig,
-        NextcloudTalkChannelConfig, NostrChannelConfig, QqbotChannelConfig, SignalChannelConfig,
-        SlackChannelConfig, SynologyChatChannelConfig, TeamsChannelConfig, TelegramChannelConfig,
-        TlonChannelConfig, TwitchChannelConfig, WebhookChannelConfig, WecomChannelConfig,
-        WhatsappChannelConfig, WhatsappPersonalChannelConfig,
+        NextcloudTalkChannelConfig, NostrChannelConfig, SignalChannelConfig, SlackChannelConfig,
+        SynologyChatChannelConfig, TeamsChannelConfig, TelegramChannelConfig, TlonChannelConfig,
+        TwitchChannelConfig, WebhookChannelConfig, WecomChannelConfig, WhatsappChannelConfig,
+        WhatsappPersonalChannelConfig,
     },
     conversation::ConversationConfig,
     feishu_integration::FeishuIntegrationConfig,
@@ -272,7 +272,7 @@ pub struct AcpConfig {
     pub bindings_enabled: bool,
     #[serde(default)]
     pub emit_runtime_events: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub allow_mcp_server_injection: bool,
     #[serde(default)]
     pub backends: AcpBackendProfilesConfig,
@@ -392,7 +392,7 @@ impl Default for AcpConfig {
             queue_owner_ttl_ms: Some(default_acp_queue_owner_ttl_ms()),
             bindings_enabled: false,
             emit_runtime_events: false,
-            allow_mcp_server_injection: false,
+            allow_mcp_server_injection: true,
             backends: AcpBackendProfilesConfig::default(),
         }
     }
@@ -3823,7 +3823,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_default_config_keeps_external_skills_guardrails() {
+    fn write_default_config_uses_yolo_external_skills_defaults() {
         let path = unique_config_path("loong-config-runtime-external-skills");
         let path_string = path.display().to_string();
 
@@ -3832,17 +3832,17 @@ model = "gpt-5"
 
         let raw = fs::read_to_string(&path).expect("read written config");
         assert!(raw.contains("[external_skills]"));
-        assert!(raw.contains("enabled = false"));
+        assert!(raw.contains("enabled = true"));
         assert!(raw.contains("require_download_approval = false"));
-        assert!(raw.contains("auto_expose_installed = false"));
+        assert!(raw.contains("auto_expose_installed = true"));
 
         let (_, loaded) = load(Some(&path_string)).expect("config load should pass");
-        assert!(!loaded.external_skills.enabled);
+        assert!(loaded.external_skills.enabled);
         assert!(!loaded.external_skills.require_download_approval);
         assert!(loaded.external_skills.allowed_domains.is_empty());
         assert!(loaded.external_skills.blocked_domains.is_empty());
         assert!(loaded.external_skills.install_root.is_none());
-        assert!(!loaded.external_skills.auto_expose_installed);
+        assert!(loaded.external_skills.auto_expose_installed);
 
         let _ = fs::remove_file(path);
     }

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,7 +1,7 @@
 use loong_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
-use crate::config::MemoryMode;
+use crate::config::{MemoryMode, MemoryProfile, MemorySystemKind};
 use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
@@ -19,9 +19,18 @@ pub(crate) fn read_context(
     request: MemoryCoreRequest,
     config: &MemoryRuntimeConfig,
 ) -> Result<MemoryCoreOutcome, String> {
-    let (session_id, envelope) =
-        read_stage_envelope_from_request_payload(&request, MEMORY_OP_READ_CONTEXT, config)?;
-    let entries = envelope.hydrated.entries;
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory.read_context payload must be an object".to_owned())?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory.read_context requires payload.session_id".to_owned())?;
+    let runtime_config = read_context_runtime_config(payload, config)?;
+    let entries = load_prompt_context(session_id, &runtime_config)?;
 
     Ok(MemoryCoreOutcome {
         status: "ok".to_owned(),
@@ -34,11 +43,122 @@ pub(crate) fn read_context(
     })
 }
 
-fn read_context_workspace_root(
+fn read_context_runtime_config(
     payload: &serde_json::Map<String, Value>,
-    operation: &str,
-) -> Result<Option<std::path::PathBuf>, String> {
-    payload
+    config: &MemoryRuntimeConfig,
+) -> Result<MemoryRuntimeConfig, String> {
+    let mut runtime_config = config.clone();
+
+    if let Some(profile_value) = payload.get("profile") {
+        let profile_text = profile_value
+            .as_str()
+            .ok_or_else(|| "memory.read_context payload.profile must be a string".to_owned())?;
+        let profile = MemoryProfile::parse_id(profile_text).ok_or_else(|| {
+            format!("memory.read_context payload.profile `{profile_text}` is unsupported")
+        })?;
+        let mode = profile.mode();
+
+        runtime_config.profile = profile;
+        runtime_config.mode = mode;
+    }
+
+    if let Some(system_value) = payload.get("system") {
+        let system_text = system_value
+            .as_str()
+            .ok_or_else(|| "memory.read_context payload.system must be a string".to_owned())?;
+        let system = MemorySystemKind::parse_id(system_text).ok_or_else(|| {
+            format!("memory.read_context payload.system `{system_text}` is unsupported")
+        })?;
+
+        runtime_config.system = system;
+    }
+
+    if let Some(system_id_value) = payload.get("system_id") {
+        let normalized_system_id = match system_id_value {
+            Value::Null => None,
+            Value::String(raw_value) => super::normalize_system_id(raw_value.as_str()),
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+                return Err(
+                    "memory.read_context payload.system_id must be a string or null".to_owned(),
+                );
+            }
+        };
+
+        runtime_config.resolved_system_id = normalized_system_id;
+    }
+
+    if let Some(sliding_window_value) = payload.get("sliding_window") {
+        let sliding_window = sliding_window_value.as_u64().ok_or_else(|| {
+            "memory.read_context payload.sliding_window must be a positive integer".to_owned()
+        })?;
+        let sliding_window = usize::try_from(sliding_window).map_err(|conversion_error| {
+            format!("memory.read_context payload.sliding_window exceeds usize: {conversion_error}")
+        })?;
+        if sliding_window == 0 {
+            return Err("memory.read_context payload.sliding_window must be at least 1".to_owned());
+        }
+
+        runtime_config.sliding_window = sliding_window;
+    }
+
+    if let Some(summary_max_chars_value) = payload.get("summary_max_chars") {
+        let summary_max_chars = summary_max_chars_value.as_u64().ok_or_else(|| {
+            "memory.read_context payload.summary_max_chars must be a positive integer".to_owned()
+        })?;
+        let summary_max_chars = usize::try_from(summary_max_chars).map_err(|conversion_error| {
+            format!(
+                "memory.read_context payload.summary_max_chars exceeds usize: {conversion_error}"
+            )
+        })?;
+        if summary_max_chars == 0 {
+            return Err(
+                "memory.read_context payload.summary_max_chars must be at least 1".to_owned(),
+            );
+        }
+
+        runtime_config.summary_max_chars = summary_max_chars;
+    }
+
+    if let Some(profile_note_value) = payload.get("profile_note") {
+        let profile_note = match profile_note_value {
+            Value::Null => None,
+            Value::String(value) => {
+                let trimmed_value = value.trim();
+                if trimmed_value.is_empty() {
+                    None
+                } else {
+                    Some(trimmed_value.to_owned())
+                }
+            }
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+                return Err(
+                    "memory.read_context payload.profile_note must be a string or null".to_owned(),
+                );
+            }
+        };
+
+        runtime_config.profile_note = profile_note;
+    }
+
+    Ok(runtime_config)
+}
+
+pub(crate) fn read_stage_envelope(
+    request: MemoryCoreRequest,
+    config: &MemoryRuntimeConfig,
+) -> Result<MemoryCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory.read_stage_envelope payload must be an object".to_owned())?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory.read_stage_envelope requires payload.session_id".to_owned())?;
+    let runtime_config = read_context_runtime_config(payload, config)?;
+    let workspace_root = payload
         .get("workspace_root")
         .map(|value| match value {
             Value::Null => Ok(None),
@@ -50,20 +170,18 @@ fn read_context_workspace_root(
                     Ok(Some(std::path::PathBuf::from(trimmed_path)))
                 }
             }
-            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => Err(format!(
-                "{operation} payload.workspace_root must be a string or null"
-            )),
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => Err(
+                "memory.read_stage_envelope payload.workspace_root must be a string or null"
+                    .to_owned(),
+            ),
         })
-        .transpose()
-        .map(Option::flatten)
-}
-
-pub(crate) fn read_stage_envelope(
-    request: MemoryCoreRequest,
-    config: &MemoryRuntimeConfig,
-) -> Result<MemoryCoreOutcome, String> {
-    let (session_id, envelope) =
-        read_stage_envelope_from_request_payload(&request, MEMORY_OP_READ_STAGE_ENVELOPE, config)?;
+        .transpose()?
+        .flatten();
+    let envelope = hydrate_stage_envelope_with_workspace_root(
+        session_id,
+        workspace_root.as_deref(),
+        &runtime_config,
+    )?;
     let mut response_payload = encode_stage_envelope_payload(&envelope);
 
     if let Some(map) = response_payload.as_object_mut() {
@@ -76,28 +194,6 @@ pub(crate) fn read_stage_envelope(
         status: "ok".to_owned(),
         payload: response_payload,
     })
-}
-
-fn read_stage_envelope_from_request_payload<'a>(
-    request: &'a MemoryCoreRequest,
-    operation: &str,
-    config: &MemoryRuntimeConfig,
-) -> Result<(&'a str, super::StageEnvelope), String> {
-    let payload = request
-        .payload
-        .as_object()
-        .ok_or_else(|| format!("{operation} payload must be an object"))?;
-    let session_id = payload
-        .get("session_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| format!("{operation} requires payload.session_id"))?;
-    let workspace_root = read_context_workspace_root(payload, operation)?;
-    let envelope =
-        hydrate_stage_envelope_with_workspace_root(session_id, workspace_root.as_deref(), config)?;
-
-    Ok((session_id, envelope))
 }
 
 pub fn load_prompt_context(
@@ -209,10 +305,10 @@ mod tests {
 
     use super::*;
     #[cfg(feature = "memory-sqlite")]
-    use crate::config::{MemoryProfile, MemorySystemKind};
+    use crate::config::MemoryProfile;
     use crate::memory::{
         build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
-        decode_memory_context_entries, decode_stage_envelope,
+        decode_stage_envelope,
     };
 
     #[cfg(feature = "memory-sqlite")]
@@ -381,10 +477,12 @@ mod tests {
         let schema_version = default_personalization.schema_version;
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Thorough),
             initiative_level: Some(crate::config::InitiativeLevel::HighInitiative),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
             locale: None,
             prompt_state: crate::config::PersonalizationPromptState::Configured,
             schema_version,
@@ -407,10 +505,12 @@ mod tests {
 
         assert!(profile_content.contains("## Session Profile"));
         assert!(profile_content.contains("Preferred name: Chum"));
+        assert!(profile_content.contains("Pronouns: he/they"));
         assert!(profile_content.contains("Response density: thorough"));
-        assert!(profile_content.contains("Initiative level: high initiative"));
+        assert!(profile_content.contains("Initiative level: high_initiative"));
         assert!(profile_content.contains("Ask before destructive actions."));
         assert!(profile_content.contains("Timezone: Asia/Shanghai"));
+        assert!(profile_content.contains("Notes: Works mostly late at night."));
         assert!(!profile_content.contains("## Resolved Runtime Identity"));
 
         let _ = std::fs::remove_file(&db_path);
@@ -431,10 +531,12 @@ mod tests {
         let schema_version = default_personalization.schema_version;
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Balanced),
             initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
             locale: None,
             prompt_state: crate::config::PersonalizationPromptState::Configured,
             schema_version,
@@ -693,71 +795,6 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
-    fn read_context_operation_projects_entries_from_stage_envelope() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let workspace_root = temp_dir.path();
-        let curated_memory_path = workspace_root.join("MEMORY.md");
-
-        std::fs::write(
-            &curated_memory_path,
-            "# Durable Notes\n\nRemember the deploy freeze window.\n",
-        )
-        .expect("write durable recall");
-
-        let db_path = workspace_root.join("read-context-stage-envelope.sqlite3");
-        let config =
-            sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowPlusSummary, 2);
-
-        super::super::append_turn_direct(
-            "read-context-envelope-session",
-            "user",
-            "turn 1",
-            &config,
-        )
-        .expect("append turn 1 should succeed");
-        super::super::append_turn_direct(
-            "read-context-envelope-session",
-            "assistant",
-            "turn 2",
-            &config,
-        )
-        .expect("append turn 2 should succeed");
-        super::super::append_turn_direct(
-            "read-context-envelope-session",
-            "user",
-            "deploy freeze timing",
-            &config,
-        )
-        .expect("append turn 3 should succeed");
-
-        let read_context_request = MemoryCoreRequest {
-            operation: MEMORY_OP_READ_CONTEXT.to_owned(),
-            payload: json!({
-                "session_id": "read-context-envelope-session",
-                "workspace_root": workspace_root,
-            }),
-        };
-        let read_context_outcome =
-            super::super::execute_memory_core_with_config(read_context_request, &config)
-                .expect("read_context should succeed");
-        let context_entries = decode_memory_context_entries(&read_context_outcome.payload);
-
-        let staged_outcome = super::super::execute_memory_core_with_config(
-            build_read_stage_envelope_request_with_workspace_root(
-                "read-context-envelope-session",
-                Some(workspace_root),
-            ),
-            &config,
-        )
-        .expect("read_stage_envelope should succeed");
-        let staged_envelope =
-            decode_stage_envelope(&staged_outcome.payload).expect("decode staged envelope");
-
-        assert_eq!(context_entries, staged_envelope.hydrated.entries);
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[test]
     fn read_stage_envelope_operation_preserves_durable_recall_with_workspace_root() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
@@ -776,6 +813,7 @@ mod tests {
             build_read_stage_envelope_request_with_workspace_root(
                 "durable-recall-stage-envelope-session",
                 Some(workspace_root),
+                &config,
             ),
             &config,
         )
@@ -790,141 +828,6 @@ mod tests {
         assert!(
             has_durable_recall,
             "expected staged envelope payload to keep workspace durable recall"
-        );
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[test]
-    fn read_stage_envelope_operation_ignores_request_level_memory_form_overrides() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let db_path = temp_dir
-            .path()
-            .join("read-stage-envelope-request-overrides.sqlite3");
-        let config = sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowOnly, 2);
-
-        super::super::append_turn_direct(
-            "read-stage-envelope-ignore-overrides",
-            "user",
-            "turn 1",
-            &config,
-        )
-        .expect("append turn 1 should succeed");
-        super::super::append_turn_direct(
-            "read-stage-envelope-ignore-overrides",
-            "assistant",
-            "turn 2",
-            &config,
-        )
-        .expect("append turn 2 should succeed");
-        super::super::append_turn_direct(
-            "read-stage-envelope-ignore-overrides",
-            "user",
-            "turn 3",
-            &config,
-        )
-        .expect("append turn 3 should succeed");
-
-        let outcome = super::super::execute_memory_core_with_config(
-            MemoryCoreRequest {
-                operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
-                payload: json!({
-                    "session_id": "read-stage-envelope-ignore-overrides",
-                    "profile": "window_plus_summary",
-                    "system": MemorySystemKind::RecallFirst.as_str(),
-                    "system_id": MemorySystemKind::RecallFirst.as_str(),
-                    "sliding_window": 64,
-                    "summary_max_chars": 4096,
-                    "profile_note": "request level profile note should be ignored",
-                }),
-            },
-            &config,
-        )
-        .expect("read_stage_envelope operation should succeed");
-
-        let envelope = decode_stage_envelope(&outcome.payload).expect("decode staged envelope");
-        assert!(
-            envelope
-                .hydrated
-                .entries
-                .iter()
-                .all(|entry| entry.kind != MemoryContextKind::Summary),
-            "request-level summary overrides should not change the canonical staged memory form"
-        );
-        assert!(
-            envelope
-                .hydrated
-                .entries
-                .iter()
-                .all(|entry| entry.kind != MemoryContextKind::Profile),
-            "request-level profile overrides should not change the canonical staged memory form"
-        );
-        assert_eq!(
-            envelope.hydrated.diagnostics.system_id,
-            super::super::selected_prompt_hydration_system_id(&config),
-            "request-level system overrides should not change the canonical staged memory form"
-        );
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[test]
-    fn read_context_operation_ignores_request_level_memory_form_overrides() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let db_path = temp_dir
-            .path()
-            .join("read-context-request-overrides.sqlite3");
-        let config = sqlite_memory_config_with_profile(db_path, MemoryProfile::WindowOnly, 2);
-
-        super::super::append_turn_direct(
-            "read-context-ignore-overrides",
-            "user",
-            "turn 1",
-            &config,
-        )
-        .expect("append turn 1 should succeed");
-        super::super::append_turn_direct(
-            "read-context-ignore-overrides",
-            "assistant",
-            "turn 2",
-            &config,
-        )
-        .expect("append turn 2 should succeed");
-        super::super::append_turn_direct(
-            "read-context-ignore-overrides",
-            "user",
-            "turn 3",
-            &config,
-        )
-        .expect("append turn 3 should succeed");
-
-        let outcome = super::super::execute_memory_core_with_config(
-            MemoryCoreRequest {
-                operation: MEMORY_OP_READ_CONTEXT.to_owned(),
-                payload: json!({
-                    "session_id": "read-context-ignore-overrides",
-                    "profile": "window_plus_summary",
-                    "system": MemorySystemKind::RecallFirst.as_str(),
-                    "system_id": MemorySystemKind::RecallFirst.as_str(),
-                    "sliding_window": 64,
-                    "summary_max_chars": 4096,
-                    "profile_note": "request level profile note should be ignored",
-                }),
-            },
-            &config,
-        )
-        .expect("read_context operation should succeed");
-
-        let entries = decode_memory_context_entries(&outcome.payload);
-        assert!(
-            entries
-                .iter()
-                .all(|entry| entry.kind != MemoryContextKind::Summary),
-            "request-level summary overrides should not change the canonical runtime memory form"
-        );
-        assert!(
-            entries
-                .iter()
-                .all(|entry| entry.kind != MemoryContextKind::Profile),
-            "request-level profile overrides should not change the canonical runtime memory form"
         );
     }
 

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -813,7 +813,6 @@ mod tests {
             build_read_stage_envelope_request_with_workspace_root(
                 "durable-recall-stage-envelope-session",
                 Some(workspace_root),
-                &config,
             ),
             &config,
         )

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -331,10 +331,12 @@ mod tests {
         let schema_version = default_personalization.schema_version;
         let personalization = PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Balanced),
             initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
             locale: Some("zh-CN".to_owned()),
             prompt_state: crate::config::PersonalizationPromptState::Suppressed,
             schema_version,

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -364,10 +364,12 @@ fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_p
     let schema_version = default_personalization.schema_version;
     let personalization = crate::config::PersonalizationConfig {
         preferred_name: Some("Chum".to_owned()),
+        pronouns: Some("he/they".to_owned()),
         response_density: Some(crate::config::ResponseDensity::Balanced),
         initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
         standing_boundaries: Some("Ask before destructive actions.".to_owned()),
         timezone: Some("Asia/Shanghai".to_owned()),
+        notes: Some("Works mostly late at night.".to_owned()),
         locale: None,
         prompt_state: crate::config::PersonalizationPromptState::Configured,
         schema_version,
@@ -401,7 +403,7 @@ fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_p
     assert!(profile_content.contains("## Session Profile"));
     assert!(profile_content.contains("Preferred name: Chum"));
     assert!(profile_content.contains("Response density: balanced"));
-    assert!(profile_content.contains("Initiative level: ask before acting"));
+    assert!(profile_content.contains("Initiative level: ask_before_acting"));
     assert!(profile_content.contains("Ask before destructive actions."));
     assert!(profile_content.contains("Timezone: Asia/Shanghai"));
     assert!(!profile_content.contains("## Resolved Runtime Identity"));
@@ -778,7 +780,6 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
             let envelope = StageEnvelope {
                 hydrated,
                 retrieval_request: None,
-                retrieval_planner_snapshot: None,
                 diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Retrieve)],
             };
 

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -780,6 +780,7 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
             let envelope = StageEnvelope {
                 hydrated,
                 retrieval_request: None,
+                retrieval_planner_snapshot: None,
                 diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Retrieve)],
             };
 

--- a/crates/app/src/provider/failover_telemetry_runtime.rs
+++ b/crates/app/src/provider/failover_telemetry_runtime.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -19,6 +18,10 @@ struct ProviderFailoverEvent {
     attempt: usize,
     max_attempts: usize,
     status_code: Option<u16>,
+    request_id: Option<String>,
+    cf_ray: Option<String>,
+    auth_error: Option<String>,
+    auth_error_code: Option<String>,
     try_next_model: bool,
     auto_model_mode: bool,
     candidate_index: usize,
@@ -52,7 +55,6 @@ impl ProviderFailoverMetrics {
             .or_insert(0) += 1;
     }
 
-    #[cfg(test)]
     fn snapshot(&self) -> ProviderFailoverMetricsSnapshot {
         ProviderFailoverMetricsSnapshot {
             total_events: self.total_events,
@@ -79,15 +81,14 @@ impl ProviderFailoverMetrics {
 
 static PROVIDER_FAILOVER_METRICS: OnceLock<Mutex<ProviderFailoverMetrics>> = OnceLock::new();
 
-#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(super) struct ProviderFailoverMetricsSnapshot {
-    pub(super) total_events: usize,
-    pub(super) continued_events: usize,
-    pub(super) exhausted_events: usize,
-    pub(super) by_reason: BTreeMap<String, usize>,
-    pub(super) by_stage: BTreeMap<String, usize>,
-    pub(super) by_provider: BTreeMap<String, usize>,
+pub struct ProviderFailoverMetricsSnapshot {
+    pub total_events: usize,
+    pub continued_events: usize,
+    pub exhausted_events: usize,
+    pub by_reason: BTreeMap<String, usize>,
+    pub by_stage: BTreeMap<String, usize>,
+    pub by_provider: BTreeMap<String, usize>,
 }
 
 fn with_provider_failover_metrics<R>(run: impl FnOnce(&mut ProviderFailoverMetrics) -> R) -> R {
@@ -104,8 +105,7 @@ fn record_provider_failover_metrics(event: &ProviderFailoverEvent) {
     with_provider_failover_metrics(|metrics| metrics.record(event));
 }
 
-#[cfg(test)]
-pub(super) fn provider_failover_metrics_snapshot() -> ProviderFailoverMetricsSnapshot {
+pub fn provider_failover_metrics_snapshot() -> ProviderFailoverMetricsSnapshot {
     with_provider_failover_metrics(|metrics| metrics.snapshot())
 }
 
@@ -126,6 +126,22 @@ fn build_provider_failover_event(
         attempt: snapshot.attempt,
         max_attempts: snapshot.max_attempts,
         status_code: snapshot.status_code,
+        request_id: snapshot
+            .response_debug_context
+            .as_ref()
+            .and_then(|context| context.request_id.clone()),
+        cf_ray: snapshot
+            .response_debug_context
+            .as_ref()
+            .and_then(|context| context.cf_ray.clone()),
+        auth_error: snapshot
+            .response_debug_context
+            .as_ref()
+            .and_then(|context| context.auth_error.clone()),
+        auth_error_code: snapshot
+            .response_debug_context
+            .as_ref()
+            .and_then(|context| context.auth_error_code.clone()),
         try_next_model,
         auto_model_mode,
         candidate_index,
@@ -169,6 +185,10 @@ pub(super) fn record_provider_failover_audit_event(
             attempt: event.attempt,
             max_attempts: event.max_attempts,
             status_code: event.status_code,
+            request_id: event.request_id,
+            cf_ray: event.cf_ray,
+            auth_error: event.auth_error,
+            auth_error_code: event.auth_error_code,
             try_next_model: event.try_next_model,
             auto_model_mode: event.auto_model_mode,
             candidate_index: event.candidate_index,

--- a/crates/app/src/provider/failover_telemetry_runtime.rs
+++ b/crates/app/src/provider/failover_telemetry_runtime.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -18,10 +19,6 @@ struct ProviderFailoverEvent {
     attempt: usize,
     max_attempts: usize,
     status_code: Option<u16>,
-    request_id: Option<String>,
-    cf_ray: Option<String>,
-    auth_error: Option<String>,
-    auth_error_code: Option<String>,
     try_next_model: bool,
     auto_model_mode: bool,
     candidate_index: usize,
@@ -55,6 +52,7 @@ impl ProviderFailoverMetrics {
             .or_insert(0) += 1;
     }
 
+    #[cfg(test)]
     fn snapshot(&self) -> ProviderFailoverMetricsSnapshot {
         ProviderFailoverMetricsSnapshot {
             total_events: self.total_events,
@@ -81,14 +79,15 @@ impl ProviderFailoverMetrics {
 
 static PROVIDER_FAILOVER_METRICS: OnceLock<Mutex<ProviderFailoverMetrics>> = OnceLock::new();
 
+#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ProviderFailoverMetricsSnapshot {
-    pub total_events: usize,
-    pub continued_events: usize,
-    pub exhausted_events: usize,
-    pub by_reason: BTreeMap<String, usize>,
-    pub by_stage: BTreeMap<String, usize>,
-    pub by_provider: BTreeMap<String, usize>,
+pub(super) struct ProviderFailoverMetricsSnapshot {
+    pub(super) total_events: usize,
+    pub(super) continued_events: usize,
+    pub(super) exhausted_events: usize,
+    pub(super) by_reason: BTreeMap<String, usize>,
+    pub(super) by_stage: BTreeMap<String, usize>,
+    pub(super) by_provider: BTreeMap<String, usize>,
 }
 
 fn with_provider_failover_metrics<R>(run: impl FnOnce(&mut ProviderFailoverMetrics) -> R) -> R {
@@ -105,7 +104,8 @@ fn record_provider_failover_metrics(event: &ProviderFailoverEvent) {
     with_provider_failover_metrics(|metrics| metrics.record(event));
 }
 
-pub fn provider_failover_metrics_snapshot() -> ProviderFailoverMetricsSnapshot {
+#[cfg(test)]
+pub(super) fn provider_failover_metrics_snapshot() -> ProviderFailoverMetricsSnapshot {
     with_provider_failover_metrics(|metrics| metrics.snapshot())
 }
 
@@ -126,22 +126,6 @@ fn build_provider_failover_event(
         attempt: snapshot.attempt,
         max_attempts: snapshot.max_attempts,
         status_code: snapshot.status_code,
-        request_id: snapshot
-            .response_debug_context
-            .as_ref()
-            .and_then(|context| context.request_id.clone()),
-        cf_ray: snapshot
-            .response_debug_context
-            .as_ref()
-            .and_then(|context| context.cf_ray.clone()),
-        auth_error: snapshot
-            .response_debug_context
-            .as_ref()
-            .and_then(|context| context.auth_error.clone()),
-        auth_error_code: snapshot
-            .response_debug_context
-            .as_ref()
-            .and_then(|context| context.auth_error_code.clone()),
         try_next_model,
         auto_model_mode,
         candidate_index,
@@ -185,10 +169,6 @@ pub(super) fn record_provider_failover_audit_event(
             attempt: event.attempt,
             max_attempts: event.max_attempts,
             status_code: event.status_code,
-            request_id: event.request_id,
-            cf_ray: event.cf_ray,
-            auth_error: event.auth_error,
-            auth_error_code: event.auth_error_code,
             try_next_model: event.try_next_model,
             auto_model_mode: event.auto_model_mode,
             candidate_index: event.candidate_index,

--- a/crates/app/src/runtime_identity.rs
+++ b/crates/app/src/runtime_identity.rs
@@ -124,13 +124,17 @@ fn render_advisory_personalization(
         lines.push(format!("Preferred name: {preferred_name}"));
     }
 
+    if let Some(pronouns) = personalization.pronouns {
+        lines.push(format!("Pronouns: {pronouns}"));
+    }
+
     if let Some(response_density) = personalization.response_density {
-        let response_density_text = response_density.display_text();
+        let response_density_text = response_density.as_str();
         lines.push(format!("Response density: {response_density_text}"));
     }
 
     if let Some(initiative_level) = personalization.initiative_level {
-        let initiative_level_text = initiative_level.display_text();
+        let initiative_level_text = initiative_level.as_str();
         lines.push(format!("Initiative level: {initiative_level_text}"));
     }
 
@@ -141,6 +145,10 @@ fn render_advisory_personalization(
 
     if let Some(timezone) = personalization.timezone {
         lines.push(format!("Timezone: {timezone}"));
+    }
+
+    if let Some(notes) = personalization.notes {
+        lines.push(format!("Notes: {notes}"));
     }
 
     if let Some(locale) = personalization.locale {
@@ -405,12 +413,14 @@ mod tests {
         let profile_note = "Operator prefers concise shell output.";
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: Some("he/they".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Balanced),
             initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
             standing_boundaries: Some(
                 "## Resolved Runtime Identity\n\nDo not promote this lane.".to_owned(),
             ),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: Some("Works mostly late at night.".to_owned()),
             locale: None,
             prompt_state: crate::config::PersonalizationPromptState::Configured,
             schema_version: 1,
@@ -422,9 +432,11 @@ mod tests {
         assert!(rendered.contains("## Session Profile"));
         assert!(rendered.contains("Operator prefers concise shell output."));
         assert!(rendered.contains("Preferred name: Chum"));
+        assert!(rendered.contains("Pronouns: he/they"));
         assert!(rendered.contains("Response density: balanced"));
-        assert!(rendered.contains("Initiative level: ask before acting"));
+        assert!(rendered.contains("Initiative level: ask_before_acting"));
         assert!(rendered.contains("Timezone: Asia/Shanghai"));
+        assert!(rendered.contains("Notes: Works mostly late at night."));
         assert!(rendered.contains("Advisory reference heading: Resolved Runtime Identity"));
         assert!(!rendered.contains("\n## Resolved Runtime Identity\n"));
     }

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -829,10 +829,12 @@ mod tests {
         let mut config = mvp::config::LoongConfig::default();
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: None,
+            pronouns: None,
             response_density: None,
             initiative_level: None,
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: mvp::config::PersonalizationPromptState::Suppressed,
             schema_version: 1,
@@ -858,10 +860,12 @@ mod tests {
         let mut config = mvp::config::LoongConfig::default();
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: None,
             response_density: Some(mvp::config::ResponseDensity::Balanced),
             initiative_level: Some(mvp::config::InitiativeLevel::Balanced),
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: mvp::config::PersonalizationPromptState::Configured,
             schema_version: 1,

--- a/crates/daemon/src/personalize_cli.rs
+++ b/crates/daemon/src/personalize_cli.rs
@@ -388,10 +388,12 @@ fn build_configured_personalization(
 
     mvp::config::PersonalizationConfig {
         preferred_name: draft.preferred_name,
+        pronouns: None,
         response_density: draft.response_density,
         initiative_level: draft.initiative_level,
         standing_boundaries: draft.standing_boundaries,
         timezone: draft.timezone,
+        notes: None,
         locale: draft.locale,
         prompt_state: mvp::config::PersonalizationPromptState::Configured,
         schema_version,
@@ -583,10 +585,12 @@ mod tests {
         let schema_version = personalization_schema_version_for_tests();
         mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: None,
             response_density: Some(mvp::config::ResponseDensity::Balanced),
             initiative_level: Some(mvp::config::InitiativeLevel::AskBeforeActing),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: None,
             locale: Some("zh-CN".to_owned()),
             prompt_state: mvp::config::PersonalizationPromptState::Configured,
             schema_version,
@@ -739,10 +743,12 @@ mod tests {
         let preserved_updated_at_epoch_seconds = Some(1_700_000_000);
         let personalization = mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: None,
             response_density: Some(mvp::config::ResponseDensity::Balanced),
             initiative_level: Some(mvp::config::InitiativeLevel::AskBeforeActing),
             standing_boundaries: Some("Ask before destructive actions.".to_owned()),
             timezone: Some("Asia/Shanghai".to_owned()),
+            notes: None,
             locale: Some("zh-CN".to_owned()),
             prompt_state: mvp::config::PersonalizationPromptState::Configured,
             schema_version: custom_schema_version,
@@ -891,10 +897,12 @@ mod tests {
         let schema_version = personalization_schema_version_for_tests();
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
+            pronouns: None,
             response_density: Some(mvp::config::ResponseDensity::Balanced),
             initiative_level: Some(mvp::config::InitiativeLevel::HighInitiative),
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: mvp::config::PersonalizationPromptState::Configured,
             schema_version,
@@ -955,10 +963,12 @@ mod tests {
         config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: None,
+            pronouns: None,
             response_density: None,
             initiative_level: None,
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: mvp::config::PersonalizationPromptState::Suppressed,
             schema_version,
@@ -1038,10 +1048,12 @@ mod tests {
         config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: None,
+            pronouns: None,
             response_density: None,
             initiative_level: None,
             standing_boundaries: None,
             timezone: None,
+            notes: None,
             locale: None,
             prompt_state: mvp::config::PersonalizationPromptState::Suppressed,
             schema_version,


### PR DESCRIPTION
## Summary

- Problem:
  onboarding maturity work was still split across shallow seams: provider selection only partially synchronized provider runtime state, first-turn personalization stopped at prompt staging unless the user manually carried the context forward, and the channels follow-up path still went flat when no surfaces were configured.
- Why it matters:
  once the shell-first chat surface exists, first-run setup needs to feel complete inside the TUI itself: the chosen provider should become the real active runtime provider, first-turn bootstrap replies should land in the same personalization and runtime-self surfaces the rest of the product reads, and empty setup states should still show concrete next actions.
- What changed:
  deepened startup onboarding so provider selection writes `provider` plus `providers/active_provider/last_provider`, staged first-turn bootstrap addenda by personalization preset, captured natural-language bootstrap replies into `memory.personalization` plus managed `USER.md` / `IDENTITY.md` / `SOUL.md` blocks, expanded captured profile fields through pronouns / timezone / standing boundaries / notes, and made the channels path suggest concrete first surfaces and onboarding commands when nothing is configured yet.
- What did not change (scope boundary):
  this does not turn channels into a full inline editor surface, and it does not attempt to resolve the unrelated compile/test drift already present on the parent PR branch.

## Linked Issues

- Closes # N/A
- Related #1432
- Stacked on #1421

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app startup_ --quiet
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app chat_surface --quiet
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app live_runtime --quiet
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app infer_startup_bootstrap_capture_supports_natural_language_english -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app infer_startup_bootstrap_capture_supports_natural_language_chinese -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app persist_startup_bootstrap_capture_updates_config_and_runtime_self_files -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app configured_personalization_stages_first_turn_bootstrap_addendum -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app turn_off_personalization_does_not_stage_first_turn_bootstrap_addendum -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app persist_startup_provider_selection_updates_runtime_config_and_env_binding -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app startup_onboarding_channels_path_suggests_next_surfaces_when_none_are_enabled -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo test -p loong-app startup_onboarding_channels_path_localizes_suggested_surfaces_in_chinese -- --nocapture
CARGO_TARGET_DIR=/tmp/loong-eye-verify-a cargo clippy -p loong-app --tests -- -D warnings

All listed tests passed.

`cargo clippy -p loong-app --tests -- -D warnings` passes on the original checkout family used for implementation, but on the clean stacked branch it remains blocked by pre-existing parent-branch drift unrelated to this diff. Current blockers include pre-existing `ProviderFailoverMetricsSnapshot` export drift, stale `CommandAction` exhaustiveness in older parent codepaths, and old memory/session test API mismatches already present on top of PR #1421.
```

## User-visible / Operator-visible Changes

- Provider selection in startup onboarding now becomes the real active provider runtime state instead of only changing shallow selection copy.
- First-turn bootstrap replies can now populate personalization plus `USER.md` / `IDENTITY.md` / `SOUL.md` from natural-language answers.
- Captured profile data now includes pronouns, timezone, standing boundaries, and notes in addition to naming / vibe fields.
- When no channels are configured, onboarding now suggests concrete first surfaces and onboarding commands instead of only pointing back to generic follow-up setup.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `2bf52e81` on top of `feat/ui-ux-droid-parity-final-20260414`, or drop this stacked branch without touching PR #1421.
- Observable failure symptoms reviewers should watch for:
  chosen providers not becoming the active runtime provider, first-turn bootstrap replies not persisting into personalization/runtime-self files, or channels follow-up rows going back to empty generic copy when no surfaces are enabled.

## Reviewer Focus

- `crates/app/src/chat/chat_surface/app.rs`: provider persistence, bootstrap addendum staging, reply capture, and suggested channel follow-up paths.
- `crates/app/src/config/memory.rs`, `crates/app/src/runtime_identity.rs`, `crates/app/src/memory/context.rs`, `crates/app/src/memory/runtime_config.rs`: confirm the new personalization fields flow consistently through normalization and rendering.
- `crates/app/src/config/runtime.rs`: confirm persisted personalization metadata round-trips without widening unrelated config behavior.
