### PR TITLE
fix: remove duplicated #[cfg(test)] attribute in daemon lib.rs

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1045,7 +1045,6 @@ fn supported_multi_channel_serve_channel_ids() -> Vec<&'static str> {
 }
 
 #[cfg(test)]
-#[cfg(test)]
 #[path = "lib_multi_channel_serve_tests.rs"]
 mod multi_channel_serve_tests;
 


### PR DESCRIPTION
## Summary

- Problem:
  `crates/daemon/src/lib.rs` had a duplicated `#[cfg(test)]` attribute (lines 1041–1042), causing `clippy::duplicated-attributes` lint failure.
- Why it matters:
  `cargo clippy --workspace --all-targets --all-features -- -D warnings` cannot pass, blocking CI.
- What changed:
  removed the duplicate `#[cfg(test)]` line.
- What did not change (scope boundary):
  no behavioral or API changes; single-line attribute dedup only.

## Linked Issues

- Closes # N/A
- Related # N/A

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [ ] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
```

Both commands pass cleanly.

## User-visible / Operator-visible Changes

- None.

## Failure Recovery

- Fast rollback or disable path:
  revert this commit; no downstream dependencies.
- Observable failure symptoms reviewers should watch for:
  `clippy::duplicated-attributes` lint fires again on the daemon crate.

## Reviewer Focus

- `crates/daemon/src/lib.rs`: confirm only the duplicate attribute line was removed and the test module declaration remains correct.
