### PR TITLE
fix(tui): keep startup logo animating after first chat input

### DIFF
--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -10543,7 +10543,8 @@ description: "actual description"
             .collect::<Vec<_>>()
             .join("\n");
 
-        std::thread::sleep(Duration::from_millis(100));
+        app.message_list
+            .rewind_startup_animation_for_test(Duration::from_millis(100));
         assert!(app.message_list.refresh_startup_animation());
 
         terminal.draw(|f| app.render(f)).expect("draw");

--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -10520,6 +10520,51 @@ description: "actual description"
     }
 
     #[test]
+    fn startup_logo_keeps_animating_with_composer_draft_after_first_message() {
+        let mut env = ScopedEnv::new();
+        env.remove("LOONG_TUI_REDUCED_MOTION");
+        env.set("TERM", "xterm-256color");
+
+        let backend = TestBackend::new(100, 20);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut app = blank_app();
+        app.message_list
+            .add_startup_header("0.1.0".to_owned(), "tutorial".to_owned(), Vec::new());
+        app.message_list.add_user_message("hi".to_owned());
+        app.message_list.add_assistant_message("hello".to_owned());
+        app.composer.set_input("draft".to_owned());
+
+        terminal.draw(|f| app.render(f)).expect("draw");
+        let before_lines = buffer_lines(&terminal);
+        let before_header = before_lines
+            .iter()
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(app.message_list.refresh_startup_animation());
+
+        terminal.draw(|f| app.render(f)).expect("draw");
+        let after_lines = buffer_lines(&terminal);
+        let after_header = after_lines
+            .iter()
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        let after = after_lines.join("\n");
+
+        assert_ne!(
+            before_header, after_header,
+            "startup header should continue animating"
+        );
+        assert!(after.contains("draft"));
+        assert!(after.contains("hello"));
+    }
+
+    #[test]
     fn pending_band_keeps_blank_padding_rows() {
         let backend = TestBackend::new(50, 18);
         let mut terminal = Terminal::new(backend).expect("terminal");

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -939,7 +939,7 @@ impl MessageList {
         if reduced_motion_enabled() {
             return None;
         }
-        if !self.startup_mode_active() {
+        if !self.has_startup_header() {
             return None;
         }
 
@@ -1013,12 +1013,14 @@ impl MessageList {
     }
 
     fn startup_mode_active(&self) -> bool {
-        self.messages.iter().all(|message| message.role == "System")
-            && self
-                .messages
-                .iter()
-                .flat_map(|message| message.contents.iter())
-                .any(|content| matches!(content, MessageContent::StartupHeader { .. }))
+        self.messages.iter().all(|message| message.role == "System") && self.has_startup_header()
+    }
+
+    fn has_startup_header(&self) -> bool {
+        self.messages
+            .iter()
+            .flat_map(|message| message.contents.iter())
+            .any(|content| matches!(content, MessageContent::StartupHeader { .. }))
     }
 }
 
@@ -5397,16 +5399,17 @@ fn styled_background_line(spans: Vec<Span<'static>>, width: u16, bg: Color) -> L
 mod tests {
     use super::{
         MessageContent, MessageList, ReadToolRequest, STARTUP_COMPACT_WORDMARK, STARTUP_EYE_FRAMES,
-        STARTUP_TIP_FADE_MS, STARTUP_TIP_HOLD_MS, STARTUP_WORDMARK, ToolStatus,
-        adjust_scroll_start_for_message_boundary, build_assistant_contents, content_plain_text,
-        dominant_block_bg, extract_read_tool_request_from_json, format_read_request_display,
-        startup_logo_eye_frame_index, startup_logo_eye_style, startup_tip_render_state,
-        startup_wordmark_eye_frame,
+        STARTUP_LOGO_EYE_FRAME_MS, STARTUP_TIP_FADE_MS, STARTUP_TIP_HOLD_MS, STARTUP_WORDMARK,
+        ToolStatus, adjust_scroll_start_for_message_boundary, build_assistant_contents,
+        content_plain_text, dominant_block_bg, extract_read_tool_request_from_json,
+        format_read_request_display, startup_logo_eye_frame_index, startup_logo_eye_style,
+        startup_tip_render_state, startup_wordmark_eye_frame,
     };
     use crate::chat::chat_surface::utils::{
         SURFACE_ACCENT, SURFACE_DIM_GRAY, SURFACE_GRAY, SURFACE_GREEN, SURFACE_RED,
         SURFACE_TOOL_BG, SURFACE_USER_MSG_BG,
     };
+    use crate::test_support::ScopedEnv;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
     use ratatui::{Terminal, backend::TestBackend, style::Color, text::Line};
     use std::time::Duration;
@@ -7797,6 +7800,33 @@ cargo test -p loong-app --lib
 
         assert!(rendered.contains("╷  ╭─╮╭─╮╭╮╷╭─╴"));
         assert!(!rendered.contains("░████████░"));
+    }
+
+    #[test]
+    fn startup_header_animation_stays_active_after_first_message() {
+        let mut env = ScopedEnv::new();
+        env.remove("LOONG_TUI_REDUCED_MOTION");
+        env.set("TERM", "xterm-256color");
+
+        let mut list = MessageList::new();
+        list.add_startup_header_with_tips(
+            "0.1.0".to_owned(),
+            "help".to_owned(),
+            Vec::new(),
+            vec!["first tip".to_owned(), "second tip".to_owned()],
+        );
+        list.add_user_message("hi".to_owned());
+        list.add_assistant_message("hello".to_owned());
+
+        assert!(list.startup_animation_active());
+        list.last_startup_animation_signature = None;
+        std::thread::sleep(Duration::from_millis(
+            STARTUP_LOGO_EYE_FRAME_MS.saturating_add(10),
+        ));
+        assert!(
+            list.refresh_startup_animation(),
+            "startup header should keep animating while it remains visible"
+        );
     }
 
     #[test]

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -914,6 +914,11 @@ impl MessageList {
         self.scroll_state.set_snap_on_next_render_for_test(value);
     }
 
+    #[cfg(test)]
+    pub(crate) fn rewind_startup_animation_for_test(&mut self, duration: Duration) {
+        self.startup_animation_started_at = Instant::now() - duration;
+    }
+
     pub fn refresh_startup_animation(&mut self) -> bool {
         if reduced_motion_enabled() {
             self.last_startup_animation_signature = None;
@@ -7820,7 +7825,7 @@ cargo test -p loong-app --lib
 
         assert!(list.startup_animation_active());
         list.last_startup_animation_signature = None;
-        std::thread::sleep(Duration::from_millis(
+        list.rewind_startup_animation_for_test(Duration::from_millis(
             STARTUP_LOGO_EYE_FRAME_MS.saturating_add(10),
         ));
         assert!(


### PR DESCRIPTION
## Summary

- Problem:
  The chat surface keeps the startup LOONG header visible after the first interaction, but its animation stopped once user or assistant messages entered the transcript.
- Why it matters:
  The logo freezing exactly when the operator starts typing makes the startup surface feel visually broken and inconsistent.
- What changed:
  Kept startup animation tied to the presence of the startup header instead of the transcript staying system-only, and added regression coverage for post-message and composer-draft animation.
- What did not change (scope boundary):
  No onboarding copy, layout structure, or non-startup animation behavior changed.

## Linked Issues

- Closes #1456
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loong-app --lib startup_ -- --test-threads=1
  PASS: 54 startup-related chat surface tests, including the new post-message/composer animation regressions.

cargo test -p loong-app --lib chat::chat_surface::message_list::tests::startup_header_animation_stays_active_after_first_message
  PASS

cargo test -p loong-app --lib chat::chat_surface::app::tests::startup_logo_keeps_animating_with_composer_draft_after_first_message
  PASS

cargo test -p loong-app --lib chat::chat_surface::app::tests::startup_header_remains_visible_after_first_message
  PASS

cargo fmt --all --check
  PASS

cargo check -p loong-app --lib
  PASS
```

Local full-workspace clippy / all-features validation was not run because the change is isolated to `loong-app` chat-surface rendering/tests and the focused `startup_` suite plus `cargo check -p loong-app --lib` already exercised the touched seam.

Process-global env in the new tests is isolated with `ScopedEnv`, which restores values after each test.

## User-visible / Operator-visible Changes

- The startup LOONG ASCII art continues animating while the startup header is still visible, even after the operator starts typing or the first transcript messages appear.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `6264ab21`.
- Observable failure symptoms reviewers should watch for:
  Startup header unexpectedly animating when no startup header is present, or early-chat transcript surfaces failing to redraw as expected.

## Reviewer Focus

- `crates/app/src/chat/chat_surface/message_list.rs`: animation activation gate should follow startup-header presence, not system-only transcript state.
- `crates/app/src/chat/chat_surface/app.rs`: regression smoke coverage for composer-draft redraw after first messages.
