### PR TITLE
Refine TUI streaming and separate workspace roots from file-root enforcement

### DIFF
--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -79,6 +79,12 @@ struct PendingRenderCache {
     lines: Vec<Line<'static>>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct LiveTranscriptState {
+    draft_preview: Option<String>,
+    tool_activity_lines: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StartupOnboardingStage {
     Language,
@@ -903,7 +909,7 @@ pub struct App {
     pub focus: Focus,
     pub pending_turn: bool,
     pub turn_start: Option<std::time::Instant>,
-    pub live_lines: Arc<StdMutex<Vec<String>>>,
+    live_transcript: Arc<StdMutex<LiveTranscriptState>>,
     pub pending_task: Option<JoinHandle<CliResult<String>>>,
     pub pending_steers: VecDeque<String>,
     pub pending_queue: VecDeque<String>,
@@ -914,6 +920,7 @@ pub struct App {
     pub live_rerender: Option<super::super::CliChatLiveSurfaceRerender>,
     pub spinner_seed: u64,
     pub last_pending_signature: Option<u64>,
+    last_live_transcript_signature: Option<u64>,
     pending_render_cache: Option<PendingRenderCache>,
     inline_skill_popup_active: bool,
     pub last_render_width: u16,
@@ -948,7 +955,7 @@ impl App {
             focus: Focus::Composer,
             pending_turn: false,
             turn_start: None,
-            live_lines: Arc::new(StdMutex::new(Vec::new())),
+            live_transcript: Arc::new(StdMutex::new(LiveTranscriptState::default())),
             pending_task: None,
             pending_steers: VecDeque::new(),
             pending_queue: VecDeque::new(),
@@ -959,6 +966,7 @@ impl App {
             live_rerender: None,
             spinner_seed: spinner_seed(),
             last_pending_signature: None,
+            last_live_transcript_signature: None,
             pending_render_cache: None,
             inline_skill_popup_active: false,
             last_render_width: render_width as u16,
@@ -1007,7 +1015,13 @@ impl App {
         let interstitial_lines =
             self.interstitial_lines_for(size.width, size.height, composer_height, palette_height);
         let interstitial_height = interstitial_lines.len() as u16;
-        let transcript_line_count = self.message_list.rendered_line_count(size.width) as u16;
+        let provisional_assistant_text = provisional_assistant_text(&self.live_transcript);
+        let transcript_line_count = self
+            .message_list
+            .rendered_line_count_with_provisional_assistant(
+                size.width,
+                provisional_assistant_text.as_deref(),
+            ) as u16;
         let bottom_band_height = interstitial_height
             + 1
             + composer_height
@@ -1065,7 +1079,11 @@ impl App {
             Rect::default()
         };
 
-        self.message_list.render(f, *transcript_area);
+        self.message_list.render_with_provisional_assistant(
+            f,
+            *transcript_area,
+            provisional_assistant_text.as_deref(),
+        );
 
         if interstitial_height > 0 {
             f.render_widget(Paragraph::new(interstitial_lines), *pending_area);
@@ -1406,7 +1424,7 @@ impl App {
 
         let max_pending_preview_lines = max_pending_height.saturating_sub(2).max(1) as usize;
         let live_lines =
-            pending_live_tool_activity_lines(&self.live_lines, max_pending_preview_lines);
+            pending_live_tool_activity_lines(&self.live_transcript, max_pending_preview_lines);
         let raw_pending_lines = build_pending_lines(
             self.turn_start,
             &live_lines,
@@ -1465,8 +1483,14 @@ pub async fn run_app<B: Backend>(
                 app.last_pending_signature = signature;
                 dirty = true;
             }
+            let live_transcript_signature = transcript_preview_signature(&app);
+            if live_transcript_signature != app.last_live_transcript_signature {
+                app.last_live_transcript_signature = live_transcript_signature;
+                dirty = true;
+            }
         } else {
             app.last_pending_signature = None;
+            app.last_live_transcript_signature = None;
         }
 
         if resize_live_rerender_ready(
@@ -1494,7 +1518,7 @@ pub async fn run_app<B: Backend>(
         let poll_timeout = if pending_live_resize_rerender {
             Duration::from_millis(16)
         } else if app.pending_turn {
-            Duration::from_millis(80)
+            Duration::from_millis(40)
         } else if app.message_list.startup_animation_active() {
             Duration::from_millis(70)
         } else {
@@ -5789,19 +5813,22 @@ async fn start_turn<B: Backend>(
     app.pending_turn = true;
     app.turn_start = Some(std::time::Instant::now());
     app.focus = Focus::Composer;
-    clear_live_lines(&app.live_lines);
+    clear_live_transcript(&app.live_transcript);
 
     terminal
         .draw(|f| app.render(f))
         .map_err(|e| format!("draw error: {}", e))?;
 
     let sink = {
-        let live_lines = Arc::clone(&app.live_lines);
-        Arc::new(move |lines: Vec<String>| {
-            if let Ok(mut state) = live_lines.lock() {
-                *state = lines;
-            }
-        })
+        let live_transcript = Arc::clone(&app.live_transcript);
+        Arc::new(
+            move |payload: super::super::CliChatLiveSurfaceRenderPayload| {
+                if let Ok(mut state) = live_transcript.lock() {
+                    state.draft_preview = payload.draft_preview;
+                    state.tool_activity_lines = payload.tool_activity_lines;
+                }
+            },
+        )
     };
     let (observer, rerender) = super::super::build_cli_chat_live_compact_observer_controller(
         Arc::clone(&app.live_render_width),
@@ -7260,7 +7287,7 @@ async fn maybe_finalize_pending_turn<B: Backend>(
     app.turn_start = None;
     app.live_rerender = None;
     app.composer_follow_up_intent = false;
-    clear_live_lines(&app.live_lines);
+    clear_live_transcript(&app.live_transcript);
     app.focus = Focus::Composer;
     if super::super::build_cli_chat_approval_screen_spec(&assistant_text).is_some() {
         app.message_list.add_rendered_lines(
@@ -7319,17 +7346,21 @@ fn spawn_pending_turn(
     })
 }
 
-fn clear_live_lines(live_lines: &Arc<StdMutex<Vec<String>>>) {
-    if let Ok(mut state) = live_lines.lock() {
-        state.clear();
+fn clear_live_transcript(live_transcript: &Arc<StdMutex<LiveTranscriptState>>) {
+    if let Ok(mut state) = live_transcript.lock() {
+        *state = LiveTranscriptState::default();
     }
 }
 
-fn pending_live_lines(live_lines: &Arc<StdMutex<Vec<String>>>, max_lines: usize) -> Vec<String> {
+fn pending_live_lines(
+    live_transcript: &Arc<StdMutex<LiveTranscriptState>>,
+    max_lines: usize,
+) -> Vec<String> {
     let max_lines = max_lines.max(1);
-    live_lines
+    live_transcript
         .lock()
         .map(|state| {
+            let state = &state.tool_activity_lines;
             let normalize = |mut lines: Vec<String>| {
                 while lines.first().is_some_and(|line| line.trim().is_empty()) {
                     lines.remove(0);
@@ -7384,13 +7415,23 @@ fn pending_live_lines(live_lines: &Arc<StdMutex<Vec<String>>>, max_lines: usize)
 }
 
 fn pending_live_tool_activity_lines(
-    live_lines: &Arc<StdMutex<Vec<String>>>,
+    live_transcript: &Arc<StdMutex<LiveTranscriptState>>,
     max_lines: usize,
 ) -> Vec<String> {
-    pending_live_lines(live_lines, max_lines)
+    pending_live_lines(live_transcript, max_lines)
         .into_iter()
         .filter(|line| pending_line_is_tool_activity(line))
         .collect()
+}
+
+fn provisional_assistant_text(
+    live_transcript: &Arc<StdMutex<LiveTranscriptState>>,
+) -> Option<String> {
+    live_transcript
+        .lock()
+        .ok()
+        .and_then(|state| state.draft_preview.clone())
+        .filter(|text| !text.trim().is_empty())
 }
 
 fn pending_line_is_tool_activity(line: &str) -> bool {
@@ -7427,7 +7468,7 @@ fn pending_render_signature(app: &App) -> Option<u64> {
         app.pending_queue
             .iter()
             .for_each(|message| message.hash(&mut hasher));
-        for line in pending_live_tool_activity_lines(&app.live_lines, 6) {
+        for line in pending_live_tool_activity_lines(&app.live_transcript, 6) {
             line.hash(&mut hasher);
         }
         return Some(hasher.finish());
@@ -7446,6 +7487,14 @@ fn pending_render_signature(app: &App) -> Option<u64> {
         composer_height,
         palette_height,
     )
+}
+
+fn transcript_preview_signature(app: &App) -> Option<u64> {
+    let preview = provisional_assistant_text(&app.live_transcript)?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    app.last_render_width.hash(&mut hasher);
+    preview.hash(&mut hasher);
+    Some(hasher.finish())
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -7504,7 +7553,7 @@ fn pending_render_signature_for_geometry(
     let max_pending_preview_lines =
         pending_signature_preview_budget_for_geometry(height, composer_height, palette_height);
     let visible_lines =
-        pending_live_tool_activity_lines(&app.live_lines, max_pending_preview_lines);
+        pending_live_tool_activity_lines(&app.live_transcript, max_pending_preview_lines);
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     focus_ring_frame(start).hash(&mut hasher);
     get_spinner_verb_with_seed(start, app.spinner_seed).hash(&mut hasher);
@@ -8511,7 +8560,7 @@ fn resize_live_rerender_ready(
 #[cfg(test)]
 mod tests {
     use super::{
-        App, Focus, StartupBootstrapCapture, StartupOnboardingAction,
+        App, Focus, LiveTranscriptState, StartupBootstrapCapture, StartupOnboardingAction,
         StartupOnboardingInteractionKind, StartupOnboardingStage, StartupOnboardingState,
         StartupPersonalizationPreset, StartupProviderOption, StartupSetupPathChoice,
         StartupSkillOption, persist_startup_personalization, startup_eye_animation_for_state,
@@ -8548,7 +8597,7 @@ mod tests {
             focus: Focus::Composer,
             pending_turn: false,
             turn_start: None,
-            live_lines: Arc::new(StdMutex::new(Vec::new())),
+            live_transcript: Arc::new(StdMutex::new(LiveTranscriptState::default())),
             pending_task: None,
             pending_steers: Default::default(),
             pending_queue: Default::default(),
@@ -8559,6 +8608,7 @@ mod tests {
             live_rerender: None,
             spinner_seed: 1,
             last_pending_signature: None,
+            last_live_transcript_signature: None,
             pending_render_cache: None,
             inline_skill_popup_active: false,
             last_render_width: 0,
@@ -9061,29 +9111,33 @@ mod tests {
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["streamed reply line".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("streamed reply line".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal);
-        assert!(
-            !lines
-                .iter()
-                .any(|line| line.contains("streamed reply line"))
-        );
+        let transcript_row = lines
+            .iter()
+            .position(|line| line.contains("streamed reply line"))
+            .expect("provisional transcript row");
+        let composer_row = lines
+            .iter()
+            .position(|line| line.contains("›"))
+            .expect("composer row");
+        assert!(transcript_row < composer_row);
     }
 
     #[test]
-    fn composer_and_footer_do_not_jump_up_after_pending_turn_finishes() {
+    fn composer_and_footer_only_reclaim_pending_preview_rows_after_turn_finishes() {
         let backend = TestBackend::new(60, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["streamed reply line".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("streamed reply line".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw pending");
@@ -9099,8 +9153,8 @@ mod tests {
 
         app.pending_turn = false;
         app.turn_start = None;
-        if let Ok(mut lines) = app.live_lines.lock() {
-            lines.clear();
+        if let Ok(mut live) = app.live_transcript.lock() {
+            *live = LiveTranscriptState::default();
         }
         app.message_list
             .add_assistant_message("streamed reply line".to_owned());
@@ -9116,8 +9170,17 @@ mod tests {
             .position(|line| line.contains("/tmp/example"))
             .expect("settled footer row");
 
-        assert!(settled_composer_row >= pending_composer_row);
-        assert!(settled_footer_row >= pending_footer_row);
+        let composer_reclaimed_rows = pending_composer_row.saturating_sub(settled_composer_row);
+        let footer_reclaimed_rows = pending_footer_row.saturating_sub(settled_footer_row);
+
+        assert!(
+            composer_reclaimed_rows <= 2,
+            "composer should only reclaim the pending preview rows, got pending={pending_composer_row} settled={settled_composer_row}"
+        );
+        assert!(
+            footer_reclaimed_rows <= 2,
+            "footer should only reclaim the pending preview rows, got pending={pending_footer_row} settled={settled_footer_row}"
+        );
     }
 
     #[test]
@@ -9128,8 +9191,8 @@ mod tests {
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["streamed reply line".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("streamed reply line".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
@@ -9142,13 +9205,13 @@ mod tests {
             .iter()
             .position(|line| line.contains("›"))
             .expect("composer row");
+        let preview_row = lines
+            .iter()
+            .position(|line| line.contains("streamed reply line"))
+            .expect("preview row");
 
         assert!(composer_row > spinner_row);
-        assert!(
-            !lines
-                .iter()
-                .any(|line| line.contains("streamed reply line"))
-        );
+        assert!(preview_row < composer_row);
     }
 
     #[test]
@@ -10509,19 +10572,29 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
-                "first streamed sentence".to_owned(),
-                "second streamed sentence".to_owned(),
-            ];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview =
+                Some("first streamed sentence\nsecond streamed sentence".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("first streamed sentence"));
-        assert!(!lines.contains("second streamed sentence"));
-        assert!(!lines.contains("╭─"));
-        assert!(!lines.contains("turn pipeline"));
+        let lines = buffer_lines(&terminal);
+        let first_row = lines
+            .iter()
+            .position(|line| line.contains("first streamed sentence"))
+            .expect("first preview row");
+        let second_row = lines
+            .iter()
+            .position(|line| line.contains("second streamed sentence"))
+            .expect("second preview row");
+        let composer_row = lines
+            .iter()
+            .position(|line| line.contains("›"))
+            .expect("composer row");
+        assert!(first_row < composer_row);
+        assert!(second_row < composer_row);
+        assert!(!lines.iter().any(|line| line.contains("╭─")));
+        assert!(!lines.iter().any(|line| line.contains("turn pipeline")));
     }
 
     #[test]
@@ -10716,8 +10789,8 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["streamed reply line".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("streamed reply line".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
@@ -10732,11 +10805,12 @@ description: "actual description"
             .expect("composer row");
 
         assert!(composer_row > user_row);
-        assert!(
-            !lines
-                .iter()
-                .any(|line| line.contains("streamed reply line"))
-        );
+        let preview_row = lines
+            .iter()
+            .position(|line| line.contains("streamed reply line"))
+            .expect("preview row");
+        assert!(preview_row > user_row);
+        assert!(preview_row < composer_row);
     }
 
     #[test]
@@ -10747,14 +10821,51 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["quiet reasoning".to_owned(), "visible reply".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("quiet reasoning\nvisible reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("quiet reasoning"));
-        assert!(!lines.contains("visible reply"));
+        assert!(lines.contains("quiet reasoning"));
+        assert!(lines.contains("visible reply"));
+    }
+
+    #[test]
+    fn pending_preview_keeps_plain_reply_with_tool_like_prefix_out_of_pending_band() {
+        let backend = TestBackend::new(70, 18);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = blank_app();
+        app.message_list.add_user_message("hi".to_owned());
+        app.pending_turn = true;
+        app.turn_start = Some(std::time::Instant::now());
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("• not a tool call\nrequest: still plain prose".to_owned());
+        }
+
+        terminal.draw(|f| app.render(f)).expect("draw");
+        let lines = buffer_lines(&terminal);
+        let composer_row = lines
+            .iter()
+            .position(|line| line.contains("›"))
+            .expect("composer row");
+        let bullet_row = lines
+            .iter()
+            .position(|line| line.contains("• not a tool call"))
+            .expect("bullet reply row");
+        let request_row = lines
+            .iter()
+            .position(|line| line.contains("request: still plain prose"))
+            .expect("request reply row");
+
+        assert!(bullet_row < composer_row);
+        assert!(request_row < composer_row);
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains("Called not a tool call")),
+            "plain transcript preview should not be restyled as pending tool activity"
+        );
     }
 
     #[test]
@@ -10765,8 +10876,8 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["visible reply".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("visible reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
@@ -10779,9 +10890,13 @@ description: "actual description"
             .iter()
             .position(|line| line.contains("›"))
             .expect("composer row");
+        let preview_row = lines
+            .iter()
+            .position(|line| line.contains("visible reply"))
+            .expect("preview row");
 
         assert!(composer_row > spinner_row);
-        assert!(!lines.iter().any(|line| line.contains("visible reply")));
+        assert!(preview_row < composer_row);
     }
 
     #[test]
@@ -10792,13 +10907,13 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["visible reply".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("visible reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("visible reply"));
+        assert!(lines.contains("visible reply"));
     }
     #[test]
     fn pending_preview_does_not_wrap_hidden_plain_reply_lines() {
@@ -10808,14 +10923,14 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["visible reply wraps across the pending band".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("visible reply wraps across the pending band".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("visible reply"));
-        assert!(!lines.contains("pending band"));
+        assert!(lines.contains("visible reply"));
+        assert!(lines.contains("pending band"));
     }
 
     #[test]
@@ -10826,18 +10941,17 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines =
-                vec![(
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some(
                 "a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 omega"
-            )
-                .to_owned()];
+                    .to_owned(),
+            );
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let rendered = buffer_lines(&terminal).join("\n");
 
-        assert!(!rendered.contains("omega"));
+        assert!(rendered.contains("omega"));
     }
 
     #[test]
@@ -10848,18 +10962,14 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
-                "quiet reasoning".to_owned(),
-                String::new(),
-                "visible reply".to_owned(),
-            ];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("quiet reasoning\n\nvisible reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("quiet reasoning"));
-        assert!(!lines.contains("visible reply"));
+        assert!(lines.contains("quiet reasoning"));
+        assert!(lines.contains("visible reply"));
     }
 
     #[test]
@@ -10870,18 +10980,14 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
-                "quiet reasoning".to_owned(),
-                String::new(),
-                "visible reply".to_owned(),
-            ];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("quiet reasoning\n\nvisible reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(!lines.contains("quiet reasoning"));
-        assert!(!lines.contains("visible reply"));
+        assert!(lines.contains("quiet reasoning"));
+        assert!(lines.contains("visible reply"));
     }
 
     #[test]
@@ -10892,40 +10998,36 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
-                "reason-1".to_owned(),
-                "reason-2".to_owned(),
-                "reason-3".to_owned(),
-                "reason-4".to_owned(),
-                String::new(),
-                "reply-1".to_owned(),
-                "reply-2".to_owned(),
-                "reply-3".to_owned(),
-            ];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some(
+                "reason-1\nreason-2\nreason-3\nreason-4\n\nreply-1\nreply-2\nreply-3".to_owned(),
+            );
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let rendered = buffer_lines(&terminal).join("\n");
 
-        assert!(!rendered.contains("reason-1"));
-        assert!(!rendered.contains("reason-2"));
-        assert!(!rendered.contains("reply-1"));
-        assert!(!rendered.contains("reply-2"));
+        assert!(rendered.contains("reason-1"));
+        assert!(rendered.contains("reason-2"));
+        assert!(rendered.contains("reply-1"));
+        assert!(rendered.contains("reply-2"));
     }
 
     #[test]
     fn pending_live_lines_trim_outer_blank_lines_and_collapse_repeats() {
-        let lines = Arc::new(StdMutex::new(vec![
-            String::new(),
-            String::new(),
-            "reasoning".to_owned(),
-            String::new(),
-            String::new(),
-            "reply".to_owned(),
-            String::new(),
-            String::new(),
-        ]));
+        let lines = Arc::new(StdMutex::new(LiveTranscriptState {
+            tool_activity_lines: vec![
+                String::new(),
+                String::new(),
+                "reasoning".to_owned(),
+                String::new(),
+                String::new(),
+                "reply".to_owned(),
+                String::new(),
+                String::new(),
+            ],
+            draft_preview: None,
+        }));
 
         let normalized = super::pending_live_lines(&lines, 6);
         assert_eq!(
@@ -10936,16 +11038,19 @@ description: "actual description"
 
     #[test]
     fn pending_live_lines_expand_with_larger_preview_budget() {
-        let lines = Arc::new(StdMutex::new(vec![
-            "reason-1".to_owned(),
-            "reason-2".to_owned(),
-            "reason-3".to_owned(),
-            String::new(),
-            "reply-1".to_owned(),
-            "reply-2".to_owned(),
-            "reply-3".to_owned(),
-            "reply-4".to_owned(),
-        ]));
+        let lines = Arc::new(StdMutex::new(LiveTranscriptState {
+            tool_activity_lines: vec![
+                "reason-1".to_owned(),
+                "reason-2".to_owned(),
+                "reason-3".to_owned(),
+                String::new(),
+                "reply-1".to_owned(),
+                "reply-2".to_owned(),
+                "reply-3".to_owned(),
+                "reply-4".to_owned(),
+            ],
+            draft_preview: None,
+        }));
 
         let compact = super::pending_live_lines(&lines, 4);
         let expanded = super::pending_live_lines(&lines, 7);
@@ -11266,14 +11371,13 @@ description: "actual description"
         ));
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["streamed preview line".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("streamed preview line".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw off tail");
         let off_tail_lines = buffer_lines(&terminal).join("\n");
         assert!(off_tail_lines.contains("PgDn / End"));
-        assert!(!off_tail_lines.contains("streamed preview line"));
 
         app.message_list
             .add_assistant_message("new-tail-line after scroll".to_owned());
@@ -11281,7 +11385,6 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw resized");
         let resized_lines = buffer_lines(&terminal).join("\n");
         assert!(resized_lines.contains("PgDn / End"));
-        assert!(!resized_lines.contains("streamed preview line"));
 
         app.message_list.handle_key(crossterm::event::KeyEvent::new(
             KeyCode::End,
@@ -11291,7 +11394,6 @@ description: "actual description"
         let restored_lines = buffer_lines(&terminal).join("\n");
 
         assert!(restored_lines.contains("new-tail-line after scroll"));
-        assert!(!restored_lines.contains("streamed preview line"));
         assert!(!restored_lines.contains("PgDn / End"));
         assert_eq!(app.message_list.scroll_offset_for_test(), 0);
     }
@@ -11415,8 +11517,8 @@ description: "actual description"
         let mut app = blank_app();
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.tool_activity_lines = vec![
                 "reason-1".to_owned(),
                 "reason-2".to_owned(),
                 "reason-3".to_owned(),
@@ -11427,8 +11529,8 @@ description: "actual description"
             ];
         }
         let before = super::pending_render_signature(&app);
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec![
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.tool_activity_lines = vec![
                 "reason-1".to_owned(),
                 "reason-2".to_owned(),
                 "reason-3".to_owned(),
@@ -11463,16 +11565,35 @@ description: "actual description"
         let mut app = blank_app();
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["reason-1".to_owned(), String::new(), "reply-1".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.tool_activity_lines =
+                vec!["reason-1".to_owned(), String::new(), "reply-1".to_owned()];
         }
         let before = super::pending_render_signature(&app);
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["reason-1".to_owned(), String::new(), "reply-2".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.tool_activity_lines =
+                vec!["reason-1".to_owned(), String::new(), "reply-2".to_owned()];
         }
         let after = super::pending_render_signature(&app);
 
         assert_eq!(before, after);
+    }
+
+    #[test]
+    fn transcript_preview_signature_changes_when_plain_preview_changes() {
+        let mut app = blank_app();
+        app.pending_turn = true;
+        app.last_render_width = 72;
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("first preview".to_owned());
+        }
+        let before = super::transcript_preview_signature(&app);
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("second preview".to_owned());
+        }
+        let after = super::transcript_preview_signature(&app);
+
+        assert_ne!(before, after);
     }
 
     #[test]
@@ -11555,8 +11676,7 @@ description: "actual description"
     }
 
     #[test]
-    fn startup_overflow_with_pending_preview_keeps_user_block_visible_without_plain_reply_preview()
-    {
+    fn startup_overflow_with_pending_preview_keeps_user_block_visible_with_transcript_preview() {
         let backend = TestBackend::new(50, 16);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -11582,12 +11702,13 @@ description: "actual description"
         app.message_list.add_user_message("hi".to_owned());
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
-        if let Ok(mut lines) = app.live_lines.lock() {
-            *lines = vec!["pending reply".to_owned()];
+        if let Ok(mut live) = app.live_transcript.lock() {
+            live.draft_preview = Some("pending reply".to_owned());
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let user_row = find_row(&terminal, "hi").expect("user row");
+        let preview_row = find_row(&terminal, "pending reply").expect("preview row");
         let composer_row = find_row(&terminal, "›").expect("composer row");
 
         assert!(row_has_background(
@@ -11595,8 +11716,9 @@ description: "actual description"
             user_row - 1,
             SURFACE_USER_MSG_BG
         ));
+        assert!(preview_row > user_row);
+        assert!(preview_row < composer_row);
         assert!(composer_row > user_row);
-        assert!(find_row(&terminal, "pending reply").is_none());
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -11183,6 +11183,35 @@ description: "actual description"
     }
 
     #[test]
+    fn width_resize_does_not_surface_internal_tool_result_or_transport_tail_in_plain_reply() {
+        let backend = TestBackend::new(72, 18);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = blank_app();
+        app.message_list.add_assistant_message(
+            concat!(
+                "我明白你的意思。\n\n",
+                "我已经核到一件关键事实：当前配置里确实存在一个更宽的 file_root。\n\n",
+                "[ok] {\"status\":\"ok\",\"tool\":\"read\",\"tool_call_id\":\"call-1\",\"payload_summary\":\"{\\\"path\\\":\\\"/workspace/demo/crates/daemon/src/lib.rs\\\",\\\"line_start\\\":1,\\\"line_end\\\":50}\",\"payload_chars\":2121,\"payload_truncated\":true}\n",
+                "candidate_index=1 candidate_count=1 profile_index=1 profile_count=1 exhausted=true error=provider request failed for model `gpt-5.4` on attempt 3/3: error sending request for url (https://api.tonsof.blue/v1/chat/completions)"
+            )
+            .to_owned(),
+        );
+
+        terminal.draw(|f| app.render(f)).expect("draw");
+        terminal.backend_mut().resize(28, 18);
+        terminal.draw(|f| app.render(f)).expect("draw");
+
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(
+            !lines.trim().is_empty(),
+            "sanitized plain reply should still leave visible assistant content after resize: {lines}"
+        );
+        assert!(!lines.contains("[ok] {\"status\":\"ok\""));
+        assert!(!lines.contains("provider request failed for model"));
+        assert!(!lines.contains("candidate_index=1"));
+    }
+
+    #[test]
     fn width_resize_keeps_pending_restore_footer_and_previews_visible() {
         let backend = TestBackend::new(72, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -1405,7 +1405,8 @@ impl App {
         }
 
         let max_pending_preview_lines = max_pending_height.saturating_sub(2).max(1) as usize;
-        let live_lines = pending_live_lines(&self.live_lines, max_pending_preview_lines);
+        let live_lines =
+            pending_live_tool_activity_lines(&self.live_lines, max_pending_preview_lines);
         let raw_pending_lines = build_pending_lines(
             self.turn_start,
             &live_lines,
@@ -7382,6 +7383,35 @@ fn pending_live_lines(live_lines: &Arc<StdMutex<Vec<String>>>, max_lines: usize)
         .unwrap_or_default()
 }
 
+fn pending_live_tool_activity_lines(
+    live_lines: &Arc<StdMutex<Vec<String>>>,
+    max_lines: usize,
+) -> Vec<String> {
+    pending_live_lines(live_lines, max_lines)
+        .into_iter()
+        .filter(|line| pending_line_is_tool_activity(line))
+        .collect()
+}
+
+fn pending_line_is_tool_activity(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('•')
+        || trimmed.starts_with("[running]")
+        || trimmed.starts_with("[pending]")
+        || trimmed.starts_with("[completed]")
+        || trimmed.starts_with("[failed]")
+        || trimmed.starts_with("[interrupted]")
+        || trimmed.starts_with("[needs_approval]")
+        || trimmed.starts_with("[denied]")
+        || trimmed.starts_with("request:")
+        || trimmed.starts_with("args:")
+        || trimmed.starts_with("stdout:")
+        || trimmed.starts_with("stderr:")
+        || trimmed.starts_with("file:")
+        || trimmed.starts_with("metrics:")
+        || trimmed.starts_with("↳ ")
+}
+
 fn pending_render_signature(app: &App) -> Option<u64> {
     if app.last_render_width == 0 || app.last_render_height == 0 {
         if !app.pending_turn {
@@ -7397,7 +7427,7 @@ fn pending_render_signature(app: &App) -> Option<u64> {
         app.pending_queue
             .iter()
             .for_each(|message| message.hash(&mut hasher));
-        for line in pending_live_lines(&app.live_lines, 6) {
+        for line in pending_live_tool_activity_lines(&app.live_lines, 6) {
             line.hash(&mut hasher);
         }
         return Some(hasher.finish());
@@ -7473,7 +7503,8 @@ fn pending_render_signature_for_geometry(
     let start = app.turn_start?;
     let max_pending_preview_lines =
         pending_signature_preview_budget_for_geometry(height, composer_height, palette_height);
-    let visible_lines = pending_live_lines(&app.live_lines, max_pending_preview_lines);
+    let visible_lines =
+        pending_live_tool_activity_lines(&app.live_lines, max_pending_preview_lines);
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     focus_ring_frame(start).hash(&mut hasher);
     get_spinner_verb_with_seed(start, app.spinner_seed).hash(&mut hasher);
@@ -9023,7 +9054,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_band_grows_when_live_lines_exist() {
+    fn pending_band_hides_plain_live_reply_lines() {
         let backend = TestBackend::new(50, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -9037,7 +9068,7 @@ mod tests {
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal);
         assert!(
-            lines
+            !lines
                 .iter()
                 .any(|line| line.contains("streamed reply line"))
         );
@@ -9090,7 +9121,7 @@ mod tests {
     }
 
     #[test]
-    fn spinner_stays_adjacent_to_composer_below_pending_content() {
+    fn spinner_stays_adjacent_to_composer_when_plain_live_reply_is_hidden() {
         let backend = TestBackend::new(60, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -9103,10 +9134,6 @@ mod tests {
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal);
-        let preview_row = lines
-            .iter()
-            .position(|line| line.contains("streamed reply line"))
-            .expect("preview row");
         let spinner_row = lines
             .iter()
             .position(|line| line.contains("..."))
@@ -9116,8 +9143,12 @@ mod tests {
             .position(|line| line.contains("›"))
             .expect("composer row");
 
-        assert!(preview_row < spinner_row);
-        assert_eq!(composer_row, spinner_row + 2);
+        assert!(composer_row > spinner_row);
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains("streamed reply line"))
+        );
     }
 
     #[test]
@@ -10471,7 +10502,7 @@ description: "actual description"
     }
 
     #[test]
-    fn pending_band_renders_compact_live_preview_without_card_chrome() {
+    fn pending_band_hides_plain_streaming_preview_text() {
         let backend = TestBackend::new(60, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10487,8 +10518,8 @@ description: "actual description"
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let lines = buffer_lines(&terminal).join("\n");
-        assert!(lines.contains("first streamed sentence"));
-        assert!(lines.contains("second streamed sentence"));
+        assert!(!lines.contains("first streamed sentence"));
+        assert!(!lines.contains("second streamed sentence"));
         assert!(!lines.contains("╭─"));
         assert!(!lines.contains("turn pipeline"));
     }
@@ -10678,7 +10709,7 @@ description: "actual description"
     }
 
     #[test]
-    fn pending_preview_renders_between_transcript_and_composer() {
+    fn pending_preview_hides_plain_streaming_reply_between_transcript_and_composer() {
         let backend = TestBackend::new(60, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10695,21 +10726,21 @@ description: "actual description"
             .iter()
             .position(|line| line.contains("hi"))
             .expect("user row");
-        let preview_row = lines
-            .iter()
-            .position(|line| line.contains("streamed reply line"))
-            .expect("preview row");
         let composer_row = lines
             .iter()
             .position(|line| line.contains("›"))
             .expect("composer row");
 
-        assert!(preview_row > user_row);
-        assert!(preview_row < composer_row);
+        assert!(composer_row > user_row);
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains("streamed reply line"))
+        );
     }
 
     #[test]
-    fn pending_preview_shows_reasoning_before_visible_reply() {
+    fn pending_preview_hides_reasoning_and_visible_reply_text() {
         let backend = TestBackend::new(70, 12);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10721,21 +10752,13 @@ description: "actual description"
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let lines = buffer_lines(&terminal);
-        let reasoning_row = lines
-            .iter()
-            .position(|line| line.contains("quiet reasoning"))
-            .expect("reasoning row");
-        let visible_row = lines
-            .iter()
-            .position(|line| line.contains("visible reply"))
-            .expect("visible row");
-
-        assert!(reasoning_row < visible_row);
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(!lines.contains("quiet reasoning"));
+        assert!(!lines.contains("visible reply"));
     }
 
     #[test]
-    fn pending_preview_keeps_blank_row_between_live_lines_and_spinner() {
+    fn pending_preview_no_longer_reserves_blank_row_for_plain_reply_preview() {
         let backend = TestBackend::new(70, 20);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10752,17 +10775,17 @@ description: "actual description"
             .iter()
             .position(|line| line.contains("..."))
             .expect("spinner row");
-        let preview_row = lines
+        let composer_row = lines
             .iter()
-            .position(|line| line.contains("visible reply"))
-            .expect("preview row");
+            .position(|line| line.contains("›"))
+            .expect("composer row");
 
-        assert_eq!(spinner_row, preview_row + 2);
-        assert!(lines[preview_row + 1].trim().is_empty());
+        assert!(composer_row > spinner_row);
+        assert!(!lines.iter().any(|line| line.contains("visible reply")));
     }
 
     #[test]
-    fn pending_preview_live_lines_are_indented_like_assistant_output() {
+    fn pending_preview_does_not_render_plain_reply_lines() {
         let backend = TestBackend::new(70, 20);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10774,16 +10797,11 @@ description: "actual description"
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let lines = buffer_lines(&terminal);
-        let preview_row = lines
-            .iter()
-            .position(|line| line.contains("visible reply"))
-            .expect("preview row");
-
-        assert!(lines[preview_row].contains("  visible reply"));
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(!lines.contains("visible reply"));
     }
     #[test]
-    fn pending_preview_wraps_long_live_lines_on_narrow_width() {
+    fn pending_preview_does_not_wrap_hidden_plain_reply_lines() {
         let backend = TestBackend::new(28, 20);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10795,28 +10813,13 @@ description: "actual description"
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let lines = buffer_lines(&terminal);
-        let first_row = lines
-            .iter()
-            .position(|line| line.contains("visible reply"))
-            .expect("first wrapped preview row");
-        let second_row = lines
-            .iter()
-            .skip(first_row + 1)
-            .position(|line| line.contains("pending band"))
-            .map(|offset| first_row + 1 + offset)
-            .expect("second wrapped preview row");
-        let composer_row = lines
-            .iter()
-            .position(|line| line.contains("›"))
-            .expect("composer row");
-
-        assert_eq!(second_row, first_row + 1);
-        assert!(composer_row > second_row);
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(!lines.contains("visible reply"));
+        assert!(!lines.contains("pending band"));
     }
 
     #[test]
-    fn pending_preview_expands_beyond_legacy_cap_when_height_allows() {
+    fn pending_preview_no_longer_expands_plain_reply_text_with_extra_height() {
         let backend = TestBackend::new(18, 24);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10834,11 +10837,11 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw");
         let rendered = buffer_lines(&terminal).join("\n");
 
-        assert!(rendered.contains("omega"));
+        assert!(!rendered.contains("omega"));
     }
 
     #[test]
-    fn pending_preview_preserves_blank_separator_between_reasoning_and_reply() {
+    fn pending_preview_hides_reasoning_reply_separator_when_plain_text_is_hidden() {
         let backend = TestBackend::new(70, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10854,22 +10857,13 @@ description: "actual description"
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let lines = buffer_lines(&terminal);
-        let reasoning_row = lines
-            .iter()
-            .position(|line| line.contains("quiet reasoning"))
-            .expect("reasoning row");
-        let visible_row = lines
-            .iter()
-            .position(|line| line.contains("visible reply"))
-            .expect("visible row");
-
-        assert!(visible_row > reasoning_row + 1);
-        assert!(lines[reasoning_row + 1].trim().is_empty());
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(!lines.contains("quiet reasoning"));
+        assert!(!lines.contains("visible reply"));
     }
 
     #[test]
-    fn pending_preview_styles_reasoning_dim_before_visible_reply() {
+    fn pending_preview_does_not_style_hidden_reasoning_lines() {
         let backend = TestBackend::new(70, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10885,19 +10879,13 @@ description: "actual description"
         }
 
         terminal.draw(|f| app.render(f)).expect("draw");
-        let buf = terminal.backend().buffer();
-        let reasoning_row = find_row(&terminal, "quiet reasoning").expect("reasoning row");
-        let visible_row = find_row(&terminal, "visible reply").expect("visible row");
-
-        assert_eq!(
-            buf[(2, reasoning_row)].fg,
-            crate::chat::chat_surface::utils::SURFACE_GRAY
-        );
-        assert_eq!(buf[(2, visible_row)].fg, ratatui::style::Color::White);
+        let lines = buffer_lines(&terminal).join("\n");
+        assert!(!lines.contains("quiet reasoning"));
+        assert!(!lines.contains("visible reply"));
     }
 
     #[test]
-    fn pending_preview_truncation_preserves_reasoning_and_visible_segments() {
+    fn pending_preview_truncation_ignores_hidden_plain_reply_segments() {
         let backend = TestBackend::new(70, 12);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -10920,13 +10908,10 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw");
         let rendered = buffer_lines(&terminal).join("\n");
 
-        assert!(rendered.contains("reason-1"));
-        assert!(rendered.contains("reason-2"));
-        assert!(!rendered.contains("reason-3"));
-        assert!(!rendered.contains("reason-4"));
-        assert!(rendered.contains("reply-1"));
-        assert!(rendered.contains("reply-2"));
-        assert!(!rendered.contains("reply-3"));
+        assert!(!rendered.contains("reason-1"));
+        assert!(!rendered.contains("reason-2"));
+        assert!(!rendered.contains("reply-1"));
+        assert!(!rendered.contains("reply-2"));
     }
 
     #[test]
@@ -11288,7 +11273,7 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw off tail");
         let off_tail_lines = buffer_lines(&terminal).join("\n");
         assert!(off_tail_lines.contains("PgDn / End"));
-        assert!(off_tail_lines.contains("streamed preview line"));
+        assert!(!off_tail_lines.contains("streamed preview line"));
 
         app.message_list
             .add_assistant_message("new-tail-line after scroll".to_owned());
@@ -11296,7 +11281,7 @@ description: "actual description"
         terminal.draw(|f| app.render(f)).expect("draw resized");
         let resized_lines = buffer_lines(&terminal).join("\n");
         assert!(resized_lines.contains("PgDn / End"));
-        assert!(resized_lines.contains("streamed preview line"));
+        assert!(!resized_lines.contains("streamed preview line"));
 
         app.message_list.handle_key(crossterm::event::KeyEvent::new(
             KeyCode::End,
@@ -11306,7 +11291,7 @@ description: "actual description"
         let restored_lines = buffer_lines(&terminal).join("\n");
 
         assert!(restored_lines.contains("new-tail-line after scroll"));
-        assert!(restored_lines.contains("streamed preview line"));
+        assert!(!restored_lines.contains("streamed preview line"));
         assert!(!restored_lines.contains("PgDn / End"));
         assert_eq!(app.message_list.scroll_offset_for_test(), 0);
     }
@@ -11474,7 +11459,7 @@ description: "actual description"
     }
 
     #[test]
-    fn pending_signature_changes_when_visible_preview_changes() {
+    fn pending_signature_ignores_plain_reply_preview_changes() {
         let mut app = blank_app();
         app.pending_turn = true;
         app.turn_start = Some(std::time::Instant::now());
@@ -11487,7 +11472,7 @@ description: "actual description"
         }
         let after = super::pending_render_signature(&app);
 
-        assert_ne!(before, after);
+        assert_eq!(before, after);
     }
 
     #[test]
@@ -11570,7 +11555,8 @@ description: "actual description"
     }
 
     #[test]
-    fn startup_overflow_with_pending_preview_keeps_user_block_and_preview_visible() {
+    fn startup_overflow_with_pending_preview_keeps_user_block_visible_without_plain_reply_preview()
+    {
         let backend = TestBackend::new(50, 16);
         let mut terminal = Terminal::new(backend).expect("terminal");
         let mut app = blank_app();
@@ -11602,7 +11588,6 @@ description: "actual description"
 
         terminal.draw(|f| app.render(f)).expect("draw");
         let user_row = find_row(&terminal, "hi").expect("user row");
-        let preview_row = find_row(&terminal, "pending reply").expect("preview row");
         let composer_row = find_row(&terminal, "›").expect("composer row");
 
         assert!(row_has_background(
@@ -11610,8 +11595,8 @@ description: "actual description"
             user_row - 1,
             SURFACE_USER_MSG_BG
         ));
-        assert!(preview_row > user_row);
-        assert!(preview_row < composer_row);
+        assert!(composer_row > user_row);
+        assert!(find_row(&terminal, "pending reply").is_none());
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -2400,16 +2400,18 @@ fn build_assistant_contents(text: &str) -> Vec<MessageContent> {
         return vec![parse_compaction_content(text)];
     }
 
-    if !assistant_text_has_explicit_structure(text) {
+    let sanitized_text = sanitize_plain_assistant_text(text);
+
+    if !assistant_text_has_explicit_structure(sanitized_text.as_str()) {
         let mut contents = Vec::new();
-        append_markdown_or_image_contents(text, &mut contents);
+        append_markdown_or_image_contents(sanitized_text.as_str(), &mut contents);
         if contents.is_empty() {
-            contents.push(MessageContent::Markdown(text.to_owned()));
+            contents.push(MessageContent::Markdown(sanitized_text));
         }
         return contents;
     }
 
-    let sections = super::super::parse_cli_chat_markdown_sections(text);
+    let sections = super::super::parse_cli_chat_markdown_sections(sanitized_text.as_str());
     let mut contents = Vec::new();
 
     for section in sections {
@@ -2452,14 +2454,87 @@ fn build_assistant_contents(text: &str) -> Vec<MessageContent> {
     }
 
     if contents.is_empty() {
-        append_markdown_or_image_contents(text, &mut contents);
+        append_markdown_or_image_contents(sanitized_text.as_str(), &mut contents);
     }
 
     if contents.is_empty() {
-        contents.push(MessageContent::Markdown(text.to_owned()));
+        contents.push(MessageContent::Markdown(sanitized_text));
     }
 
     contents
+}
+
+fn sanitize_plain_assistant_text(text: &str) -> String {
+    let mut visible_lines = Vec::new();
+    let mut saw_visible_content = false;
+    let mut internal_tail_started = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let internal_tail_line = looks_like_internal_tool_result_line(trimmed)
+            || looks_like_provider_transport_tail(trimmed);
+
+        if !internal_tail_started && internal_tail_line && saw_visible_content {
+            internal_tail_started = true;
+        }
+
+        if internal_tail_started {
+            continue;
+        }
+
+        if !trimmed.is_empty() {
+            saw_visible_content = true;
+        }
+        visible_lines.push(line);
+    }
+
+    if !internal_tail_started {
+        return text.to_owned();
+    }
+
+    while visible_lines
+        .last()
+        .is_some_and(|line| line.trim().is_empty())
+    {
+        visible_lines.pop();
+    }
+
+    if visible_lines.is_empty() {
+        text.to_owned()
+    } else {
+        visible_lines.join("\n")
+    }
+}
+
+fn looks_like_internal_tool_result_line(line: &str) -> bool {
+    looks_like_status_prefixed_tool_result_envelope(line)
+        || line.starts_with("[tool_result]")
+        || line.starts_with("[tool_failure]")
+}
+
+fn looks_like_provider_transport_tail(line: &str) -> bool {
+    line.contains("provider request failed for model `")
+        || (line.contains("candidate_index=")
+            && line.contains("candidate_count=")
+            && line.contains("profile_index="))
+        || line.contains("transport_failure")
+}
+
+fn looks_like_status_prefixed_tool_result_envelope(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some((prefix, payload)) = trimmed.split_once(' ') else {
+        return false;
+    };
+    let Some(status_marker) = prefix
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    else {
+        return false;
+    };
+    if status_marker.trim().is_empty() {
+        return false;
+    }
+    serde_json::from_str::<serde_json::Value>(payload).is_ok()
 }
 
 fn assistant_text_has_explicit_structure(text: &str) -> bool {
@@ -5209,8 +5284,8 @@ mod tests {
     use super::{
         MessageContent, MessageList, ReadToolRequest, STARTUP_COMPACT_WORDMARK, STARTUP_EYE_FRAMES,
         STARTUP_TIP_FADE_MS, STARTUP_TIP_HOLD_MS, STARTUP_WORDMARK, ToolStatus,
-        adjust_scroll_start_for_message_boundary, build_assistant_contents, dominant_block_bg,
-        extract_read_tool_request_from_json, format_read_request_display,
+        adjust_scroll_start_for_message_boundary, build_assistant_contents, content_plain_text,
+        dominant_block_bg, extract_read_tool_request_from_json, format_read_request_display,
         startup_logo_eye_frame_index, startup_logo_eye_style, startup_tip_render_state,
         startup_wordmark_eye_frame,
     };
@@ -6495,6 +6570,32 @@ mod tests {
             [MessageContent::Markdown(markdown)]
                 if markdown == text
         ));
+    }
+
+    #[test]
+    fn assistant_reply_does_not_leave_internal_tool_result_and_provider_transport_tail_inline() {
+        let text = concat!(
+            "我明白你的意思。\n\n",
+            "我已经核到一件关键事实：当前配置里确实存在一个更宽的 file_root。\n\n",
+            "[ok] {\"status\":\"ok\",\"tool\":\"read\",\"tool_call_id\":\"call-1\",\"payload_summary\":\"{\\\"path\\\":\\\"/workspace/demo/crates/daemon/src/lib.rs\\\",\\\"line_start\\\":1,\\\"line_end\\\":50}\",\"payload_chars\":2121,\"payload_truncated\":true}\n",
+            "candidate_index=1 candidate_count=1 profile_index=1 profile_count=1 exhausted=true error=provider request failed for model `gpt-5.4` on attempt 3/3: error sending request for url (https://api.tonsof.blue/v1/chat/completions)"
+        );
+
+        let contents = build_assistant_contents(text);
+        let plain_text = contents
+            .iter()
+            .filter_map(content_plain_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            !plain_text.contains("[ok] {\"status\":\"ok\""),
+            "raw tool result envelope should not leak into plain transcript markdown: {plain_text}"
+        );
+        assert!(
+            !plain_text.contains("provider request failed for model"),
+            "provider transport tail should not remain inline in the plain transcript: {plain_text}"
+        );
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -441,6 +441,18 @@ impl MessageList {
         self.ensure_render_cache(width).len()
     }
 
+    pub fn rendered_line_count_with_provisional_assistant(
+        &mut self,
+        width: u16,
+        provisional_assistant_text: Option<&str>,
+    ) -> usize {
+        if provisional_assistant_text.is_none_or(|text| text.trim().is_empty()) {
+            return self.rendered_line_count(width);
+        }
+        self.rendered_lines_with_provisional_assistant(width, provisional_assistant_text)
+            .len()
+    }
+
     fn ensure_render_cache(&mut self, width: u16) -> &Vec<Line<'static>> {
         let needs_rebuild = self
             .render_cache
@@ -669,6 +681,102 @@ impl MessageList {
             .apply_rendered_scroll_start(max_scroll_start, scroll_start);
 
         let visible_lines = self.viewport_lines(area.width, area.height, scroll_start, top_padding);
+        let paragraph = Paragraph::new(Text::from(visible_lines));
+
+        f.render_widget(paragraph, area);
+    }
+
+    pub fn render_with_provisional_assistant(
+        &mut self,
+        f: &mut Frame,
+        area: Rect,
+        provisional_assistant_text: Option<&str>,
+    ) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        if provisional_assistant_text.is_none_or(|text| text.trim().is_empty()) {
+            self.render(f, area);
+            return;
+        }
+
+        let rendered_lines =
+            self.rendered_lines_with_provisional_assistant(area.width, provisional_assistant_text);
+        self.render_explicit_lines(f, area, rendered_lines, self.startup_mode_active());
+    }
+
+    fn rendered_lines_with_provisional_assistant(
+        &mut self,
+        width: u16,
+        provisional_assistant_text: Option<&str>,
+    ) -> Vec<Line<'static>> {
+        let mut rendered_lines = self.get_rendered_lines(width);
+        let Some(text) = provisional_assistant_text.map(str::trim) else {
+            return rendered_lines;
+        };
+        if text.is_empty() {
+            return rendered_lines;
+        }
+        rendered_lines.extend(render_provisional_assistant_message_lines(text, width));
+        rendered_lines
+    }
+
+    fn render_explicit_lines(
+        &mut self,
+        f: &mut Frame,
+        area: Rect,
+        rendered_lines: Vec<Line<'static>>,
+        startup_mode: bool,
+    ) {
+        self.page_step = page_step_for_height(area.height);
+        self.mouse_step = mouse_step_for_height(area.height);
+        let top_padding = if startup_mode {
+            startup_top_padding(rendered_lines.len(), area.height)
+        } else {
+            0
+        };
+
+        let total_lines = rendered_lines.len().saturating_add(top_padding);
+        if total_lines == 0 {
+            self.last_render_height = area.height;
+            self.scroll_state.reset_for_empty_render();
+            f.render_widget(
+                Paragraph::new(Text::from(Vec::<Line<'static>>::new())),
+                area,
+            );
+            return;
+        }
+        let max_scroll_start = total_lines.saturating_sub(area.height as usize);
+        let raw_scroll_val = self.scroll_state.raw_scroll_start(max_scroll_start);
+        let mut scroll_start = if self.scroll_state.follow_tail() {
+            raw_scroll_val
+        } else if !self.scroll_state.snap_on_next_render() {
+            self.scroll_state.last_scroll_start().min(max_scroll_start)
+        } else {
+            let centered_lines = if startup_mode {
+                vertically_center_startup_lines(rendered_lines.clone(), area.height)
+            } else {
+                rendered_lines.clone()
+            };
+            adjust_scroll_start_for_message_boundary(&centered_lines, raw_scroll_val)
+        };
+        scroll_start = scroll_start.min(max_scroll_start);
+        self.last_render_height = area.height;
+        self.scroll_state
+            .apply_rendered_scroll_start(max_scroll_start, scroll_start);
+
+        let visible_end = scroll_start.saturating_add(area.height as usize);
+        let visible_lines = (scroll_start..visible_end)
+            .filter_map(|visual_index| {
+                if visual_index < top_padding {
+                    Some(Line::from(""))
+                } else {
+                    rendered_lines
+                        .get(visual_index.saturating_sub(top_padding))
+                        .cloned()
+                }
+            })
+            .collect::<Vec<_>>();
         let paragraph = Paragraph::new(Text::from(visible_lines));
 
         f.render_widget(paragraph, area);
@@ -1042,6 +1150,12 @@ fn normalize_rendered_system_line(line: &str) -> Option<String> {
     }
 
     Some(trimmed.to_owned())
+}
+
+fn render_provisional_assistant_message_lines(text: &str, width: u16) -> Vec<Line<'static>> {
+    let mut list = MessageList::new();
+    list.add_assistant_message(text.to_owned());
+    list.get_rendered_lines(width)
 }
 
 fn render_rendered_system_line(line: &str, width: u16) -> Vec<Line<'static>> {

--- a/crates/app/src/chat/live_runtime.rs
+++ b/crates/app/src/chat/live_runtime.rs
@@ -9,7 +9,7 @@ use super::*;
 use serde_json::Value;
 
 const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 8;
-const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 48;
+const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 24;
 const CLI_CHAT_LIVE_PREVIEW_INITIAL_EMIT_CHARS: usize = 4;
 const CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS: usize = 4096;
 const CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS: usize = 1024;
@@ -20,7 +20,15 @@ const CLI_CHAT_LIVE_PREVIEW_CATCH_UP_ENTER_VISUAL_LINE_GROWTH: usize = 2;
 const CLI_CHAT_LIVE_PREVIEW_CATCH_UP_ENTER_MIN_VISUAL_LINES: usize = 4;
 const CLI_CHAT_LIVE_PREVIEW_SMOOTH_MIN_INTERVAL_MS: u64 = 40;
 const CLI_CHAT_LIVE_PREVIEW_CATCH_UP_MIN_INTERVAL_MS: u64 = 16;
-pub(super) type CliChatLiveSurfaceSink = Arc<dyn Fn(Vec<String>) + Send + Sync>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CliChatLiveSurfaceRenderPayload {
+    pub lines: Vec<String>,
+    pub draft_preview: Option<String>,
+    pub tool_activity_lines: Vec<String>,
+}
+
+pub(super) type CliChatLiveSurfaceSink = Arc<dyn Fn(CliChatLiveSurfaceRenderPayload) + Send + Sync>;
 pub(super) type CliChatLiveSurfaceRerender = Arc<dyn Fn() + Send + Sync>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,8 +163,8 @@ pub(super) struct CliChatLiveSurfaceObserver {
 pub(super) fn build_cli_chat_live_surface_observer(
     render_width: usize,
 ) -> ConversationTurnObserverHandle {
-    let render_sink: CliChatLiveSurfaceSink = Arc::new(|lines| {
-        print_rendered_cli_chat_lines(&lines);
+    let render_sink: CliChatLiveSurfaceSink = Arc::new(|payload| {
+        print_rendered_cli_chat_lines(&payload.lines);
     });
     build_cli_chat_live_surface_observer_with_sink(render_width, render_sink)
 }
@@ -282,13 +290,27 @@ impl CliChatLiveSurfaceObserver {
                         );
                     state.last_emitted_snapshot = Some(snapshot);
                     state.last_emitted_lines = Some(lines.clone());
-                    Some(lines)
+                    Some(CliChatLiveSurfaceRenderPayload {
+                        lines,
+                        draft_preview: state
+                            .last_emitted_snapshot
+                            .as_ref()
+                            .and_then(|snapshot| snapshot.draft_preview.clone())
+                            .filter(|text| !text.trim().is_empty()),
+                        tool_activity_lines: state
+                            .last_emitted_snapshot
+                            .as_ref()
+                            .map(|snapshot| {
+                                format_cli_chat_live_tool_activity_lines(snapshot.tools.as_slice())
+                            })
+                            .unwrap_or_default(),
+                    })
                 })
             }
         };
 
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
+        if let Some(payload) = lines_to_render {
+            (self.render_sink)(payload);
         }
     }
 
@@ -314,8 +336,8 @@ impl CliChatLiveSurfaceObserver {
             }
         };
 
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
+        if let Some(payload) = lines_to_render {
+            (self.render_sink)(payload);
         }
     }
 
@@ -335,8 +357,8 @@ impl CliChatLiveSurfaceObserver {
             }
         };
 
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
+        if let Some(payload) = lines_to_render {
+            (self.render_sink)(payload);
         }
     }
 
@@ -356,8 +378,8 @@ impl CliChatLiveSurfaceObserver {
             }
         };
 
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
+        if let Some(payload) = lines_to_render {
+            (self.render_sink)(payload);
         }
     }
 
@@ -423,15 +445,15 @@ impl CliChatLiveSurfaceObserver {
             }
         };
 
-        if let Some(lines) = lines_to_render {
-            (self.render_sink)(lines);
+        if let Some(payload) = lines_to_render {
+            (self.render_sink)(payload);
         }
     }
 
     fn prepare_live_surface_lines(
         &self,
         state: &mut CliChatLiveSurfaceState,
-    ) -> Option<Vec<String>> {
+    ) -> Option<CliChatLiveSurfaceRenderPayload> {
         let snapshot = build_cli_chat_live_surface_snapshot(state)?;
         if state.last_emitted_snapshot.as_ref() == Some(&snapshot) {
             return None;
@@ -445,6 +467,8 @@ impl CliChatLiveSurfaceObserver {
                 render_cli_chat_live_compact_lines_with_width(&snapshot, self.render_width())
             }
         };
+        let tool_activity_lines =
+            format_cli_chat_live_tool_activity_lines(snapshot.tools.as_slice());
         state.last_preview_emit_chars_seen = state.total_text_chars_seen;
         state.last_preview_emit_visual_line_count = cli_chat_live_preview_visual_line_count(
             snapshot.draft_preview.as_deref(),
@@ -455,7 +479,15 @@ impl CliChatLiveSurfaceObserver {
             return None;
         }
         state.last_emitted_lines = Some(lines.clone());
-        Some(lines)
+        Some(CliChatLiveSurfaceRenderPayload {
+            lines,
+            draft_preview: state
+                .last_emitted_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.draft_preview.clone())
+                .filter(|text| !text.trim().is_empty()),
+            tool_activity_lines,
+        })
     }
 }
 
@@ -2437,8 +2469,8 @@ fn build_cli_chat_live_tool_section(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliChatLiveFileChangeView, CliChatLiveOutputView, CliChatLiveSurfaceSink,
-        CliChatLiveSurfaceSnapshot, CliChatLiveToolSnapshot,
+        CliChatLiveFileChangeView, CliChatLiveOutputView, CliChatLiveSurfaceRenderPayload,
+        CliChatLiveSurfaceSink, CliChatLiveSurfaceSnapshot, CliChatLiveToolSnapshot,
         build_cli_chat_live_compact_observer_controller,
         render_cli_chat_live_compact_lines_with_width,
         render_cli_chat_live_surface_lines_with_width, render_live_preview_segment_lines,
@@ -3204,7 +3236,7 @@ mod tests {
         assert!(!super::should_emit_cli_chat_live_preview(
             &state,
             80,
-            Some(120)
+            Some(110)
         ));
         assert!(super::should_emit_cli_chat_live_preview(
             &state,
@@ -3231,6 +3263,24 @@ mod tests {
     }
 
     #[test]
+    fn preview_emit_on_wide_widths_no_longer_waits_for_huge_stable_bursts() {
+        let state = super::CliChatLiveSurfaceState {
+            draft_preview: "hello world this is a stable chunk ".to_owned(),
+            last_preview_emit_chars_seen: 8,
+            last_preview_emit_visual_line_count: 1,
+            last_preview_emit_elapsed_ms: Some(100),
+            total_text_chars_seen: 32,
+            ..Default::default()
+        };
+
+        assert!(super::should_emit_cli_chat_live_preview(
+            &state,
+            80,
+            Some(140)
+        ));
+    }
+
+    #[test]
     fn delta_commit_boundary_detects_newline_and_structural_tokens() {
         assert!(super::cli_chat_live_delta_has_commit_boundary(
             "line done\n"
@@ -3245,7 +3295,8 @@ mod tests {
 
     #[test]
     fn compact_observer_rerenders_preview_when_width_changes() {
-        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let captured_batches =
+            Arc::new(StdMutex::new(Vec::<CliChatLiveSurfaceRenderPayload>::new()));
         let render_sink: CliChatLiveSurfaceSink = {
             let captured_batches = Arc::clone(&captured_batches);
             Arc::new(move |lines| {
@@ -3281,13 +3332,19 @@ mod tests {
             .lock()
             .expect("captured batches lock should not be poisoned");
         let last_batch = batches.last().expect("rerender batch");
-        assert!(last_batch.len() > 1);
-        assert!(last_batch.iter().any(|line| line.contains("alpha beta")));
+        assert!(last_batch.lines.len() > 1);
+        assert!(
+            last_batch
+                .lines
+                .iter()
+                .any(|line| line.contains("alpha beta"))
+        );
     }
 
     #[test]
     fn compact_observer_commits_preview_immediately_on_newline_boundary() {
-        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let captured_batches =
+            Arc::new(StdMutex::new(Vec::<CliChatLiveSurfaceRenderPayload>::new()));
         let render_sink: CliChatLiveSurfaceSink = {
             let captured_batches = Arc::clone(&captured_batches);
             Arc::new(move |lines| {
@@ -3320,12 +3377,13 @@ mod tests {
             .lock()
             .expect("captured batches lock should not be poisoned");
         let last_batch = batches.last().expect("newline-triggered batch");
-        assert!(last_batch.iter().any(|line| line.contains("ok")));
+        assert!(last_batch.lines.iter().any(|line| line.contains("ok")));
     }
 
     #[test]
     fn compact_observer_skips_rerender_when_width_change_keeps_same_lines() {
-        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let captured_batches =
+            Arc::new(StdMutex::new(Vec::<CliChatLiveSurfaceRenderPayload>::new()));
         let render_sink: CliChatLiveSurfaceSink = {
             let captured_batches = Arc::clone(&captured_batches);
             Arc::new(move |lines| {
@@ -3484,7 +3542,7 @@ mod tests {
         assert_eq!(super::cli_chat_live_preview_emit_stride(4), 8);
         assert_eq!(super::cli_chat_live_preview_emit_stride(12), 12);
         assert_eq!(super::cli_chat_live_preview_emit_stride(20), 20);
-        assert_eq!(super::cli_chat_live_preview_emit_stride(80), 48);
+        assert_eq!(super::cli_chat_live_preview_emit_stride(80), 24);
     }
 
     #[test]

--- a/crates/app/src/chat/tests.rs
+++ b/crates/app/src/chat/tests.rs
@@ -2010,7 +2010,9 @@ fn render_cli_chat_live_surface_lines_show_pipeline_status_and_preview() {
 
 #[test]
 fn cli_chat_live_surface_observer_emits_phase_and_stream_preview_batches() {
-    let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+    let captured_batches = Arc::new(StdMutex::new(Vec::<
+        crate::chat::CliChatLiveSurfaceRenderPayload,
+    >::new()));
     let render_sink: CliChatLiveSurfaceSink = {
         let captured_batches = Arc::clone(&captured_batches);
         Arc::new(move |lines| {
@@ -2048,23 +2050,34 @@ fn cli_chat_live_surface_observer_emits_phase_and_stream_preview_batches() {
 
     let preview_batch = batches
         .iter()
-        .find(|lines| lines.iter().any(|line| line.contains("draft preview")))
+        .find(|payload| {
+            payload
+                .lines
+                .iter()
+                .any(|line| line.contains("draft preview"))
+        })
         .expect("preview batch");
     assert!(
         preview_batch
+            .lines
             .iter()
             .any(|line| line.contains("Draft response")),
         "preview batch should include the streamed text: {preview_batch:#?}"
     );
     assert!(
-        preview_batch.iter().any(|line| line.contains("ttft 42ms")),
+        preview_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("ttft 42ms")),
         "preview batch should include the first-token latency in the title: {preview_batch:#?}"
     );
 }
 
 #[test]
 fn cli_chat_live_surface_observer_renders_tool_lifecycle_updates() {
-    let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+    let captured_batches = Arc::new(StdMutex::new(Vec::<
+        crate::chat::CliChatLiveSurfaceRenderPayload,
+    >::new()));
     let render_sink: CliChatLiveSurfaceSink = {
         let captured_batches = Arc::clone(&captured_batches);
         Arc::new(move |lines| {
@@ -2118,16 +2131,27 @@ fn cli_chat_live_surface_observer_renders_tool_lifecycle_updates() {
         .expect("captured batches lock should not be poisoned");
     let running_batch = batches
         .iter()
-        .find(|lines| lines.iter().any(|line| line.contains("tool activity")))
+        .find(|payload| {
+            payload
+                .lines
+                .iter()
+                .any(|line| line.contains("tool activity"))
+        })
         .expect("running tool batch");
     let completed_batch = batches
         .iter()
         .rev()
-        .find(|lines| lines.iter().any(|line| line.contains("• Closed read · ok")))
+        .find(|payload| {
+            payload
+                .lines
+                .iter()
+                .any(|line| line.contains("• Closed read · ok"))
+        })
         .expect("completed tool batch");
 
     assert!(
         running_batch
+            .lines
             .iter()
             .any(|line| line.contains("• Called read")),
         "tool batch should surface the running tool state: {running_batch:#?}"
@@ -2135,15 +2159,18 @@ fn cli_chat_live_surface_observer_renders_tool_lifecycle_updates() {
 
     assert!(
         completed_batch
+            .lines
             .iter()
             .any(|line| line.contains("• Closed read · ok")),
         "tool batch should surface the completed tool state: {completed_batch:#?}"
     );
     assert!(
         completed_batch
+            .lines
             .iter()
             .any(|line| line.contains("request path=README.md"))
             || completed_batch
+                .lines
                 .iter()
                 .any(|line| line.contains("args path=README.md")),
         "tool batch should preserve streamed tool args: {completed_batch:#?}"
@@ -2152,7 +2179,9 @@ fn cli_chat_live_surface_observer_renders_tool_lifecycle_updates() {
 
 #[test]
 fn cli_chat_live_surface_observer_renders_runtime_output_and_file_change_updates() {
-    let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+    let captured_batches = Arc::new(StdMutex::new(Vec::<
+        crate::chat::CliChatLiveSurfaceRenderPayload,
+    >::new()));
     let render_sink: CliChatLiveSurfaceSink = {
         let captured_batches = Arc::clone(&captured_batches);
         Arc::new(move |lines| {
@@ -2213,28 +2242,35 @@ fn cli_chat_live_surface_observer_renders_runtime_output_and_file_change_updates
 
     assert!(
         final_batch
+            .lines
             .iter()
             .any(|line| line.contains("• Closed exec · ok")),
         "runtime output should surface the visible tool name: {final_batch:#?}"
     );
     assert!(
         final_batch
+            .lines
             .iter()
             .any(|line| line.contains("stdout 2 lines · 22 bytes")),
         "runtime output should surface stdout counters: {final_batch:#?}"
     );
     assert!(
-        final_batch.iter().any(|line| line.contains("first line")),
+        final_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("first line")),
         "runtime output should retain stdout preview lines: {final_batch:#?}"
     );
     assert!(
         final_batch
+            .lines
             .iter()
             .any(|line| line.contains("file edit src/lib.rs (+2 / -1)")),
         "runtime output should surface file change summaries: {final_batch:#?}"
     );
     assert!(
         final_batch
+            .lines
             .iter()
             .any(|line| line.contains("metrics 42ms · exit=0")),
         "runtime output should surface command metrics: {final_batch:#?}"
@@ -2323,7 +2359,9 @@ fn parse_markdown_heading_follows_commonmark_atx_rules() {
 
 #[test]
 fn cli_chat_live_surface_observer_resets_request_scoped_buffers_between_rounds() {
-    let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+    let captured_batches = Arc::new(StdMutex::new(Vec::<
+        crate::chat::CliChatLiveSurfaceRenderPayload,
+    >::new()));
     let render_sink: CliChatLiveSurfaceSink = {
         let captured_batches = Arc::clone(&captured_batches);
         Arc::new(move |lines| {
@@ -2376,19 +2414,29 @@ fn cli_chat_live_surface_observer_resets_request_scoped_buffers_between_rounds()
     let last_batch = batches.last().expect("follow-up request batch");
 
     assert!(
-        !last_batch.iter().any(|line| line.contains("draft preview")),
+        !last_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("draft preview")),
         "follow-up provider requests should reset the previous draft preview: {last_batch:#?}"
     );
     assert!(
-        !last_batch.iter().any(|line| line.contains("tool activity")),
+        !last_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("tool activity")),
         "follow-up provider requests should not reuse prior tool activity lines: {last_batch:#?}"
     );
     assert!(
-        !last_batch.iter().any(|line| line.contains("ttft 55ms")),
+        !last_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("ttft 55ms")),
         "follow-up provider requests should reset prior first-token latency: {last_batch:#?}"
     );
     assert!(
         !last_batch
+            .lines
             .iter()
             .any(|line| line.contains("Draft response")),
         "follow-up provider requests should not carry the previous request preview text: {last_batch:#?}"
@@ -2397,7 +2445,9 @@ fn cli_chat_live_surface_observer_resets_request_scoped_buffers_between_rounds()
 
 #[test]
 fn cli_chat_live_surface_observer_waits_for_tools_phase_before_rendering_tool_activity() {
-    let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+    let captured_batches = Arc::new(StdMutex::new(Vec::<
+        crate::chat::CliChatLiveSurfaceRenderPayload,
+    >::new()));
     let render_sink: CliChatLiveSurfaceSink = {
         let captured_batches = Arc::clone(&captured_batches);
         Arc::new(move |lines| {
@@ -2455,11 +2505,15 @@ fn cli_chat_live_surface_observer_waits_for_tools_phase_before_rendering_tool_ac
     let last_batch = batches.last().expect("running-tools batch");
 
     assert!(
-        last_batch.iter().any(|line| line.contains("tool activity")),
+        last_batch
+            .lines
+            .iter()
+            .any(|line| line.contains("tool activity")),
         "the tools phase should render the accumulated tool activity: {last_batch:#?}"
     );
     assert!(
         last_batch
+            .lines
             .iter()
             .any(|line| line.contains("• Called search")),
         "the tools phase should surface the streamed tool metadata: {last_batch:#?}"

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -1563,16 +1563,15 @@ pub(super) fn resolve_safe_file_path_with_config(
     raw: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<PathBuf, String> {
-    let access_root = config
-        .filesystem_access_root()
-        .map(Path::to_path_buf)
-        .or_else(|| config.file_root.clone())
+    let allowed_roots = collect_allowed_roots(config)?;
+    let primary_root = allowed_roots
+        .first()
+        .cloned()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-    let access_root = canonicalize_or_fallback(access_root)?;
     let resolution_root = config
         .path_resolution_root()
         .map(Path::to_path_buf)
-        .unwrap_or_else(|| access_root.clone());
+        .unwrap_or_else(|| primary_root.clone());
 
     let candidate = Path::new(raw);
     let combined = if candidate.is_absolute() {
@@ -1581,7 +1580,7 @@ pub(super) fn resolve_safe_file_path_with_config(
         resolution_root.join(candidate)
     };
     let normalized = super::normalize_without_fs(&combined);
-    resolve_path_within_root(&access_root, &normalized)
+    resolve_path_within_allowed_roots(&allowed_roots, &primary_root, &normalized)
 }
 
 pub(super) fn resolve_safe_directory_path_with_config(
@@ -1618,7 +1617,38 @@ fn canonicalize_or_fallback(path: PathBuf) -> Result<PathBuf, String> {
     Ok(super::normalize_without_fs(&path))
 }
 
-fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, String> {
+fn collect_allowed_roots(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<PathBuf>, String> {
+    let mut raw_roots = Vec::new();
+
+    if let Some(file_root) = config.file_root.as_ref() {
+        raw_roots.push(file_root.clone());
+    }
+
+    if let Some(workspace_root) = config.workspace_root.as_ref() {
+        let workspace_root_is_new = raw_roots.iter().all(|root| root != workspace_root);
+        if workspace_root_is_new {
+            raw_roots.push(workspace_root.clone());
+        }
+    }
+
+    if raw_roots.is_empty() {
+        let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        raw_roots.push(current_dir);
+    }
+
+    raw_roots
+        .into_iter()
+        .map(canonicalize_or_fallback)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn resolve_path_within_allowed_roots(
+    allowed_roots: &[PathBuf],
+    primary_root: &Path,
+    normalized: &Path,
+) -> Result<PathBuf, String> {
     if normalized.exists() {
         let canonical = dunce::canonicalize(normalized).map_err(|error| {
             format!(
@@ -1627,7 +1657,7 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
             )
         })?;
         let canonical = dunce::simplified(&canonical).to_path_buf();
-        ensure_path_within_root(root, &canonical)?;
+        ensure_path_within_allowed_roots(allowed_roots, primary_root, &canonical)?;
         return Ok(canonical);
     }
 
@@ -1639,32 +1669,33 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
         )
     })?;
     let canonical_ancestor = dunce::simplified(&canonical_ancestor).to_path_buf();
-    ensure_path_within_root(root, &canonical_ancestor)?;
+    ensure_path_within_allowed_roots(allowed_roots, primary_root, &canonical_ancestor)?;
 
     let mut reconstructed = canonical_ancestor;
     for component in suffix {
         reconstructed.push(component);
     }
-    ensure_path_within_root(root, &reconstructed)?;
+    ensure_path_within_allowed_roots(allowed_roots, primary_root, &reconstructed)?;
     Ok(reconstructed)
 }
 
-fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
-    let normalized_root = if root.exists() {
-        dunce::canonicalize(root)
-            .map(|resolved| dunce::simplified(&resolved).to_path_buf())
-            .unwrap_or_else(|_| dunce::simplified(root).to_path_buf())
-    } else {
-        dunce::simplified(root).to_path_buf()
-    };
+fn ensure_path_within_allowed_roots(
+    allowed_roots: &[PathBuf],
+    primary_root: &Path,
+    path: &Path,
+) -> Result<(), String> {
     let normalized_path = dunce::simplified(path);
-    if normalized_path.starts_with(&normalized_root) {
+    let path_is_allowed = allowed_roots
+        .iter()
+        .any(|allowed_root| normalized_path.starts_with(allowed_root));
+    if path_is_allowed {
         return Ok(());
     }
+
     Err(format!(
         "policy_denied: file path {} escapes configured file root {}",
         path.display(),
-        root.display()
+        primary_root.display()
     ))
 }
 

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -1371,10 +1371,8 @@ fn resolve_search_root(
     match root {
         Some(path) => resolve_safe_file_path_with_config(path, config),
         None => config
-            .file_root
-            .clone()
-            .map(canonicalize_or_fallback)
-            .transpose()?
+            .path_resolution_root()
+            .map(Path::to_path_buf)
             .or_else(|| std::env::current_dir().ok())
             .map(|path| canonicalize_or_fallback(path).unwrap_or_else(|_| PathBuf::from(".")))
             .ok_or_else(|| format!("{tool_name} could not determine a workspace root")),
@@ -1565,20 +1563,25 @@ pub(super) fn resolve_safe_file_path_with_config(
     raw: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<PathBuf, String> {
-    let root = config
-        .file_root
-        .clone()
+    let access_root = config
+        .filesystem_access_root()
+        .map(Path::to_path_buf)
+        .or_else(|| config.file_root.clone())
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-    let root = canonicalize_or_fallback(root)?;
+    let access_root = canonicalize_or_fallback(access_root)?;
+    let resolution_root = config
+        .path_resolution_root()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| access_root.clone());
 
     let candidate = Path::new(raw);
     let combined = if candidate.is_absolute() {
         candidate.to_path_buf()
     } else {
-        root.join(candidate)
+        resolution_root.join(candidate)
     };
     let normalized = super::normalize_without_fs(&combined);
-    resolve_path_within_root(&root, &normalized)
+    resolve_path_within_root(&access_root, &normalized)
 }
 
 pub(super) fn resolve_safe_directory_path_with_config(
@@ -1628,8 +1631,6 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
         return Ok(canonical);
     }
 
-    ensure_path_within_root(root, normalized)?;
-
     let (ancestor, suffix) = split_existing_ancestor(normalized)?;
     let canonical_ancestor = dunce::canonicalize(&ancestor).map_err(|error| {
         format!(
@@ -1649,9 +1650,15 @@ fn resolve_path_within_root(root: &Path, normalized: &Path) -> Result<PathBuf, S
 }
 
 fn ensure_path_within_root(root: &Path, path: &Path) -> Result<(), String> {
-    let normalized_root = dunce::simplified(root);
+    let normalized_root = if root.exists() {
+        dunce::canonicalize(root)
+            .map(|resolved| dunce::simplified(&resolved).to_path_buf())
+            .unwrap_or_else(|_| dunce::simplified(root).to_path_buf())
+    } else {
+        dunce::simplified(root).to_path_buf()
+    };
     let normalized_path = dunce::simplified(path);
-    if normalized_path.starts_with(normalized_root) {
+    if normalized_path.starts_with(&normalized_root) {
         return Ok(());
     }
     Err(format!(
@@ -1875,6 +1882,35 @@ mod tests {
 
         let written = fs::read_to_string(root.join("safe/note.txt")).expect("read written file");
         assert_eq!(written, "hello");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn resolve_safe_file_path_accepts_private_var_alias_inside_root() {
+        let base = unique_temp_dir("loong-file-private-var-alias");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let child = root.join("nested.txt");
+        fs::write(&child, "ok").expect("write child");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let raw = child.display().to_string();
+        let normalized_raw = if raw.starts_with("/private/var/") {
+            raw.replacen("/private/var/", "/var/", 1)
+        } else {
+            raw
+        };
+
+        let resolved = resolve_safe_file_path_with_config(&normalized_raw, &config)
+            .expect("alias path under root should resolve");
+
+        assert_eq!(
+            resolved,
+            dunce::canonicalize(&child).expect("canonicalize child path")
+        );
         let _ = fs::remove_dir_all(base);
     }
 

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -89,7 +89,13 @@ impl FilePolicyExtension {
         };
 
         let effective_root = self.canon_root.as_deref().unwrap_or(root);
-        let normalized_effective_root = super::normalize_without_fs(effective_root);
+        let normalized_effective_root = if effective_root.exists() {
+            dunce::canonicalize(effective_root)
+                .map(|resolved| dunce::simplified(&resolved).to_path_buf())
+                .unwrap_or_else(|_| super::normalize_without_fs(effective_root))
+        } else {
+            super::normalize_without_fs(effective_root)
+        };
 
         let candidate = Path::new(raw_path);
         let combined = if candidate.is_absolute() {

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -100,7 +100,8 @@ impl FilePolicyExtension {
 
         // 1. Try full canonicalize (works when the path already exists).
         if let Ok(canon) = combined.canonicalize() {
-            return !canon.starts_with(&normalized_effective_root);
+            let normalized_canon = dunce::simplified(&canon).to_path_buf();
+            return !normalized_canon.starts_with(&normalized_effective_root);
         }
 
         // 1.5. Path is a symlink but canonicalize failed (dangling target) —
@@ -117,7 +118,13 @@ impl FilePolicyExtension {
                     };
                     symlink_parent.join(&target)
                 };
-                let normalized_target = super::normalize_without_fs(&resolved);
+                let normalized_target = if resolved.exists() {
+                    dunce::canonicalize(&resolved)
+                        .map(|resolved| dunce::simplified(&resolved).to_path_buf())
+                        .unwrap_or_else(|_| super::normalize_without_fs(&resolved))
+                } else {
+                    super::normalize_without_fs(&resolved)
+                };
                 return !normalized_target.starts_with(&normalized_effective_root);
             }
             // Cannot read the link — conservatively deny.
@@ -129,7 +136,13 @@ impl FilePolicyExtension {
         //    as `file.write "nested/new.txt"` and keeps `/var` vs
         //    `/private/var` aliases aligned on macOS.
         if let Some(reconstructed_path) = reconstruct_from_existing_ancestor(&combined) {
-            let normalized_reconstructed = super::normalize_without_fs(&reconstructed_path);
+            let normalized_reconstructed = if reconstructed_path.exists() {
+                dunce::canonicalize(&reconstructed_path)
+                    .map(|resolved| dunce::simplified(&resolved).to_path_buf())
+                    .unwrap_or_else(|_| super::normalize_without_fs(&reconstructed_path))
+            } else {
+                super::normalize_without_fs(&reconstructed_path)
+            };
             return !normalized_reconstructed.starts_with(&normalized_effective_root);
         }
 
@@ -233,7 +246,11 @@ pub(crate) fn authorize_direct_file_payload(
     payload: &serde_json::Map<String, serde_json::Value>,
     rt: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<(), String> {
-    let extension = FilePolicyExtension::new(rt.file_root.clone());
+    let extension = FilePolicyExtension::new(
+        rt.filesystem_access_root()
+            .map(std::path::Path::to_path_buf)
+            .or_else(|| rt.file_root.clone()),
+    );
     extension
         .authorize_file_payload(tool_name, payload)
         .map_err(|error| format!("policy_denied: {error}"))

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -5,27 +5,81 @@ use loong_contracts::{Capability, PolicyError};
 use loong_kernel::{PolicyExtension, PolicyExtensionContext};
 
 pub struct FilePolicyExtension {
-    file_root: Option<PathBuf>,
-    canon_root: Option<PathBuf>,
+    primary_root: Option<PathBuf>,
+    normalized_allowed_roots: Vec<PathBuf>,
+    resolution_root: Option<PathBuf>,
+    canon_resolution_root: Option<PathBuf>,
 }
 
 impl FilePolicyExtension {
-    pub fn new(file_root: Option<PathBuf>) -> Self {
-        let canon_root = file_root.as_ref().and_then(|r| r.canonicalize().ok());
-        if file_root.is_some() && canon_root.is_none() {
+    pub fn new(access_root: Option<PathBuf>) -> Self {
+        let allowed_roots = access_root.iter().cloned().collect();
+        Self::from_roots(allowed_roots, access_root.clone(), access_root)
+    }
+
+    pub fn with_resolution_root(
+        access_root: Option<PathBuf>,
+        resolution_root: Option<PathBuf>,
+    ) -> Self {
+        let allowed_roots = access_root.iter().cloned().collect();
+        let primary_root = access_root.clone();
+        let effective_resolution_root = resolution_root.or(access_root);
+        Self::from_roots(allowed_roots, primary_root, effective_resolution_root)
+    }
+
+    pub fn from_runtime_config(rt: &super::runtime_config::ToolRuntimeConfig) -> Self {
+        let mut allowed_roots = Vec::new();
+
+        if let Some(file_root) = rt.file_root.as_ref() {
+            allowed_roots.push(file_root.clone());
+        }
+
+        if let Some(workspace_root) = rt.workspace_root.as_ref() {
+            let workspace_root_is_new = allowed_roots.iter().all(|root| root != workspace_root);
+            if workspace_root_is_new {
+                allowed_roots.push(workspace_root.clone());
+            }
+        }
+
+        let primary_root = allowed_roots.first().cloned();
+        let resolution_root = rt
+            .path_resolution_root()
+            .map(Path::to_path_buf)
+            .or_else(|| primary_root.clone());
+
+        Self::from_roots(allowed_roots, primary_root, resolution_root)
+    }
+
+    fn from_roots(
+        allowed_roots: Vec<PathBuf>,
+        primary_root: Option<PathBuf>,
+        resolution_root: Option<PathBuf>,
+    ) -> Self {
+        if primary_root.is_some() && allowed_roots.is_empty() {
             #[cfg(feature = "tool-file")]
             #[allow(clippy::print_stderr)]
             {
                 eprintln!(
                     "warning: file_root {:?} could not be canonicalized; \
                      symlink-aware path checks will use raw path comparison",
-                    file_root.as_deref().unwrap_or(Path::new("")),
+                    primary_root.as_deref().unwrap_or(Path::new("")),
                 );
             }
         }
+
+        let normalized_allowed_roots = allowed_roots
+            .iter()
+            .map(|root| normalize_path_for_policy(root.as_path()))
+            .collect();
+        let canon_resolution_root = resolution_root
+            .as_deref()
+            .and_then(canonicalize_existing_path_for_policy);
+
         Self {
-            file_root,
-            canon_root,
+            primary_root,
+            normalized_allowed_roots,
+            resolution_root,
+            canon_resolution_root,
         }
     }
 
@@ -83,31 +137,31 @@ impl FilePolicyExtension {
     ///   and `b` does not exist under the target), layer 4 cannot detect the
     ///   escape. The execution layer catches this at open time.
     fn path_escapes_root(&self, raw_path: &str) -> bool {
-        let root = match self.file_root.as_deref() {
-            Some(r) => r,
-            None => return false,
-        };
+        if self.normalized_allowed_roots.is_empty() {
+            return false;
+        }
 
-        let effective_root = self.canon_root.as_deref().unwrap_or(root);
-        let normalized_effective_root = if effective_root.exists() {
-            dunce::canonicalize(effective_root)
-                .map(|resolved| dunce::simplified(&resolved).to_path_buf())
-                .unwrap_or_else(|_| super::normalize_without_fs(effective_root))
-        } else {
-            super::normalize_without_fs(effective_root)
+        let resolution_root = self
+            .resolution_root
+            .as_deref()
+            .or(self.primary_root.as_deref());
+        let effective_resolution_root = self.canon_resolution_root.as_deref().or(resolution_root);
+        let effective_resolution_root = match effective_resolution_root {
+            Some(root) => root,
+            None => return false,
         };
 
         let candidate = Path::new(raw_path);
         let combined = if candidate.is_absolute() {
             candidate.to_path_buf()
         } else {
-            effective_root.join(candidate)
+            effective_resolution_root.join(candidate)
         };
 
         // 1. Try full canonicalize (works when the path already exists).
         if let Ok(canon) = combined.canonicalize() {
             let normalized_canon = dunce::simplified(&canon).to_path_buf();
-            return !normalized_canon.starts_with(&normalized_effective_root);
+            return !self.path_is_within_allowed_roots(normalized_canon.as_path());
         }
 
         // 1.5. Path is a symlink but canonicalize failed (dangling target) —
@@ -117,21 +171,15 @@ impl FilePolicyExtension {
                 let resolved = if target.is_absolute() {
                     target
                 } else {
-                    let raw_parent = combined.parent().unwrap_or(effective_root);
-                    let symlink_parent = match raw_parent.canonicalize() {
-                        Ok(parent) => parent,
-                        Err(_) => return true,
+                    let raw_parent = combined.parent().unwrap_or(effective_resolution_root);
+                    let symlink_parent = match canonicalize_existing_path_for_policy(raw_parent) {
+                        Some(parent) => parent,
+                        None => return true,
                     };
                     symlink_parent.join(&target)
                 };
-                let normalized_target = if resolved.exists() {
-                    dunce::canonicalize(&resolved)
-                        .map(|resolved| dunce::simplified(&resolved).to_path_buf())
-                        .unwrap_or_else(|_| super::normalize_without_fs(&resolved))
-                } else {
-                    super::normalize_without_fs(&resolved)
-                };
-                return !normalized_target.starts_with(&normalized_effective_root);
+                let normalized_target = normalize_path_for_policy(resolved.as_path());
+                return !self.path_is_within_allowed_roots(normalized_target.as_path());
             }
             // Cannot read the link — conservatively deny.
             return true;
@@ -142,19 +190,19 @@ impl FilePolicyExtension {
         //    as `file.write "nested/new.txt"` and keeps `/var` vs
         //    `/private/var` aliases aligned on macOS.
         if let Some(reconstructed_path) = reconstruct_from_existing_ancestor(&combined) {
-            let normalized_reconstructed = if reconstructed_path.exists() {
-                dunce::canonicalize(&reconstructed_path)
-                    .map(|resolved| dunce::simplified(&resolved).to_path_buf())
-                    .unwrap_or_else(|_| super::normalize_without_fs(&reconstructed_path))
-            } else {
-                super::normalize_without_fs(&reconstructed_path)
-            };
-            return !normalized_reconstructed.starts_with(&normalized_effective_root);
+            let normalized_reconstructed = normalize_path_for_policy(reconstructed_path.as_path());
+            return !self.path_is_within_allowed_roots(normalized_reconstructed.as_path());
         }
 
         // 3. Neither path nor parent exists — fall back to pure normalization.
         let normalized = super::normalize_without_fs(&combined);
-        !normalized.starts_with(&normalized_effective_root)
+        !self.path_is_within_allowed_roots(normalized.as_path())
+    }
+
+    fn path_is_within_allowed_roots(&self, path: &Path) -> bool {
+        self.normalized_allowed_roots
+            .iter()
+            .any(|allowed_root| path.starts_with(allowed_root))
     }
 
     fn raw_paths_for_request<'a>(
@@ -196,7 +244,7 @@ impl FilePolicyExtension {
         tool_name: &str,
         payload: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<(), PolicyError> {
-        let Some(root) = self.file_root.as_deref() else {
+        let Some(root) = self.primary_root.as_deref() else {
             return Ok(());
         };
 
@@ -222,6 +270,25 @@ impl FilePolicyExtension {
     }
 }
 
+fn canonicalize_existing_path_for_policy(path: &Path) -> Option<PathBuf> {
+    if !path.exists() {
+        return None;
+    }
+
+    dunce::canonicalize(path)
+        .ok()
+        .map(|resolved| dunce::simplified(&resolved).to_path_buf())
+}
+
+fn normalize_path_for_policy(path: &Path) -> PathBuf {
+    let canonicalized_path = canonicalize_existing_path_for_policy(path);
+    if let Some(canonicalized_path) = canonicalized_path {
+        return canonicalized_path;
+    }
+
+    super::normalize_without_fs(path)
+}
+
 fn reconstruct_from_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let mut suffix_components = Vec::new();
     let mut cursor = path;
@@ -232,7 +299,7 @@ fn reconstruct_from_existing_ancestor(path: &Path) -> Option<PathBuf> {
         cursor = cursor.parent()?;
     }
 
-    let mut reconstructed = cursor.canonicalize().ok()?;
+    let mut reconstructed = canonicalize_existing_path_for_policy(cursor)?;
     for component in suffix_components.iter().rev() {
         reconstructed.push(component);
     }
@@ -252,11 +319,7 @@ pub(crate) fn authorize_direct_file_payload(
     payload: &serde_json::Map<String, serde_json::Value>,
     rt: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<(), String> {
-    let extension = FilePolicyExtension::new(
-        rt.filesystem_access_root()
-            .map(std::path::Path::to_path_buf)
-            .or_else(|| rt.file_root.clone()),
-    );
+    let extension = FilePolicyExtension::from_runtime_config(rt);
     extension
         .authorize_file_payload(tool_name, payload)
         .map_err(|error| format!("policy_denied: {error}"))

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -926,10 +926,12 @@ pub fn execute_tool_core_with_config(
     let mut effective_config = config
         .workspace_root
         .clone()
-        .map(|workspace_root| config.with_file_root_override(workspace_root))
+        .map(|workspace_root| config.with_workspace_root_override(workspace_root))
         .unwrap_or_else(|| config.clone());
     if let Some(workspace_root) = workspace_root {
-        effective_config = effective_config.with_file_root_override(workspace_root);
+        effective_config = effective_config
+            .with_workspace_root_override(workspace_root.clone())
+            .with_file_root_override(workspace_root);
     }
     if let Some(runtime_narrowing) = runtime_narrowing {
         effective_config = effective_config.narrowed(&runtime_narrowing);

--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -129,8 +129,7 @@ fn parse_optional_process_cwd<'a>(
 
 #[cfg(feature = "tool-shell")]
 fn default_process_cwd_with_config(config: &super::runtime_config::ToolRuntimeConfig) -> PathBuf {
-    let configured_root = config.file_root.clone();
-    if let Some(configured_root) = configured_root {
+    if let Some(configured_root) = config.path_resolution_root().map(Path::to_path_buf) {
         return configured_root;
     }
 
@@ -147,7 +146,7 @@ fn resolve_process_cwd_override(
     config: &super::runtime_config::ToolRuntimeConfig,
     tool_name: &str,
 ) -> Result<PathBuf, String> {
-    if config.file_root.is_some() {
+    if config.filesystem_access_root().is_some() {
         return super::file::resolve_safe_directory_path_with_config(raw_cwd, config);
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -750,10 +750,25 @@ impl ToolRuntimeConfig {
         configured_workspace_root.or(fallback_file_root)
     }
 
+    pub fn path_resolution_root(&self) -> Option<&Path> {
+        self.workspace_root.as_deref().or(self.file_root.as_deref())
+    }
+
+    pub fn filesystem_access_root(&self) -> Option<&Path> {
+        match (self.file_root.as_deref(), self.workspace_root.as_deref()) {
+            (Some(file_root), Some(workspace_root)) if workspace_root.starts_with(file_root) => {
+                Some(file_root)
+            }
+            (_, Some(workspace_root)) => Some(workspace_root),
+            (Some(file_root), None) => Some(file_root),
+            (None, None) => None,
+        }
+    }
+
     pub fn default_working_directory(&self) -> PathBuf {
-        let configured_root = self.file_root.clone();
-        let fallback_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        configured_root.unwrap_or(fallback_root)
+        self.path_resolution_root()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
     }
 
     pub fn from_loong_config(config: &LoongConfig, config_path: Option<&Path>) -> Self {

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -242,6 +242,34 @@ mod tests {
     }
 
     #[test]
+    fn shell_exec_defaults_cwd_to_runtime_workspace_root_without_shrinking_file_root() {
+        let root = unique_temp_dir("loong-shell-default-cwd-root");
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace root");
+        let mut config = shell_test_config(&root);
+        config.workspace_root = Some(workspace.clone());
+        let request = ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({
+                "command": "pwd"
+            }),
+        };
+
+        let outcome = execute_shell_tool_for_subprocess_test(request, &config)
+            .expect("shell.exec should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["cwd"], workspace.display().to_string());
+        let stdout = outcome.payload["stdout"]
+            .as_str()
+            .expect("stdout should be text");
+        assert!(
+            stdout.ends_with(workspace.display().to_string().as_str()),
+            "expected pwd output to resolve inside runtime workspace root, got: {stdout}"
+        );
+    }
+
+    #[test]
     fn shell_exec_rejects_cwd_that_escapes_configured_file_root() {
         let root = unique_temp_dir("loong-shell-cwd-root");
         let outside = unique_temp_dir("loong-shell-cwd-outside");

--- a/crates/app/src/tools/workspace_root_tests.rs
+++ b/crates/app/src/tools/workspace_root_tests.rs
@@ -49,6 +49,8 @@ fn file_read_uses_runtime_workspace_root_from_runtime_config() {
     std::fs::create_dir_all(&runtime_root).expect("create runtime root");
     std::fs::write(outer_root.join("note.txt"), "outer").expect("write outer note");
     std::fs::write(runtime_root.join("note.txt"), "runtime").expect("write runtime note");
+    let expected_path =
+        dunce::canonicalize(runtime_root.join("note.txt")).expect("canonicalize runtime note");
 
     let mut config = test_tool_runtime_config(outer_root.clone());
     config.workspace_root = Some(runtime_root.clone());
@@ -66,12 +68,52 @@ fn file_read_uses_runtime_workspace_root_from_runtime_config() {
 
     assert_eq!(outcome.status, "ok");
     assert_eq!(outcome.payload["content"], "runtime");
-    let expected_path =
-        dunce::canonicalize(runtime_root.join("note.txt")).expect("canonicalize runtime note");
     assert_eq!(outcome.payload["path"], expected_path.display().to_string());
 
     std::fs::remove_dir_all(&outer_root).ok();
     std::fs::remove_dir_all(&runtime_root).ok();
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn file_read_relative_resolution_uses_workspace_root_without_shrinking_file_root_access() {
+    let outer_root = std::env::temp_dir().join(format!(
+        "loong-file-read-relative-resolution-outer-{}",
+        std::process::id()
+    ));
+    let runtime_root = outer_root.join("workspace");
+    std::fs::create_dir_all(&runtime_root).expect("create runtime root");
+    std::fs::write(outer_root.join("outer.txt"), "outer").expect("write outer note");
+    std::fs::write(runtime_root.join("inner.txt"), "inner").expect("write runtime note");
+
+    let mut config = test_tool_runtime_config(outer_root.clone());
+    config.workspace_root = Some(runtime_root);
+
+    let relative_outcome = execute_tool_core_with_test_context(
+        ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({
+                "path": "inner.txt"
+            }),
+        },
+        &config,
+    )
+    .expect("relative path should resolve from workspace root");
+    assert_eq!(relative_outcome.payload["content"], "inner");
+
+    let absolute_outcome = execute_tool_core_with_test_context(
+        ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({
+                "path": outer_root.join("outer.txt").display().to_string()
+            }),
+        },
+        &config,
+    )
+    .expect("absolute path inside file_root should still be allowed");
+    assert_eq!(absolute_outcome.payload["content"], "outer");
+
+    std::fs::remove_dir_all(&outer_root).ok();
 }
 
 #[cfg(feature = "tool-file")]


### PR DESCRIPTION
## Summary

- Problem:
  The current interactive chat path had two related operator-facing seams. The TUI could leak internal tool/provider tail text or render assistant streaming in a jarring double-pass way, and the tool runtime could let the launch workspace root incorrectly collapse the effective file sandbox root even when `tools.file_root` was intentionally broader.
- Why it matters:
  The first issue made the chat surface feel unstable and low-trust. The second broke expected access to valid paths outside the current workspace while still inside the configured file root.
- What changed:
  Hardened transcript/pending rendering, moved live chat preview handling onto a structured payload, and separated workspace-relative path resolution from true file-root enforcement in the tool runtime.
- What did not change (scope boundary):
  This does not redesign the overall chat layout or replace the broader workspace-guidance/runtime-self model. It only tightens the current rendering and root-enforcement seams.

## Linked Issues

- Closes #1448
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy -p loong-app --all-targets --all-features -- -D warnings
./scripts/cargo-local-toolchain.sh test -p loong-app --lib --quiet
cargo test -p loong-app pending_preview_ -- --nocapture
cargo test -p loong-app pending_signature_ -- --nocapture
cargo test -p loong-app preview_emit_ -- --nocapture
cargo test -p loong-app cli_chat_live_surface_observer_ -- --nocapture
cargo test -p loong-app compact_observer_ -- --nocapture
cargo test -p loong-app width_resize_ -- --nocapture
cargo test -p loong-app workspace_root_tests -- --nocapture
cargo test -p loong-app file_write_ -- --nocapture
cargo test -p loong-app feishu_messages_resource_get_tool_ -- --nocapture
cargo test -p loong-app shell_exec_rejects_missing_cwd_directory -- --nocapture
cargo test -p loong-app pending_preview_keeps_plain_reply_with_tool_like_prefix_out_of_pending_band -- --nocapture
cargo test -p loong-app transcript_preview_signature_changes_when_plain_preview_changes -- --nocapture

Result summary:
- loong-app lib suite passed: 4143 passed, 0 failed
- focused TUI streaming / resize / pending suites passed
- focused workspace_root / file_root / shell / feishu resource suites passed
```

## User-visible / Operator-visible Changes

- Assistant streaming now stays in a single transcript path instead of presenting a visible duplicate pass between pending and settled output.
- Internal tool/provider tail lines are hidden from normal assistant transcript rendering.
- Interactive chat can keep workspace-relative behavior without incorrectly shrinking a broader configured `tools.file_root` access boundary.

## Failure Recovery

- Fast rollback or disable path:
  Revert `c00b1e5a` to restore the prior workspace-root/file-root coupling, or revert `478caa8d` plus the chat rendering follow-ups to restore the prior pending/transcript rendering behavior.
- Observable failure symptoms reviewers should watch for:
  Transcript preview lines misclassified as tool activity, file paths inside a configured file root being denied when they should succeed, or assistant transcript rows jumping unexpectedly after a pending turn settles.

## Reviewer Focus

- `crates/app/src/chat/chat_surface/app.rs`, `message_list.rs`, and `live_runtime.rs` for the transcript/pending/render cadence seams.
- `crates/app/src/tools/runtime_config.rs`, `file.rs`, `file_policy_ext.rs`, `process_exec.rs`, and `mod.rs` for the split between workspace-relative resolution and actual file-root enforcement.
- The new regression tests around pending preview prefixes and workspace-root/file-root interactions.
