### PR TITLE
Converge the public interactive CLI on root loong

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ loong                        # Open the main TUI; if config is missing, first-ru
 ```bash
 loong ask --message "Summarize this repo in one sentence."  # Single-turn query to verify config
 loong onboard                # Reopen the deeper guided setup flow when you want to tune provider or tooling
-loong chat                   # Explicit alias for the interactive conversation surface
+loong                        # Main interactive coding-agent surface
 loong doctor --fix           # Check environment and auto-fix common issues
 loong update                 # Replace this install with the latest stable GitHub release
 ```
@@ -156,7 +156,7 @@ loong update                 # Replace this install with the latest stable GitHu
 
 Loong keeps `loong` as the only public binary, but the canonical command story is intentionally grouped:
 
-- product path at root: `loong`, `ask`, `onboard`, `chat`, `doctor`, `status`, `update`
+- product path at root: `loong`, `ask`, `onboard`, `doctor`, `status`, `update`
 - operator shells at root: `sessions`, `skills`, `channels`, `gateway`, `runtime`, `plugins`, `feishu`, `completions`
 
 Running `loong` is the main interactive product path. On a fresh install it opens the same TUI shell and keeps first-run setup inline; once config exists it drops straight into the coding-agent surface. Running `onboard` is the explicit deeper reconfiguration lane — it writes a working config to `~/.loong/config.toml` without asking you to hand-edit TOML. The snippets below show what that file looks like on `dev` today, when you want to add another provider or wire up a channel.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -144,7 +144,7 @@ loong onboard                # 交互式初始化，配置 provider 和 model
 
 ```bash
 loong ask --message "用一句话总结这个仓库"  # 单轮提问，验证配置是否生效
-loong chat                   # 进入多轮对话
+loong                        # 进入主交互 coding TUI
 loong doctor --fix           # 检查环境并自动修复常见问题
 loong update                 # 把当前安装升级到最新稳定版 GitHub Release
 ```

--- a/crates/app/src/tools/config_import.rs
+++ b/crates/app/src/tools/config_import.rs
@@ -18,6 +18,17 @@ const MAP_SKILLS_MODE_KEY: &str = "map_skills";
 const APPLY_SKILLS_PLAN_KEY: &str = "apply_skills_plan";
 const SKILLS_MANIFEST_PATH_KEY: &str = "skills_manifest_path";
 
+fn shell_quote_argument(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn format_root_entry_with_config(config_path: &Path) -> String {
+    let config_path_display = config_path.display().to_string();
+    let quoted_config_path = shell_quote_argument(config_path_display.as_str());
+    let command_name = config::active_cli_command_name();
+    format!("LOONG_CONFIG_PATH={quoted_config_path} {command_name}")
+}
+
 pub(super) fn config_import_mode(payload: &serde_json::Map<String, Value>) -> &str {
     let raw_mode = payload.get("mode");
     let raw_mode = raw_mode.and_then(Value::as_str);
@@ -282,13 +293,7 @@ pub(super) fn execute_config_import_tool_with_config(
             "config_toml": config_toml,
             "next_step": written_output_path
                 .as_ref()
-                .map(|path| {
-                    format!(
-                        "{} chat --config {}",
-                        config::active_cli_command_name(),
-                        path.display()
-                    )
-                }),
+                .map(|path| format_root_entry_with_config(path)),
         }),
     })
 }

--- a/crates/daemon/src/command_kind.rs
+++ b/crates/daemon/src/command_kind.rs
@@ -37,7 +37,6 @@ impl Commands {
             Self::Channels { .. } => "channels",
             Self::Runtime { .. } => "runtime",
             Self::Ask { .. } => "ask",
-            Self::Chat { .. } => "chat",
             Self::Gateway { .. } => "gateway",
             Self::Feishu { .. } => "feishu",
             Self::Weixin { .. } => "weixin",
@@ -49,7 +48,7 @@ impl Commands {
 
 #[cfg(test)]
 mod tests {
-    use crate::Commands;
+    use crate::{Commands, ResolvedCommand};
     #[test]
     fn command_kind_for_logging_uses_stable_variant_names() {
         assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
@@ -107,6 +106,11 @@ mod tests {
             }
             .command_kind_for_logging(),
             "runtime"
+        );
+        assert_eq!(
+            ResolvedCommand::Interactive(crate::InteractiveCliArgs::default())
+                .command_kind_for_logging(),
+            "interactive_root"
         );
         assert_eq!(
             Commands::Weixin {

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2790,7 +2790,7 @@ fn build_doctor_next_steps_with_channel_surfaces_and_path_env(
         ) {
             let prefix = match action.kind {
                 crate::next_actions::SetupNextActionKind::Ask => "Get a first answer",
-                crate::next_actions::SetupNextActionKind::Chat => "Continue in chat",
+                crate::next_actions::SetupNextActionKind::Chat => "Continue in loong",
                 crate::next_actions::SetupNextActionKind::Personalize => {
                     "Set your working preferences"
                 }
@@ -6368,9 +6368,9 @@ mod tests {
         );
         assert!(
             next_steps.iter().any(|step| {
-                step == "Continue in chat: LOONG_CONFIG_PATH='/tmp/loong.toml' loong"
+                step == "Continue in loong: LOONG_CONFIG_PATH='/tmp/loong.toml' loong"
             }),
-            "green doctor runs should still advertise chat as the follow-up path: {next_steps:#?}"
+            "green doctor runs should still advertise the root interactive surface as the follow-up path: {next_steps:#?}"
         );
         assert!(
             next_steps.iter().any(|step| {

--- a/crates/daemon/src/import_cli.rs
+++ b/crates/daemon/src/import_cli.rs
@@ -1070,7 +1070,7 @@ mod tests {
         assert!(rendered.contains("also available"), "{rendered}");
         assert!(rendered.contains("continue setup"), "{rendered}");
         assert!(
-            rendered.contains("- chat: LOONG_CONFIG_PATH='/tmp/config.toml' loong"),
+            rendered.contains("- loong: LOONG_CONFIG_PATH='/tmp/config.toml' loong"),
             "{rendered}"
         );
         assert!(

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -258,7 +258,9 @@ pub use session_cli::{
 use task_execution::execute_daemon_task_with_supervisor;
 pub use task_execution::{DaemonTaskExecution, run_demo, run_task_cli};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
-pub use turn_cli::{TurnCommands, build_cli_chat_options, run_ask_cli, run_chat_cli};
+pub use turn_cli::{
+    InteractiveCliArgs, TurnCommands, build_cli_chat_options, run_ask_cli, run_chat_cli,
+};
 pub use update_cli::run_update_cli;
 #[rustfmt::skip]
 use tool_calling_readiness::{RuntimeSnapshotToolCallingState, collect_runtime_snapshot_tool_calling_state};
@@ -484,8 +486,25 @@ impl std::str::FromStr for MultiChannelServeChannelAccount {
     version
 )]
 pub struct Cli {
+    #[command(flatten)]
+    pub interactive: InteractiveCliArgs,
     #[command(subcommand)]
     pub command: Option<Commands>,
+}
+
+#[derive(Debug)]
+pub enum ResolvedCommand {
+    Cli(Box<Commands>),
+    Interactive(InteractiveCliArgs),
+}
+
+impl ResolvedCommand {
+    pub fn command_kind_for_logging(&self) -> &'static str {
+        match self {
+            Self::Cli(command) => command.command_kind_for_logging(),
+            Self::Interactive(_) => "interactive_root",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -916,7 +935,7 @@ pub enum Commands {
     },
     #[command(
         about = "Run one non-interactive assistant turn",
-        long_about = "Run one non-interactive one-shot assistant turn.\n\nUse this when you want a fast answer without entering the interactive `loong chat` REPL. The command reuses the normal CLI conversation runtime, session memory, provider selection, and ACP options."
+        long_about = "Run one non-interactive one-shot assistant turn.\n\nUse this when you want a fast answer without entering the interactive root `loong` surface. The command reuses the normal CLI conversation runtime, session memory, provider selection, and ACP options."
     )]
     Ask {
         /// Path to the Loong config file, or omit to use normal config discovery
@@ -935,27 +954,6 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         acp_event_stream: bool,
         /// Bootstrap an MCP server before the ACP turn starts; repeat to add more servers
-        #[arg(long = "acp-bootstrap-mcp-server")]
-        acp_bootstrap_mcp_server: Vec<String>,
-        /// Working directory used for ACP and bootstrapped MCP server context
-        #[arg(long = "acp-cwd")]
-        acp_cwd: Option<String>,
-    },
-    /// Start interactive CLI chat channel with sliding-window memory
-    Chat {
-        /// Path to the Loong config file, or omit to use normal config discovery
-        #[arg(long)]
-        config: Option<String>,
-        /// Session id or selector such as `latest`; defaults to the normal CLI session
-        #[arg(long)]
-        session: Option<String>,
-        /// Enable ACP bridge behavior for this chat session
-        #[arg(long, default_value_t = false)]
-        acp: bool,
-        /// Stream ACP turn events while chat turns run
-        #[arg(long, default_value_t = false)]
-        acp_event_stream: bool,
-        /// Bootstrap an MCP server before the ACP session starts; repeat to add more servers
         #[arg(long = "acp-bootstrap-mcp-server")]
         acp_bootstrap_mcp_server: Vec<String>,
         /// Working directory used for ACP and bootstrapped MCP server context
@@ -1067,7 +1065,7 @@ pub(crate) fn resolved_default_entry_config_path() -> PathBuf {
     default_entry_config_path_override().unwrap_or_else(mvp::config::default_config_path)
 }
 
-fn default_onboard_command() -> Commands {
+pub(crate) fn default_onboard_command() -> Commands {
     Commands::Onboard {
         output: None,
         force: false,
@@ -1085,45 +1083,36 @@ fn default_onboard_command() -> Commands {
     }
 }
 
-fn default_chat_command() -> Commands {
-    Commands::Chat {
-        config: None,
-        session: None,
-        acp: false,
-        acp_event_stream: false,
-        acp_bootstrap_mcp_server: Vec::new(),
-        acp_cwd: None,
-    }
-}
-
-const fn should_resolve_default_entry_to_chat(
-    config_exists: bool,
+const fn should_resolve_default_entry_to_interactive_surface(
+    _config_exists: bool,
     config_path_is_directory: bool,
-    interactive_terminal: bool,
+    _interactive_terminal: bool,
 ) -> bool {
-    config_exists || (!config_path_is_directory && interactive_terminal)
+    !config_path_is_directory
 }
 
-pub fn resolve_default_entry_command() -> Commands {
+pub fn resolve_default_entry_command(cli: &Cli) -> ResolvedCommand {
     let config_path = resolved_default_entry_config_path();
     let config_exists = config_path.is_file();
     let config_path_is_directory = config_path.is_dir();
     let interactive_terminal = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
-    if should_resolve_default_entry_to_chat(
+    if should_resolve_default_entry_to_interactive_surface(
         config_exists,
         config_path_is_directory,
         interactive_terminal,
     ) {
-        default_chat_command()
+        ResolvedCommand::Interactive(cli.interactive.clone())
     } else {
-        default_onboard_command()
+        ResolvedCommand::Cli(Box::new(default_onboard_command()))
     }
 }
 
-pub fn resolve_default_entry_post_onboard_command() -> Option<Commands> {
+pub fn resolve_default_entry_post_onboard_command(
+    interactive: &InteractiveCliArgs,
+) -> Option<ResolvedCommand> {
     resolved_default_entry_config_path()
         .is_file()
-        .then(default_chat_command)
+        .then(|| ResolvedCommand::Interactive(interactive.clone()))
 }
 
 pub fn redacted_command_name(command: &Commands) -> &'static str {
@@ -1181,7 +1170,7 @@ fn render_welcome_banner(config_path: &Path, config: &mvp::config::LoongConfig) 
         tone: mvp::tui_surface::TuiCalloutTone::Info,
         title: Some("operator flow".to_owned()),
         lines: vec![
-            "Start with a first answer, then continue in chat for follow-up work.".to_owned(),
+            "Start with a first answer, then continue in the root loong surface for follow-up work.".to_owned(),
             "Use doctor when setup or runtime health feels off instead of debugging the config by hand.".to_owned(),
         ],
     });

--- a/crates/daemon/src/lib_first_run_entry_tests.rs
+++ b/crates/daemon/src/lib_first_run_entry_tests.rs
@@ -38,7 +38,13 @@ fn resolve_default_entry_command_routes_to_onboard_when_config_is_missing() {
     let (_env, _home, _config_path) = isolated_home("loong-default-entry-missing");
 
     assert!(
-        matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
+        matches!(
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Cli(command) if matches!(command.as_ref(), Commands::Onboard { .. })
+        ),
         "missing config should route to onboard"
     );
 }
@@ -50,13 +56,19 @@ fn resolve_default_entry_command_ignores_legacy_home_when_config_is_missing() {
     fs::create_dir_all(&legacy_home).expect("create legacy home");
 
     assert!(
-        matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
+        matches!(
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Cli(command) if matches!(command.as_ref(), Commands::Onboard { .. })
+        ),
         "legacy home alone should still route to onboard"
     );
 }
 
 #[test]
-fn resolve_default_entry_command_routes_to_chat_when_default_config_exists() {
+fn resolve_default_entry_command_routes_to_root_interactive_surface_when_default_config_exists() {
     let (_env, _home, config_path) = isolated_home("loong-default-entry-present");
 
     mvp::config::write(
@@ -68,26 +80,38 @@ fn resolve_default_entry_command_routes_to_chat_when_default_config_exists() {
 
     assert!(
         matches!(
-            resolve_default_entry_command(),
-            Commands::Chat {
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Interactive(InteractiveCliArgs {
                 config: None,
                 session: None,
                 acp: false,
                 acp_event_stream: false,
                 acp_bootstrap_mcp_server,
                 acp_cwd: None,
-            } if acp_bootstrap_mcp_server.is_empty()
+            }) if acp_bootstrap_mcp_server.is_empty()
         ),
-        "present config should route to chat"
+        "present config should route to the root interactive surface"
     );
 }
 
 #[test]
-fn should_resolve_default_entry_to_chat_prefers_chat_for_interactive_first_run() {
-    assert!(should_resolve_default_entry_to_chat(false, false, true));
-    assert!(should_resolve_default_entry_to_chat(true, false, false));
-    assert!(!should_resolve_default_entry_to_chat(false, true, true));
-    assert!(!should_resolve_default_entry_to_chat(false, false, false));
+fn should_resolve_default_entry_to_chat_prefers_root_interactive_surface_for_interactive_first_run()
+{
+    assert!(should_resolve_default_entry_to_interactive_surface(
+        false, false, true
+    ));
+    assert!(should_resolve_default_entry_to_interactive_surface(
+        true, false, false
+    ));
+    assert!(!should_resolve_default_entry_to_interactive_surface(
+        false, true, true
+    ));
+    assert!(!should_resolve_default_entry_to_interactive_surface(
+        false, false, false
+    ));
 }
 
 #[test]
@@ -106,13 +130,19 @@ fn resolve_default_entry_command_ignores_loongclaw_config_path_without_compat_sh
     env.set("LOONGCLAW_CONFIG_PATH", &config_path);
 
     assert!(
-        matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
+        matches!(
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Cli(command) if matches!(command.as_ref(), Commands::Onboard { .. })
+        ),
         "legacy env override should not bypass the canonical default-entry path without compatibility shims"
     );
 }
 
 #[test]
-fn resolve_default_entry_command_honors_loong_config_path_override() {
+fn resolve_default_entry_command_honors_loong_config_path_override_for_root_interactive_surface() {
     let mut env = ScopedEnv::new();
     let config_path = unique_temp_dir("loong-default-entry-env").join("custom-config.toml");
     if let Some(parent) = config_path.parent() {
@@ -128,17 +158,20 @@ fn resolve_default_entry_command_honors_loong_config_path_override() {
 
     assert!(
         matches!(
-            resolve_default_entry_command(),
-            Commands::Chat {
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Interactive(InteractiveCliArgs {
                 config: None,
                 session: None,
                 acp: false,
                 acp_event_stream: false,
                 acp_bootstrap_mcp_server,
                 acp_cwd: None,
-            } if acp_bootstrap_mcp_server.is_empty()
+            }) if acp_bootstrap_mcp_server.is_empty()
         ),
-        "new env override config should route to chat"
+        "new env override config should route to the root interactive surface"
     );
 }
 
@@ -150,13 +183,20 @@ fn resolve_default_entry_command_routes_to_onboard_when_config_path_is_a_directo
     env.set("LOONG_CONFIG_PATH", &config_dir);
 
     assert!(
-        matches!(resolve_default_entry_command(), Commands::Onboard { .. }),
+        matches!(
+            resolve_default_entry_command(&Cli {
+                interactive: InteractiveCliArgs::default(),
+                command: None,
+            }),
+            ResolvedCommand::Cli(command) if matches!(command.as_ref(), Commands::Onboard { .. })
+        ),
         "directory config path should still route to onboard"
     );
 }
 
 #[test]
-fn resolve_default_entry_post_onboard_command_returns_chat_once_config_exists() {
+fn resolve_default_entry_post_onboard_command_returns_root_interactive_surface_once_config_exists()
+{
     let (_env, _home, config_path) = isolated_home("loong-default-entry-post-onboard-present");
 
     mvp::config::write(
@@ -168,17 +208,17 @@ fn resolve_default_entry_post_onboard_command_returns_chat_once_config_exists() 
 
     assert!(
         matches!(
-            resolve_default_entry_post_onboard_command(),
-            Some(Commands::Chat {
+            resolve_default_entry_post_onboard_command(&InteractiveCliArgs::default()),
+            Some(ResolvedCommand::Interactive(InteractiveCliArgs {
                 config: None,
                 session: None,
                 acp: false,
                 acp_event_stream: false,
                 acp_bootstrap_mcp_server,
                 acp_cwd: None,
-            }) if acp_bootstrap_mcp_server.is_empty()
+            })) if acp_bootstrap_mcp_server.is_empty()
         ),
-        "a written default config should hand off into chat after onboarding"
+        "a written default config should hand off into the root interactive surface after onboarding"
     );
 }
 
@@ -187,8 +227,8 @@ fn resolve_default_entry_post_onboard_command_stays_none_when_config_is_still_mi
     let (_env, _home, _config_path) = isolated_home("loong-default-entry-post-onboard-missing");
 
     assert!(
-        resolve_default_entry_post_onboard_command().is_none(),
-        "missing config should not try to continue into chat after onboarding exits"
+        resolve_default_entry_post_onboard_command(&InteractiveCliArgs::default()).is_none(),
+        "missing config should not try to continue into the root interactive surface after onboarding exits"
     );
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -173,23 +173,40 @@ fn main() {
     loong_daemon::make_env_compatible();
     check_legacy_home_migration();
     let cli = parse_cli();
+    let default_entry_interactive = cli.interactive.clone();
     let invoked_as_default_entry = cli.command.is_none();
     let command_source = if cli.command.is_some() {
         "explicit"
     } else {
         "default"
     };
-    let command = cli.command.unwrap_or_else(resolve_default_entry_command);
-    let command_kind = command.command_kind_for_logging();
-    let redacted_command = redacted_command_name(&command);
+    let resolved_command = match cli.command {
+        Some(command) => ResolvedCommand::Cli(Box::new(command)),
+        None => resolve_default_entry_command(&cli),
+    };
+    let command_kind = resolved_command.command_kind_for_logging();
+    let redacted_command = match &resolved_command {
+        ResolvedCommand::Cli(command) => redacted_command_name(command),
+        ResolvedCommand::Interactive(_) => "interactive_root",
+    };
     tracing::debug!(
         target: "loong.daemon",
         command_source,
         command = %redacted_command,
         "resolved CLI command"
     );
-    let result = build_daemon_runtime(&command)
-        .and_then(|runtime| runtime.block_on(run_command(command, invoked_as_default_entry)));
+    let interactive_runtime_seed = Commands::Welcome;
+    let runtime_seed_command = match &resolved_command {
+        ResolvedCommand::Cli(command) => command.as_ref(),
+        ResolvedCommand::Interactive(_) => &interactive_runtime_seed,
+    };
+    let result = build_daemon_runtime(runtime_seed_command).and_then(|runtime| {
+        runtime.block_on(run_resolved_command(
+            resolved_command,
+            invoked_as_default_entry,
+            default_entry_interactive,
+        ))
+    });
     if let Err(error) = result {
         let error_code = error_code(error.as_str());
         tracing::error!(
@@ -207,7 +224,34 @@ fn main() {
     }
 }
 
-async fn run_command(command: Commands, invoked_as_default_entry: bool) -> CliResult<()> {
+async fn run_resolved_command(
+    command: ResolvedCommand,
+    invoked_as_default_entry: bool,
+    default_entry_interactive: InteractiveCliArgs,
+) -> CliResult<()> {
+    match command {
+        ResolvedCommand::Cli(command) => {
+            run_command(*command, invoked_as_default_entry, default_entry_interactive).await
+        }
+        ResolvedCommand::Interactive(args) => {
+            run_chat_cli(
+                args.config.as_deref(),
+                args.session.as_deref(),
+                args.acp,
+                args.acp_event_stream,
+                &args.acp_bootstrap_mcp_server,
+                args.acp_cwd.as_deref(),
+            )
+            .await
+        }
+    }
+}
+
+async fn run_command(
+    command: Commands,
+    invoked_as_default_entry: bool,
+    default_entry_interactive: InteractiveCliArgs,
+) -> CliResult<()> {
     match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -366,9 +410,15 @@ async fn run_command(command: Commands, invoked_as_default_entry: bool) -> CliRe
             .await?;
 
             if invoked_as_default_entry
-                && let Some(follow_up_command) = resolve_default_entry_post_onboard_command()
+                && let Some(follow_up_command) =
+                    resolve_default_entry_post_onboard_command(&default_entry_interactive)
             {
-                return Box::pin(run_command(follow_up_command, false)).await;
+                return Box::pin(run_resolved_command(
+                    follow_up_command,
+                    false,
+                    default_entry_interactive,
+                ))
+                .await;
             }
 
             Ok(())
@@ -529,24 +579,6 @@ async fn run_command(command: Commands, invoked_as_default_entry: bool) -> CliRe
                 config.as_deref(),
                 session.as_deref(),
                 &message,
-                acp,
-                acp_event_stream,
-                &acp_bootstrap_mcp_server,
-                acp_cwd.as_deref(),
-            )
-            .await
-        }
-        Commands::Chat {
-            config,
-            session,
-            acp,
-            acp_event_stream,
-            acp_bootstrap_mcp_server,
-            acp_cwd,
-        } => {
-            run_chat_cli(
-                config.as_deref(),
-                session.as_deref(),
                 acp,
                 acp_event_stream,
                 &acp_bootstrap_mcp_server,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -231,7 +231,12 @@ async fn run_resolved_command(
 ) -> CliResult<()> {
     match command {
         ResolvedCommand::Cli(command) => {
-            run_command(*command, invoked_as_default_entry, default_entry_interactive).await
+            run_command(
+                *command,
+                invoked_as_default_entry,
+                default_entry_interactive,
+            )
+            .await
         }
         ResolvedCommand::Interactive(args) => {
             run_chat_cli(

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -66,7 +66,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Chat,
             channel_action_id: None,
-            label: "chat".to_owned(),
+            label: "loong".to_owned(),
             command: crate::cli_handoff::format_root_entry_with_config(config_path),
         });
         if should_suggest_personalization(config) {

--- a/crates/daemon/src/onboard_finalize.rs
+++ b/crates/daemon/src/onboard_finalize.rs
@@ -744,7 +744,7 @@ mod tests {
                 },
                 OnboardingAction {
                     kind: OnboardingActionKind::Chat,
-                    label: "chat".to_owned(),
+                    label: "loong".to_owned(),
                     command: "LOONG_CONFIG_PATH='/tmp/loong.toml' loong".to_owned(),
                 },
                 OnboardingAction {
@@ -783,7 +783,7 @@ mod tests {
                 TuiSectionSpec::ActionGroup { title: Some(title), items, .. }
                     if title == "also available"
                         && items.iter().all(|item| item.label != "channels")
-                        && items.iter().any(|item| item.label == "chat")
+                        && items.iter().any(|item| item.label == "loong")
                         && items.iter().any(|item| item.label == personalize_action_label())
             )),
             "expected general follow-up actions to stay separate from setup surfaces: {spec:#?}"

--- a/crates/daemon/src/turn_cli.rs
+++ b/crates/daemon/src/turn_cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::Subcommand;
+use clap::{Args, Subcommand};
 
 use crate::CliResult;
 use crate::mvp;
@@ -34,6 +34,28 @@ pub enum TurnCommands {
         #[arg(long = "acp-cwd")]
         acp_cwd: Option<String>,
     },
+}
+
+#[derive(Args, Debug, Clone, Default, PartialEq, Eq)]
+pub struct InteractiveCliArgs {
+    /// Path to the Loong config file, or omit to use normal config discovery
+    #[arg(long)]
+    pub config: Option<String>,
+    /// Session id or selector such as `latest`; defaults to the normal CLI session
+    #[arg(long)]
+    pub session: Option<String>,
+    /// Enable ACP bridge behavior for this interactive session
+    #[arg(long, default_value_t = false)]
+    pub acp: bool,
+    /// Stream ACP turn events while interactive turns run
+    #[arg(long, default_value_t = false)]
+    pub acp_event_stream: bool,
+    /// Bootstrap an MCP server before the ACP session starts; repeat to add more servers
+    #[arg(long = "acp-bootstrap-mcp-server")]
+    pub acp_bootstrap_mcp_server: Vec<String>,
+    /// Working directory used for ACP and bootstrapped MCP server context
+    #[arg(long = "acp-cwd")]
+    pub acp_cwd: Option<String>,
 }
 
 pub async fn run_chat_cli(

--- a/crates/daemon/tests/integration/ask_and_spec_cli_root.rs
+++ b/crates/daemon/tests/integration/ask_and_spec_cli_root.rs
@@ -102,8 +102,8 @@ fn cli_ask_help_mentions_one_shot_assistant_usage() {
         "ask help should explain ACP event streaming for runtime debugging: {help}"
     );
     assert!(
-        help.contains("loong chat"),
-        "ask help should point users to chat for the interactive path: {help}"
+        help.contains("root `loong` surface"),
+        "ask help should point users to the root interactive path: {help}"
     );
 }
 

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -134,7 +134,6 @@ impl ChatCliFixture {
         let loong_home = self.home_dir.join(".loong");
         let mut command = Command::new(env!("CARGO_BIN_EXE_loong"));
         command
-            .arg("chat")
             .current_dir(&self.root)
             .env("HOME", &self.home_dir)
             .env("LOONG_HOME", &loong_home)
@@ -404,7 +403,7 @@ fn chat_cli_latest_session_selector_process_uses_selected_root_session_history()
     fixture.set_turn_timestamps("root-archived", 500);
     fixture.archive_session("root-archived", 600);
 
-    let output = fixture.run_process(&["chat", "--session", "latest"], Some(b"/history\n/exit\n"));
+    let output = fixture.run_process(&["--session", "latest"], Some(b"/history\n/exit\n"));
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 
@@ -443,7 +442,7 @@ fn chat_cli_latest_session_selector_process_rejects_missing_resumable_root() {
     let fixture = LatestSelectorCliFixture::new("chat-latest-selector-empty");
     fixture.write_config_with(|_| {});
 
-    let output = fixture.run_process(&["chat", "--session", "latest"], None);
+    let output = fixture.run_process(&["--session", "latest"], None);
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -2019,7 +2019,10 @@ fn root_interactive_flags_still_parse_on_the_main_entrypoint() {
     ])
     .expect("root interactive flags should parse on the main entrypoint");
 
-    assert!(cli.command.is_none(), "root interactive path should not synthesize a subcommand");
+    assert!(
+        cli.command.is_none(),
+        "root interactive path should not synthesize a subcommand"
+    );
     assert_eq!(cli.interactive.session.as_deref(), Some("telegram:42"));
     assert!(cli.interactive.acp);
     assert!(cli.interactive.acp_event_stream);
@@ -2027,7 +2030,10 @@ fn root_interactive_flags_still_parse_on_the_main_entrypoint() {
         cli.interactive.acp_bootstrap_mcp_server,
         vec!["filesystem".to_owned(), "search".to_owned()]
     );
-    assert_eq!(cli.interactive.acp_cwd.as_deref(), Some("/workspace/project"));
+    assert_eq!(
+        cli.interactive.acp_cwd.as_deref(),
+        Some("/workspace/project")
+    );
 }
 
 #[test]

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -141,7 +141,6 @@ fn root_help_prefers_grouped_namespaces_and_hides_flat_legacy_aliases() {
         "onboard",
         "ask",
         "turn",
-        "chat",
         "doctor",
         "status",
         "update",
@@ -171,6 +170,11 @@ fn root_help_prefers_grouped_namespaces_and_hides_flat_legacy_aliases() {
             .iter()
             .any(|value| value == "runtime" || value == "ops"),
         "root help should expose one grouped runtime/operator namespace: {visible_root_subcommands:?}"
+    );
+
+    assert!(
+        !visible_root_subcommands.iter().any(|value| value == "chat"),
+        "root help should not expose the removed `chat` subcommand: {visible_root_subcommands:?}"
     );
 
     for legacy in [
@@ -1989,10 +1993,19 @@ fn format_acp_event_summary_includes_routing_intent_and_provenance() {
 }
 
 #[test]
-fn chat_cli_accepts_acp_runtime_option_flags() {
+fn chat_cli_is_no_longer_exposed_as_a_public_subcommand() {
+    let error = try_parse_cli(["loong", "chat"]).expect_err("chat subcommand should be removed");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("unrecognized subcommand") || rendered.contains("unexpected argument"),
+        "removing chat should fail through clap parsing: {rendered}"
+    );
+}
+
+#[test]
+fn root_interactive_flags_still_parse_on_the_main_entrypoint() {
     let cli = try_parse_cli([
         "loong",
-        "chat",
         "--session",
         "telegram:42",
         "--acp",
@@ -2004,28 +2017,17 @@ fn chat_cli_accepts_acp_runtime_option_flags() {
         "--acp-cwd",
         "/workspace/project",
     ])
-    .expect("chat CLI should parse ACP runtime option flags");
+    .expect("root interactive flags should parse on the main entrypoint");
 
-    match cli.command {
-        Some(Commands::Chat {
-            session,
-            acp,
-            acp_event_stream,
-            acp_bootstrap_mcp_server,
-            acp_cwd,
-            ..
-        }) => {
-            assert_eq!(session.as_deref(), Some("telegram:42"));
-            assert!(acp);
-            assert!(acp_event_stream);
-            assert_eq!(
-                acp_bootstrap_mcp_server,
-                vec!["filesystem".to_owned(), "search".to_owned()]
-            );
-            assert_eq!(acp_cwd.as_deref(), Some("/workspace/project"));
-        }
-        other => panic!("unexpected command parse result: {other:?}"),
-    }
+    assert!(cli.command.is_none(), "root interactive path should not synthesize a subcommand");
+    assert_eq!(cli.interactive.session.as_deref(), Some("telegram:42"));
+    assert!(cli.interactive.acp);
+    assert!(cli.interactive.acp_event_stream);
+    assert_eq!(
+        cli.interactive.acp_bootstrap_mcp_server,
+        vec!["filesystem".to_owned(), "search".to_owned()]
+    );
+    assert_eq!(cli.interactive.acp_cwd.as_deref(), Some("/workspace/project"));
 }
 
 #[test]

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -771,14 +771,14 @@ fn import_cli_apply_summary_includes_registry_channel_actions() {
     assert!(
         lines
             .iter()
-            .any(|line| line == "- chat: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
-        "apply summary should surface interactive chat immediately after the primary ask step: {lines:#?}"
+            .any(|line| line == "- loong: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
+        "apply summary should surface the root interactive entrypoint immediately after the primary ask step: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| {
             line == "- Telegram: loong channels serve telegram --config '/tmp/loong-config.toml'"
         }),
-        "apply summary should continue surfacing registry-driven channel handoff commands after ask/chat: {lines:#?}"
+        "apply summary should continue surfacing registry-driven channel handoff commands after ask/root-entry: {lines:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -151,8 +151,8 @@ fn cli_ask_help_mentions_one_shot_assistant_usage() {
         "ask help should require an inline message input: {help}"
     );
     assert!(
-        help.contains("loong chat"),
-        "ask help should point users to chat for the interactive path: {help}"
+        help.contains("root `loong` surface"),
+        "ask help should point users to the root interactive path: {help}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -6130,7 +6130,7 @@ fn onboarding_success_summary_derives_structured_actions() {
         loong_daemon::onboard_cli::OnboardingActionKind::Channel
     );
     assert_eq!(summary.next_actions[0].label, "first answer");
-    assert_eq!(summary.next_actions[1].label, "chat");
+    assert_eq!(summary.next_actions[1].label, "loong");
     assert_eq!(
         summary.next_actions[2].label,
         "teach Loong your working style"
@@ -7895,13 +7895,13 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
         "narrow renderer should group secondary channel actions under a separate heading: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("- chat:"))
+        lines.iter().any(|line| line.contains("- loong:"))
             && rendered.contains("LOONG_CONFIG_PATH='/tmp/loong-config.tom")
             && rendered.contains("l' loong")
             && rendered.contains(
                 "- Telegram: loong channels serve telegram --config '/tmp/loong-config.toml'"
             ),
-        "narrow renderer should keep secondary chat and channel actions visible after the primary ask example: {lines:#?}"
+        "narrow renderer should keep secondary root-entry and channel actions visible after the primary ask example: {lines:#?}"
     );
 }
 
@@ -8445,8 +8445,8 @@ fn onboarding_success_summary_groups_secondary_channel_actions_after_primary_han
         "wide success summary should group secondary channel actions under a separate heading: {lines:#?}"
     );
     assert!(
-        rendered.contains("- chat: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
-        "wide success summary should still surface interactive chat as a secondary follow-up: {lines:#?}"
+        rendered.contains("- loong: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
+        "wide success summary should still surface the root interactive entrypoint as a secondary follow-up: {lines:#?}"
     );
     assert!(
         lines.iter().any(|line| line
@@ -8487,8 +8487,8 @@ fn onboarding_success_summary_uses_channel_handoff_when_cli_is_disabled() {
     assert!(
         lines
             .iter()
-            .all(|line| line != "- chat: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
-        "success summary should not keep chat as the primary handoff once cli is disabled: {lines:#?}"
+            .all(|line| line != "- loong: LOONG_CONFIG_PATH='/tmp/loong-config.toml' loong"),
+        "success summary should not keep the root interactive handoff once cli is disabled: {lines:#?}"
     );
 }
 
@@ -8868,7 +8868,7 @@ fn onboarding_success_summary_lists_doctor_followup_for_plugin_backed_channels_w
         .next_actions
         .iter()
         .position(|action| action.kind == loong_daemon::onboard_cli::OnboardingActionKind::Ask);
-    let chat_position = summary
+    let loong_position = summary
         .next_actions
         .iter()
         .position(|action| action.kind == loong_daemon::onboard_cli::OnboardingActionKind::Chat);
@@ -8891,9 +8891,9 @@ fn onboarding_success_summary_lists_doctor_followup_for_plugin_backed_channels_w
         "cli-enabled plugin-backed setups should keep the direct ask handoff first: {summary:#?}"
     );
     assert_eq!(
-        chat_position,
+        loong_position,
         Some(1),
-        "cli-enabled plugin-backed setups should keep the chat handoff second: {summary:#?}"
+        "cli-enabled plugin-backed setups should keep the root interactive handoff second: {summary:#?}"
     );
     let personalize_position = personalize_position.expect(
         "cli-enabled plugin-backed setups should keep the personalization handoff visible before diagnostics",

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -64,7 +64,7 @@ The current product contract is:
 3. Reopen `loong onboard` only when the operator wants the deeper guided setup flow explicitly.
 4. Get first value through a concrete one-shot command such as
    `loong ask --message "Summarize this repository and suggest the best next step."`,
-   while `loong chat` remains an explicit alias for the interactive conversation surface.
+   then continue in root `loong`.
 5. If anything is broken, use `loong doctor` or `loong doctor --fix`.
 6. Enable gateway or channel surfaces only after the base CLI flow is healthy.
 

--- a/site/get-started/first-run.mdx
+++ b/site/get-started/first-run.mdx
@@ -19,7 +19,7 @@ Onboarding is the supported first-run path. It is expected to detect reusable co
 When you need follow-up work:
 
 ```bash
-loong chat
+loong
 ```
 
 If you want to inspect the active provider's model catalog after credentials are healthy:
@@ -34,7 +34,7 @@ loong runtime models list
 
 - `loong onboard` finishes without leaving you in raw config editing as step zero.
 - `loong ask` produces one useful answer.
-- `loong chat` is available for follow-up work.
+- rerun `loong` for follow-up work in the interactive surface.
 - `loong doctor` is there as the repair path if something still looks off.
 
 ## If First Run Feels Incomplete

--- a/site/reference/roadmap-and-product.mdx
+++ b/site/reference/roadmap-and-product.mdx
@@ -40,7 +40,7 @@ The public MVP journey is intentionally short:
 
 1. Install Loong through the documented installer or source path.
 2. Run `loong onboard`.
-3. Reach a first useful answer with `loong ask` or continue in `loong chat`.
+3. Reach a first useful answer with `loong ask` or continue in root `loong`.
 4. Use `loong doctor` when runtime health or setup truth is unclear.
 5. Add gateway, channels, memory, and richer operator surfaces only after the base path is healthy.
 

--- a/site/reference/why-loong.mdx
+++ b/site/reference/why-loong.mdx
@@ -83,7 +83,7 @@ use later.
 
 The public shape already reflects that stance in concrete ways:
 
-- **Runnable operator path**: `loong onboard`, `loong ask`, `loong chat`, and
+- **Runnable operator path**: `loong onboard`, `loong ask`, `loong`, and
   `loong doctor` are treated as the shortest supported success path.
 - **Operator-visible runtime surface**: commands such as `audit`, `tasks`,
   `skills`, `plugins`, `channels`, `runtime snapshot`, and gateway control are

--- a/site/use-loong/channel-recipes.mdx
+++ b/site/use-loong/channel-recipes.mdx
@@ -476,7 +476,7 @@ Important boundary:
 
 ## Channel Rollout Order
 
-1. Get `loong ask` or `loong chat` healthy first.
+1. Get `loong ask` or the root `loong` interactive surface healthy first.
 2. Add one gateway-supervised service channel, one standalone native-serve surface, or one outbound-only surface.
 3. Verify with `loong doctor` and `loong channels`.
 4. Only then graduate to `gateway run` or `gateway run`.


### PR DESCRIPTION
## Summary

- Problem:
  The CLI exposed both root `loong` and `loong chat` as public interactive entrypoints even though they led into the same interactive coding surface.
- Why it matters:
  That duplication made the product contract noisier than necessary, caused docs/help/follow-up drift, and left extra parser and test surface complexity for no user-facing gain.
- What changed:
  Removed the public `loong chat` subcommand, moved the interactive root path onto an internal `ResolvedCommand::Interactive(...)` flow, preserved root interactive flags on `loong`, and aligned docs/help/follow-up outputs to point users back to root `loong`.
- What did not change (scope boundary):
  The interactive runtime itself was not replaced. `loong` still enters the same coding surface, and `loong ask` remains the non-interactive one-shot entrypoint.

## Linked Issues

- Closes #1452

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
./scripts/cargo-local-toolchain.sh clippy -p loong --lib --tests -- -D warnings
cargo test -p loong --features test-support --test daemon_cli -- --nocapture
cargo test -p loong --features test-support --test integration cli_ask_help_mentions_one_shot_assistant_usage -- --nocapture
cargo test -p loong --features test-support --test integration root_help_prefers_grouped_namespaces_and_hides_flat_legacy_aliases -- --nocapture
cargo run -p loong -- --help

Result: all commands passed on the final branch state.
Notes:
- The main regression surface was the daemon CLI command tree plus root-entry handoff behavior.
- I added explicit coverage that root interactive flags still parse on `loong` after removing the public `chat` subcommand.
- The daemon CLI suite now passes with `218 passed; 0 failed` on this branch.
```

## User-visible / Operator-visible Changes

- `loong` is now the only public interactive entrypoint.
- `loong chat` no longer appears in help and no longer parses as a public subcommand.
- Follow-up commands and docs now point users to root `loong` instead of `loong chat --config ...`.
- Root interactive flags such as `--config`, `--session`, and ACP-related options stay available on `loong` itself.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `c3015ad9`.
- Observable failure symptoms reviewers should watch for:
  - `loong` with no subcommand stops entering the interactive surface
  - root interactive flags such as `--session latest` stop routing correctly
  - onboarding/doctor/import follow-up commands still surface removed `loong chat` text

## Reviewer Focus

- `crates/daemon/src/lib.rs` and `crates/daemon/src/main.rs`: root entry resolution and internal interactive dispatch
- `crates/daemon/src/turn_cli.rs`: root interactive flag surface
- `crates/daemon/src/next_actions.rs`, `doctor_cli.rs`, `onboard_finalize.rs`, `import_cli.rs`, and `crates/app/src/tools/config_import.rs`: follow-up command convergence on root `loong`
- `crates/daemon/tests/integration/chat_cli.rs` and `cli_tests.rs`: root-entry behavior coverage after removing the public subcommand
