### PR TITLE
fix(tools): preserve tracing field JSON types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1168,27 +1168,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
+checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
+checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
+checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1207,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
+checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
+checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1248,24 +1248,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
+checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
+checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
+checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1287,15 +1287,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
+checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f843b80360d7fdf61a6124642af7597f6d55724cf521210c34af8a1c66daca6e"
+checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
+checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "crc32fast"
@@ -1823,7 +1823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2706,7 +2706,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3043,6 +3043,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "wait-timeout",
  "wat",
@@ -3452,7 +3453,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3919,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3962,9 +3963,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df866b7fd522992ccc6682e58b2741cc7972b163b661db24c4328f4c914cb09d"
+checksum = "b9326e3a0093d170582cf64ed9e4cf253b8aac155ec4a294ff62330450bbf094"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3974,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dfa8354acc622b3857e1bb1a4e4315d3bc1a44ad31d5653c3e87c0da9306d7"
+checksum = "00c6433917e3789605b1f4cd2a589f637ff17212344e7fa5ba99544625ba52c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4482,7 +4483,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4967,7 +4968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5244,7 +5245,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6137,9 +6138,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca3f777dfb4db45915f95eeb25cac7f2eeb268797a27e5eb78b072618135c7f"
+checksum = "372db8bbad8ec962038101f75ab2c3ffcd18797d7d3ae877a58ab9873cd0c4bd"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -6174,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5ca1af838cec374931242d07af5d354aedf63f297f95b3625ac863e516ef67"
+checksum = "1e15aa0d1545e48d9b25ca604e9e27b4cd6d5886d30ac5787b57b3a2daf85b57"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -6203,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -6214,9 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ceb5e079877e7e4565c1e2d86d9db889175d55f7ca0001315576d08c71e634"
+checksum = "98c032f422e39061dfc43f32190c0a3526b04161ec4867f362958f3fe9d1fe29"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6241,9 +6242,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18f8bb05d25e0d4cca7278147c9f9e2f26f66886ef754b562bf729128f1e537"
+checksum = "d8dd76d80adf450cc260ba58f23c28030401930b19149695b1d121f7d621e791"
 dependencies = [
  "cc",
  "cfg-if",
@@ -6256,9 +6257,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f1070b31154ee463937b477ca0b2962bf450b40fc59799bef2f656b15da73"
+checksum = "ab453cc600b28ee5d3f9495aa6d4cb2c81eda40903e9287296b548fba8b2391d"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -6266,9 +6267,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd683a94490bf755d016a09697b0955602c50106b1ded97d16983ab2ded9fed"
+checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6278,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471746ce113c3c1862ce2c0674acb35399a4b3ed3ef4531dc087f333c74f064"
+checksum = "f1dfe405bd6adb1386d935a30f16a236bd4ef0d3c383e7cbbab98d063c9d9b73"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6291,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6af582ec18b674bf7a17775d6fbfbddfcc143f0edbd89c9c1778239c8aa92ed"
+checksum = "2a9b9165fc45d42c81edfe3e9cb458e58720594ad5db6553c4079ea041a4a581"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6472,7 +6473,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,12 @@ base64 = "0.22"
 bech32 = "0.11"
 ed25519-dalek = "2.2"
 secp256k1 = "0.31"
-wasmtime = { version = "44.0.0", default-features = false, features = ["std", "runtime", "cranelift"] }
+wasmtime = { version = "44.0.1", default-features = false, features = ["std", "runtime", "cranelift"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
 tracing = "0.1"
+tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -8498,7 +8498,7 @@ mod tests {
         CliChatOptions, CliSessionRequirement, initialize_cli_turn_runtime_with_loaded_config,
     };
     use crate::config::{LoongConfig, ProviderConfig, ProviderKind, ReasoningEffort};
-    use crate::test_support::ScopedEnv;
+    use crate::test_support::{ScopedEnv, unique_temp_dir};
     use crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
@@ -8676,9 +8676,16 @@ mod tests {
     }
 
     fn test_runtime_with_path(path: PathBuf) -> crate::chat::CliTurnRuntime {
+        let mut config = LoongConfig::default();
+        config.audit.path = unique_temp_dir("loong-chat-surface-audit")
+            .join("audit")
+            .join("events.jsonl")
+            .display()
+            .to_string();
+
         initialize_cli_turn_runtime_with_loaded_config(
             path,
-            LoongConfig::default(),
+            config,
             Some("chat-surface-test"),
             &CliChatOptions::default(),
             "chat-surface-test",

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -55,6 +55,10 @@ pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
     keys
 }
 
+pub(crate) fn json_string_array(values: &[String]) -> String {
+    serde_json::to_string(values).unwrap_or_else(|_error| "[]".to_owned())
+}
+
 fn truncate_logged_json_key(key: &str) -> String {
     let key_chars = key.chars().count();
     if key_chars <= MAX_LOGGED_JSON_KEY_CHARS {
@@ -150,7 +154,7 @@ fn redact_long_hex_tokens(input: &str) -> String {
 mod tests {
     use serde_json::{Map, Value, json};
 
-    use super::{json_value_kind, summarize_error, top_level_json_keys};
+    use super::{json_string_array, json_value_kind, summarize_error, top_level_json_keys};
 
     #[test]
     fn json_value_kind_labels_common_shapes() {
@@ -204,6 +208,14 @@ mod tests {
         let first_key = keys.first().expect("first key should exist");
 
         assert!(first_key.chars().count() <= 48);
+    }
+
+    #[test]
+    fn json_string_array_encodes_keys_as_json_array() {
+        let encoded = json_string_array(&["path".to_owned(), "quoted\"key".to_owned()]);
+        let decoded: Value = serde_json::from_str(&encoded).expect("encoded keys should parse");
+
+        assert_eq!(decoded, json!(["path", "quoted\"key"]));
     }
 
     #[test]

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -214,7 +214,7 @@ fn render_compact_brand_header_with_version(
     let brand = "LOONG";
     let width = width.max(display_width(brand));
     let combined = format!("{brand}  {version}");
-    let mut lines = if combined.len() <= width {
+    let mut lines = if display_width(combined.as_str()) <= width {
         vec![BrandLine::new(BrandLineRole::Banner, combined)]
     } else {
         let mut compact_lines = vec![BrandLine::new(BrandLineRole::Banner, brand)];
@@ -765,7 +765,9 @@ mod tests {
         );
 
         assert!(
-            lines.iter().all(|line| line.text.len() <= 18),
+            lines
+                .iter()
+                .all(|line| display_width(line.text.as_str()) <= 18),
             "full brand header should respect narrow widths for version and subtitle lines: {lines:#?}"
         );
         assert_eq!(lines[0].text, "LOONG");
@@ -952,7 +954,7 @@ mod tests {
         );
 
         assert!(
-            lines.iter().all(|line| line.len() <= 28),
+            lines.iter().all(|line| display_width(line) <= 28),
             "shared presentation wrapping should split oversized single segments instead of overflowing the target width: {lines:#?}"
         );
         assert!(
@@ -969,7 +971,7 @@ mod tests {
             render_wrapped_display_line("- press Enter to use suggested env: OPENAI_API_KEY", 22);
 
         assert!(
-            lines.iter().all(|line| line.len() <= 22),
+            lines.iter().all(|line| display_width(line) <= 22),
             "long label prefixes should wrap instead of overflowing narrow widths: {lines:#?}"
         );
         assert_eq!(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -971,17 +971,18 @@ pub fn execute_tool_core_with_config(
         }
     };
     let result = execute_request();
-    let duration_ms = started_at.elapsed().as_millis();
+    let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
     match &result {
         Ok(outcome) => {
             if debug_log_enabled {
+                let payload_keys_json = crate::observability::json_string_array(&payload_keys);
                 tracing::debug!(
                     target: "loong.tools",
                     requested_tool_name = %requested_tool_name,
                     canonical_tool_name = %canonical_name,
                     inner_tool_name = %inner_tool_name,
                     payload_kind,
-                    payload_keys = ?payload_keys,
+                    payload_keys_json = payload_keys_json.as_str(),
                     status = %outcome.status,
                     duration_ms,
                     "tool execution completed"
@@ -991,26 +992,28 @@ pub fn execute_tool_core_with_config(
         Err(error) => {
             if is_expected_tool_request_error(error) {
                 if debug_log_enabled {
+                    let payload_keys_json = crate::observability::json_string_array(&payload_keys);
                     tracing::debug!(
                         target: "loong.tools",
                         requested_tool_name = %requested_tool_name,
                         canonical_tool_name = %canonical_name,
                         inner_tool_name = %inner_tool_name,
                         payload_kind,
-                        payload_keys = ?payload_keys,
+                        payload_keys_json = payload_keys_json.as_str(),
                         duration_ms,
                         error = %crate::observability::summarize_error(error),
                         "tool execution rejected"
                     );
                 }
             } else if warn_log_enabled {
+                let payload_keys_json = crate::observability::json_string_array(&payload_keys);
                 tracing::warn!(
                     target: "loong.tools",
                     requested_tool_name = %requested_tool_name,
                     canonical_tool_name = %canonical_name,
                     inner_tool_name = %inner_tool_name,
                     payload_kind,
-                    payload_keys = ?payload_keys,
+                    payload_keys_json = payload_keys_json.as_str(),
                     duration_ms,
                     error = %crate::observability::summarize_error(error),
                     "tool execution failed"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -89,6 +89,7 @@ semver.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
 tracing.workspace = true
+tracing-log.workspace = true
 tracing-subscriber.workspace = true
 wait-timeout = "0.2"
 qrcode = { version = "0.14", default-features = false }

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,12 +1,23 @@
-use std::fmt::Debug;
+use std::collections::BTreeMap;
+use std::fmt::{self, Debug};
 use std::io::{self, IsTerminal, Write};
 
+use serde_json::{Map, Value};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::field::RecordFields;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::format::{FormatFields, Writer};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormattedFields};
+use tracing_subscriber::registry::{LookupSpan, SpanRef};
 use tracing_subscriber::util::SubscriberInitExt;
 
 const DEFAULT_LOG_FILTER: &str = "warn";
 const MAX_ERROR_CHARS: usize = 240;
+const PAYLOAD_KEYS_FIELD: &str = "payload_keys";
+const PAYLOAD_KEYS_JSON_FIELD: &str = "payload_keys_json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LogFormat {
@@ -82,7 +93,11 @@ pub fn init_tracing() {
     let init_result = match log_format {
         LogFormat::Compact => base.compact().finish().try_init(),
         LogFormat::Pretty => base.pretty().finish().try_init(),
-        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+        LogFormat::Json => base
+            .event_format(LoongJsonEventFormat)
+            .fmt_fields(LoongJsonFields)
+            .finish()
+            .try_init(),
     };
 
     if let Err(error) = init_result {
@@ -91,10 +106,244 @@ pub fn init_tracing() {
     }
 }
 
+#[derive(Debug, Default)]
+struct LoongJsonFields;
+
+impl<'writer> FormatFields<'writer> for LoongJsonFields {
+    fn format_fields<R: RecordFields>(
+        &self,
+        mut writer: Writer<'writer>,
+        fields: R,
+    ) -> fmt::Result {
+        let mut recorder = LoongJsonRecorder::default();
+        fields.record(&mut recorder);
+        write_json_map(&mut writer, recorder.into_values())
+    }
+
+    fn add_fields(
+        &self,
+        current: &'writer mut FormattedFields<Self>,
+        fields: &tracing::span::Record<'_>,
+    ) -> fmt::Result {
+        if current.is_empty() {
+            let mut writer = current.as_writer();
+            let mut recorder = LoongJsonRecorder::default();
+            fields.record(&mut recorder);
+            write_json_map(&mut writer, recorder.into_values())?;
+            return Ok(());
+        }
+
+        let mut recorder = LoongJsonRecorder::with_values(
+            serde_json::from_str(&current.fields).map_err(|_error| fmt::Error)?,
+        );
+        fields.record(&mut recorder);
+        current.fields = encode_json_map(recorder.into_values())?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct LoongJsonEventFormat;
+
+impl<S, N> FormatEvent<S, N> for LoongJsonEventFormat
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        let mut object = Map::new();
+        object.insert("timestamp".to_owned(), Value::String(utc_timestamp()));
+        object.insert("level".to_owned(), Value::String(meta.level().to_string()));
+
+        let mut recorder = LoongJsonRecorder::default();
+        event.record(&mut recorder);
+        extend_json_object(&mut object, recorder.into_values());
+
+        object.insert("target".to_owned(), Value::String(meta.target().to_owned()));
+        record_current_span_context(ctx, event, &mut object);
+
+        let encoded = serde_json::to_string(&Value::Object(object)).map_err(|_error| fmt::Error)?;
+        writer.write_str(&encoded)?;
+        writer.write_char('\n')
+    }
+}
+
+#[derive(Debug, Default)]
+struct LoongJsonRecorder {
+    values: BTreeMap<String, Value>,
+}
+
+impl LoongJsonRecorder {
+    fn with_values(values: BTreeMap<String, Value>) -> Self {
+        Self { values }
+    }
+
+    fn into_values(self) -> BTreeMap<String, Value> {
+        self.values
+    }
+
+    fn insert_value(&mut self, field: &Field, value: Value) {
+        self.values
+            .insert(json_field_name(field.name()).to_owned(), value);
+    }
+
+    fn insert_string_or_structured_json(&mut self, field: &Field, value: &str) {
+        let field_name = json_field_name(field.name());
+        match structured_json_field_value(field_name, value) {
+            Some((output_field, value)) => {
+                self.values.insert(output_field.to_owned(), value);
+            }
+            None => {
+                self.values
+                    .insert(field_name.to_owned(), Value::String(value.to_owned()));
+            }
+        }
+    }
+}
+
+impl Visit for LoongJsonRecorder {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.insert_value(field, Value::from(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert_value(field, Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert_value(field, Value::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert_value(field, Value::from(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert_string_or_structured_json(field, value);
+    }
+
+    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+        let bytes = value
+            .iter()
+            .map(|byte| Value::from(u64::from(*byte)))
+            .collect::<Vec<_>>();
+        self.insert_value(field, Value::Array(bytes));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name().starts_with("log.") {
+            return;
+        }
+        self.insert_string_or_structured_json(field, &format!("{value:?}"));
+    }
+}
+
+fn write_json_map(writer: &mut dyn fmt::Write, values: BTreeMap<String, Value>) -> fmt::Result {
+    let encoded = encode_json_map(values)?;
+    writer.write_str(&encoded)
+}
+
+fn encode_json_map(values: BTreeMap<String, Value>) -> Result<String, fmt::Error> {
+    serde_json::to_string(&values).map_err(|_error| fmt::Error)
+}
+
+fn extend_json_object(object: &mut Map<String, Value>, values: BTreeMap<String, Value>) {
+    for (field, value) in values {
+        object.insert(field, value);
+    }
+}
+
+fn record_current_span_context<S, N>(
+    ctx: &FmtContext<'_, S, N>,
+    event: &Event<'_>,
+    object: &mut Map<String, Value>,
+) where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    let Some(current_span) = event
+        .parent()
+        .and_then(|id| ctx.span(id))
+        .or_else(|| ctx.lookup_current())
+    else {
+        return;
+    };
+
+    let spans = current_span
+        .scope()
+        .from_root()
+        .map(span_json::<S, N>)
+        .collect::<Vec<_>>();
+
+    if let Some(current) = spans.last() {
+        object.insert("span".to_owned(), current.clone());
+    }
+    object.insert("spans".to_owned(), Value::Array(spans));
+}
+
+fn span_json<S, N>(span: SpanRef<'_, S>) -> Value
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    let mut object = Map::new();
+    let extensions = span.extensions();
+    if let Some(fields) = extensions.get::<FormattedFields<N>>()
+        && let Ok(Value::Object(recorded)) = serde_json::from_str::<Value>(&fields.fields)
+    {
+        for (field, value) in recorded {
+            object.insert(field, value);
+        }
+    }
+    object.insert(
+        "name".to_owned(),
+        Value::String(span.metadata().name().to_owned()),
+    );
+    Value::Object(object)
+}
+
+fn utc_timestamp() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_error| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn json_field_name(name: &str) -> &str {
+    match name.strip_prefix("r#") {
+        Some(stripped) => stripped,
+        None => name,
+    }
+}
+
+fn structured_json_field_value(field_name: &str, value: &str) -> Option<(&'static str, Value)> {
+    if field_name != PAYLOAD_KEYS_JSON_FIELD {
+        return None;
+    }
+
+    let parsed = serde_json::from_str::<Value>(value).ok()?;
+    parsed.is_array().then_some((PAYLOAD_KEYS_FIELD, parsed))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::{Value, json};
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::fmt::format::FmtSpan;
+
     use super::{
-        LogFormat, build_env_filter, debug_variant_name, resolved_log_directive, summarize_error,
+        LogFormat, LoongJsonEventFormat, LoongJsonFields, build_env_filter, debug_variant_name,
+        resolved_log_directive, summarize_error,
     };
     use crate::Commands;
 
@@ -118,6 +367,83 @@ mod tests {
         assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
         assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
         assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn json_logs_emit_payload_keys_array_and_duration_number() {
+        let event = capture_json_event("loong.tools=debug", || {
+            let payload_keys =
+                serde_json::to_string(&["path".to_owned()]).expect("keys should encode");
+            tracing::debug!(
+                target: "loong.tools",
+                payload_keys_json = payload_keys.as_str(),
+                duration_ms = 7_u64,
+                "tool execution completed"
+            );
+        });
+
+        assert_eq!(event.get("payload_keys"), Some(&json!(["path"])));
+        assert!(event.get("payload_keys_json").is_none());
+        assert_eq!(event.get("duration_ms"), Some(&json!(7)));
+    }
+
+    #[test]
+    fn json_logs_do_not_coerce_public_payload_keys_strings() {
+        let event = capture_json_event("info", || {
+            tracing::info!(
+                target: "loong.test",
+                payload_keys = "[\"literal\"]",
+                "ordinary event"
+            );
+        });
+
+        assert_eq!(event.get("payload_keys"), Some(&json!("[\"literal\"]")));
+    }
+
+    #[test]
+    fn json_logs_preserve_log_backed_target_metadata() {
+        let event = capture_json_event("info", || {
+            let record = tracing_log::log::Record::builder()
+                .args(format_args!("from log facade"))
+                .level(tracing_log::log::Level::Info)
+                .target("dependency.crate")
+                .file(Some("dependency.rs"))
+                .line(Some(42))
+                .module_path(Some("dependency::module"))
+                .build();
+            tracing_log::format_trace(&record).expect("log record should dispatch");
+        });
+
+        assert_eq!(event.get("target"), Some(&json!("dependency.crate")));
+        assert_eq!(event.get("message"), Some(&json!("from log facade")));
+    }
+
+    #[test]
+    fn json_logs_preserve_span_context() {
+        let event = capture_json_event("loong.test=info", || {
+            let span = tracing::info_span!(target: "loong.test", "operation", request_id = 42_u64);
+            let _guard = span.enter();
+            tracing::info!(target: "loong.test", "inside span");
+        });
+
+        assert_eq!(event.pointer("/span/name"), Some(&json!("operation")));
+        assert_eq!(event.pointer("/span/request_id"), Some(&json!(42)));
+        assert_eq!(event.pointer("/spans/0/name"), Some(&json!("operation")));
+        assert_eq!(event.pointer("/spans/0/request_id"), Some(&json!(42)));
+    }
+
+    #[test]
+    fn json_logs_emit_close_span_events_as_json() {
+        let events = capture_json_events("loong.test=info", || {
+            let span = tracing::info_span!(target: "loong.test", "operation", request_id = 42_u64);
+            let _guard = span.enter();
+        });
+
+        assert!(
+            events
+                .iter()
+                .any(|event| event.get("message") == Some(&json!("close")))
+        );
     }
 
     #[test]
@@ -155,5 +481,70 @@ mod tests {
 
         assert_eq!(welcome, "Welcome");
         assert_eq!(turn_run, "Turn");
+    }
+
+    fn capture_json_event(filter: &str, emit: impl FnOnce()) -> Value {
+        capture_json_events(filter, emit)
+            .into_iter()
+            .next()
+            .expect("captured log line")
+    }
+
+    fn capture_json_events(filter: &str, emit: impl FnOnce()) -> Vec<Value> {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(logs.clone())
+            .with_target(true)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_ansi(false)
+            .event_format(LoongJsonEventFormat)
+            .fmt_fields(LoongJsonFields)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, emit);
+
+        let output = logs.output();
+        output
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("log line should be JSON"))
+            .collect()
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl CapturedLogs {
+        fn output(&self) -> String {
+            let output = self.output.lock().expect("captured logs lock").clone();
+            String::from_utf8(output).expect("captured logs should be UTF-8")
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for CapturedLogs {
+        type Writer = CapturedLogWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturedLogWriter {
+                output: Arc::clone(&self.output),
+            }
+        }
+    }
+
+    struct CapturedLogWriter {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for CapturedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.output.lock().expect("captured logs lock").extend(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 }

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -32,6 +32,15 @@ fn assert_compact_loong_header(lines: &[String], context: &str) {
     );
 }
 
+fn assert_lines_fit_display_width(lines: &[String], width: usize, context: &str) {
+    assert!(
+        lines
+            .iter()
+            .all(|line| mvp::presentation::display_width(line) <= width),
+        "{context} should fit within {width} display columns: {lines:#?}"
+    );
+}
+
 fn collapse_wrapped_lines(lines: &[String]) -> String {
     lines
         .iter()
@@ -5460,10 +5469,7 @@ fn onboard_starting_point_selection_screen_wraps_header_title_and_subtitle_on_na
     let lines =
         loong_daemon::onboard_cli::render_starting_point_selection_screen_lines(&[candidate], 22);
 
-    assert!(
-        lines.iter().all(|line| line.len() <= 22),
-        "starting-point screen should keep brand subtitle and title within narrow widths: {lines:#?}"
-    );
+    assert_lines_fit_display_width(&lines, 22, "starting-point screen brand subtitle and title");
     assert_eq!(lines[0], "LOONG");
     assert!(
         lines.iter().any(|line| line == "choose detected"),
@@ -5558,10 +5564,7 @@ fn onboard_model_selection_screen_wraps_compact_header_and_progress_on_narrow_wi
 
     let lines = loong_daemon::onboard_cli::render_model_selection_screen_lines(&config, 22);
 
-    assert!(
-        lines.iter().all(|line| line.len() <= 22),
-        "model screen should keep compact header and progress copy within narrow terminal widths: {lines:#?}"
-    );
+    assert_lines_fit_display_width(&lines, 22, "model screen compact header and progress copy");
     assert_eq!(
         lines[0], "LOONG",
         "narrow model screen should split the compact header instead of forcing brand and version onto one line: {lines:#?}"
@@ -5676,10 +5679,7 @@ fn onboard_api_key_env_screen_wraps_long_unbroken_env_names() {
         36,
     );
 
-    assert!(
-        lines.iter().all(|line| line.len() <= 36),
-        "credential-env screen should split long env tokens instead of letting them overflow narrow widths: {lines:#?}"
-    );
+    assert_lines_fit_display_width(&lines, 36, "credential-env screen long env tokens");
     assert!(
         lines
             .iter()
@@ -5698,10 +5698,7 @@ fn onboard_api_key_env_screen_wraps_progress_line_on_narrow_width() {
         22,
     );
 
-    assert!(
-        lines.iter().all(|line| line.len() <= 22),
-        "credential-env screen should keep the progress line within narrow terminal widths: {lines:#?}"
-    );
+    assert_lines_fit_display_width(&lines, 22, "credential-env screen progress line");
     assert!(
         lines.iter().any(|line| line == "step 3 of 8 ·"),
         "narrow credential-env screen should keep the step label on the first wrapped line: {lines:#?}"


### PR DESCRIPTION
## Summary

- Problem: `loong.tools` JSON tracing events emitted `payload_keys` and `duration_ms` with the wrong JSON types under `LOONG_LOG_FORMAT=json`, and the first formatter fix broadened JSON logging behavior without preserving log-backed metadata parity.
- Why it matters: external observability consumers should be able to read tool event fields as native JSON values without parse-twice workarounds, while daemon JSON logs should preserve the formatter compatibility behavior they replaced.
- What changed: tool execution events now emit internal `payload_keys_json`; the daemon JSON formatter expands only that internal field into public `payload_keys`, records `duration_ms` as `u64`, uses `tracing_log::NormalizeEvent` for log-backed metadata, and adds regression coverage for tool fields, public `payload_keys` strings, log-backed targets, span context, close span events, Unicode-aware terminal display-width wrapping, and chat-surface test audit-journal isolation. The PR also bumps Wasmtime to `44.0.1` to clear `RUSTSEC-2026-0114`, which was surfaced by the Security advisory gate after dependency metadata changed.
- What did not change (scope boundary): tool execution behavior, provider behavior, config shape, and non-JSON log modes are not intended to change.

## Linked Issues

- Closes # N/A
- Related # N/A

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: The PR replaces daemon JSON event formatting behavior, updates the Wasmtime dependency family to clear a current RustSec advisory, fixes a display-width assumption that only fails when CI embeds a nonempty build SHA into narrow terminal headers, and isolates chat-surface test audit journals to avoid Windows file-lock races in parallel test execution.
- Rollout / guardrails: Regression tests cover the target tool event shape plus formatter parity seams for log-backed target metadata, span context, close events, non-tool `payload_keys` strings, Unicode-aware narrow-width header wrapping, and the Windows-failing chat-surface test paths. The wrapper trace harness verifies the release binary emits public `payload_keys` as an array and no `payload_keys_json` leak.
- Rollback path: Revert this PR to restore the prior tracing formatter and dependency lockfile; if only the Wasmtime update causes an issue, revert the dependency bump separately after the advisory policy is handled.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
PASS on 36157303.

./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
PASS on 36157303.

./scripts/cargo-local-toolchain.sh test -p loong observability --lib
PASS: 11 observability tests, including JSON payload_keys, log-backed target metadata, span context, and close span events.

./scripts/cargo-local-toolchain.sh test -p loong-app json_string_array_encodes_keys_as_json_array --lib
PASS

LOONG_GIT_SHA=2dabe96155c1dfa1e490c0aecc7642750bbbb724 \
  ./scripts/cargo-local-toolchain.sh test -p loong-app presentation_ --lib
PASS: 27 presentation tests with CI-style nonempty build SHA.

LOONG_GIT_SHA=2dabe96155c1dfa1e490c0aecc7642750bbbb724 \
  ./scripts/cargo-local-toolchain.sh test -p loong --test integration screen_wraps
PASS: 9 integration tests, including the three narrow onboarding tests that failed on GitHub Actions.

./scripts/cargo-local-toolchain.sh test -p loong-app model_palette_entries_open_reasoning_for_reasoning_capable_models --lib
PASS: focused reproduction for one Windows file-lock failure.

./scripts/cargo-local-toolchain.sh test -p loong-app startup_onboarding_provider_stage_lists_all_sorted_provider_kinds --lib
PASS: focused reproduction for the second Windows file-lock failure.

LOONG_GIT_SHA=2dabe96155c1dfa1e490c0aecc7642750bbbb724 \
  GITHUB_EVENT_NAME=pull_request \
  TOUCHED_PATHS_JSON='["Cargo.lock","Cargo.toml","crates/app/src/chat/chat_surface/app.rs","crates/app/src/observability.rs","crates/app/src/presentation.rs","crates/app/src/tools/mod.rs","crates/daemon/Cargo.toml","crates/daemon/src/observability.rs","crates/daemon/tests/integration/onboard_cli.rs"]' \
  ./scripts/run_changed_rust_ci_job.sh
PASS on 36157303: CI-style default feature lane selected the full package closure; daemon integration result included 1016 passed.

LOONG_GIT_SHA=2dabe96155c1dfa1e490c0aecc7642750bbbb724 \
  GITHUB_EVENT_NAME=pull_request \
  TOUCHED_PATHS_JSON='["Cargo.lock","Cargo.toml","crates/app/src/observability.rs","crates/app/src/presentation.rs","crates/app/src/tools/mod.rs","crates/daemon/Cargo.toml","crates/daemon/src/observability.rs","crates/daemon/tests/integration/onboard_cli.rs"]' \
  ./scripts/run_changed_rust_ci_job.sh --all-features
PASS on c9d5e16f before the final test-only chat-surface audit-journal isolation patch. The final patch is covered by the default CI-style lane and all-features clippy; the refreshed remote all-features job should be treated as final all-features evidence.

cargo audit
PASS: no vulnerabilities; existing unmaintained warnings are already allowed.

./scripts/cargo-deny-local.sh check advisories bans licenses sources
PASS: advisories, bans, licenses, and sources ok.

./scripts/check_architecture_boundaries.sh
PASS

./scripts/check_dep_graph.sh
PASS

cargo build -p loong --release
PASS

TARGET=/Volumes/xj-sandisk-4T/dev/eastreams/loong/.worktrees/fix-tracing-field-encoding/target/release/loong \
  task loong:trace SLUG=fix-review-findings-final -- turn run --message "hello"
PASS: wrapper trace harness produced the expected JSON event shape:
{"message":"tool execution completed","payload_keys":["path"],"duration_ms":0,"payload_keys_type":"array","duration_ms_type":"number","payload_keys_json_present":false}
```

## User-visible / Operator-visible Changes

- JSON log consumers now see `payload_keys` as a native array and `duration_ms` as a native number for tool execution completed/rejected/failed events.
- Narrow onboarding and presentation headers now use terminal display width rather than UTF-8 byte length when deciding whether version text fits.
- No CLI command behavior or config surface changes are intended.

## Failure Recovery

- Fast rollback or disable path: revert this PR; operators can also use non-JSON log formats as an immediate observability workaround if JSON formatting regresses.
- Observable failure symptoms reviewers should watch for: malformed JSON log lines, missing or string-typed `payload_keys`, string-typed `duration_ms`, incorrect `target` values for log-backed records, missing span context/close event JSON fields, or narrow terminal header lines overflowing their target display columns.

## Reviewer Focus

- `crates/daemon/src/observability.rs`: custom JSON formatter parity with `tracing_subscriber` behavior, especially log-backed metadata and span serialization.
- `crates/app/src/tools/mod.rs`: the three tool execution log paths should all emit `payload_keys_json` internally and `duration_ms` as `u64`.
- `crates/app/src/presentation.rs` / `crates/daemon/tests/integration/onboard_cli.rs`: display-width checks should count terminal columns, not UTF-8 bytes.
- `crates/app/src/chat/chat_surface/app.rs`: test runtimes should use isolated audit journals so parallel Windows tests do not contend on one default temp-home journal.
- `Cargo.toml` / `Cargo.lock`: Wasmtime `44.0.1` bump is included only to satisfy the current advisory gate after dependency metadata changed.
