### PR TITLE
docs: align public skills docs with shipped naming

### DIFF
--- a/crates/daemon/src/doctor_security_cli.rs
+++ b/crates/daemon/src/doctor_security_cli.rs
@@ -672,7 +672,7 @@ fn assess_skills_probe_failure(
     evidence.push(auto_expose_evidence);
 
     let summary =
-        "The effective external-skills runtime policy could not be resolved through the policy surface, so the live posture is unknown."
+        "The effective skills runtime policy could not be resolved through the policy surface, so the live posture is unknown."
             .to_owned();
     let cli = mvp::config::active_cli_command_name();
     let next_steps = vec![

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -97,7 +97,7 @@ pub enum SkillsPolicyCommands {
         #[arg(long, default_value_t = false)]
         approve_policy_update: bool,
     },
-    /// Reset persisted external-skills policy fields back to config defaults
+    /// Reset persisted skills policy fields back to config defaults
     Reset {
         #[arg(long, default_value_t = false)]
         approve_policy_update: bool,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -234,7 +234,7 @@ Provider runtime binding:
 
 - `loong doctor security` is the operator-facing exposure audit for the current local runtime
 - It reports `covered`, `partial`, `exposed`, and `unknown` findings instead of collapsing everything into pass/fail
-- Current audit categories include durable audit retention, shell posture, tool file-root confinement, web-fetch egress, external-skills posture, secret hygiene, and browser automation surfaces
+- Current audit categories include durable audit retention, shell posture, tool file-root confinement, web-fetch egress, skills posture, secret hygiene, and browser automation surfaces
 - `loong doctor security --json` provides a stable machine-readable report for local automation and support workflows
 
 ### Web HTTP SSRF Guardrails

--- a/site/docs.json
+++ b/site/docs.json
@@ -32,7 +32,7 @@
           "use-loong/common-setups",
           "use-loong/configuration-patterns",
           "use-loong/configuration-reference",
-          "use-loong/managed-skills",
+          "use-loong/skills",
           "use-loong/browser-and-web-boundaries",
           "use-loong/volcengine-feishu-lark-playbook",
           "use-loong/wecom-rollout-playbook",

--- a/site/get-started/doctor-and-health.mdx
+++ b/site/get-started/doctor-and-health.mdx
@@ -88,6 +88,6 @@ Use the debug bundle when:
 ## What Comes Next
 
 - Return to [First Run](/get-started/first-run) if you still have not reached a first useful answer.
-- Continue to [Managed Skills](/use-loong/managed-skills) when the blocker is install policy, skill exposure, or `agent-browser` setup.
+- Continue to [Skills](/use-loong/skills) when the blocker is install policy, skill exposure, or browser automation setup.
 - Continue to [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) when the blocker is a private host, domain allowlist, or browser runtime gate.
 - Move on to [Use Loong](/use-loong/overview) once the base local runtime is healthy.

--- a/site/get-started/overview.mdx
+++ b/site/get-started/overview.mdx
@@ -47,6 +47,6 @@ The public docs lead with the base CLI path first. Channel setup, gateway surfac
 - If you want the practical provider and channel setup walkthroughs right away, go to [Provider Guides](/use-loong/provider-guides/index) and [Channel Guides](/use-loong/channel-guides/index).
 - Keep [Provider Recipes](/use-loong/provider-recipes) and [Channel Recipes](/use-loong/channel-recipes) for representative rollout patterns after the exact built-in surface is clear.
 - If you already know the target stack and want one complete rollout path, go to [Common Setups](/use-loong/common-setups) and then the dedicated playbook that matches it.
-- If the next blocker is managed skill install, `agent-browser` setup, or private-host and domain policy, continue to [Managed Skills](/use-loong/managed-skills) and [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries).
+- If the next blocker is skill install, browser automation setup, or private-host and domain policy, continue to [Skills](/use-loong/skills) and [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries).
 - If you want to understand the current public runtime surface, continue to [Use Loong](/use-loong/overview).
 - If you need the detailed channel matrix instead of the first-run path, jump to [Channels](/use-loong/channels).

--- a/site/index.mdx
+++ b/site/index.mdx
@@ -16,7 +16,7 @@ This site stays short at the top, then branches into focused tracks instead of t
 | install Loong and reach first value fast | [Get Started](/get-started/overview) | install, onboard, first-run, and doctor guidance |
 | follow one complete provider-plus-channel rollout path | [Common Setups](/use-loong/common-setups) | end-to-end playbooks for hosted, service-channel, local, and gateway-owned setups |
 | understand the shared public config shape first | [Configuration Patterns](/use-loong/configuration-patterns) | provider profiles, channel accounts, gateway selectors, memory, and trust toggles |
-| unblock managed skills, agent-browser setup, or web policy gates | [Managed Skills](/use-loong/managed-skills) and [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) | install flow, persisted policy, external browser automation setup, and private-host/domain troubleshooting |
+| unblock skills, browser automation setup, or web policy gates | [Skills](/use-loong/skills) and [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) | install flow, persisted policy, browser automation setup, and private-host/domain troubleshooting |
 | configure a provider or channel right now | [Provider Guides](/use-loong/provider-guides/index) and [Channel Guides](/use-loong/channel-guides/index) | one page per built-in provider or channel, with recipes kept for representative rollout patterns |
 | understand the public runtime model before configuring it | [Use Loong](/use-loong/overview) | the current surface shape, page map, and capability boundaries |
 | extend or evaluate the architecture | [Build On Loong](/build-on-loong/overview) | crate boundaries, contribution workflow, and builder-facing contracts |

--- a/site/use-loong/browser-and-web-boundaries.mdx
+++ b/site/use-loong/browser-and-web-boundaries.mdx
@@ -189,7 +189,7 @@ That path solves a different problem than `tools.web`:
 
 ## Continue Reading
 
-- Continue to [Managed Skills](/use-loong/managed-skills) when the issue is skill install, `agent-browser` setup, or download policy rather than raw URL policy.
+- Continue to [Skills](/use-loong/skills) when the issue is skill install, `agent-browser` setup, or download policy rather than raw URL policy.
 - Continue to [Configuration Patterns](/use-loong/configuration-patterns) when you want the wider operator config map around providers, channels, memory, and trust toggles.
 - Continue to [Tool Surface](/use-loong/tool-surface) when you want the broader truthful-tool contract behind these boundaries.
 - Continue to [Doctor And Health](/get-started/doctor-and-health) when you want the repair-first operator path.

--- a/site/use-loong/configuration-patterns.mdx
+++ b/site/use-loong/configuration-patterns.mdx
@@ -23,7 +23,7 @@ guides, channel guides, rollout recipes, or the deeper
 | one service-channel account that should own a reply loop | [Single-Account Channel Shape](#single-account-channel-shape) |
 | several channel accounts with stable selector ids | [Multi-Account Channel Shape](#multi-account-channel-shape) |
 | `gateway run` or `gateway run` selectors | [Gateway Selector Rule](#gateway-selector-rule) |
-| managed skill install, exposure, and persisted download policy | [Managed Skills](/use-loong/managed-skills) |
+| skill install, exposure, and persisted download policy | [Skills](/use-loong/skills) |
 | built-in web or browser private-host and domain rules | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) |
 | outbound sends to a private bridge or self-hosted HTTP endpoint | [Outbound HTTP Trust Toggle](#outbound-http-trust-toggle) |
 | the current public memory shape | [Memory Profile Shape](#memory-profile-shape) |
@@ -36,10 +36,10 @@ Loong keeps the top-level operator config explicit:
 - `providers.<id>` stores reviewed provider profiles
 - channel families such as `feishu`, `telegram`, or `wecom` keep their own
   account-aware config blocks
-- `external_skills` keeps managed skill enablement and download policy explicit
+- `skills` keeps skill enablement and download policy explicit
 - `tools.browser` and `tools.web` keep bounded page browsing, session limits,
   and trust boundaries explicit, while richer browser automation stays an
-  installable managed skill instead of a hidden sidecar lane
+  installable skill instead of a hidden sidecar lane
 - `memory.profile` stays operator-visible as the continuity choice instead of exposing multiple public memory forms or hiding behind prompt logic
 - top-level runtime toggles such as `outbound_http` stay explicit
 
@@ -77,19 +77,19 @@ Secret reference note:
 
 Other governed operator-facing config families live alongside that core shape:
 
-- [Managed Skills](/use-loong/managed-skills) covers `[external_skills]`
-  enablement, install policy, and `agent-browser` setup.
+- [Skills](/use-loong/skills) covers `[skills]`
+  enablement, install policy, and browser automation setup.
 - [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries)
   covers `[tools.browser]`, `[tools.web]`, and
   when `[outbound_http] allow_private_hosts = true` is the right owner.
 
 ## Skills And Browser Boundary Shape
 
-When the `config.toml` question is really about managed skills, browser
+When the `config.toml` question is really about skills, browser
 enablement, or domain restrictions, the public shape looks like this:
 
 ```toml
-[external_skills]
+[skills]
 enabled = false
 require_download_approval = true
 auto_expose_installed = false
@@ -112,18 +112,18 @@ allow_private_hosts = false
 
 Read that block with these owner rules:
 
-- `[external_skills]` governs managed skill discovery, download approval,
+- `[skills]` governs skill discovery, download approval,
   install location, and runtime exposure policy
 - `[tools.browser]` governs built-in bounded page browsing and local session,
   link, and text limits
 - `[tools.web]` governs built-in web fetch and built-in browser host and domain
   trust
-- richer browser automation is exposed through managed skills such as
-  `agent-browser`, not a separate config block
+- richer browser automation is exposed through skills, not a separate config
+  block
 - `[outbound_http]` governs HTTP-backed outbound delivery, not the built-in
   browser
 
-Continue to [Managed Skills](/use-loong/managed-skills) when the blocker is
+Continue to [Skills](/use-loong/skills) when the blocker is
 install or exposure policy. Continue to
 [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) when
 the blocker is private hosts, domains, or browser automation runtime
@@ -335,7 +335,7 @@ continuity model and progression rules.
 | choose the provider lane first | [Providers And Models](/use-loong/providers-and-models) |
 | follow provider-specific config walkthroughs | [Provider Guides](/use-loong/provider-guides/index) and [Provider Recipes](/use-loong/provider-recipes) |
 | understand the delivery-surface model first | [Channels](/use-loong/channels) |
-| manage skill install and exposure policy | [Managed Skills](/use-loong/managed-skills) |
+| manage skill install and exposure policy | [Skills](/use-loong/skills) |
 | debug private-host, domain, or browser runtime gates | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) |
 | follow channel setup and smoke-test paths | [Channel Guides](/use-loong/channel-guides/index), [Channel Recipes](/use-loong/channel-recipes), and [Channel Setup](/use-loong/channel-setup) |
 | choose between foreground serve loops and gateway ownership | [Gateway And Supervision](/use-loong/gateway-and-supervision) |

--- a/site/use-loong/configuration-reference.mdx
+++ b/site/use-loong/configuration-reference.mdx
@@ -37,7 +37,7 @@ loong validate-config --config /path/to/custom-config.toml
 - [memory](#memory) - Memory and conversation history
 - [conversation](#conversation) - Conversation runtime behavior
 - [acp](#acp) - Agent Control Plane settings
-- [external_skills](#external_skills) - External skill management
+- [skills](#skills) - External skill management
 - [audit](#audit) - Audit logging
 - [channels](#channels) - Channel-specific settings
 - [feishu_integration](#feishu_integration) - Feishu OAuth integration settings
@@ -592,13 +592,13 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
 
 ---
 
-## external_skills
+## skills
 
-Configuration for external skill management.
+Configuration for skills.
 
 | Field | Type | Default | Valid Values | Description |
 |-------|------|---------|--------------|-------------|
-| `enabled` | boolean | `false` | `true`, `false` | Enable external skills |
+| `enabled` | boolean | `false` | `true`, `false` | Enable skills |
 | `require_download_approval` | boolean | `true` | `true`, `false` | Require approval for downloads |
 | `allowed_domains` | string[] | `[]` | Domain names | Allowed download domains |
 | `blocked_domains` | string[] | `[]` | Domain names | Blocked download domains |
@@ -608,7 +608,7 @@ Configuration for external skill management.
 ### Example
 
 ```toml
-[external_skills]
+[skills]
 enabled = true
 require_download_approval = true
 allowed_domains = ["github.com", "gist.github.com"]

--- a/site/use-loong/overview.mdx
+++ b/site/use-loong/overview.mdx
@@ -20,7 +20,7 @@ This section is organized in two layers on purpose:
 | --- | --- | --- |
 | reach one complete hosted team-chat rollout quickly | [Common Setups](/use-loong/common-setups) | start with the playbook that matches the real rollout shape, then fall back to [Provider Guides](/use-loong/provider-guides/index) or [Channel Guides](/use-loong/channel-guides/index) when you need the broader map |
 | understand the shared public config shape before deep recipes | [Configuration Patterns](/use-loong/configuration-patterns) | [Configuration Reference](/use-loong/configuration-reference), [Provider Guides](/use-loong/provider-guides/index), [Channel Setup](/use-loong/channel-setup), or [Memory Profiles](/use-loong/memory-profiles) |
-| unblock managed skills, agent-browser setup, or domain-policy friction | [Managed Skills](/use-loong/managed-skills) | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries), [Doctor And Health](/get-started/doctor-and-health), or [Tool Surface](/use-loong/tool-surface) |
+| unblock skills, browser automation setup, or domain-policy friction | [Skills](/use-loong/skills) | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries), [Doctor And Health](/get-started/doctor-and-health), or [Tool Surface](/use-loong/tool-surface) |
 | choose a provider first, then configure it directly | [Providers And Models](/use-loong/providers-and-models) | [Provider Guides](/use-loong/provider-guides/index) and [Provider Recipes](/use-loong/provider-recipes) |
 | choose a delivery surface first, then configure it directly | [Channels](/use-loong/channels) | [Channel Guides](/use-loong/channel-guides/index), [Channel Recipes](/use-loong/channel-recipes), and [Gateway And Supervision](/use-loong/gateway-and-supervision) |
 | understand the runtime surface before touching config | this page | [Providers And Models](/use-loong/providers-and-models), [Channels](/use-loong/channels), and [Tools And Memory](/use-loong/tools-and-memory) |
@@ -54,7 +54,7 @@ complete rollout path.
 3. Use `Providers And Models` or `Channels` when you still need to choose the right lane first.
 4. Drop into recipe pages when the chooser pages stop being concrete enough.
 5. Add channel or gateway surfaces only after the local assistant path is healthy.
-6. Turn on memory or managed-skills flows when you need continuity or reuse rather than on day zero.
+6. Turn on memory or skills flows when you need continuity or reuse rather than on day zero.
 
 ## Current Public Runtime Shape
 
@@ -77,7 +77,7 @@ complete rollout path.
 | [Gateway Rollout](/use-loong/gateway-rollout-playbook) | you want the multi-channel ownership sequence as one playbook |
 | [Configuration Patterns](/use-loong/configuration-patterns) | you want the shared public config shape before field-level specs or recipes |
 | [Configuration Reference](/use-loong/configuration-reference) | you want the field-level public config contract, validation semantics, and default paths in the main docs surface |
-| [Managed Skills](/use-loong/managed-skills) | you want the operator path for discovery, install, policy, and external browser automation skill setup |
+| [Skills](/use-loong/skills) | you want the operator path for discovery, install, policy, and browser automation skill setup |
 | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) | you want private-host, domain, and browser runtime troubleshooting without guessing which config lane owns it |
 | [Providers And Models](/use-loong/providers-and-models) | you want the public provider and model-selection contract before touching config |
 | [Provider Guides](/use-loong/provider-guides/index) | you want the exact built-in contract for one provider kind |

--- a/site/use-loong/skills.mdx
+++ b/site/use-loong/skills.mdx
@@ -1,16 +1,16 @@
 ---
-title: Managed Skills
-description: Install, expose, and troubleshoot managed external skills without guessing.
+title: Skills
+description: Install, expose, and troubleshoot skills without guessing.
 ---
 
-# Managed Skills
+# Skills
 
 Use this page when the question is no longer "does Loong support skills?"
 and is now "how do I discover, install, expose, and troubleshoot them on
 purpose?"
 
 `loong skills` is the public operator surface for discovery, install, removal,
-and persisted policy updates around managed external skills.
+and persisted policy updates around skills.
 
 ## Start Here
 
@@ -26,10 +26,10 @@ and persisted policy updates around managed external skills.
 
 ## Default Public Posture
 
-Managed external skills start from a fail-closed default:
+Skills start from a fail-closed default:
 
 ```toml
-[external_skills]
+[skills]
 enabled = false
 require_download_approval = true
 allowed_domains = []
@@ -39,27 +39,27 @@ auto_expose_installed = false
 
 Rules that matter:
 
-- `enabled = false` keeps the managed runtime fail-closed rather than silently
+- `enabled = false` keeps the skills runtime fail-closed rather than silently
   widening capability.
 - `require_download_approval = true` means remote skill downloads require an
   explicit operator approval step.
 - `auto_expose_installed = false` means installation and runtime visibility are
   kept separate until you turn that gate on.
-- `install_root` is optional and is the right place to pin a stable managed
-  skill location when the default runtime-owned path is not enough.
+- `install_root` is optional and is the right place to pin a stable skill
+  location when the default runtime-owned path is not enough.
 
 If you want the broader config map before this page gets operational, start with
 [Configuration Patterns](/use-loong/configuration-patterns).
 
 ## Operator Mental Model
 
-Managed external skills have four separate states:
+Skills have four separate states:
 
 1. discovery: `loong skills list`, `search`, `recommend`, and `info` tell you
    what the runtime can resolve; they do not install anything
 2. installation: `loong skills install` or `fetch --install` copies a skill
-   into the managed install root
-3. exposure: `external_skills.enabled` and `auto_expose_installed` decide
+   into the install root
+3. exposure: `skills.enabled` and `auto_expose_installed` decide
    whether installed skills become part of the usable runtime surface
 4. runtime readiness: some skills, especially browser automation helpers such
    as `agent-browser`, still depend on shell policy or an external runtime
@@ -110,7 +110,7 @@ Operational notes:
   rules, and `auto_expose_installed`, but `install_root` still belongs in
   config.
 - `skills install-bundled <skill_id>` also exists for first-party packaged
-  managed skills, including `agent-browser`.
+  skills, including `agent-browser`.
 
 ## Local Install vs Remote Fetch
 
@@ -134,7 +134,7 @@ Choose deliberately:
 - `install` is best for local archives, unpacked directories, or reviewed build
   artifacts you already trust.
 - `fetch --install` is best when you want one operator command that both
-  downloads and installs under the governed external-skills policy.
+  downloads and installs under the governed skills policy.
 - domain allow/block rules apply to `fetch` and belong in persisted policy
   rather than being hidden in ad-hoc shell aliases.
 
@@ -165,7 +165,7 @@ When you want the config to be explicit instead of relying only on CLI
 mutations, this is the public shape to keep in mind:
 
 ```toml
-[external_skills]
+[skills]
 enabled = true
 require_download_approval = true
 allowed_domains = ["skills.sh"]
@@ -188,7 +188,7 @@ Use this when:
 | --- | --- | --- |
 | `skills fetch` is rejected before download starts | download approval or domain policy is blocking it | run `loong skills policy get`, then retry with `--approve-download` or update policy deliberately |
 | a skill installed but does not show up as usable | install succeeded, but the runtime exposure gate is still closed | set `auto_expose_installed = true` through `skills policy set` |
-| you do not know where managed skills should live | the runtime default is acceptable until you need a reviewed location | set `external_skills.install_root` in config when you need a stable explicit path |
+| you do not know where skills should live | the runtime default is acceptable until you need a reviewed location | set `skills.install_root` in config when you need a stable explicit path |
 | `agent-browser` still does not run after install | shell policy or the runtime binary is still missing | remove `agent-browser` from `shell_deny`, verify `agent-browser open example.com`, then rerun `loong doctor` |
 
 ## Continue Reading

--- a/site/use-loong/tool-surface.mdx
+++ b/site/use-loong/tool-surface.mdx
@@ -70,7 +70,7 @@ That distinction matters because:
 
 ## Continue Reading
 
-- Go to [Managed Skills](/use-loong/managed-skills) when the real problem is install, exposure, or external-skills policy rather than the abstract tool contract.
+- Go to [Skills](/use-loong/skills) when the real problem is install, exposure, or skills policy rather than the abstract tool contract.
 - Go to [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) when the real problem is private hosts, domain policy, or external browser automation runtime readiness.
 - Go to [Tools And Memory](/use-loong/tools-and-memory) for the higher-level governed-capability overview.
 - Go to [Memory Profiles](/use-loong/memory-profiles) for continuity behavior and profile selection.

--- a/site/use-loong/tools-and-memory.mdx
+++ b/site/use-loong/tools-and-memory.mdx
@@ -48,7 +48,7 @@ The current public profiles include:
 | If you want... | Start here |
 | --- | --- |
 | the visible-tool contract | [Tool Surface](/use-loong/tool-surface) |
-| the operator path for installable managed skills | [Managed Skills](/use-loong/managed-skills) |
+| the operator path for installable skills | [Skills](/use-loong/skills) |
 | private-host, domain, or browser runtime troubleshooting | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) |
 | continuity and profile selection | [Memory Profiles](/use-loong/memory-profiles) |
 | the supporting safety posture | [Security And Reliability](/reference/security-and-reliability) |
@@ -56,7 +56,7 @@ The current public profiles include:
 ## Where To Go Next
 
 - Continue to [Tool Surface](/use-loong/tool-surface) for the truthful visible-tool contract.
-- Continue to [Managed Skills](/use-loong/managed-skills) for install, policy, and external browser automation skill setup.
+- Continue to [Skills](/use-loong/skills) for install, policy, and external browser automation skill setup.
 - Continue to [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) for private-host, domain, and browser runtime troubleshooting.
 - Continue to [Memory Profiles](/use-loong/memory-profiles) for the public continuity contract.
 - Continue to [Reference](/reference/overview) if you want the supporting roadmap, reliability, and release material.


### PR DESCRIPTION
## Summary
Align the public docs and light user-facing wording with the shipped `skills` surface.

This PR:
- renames the public docs page from `Managed Skills` to `Skills`
- updates docs navigation and links from `/use-loong/managed-skills` to `/use-loong/skills`
- replaces stale public `[external_skills]` / `external_skills.*` references with `[skills]` / `skills.*`
- removes a few lingering public wording leftovers such as `external-skills runtime policy`
- keeps overview pages focused on the `skills` capability surface instead of using a concrete skill name as the category label

## Validation
- `./scripts/cargo-local-toolchain.sh check -p loong-app`

Closes #1454
