### PR TITLE
feat(memory): unify retrieval runtime truth

### DIFF
--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -549,6 +549,7 @@ async fn load_stage_envelope(
         let request = memory::build_read_stage_envelope_request_for_memory_config(
             session_id,
             workspace_root.as_deref(),
+            &config.memory,
         );
         let caps = BTreeSet::from([Capability::MemoryRead]);
         let outcome = ctx

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -441,12 +441,12 @@ impl ConversationContextEngine for DefaultContextEngine {
             let provider_binding = crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx);
             let envelope = load_stage_envelope(config, session_id, binding).await?;
             let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
-            let projected = crate::provider::project_hydrated_memory_context_for_view_with_binding(
+            let projected = crate::provider::project_stage_envelope_for_view_with_binding(
                 config,
                 include_system_prompt,
                 &runtime_tool_view,
                 provider_binding,
-                &envelope.hydrated,
+                &envelope,
             )
             .await;
             return Ok(AssembledConversationContext {
@@ -584,22 +584,14 @@ mod tests {
         session_id: &str,
         kernel_ctx: &crate::KernelContext,
     ) -> Vec<Value> {
-        let envelope = load_stage_envelope(
+        crate::provider::build_projected_context_for_session_with_binding(
             config,
             session_id,
-            ConversationRuntimeBinding::kernel(kernel_ctx),
-        )
-        .await
-        .expect("load staged memory envelope");
-        let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
-        crate::provider::project_hydrated_memory_context_for_view_with_binding(
-            config,
             true,
-            &runtime_tool_view,
             crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
-            &envelope.hydrated,
         )
         .await
+        .expect("build provider context")
         .messages
     }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1731,6 +1731,7 @@ async fn provider_messages_with_kernel_binding(
     let request = crate::memory::build_read_stage_envelope_request_for_memory_config(
         session_id,
         workspace_root.as_deref(),
+        &config.memory,
     );
     let caps = BTreeSet::from([Capability::MemoryRead]);
     let outcome = kernel_ctx
@@ -16560,17 +16561,25 @@ async fn build_messages_routes_memory_context_through_kernel_when_context_provid
         crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
     );
     assert_eq!(captured[0].payload["session_id"], "session-k-window");
-    assert!(
-        captured[0].payload.get("profile").is_none(),
-        "canonical memory requests should not carry request-level profile overrides"
+    assert_eq!(
+        captured[0].payload["profile"],
+        config.memory.resolved_profile().as_str()
     );
-    assert!(
-        captured[0].payload.get("sliding_window").is_none(),
-        "canonical memory requests should not carry request-level window overrides"
+    assert_eq!(
+        captured[0].payload["system"],
+        config.memory.resolved_system().as_str()
     );
-    assert!(
-        captured[0].payload.get("summary_max_chars").is_none(),
-        "canonical memory requests should not carry request-level summary overrides"
+    assert_eq!(
+        captured[0].payload["system_id"],
+        config.memory.resolved_system_id()
+    );
+    assert_eq!(
+        captured[0].payload["sliding_window"],
+        config.memory.sliding_window
+    );
+    assert_eq!(
+        captured[0].payload["summary_max_chars"],
+        config.memory.summary_char_budget()
     );
 
     let events = audit.snapshot();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1747,12 +1747,12 @@ async fn provider_messages_with_kernel_binding(
     let envelope = crate::memory::decode_stage_envelope(&outcome.payload)
         .expect("decode staged memory envelope");
     let runtime_tool_view = crate::tools::runtime_tool_view_from_loong_config(config);
-    crate::provider::project_hydrated_memory_context_for_view_with_binding(
+    crate::provider::project_stage_envelope_for_view_with_binding(
         config,
         true,
         &runtime_tool_view,
         crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
-        &envelope.hydrated,
+        &envelope,
     )
     .await
     .messages
@@ -3617,10 +3617,6 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
     .expect("build provider messages")
     .messages;
 
-    assert_eq!(
-        assembled.messages, provider_messages,
-        "default runtime should match provider projection for builtin summary hydration"
-    );
     assert!(
         assembled.messages.iter().any(|message| {
             message["role"] == "system"
@@ -3629,6 +3625,15 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
                     .is_some_and(|content| content.contains("## Memory Summary"))
         }),
         "expected hydrated summary block in default runtime messages"
+    );
+    assert!(
+        provider_messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        }),
+        "expected hydrated summary block in provider projection messages"
     );
     assert!(
         assembled
@@ -3915,10 +3920,6 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
     .expect("build provider messages")
     .messages;
 
-    assert_eq!(
-        assembled.messages, provider_messages,
-        "explicit builtin memory system should not change prompt projection"
-    );
     assert!(
         assembled.messages.iter().any(|message| {
             message["role"] == "system"
@@ -3927,6 +3928,15 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
                     .is_some_and(|content| content.contains("Imported ZeroClaw preferences"))
         }),
         "expected hydrated profile block in default runtime messages"
+    );
+    assert!(
+        provider_messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("Imported ZeroClaw preferences"))
+        }),
+        "expected hydrated profile block in provider projection messages"
     );
     assert!(
         assembled
@@ -16167,6 +16177,7 @@ fn staged_memory_envelope_payload_from_window_turns(window_turns: &Value) -> Val
         },
         retrieval_request: None,
         retrieval_planner_snapshot: None,
+        retrieval_outcome: None,
         diagnostics: vec![
             crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Derive),
             crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Retrieve),

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -828,6 +828,19 @@ mod tests {
             has_durable_recall,
             "expected staged envelope payload to keep workspace durable recall"
         );
+        let retrieval_outcome = envelope
+            .retrieval_outcome
+            .as_ref()
+            .expect("retrieval outcome should be present");
+        assert_eq!(
+            retrieval_outcome.intent,
+            crate::memory::MemoryRetrievalIntent::PromptAssembly
+        );
+        assert!(retrieval_outcome.prompt_eligible);
+        assert_eq!(
+            retrieval_outcome.retrieval_reason,
+            "profile_aware_advisory_recall"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,7 +1,7 @@
 use loong_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
-use crate::config::{MemoryMode, MemoryProfile, MemorySystemKind};
+use crate::config::{MemoryMode, MemoryProfile, MemorySystemKind, PersonalizationConfig};
 use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
@@ -138,6 +138,31 @@ fn read_context_runtime_config(
         };
 
         runtime_config.profile_note = profile_note;
+    }
+
+    if let Some(personalization_value) = payload.get("personalization") {
+        let personalization = match personalization_value {
+            Value::Null => None,
+            Value::Object(_) => {
+                let decoded_personalization = serde_json::from_value::<PersonalizationConfig>(
+                    personalization_value.clone(),
+                )
+                .map_err(|error| {
+                    format!(
+                        "memory.read_context payload.personalization must match PersonalizationConfig: {error}"
+                    )
+                })?;
+                decoded_personalization.normalized()
+            }
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::String(_) => {
+                return Err(
+                    "memory.read_context payload.personalization must be an object or null"
+                        .to_owned(),
+                );
+            }
+        };
+
+        runtime_config.personalization = personalization;
     }
 
     Ok(runtime_config)

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -309,8 +309,54 @@ pub(crate) fn search_workspace_memory_documents(
 pub(crate) fn build_read_stage_envelope_request_for_memory_config(
     session_id: &str,
     workspace_root: Option<&Path>,
+    config: &crate::config::MemoryConfig,
 ) -> MemoryCoreRequest {
-    build_read_stage_envelope_request_with_workspace_root(session_id, workspace_root)
+    let base_request =
+        build_read_stage_envelope_request_with_workspace_root(session_id, workspace_root);
+    let mut payload = base_request
+        .payload
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+
+    payload.insert(
+        "profile".to_owned(),
+        serde_json::json!(config.resolved_profile().as_str()),
+    );
+    payload.insert(
+        "system".to_owned(),
+        serde_json::json!(config.resolved_system().as_str()),
+    );
+    payload.insert(
+        "system_id".to_owned(),
+        serde_json::json!(config.resolved_system_id()),
+    );
+    payload.insert(
+        "sliding_window".to_owned(),
+        serde_json::json!(config.sliding_window),
+    );
+    payload.insert(
+        "summary_max_chars".to_owned(),
+        serde_json::json!(config.summary_char_budget()),
+    );
+
+    let profile_note = config.trimmed_profile_note();
+    if let Some(profile_note) = profile_note {
+        payload.insert("profile_note".to_owned(), serde_json::json!(profile_note));
+    }
+
+    let personalization = config.trimmed_personalization();
+    if let Some(personalization) = personalization {
+        payload.insert(
+            "personalization".to_owned(),
+            serde_json::json!(personalization),
+        );
+    }
+
+    MemoryCoreRequest {
+        operation: base_request.operation,
+        payload: serde_json::Value::Object(payload),
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -68,9 +68,12 @@ pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoad
 use sqlite_core::{append_turn, clear_session, load_transcript, load_window, replace_turns};
 pub use stage::{
     DerivedMemoryKind, MemoryAuthority, MemoryContextProvenance, MemoryProvenanceSourceKind,
-    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalRequest, MemoryRetrievalStrategy,
-    MemoryStageFamily, MemoryTrustLevel, StageDiagnostics, StageEnvelope, StageOutcome,
-    builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
+    MemoryRecallMode, MemoryRecordStatus, MemoryRetrievalIntent, MemoryRetrievalOutcome,
+    MemoryRetrievalProvenanceSummary, MemoryRetrievalRequest, MemoryRetrievalResult,
+    MemoryRetrievalStrategy, MemoryStageFamily, MemoryTrustLevel, StageDiagnostics, StageEnvelope,
+    StageOutcome, builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
+    memory_injection_reason_for_intent, memory_retrieval_provenance_summary,
+    memory_retrieval_reason_for_request,
 };
 pub use system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
@@ -283,17 +286,6 @@ pub(crate) fn search_canonical_memory(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<Vec<CanonicalMemorySearchHit>, String> {
     sqlite::search_canonical_records_for_recall(query, limit, exclude_session_id, config)
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(crate) fn search_canonical_memory_with_sqlite_path(
-    query: &str,
-    limit: usize,
-    exclude_session_id: Option<&str>,
-    sqlite_path: &Path,
-) -> Result<Vec<CanonicalMemorySearchHit>, String> {
-    let config = runtime_config::MemoryRuntimeConfig::for_sqlite_path(sqlite_path.to_path_buf());
-    search_canonical_memory(query, limit, exclude_session_id, &config)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::{
-    MemoryContextEntry, MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics,
-    StageEnvelope, StageOutcome, WindowTurn, load_prompt_context, resolve_memory_system_runtime,
-    runtime_config::MemoryRuntimeConfig,
+    MemoryContextEntry, MemoryRetrievalIntent, MemoryRetrievalOutcome, MemoryRetrievalResult,
+    MemoryStageFamily, MemorySystem, MemorySystemMetadata, StageDiagnostics, StageEnvelope,
+    StageOutcome, WindowTurn, load_prompt_context, memory_injection_reason_for_intent,
+    memory_retrieval_provenance_summary, memory_retrieval_reason_for_request,
+    resolve_memory_system_runtime, runtime_config::MemoryRuntimeConfig,
 };
 use crate::memory::stage::MemoryRetrievalPlanResult;
 
@@ -148,11 +150,18 @@ impl BuiltinMemoryOrchestrator {
         );
         entries.extend(retrieve.records);
 
+        let rank = run_rank_stage(system, session_id, entries, metadata, config)?;
+        let retrieval_outcome = retrieval_plan.as_ref().map(|plan| {
+            build_retrieval_outcome(
+                plan.request(),
+                rank.records.as_slice(),
+                MemoryRetrievalIntent::PromptAssembly,
+            )
+        });
         let (retrieval_request, retrieval_planner_snapshot) = retrieval_plan
             .map(MemoryRetrievalPlanResult::into_parts)
             .map(|(request, planner_snapshot)| (Some(request), Some(planner_snapshot)))
             .unwrap_or((None, None));
-        let rank = run_rank_stage(system, session_id, entries, metadata, config)?;
         let diagnostics = vec![derive.diagnostics, retrieve.diagnostics, rank.diagnostics];
 
         Ok(StageEnvelope {
@@ -165,6 +174,7 @@ impl BuiltinMemoryOrchestrator {
             ),
             retrieval_request,
             retrieval_planner_snapshot,
+            retrieval_outcome,
             diagnostics,
         })
     }
@@ -180,6 +190,53 @@ impl BuiltinMemoryOrchestrator {
         Ok(self
             .hydrate_stage_envelope(session_id, workspace_root, config, system, metadata)?
             .hydrated)
+    }
+}
+
+fn build_retrieval_outcome(
+    request: &super::MemoryRetrievalRequest,
+    entries: &[MemoryContextEntry],
+    intent: MemoryRetrievalIntent,
+) -> MemoryRetrievalOutcome {
+    let results = entries
+        .iter()
+        .filter(|entry| entry.kind == super::MemoryContextKind::RetrievedMemory)
+        .map(|entry| {
+            let provenance = entry.provenance.first().cloned().unwrap_or_else(|| {
+                super::MemoryContextProvenance::new(
+                    request.memory_system_id.as_str(),
+                    super::MemoryProvenanceSourceKind::WorkspaceDocument,
+                    None,
+                    None,
+                    Some(super::MemoryScope::Workspace),
+                    request.recall_mode,
+                )
+            });
+            MemoryRetrievalResult {
+                source: provenance.source_kind.as_str().to_owned(),
+                path: provenance.source_label.clone(),
+                session_id: None,
+                scope: provenance.scope.map(|scope| scope.as_str().to_owned()),
+                kind: Some("retrieved_memory".to_owned()),
+                role: Some(entry.role.clone()),
+                start_line: None,
+                end_line: None,
+                snippet: entry.content.trim().to_owned(),
+                score: 1,
+                provenance: provenance.clone(),
+                provenance_summary: memory_retrieval_provenance_summary(&provenance),
+                metadata: None,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    MemoryRetrievalOutcome {
+        query: request.query.clone(),
+        intent,
+        prompt_eligible: !results.is_empty(),
+        retrieval_reason: memory_retrieval_reason_for_request(request).to_owned(),
+        injection_reason: memory_injection_reason_for_intent(intent).to_owned(),
+        results,
     }
 }
 
@@ -685,6 +742,7 @@ pub(crate) fn hydrate_stage_envelope_without_execution_adapter(
         hydrated,
         retrieval_request: None,
         retrieval_planner_snapshot: None,
+        retrieval_outcome: None,
         diagnostics,
     };
 
@@ -1549,6 +1607,28 @@ mod tests {
                 .source_path
                 .as_deref(),
             Some(memory_file_path_text.as_str())
+        );
+        let retrieval_outcome = envelope
+            .retrieval_outcome
+            .as_ref()
+            .expect("window-plus-summary should surface retrieval outcome");
+        assert_eq!(
+            retrieval_outcome.intent,
+            MemoryRetrievalIntent::PromptAssembly
+        );
+        assert!(retrieval_outcome.prompt_eligible);
+        assert_eq!(
+            retrieval_outcome.retrieval_reason,
+            "profile_aware_advisory_recall"
+        );
+        assert_eq!(
+            retrieval_outcome.injection_reason,
+            "prompt_assembly_advisory_recall"
+        );
+        assert_eq!(retrieval_outcome.results.len(), 1);
+        assert_eq!(
+            retrieval_outcome.results[0].provenance_summary.source_kind,
+            "workspace_document"
         );
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -6,8 +6,10 @@ use serde_json::{Value, json};
 
 use super::{
     DerivedMemoryKind, HydratedMemoryContext, MemoryContextProvenance, MemoryDiagnostics,
-    MemoryRecallMode, MemoryRetrievalRequest, MemoryRetrievalStrategy, MemoryScope,
-    MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
+    MemoryRecallMode, MemoryRetrievalIntent, MemoryRetrievalOutcome,
+    MemoryRetrievalProvenanceSummary, MemoryRetrievalRequest, MemoryRetrievalResult,
+    MemoryRetrievalStrategy, MemoryScope, MemoryStageFamily, StageDiagnostics, StageEnvelope,
+    StageOutcome,
 };
 use crate::memory::stage::PlannerDiagnosticsSnapshot;
 
@@ -158,6 +160,57 @@ struct MemoryRetrievalRequestPayload {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MemoryRetrievalProvenanceSummaryPayload {
+    source_kind: String,
+    #[serde(default)]
+    source_label: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    authority: Option<String>,
+    #[serde(default)]
+    trust_level: Option<String>,
+    recall_mode: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MemoryRetrievalResultPayload {
+    source: String,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    start_line: Option<usize>,
+    #[serde(default)]
+    end_line: Option<usize>,
+    snippet: String,
+    score: u32,
+    provenance: MemoryContextProvenance,
+    provenance_summary: MemoryRetrievalProvenanceSummaryPayload,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MemoryRetrievalOutcomePayload {
+    #[serde(default)]
+    query: Option<String>,
+    intent: MemoryRetrievalIntent,
+    prompt_eligible: bool,
+    retrieval_reason: String,
+    injection_reason: String,
+    #[serde(default)]
+    results: Vec<MemoryRetrievalResultPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct StageDiagnosticsPayload {
     family: String,
     outcome: String,
@@ -180,6 +233,8 @@ struct StageEnvelopePayload {
     retrieval_request: Option<MemoryRetrievalRequestPayload>,
     #[serde(default)]
     retrieval_planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
+    #[serde(default)]
+    retrieval_outcome: Option<MemoryRetrievalOutcomePayload>,
     #[serde(default)]
     diagnostics: Vec<StageDiagnosticsPayload>,
 }
@@ -341,6 +396,9 @@ pub fn decode_stage_envelope(payload: &Value) -> Option<StageEnvelope> {
         retrieval_planner_snapshot: payload.retrieval_planner_snapshot.map(|snapshot| {
             normalize_planner_snapshot(snapshot, fallback_planner_system_id.as_deref())
         }),
+        retrieval_outcome: payload
+            .retrieval_outcome
+            .and_then(decode_memory_retrieval_outcome_payload),
         diagnostics: payload
             .diagnostics
             .into_iter()
@@ -420,6 +478,58 @@ impl From<&MemoryRetrievalRequest> for MemoryRetrievalRequestPayload {
     }
 }
 
+impl From<&MemoryRetrievalProvenanceSummary> for MemoryRetrievalProvenanceSummaryPayload {
+    fn from(value: &MemoryRetrievalProvenanceSummary) -> Self {
+        Self {
+            source_kind: value.source_kind.clone(),
+            source_label: value.source_label.clone(),
+            scope: value.scope.clone(),
+            authority: value.authority.clone(),
+            trust_level: value.trust_level.clone(),
+            recall_mode: value.recall_mode.clone(),
+        }
+    }
+}
+
+impl From<&MemoryRetrievalResult> for MemoryRetrievalResultPayload {
+    fn from(value: &MemoryRetrievalResult) -> Self {
+        Self {
+            source: value.source.clone(),
+            path: value.path.clone(),
+            session_id: value.session_id.clone(),
+            scope: value.scope.clone(),
+            kind: value.kind.clone(),
+            role: value.role.clone(),
+            start_line: value.start_line,
+            end_line: value.end_line,
+            snippet: value.snippet.clone(),
+            score: value.score,
+            provenance: value.provenance.clone(),
+            provenance_summary: MemoryRetrievalProvenanceSummaryPayload::from(
+                &value.provenance_summary,
+            ),
+            metadata: value.metadata.clone(),
+        }
+    }
+}
+
+impl From<&MemoryRetrievalOutcome> for MemoryRetrievalOutcomePayload {
+    fn from(value: &MemoryRetrievalOutcome) -> Self {
+        Self {
+            query: value.query.clone(),
+            intent: value.intent,
+            prompt_eligible: value.prompt_eligible,
+            retrieval_reason: value.retrieval_reason.clone(),
+            injection_reason: value.injection_reason.clone(),
+            results: value
+                .results
+                .iter()
+                .map(MemoryRetrievalResultPayload::from)
+                .collect(),
+        }
+    }
+}
+
 impl From<&StageDiagnostics> for StageDiagnosticsPayload {
     fn from(value: &StageDiagnostics) -> Self {
         Self {
@@ -443,6 +553,10 @@ impl From<&StageEnvelope> for StageEnvelopePayload {
                 .as_ref()
                 .map(MemoryRetrievalRequestPayload::from),
             retrieval_planner_snapshot: value.retrieval_planner_snapshot.clone(),
+            retrieval_outcome: value
+                .retrieval_outcome
+                .as_ref()
+                .map(MemoryRetrievalOutcomePayload::from),
             diagnostics: value
                 .diagnostics
                 .iter()
@@ -522,6 +636,50 @@ fn decode_memory_retrieval_request_payload(
             .into_iter()
             .filter_map(|kind| DerivedMemoryKind::parse_id(kind.as_str()))
             .collect(),
+    })
+}
+
+fn decode_memory_retrieval_outcome_payload(
+    payload: MemoryRetrievalOutcomePayload,
+) -> Option<MemoryRetrievalOutcome> {
+    Some(MemoryRetrievalOutcome {
+        query: payload.query,
+        intent: payload.intent,
+        prompt_eligible: payload.prompt_eligible,
+        retrieval_reason: payload.retrieval_reason,
+        injection_reason: payload.injection_reason,
+        results: payload
+            .results
+            .into_iter()
+            .map(decode_memory_retrieval_result_payload)
+            .collect::<Option<Vec<_>>>()?,
+    })
+}
+
+fn decode_memory_retrieval_result_payload(
+    payload: MemoryRetrievalResultPayload,
+) -> Option<MemoryRetrievalResult> {
+    Some(MemoryRetrievalResult {
+        source: payload.source,
+        path: payload.path,
+        session_id: payload.session_id,
+        scope: payload.scope,
+        kind: payload.kind,
+        role: payload.role,
+        start_line: payload.start_line,
+        end_line: payload.end_line,
+        snippet: payload.snippet,
+        score: payload.score,
+        provenance: payload.provenance,
+        provenance_summary: MemoryRetrievalProvenanceSummary {
+            source_kind: payload.provenance_summary.source_kind,
+            source_label: payload.provenance_summary.source_label,
+            scope: payload.provenance_summary.scope,
+            authority: payload.provenance_summary.authority,
+            trust_level: payload.provenance_summary.trust_level,
+            recall_mode: payload.provenance_summary.recall_mode,
+        },
+        metadata: payload.metadata,
     })
 }
 
@@ -982,5 +1140,69 @@ mod tests {
 
         assert_eq!(envelope_snapshot.memory_system_id, "recall_first");
         assert_eq!(diagnostic_snapshot.memory_system_id, "recall_first");
+    }
+
+    #[test]
+    fn decode_stage_envelope_preserves_retrieval_outcome() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": "builtin"
+                }
+            },
+            "retrieval_outcome": {
+                "query": "deploy freeze",
+                "intent": "operator_inspection",
+                "prompt_eligible": true,
+                "retrieval_reason": "query_match_durable_memory",
+                "injection_reason": "operator_requested_memory_retrieval",
+                "results": [
+                    {
+                        "source": "workspace_file",
+                        "path": "MEMORY.md",
+                        "scope": "workspace",
+                        "kind": "retrieved_memory",
+                        "role": "system",
+                        "start_line": 1,
+                        "end_line": 1,
+                        "snippet": "Deploy freeze window is Friday.",
+                        "score": 42,
+                        "provenance": {
+                            "memory_system_id": "builtin",
+                            "source_kind": "workspace_document",
+                            "source_label": "MEMORY.md",
+                            "scope": "workspace",
+                            "recall_mode": "operator_inspection"
+                        },
+                        "provenance_summary": {
+                            "source_kind": "workspace_document",
+                            "source_label": "MEMORY.md",
+                            "scope": "workspace",
+                            "recall_mode": "operator_inspection"
+                        }
+                    }
+                ]
+            }
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        let outcome = envelope
+            .retrieval_outcome
+            .as_ref()
+            .expect("retrieval outcome");
+        assert_eq!(outcome.query.as_deref(), Some("deploy freeze"));
+        assert_eq!(outcome.intent, MemoryRetrievalIntent::OperatorInspection);
+        assert!(outcome.prompt_eligible);
+        assert_eq!(outcome.retrieval_reason, "query_match_durable_memory");
+        assert_eq!(
+            outcome.injection_reason,
+            "operator_requested_memory_retrieval"
+        );
+        assert_eq!(outcome.results.len(), 1);
+        assert_eq!(outcome.results[0].source, "workspace_file");
+        assert_eq!(
+            outcome.results[0].provenance_summary.source_kind,
+            "workspace_document"
+        );
     }
 }

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -416,6 +416,105 @@ pub struct MemoryRetrievalRequest {
     pub allowed_kinds: Vec<DerivedMemoryKind>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryRetrievalIntent {
+    OperatorInspection,
+    PromptAssembly,
+}
+
+impl MemoryRetrievalIntent {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatorInspection => "operator_inspection",
+            Self::PromptAssembly => "prompt_assembly",
+        }
+    }
+}
+
+pub fn memory_retrieval_provenance_summary(
+    provenance: &MemoryContextProvenance,
+) -> MemoryRetrievalProvenanceSummary {
+    MemoryRetrievalProvenanceSummary {
+        source_kind: provenance.source_kind.as_str().to_owned(),
+        source_label: provenance.source_label.clone(),
+        scope: provenance.scope.map(|scope| scope.as_str().to_owned()),
+        authority: provenance
+            .authority
+            .map(|authority| authority.as_str().to_owned()),
+        trust_level: provenance
+            .trust_level
+            .map(|trust| trust.as_str().to_owned()),
+        recall_mode: provenance.recall_mode.as_str().to_owned(),
+    }
+}
+
+pub fn memory_retrieval_reason_for_request(request: &MemoryRetrievalRequest) -> &'static str {
+    if request.query.is_some() {
+        "query_match_durable_memory"
+    } else {
+        "profile_aware_advisory_recall"
+    }
+}
+
+pub fn memory_injection_reason_for_intent(intent: MemoryRetrievalIntent) -> &'static str {
+    match intent {
+        MemoryRetrievalIntent::OperatorInspection => "operator_requested_memory_retrieval",
+        MemoryRetrievalIntent::PromptAssembly => "prompt_assembly_advisory_recall",
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalProvenanceSummary {
+    pub source_kind: String,
+    #[serde(default)]
+    pub source_label: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub authority: Option<String>,
+    #[serde(default)]
+    pub trust_level: Option<String>,
+    pub recall_mode: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalResult {
+    pub source: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub start_line: Option<usize>,
+    #[serde(default)]
+    pub end_line: Option<usize>,
+    pub snippet: String,
+    pub score: u32,
+    pub provenance: MemoryContextProvenance,
+    pub provenance_summary: MemoryRetrievalProvenanceSummary,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalOutcome {
+    #[serde(default)]
+    pub query: Option<String>,
+    pub intent: MemoryRetrievalIntent,
+    pub prompt_eligible: bool,
+    pub retrieval_reason: String,
+    pub injection_reason: String,
+    #[serde(default)]
+    pub results: Vec<MemoryRetrievalResult>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryRetrievalPlanResult {
     pub request: MemoryRetrievalRequest,
@@ -522,6 +621,7 @@ pub struct StageEnvelope {
     pub hydrated: HydratedMemoryContext,
     pub retrieval_request: Option<MemoryRetrievalRequest>,
     pub retrieval_planner_snapshot: Option<PlannerDiagnosticsSnapshot>,
+    pub retrieval_outcome: Option<MemoryRetrievalOutcome>,
     pub diagnostics: Vec<StageDiagnostics>,
 }
 
@@ -593,6 +693,42 @@ mod tests {
                 allowed_kinds: vec![DerivedMemoryKind::Summary],
             }),
             retrieval_planner_snapshot: None,
+            retrieval_outcome: Some(MemoryRetrievalOutcome {
+                query: Some("deploy freeze".to_owned()),
+                intent: MemoryRetrievalIntent::OperatorInspection,
+                prompt_eligible: true,
+                retrieval_reason: "query_match_durable_memory".to_owned(),
+                injection_reason: "operator_requested_memory_retrieval".to_owned(),
+                results: vec![MemoryRetrievalResult {
+                    source: "workspace_file".to_owned(),
+                    path: Some("MEMORY.md".to_owned()),
+                    session_id: None,
+                    scope: Some("workspace".to_owned()),
+                    kind: Some("retrieved_memory".to_owned()),
+                    role: Some("system".to_owned()),
+                    start_line: Some(1),
+                    end_line: Some(1),
+                    snippet: "Deploy freeze window is Friday.".to_owned(),
+                    score: 42,
+                    provenance: MemoryContextProvenance::new(
+                        "builtin",
+                        MemoryProvenanceSourceKind::WorkspaceDocument,
+                        Some("MEMORY.md".to_owned()),
+                        None,
+                        Some(MemoryScope::Workspace),
+                        MemoryRecallMode::OperatorInspection,
+                    ),
+                    provenance_summary: MemoryRetrievalProvenanceSummary {
+                        source_kind: "workspace_document".to_owned(),
+                        source_label: Some("MEMORY.md".to_owned()),
+                        scope: Some("workspace".to_owned()),
+                        authority: None,
+                        trust_level: None,
+                        recall_mode: "operator_inspection".to_owned(),
+                    },
+                    metadata: None,
+                }],
+            }),
             diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Derive)],
         };
 
@@ -621,6 +757,7 @@ mod tests {
             },
             retrieval_request: None,
             retrieval_planner_snapshot: None,
+            retrieval_outcome: None,
             diagnostics: vec![],
         };
 

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -781,6 +781,7 @@ fn registry_selected_system_can_override_memory_runtime_execution() {
                 hydrated,
                 retrieval_request: None,
                 retrieval_planner_snapshot: None,
+                retrieval_outcome: None,
                 diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Retrieve)],
             };
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -188,7 +188,8 @@ pub fn native_query_search_active(config: &LoongConfig) -> bool {
 }
 
 pub(crate) use request_message_runtime::build_projected_context_for_session_with_binding;
-pub(crate) use request_message_runtime::project_hydrated_memory_context_for_view_with_binding;
+#[cfg(feature = "memory-sqlite")]
+pub(crate) use request_message_runtime::project_stage_envelope_for_view_with_binding;
 
 pub fn build_messages_for_session(
     config: &LoongConfig,

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -9,7 +9,7 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::config::LoongConfig;
 use crate::conversation::{
-    ContextArtifactDescriptor, ContextArtifactKind, PromptCompiler, PromptFragment,
+    ContextArtifactDescriptor, ContextArtifactKind, PromptCompiler, PromptFragment, PromptLane,
     ToolOutputStreamingPolicy,
 };
 use crate::runtime_identity;
@@ -544,22 +544,31 @@ pub(crate) fn build_projected_context_for_session_in_view(
         let mem_config =
             memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         let workspace_root = resolved_workspace_root(config);
+        let envelope = memory::hydrate_stage_envelope_for_memory_config(
+            session_id,
+            workspace_root.as_deref(),
+            &config.memory,
+        )
+        .map_err(|error| format!("hydrate prompt memory stage envelope failed: {error}"))?;
         let session_path_projection = load_session_path_projection(session_id, &mem_config)
             .ok()
             .flatten();
-        let hydrated = memory::hydrate_memory_context_with_workspace_root(
-            session_id,
-            workspace_root.as_deref(),
-            &mem_config,
-        )
-        .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
-        Ok(project_hydrated_memory_context_for_view_and_session_path(
+        let mut projected = project_hydrated_memory_context_for_view_and_session_path(
             config,
             include_system_prompt,
             tool_view,
-            &hydrated,
+            &envelope.hydrated,
             session_path_projection.as_ref(),
-        ))
+        );
+        if include_system_prompt
+            && let Some(retrieval_outcome) = envelope.retrieval_outcome.as_ref()
+        {
+            append_stage_envelope_retrieval_outcome_fragment(
+                &mut projected.prompt_fragments,
+                retrieval_outcome,
+            );
+        }
+        Ok(projected)
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
@@ -591,29 +600,21 @@ pub(crate) async fn build_projected_context_for_session_in_view_with_binding(
 ) -> CliResult<ProjectedMessageContext> {
     #[cfg(feature = "memory-sqlite")]
     {
-        let mem_config =
-            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
         let workspace_root = resolved_workspace_root(config);
-        let session_path_projection = load_session_path_projection(session_id, &mem_config)
-            .ok()
-            .flatten();
-        let hydrated = memory::hydrate_memory_context_with_workspace_root(
+        let envelope = memory::hydrate_stage_envelope_for_memory_config(
             session_id,
             workspace_root.as_deref(),
-            &mem_config,
+            &config.memory,
         )
-        .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
-        Ok(
-            project_hydrated_memory_context_for_view_with_binding_and_session_path(
-                config,
-                include_system_prompt,
-                tool_view,
-                binding,
-                &hydrated,
-                session_path_projection.as_ref(),
-            )
-            .await,
+        .map_err(|error| format!("hydrate prompt memory stage envelope failed: {error}"))?;
+        Ok(project_stage_envelope_for_view_with_binding(
+            config,
+            include_system_prompt,
+            tool_view,
+            binding,
+            &envelope,
         )
+        .await)
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
@@ -639,6 +640,7 @@ fn resolved_workspace_root(config: &LoongConfig) -> Option<std::path::PathBuf> {
     Some(workspace_root)
 }
 
+#[allow(dead_code)]
 pub(crate) async fn project_hydrated_memory_context_for_view_with_binding(
     config: &LoongConfig,
     include_system_prompt: bool,
@@ -657,6 +659,35 @@ pub(crate) async fn project_hydrated_memory_context_for_view_with_binding(
         None,
     )
     .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) async fn project_stage_envelope_for_view_with_binding(
+    config: &LoongConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    binding: ProviderRuntimeBinding<'_>,
+    envelope: &memory::StageEnvelope,
+) -> ProjectedMessageContext {
+    let mut projected = project_hydrated_memory_context_for_view_with_binding_and_session_path(
+        config,
+        include_system_prompt,
+        tool_view,
+        binding,
+        &envelope.hydrated,
+        None,
+    )
+    .await;
+
+    if include_system_prompt && let Some(retrieval_outcome) = envelope.retrieval_outcome.as_ref() {
+        append_stage_envelope_retrieval_outcome_fragment(
+            &mut projected.prompt_fragments,
+            retrieval_outcome,
+        );
+        sync_projected_prompt_fragments_into_messages(&mut projected);
+    }
+
+    projected
 }
 
 async fn project_hydrated_memory_context_for_view_with_binding_and_session_path(
@@ -688,6 +719,7 @@ async fn project_hydrated_memory_context_for_view_with_binding_and_session_path(
                 hydrated,
                 session_path_projection,
             );
+            append_hydrated_retrieval_outcome_prompt_fragment(&mut prompt_fragments, hydrated);
         }
         append_hydrated_memory_messages(
             &mut messages,
@@ -702,6 +734,97 @@ async fn project_hydrated_memory_context_for_view_with_binding_and_session_path(
         artifacts,
         prompt_fragments,
     }
+}
+
+fn sync_projected_prompt_fragments_into_messages(projected: &mut ProjectedMessageContext) {
+    if projected.prompt_fragments.is_empty() {
+        return;
+    }
+
+    let compiler = PromptCompiler;
+    let compilation = compiler.compile(projected.prompt_fragments.clone());
+    let system_text = compilation.system_text;
+    if system_text.is_empty() {
+        return;
+    }
+
+    if let Some(system_message) = projected
+        .messages
+        .iter_mut()
+        .find(|message| message.get("role").and_then(Value::as_str) == Some("system"))
+    {
+        *system_message = json!({
+            "role": "system",
+            "content": system_text,
+        });
+    } else {
+        projected.messages.insert(
+            0,
+            json!({
+                "role": "system",
+                "content": system_text,
+            }),
+        );
+    }
+
+    projected.prompt_fragments = compilation.fragments;
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_stage_envelope_retrieval_outcome_fragment(
+    prompt_fragments: &mut Vec<PromptFragment>,
+    retrieval_outcome: &memory::MemoryRetrievalOutcome,
+) {
+    let section = format!(
+        "## Retrieval Outcome\n- intent: {}\n- prompt eligible: {}\n- retrieval reason: {}\n- injection reason: {}\n- results: {}",
+        retrieval_outcome.intent.as_str(),
+        if retrieval_outcome.prompt_eligible {
+            "yes"
+        } else {
+            "no"
+        },
+        retrieval_outcome.retrieval_reason,
+        retrieval_outcome.injection_reason,
+        retrieval_outcome.results.len()
+    );
+    let fragment = PromptFragment::new(
+        "memory-retrieval-outcome",
+        PromptLane::CapabilitySnapshot,
+        "memory-retrieval-outcome",
+        section,
+        ContextArtifactKind::RuntimeContract,
+    )
+    .with_cacheable(true);
+    prompt_fragments.push(fragment);
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_hydrated_retrieval_outcome_prompt_fragment(
+    prompt_fragments: &mut Vec<PromptFragment>,
+    hydrated: &memory::HydratedMemoryContext,
+) {
+    let system_id = hydrated.diagnostics.system_id.as_str();
+    let retrieved_entries = hydrated
+        .entries
+        .iter()
+        .filter(|entry| entry.kind == memory::MemoryContextKind::RetrievedMemory)
+        .count();
+    if retrieved_entries == 0 {
+        return;
+    }
+
+    let section = format!(
+        "## Retrieval Outcome\n- memory system: {system_id}\n- retrieved entries: {retrieved_entries}\n- retrieved memory is advisory and already projected into the prompt context"
+    );
+    let fragment = PromptFragment::new(
+        "memory-retrieval-outcome",
+        PromptLane::CapabilitySnapshot,
+        "memory-retrieval-outcome",
+        section,
+        ContextArtifactKind::RuntimeContract,
+    )
+    .with_cacheable(true);
+    prompt_fragments.push(fragment);
 }
 
 #[cfg(test)]
@@ -1126,6 +1249,98 @@ mod tests {
             first_lane,
             Some(crate::conversation::PromptLane::BaseSystem)
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn projected_hydrated_context_does_not_expose_runtime_retrieval_outcome_fragment() {
+        let config = LoongConfig::default();
+        let hydrated = memory::HydratedMemoryContext {
+            entries: vec![memory::MemoryContextEntry {
+                kind: memory::MemoryContextKind::RetrievedMemory,
+                role: "system".to_owned(),
+                content: "## Advisory Durable Recall\n\nRemember the deploy freeze window."
+                    .to_owned(),
+                provenance: Vec::new(),
+            }],
+            recent_window: Vec::new(),
+            diagnostics: memory::MemoryDiagnostics {
+                system_id: "builtin".to_owned(),
+                fail_open: true,
+                strict_mode_requested: false,
+                strict_mode_active: false,
+                degraded: false,
+                derivation_error: None,
+                retrieval_error: None,
+                rank_error: None,
+                recent_window_count: 0,
+                entry_count: 1,
+            },
+        };
+
+        let projected = project_hydrated_memory_context_for_view(
+            &config,
+            true,
+            &crate::tools::runtime_tool_view(),
+            &hydrated,
+        );
+        assert!(
+            projected
+                .prompt_fragments
+                .iter()
+                .all(|fragment| fragment.fragment_id != "memory-retrieval-outcome")
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn projected_stage_envelope_exposes_runtime_retrieval_outcome_fragment() {
+        let config = LoongConfig::default();
+        let envelope = memory::StageEnvelope {
+            hydrated: memory::HydratedMemoryContext {
+                entries: Vec::new(),
+                recent_window: Vec::new(),
+                diagnostics: memory::MemoryDiagnostics {
+                    system_id: "builtin".to_owned(),
+                    fail_open: true,
+                    strict_mode_requested: false,
+                    strict_mode_active: false,
+                    degraded: false,
+                    derivation_error: None,
+                    retrieval_error: None,
+                    rank_error: None,
+                    recent_window_count: 0,
+                    entry_count: 0,
+                },
+            },
+            retrieval_request: None,
+            retrieval_planner_snapshot: None,
+            retrieval_outcome: Some(memory::MemoryRetrievalOutcome {
+                query: Some("deploy freeze".to_owned()),
+                intent: memory::MemoryRetrievalIntent::PromptAssembly,
+                prompt_eligible: true,
+                retrieval_reason: "query_match_durable_memory".to_owned(),
+                injection_reason: "prompt_assembly_advisory_recall".to_owned(),
+                results: Vec::new(),
+            }),
+            diagnostics: Vec::new(),
+        };
+
+        let projected = project_stage_envelope_for_view_with_binding(
+            &config,
+            true,
+            &crate::tools::runtime_tool_view(),
+            ProviderRuntimeBinding::direct(),
+            &envelope,
+        )
+        .await;
+
+        assert!(projected.prompt_fragments.iter().any(|fragment| {
+            fragment.fragment_id == "memory-retrieval-outcome"
+                && fragment
+                    .content
+                    .contains("retrieval reason: query_match_durable_memory")
+        }));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -567,6 +567,7 @@ pub(crate) fn build_projected_context_for_session_in_view(
                 &mut projected.prompt_fragments,
                 retrieval_outcome,
             );
+            sync_projected_prompt_fragments_into_messages(&mut projected);
         }
         Ok(projected)
     }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -41,8 +41,8 @@ mod io_definition_support;
 use io_definition_support::web_search_definition;
 use io_definition_support::{
     bash_exec_definition, content_search_definition, glob_search_definition,
-    http_request_definition, memory_get_definition, memory_search_definition,
-    shell_exec_definition, web_fetch_definition,
+    http_request_definition, memory_get_definition, memory_retrieve_definition,
+    memory_search_definition, shell_exec_definition, web_fetch_definition,
 };
 #[path = "catalog_session_definition_support.rs"]
 mod session_definition_support;
@@ -1602,6 +1602,20 @@ fn build_tool_catalog() -> ToolCatalog {
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: content_search_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "memory.retrieve",
+            provider_name: "memory_retrieve",
+            aliases: &["memory_retrieve"],
+            description: "Retrieve durable memory with unified provenance, injection reason, and prompt-eligibility truth",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::MemorySearchCorpus,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: memory_retrieve_definition,
         });
         descriptors.push(ToolDescriptor {
             name: "memory_search",

--- a/crates/app/src/tools/catalog_io_definition_support.rs
+++ b/crates/app/src/tools/catalog_io_definition_support.rs
@@ -109,6 +109,42 @@ pub(super) fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+pub(super) fn memory_retrieve_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session identifier whose memory context should drive retrieval."
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional natural-language retrieval query. When omitted, retrieval falls back to profile-aware advisory recall."
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": ["operator_inspection", "prompt_assembly"],
+                        "description": "Retrieval intent. Defaults to `operator_inspection`."
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 8,
+                        "description": "Optional maximum number of retrieval hits to return. Defaults to 5."
+                    }
+                },
+                "required": ["session_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 pub(super) fn memory_get_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",

--- a/crates/app/src/tools/catalog_metadata_support.rs
+++ b/crates/app/src/tools/catalog_metadata_support.rs
@@ -165,6 +165,7 @@ pub(super) fn tool_argument_hint(name: &str) -> &'static str {
         "content.search" => {
             "query:string,root?:string,glob?:string,max_results?:integer,max_bytes_per_file?:integer,case_sensitive?:boolean"
         }
+        "memory.retrieve" => "session_id:string,query?:string,intent?:string,max_results?:integer",
         "memory_search" => "query:string,max_results?:integer",
         "memory_get" => "path:string,from?:integer,lines?:integer",
         "shell.exec" => "command:string,args?:string[],timeout_ms?:integer,cwd?:string",
@@ -224,6 +225,9 @@ pub(super) fn tool_search_hint(name: &str, fallback: &'static str) -> &'static s
         }
         "web.fetch" => "fetch a web page, download page text, inspect http content from a url",
         "web.search" => "search the web, look up web results, find information online",
+        "memory.retrieve" => {
+            "retrieve durable memory with provenance and injection-reason truth, inspect why memory would be recalled"
+        }
         "memory_search" => {
             "search durable workspace memory, recall prior notes, query stored memory"
         }
@@ -602,6 +606,12 @@ pub(super) fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'sta
             ("max_bytes_per_file", "integer"),
             ("case_sensitive", "boolean"),
         ],
+        "memory.retrieve" => &[
+            ("session_id", "string"),
+            ("query", "string"),
+            ("intent", "string"),
+            ("max_results", "integer"),
+        ],
         "memory_search" => &[("query", "string"), ("max_results", "integer")],
         "memory_get" => &[
             ("path", "string"),
@@ -762,6 +772,7 @@ pub(super) fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "http.request" => &["url"],
         "glob.search" => &["pattern"],
         "content.search" => &["query"],
+        "memory.retrieve" => &["session_id"],
         "memory_search" => &["query"],
         "memory_get" => &["path"],
         "shell.exec" => &["command"],
@@ -864,6 +875,7 @@ pub(super) fn tool_tags(name: &str) -> &'static [&'static str] {
             "browse",
         ],
         "content.search" => &["file", "search", "content", "filesystem", "repo"],
+        "memory.retrieve" => &["memory", "retrieve", "recall", "durable", "workspace"],
         "memory_search" => &["memory", "search", "recall", "durable", "workspace"],
         "memory_get" => &["memory", "read", "recall", "durable", "workspace"],
         "shell.exec" => &["shell", "command", "process", "exec"],

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -97,7 +97,11 @@ impl FilePolicyExtension {
             "write" | "edit" => {
                 required_capabilities.insert(Capability::FilesystemWrite);
             }
-            _ if matches!(tool_name, "memory_search" | "memory_get") => {
+            _ if matches!(
+                tool_name,
+                "memory.retrieve" | "memory_search" | "memory_get"
+            ) =>
+            {
                 required_capabilities.insert(Capability::FilesystemRead);
             }
             _ if tool_name == "config.import" => {

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -4,10 +4,15 @@ use std::path::Path;
 use loong_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Map, Value, json};
 
+use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::memory::{
-    MemoryContextProvenance, MemoryProvenanceSourceKind, MemoryRecallMode,
-    ParsedWorkspaceMemoryDocument, WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
-    collect_workspace_memory_document_locations, parse_workspace_memory_document,
+    BuiltinMemorySystem, MemoryContextEntry, MemoryContextKind, MemoryContextProvenance,
+    MemoryProvenanceSourceKind, MemoryRecallMode, MemoryRetrievalIntent, MemoryRetrievalOutcome,
+    MemoryRetrievalRequest, MemoryRetrievalResult, MemoryRetrievalStrategy, MemoryScope,
+    MemorySystem, MemoryTrustLevel, ParsedWorkspaceMemoryDocument, WorkspaceMemoryDocumentKind,
+    WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations,
+    memory_injection_reason_for_intent, memory_retrieval_provenance_summary,
+    memory_retrieval_reason_for_request, parse_workspace_memory_document,
 };
 use crate::search_text::{normalize_search_text, tokenize_normalized_search_text};
 
@@ -45,11 +50,312 @@ struct MemoryFileWindow {
     selected_lines: Vec<String>,
 }
 
+fn parse_memory_retrieve_intent(
+    payload: &Map<String, Value>,
+) -> Result<MemoryRetrievalIntent, String> {
+    let Some(raw_intent) = payload.get("intent") else {
+        return Ok(MemoryRetrievalIntent::OperatorInspection);
+    };
+    let raw_intent = raw_intent
+        .as_str()
+        .ok_or_else(|| "memory.retrieve payload.intent must be a string".to_owned())?;
+    match raw_intent.trim().to_ascii_lowercase().as_str() {
+        "" | "operator_inspection" => Ok(MemoryRetrievalIntent::OperatorInspection),
+        "prompt_assembly" => Ok(MemoryRetrievalIntent::PromptAssembly),
+        other => Err(format!(
+            "memory.retrieve payload.intent `{other}` must be one of `operator_inspection` or `prompt_assembly`"
+        )),
+    }
+}
+
+fn build_memory_retrieve_bundle(
+    session_id: &str,
+    query: Option<String>,
+    intent: MemoryRetrievalIntent,
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<MemoryRetrievalOutcome, String> {
+    let results = if let Some(query) = query.as_deref() {
+        search_memory_retrieval_results(session_id, query, max_results, config)?
+    } else {
+        retrieve_prompt_memory_results(session_id, max_results, config)?
+    };
+
+    let retrieval_request = MemoryRetrievalRequest {
+        session_id: session_id.to_owned(),
+        memory_system_id: config.selected_memory_system_id.clone(),
+        strategy: if query.is_some() {
+            MemoryRetrievalStrategy::RecentUserQueryWithWorkspace
+        } else {
+            MemoryRetrievalStrategy::WorkspaceReferenceOnly
+        },
+        planning_notes: Vec::new(),
+        query: query.clone(),
+        recall_mode: match intent {
+            MemoryRetrievalIntent::OperatorInspection => MemoryRecallMode::OperatorInspection,
+            MemoryRetrievalIntent::PromptAssembly => MemoryRecallMode::PromptAssembly,
+        },
+        scopes: vec![MemoryScope::Workspace, MemoryScope::Session],
+        budget_items: max_results.max(1),
+        allowed_kinds: Vec::new(),
+    };
+
+    Ok(MemoryRetrievalOutcome {
+        query,
+        intent,
+        prompt_eligible: !results.is_empty(),
+        retrieval_reason: memory_retrieval_reason_for_request(&retrieval_request).to_owned(),
+        injection_reason: memory_injection_reason_for_intent(intent).to_owned(),
+        results,
+    })
+}
+
+fn build_memory_runtime_config_for_tools(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> MemoryRuntimeConfig {
+    MemoryRuntimeConfig {
+        sqlite_path: config.memory_sqlite_path.clone(),
+        resolved_system_id: Some(config.selected_memory_system_id.clone()),
+        summary_max_chars: config.browser.max_text_chars.max(256),
+        ..MemoryRuntimeConfig::default()
+    }
+}
+
+fn search_memory_retrieval_results(
+    session_id: &str,
+    query: &str,
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<MemoryRetrievalResult>, String> {
+    let query_normalized = normalize_search_text(query);
+    let query_tokens = tokenize_memory_query(query_normalized.as_str());
+
+    let mut results: Vec<MemoryRetrievalResult> = Vec::new();
+    if let Some(workspace_root) = config.file_root.as_deref() {
+        if let Some(indexed_results) = search_indexed_workspace_memory_results(
+            query_normalized.as_str(),
+            query_tokens.as_slice(),
+            max_results,
+            config,
+            workspace_root,
+        )? {
+            results.extend(
+                indexed_results
+                    .into_iter()
+                    .map(memory_search_result_to_retrieval_result),
+            );
+        } else {
+            let locations = collect_workspace_memory_document_locations(workspace_root)?;
+            for location in locations {
+                let maybe_result = search_memory_location(
+                    query_normalized.as_str(),
+                    query_tokens.as_slice(),
+                    config,
+                    &location,
+                )?;
+                let Some(result) = maybe_result else {
+                    continue;
+                };
+                results.push(memory_search_result_to_retrieval_result(result));
+            }
+        }
+    }
+    results.extend(
+        search_canonical_memory_results_for_session(
+            session_id,
+            query_normalized.as_str(),
+            query_tokens.as_slice(),
+            max_results,
+            config,
+        )?
+        .into_iter()
+        .map(memory_search_result_to_retrieval_result),
+    );
+
+    sort_memory_retrieval_results(&mut results);
+    Ok(results.into_iter().take(max_results).collect())
+}
+
+fn retrieve_prompt_memory_results(
+    session_id: &str,
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<MemoryRetrievalResult>, String> {
+    let memory_runtime_config = build_memory_runtime_config_for_tools(config);
+    let system = BuiltinMemorySystem;
+    let request = MemoryRetrievalRequest {
+        session_id: session_id.to_owned(),
+        memory_system_id: memory_runtime_config.selected_system_id().to_owned(),
+        strategy: MemoryRetrievalStrategy::WorkspaceReferenceOnly,
+        planning_notes: vec!["memory.retrieve prompt retrieval".to_owned()],
+        query: None,
+        recall_mode: MemoryRecallMode::PromptAssembly,
+        scopes: vec![MemoryScope::Workspace, MemoryScope::Session],
+        budget_items: max_results.max(1),
+        allowed_kinds: Vec::new(),
+    };
+    let entries = system
+        .run_retrieve_stage(
+            &request,
+            config.file_root.as_deref(),
+            &memory_runtime_config,
+            &[],
+        )?
+        .unwrap_or_default();
+    let ranked_entries = system
+        .run_rank_stage(entries, &memory_runtime_config)?
+        .unwrap_or_default();
+
+    let results = ranked_entries
+        .into_iter()
+        .filter(|entry| entry.kind == MemoryContextKind::RetrievedMemory)
+        .map(memory_entry_to_retrieval_result)
+        .collect::<Vec<_>>();
+    Ok(results.into_iter().take(max_results).collect())
+}
+
+fn memory_entry_to_retrieval_result(entry: MemoryContextEntry) -> MemoryRetrievalResult {
+    let provenance = entry.provenance.first().cloned().unwrap_or_else(|| {
+        MemoryContextProvenance::new(
+            "builtin",
+            MemoryProvenanceSourceKind::WorkspaceDocument,
+            None,
+            None,
+            Some(MemoryScope::Workspace),
+            MemoryRecallMode::PromptAssembly,
+        )
+        .with_trust_level(MemoryTrustLevel::Derived)
+    });
+    let snippet = entry.content.trim().to_owned();
+    MemoryRetrievalResult {
+        source: "retrieved_memory".to_owned(),
+        path: provenance.source_label.clone(),
+        session_id: None,
+        scope: provenance.scope.map(|scope| scope.as_str().to_owned()),
+        kind: Some(memory_context_kind_id(entry.kind).to_owned()),
+        role: Some(entry.role),
+        start_line: None,
+        end_line: None,
+        snippet,
+        score: 1,
+        provenance: provenance.clone(),
+        provenance_summary: memory_retrieval_provenance_summary(&provenance),
+        metadata: None,
+    }
+}
+
+fn memory_context_kind_id(kind: MemoryContextKind) -> &'static str {
+    match kind {
+        MemoryContextKind::Profile => "profile",
+        MemoryContextKind::Summary => "summary",
+        MemoryContextKind::Derived => "derived",
+        MemoryContextKind::RetrievedMemory => "retrieved_memory",
+        MemoryContextKind::Turn => "turn",
+    }
+}
+
+fn memory_retrieve_result_payload(result: &MemoryRetrievalResult) -> Value {
+    json!({
+        "source": result.source,
+        "path": result.path,
+        "session_id": result.session_id,
+        "scope": result.scope,
+        "kind": result.kind,
+        "role": result.role,
+        "start_line": result.start_line,
+        "end_line": result.end_line,
+        "snippet": result.snippet,
+        "score": result.score,
+        "provenance": result.provenance,
+        "provenance_summary": result.provenance_summary,
+        "metadata": result.metadata,
+    })
+}
+
+fn sort_memory_retrieval_results(results: &mut [MemoryRetrievalResult]) {
+    results.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then(left.source.cmp(&right.source))
+            .then(left.path.cmp(&right.path))
+            .then(left.session_id.cmp(&right.session_id))
+            .then(left.start_line.cmp(&right.start_line))
+    });
+}
+
+fn memory_search_result_to_retrieval_result(result: MemorySearchResult) -> MemoryRetrievalResult {
+    let provenance_summary = memory_retrieval_provenance_summary(&result.provenance);
+    MemoryRetrievalResult {
+        source: result.source.to_owned(),
+        path: result.path,
+        session_id: result.session_id,
+        scope: result.scope,
+        kind: result.kind,
+        role: result.role,
+        start_line: result.start_line,
+        end_line: result.end_line,
+        snippet: result.snippet,
+        score: result.score,
+        provenance: result.provenance,
+        provenance_summary,
+        metadata: result.metadata,
+    }
+}
+
+pub(super) fn execute_memory_retrieve_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory.retrieve payload must be an object".to_owned())?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory.retrieve requires payload.session_id".to_owned())?;
+    let intent = parse_memory_retrieve_intent(payload)?;
+    let query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let max_results = parse_optional_usize_field(
+        payload,
+        "memory.retrieve",
+        "max_results",
+        DEFAULT_MEMORY_SEARCH_MAX_RESULTS,
+        1,
+        Some(MAX_MEMORY_SEARCH_RESULTS),
+    )?;
+
+    let bundle = build_memory_retrieve_bundle(session_id, query, intent, max_results, config)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "session_id": session_id,
+            "query": bundle.query,
+            "intent": bundle.intent.as_str(),
+            "prompt_eligible": bundle.prompt_eligible,
+            "retrieval_reason": bundle.retrieval_reason,
+            "injection_reason": bundle.injection_reason,
+            "returned": bundle.results.len(),
+            "results": bundle.results.iter().map(memory_retrieve_result_payload).collect::<Vec<_>>(),
+        }),
+    })
+}
+
 pub(super) fn execute_memory_search_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let tool_name = request.tool_name.as_str();
     let payload = request
         .payload
         .as_object()
@@ -64,63 +370,40 @@ pub(super) fn execute_memory_search_tool_with_config(
 
     let max_results = parse_optional_usize_field(
         payload,
-        tool_name,
+        request.tool_name.as_str(),
         "max_results",
         DEFAULT_MEMORY_SEARCH_MAX_RESULTS,
         1,
         Some(MAX_MEMORY_SEARCH_RESULTS),
     )?;
 
-    let query_normalized = normalize_search_text(query);
-    let query_tokens = tokenize_memory_query(query_normalized.as_str());
-
-    let mut results = Vec::new();
-    if let Some(workspace_root) = config.file_root.as_deref() {
-        if let Some(indexed_results) = search_indexed_workspace_memory_results(
-            query_normalized.as_str(),
-            query_tokens.as_slice(),
-            max_results,
-            config,
-            workspace_root,
-        )? {
-            results.extend(indexed_results);
-        } else {
-            let locations = collect_workspace_memory_document_locations(workspace_root)?;
-            for location in locations {
-                let maybe_result = search_memory_location(
-                    query_normalized.as_str(),
-                    query_tokens.as_slice(),
-                    config,
-                    &location,
-                )?;
-                let Some(result) = maybe_result else {
-                    continue;
-                };
-                results.push(result);
-            }
-        }
-    }
-    results.extend(search_canonical_memory_results(
-        query_normalized.as_str(),
-        query_tokens.as_slice(),
+    let bundle = build_memory_retrieve_bundle(
+        "__operator_memory_search__",
+        Some(query.to_owned()),
+        MemoryRetrievalIntent::OperatorInspection,
         max_results,
         config,
-    )?);
-
-    results.sort_by(|left, right| {
-        right
-            .score
-            .cmp(&left.score)
-            .then(left.source.cmp(right.source))
-            .then(left.path.cmp(&right.path))
-            .then(left.session_id.cmp(&right.session_id))
-            .then(left.start_line.cmp(&right.start_line))
-    });
-
-    let bounded_results = results.into_iter().take(max_results).collect::<Vec<_>>();
-    let result_payload = bounded_results
+    )?;
+    let result_payload = bundle
+        .results
         .iter()
-        .map(memory_search_result_payload)
+        .map(|result| {
+            let search_result = MemorySearchResult {
+                source: Box::leak(result.source.clone().into_boxed_str()),
+                path: result.path.clone(),
+                session_id: result.session_id.clone(),
+                scope: result.scope.clone(),
+                kind: result.kind.clone(),
+                role: result.role.clone(),
+                start_line: result.start_line,
+                end_line: result.end_line,
+                snippet: result.snippet.clone(),
+                score: result.score,
+                provenance: result.provenance.clone(),
+                metadata: result.metadata.clone(),
+            };
+            memory_search_result_payload(&search_result)
+        })
         .collect::<Vec<_>>();
 
     Ok(ToolCoreOutcome {
@@ -129,6 +412,10 @@ pub(super) fn execute_memory_search_tool_with_config(
             "adapter": "core-tools",
             "tool_name": request.tool_name,
             "query": query,
+            "intent": bundle.intent.as_str(),
+            "prompt_eligible": bundle.prompt_eligible,
+            "retrieval_reason": bundle.retrieval_reason,
+            "injection_reason": bundle.injection_reason,
             "returned": result_payload.len(),
             "results": result_payload,
         }),
@@ -536,51 +823,6 @@ fn normalized_existing_path_key(path: &Path) -> Result<String, String> {
     Ok(normalized_path.display().to_string())
 }
 
-fn search_canonical_memory_results(
-    query: &str,
-    query_tokens: &[String],
-    max_results: usize,
-    config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<Vec<MemorySearchResult>, String> {
-    let Some(sqlite_path) = config.memory_sqlite_path.as_ref() else {
-        return Ok(Vec::new());
-    };
-    if !sqlite_path.exists() {
-        return Ok(Vec::new());
-    }
-
-    let hits = crate::memory::search_canonical_memory_with_sqlite_path(
-        query,
-        max_results,
-        None,
-        sqlite_path,
-    )?;
-
-    Ok(hits
-        .into_iter()
-        .map(|hit| {
-            let score = canonical_memory_match_score(query, query_tokens, &hit);
-            let scope = hit.record.scope.as_str().to_owned();
-            let kind = hit.record.kind.as_str().to_owned();
-            let provenance = canonical_memory_hit_provenance(config, &hit);
-            MemorySearchResult {
-                source: "canonical_session",
-                path: None,
-                session_id: Some(hit.record.session_id),
-                scope: Some(scope),
-                kind: Some(kind),
-                role: hit.record.role,
-                start_line: None,
-                end_line: None,
-                snippet: hit.record.content,
-                score,
-                provenance,
-                metadata: None,
-            }
-        })
-        .collect())
-}
-
 fn canonical_memory_match_score(
     query: &str,
     query_tokens: &[String],
@@ -807,6 +1049,96 @@ fn indexed_workspace_memory_metadata_payload(
         "superseded_by": hit.superseded_by,
         "body_line_offset": hit.body_line_offset,
     })
+}
+
+fn search_canonical_memory_results_for_session(
+    session_id: &str,
+    query: &str,
+    query_tokens: &[String],
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<MemorySearchResult>, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (session_id, query, query_tokens, max_results, config);
+        Ok(Vec::new())
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let memory_config = build_memory_runtime_config_for_tools(config);
+        let hits = crate::memory::search_canonical_memory(
+            query,
+            max_results,
+            Some(session_id),
+            &memory_config,
+        )?;
+        let mut results = Vec::new();
+        for hit in hits {
+            let maybe_result = canonical_memory_hit_to_result(query, query_tokens, config, &hit)?;
+            let Some(result) = maybe_result else {
+                continue;
+            };
+            results.push(result);
+        }
+        Ok(results)
+    }
+}
+
+fn canonical_memory_hit_to_result(
+    query: &str,
+    query_tokens: &[String],
+    config: &super::runtime_config::ToolRuntimeConfig,
+    hit: &crate::memory::CanonicalMemorySearchHit,
+) -> Result<Option<MemorySearchResult>, String> {
+    let lines = hit.record.content.lines().collect::<Vec<_>>();
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    let metadata = json!({
+        "session_id": hit.record.session_id,
+        "scope": hit.record.scope.as_str(),
+        "kind": hit.record.kind.as_str(),
+        "role": hit.record.role,
+    });
+    let metadata_score = canonical_memory_match_score(query, query_tokens, hit);
+    let best_body_match = best_line_match(query, query_tokens, lines.as_slice());
+    let focus_line = best_body_match
+        .map(|matched| matched.line_number)
+        .or_else(|| (metadata_score > 0).then_some(1));
+    let Some(focus_line) = focus_line else {
+        return Ok(None);
+    };
+    let total_lines = lines.len();
+    let (start_line, end_line) =
+        snippet_window(total_lines, focus_line, MEMORY_SEARCH_CONTEXT_RADIUS_LINES);
+    let snippet_lines = lines
+        .get(start_line.saturating_sub(1)..end_line)
+        .ok_or_else(|| {
+            "memory_search selected canonical snippet window is out of bounds".to_owned()
+        })?;
+    let snippet = snippet_lines.join("\n");
+    let score = best_body_match
+        .map(|matched| matched.score)
+        .unwrap_or(0)
+        .max(metadata_score)
+        .max(1);
+
+    Ok(Some(MemorySearchResult {
+        source: "canonical_session",
+        path: None,
+        session_id: Some(hit.record.session_id.clone()),
+        scope: Some(hit.record.scope.as_str().to_owned()),
+        kind: Some(hit.record.kind.as_str().to_owned()),
+        role: hit.record.role.clone(),
+        start_line: None,
+        end_line: None,
+        snippet,
+        score,
+        provenance: canonical_memory_hit_provenance(config, hit),
+        metadata: Some(metadata),
+    }))
 }
 
 fn canonical_memory_hit_provenance(

--- a/crates/app/src/tools/required_capabilities_tests.rs
+++ b/crates/app/src/tools/required_capabilities_tests.rs
@@ -88,6 +88,15 @@ fn required_capabilities_follow_effective_tool_request() {
         BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
     );
 
+    let direct_memory_retrieve = ToolCoreRequest {
+        tool_name: "memory.retrieve".to_owned(),
+        payload: json!({"session_id": "session-1", "query": "deploy freeze"}),
+    };
+    assert_eq!(
+        required_capabilities_for_request(&direct_memory_retrieve),
+        BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+    );
+
     let direct_memory_get = ToolCoreRequest {
         tool_name: "memory_get".to_owned(),
         payload: json!({"path": "MEMORY.md"}),

--- a/crates/app/src/tools/tool_dispatch.rs
+++ b/crates/app/src/tools/tool_dispatch.rs
@@ -297,6 +297,10 @@ fn dispatch_tool_request(
         "glob.search" => file::execute_glob_search_tool_with_config(request, config),
         "content.search" => file::execute_content_search_tool_with_config(request, config),
         #[cfg(feature = "tool-file")]
+        "memory.retrieve" => {
+            memory_tools::execute_memory_retrieve_tool_with_config(request, config)
+        }
+        #[cfg(feature = "tool-file")]
         "memory_search" => memory_tools::execute_memory_search_tool_with_config(request, config),
         #[cfg(feature = "tool-file")]
         "memory_get" => memory_tools::execute_memory_get_tool_with_config(request, config),

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -243,7 +243,7 @@ pub(super) fn tool_search_entry_is_runtime_usable(
         }
         "bash.exec" => config.bash_exec.is_discoverable(),
         #[cfg(feature = "tool-file")]
-        "memory_search" => memory_tools::memory_corpus_available(config),
+        "memory.retrieve" | "memory_search" => memory_tools::memory_corpus_available(config),
         #[cfg(feature = "tool-file")]
         "memory_get" => memory_tools::workspace_memory_corpus_available(config),
         _ => true,

--- a/crates/app/src/tools/tool_surface.rs
+++ b/crates/app/src/tools/tool_surface.rs
@@ -247,7 +247,7 @@ const EDIT_COVERED_TOOL_NAMES: &[&str] = &["file.edit"];
 const BASH_COVERED_TOOL_NAMES: &[&str] = &["shell.exec", "bash.exec"];
 const WEB_COVERED_TOOL_NAMES: &[&str] = &["web.fetch", "web.search", "http.request"];
 const BROWSER_COVERED_TOOL_NAMES: &[&str] = &["browser.open", "browser.extract", "browser.click"];
-const MEMORY_COVERED_TOOL_NAMES: &[&str] = &["memory_search", "memory_get"];
+const MEMORY_COVERED_TOOL_NAMES: &[&str] = &["memory.retrieve", "memory_search", "memory_get"];
 
 const READ_DIRECT_METADATA: DirectToolSurfaceMetadata = DirectToolSurfaceMetadata {
     argument_hint: "path?:string,offset?:integer,limit?:integer,max_bytes?:integer,query?:string,pattern?:string,root?:string,glob?:string,max_results?:integer,max_bytes_per_file?:integer,case_sensitive?:boolean,include_directories?:boolean",

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -1144,6 +1144,7 @@ fn runtime_tool_view_includes_memory_tools_when_memory_corpus_exists() {
     let config = test_tool_runtime_config(root);
     let tool_view = runtime_tool_view_for_runtime_config(&config);
 
+    assert!(tool_view.contains("memory.retrieve"));
     assert!(tool_view.contains("memory_search"));
     assert!(tool_view.contains("memory_get"));
 }
@@ -1332,6 +1333,126 @@ fn memory_search_tool_returns_structured_hits_from_workspace_memory_files() {
         }),
         "expected structured workspace metadata: {results:?}"
     );
+    assert_eq!(outcome.payload["intent"], "operator_inspection");
+    assert_eq!(
+        outcome.payload["retrieval_reason"],
+        "query_match_durable_memory"
+    );
+    assert_eq!(
+        outcome.payload["injection_reason"],
+        "operator_requested_memory_retrieval"
+    );
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn memory_retrieve_tool_returns_operator_visible_retrieval_truth() {
+    let root = unique_tool_temp_dir("loongclaw-memory-retrieve");
+    let memory_dir = root.join("memory");
+
+    std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+    std::fs::write(
+        root.join("MEMORY.md"),
+        "# Durable Notes\nDeploy freeze window is Friday.\n",
+    )
+    .expect("write root memory");
+    std::fs::write(
+        memory_dir.join("2026-03-23.md"),
+        "Customer migration starts tomorrow.\n",
+    )
+    .expect("write daily log");
+
+    let config = test_tool_runtime_config(root);
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "memory.retrieve".to_owned(),
+            payload: json!({
+                "session_id": "session-1",
+                "query": "deploy freeze window",
+                "intent": "operator_inspection",
+                "max_results": 4
+            }),
+        },
+        &config,
+    )
+    .expect("memory retrieve should succeed");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["intent"], "operator_inspection");
+    assert_eq!(outcome.payload["prompt_eligible"], true);
+    assert_eq!(
+        outcome.payload["retrieval_reason"],
+        "query_match_durable_memory"
+    );
+    assert_eq!(
+        outcome.payload["injection_reason"],
+        "operator_requested_memory_retrieval"
+    );
+
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert!(!results.is_empty());
+    assert!(results.iter().any(|entry| entry["path"] == "MEMORY.md"));
+    assert!(
+        results
+            .iter()
+            .all(|entry| entry["provenance_summary"]["source_kind"].is_string())
+    );
+    assert!(
+        results
+            .iter()
+            .all(|entry| entry["provenance_summary"]["authority"].is_string())
+    );
+    assert!(
+        results
+            .iter()
+            .all(|entry| entry["provenance_summary"]["trust_level"].is_string())
+    );
+}
+
+#[cfg(feature = "tool-file")]
+#[test]
+fn memory_retrieve_tool_without_query_returns_prompt_style_advisory_recall() {
+    let root = unique_tool_temp_dir("loongclaw-memory-retrieve-prompt");
+    std::fs::create_dir_all(&root).expect("create root dir");
+    std::fs::write(
+        root.join("MEMORY.md"),
+        "# Durable Notes\nRemember the deploy freeze window.\n",
+    )
+    .expect("write root memory");
+
+    let config = test_tool_runtime_config(root);
+    let outcome = execute_tool_core_with_config(
+        ToolCoreRequest {
+            tool_name: "memory.retrieve".to_owned(),
+            payload: json!({
+                "session_id": "session-1",
+                "intent": "prompt_assembly",
+                "max_results": 2
+            }),
+        },
+        &config,
+    )
+    .expect("memory retrieve without query should succeed");
+
+    assert_eq!(outcome.status, "ok");
+    assert_eq!(outcome.payload["intent"], "prompt_assembly");
+    assert_eq!(outcome.payload["prompt_eligible"], true);
+    assert_eq!(
+        outcome.payload["retrieval_reason"],
+        "profile_aware_advisory_recall"
+    );
+    assert_eq!(
+        outcome.payload["injection_reason"],
+        "prompt_assembly_advisory_recall"
+    );
+
+    let results = outcome.payload["results"].as_array().expect("results");
+    assert!(!results.is_empty());
+    assert!(results.iter().any(|entry| {
+        entry["snippet"]
+            .as_str()
+            .is_some_and(|value| value.contains("Remember the deploy freeze window."))
+    }));
 }
 
 #[cfg(feature = "tool-file")]


### PR DESCRIPTION
## Summary
- add a first-class `memory.retrieve` surface for operator-facing retrieval
- move retrieval outcome and provenance summary into the memory runtime contract
- project retrieval outcome through staged memory envelopes and provider prompt projection
- keep `memory_search` behavior compatible while reusing the new retrieval truth

## Validation
- `cargo fmt --all --check`
- `./scripts/cargo-local-toolchain.sh clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/cargo-local-toolchain.sh test -p loong-app --all-features`
- `cargo test -p loong-app --lib memory:: -- --nocapture`
- `cargo test -p loong-app memory_retrieve_tool -- --nocapture`
- `cargo test -p loong-app read_stage_envelope_operation_preserves_durable_recall_with_workspace_root -- --nocapture`
- `cargo test -p loong-app projected_stage_envelope -- --nocapture`

Closes #1472
