### PR TITLE
Gate Feishu group chat on bot @-mentions when enabled

### DIFF
--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use std::future::Future;
+use std::sync::{Arc, OnceLock};
 
 use crate::CliResult;
 use crate::channel::feishu::api::FeishuClient;
@@ -103,6 +104,7 @@ pub(super) struct FeishuAdapter {
     client: FeishuClient,
     receive_id_type: String,
     tenant_access_token: Option<String>,
+    bot_open_id: Arc<OnceLock<String>>,
 }
 
 impl FeishuAdapter {
@@ -122,12 +124,43 @@ impl FeishuAdapter {
             )?,
             receive_id_type: config.receive_id_type.clone(),
             tenant_access_token: None,
+            bot_open_id: Arc::new(OnceLock::new()),
         })
     }
 
     pub(super) async fn refresh_tenant_token(&mut self) -> CliResult<()> {
-        self.tenant_access_token = Some(self.client.get_tenant_access_token().await?);
+        let token = self.client.get_tenant_access_token().await?;
+        self.tenant_access_token = Some(token);
+        // Only needed for the require-mention filter; a lookup failure must
+        // not break the channel — log and retry on the next refresh.
+        if self.bot_open_id.get().is_none()
+            && let Some(token) = self.tenant_access_token.as_deref()
+        {
+            match self.client.get_bot_info(token).await {
+                Ok(info) => {
+                    if let Some(value) = info
+                        .open_id
+                        .as_ref()
+                        .map(|value| value.trim().to_owned())
+                        .filter(|value| !value.is_empty())
+                    {
+                        let _ = self.bot_open_id.set(value);
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "loong.channel.feishu",
+                        action = "bot_info_lookup",
+                        "feishu bot info lookup failed: {error}"
+                    );
+                }
+            }
+        }
         Ok(())
+    }
+
+    pub(super) fn bot_open_id_handle(&self) -> Arc<OnceLock<String>> {
+        Arc::clone(&self.bot_open_id)
     }
 
     pub(super) async fn resolve_operator_outbound_message(

--- a/crates/app/src/channel/feishu/api/client.rs
+++ b/crates/app/src/channel/feishu/api/client.rs
@@ -73,6 +73,11 @@ pub struct FeishuUserInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct FeishuBotInfo {
+    pub open_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct FeishuWsEndpointClientConfig {
     #[serde(rename = "ReconnectCount", default)]
     pub reconnect_count: Option<i64>,
@@ -370,6 +375,17 @@ impl FeishuClient {
             )
             .await?;
         parse_user_info_response(&payload)
+    }
+
+    /// Fetch the bot's own profile, including its `open_id`. Used at
+    /// onboarding to identify the bot when applying inbound mention
+    /// filters; the value is cached by the caller and never persisted to
+    /// disk or surfaced through public configuration.
+    pub async fn get_bot_info(&self, tenant_access_token: &str) -> CliResult<FeishuBotInfo> {
+        let payload = self
+            .get_json("/open-apis/bot/v3/info", Some(tenant_access_token), &[])
+            .await?;
+        parse_bot_info_response(&payload)
     }
 
     pub async fn get_json(
@@ -720,6 +736,30 @@ pub fn parse_user_info_response(payload: &Value) -> CliResult<FeishuUserInfo> {
     })
 }
 
+pub fn parse_bot_info_response(payload: &Value) -> CliResult<FeishuBotInfo> {
+    if let Some(code) = payload.get("code").and_then(Value::as_i64)
+        && code != 0
+    {
+        let detail = payload
+            .get("msg")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("<no msg>");
+        return Err(format!(
+            "feishu bot info request failed with code {code}: {detail}"
+        ));
+    }
+    let scope = payload
+        .get("bot")
+        .and_then(Value::as_object)
+        .or_else(|| payload.as_object())
+        .ok_or_else(|| "feishu bot info payload is not an object".to_owned())?;
+    Ok(FeishuBotInfo {
+        open_id: string_field(scope, "open_id"),
+    })
+}
+
 pub fn parse_tenant_access_token_response(payload: &Value) -> CliResult<String> {
     payload
         .get("tenant_access_token")
@@ -929,6 +969,37 @@ mod tests {
         let token = parse_tenant_access_token_response(&payload).expect("parse tenant token");
 
         assert_eq!(token, "t-123");
+    }
+
+    #[test]
+    fn parse_bot_info_response_reads_open_id_from_bot_payload() {
+        let payload = serde_json::json!({
+            "code": 0,
+            "msg": "ok",
+            "bot": {
+                "app_name": "Loong",
+                "open_id": "ou_bot_xyz"
+            }
+        });
+
+        let info = parse_bot_info_response(&payload).expect("parse bot info");
+
+        assert_eq!(info.open_id.as_deref(), Some("ou_bot_xyz"));
+    }
+
+    #[test]
+    fn parse_bot_info_response_surfaces_non_zero_code_with_msg() {
+        let payload = serde_json::json!({
+            "code": 99991672,
+            "msg": "Access denied. App has no permission to access the API."
+        });
+
+        let error = parse_bot_info_response(&payload).expect_err("expect Err on non-zero code");
+
+        assert!(
+            error.contains("99991672") && error.contains("Access denied"),
+            "expected error to surface code and msg, got: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/channel/feishu/api/mod.rs
+++ b/crates/app/src/channel/feishu/api/mod.rs
@@ -16,7 +16,7 @@ pub use auth::{
     summarize_message_write_scope_status,
 };
 pub use client::{
-    FeishuClient, FeishuUserInfo, FeishuWsEndpoint, FeishuWsEndpointClientConfig,
+    FeishuBotInfo, FeishuClient, FeishuUserInfo, FeishuWsEndpoint, FeishuWsEndpointClientConfig,
     parse_user_info_response,
 };
 pub use error::FeishuApiError;

--- a/crates/app/src/channel/feishu/payload/inbound.rs
+++ b/crates/app/src/channel/feishu/payload/inbound.rs
@@ -106,11 +106,34 @@ pub(in crate::channel::feishu) fn parse_feishu_inbound_payload(
     )
 }
 
+#[cfg(test)]
 pub(in crate::channel::feishu) fn parse_feishu_inbound_payload_with_access_policy(
     payload: &Value,
     transport_auth: FeishuTransportAuth<'_>,
     access_policy: &ChannelInboundAccessPolicy<String>,
     ignore_bot_messages: bool,
+    configured_account_id: &str,
+    account_id: &str,
+) -> CliResult<FeishuWebhookAction> {
+    parse_feishu_inbound_payload_with_options(
+        payload,
+        transport_auth,
+        access_policy,
+        ignore_bot_messages,
+        false,
+        None,
+        configured_account_id,
+        account_id,
+    )
+}
+
+pub(in crate::channel::feishu) fn parse_feishu_inbound_payload_with_options(
+    payload: &Value,
+    transport_auth: FeishuTransportAuth<'_>,
+    access_policy: &ChannelInboundAccessPolicy<String>,
+    ignore_bot_messages: bool,
+    require_mention: bool,
+    bot_id: Option<&str>,
     configured_account_id: &str,
     account_id: &str,
 ) -> CliResult<FeishuWebhookAction> {
@@ -211,6 +234,10 @@ pub(in crate::channel::feishu) fn parse_feishu_inbound_payload_with_access_polic
         return Ok(FeishuWebhookAction::Ignore);
     }
 
+    if require_mention && feishu_group_message_lacks_bot_mention(message, bot_id) {
+        return Ok(FeishuWebhookAction::Ignore);
+    }
+
     let message_id = required_string_field(message, "message_id")
         .ok_or_else(|| "feishu message event missing message.message_id".to_owned())?;
     let root_id = optional_string_field(message, "root_id");
@@ -297,6 +324,66 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
     )
 }
 
+/// Returns `true` only when the inbound message is a Feishu group chat
+/// message that does not @-mention this bot according to the event's
+/// `mentions` field. We require an entry whose `mentioned_type` is `"bot"`
+/// and whose `id` block (any of `open_id`/`user_id`/`union_id`) matches
+/// `bot_id`. Non-group chats (e.g. p2p) always return `false` so the
+/// require-mention filter is scoped to group chats.
+fn feishu_group_message_lacks_bot_mention(
+    message: &serde_json::Map<String, Value>,
+    bot_id: Option<&str>,
+) -> bool {
+    let chat_type = message
+        .get("chat_type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    if chat_type != "group" {
+        return false;
+    }
+    let Some(mentions) = message.get("mentions").and_then(Value::as_array) else {
+        return true;
+    };
+    !mentions
+        .iter()
+        .any(|entry| feishu_mention_targets_bot(entry, bot_id))
+}
+
+fn feishu_mention_targets_bot(entry: &Value, bot_id: Option<&str>) -> bool {
+    let Some(map) = entry.as_object() else {
+        return false;
+    };
+    let mentioned_type = map
+        .get("mentioned_type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    if !mentioned_type.eq_ignore_ascii_case("bot") {
+        return false;
+    }
+    let Some(id) = map.get("id").and_then(Value::as_object) else {
+        return false;
+    };
+    let candidates: Vec<&str> = ["open_id", "user_id", "union_id"]
+        .into_iter()
+        .filter_map(|key| {
+            id.get(key)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .collect();
+    match bot_id.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(expected) => candidates.contains(&expected),
+        // Without a configured bot identifier we cannot prove the bot was the
+        // mention target. Treat any `mentioned_type=bot` entry as a match so
+        // the filter remains permissive for single-bot chats.
+        None => !candidates.is_empty(),
+    }
+}
+
+#[cfg(test)]
 pub(in crate::channel::feishu) fn parse_feishu_webhook_payload_with_access_policy(
     payload: &Value,
     verification_token: Option<&str>,
@@ -311,6 +398,29 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload_with_access_polic
         FeishuTransportAuth::webhook(verification_token, encrypt_key),
         access_policy,
         ignore_bot_messages,
+        configured_account_id,
+        account_id,
+    )
+}
+
+pub(in crate::channel::feishu) fn parse_feishu_webhook_payload_with_options(
+    payload: &Value,
+    verification_token: Option<&str>,
+    encrypt_key: Option<&str>,
+    access_policy: &ChannelInboundAccessPolicy<String>,
+    ignore_bot_messages: bool,
+    require_mention: bool,
+    bot_id: Option<&str>,
+    configured_account_id: &str,
+    account_id: &str,
+) -> CliResult<FeishuWebhookAction> {
+    parse_feishu_inbound_payload_with_options(
+        payload,
+        FeishuTransportAuth::webhook(verification_token, encrypt_key),
+        access_policy,
+        ignore_bot_messages,
+        require_mention,
+        bot_id,
         configured_account_id,
         account_id,
     )

--- a/crates/app/src/channel/feishu/payload/mod.rs
+++ b/crates/app/src/channel/feishu/payload/mod.rs
@@ -3,9 +3,11 @@ mod inbound;
 mod outbound;
 mod types;
 
+#[cfg(test)]
+pub(super) use inbound::parse_feishu_webhook_payload_with_access_policy;
 pub(super) use inbound::{
-    FeishuTransportAuth, normalize_webhook_path, parse_feishu_inbound_payload_with_access_policy,
-    parse_feishu_webhook_payload_with_access_policy,
+    FeishuTransportAuth, normalize_webhook_path, parse_feishu_inbound_payload_with_options,
+    parse_feishu_webhook_payload_with_options,
 };
 #[cfg(test)]
 pub(super) use inbound::{parse_feishu_inbound_payload, parse_feishu_webhook_payload};

--- a/crates/app/src/channel/feishu/payload/tests.rs
+++ b/crates/app/src/channel/feishu/payload/tests.rs
@@ -1762,3 +1762,322 @@ fn feishu_message_event_requires_verification_token_configuration() {
 
     assert!(error.contains("verification token is not configured"));
 }
+
+fn feishu_group_text_payload_with_optional_mentions(mentions: Option<Value>) -> Value {
+    let mut message = serde_json::Map::new();
+    message.insert("chat_id".to_owned(), Value::String("oc_group_1".to_owned()));
+    message.insert("chat_type".to_owned(), Value::String("group".to_owned()));
+    message.insert(
+        "message_id".to_owned(),
+        Value::String("om_mention_1".to_owned()),
+    );
+    message.insert("message_type".to_owned(), Value::String("text".to_owned()));
+    message.insert(
+        "content".to_owned(),
+        Value::String("{\"text\":\"hello loong\"}".to_owned()),
+    );
+    if let Some(mentions) = mentions {
+        message.insert("mentions".to_owned(), mentions);
+    }
+
+    json!({
+        "token": "token-123",
+        "header": {
+            "event_id": "evt_mention_filter",
+            "event_type": "im.message.receive_v1"
+        },
+        "event": {
+            "sender": {
+                "sender_type": "user",
+                "sender_id": {
+                    "open_id": "ou_human_1"
+                }
+            },
+            "message": Value::Object(message)
+        }
+    })
+}
+
+fn feishu_mention_filter_access_policy() -> ChannelInboundAccessPolicy<String> {
+    ChannelInboundAccessPolicy::from_string_lists(&["oc_group_1".to_owned()], &[], true)
+}
+
+const FEISHU_TEST_BOT_OPEN_ID: &str = "ou_bot_loong";
+
+fn feishu_test_bot_mention() -> Value {
+    json!({
+        "key": "@_user_1",
+        "mentioned_type": "bot",
+        "id": {
+            "open_id": FEISHU_TEST_BOT_OPEN_ID,
+            "union_id": "on_bot_loong",
+            "user_id": "u_bot_loong"
+        },
+        "name": "loong-bot",
+        "tenant_key": "tenant_1"
+    })
+}
+
+#[test]
+fn feishu_group_chat_message_without_mentions_is_ignored_when_require_mention_enabled() {
+    let payload = feishu_group_text_payload_with_optional_mentions(None);
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    assert!(matches!(action, FeishuWebhookAction::Ignore));
+}
+
+#[test]
+fn feishu_group_chat_message_with_bot_mention_proceeds_when_require_mention_enabled() {
+    let payload =
+        feishu_group_text_payload_with_optional_mentions(Some(json!([feishu_test_bot_mention()])));
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    let event = expect_inbound(action);
+    assert_eq!(event.event_id, "evt_mention_filter");
+    assert_eq!(event.text, "hello loong");
+}
+
+#[test]
+fn feishu_group_chat_message_proceeds_when_require_mention_disabled() {
+    let payload = feishu_group_text_payload_with_optional_mentions(None);
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        false,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    let event = expect_inbound(action);
+    assert_eq!(event.event_id, "evt_mention_filter");
+    assert_eq!(event.text, "hello loong");
+}
+
+#[test]
+fn feishu_group_chat_user_only_mention_is_ignored_when_require_mention_enabled() {
+    let payload = feishu_group_text_payload_with_optional_mentions(Some(json!([
+        {
+            "key": "@_user_1",
+            "mentioned_type": "user",
+            "id": {
+                "open_id": "ou_someone_else",
+                "union_id": "on_someone_else",
+                "user_id": "u_someone_else"
+            },
+            "name": "Alice",
+            "tenant_key": "tenant_1"
+        }
+    ])));
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    assert!(matches!(action, FeishuWebhookAction::Ignore));
+}
+
+#[test]
+fn feishu_group_chat_other_bot_mention_is_ignored_when_bot_id_does_not_match() {
+    let payload = feishu_group_text_payload_with_optional_mentions(Some(json!([
+        {
+            "key": "@_user_1",
+            "mentioned_type": "bot",
+            "id": {
+                "open_id": "ou_other_bot",
+                "union_id": "on_other_bot",
+                "user_id": "u_other_bot"
+            },
+            "name": "OtherBot",
+            "tenant_key": "tenant_1"
+        }
+    ])));
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    assert!(matches!(action, FeishuWebhookAction::Ignore));
+}
+
+#[test]
+fn feishu_p2p_chat_message_bypasses_require_mention_filter() {
+    let payload = json!({
+        "token": "token-123",
+        "header": {
+            "event_id": "evt_mention_p2p",
+            "event_type": "im.message.receive_v1"
+        },
+        "event": {
+            "sender": {
+                "sender_type": "user",
+                "sender_id": {
+                    "open_id": "ou_human_2"
+                }
+            },
+            "message": {
+                "chat_id": "oc_p2p_1",
+                "chat_type": "p2p",
+                "message_id": "om_p2p_1",
+                "message_type": "text",
+                "content": "{\"text\":\"private hi\"}"
+            }
+        }
+    });
+    let access_policy =
+        ChannelInboundAccessPolicy::from_string_lists(&["oc_p2p_1".to_owned()], &[], true);
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        Some(FEISHU_TEST_BOT_OPEN_ID),
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu p2p payload");
+
+    let event = expect_inbound(action);
+    assert_eq!(event.text, "private hi");
+}
+
+#[test]
+fn feishu_group_chat_unknown_bot_id_passes_any_bot_mention_when_require_mention_enabled() {
+    let payload = feishu_group_text_payload_with_optional_mentions(Some(json!([
+        {
+            "key": "@_user_1",
+            "mentioned_type": "bot",
+            "id": {
+                "open_id": "ou_some_bot",
+                "union_id": "on_some_bot",
+                "user_id": "u_some_bot"
+            },
+            "name": "AnyBot",
+            "tenant_key": "tenant_1"
+        }
+    ])));
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        None,
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    let event = expect_inbound(action);
+    assert_eq!(event.text, "hello loong");
+}
+
+#[test]
+fn feishu_group_chat_unknown_bot_id_still_ignores_missing_mentions() {
+    let payload = feishu_group_text_payload_with_optional_mentions(None);
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        None,
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    assert!(matches!(action, FeishuWebhookAction::Ignore));
+}
+
+#[test]
+fn feishu_group_chat_unknown_bot_id_still_ignores_user_only_mentions() {
+    let payload = feishu_group_text_payload_with_optional_mentions(Some(json!([
+        {
+            "key": "@_user_1",
+            "mentioned_type": "user",
+            "id": {
+                "open_id": "ou_someone_else"
+            },
+            "name": "Alice",
+            "tenant_key": "tenant_1"
+        }
+    ])));
+    let access_policy = feishu_mention_filter_access_policy();
+
+    let action = parse_feishu_webhook_payload_with_options(
+        &payload,
+        Some("token-123"),
+        None,
+        &access_policy,
+        true,
+        true,
+        None,
+        "feishu_main",
+        "feishu_main",
+    )
+    .expect("parse feishu group payload");
+
+    assert!(matches!(action, FeishuWebhookAction::Ignore));
+}

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -3,7 +3,7 @@ use std::{
     convert::Infallible,
     path::PathBuf,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     task::{Context, Poll},
 };
 
@@ -52,6 +52,8 @@ pub(in crate::channel) struct FeishuWebhookState {
     access_policy: ChannelInboundAccessPolicy<String>,
     ack_reactions: bool,
     ignore_bot_messages: bool,
+    require_mention: bool,
+    bot_id: Arc<OnceLock<String>>,
     seen_events: Arc<Mutex<RecentIdCache>>,
     seen_ack_reactions: Arc<Mutex<RecentIdCache>>,
     kernel_ctx: Arc<KernelContext>,
@@ -110,6 +112,8 @@ impl FeishuWebhookState {
             access_policy,
             ack_reactions: resolved.ack_reactions,
             ignore_bot_messages: resolved.ignore_bot_messages,
+            require_mention: resolved.require_mention,
+            bot_id: adapter.bot_open_id_handle(),
             config,
             resolved_path,
             adapter: Arc::new(Mutex::new(adapter)),
@@ -124,11 +128,13 @@ impl FeishuWebhookState {
         &self,
         payload: &Value,
     ) -> CliResult<FeishuWebhookAction> {
-        super::payload::parse_feishu_inbound_payload_with_access_policy(
+        super::payload::parse_feishu_inbound_payload_with_options(
             payload,
             super::payload::FeishuTransportAuth::websocket(),
             &self.access_policy,
             self.ignore_bot_messages,
+            self.require_mention,
+            self.bot_id.get().map(String::as_str),
             self.configured_account_id.as_str(),
             self.account_id.as_str(),
         )
@@ -625,12 +631,14 @@ async fn handle_feishu_webhook_payload(
 ) -> Result<FeishuWebhookSuccessResponse, (StatusCode, String)> {
     verify_feishu_signature(headers, raw_body, &payload, state.encrypt_key.as_deref())?;
 
-    let parsed = super::payload::parse_feishu_webhook_payload_with_access_policy(
+    let parsed = super::payload::parse_feishu_webhook_payload_with_options(
         &payload,
         state.verification_token.as_deref(),
         state.encrypt_key.as_deref(),
         &state.access_policy,
         state.ignore_bot_messages,
+        state.require_mention,
+        state.bot_id.get().map(String::as_str),
         state.configured_account_id.as_str(),
         state.account_id.as_str(),
     )

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -7075,6 +7075,54 @@ mod tests {
     }
 
     #[test]
+    fn feishu_multi_account_resolution_merges_require_mention_override() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "mode": "websocket",
+            "app_id": "cli_base",
+            "app_secret": "base-secret",
+            "allowed_chat_ids": ["oc_base"],
+            "allowed_sender_ids": ["ou_owner"],
+            "require_mention": true,
+            "accounts": {
+                "Ops": {
+                    "account_id": "Ops-Bot",
+                    "app_id": "cli_ops",
+                    "app_secret": "ops-secret",
+                    "allowed_chat_ids": ["oc_ops"],
+                    "allowed_sender_ids": ["ou_ops"],
+                    "require_mention": false
+                },
+                "Backup": {
+                    "enabled": false,
+                    "app_id": "cli_backup",
+                    "app_secret": "backup-secret"
+                }
+            },
+            "default_account": "Ops"
+        }))
+        .expect("deserialize feishu multi-account config");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default feishu account");
+        assert_eq!(resolved.configured_account_id, "ops");
+        assert_eq!(resolved.account.id, "ops-bot");
+        assert_eq!(resolved.allowed_chat_ids, vec!["oc_ops".to_owned()]);
+        assert_eq!(resolved.allowed_sender_ids, vec!["ou_ops".to_owned()]);
+        assert!(!resolved.require_mention);
+
+        let backup = config
+            .resolve_account(Some("Backup"))
+            .expect("resolve backup feishu account");
+        assert_eq!(backup.configured_account_id, "backup");
+        assert!(!backup.enabled);
+        assert_eq!(backup.allowed_chat_ids, vec!["oc_base".to_owned()]);
+        assert_eq!(backup.allowed_sender_ids, vec!["ou_owner".to_owned()]);
+        assert!(backup.require_mention);
+    }
+
+    #[test]
     fn feishu_resolve_account_for_session_account_id_matches_runtime_identity() {
         let config: FeishuChannelConfig = serde_json::from_value(json!({
             "default_account": "Lark Prod",

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -254,6 +254,8 @@ pub struct FeishuAccountConfig {
     #[serde(default)]
     pub ignore_bot_messages: Option<bool>,
     #[serde(default)]
+    pub require_mention: Option<bool>,
+    #[serde(default)]
     pub acp: Option<ChannelAcpConfig>,
 }
 
@@ -298,6 +300,7 @@ pub struct ResolvedFeishuChannelConfig {
     pub allowed_sender_ids: Vec<String>,
     pub ack_reactions: bool,
     pub ignore_bot_messages: bool,
+    pub require_mention: bool,
     pub acp: ChannelAcpConfig,
 }
 
@@ -500,6 +503,8 @@ pub struct FeishuChannelConfig {
     pub ack_reactions: bool,
     #[serde(default = "default_true")]
     pub ignore_bot_messages: bool,
+    #[serde(default)]
+    pub require_mention: bool,
     #[serde(default)]
     pub acp: ChannelAcpConfig,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -2087,6 +2092,7 @@ impl Default for FeishuChannelConfig {
             allowed_sender_ids: Vec::new(),
             ack_reactions: true,
             ignore_bot_messages: true,
+            require_mention: false,
             acp: ChannelAcpConfig::default(),
             accounts: BTreeMap::new(),
         }
@@ -2688,6 +2694,9 @@ impl FeishuChannelConfig {
             ignore_bot_messages: account_override
                 .and_then(|account| account.ignore_bot_messages)
                 .unwrap_or(self.ignore_bot_messages),
+            require_mention: account_override
+                .and_then(|account| account.require_mention)
+                .unwrap_or(self.require_mention),
             acp: resolve_channel_acp_config(
                 &self.acp,
                 account_override.and_then(|account| account.acp.as_ref()),
@@ -2719,6 +2728,7 @@ impl FeishuChannelConfig {
             allowed_sender_ids: merged.allowed_sender_ids,
             ack_reactions: merged.ack_reactions,
             ignore_bot_messages: merged.ignore_bot_messages,
+            require_mention: merged.require_mention,
             acp: merged.acp,
         })
     }

--- a/site/use-loong/channel-guides/feishu.mdx
+++ b/site/use-loong/channel-guides/feishu.mdx
@@ -37,6 +37,7 @@ receive_id_type = "chat_id"
 app_id_env = "FEISHU_APP_ID"
 app_secret_env = "FEISHU_APP_SECRET"
 allowed_chat_ids = ["oc_ops_room"]
+require_mention = true
 ```
 
 ## Smoke Test
@@ -81,6 +82,7 @@ This surface can run directly through its own `*-serve` command, or under [Gatew
 
 - `loong feishu onboard` is the recommended first-run path for both Feishu and Lark. Use `--domain lark` to start on the international lane, or keep the default Feishu lane and let the registration poll switch to Lark when the scanned tenant reports `tenant_brand = "lark"`.
 - Webhook mode additionally needs `verification_token` and `encrypt_key`; websocket mode does not.
+- Set `require_mention = true` when multiple bots share the same group and you only want Loong to react when this bot is explicitly @-mentioned. P2P chats still bypass that gate.
 - QR onboarding only provisions `app_id` and `app_secret`, so it currently targets websocket mode. Use `loong feishu onboard --manual --mode webhook ...` when you need webhook callback credentials.
 - When QR onboarding receives the configuring user's `open_id` and no Feishu inbound allowlists are already configured, Loong bootstraps `allowed_chat_ids = ["*"]` plus `allowed_sender_ids = [owner_open_id]` so that same user can immediately start a direct chat with the bot after setup.
 - Use `allowed_chat_ids` as the trust boundary instead of treating it as a convenience filter.

--- a/site/use-loong/configuration-reference.mdx
+++ b/site/use-loong/configuration-reference.mdx
@@ -710,6 +710,7 @@ Channel configuration uses top-level TOML tables such as `[cli]`, `[telegram]`, 
 | `webhook_bind` | string | `"127.0.0.1:8080"` | Address | Webhook bind address |
 | `webhook_path` | string | `"/feishu/events"` | Path | Webhook path |
 | `allowed_chat_ids` | string[] | `[]` | Chat IDs | Allowed chat IDs |
+| `require_mention` | boolean | `false` | `true`, `false` | When enabled, ignore Feishu group messages that do not @-mention this bot |
 | `ignore_bot_messages` | boolean | `true` | `true`, `false` | Ignore bot messages |
 | `acp` | table | `{}` | ACP config table | ACP overrides for this channel |
 | `accounts` | map | `{}` | Account ID -> account config | Per-account overrides |
@@ -735,6 +736,7 @@ Channel configuration uses top-level TOML tables such as `[cli]`, `[telegram]`, 
 | `encrypt_key` | string? | `null` | Key string | Encryption key |
 | `encrypt_key_env` | string? | `null` | Env var name | Env var for encrypt key |
 | `allowed_chat_ids` | string[]? | `null` | Chat IDs | Allowed chat IDs |
+| `require_mention` | boolean? | `null` | `true`, `false` | Override whether group messages must @-mention this bot |
 | `ignore_bot_messages` | boolean? | `null` | `true`, `false` | Ignore bot messages override |
 | `acp` | table? | `null` | - | ACP configuration |
 


### PR DESCRIPTION
## Summary

- Problem:
  Feishu group chats fan out every message to every bot, so operators running multiple bots in one room get noise from messages they were never addressed in.
- Why it matters:
  Without an opt-in @-mention gate, the bot reacts to unrelated chatter (and to messages targeted at other bots), which is the exact failure mode #1211 calls out.
- What changed:
  Added an opt-in `require_mention` config (default off, per-channel and per-account override) that, when enabled, ignores group-chat messages whose `mentions` list does not target this bot. The bot's own `open_id` is resolved lazily via `/open-apis/bot/v3/info` and shared between the adapter and the webhook state via `Arc<OnceLock<String>>`, so a delayed resolution becomes visible to the filter without rebuilding state. Webhook and WebSocket inbound paths both route through the new option, and `parse_bot_info_response` now surfaces non-zero Feishu `code` responses instead of swallowing them.
- What did not change (scope boundary):
  P2P / single chats bypass the filter entirely; behavior with `require_mention=false` is unchanged; no kernel / contracts / policy surface touched; no schema changes.

## Linked Issues

- Closes #1211
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)
- [x] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh fmt --all -- --check
  PASS

./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings
  PASS

./scripts/cargo-local-toolchain.sh test -p loong-app --all-features --lib channel::feishu
  PASS: 212 passed; 0 failed; 0 ignored

./scripts/cargo-local-toolchain.sh test -p loong-app --all-features --lib -- \
  channel::feishu::payload::tests channel::feishu::api::client::tests::parse_bot_info
  PASS: 45 passed (covers all new require-mention paths + the bot-info code != 0 path)
```

Full workspace test was not run locally; the changes are scoped to `loong-app` Feishu channel surfaces, and clippy --workspace --all-targets --all-features covered cross-feature compile. CI runs the full workspace test gate.

Behavior matrix (require_mention defaults to `false`, backwards compatible):

| Scenario | require_mention=false | require_mention=true, bot_id known | require_mention=true, bot_id pending |
|---|---|---|---|
| Group chat, no `mentions` field | proceed | ignore | ignore |
| Group chat, mention targets this bot's `open_id` | proceed | proceed | proceed (any bot mention) |
| Group chat, mention targets another bot | proceed | ignore | proceed (single-bot fallback) |
| Group chat, user-only mentions | proceed | ignore | ignore |
| P2P chat | proceed | proceed | proceed |

The "single-bot fallback" is intentional: when bot info lookup has not yet succeeded, multi-bot rooms cannot disambiguate, so we stay permissive on `mentioned_type=bot` rather than dead-channel. Once the next token refresh resolves the bot's `open_id`, the shared `OnceLock` makes the strict-match branch active in-place.

## User-visible / Operator-visible Changes

- New optional config field on Feishu channel and per-account block:

  ```toml
  [channels.feishu]
  require_mention = false   # default; existing deployments unchanged

  [channels.feishu.accounts.main]
  require_mention = true    # opt-in per account
  ```

- When enabled, group messages without an @-mention of this bot are silently ignored at the channel layer (logged at debug only).
- P2P and other chat types are unaffected.

## Failure Recovery

- Fast rollback or disable path:
  Set `require_mention = false` (or omit it) on the channel/account; behavior reverts to pre-#1211.
- Observable failure symptoms reviewers should watch for:
  - Inbound group messages still triggering the bot when `require_mention=true` and the message clearly does not @ this bot — check the `loong.channel.feishu / action=bot_info_lookup` warn log for a missing `bot:info` scope.
  - Bot info lookup repeatedly failing in logs: `feishu bot info request failed with code <N>: <msg>` — non-fatal, but the filter degrades to single-bot fallback until the API call succeeds.

## Reviewer Focus

- `crates/app/src/channel/feishu/payload/inbound.rs`: `feishu_group_message_lacks_bot_mention` and `feishu_mention_targets_bot` — the single-bot fallback semantics and the `id` block matcher.
- `crates/app/src/channel/feishu/webhook.rs:55-116`: `bot_id` is `Arc<OnceLock<String>>` shared with the adapter, not a snapshot — delayed bot-info resolution becomes visible without rebuilding state.
- `crates/app/src/channel/feishu/adapter.rs:130-160`: `refresh_tenant_token` retries `bot/v3/info` on every token refresh until it lands a value; failures are warn-and-continue.
- `crates/app/src/channel/feishu/api/client.rs:739-768`: `parse_bot_info_response` now surfaces non-zero `code` with `msg`.
- `crates/app/src/config/channels.rs`: `require_mention` resolution chain (account override > channel default > `false`).