### PR TITLE
streamline release assets and humanize packaged artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,18 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           archive="${PACKAGE_NAME}-${RELEASE_TAG}-${{ matrix.target }}.tar.gz"
-          tar -C "target/${{ matrix.target }}/release" -czf "dist/${archive}" "${BIN_NAME}${{ matrix.ext }}"
-          cd dist && shasum -a 256 "${archive}" > "${archive}.sha256"
+          staging_dir="dist/package-${{ matrix.target }}"
+          mkdir -p "${staging_dir}"
+          cp "target/${{ matrix.target }}/release/${BIN_NAME}${{ matrix.ext }}" "${staging_dir}/${BIN_NAME}${{ matrix.ext }}"
+          if [[ "${{ matrix.target }}" == *-pc-windows-* ]]; then
+            :
+          else
+            "target/${{ matrix.target }}/release/${BIN_NAME}${{ matrix.ext }}" completions bash > "${staging_dir}/loong.bash"
+            "target/${{ matrix.target }}/release/${BIN_NAME}${{ matrix.ext }}" completions zsh > "${staging_dir}/_loong"
+            "target/${{ matrix.target }}/release/${BIN_NAME}${{ matrix.ext }}" completions fish > "${staging_dir}/loong.fish"
+            "target/${{ matrix.target }}/release/${BIN_NAME}${{ matrix.ext }}" completions elvish > "${staging_dir}/loong.elv"
+          fi
+          tar -C "${staging_dir}" -czf "dist/${archive}" .
 
       - name: Package archive (Windows)
         if: matrix.archive == 'zip'
@@ -225,9 +235,11 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $archive = "${env:PACKAGE_NAME}-${env:RELEASE_TAG}-${{ matrix.target }}.zip"
-          Compress-Archive -Path "target/${{ matrix.target }}/release/${env:BIN_NAME}${{ matrix.ext }}" -DestinationPath "dist/$archive" -Force
-          $hash = (Get-FileHash -Algorithm SHA256 "dist/$archive").Hash.ToLowerInvariant()
-          Set-Content -Path "dist/$archive.sha256" -Value "$hash  $archive"
+          $stagingDir = Join-Path "dist" "package-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${env:BIN_NAME}${{ matrix.ext }}" (Join-Path $stagingDir "${env:BIN_NAME}${{ matrix.ext }}") -Force
+          "target/${{ matrix.target }}/release/${env:BIN_NAME}${{ matrix.ext }}" completions powershell | Out-File -Encoding utf8 (Join-Path $stagingDir "loong.ps1")
+          Compress-Archive -Path (Join-Path $stagingDir '*') -DestinationPath "dist/$archive" -Force
 
       - name: Verify glibc floor (Linux GNU targets)
         if: endsWith(matrix.target, '-unknown-linux-gnu')
@@ -269,17 +281,22 @@ jobs:
           cp scripts/install.sh dist/install.sh
           cp scripts/install.ps1 dist/install.ps1
 
-      - name: Generate shell completions
+      - name: Generate SHA256 manifest
+        shell: bash
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          tar -xzf "dist/loong-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz" -C /tmp loong
-          /tmp/loong completions bash        > dist/loong.bash
-          /tmp/loong completions zsh         > dist/_loong
-          /tmp/loong completions fish        > dist/loong.fish
-          /tmp/loong completions powershell  > dist/loong.ps1
-          /tmp/loong completions elvish      > dist/loong.elv
+          . ./scripts/release_artifact_lib.sh
+          manifest_name="$(release_archive_manifest_name "${RELEASE_TAG}")"
+          (
+            cd dist
+            shasum -a 256 \
+              loong-*.tar.gz \
+              loong-*.zip \
+              install.sh \
+              install.ps1 > "${manifest_name}"
+          )
 
       - name: Resolve release channel
         id: release_meta

--- a/docs/releases/support/TEMPLATE.md
+++ b/docs/releases/support/TEMPLATE.md
@@ -40,12 +40,16 @@ like a primary reader-facing product doc.
 ## Artifacts
 | Asset | Size (bytes) | SHA256 | Download |
 |---|---:|---|---|
-| loong-vX.Y.Z[-suffix]-x86_64-unknown-linux-gnu.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
-| loong.bash | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/loong.bash) |
-| _loong | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/_loong) |
-| loong.fish | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/loong.fish) |
-| loong.ps1 | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/loong.ps1) |
-| loong.elv | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/loong.elv) |
+| loong-vX.Y.Z[-suffix]-macos-arm64.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-macos-x64.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-linux-x64-gnu.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-linux-x64-musl.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-linux-arm64-gnu.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-android-arm64.tar.gz | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-windows-x64.zip | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loong-vX.Y.Z[-suffix]-SHA256SUMS.txt | 0 | n/a | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| install.sh | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/install.sh) |
+| install.ps1 | 0 | <sha256> | [link](https://github.com/eastreams/loong/releases/download/vX.Y.Z[-suffix]/install.ps1) |
 
 ## Verification
 | Check | Result | Evidence |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,11 +88,23 @@ function Resolve-ReleaseTarget([string]$Platform, [string]$Arch) {
 }
 
 function Get-ReleaseArchiveName([string]$PackageName, [string]$Tag, [string]$Target) {
-    return "$PackageName-$Tag-$Target.zip"
+    $targetLabel = switch ($Target) {
+        "aarch64-apple-darwin" { "macos-arm64"; break }
+        "x86_64-apple-darwin" { "macos-x64"; break }
+        "aarch64-linux-android" { "android-arm64"; break }
+        "aarch64-unknown-linux-gnu" { "linux-arm64-gnu"; break }
+        "x86_64-unknown-linux-gnu" { "linux-x64-gnu"; break }
+        "x86_64-unknown-linux-musl" { "linux-x64-musl"; break }
+        "x86_64-pc-windows-msvc" { "windows-x64"; break }
+        default { throw "unsupported release target label for $Target" }
+    }
+
+    $extension = if ($Target -like "*-pc-windows-*") { "zip" } else { "tar.gz" }
+    return "$PackageName-$Tag-$targetLabel.$extension"
 }
 
 function Get-ReleaseChecksumName([string]$PackageName, [string]$Tag, [string]$Target) {
-    return "$(Get-ReleaseArchiveName -PackageName $PackageName -Tag $Tag -Target $Target).sha256"
+    return "loong-$Tag-SHA256SUMS.txt"
 }
 
 function Install-Binary([string]$SourceBinary) {
@@ -178,11 +190,14 @@ function Install-FromRelease {
         Invoke-WebRequest -Headers @{ "User-Agent" = "Loong-Install" } -Uri $archiveUrl -OutFile $archivePath
         Invoke-WebRequest -Headers @{ "User-Agent" = "Loong-Install" } -Uri $checksumUrl -OutFile $checksumPath
 
-        $checksumText = (Get-Content -Raw -Path $checksumPath).Trim()
-        if ([string]::IsNullOrWhiteSpace($checksumText)) {
-            throw "checksum file $checksumName did not contain a SHA256 value"
+        $checksumText = Get-Content -Raw -Path $checksumPath
+        $checksumEntry = $checksumText -split "`r?`n" | Where-Object {
+            $_ -match "^[0-9a-fA-F]+\s+$([regex]::Escape($archiveName))$"
+        } | Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace($checksumEntry)) {
+            throw "checksum manifest $checksumName did not contain an entry for $archiveName"
         }
-        $expectedSha = $checksumText.Split([char[]]" `t`r`n", [System.StringSplitOptions]::RemoveEmptyEntries)[0].ToLowerInvariant()
+        $expectedSha = $checksumEntry.Split([char[]]" `t", [System.StringSplitOptions]::RemoveEmptyEntries)[0].ToLowerInvariant()
         $actualSha = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLowerInvariant()
         if ($expectedSha -ne $actualSha) {
             throw "checksum verification failed for $archiveName"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ else
     local package_name="${1:?package_name is required}"
     local tag="${2:?tag is required}"
     local target="${3:?target is required}"
-    printf '%s.sha256\n' "$(release_archive_name "$package_name" "$tag" "$target")"
+    printf 'loong-%s-SHA256SUMS.txt\n' "$tag"
   }
 
   release_binary_name_for_target() {
@@ -845,9 +845,9 @@ install_from_release() {
   curl -fsSL --retry 3 --retry-delay 1 -o "${archive_path}" "${archive_url}"
   curl -fsSL --retry 3 --retry-delay 1 -o "${checksum_path}" "${checksum_url}"
 
-  expected_sha="$(awk '{print $1}' "${checksum_path}" | head -n 1)"
+  expected_sha="$(awk -v archive_name="${archive_name}" '$2 == archive_name { print $1 }' "${checksum_path}" | head -n 1)"
   if [[ -z "${expected_sha}" ]]; then
-    echo "error: checksum file ${checksum_name} did not contain a SHA256 value" >&2
+    echo "error: checksum manifest ${checksum_name} did not contain an entry for ${archive_name}" >&2
     exit 1
   fi
   actual_sha="$(sha256_file "${archive_path}")"

--- a/scripts/release_artifact_lib.sh
+++ b/scripts/release_artifact_lib.sh
@@ -19,20 +19,44 @@ release_archive_extension_for_target() {
   esac
 }
 
+release_asset_target_label() {
+  local target="${1:?target is required}"
+  case "$target" in
+    aarch64-apple-darwin) printf 'macos-arm64\n' ;;
+    x86_64-apple-darwin) printf 'macos-x64\n' ;;
+    aarch64-linux-android) printf 'android-arm64\n' ;;
+    aarch64-unknown-linux-gnu) printf 'linux-arm64-gnu\n' ;;
+    x86_64-unknown-linux-gnu) printf 'linux-x64-gnu\n' ;;
+    x86_64-unknown-linux-musl) printf 'linux-x64-musl\n' ;;
+    x86_64-pc-windows-msvc) printf 'windows-x64\n' ;;
+    *)
+      echo "unsupported release asset target label for ${target}" >&2
+      return 1
+      ;;
+  esac
+}
+
 release_archive_name() {
   local package_name="${1:?package_name is required}"
   local tag="${2:?tag is required}"
   local target="${3:?target is required}"
   local archive_ext
+  local target_label
   archive_ext="$(release_archive_extension_for_target "$target")"
-  printf '%s-%s-%s.%s\n' "$package_name" "$tag" "$target" "$archive_ext"
+  target_label="$(release_asset_target_label "$target")"
+  printf '%s-%s-%s.%s\n' "$package_name" "$tag" "$target_label" "$archive_ext"
 }
 
 release_archive_checksum_name() {
   local package_name="${1:?package_name is required}"
   local tag="${2:?tag is required}"
   local target="${3:?target is required}"
-  printf '%s.sha256\n' "$(release_archive_name "$package_name" "$tag" "$target")"
+  printf '%s\n' "$(release_archive_manifest_name "$tag")"
+}
+
+release_archive_manifest_name() {
+  local tag="${1:?tag is required}"
+  printf 'loong-%s-SHA256SUMS.txt\n' "$tag"
 }
 
 release_binary_name_for_target() {

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -124,7 +124,7 @@ EOF
   esac
 
   checksum_path="$release_dir/$checksum_name"
-  printf '%s  %s\n' "$(sha256_file "$archive_path")" "$archive_name" >"$checksum_path"
+  printf '%s  %s\n' "$(sha256_file "$archive_path")" "$archive_name" >>"$checksum_path"
 }
 
 make_linux_dual_libc_fixture() {
@@ -1064,7 +1064,7 @@ run_release_override_install_and_onboard_preserves_signal_source_when_multiple_c
 }
 
 run_checksum_mismatch_fails_test() {
-  local fixture install_dir output_file tag target checksum_name
+  local fixture install_dir output_file tag target checksum_name archive_name
   fixture="$(make_release_fixture "v0.1.2")"
   trap 'rm -rf "$fixture"' RETURN
   install_dir="$fixture/install"
@@ -1072,7 +1072,8 @@ run_checksum_mismatch_fails_test() {
   tag="v0.1.2"
   target="$(host_target)"
   checksum_name="$(release_archive_checksum_name "$PACKAGE_NAME" "$tag" "$target")"
-  printf 'deadbeef  wrong-archive\n' >"$fixture/releases/download/$tag/$checksum_name"
+  archive_name="$(release_archive_name "$PACKAGE_NAME" "$tag" "$target")"
+  printf 'deadbeef  %s\n' "$archive_name" >"$fixture/releases/download/$tag/$checksum_name"
 
   if (
     cd "$REPO_ROOT"

--- a/scripts/test_release_artifact_lib.sh
+++ b/scripts/test_release_artifact_lib.sh
@@ -48,28 +48,28 @@ EOF
     "$(release_doc_backticked_field "$tmp_dir/v0.1.2.md" "Trace path")"
   assert_equals ".docs/releases/v0.1.2-debug.md" "$(release_debug_doc_relpath "v0.1.2")"
   assert_equals \
-    "loong-v0.1.2-x86_64-unknown-linux-gnu.tar.gz" \
+    "loong-v0.1.2-linux-x64-gnu.tar.gz" \
     "$(release_archive_name "loong" "v0.1.2" "x86_64-unknown-linux-gnu")"
   assert_equals \
-    "loong-v0.1.2-aarch64-apple-darwin.tar.gz" \
+    "loong-v0.1.2-macos-arm64.tar.gz" \
     "$(release_archive_name "loong" "v0.1.2" "aarch64-apple-darwin")"
   assert_equals \
-    "loong-v0.1.2-aarch64-unknown-linux-gnu.tar.gz" \
+    "loong-v0.1.2-linux-arm64-gnu.tar.gz" \
     "$(release_archive_name "loong" "v0.1.2" "aarch64-unknown-linux-gnu")"
   assert_equals \
-    "loong-v0.1.2-aarch64-linux-android.tar.gz" \
+    "loong-v0.1.2-android-arm64.tar.gz" \
     "$(release_archive_name "loong" "v0.1.2" "aarch64-linux-android")"
   assert_equals \
-    "loong-v0.1.2-x86_64-unknown-linux-musl.tar.gz" \
+    "loong-v0.1.2-linux-x64-musl.tar.gz" \
     "$(release_archive_name "loong" "v0.1.2" "x86_64-unknown-linux-musl")"
   assert_equals \
-    "loong-v0.1.2-x86_64-pc-windows-msvc.zip" \
+    "loong-v0.1.2-windows-x64.zip" \
     "$(release_archive_name "loong" "v0.1.2" "x86_64-pc-windows-msvc")"
   assert_equals \
-    "loong-v0.1.2-x86_64-pc-windows-msvc.zip.sha256" \
+    "loong-v0.1.2-SHA256SUMS.txt" \
     "$(release_archive_checksum_name "loong" "v0.1.2" "x86_64-pc-windows-msvc")"
   assert_equals \
-    "loong-v0.1.2-x86_64-unknown-linux-musl.tar.gz.sha256" \
+    "loong-v0.1.2-SHA256SUMS.txt" \
     "$(release_archive_checksum_name "loong" "v0.1.2" "x86_64-unknown-linux-musl")"
   assert_equals \
     "x86_64-unknown-linux-gnu" \


### PR DESCRIPTION
## Summary

- replace raw rust target triples in public release asset names with human-readable platform labels
- keep the current supported platform set, including linux musl, linux arm64 gnu, android arm64, macos arm64/x64, and windows x64
- stop publishing standalone completion assets and package shell completions inside platform archives instead
- replace per-asset checksum sidecars with a single release-level checksum manifest
- align release helpers, installers, and release-support docs with the slimmer asset surface

## Linked Issues

- Closes #1461

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `bash scripts/test_release_artifact_lib.sh`
- [x] `bash scripts/test_release_workflow_hardening.sh`
- [x] `bash scripts/test_install_sh.sh`
- [x] `cargo fmt --all -- --check`

## User-visible / Operator-visible Changes

- release assets read like `linux-x64-musl` and `macos-arm64` instead of raw rust target triples
- shell completion files are no longer uploaded as standalone release assets
- release pages expose one checksum manifest instead of one checksum sidecar per archive
- installers verify downloads against the shared checksum manifest
