### PR TITLE
Stabilize IM conversation session routing and explicit reset

### DIFF
--- a/crates/app/src/channel/core/types.rs
+++ b/crates/app/src/channel/core/types.rs
@@ -153,6 +153,10 @@ pub struct ChannelSession {
     pub conversation_id: String,
     pub participant_id: Option<String>,
     pub thread_id: Option<String>,
+    #[serde(default)]
+    pub identity_participant_scoped: bool,
+    #[serde(default)]
+    pub identity_thread_scoped: bool,
 }
 
 impl ChannelSession {
@@ -164,6 +168,8 @@ impl ChannelSession {
             conversation_id: conversation_id.into(),
             participant_id: None,
             thread_id: None,
+            identity_participant_scoped: false,
+            identity_thread_scoped: false,
         }
     }
 
@@ -179,6 +185,8 @@ impl ChannelSession {
             conversation_id: conversation_id.into(),
             participant_id: None,
             thread_id: None,
+            identity_participant_scoped: false,
+            identity_thread_scoped: false,
         }
     }
 
@@ -194,6 +202,8 @@ impl ChannelSession {
             conversation_id: conversation_id.into(),
             participant_id: None,
             thread_id: Some(thread_id.into()),
+            identity_participant_scoped: true,
+            identity_thread_scoped: true,
         }
     }
 
@@ -210,6 +220,8 @@ impl ChannelSession {
             conversation_id: conversation_id.into(),
             participant_id: None,
             thread_id: Some(thread_id.into()),
+            identity_participant_scoped: true,
+            identity_thread_scoped: true,
         }
     }
 
@@ -225,6 +237,16 @@ impl ChannelSession {
 
     pub fn with_thread_id(mut self, thread_id: impl Into<String>) -> Self {
         self.thread_id = Some(thread_id.into());
+        self
+    }
+
+    pub fn with_identity_participant_scoped(mut self, scoped: bool) -> Self {
+        self.identity_participant_scoped = scoped;
+        self
+    }
+
+    pub fn with_identity_thread_scoped(mut self, scoped: bool) -> Self {
+        self.identity_thread_scoped = scoped;
         self
     }
 
@@ -261,10 +283,14 @@ impl ChannelSession {
             parts.push(encode_route_session_segment(account_id));
         }
         parts.push(encode_route_session_segment(conversation_id));
-        if let Some(participant_id) = participant_id {
+        if self.identity_participant_scoped
+            && let Some(participant_id) = participant_id
+        {
             parts.push(encode_route_session_segment(participant_id));
         }
-        if let Some(thread_id) = thread_id {
+        if self.identity_thread_scoped
+            && let Some(thread_id) = thread_id
+        {
             parts.push(encode_route_session_segment(thread_id));
         }
         parts.join(":")
@@ -276,10 +302,14 @@ impl ChannelSession {
         if let Some(account_id) = self.account_id.as_deref() {
             address = address.with_account_id(account_id);
         }
-        if let Some(participant_id) = self.participant_id.as_deref() {
+        if self.identity_participant_scoped
+            && let Some(participant_id) = self.participant_id.as_deref()
+        {
             address = address.with_participant_id(participant_id);
         }
-        if let Some(thread_id) = self.thread_id.as_deref() {
+        if self.identity_thread_scoped
+            && let Some(thread_id) = self.thread_id.as_deref()
+        {
             address = address.with_thread_id(thread_id);
         }
         address

--- a/crates/app/src/channel/feishu/payload/tests.rs
+++ b/crates/app/src/channel/feishu/payload/tests.rs
@@ -149,7 +149,7 @@ fn feishu_message_event_parses_text_payload() {
     assert_eq!(event.session.configured_account_id.as_deref(), Some("work"));
     assert_eq!(
         event.session.session_key(),
-        "feishu:cfg=work:feishu_cli_a1b2c3:oc_123:ou_sender_1:om_root_1"
+        "feishu:cfg=work:feishu_cli_a1b2c3:oc_123"
     );
     assert_eq!(
         event.reply_target,
@@ -306,10 +306,7 @@ fn feishu_message_event_uses_thread_id_and_sender_open_id_when_present() {
 
     let event = expect_inbound(action);
 
-    assert_eq!(
-        event.session.session_key(),
-        "feishu:feishu_main:oc_123:ou_123:omt_456"
-    );
+    assert_eq!(event.session.session_key(), "feishu:feishu_main:oc_123");
     assert_eq!(event.session.thread_id.as_deref(), Some("omt_456"));
     assert_eq!(event.reply_target.feishu_reply_chat_id(), Some("oc_123"));
     assert_eq!(event.reply_target.feishu_reply_in_thread(), Some(true));
@@ -425,10 +422,7 @@ fn feishu_card_callback_v2_payload_is_not_ignored() {
         Some("om_callback_1")
     );
     assert_eq!(event.context.open_chat_id.as_deref(), Some("oc_123"));
-    assert_eq!(
-        event.session.session_key(),
-        "feishu:feishu_main:oc_123:ou_operator_1:om_callback_1"
-    );
+    assert_eq!(event.session.session_key(), "feishu:feishu_main:oc_123");
     assert_eq!(
         event.principal.as_ref().map(|value| value.open_id.as_str()),
         Some("ou_operator_1")
@@ -554,10 +548,7 @@ fn feishu_card_callback_v1_payload_is_not_ignored() {
         Some("om_callback_legacy")
     );
     assert_eq!(event.context.open_chat_id.as_deref(), Some("oc_123"));
-    assert_eq!(
-        event.session.session_key(),
-        "feishu:feishu_main:oc_123:ou_operator_legacy:om_callback_legacy"
-    );
+    assert_eq!(event.session.session_key(), "feishu:feishu_main:oc_123");
     assert_eq!(
         event
             .principal
@@ -1674,7 +1665,7 @@ fn feishu_encrypted_payload_parses_with_encrypt_key() {
     assert_eq!(event.event_id, "evt_encrypted_1");
     assert_eq!(
         event.session.session_key(),
-        "feishu:feishu_cli_a1b2c3:oc_encrypt:ou_sender_encrypt:om_thread_encrypt"
+        "feishu:feishu_cli_a1b2c3:oc_encrypt"
     );
     assert_eq!(
         event.reply_target,

--- a/crates/app/src/channel/inbound_turn.rs
+++ b/crates/app/src/channel/inbound_turn.rs
@@ -76,12 +76,32 @@ fn resolve_channel_conversation_address(
         }
     };
 
-    let mut effective = ConversationSessionAddress::from_session_id(active_session_id)
+    Ok(build_effective_channel_conversation_address(
+        active_session_id.as_str(),
+        session,
+    ))
+}
+
+fn build_effective_channel_conversation_address(
+    session_id: &str,
+    session: &ChannelSession,
+) -> ConversationSessionAddress {
+    let mut effective = ConversationSessionAddress::from_session_id(session_id)
         .with_channel_scope(session.platform.as_str(), session.conversation_id.clone());
     if let Some(account_id) = session.account_id.as_deref() {
         effective = effective.with_account_id(account_id);
     }
-    Ok(effective)
+    if session.identity_participant_scoped
+        && let Some(participant_id) = session.participant_id.as_deref()
+    {
+        effective = effective.with_participant_id(participant_id);
+    }
+    if session.identity_thread_scoped
+        && let Some(thread_id) = session.thread_id.as_deref()
+    {
+        effective = effective.with_thread_id(thread_id);
+    }
+    effective
 }
 
 fn unix_time_ms_now() -> i64 {
@@ -383,15 +403,10 @@ async fn maybe_reset_channel_session(
         && let Some(binding) = prior_binding.as_ref()
     {
         let manager = crate::acp::shared_acp_session_manager(config)?;
-        let mut active_address =
-            ConversationSessionAddress::from_session_id(binding.active_session_id.clone())
-                .with_channel_scope(
-                    message.session.platform.as_str(),
-                    message.session.conversation_id.clone(),
-                );
-        if let Some(account_id) = message.session.account_id.as_deref() {
-            active_address = active_address.with_account_id(account_id);
-        }
+        let active_address = build_effective_channel_conversation_address(
+            binding.active_session_id.as_str(),
+            &message.session,
+        );
         if let Ok(route) =
             crate::acp::derive_acp_conversation_route_for_address(config, &active_address)
         {
@@ -662,6 +677,32 @@ mod tests {
             .expect("load route binding")
             .expect("route binding exists");
         assert_eq!(binding.active_session_id, first.session_id);
+    }
+
+    #[test]
+    fn resolve_channel_conversation_address_preserves_opt_in_thread_scope() {
+        let config = isolated_config("thread-scope");
+        let session = ChannelSession::with_account(ChannelPlatform::Telegram, "bot_123456", "42")
+            .with_thread_id("7")
+            .with_identity_thread_scoped(true);
+
+        let address = resolve_channel_conversation_address(&config, &session)
+            .expect("resolve thread-scoped route address");
+
+        assert_eq!(address.session_id, "telegram:bot_123456:42:7");
+        assert_eq!(address.channel_id.as_deref(), Some("telegram"));
+        assert_eq!(address.account_id.as_deref(), Some("bot_123456"));
+        assert_eq!(address.conversation_id.as_deref(), Some("42"));
+        assert_eq!(address.thread_id.as_deref(), Some("7"));
+        assert!(address.participant_id.is_none());
+
+        let repo = SessionRepository::new(&SessionStoreConfig::from_memory_config(&config.memory))
+            .expect("session repository");
+        let binding = repo
+            .load_session_route_binding("telegram:bot_123456:42:7")
+            .expect("load route binding")
+            .expect("route binding exists");
+        assert_eq!(binding.active_session_id, address.session_id);
     }
 
     #[tokio::test]

--- a/crates/app/src/channel/inbound_turn.rs
+++ b/crates/app/src/channel/inbound_turn.rs
@@ -452,7 +452,9 @@ fn fresh_local_session_id(route_session_id: &str) -> String {
             sanitized.push('_');
         }
     }
-    format!("{sanitized}__new__{}", unix_time_ms_now())
+    let timestamp_ms = unix_time_ms_now();
+    let random_suffix = rand::random::<u64>();
+    format!("{sanitized}__new__{timestamp_ms}_{random_suffix:016x}")
 }
 
 pub(super) fn reload_channel_turn_config(

--- a/crates/app/src/channel/inbound_turn.rs
+++ b/crates/app/src/channel/inbound_turn.rs
@@ -10,6 +10,8 @@ use crate::{
         ConversationIngressPrivateContext, ConversationRuntime, ConversationRuntimeBinding,
         ConversationSessionAddress, ConversationTurnCoordinator, ProviderErrorMode,
     },
+    session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState},
+    session::store::SessionStoreConfig,
 };
 
 use super::{
@@ -32,7 +34,7 @@ fn prepare_channel_inbound_turn(
     message: &ChannelInboundMessage,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<PreparedChannelInboundTurn> {
-    let address = message.session.conversation_address();
+    let address = resolve_channel_conversation_address(config, &message.session)?;
     let acp_turn_hints = resolve_channel_acp_turn_hints(config, &message.session)?;
     let ingress = channel_message_ingress_context(message);
     let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
@@ -43,6 +45,50 @@ fn prepare_channel_inbound_turn(
         ingress,
         feedback_capture,
     })
+}
+
+fn resolve_channel_conversation_address(
+    config: &LoongConfig,
+    session: &ChannelSession,
+) -> CliResult<ConversationSessionAddress> {
+    let route_address = session.conversation_address();
+    let route_session_id = route_address.session_id.trim();
+    if route_session_id.is_empty() {
+        return Err("channel conversation route requires a non-empty session id".to_owned());
+    }
+
+    let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config)?;
+    let active_session_id = match repo.load_session_route_binding(route_session_id)? {
+        Some(binding) => binding.active_session_id,
+        None => {
+            let active_session_id = route_session_id.to_owned();
+            let _ = repo.ensure_session(NewSessionRecord {
+                session_id: active_session_id.clone(),
+                kind: SessionKind::Root,
+                parent_session_id: None,
+                label: Some(route_session_id.to_owned()),
+                state: SessionState::Ready,
+            })?;
+            let _ =
+                repo.upsert_session_route_binding(route_session_id, active_session_id.as_str())?;
+            active_session_id
+        }
+    };
+
+    let mut effective = ConversationSessionAddress::from_session_id(active_session_id)
+        .with_channel_scope(session.platform.as_str(), session.conversation_id.clone());
+    if let Some(account_id) = session.account_id.as_deref() {
+        effective = effective.with_account_id(account_id);
+    }
+    Ok(effective)
+}
+
+fn unix_time_ms_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -195,6 +241,10 @@ pub async fn process_inbound_with_provider_and_error_mode(
     error_mode: ProviderErrorMode,
     retry_progress: crate::provider::ProviderRetryProgressCallback,
 ) -> CliResult<String> {
+    if let Some(reply) = maybe_reset_channel_session(config, message).await? {
+        return Ok(reply);
+    }
+
     let started_at = std::time::Instant::now();
     let result = match reload_channel_turn_config(config, resolved_path) {
         Ok(turn_config) => {
@@ -308,6 +358,86 @@ pub async fn process_inbound_with_provider_and_error_mode(
         }
     }
     result
+}
+
+async fn maybe_reset_channel_session(
+    config: &LoongConfig,
+    message: &ChannelInboundMessage,
+) -> CliResult<Option<String>> {
+    if !is_channel_session_reset_command(message.text.as_str()) {
+        return Ok(None);
+    }
+
+    let route_address = message.session.conversation_address();
+    let route_session_id = route_address.session_id.trim();
+    if route_session_id.is_empty() {
+        return Err("channel session reset requires a stable route session id".to_owned());
+    }
+
+    let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config)?;
+    let prior_binding = repo.load_session_route_binding(route_session_id)?;
+
+    if config.acp.enabled
+        && config.acp.dispatch_enabled()
+        && let Some(binding) = prior_binding.as_ref()
+    {
+        let manager = crate::acp::shared_acp_session_manager(config)?;
+        let mut active_address =
+            ConversationSessionAddress::from_session_id(binding.active_session_id.clone())
+                .with_channel_scope(
+                    message.session.platform.as_str(),
+                    message.session.conversation_id.clone(),
+                );
+        if let Some(account_id) = message.session.account_id.as_deref() {
+            active_address = active_address.with_account_id(account_id);
+        }
+        if let Ok(route) =
+            crate::acp::derive_acp_conversation_route_for_address(config, &active_address)
+        {
+            let _ = manager.close(config, route.session_key.as_str()).await;
+        }
+    }
+
+    let next_session_id = fresh_local_session_id(route_session_id);
+    let _ = repo.ensure_session(NewSessionRecord {
+        session_id: next_session_id.clone(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some(route_session_id.to_owned()),
+        state: SessionState::Ready,
+    })?;
+    let _ = repo.upsert_session_route_binding(route_session_id, next_session_id.as_str())?;
+
+    Ok(Some(format!(
+        "Started a new session for this conversation. Session ID: {}",
+        next_session_id
+    )))
+}
+
+fn is_channel_session_reset_command(input: &str) -> bool {
+    let trimmed = input.trim();
+    let command = trimmed.split_whitespace().next().unwrap_or_default().trim();
+    if command != trimmed {
+        return false;
+    }
+    let normalized = command
+        .split_once('@')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(command);
+    matches!(normalized, "/new" | ":new" | "/reset" | ":reset")
+}
+
+fn fresh_local_session_id(route_session_id: &str) -> String {
+    let mut sanitized = String::with_capacity(route_session_id.len());
+    for ch in route_session_id.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-') {
+            sanitized.push(ch);
+        } else {
+            sanitized.push('_');
+        }
+    }
+    format!("{sanitized}__new__{}", unix_time_ms_now())
 }
 
 pub(super) fn reload_channel_turn_config(
@@ -482,4 +612,135 @@ fn normalized_feishu_callback_context(
         return None;
     }
     Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{maybe_reset_channel_session, resolve_channel_conversation_address};
+    use crate::channel::{ChannelPlatform, ChannelSession};
+    use crate::config::LoongConfig;
+    use crate::session::repository::SessionRepository;
+    use crate::session::store::SessionStoreConfig;
+
+    fn isolated_config(test_name: &str) -> LoongConfig {
+        let sqlite_path = std::env::temp_dir().join(format!(
+            "loong-im-route-binding-{test_name}-{}.sqlite3",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&sqlite_path);
+        let mut config = LoongConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        config
+    }
+
+    #[test]
+    fn resolve_channel_conversation_address_reuses_existing_route_binding() {
+        let config = isolated_config("reuse");
+        let session =
+            ChannelSession::with_account(ChannelPlatform::Feishu, "lark_cli_a1b2c3", "oc_123")
+                .with_configured_account_id("work")
+                .with_participant_id("ou_sender_1")
+                .with_thread_id("om_thread_1");
+
+        let first = resolve_channel_conversation_address(&config, &session)
+            .expect("resolve first route address");
+        let second = resolve_channel_conversation_address(&config, &session)
+            .expect("resolve second route address");
+
+        assert_eq!(first.session_id, second.session_id);
+        assert_eq!(first.session_id, "feishu:cfg=work:lark_cli_a1b2c3:oc_123");
+        assert_eq!(first.channel_id.as_deref(), Some("feishu"));
+        assert_eq!(first.account_id.as_deref(), Some("lark_cli_a1b2c3"));
+        assert_eq!(first.conversation_id.as_deref(), Some("oc_123"));
+        assert!(first.participant_id.is_none());
+        assert!(first.thread_id.is_none());
+
+        let repo = SessionRepository::new(&SessionStoreConfig::from_memory_config(&config.memory))
+            .expect("session repository");
+        let binding = repo
+            .load_session_route_binding("feishu:cfg=work:lark_cli_a1b2c3:oc_123")
+            .expect("load route binding")
+            .expect("route binding exists");
+        assert_eq!(binding.active_session_id, first.session_id);
+    }
+
+    #[tokio::test]
+    async fn reset_command_rotates_route_binding_to_new_local_session() {
+        let config = isolated_config("reset");
+        let session =
+            ChannelSession::with_account(ChannelPlatform::Feishu, "lark_cli_a1b2c3", "oc_123")
+                .with_configured_account_id("work");
+        let message = crate::channel::ChannelInboundMessage {
+            session: session.clone(),
+            reply_target: crate::channel::ChannelOutboundTarget::feishu_receive_id("oc_123"),
+            text: "/new".to_owned(),
+            delivery: crate::channel::ChannelDelivery::default(),
+        };
+
+        let before = resolve_channel_conversation_address(&config, &session)
+            .expect("resolve initial route address");
+        let memory_config = SessionStoreConfig::from_memory_config(&config.memory);
+        crate::session::store::append_session_turn_direct(
+            before.session_id.as_str(),
+            "user",
+            "before reset",
+            &memory_config,
+        )
+        .expect("seed prior session history");
+        let reply = maybe_reset_channel_session(&config, &message)
+            .await
+            .expect("reset channel session")
+            .expect("reset reply");
+        let after = resolve_channel_conversation_address(&config, &session)
+            .expect("resolve route address after reset");
+
+        assert!(reply.contains("Started a new session"));
+        assert_ne!(before.session_id, after.session_id);
+        assert!(!after.session_id.contains(':'));
+
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        let binding = repo
+            .load_session_route_binding("feishu:cfg=work:lark_cli_a1b2c3:oc_123")
+            .expect("load route binding")
+            .expect("route binding exists");
+        assert_eq!(binding.active_session_id, after.session_id);
+        assert!(
+            repo.load_session(before.session_id.as_str())
+                .expect("load prior session")
+                .is_some()
+        );
+
+        let resumed = crate::chat::initialize_cli_turn_runtime_with_loaded_config(
+            std::path::PathBuf::from("/tmp/loong.toml"),
+            config.clone(),
+            Some(after.session_id.as_str()),
+            &crate::chat::CliChatOptions::default(),
+            "cli-chat-im-reset-resume-test",
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("reopen rotated IM local session");
+        assert_eq!(resumed.session_id, after.session_id);
+
+        let prior_resumed = crate::chat::initialize_cli_turn_runtime_with_loaded_config(
+            std::path::PathBuf::from("/tmp/loong.toml"),
+            config.clone(),
+            Some(before.session_id.as_str()),
+            &crate::chat::CliChatOptions::default(),
+            "cli-chat-im-prior-session-test",
+            crate::chat::CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("reopen prior IM local session");
+        assert_eq!(prior_resumed.session_id, before.session_id);
+    }
+
+    #[test]
+    fn reset_command_parser_accepts_exact_commands_and_optional_mentions_only() {
+        assert!(super::is_channel_session_reset_command("/new"));
+        assert!(super::is_channel_session_reset_command("/new@LoongBot"));
+        assert!(super::is_channel_session_reset_command("/reset"));
+        assert!(!super::is_channel_session_reset_command("/new please"));
+        assert!(!super::is_channel_session_reset_command("please /new"));
+    }
 }

--- a/crates/app/src/channel/matrix.rs
+++ b/crates/app/src/channel/matrix.rs
@@ -647,7 +647,11 @@ mod tests {
         assert_eq!(inbox.len(), 1);
         assert_eq!(
             inbox[0].session.session_key(),
-            "matrix:ops-bot:~b64~IW9wczpleGFtcGxlLm9yZw:~b64~QGFsaWNlOmV4YW1wbGUub3Jn"
+            "matrix:ops-bot:~b64~IW9wczpleGFtcGxlLm9yZw"
+        );
+        assert_eq!(
+            inbox[0].session.participant_id.as_deref(),
+            Some("@alice:example.org")
         );
         assert_eq!(inbox[0].text, "hello matrix");
         assert_eq!(inbox[0].reply_target.id, "!ops:example.org");

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -871,14 +871,11 @@ mod tests {
         feature = "channel-matrix"
     ))]
     #[test]
-    fn channel_session_key_includes_participant_id_when_present() {
+    fn channel_session_key_excludes_participant_id_by_default() {
         let session =
             ChannelSession::with_account(ChannelPlatform::Feishu, "lark_cli_a1b2c3", "oc_123")
                 .with_participant_id("ou_sender_1");
-        assert_eq!(
-            session.session_key(),
-            "feishu:lark_cli_a1b2c3:oc_123:ou_sender_1"
-        );
+        assert_eq!(session.session_key(), "feishu:lark_cli_a1b2c3:oc_123");
     }
 
     #[cfg(any(
@@ -906,11 +903,27 @@ mod tests {
         feature = "channel-matrix"
     ))]
     #[test]
-    fn channel_session_key_includes_account_participant_and_thread_when_present() {
+    fn channel_session_key_excludes_account_participant_and_thread_by_default() {
         let session =
             ChannelSession::with_account(ChannelPlatform::Feishu, "lark_cli_a1b2c3", "oc_123")
                 .with_participant_id("ou_sender_1")
                 .with_thread_id("om_root_1");
+        assert_eq!(session.session_key(), "feishu:lark_cli_a1b2c3:oc_123");
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[test]
+    fn channel_session_key_can_opt_into_participant_and_thread_identity() {
+        let session =
+            ChannelSession::with_account(ChannelPlatform::Feishu, "lark_cli_a1b2c3", "oc_123")
+                .with_participant_id("ou_sender_1")
+                .with_thread_id("om_root_1")
+                .with_identity_participant_scoped(true)
+                .with_identity_thread_scoped(true);
         assert_eq!(
             session.session_key(),
             "feishu:lark_cli_a1b2c3:oc_123:ou_sender_1:om_root_1"
@@ -1639,7 +1652,9 @@ mod tests {
             "!ops:example.org",
         )
         .with_participant_id("@alice:example.org")
-        .with_thread_id("$event:example.org");
+        .with_thread_id("$event:example.org")
+        .with_identity_participant_scoped(true)
+        .with_identity_thread_scoped(true);
 
         assert_eq!(
             session.session_key(),

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -914,7 +914,9 @@ pub(super) fn parse_telegram_updates(
             chat_id.to_string(),
         );
         if let Some(ref tid) = thread_id {
-            session.thread_id = Some(tid.clone());
+            session = session
+                .with_thread_id(tid.clone())
+                .with_identity_thread_scoped(true);
         }
 
         inbox.push(ChannelInboundMessage {

--- a/crates/app/src/chat/latest_session_selector_tests.rs
+++ b/crates/app/src/chat/latest_session_selector_tests.rs
@@ -195,6 +195,35 @@ fn cli_runtime_keeps_explicit_literal_session_id() {
 }
 
 #[test]
+fn cli_runtime_reopens_explicit_im_local_session_id() {
+    let (config, memory_config, sqlite_path) = init_chat_test_memory("im-local-session");
+    let repo = SessionRepository::new(&memory_config).expect("repository");
+
+    create_root_session(&repo, "feishu:cfg=work:lark_cli_a1b2c3:oc_123");
+    append_session_turn(
+        "feishu:cfg=work:lark_cli_a1b2c3:oc_123",
+        "user",
+        "hello from im",
+        &memory_config,
+    );
+
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loong.toml"),
+        config,
+        Some("feishu:cfg=work:lark_cli_a1b2c3:oc_123"),
+        &CliChatOptions::default(),
+        "cli-chat-im-local-session-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("explicit IM local session runtime");
+
+    assert_eq!(runtime.session_id, "feishu:cfg=work:lark_cli_a1b2c3:oc_123");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
 fn concurrent_cli_runtime_keeps_latest_literal_when_explicit_session_is_required() {
     let (config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-latest");
     let runtime = initialize_cli_turn_runtime_with_loaded_config(

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -2772,6 +2772,14 @@ fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(),
         );
         CREATE INDEX IF NOT EXISTS idx_session_events_session_id
           ON session_events(session_id, id);
+        CREATE TABLE IF NOT EXISTS session_route_bindings(
+          route_session_id TEXT PRIMARY KEY,
+          active_session_id TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_route_bindings_active_session_id
+          ON session_route_bindings(active_session_id, updated_at, route_session_id);
         ",
     )
     .map_err(|error| format!("backfill session turn index metadata failed: {error}"))?;

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -124,6 +124,14 @@ pub struct SessionHeadRecord {
     pub updated_at: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRouteBindingRecord {
+    pub route_session_id: String,
+    pub active_session_id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionArtifactKind {
     Checkpoint,
@@ -673,6 +681,63 @@ impl SessionRepository {
                 .ok_or_else(|| format!("session `{session_id}` missing after concurrent insert")),
             Err(error) => Err(error),
         }
+    }
+
+    pub fn load_session_route_binding(
+        &self,
+        route_session_id: &str,
+    ) -> Result<Option<SessionRouteBindingRecord>, String> {
+        let route_session_id = normalize_required_text(route_session_id, "route_session_id")?;
+        let conn = self.open_connection()?;
+        conn.query_row(
+            "SELECT route_session_id, active_session_id, created_at, updated_at
+             FROM session_route_bindings
+             WHERE route_session_id = ?1",
+            params![route_session_id],
+            |row| {
+                Ok(SessionRouteBindingRecord {
+                    route_session_id: row.get(0)?,
+                    active_session_id: row.get(1)?,
+                    created_at: row.get(2)?,
+                    updated_at: row.get(3)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|error| format!("load session route binding failed: {error}"))
+    }
+
+    pub fn upsert_session_route_binding(
+        &self,
+        route_session_id: &str,
+        active_session_id: &str,
+    ) -> Result<SessionRouteBindingRecord, String> {
+        let route_session_id = normalize_required_text(route_session_id, "route_session_id")?;
+        let active_session_id = normalize_required_text(active_session_id, "active_session_id")?;
+        let ts = unix_ts_now();
+        let mut conn = self.open_connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("open session route binding transaction failed: {error}"))?;
+        tx.execute(
+            "INSERT INTO session_route_bindings(
+                route_session_id,
+                active_session_id,
+                created_at,
+                updated_at
+             ) VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(route_session_id) DO UPDATE SET
+                active_session_id = excluded.active_session_id,
+                updated_at = excluded.updated_at",
+            params![route_session_id, active_session_id, ts, ts],
+        )
+        .map_err(|error| format!("upsert session route binding failed: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("commit session route binding transaction failed: {error}"))?;
+        self.load_session_route_binding(route_session_id.as_str())?
+            .ok_or_else(|| {
+                format!("session route binding `{route_session_id}` disappeared after upsert")
+            })
     }
 
     pub fn create_session_with_event(
@@ -7532,5 +7597,30 @@ mod tests {
             pending_root_requests[0].approval_request_id,
             "apr-root-pending"
         );
+    }
+
+    #[test]
+    fn session_route_binding_upsert_and_reload_round_trip() {
+        let config = isolated_memory_config("session-route-binding");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        let created = repo
+            .upsert_session_route_binding("feishu:lark_cli_a1b2c3:oc_123", "im:session:1")
+            .expect("create route binding");
+        assert_eq!(created.route_session_id, "feishu:lark_cli_a1b2c3:oc_123");
+        assert_eq!(created.active_session_id, "im:session:1");
+
+        let updated = repo
+            .upsert_session_route_binding("feishu:lark_cli_a1b2c3:oc_123", "im:session:2")
+            .expect("update route binding");
+        assert_eq!(updated.route_session_id, "feishu:lark_cli_a1b2c3:oc_123");
+        assert_eq!(updated.active_session_id, "im:session:2");
+        assert!(updated.updated_at >= updated.created_at);
+
+        let loaded = repo
+            .load_session_route_binding("feishu:lark_cli_a1b2c3:oc_123")
+            .expect("load route binding")
+            .expect("route binding exists");
+        assert_eq!(loaded, updated);
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  IM-backed conversations could fragment one chat window into multiple local sessions because session identity was coupled too tightly to message-level context.
- Why it matters:
  Operators expect one IM conversation window to stay on one local Loong session until they explicitly reset it with `/new` or `/reset`, and they expect both old and new sessions to remain resumable.
- What changed:
  Added a shared IM route-binding layer that maps a stable IM route to the current local session, keeps Feishu-style sender/thread/message context in ingress metadata instead of always fragmenting identity, and rotates the binding to a fresh local session on explicit reset commands.
- What did not change (scope boundary):
  ACP still supports explicit fine-grained thread/participant routing when a caller intentionally supplies that structured address; this PR only changes the default IM inbound session contract.

## Linked Issues

- Closes #1450
- Related #1437

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo check -p loong-app
cargo test -p loong-app channel::tests:: -- --nocapture
cargo test -p loong-app channel::inbound_turn::tests:: -- --nocapture
cargo test -p loong-app chat::latest_session_selector_tests:: -- --nocapture
cargo test -p loong-app handle_turn_with_runtime_and_address_enforces_account_and_thread_dispatch_scope -- --nocapture
cargo test -p loong-app handle_turn_with_runtime_reuses_shared_acp_session_between_turns -- --nocapture

Result: all passed locally.
Notes:
- I intentionally used targeted crate/test coverage instead of workspace-wide all-features verification because the touched logic is isolated to `loong-app` channel/session runtime surfaces, and the repo memory guidance for this area favored exact changed-surface verification plus crate-level compile checks.
- Added focused regression coverage for:
  - stable IM route -> local session reuse
  - explicit `/new` and `/reset` binding rotation
  - reopening both the current and prior IM local session ids through the normal CLI runtime path
  - preserving Telegram thread/topic-scoped identity where the adapter explicitly opts in
```

## User-visible / Operator-visible Changes

- IM conversations now default to one stable local session per conversation window instead of fragmenting around message-level Feishu context.
- `/new` and `/reset` now rotate that IM conversation onto a fresh local session while preserving the previous session for later reopen/resume.
- Feishu keeps sender/thread/message context for ingress and reply behavior without treating every message/thread detail as a new default session.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `d658a06c5f9663a12d33617838f22d4d9b506022`.
- Observable failure symptoms reviewers should watch for:
  - IM follow-up turns unexpectedly opening brand-new local sessions without `/new` or `/reset`
  - Telegram topic/thread conversations collapsing into parent-chat session identity
  - Explicitly reopened IM local session ids failing to load through the CLI/runtime path

## Reviewer Focus

- `crates/app/src/channel/inbound_turn.rs`: shared IM route-binding creation, reset rotation, and ACP cleanup handoff.
- `crates/app/src/channel/core/types.rs`: default identity vs opt-in participant/thread identity split.
- `crates/app/src/channel/telegram.rs`: explicit topic/thread identity opt-in for Telegram forum-style windows.
- `crates/app/src/session/repository.rs` and `crates/app/src/memory/sqlite.rs`: persistent `session_route_bindings` storage and lookup semantics.
