### PR TITLE
feat(tasks): make background task surfaces task-first

### DIFF
--- a/crates/app/src/control_plane.rs
+++ b/crates/app/src/control_plane.rs
@@ -1722,6 +1722,8 @@ pub struct ControlPlaneSessionObservationView {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ControlPlaneTaskSummaryView {
     pub task_id: String,
+    pub task_session_id: String,
+    pub owner_session_id: String,
     pub session_id: String,
     pub scope_session_id: String,
     pub label: Option<String>,
@@ -2142,6 +2144,8 @@ impl ControlPlaneRepositoryView {
 
         let task_view = ControlPlaneTaskSummaryView {
             task_id: task_id.clone(),
+            task_session_id: session.session_id.clone(),
+            owner_session_id: session.session_id.clone(),
             session_id: session.session_id.clone(),
             scope_session_id: self.current_session_id.clone(),
             label: session.label.clone(),
@@ -3732,6 +3736,8 @@ mod tests {
 
         let task = tasks.tasks.first().expect("first background task");
         assert_eq!(task.task_id, "task-child");
+        assert_eq!(task.task_session_id, "child-session");
+        assert_eq!(task.owner_session_id, "child-session");
         assert_eq!(task.workflow.workflow_id, "root-session");
         assert_eq!(
             task.workflow.task.as_deref(),
@@ -3763,6 +3769,8 @@ mod tests {
             .expect("background task detail");
 
         assert_eq!(task.task_id, "task-child");
+        assert_eq!(task.task_session_id, "child-session");
+        assert_eq!(task.owner_session_id, "child-session");
         assert_eq!(task.workflow.workflow_id, "root-session");
         assert_eq!(
             task.workflow
@@ -3792,6 +3800,8 @@ mod tests {
             .expect("background task legacy alias")
             .expect("background task legacy detail");
         assert_eq!(legacy_alias.task_id, "task-child");
+        assert_eq!(legacy_alias.task_session_id, "child-session");
+        assert_eq!(legacy_alias.owner_session_id, "child-session");
         assert_eq!(legacy_alias.session_id, "child-session");
 
         let hidden_error = view

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4080,10 +4080,7 @@ async fn handle_turn_with_runtime_records_task_progress_event() {
         .as_object()
         .expect("raw task progress payload");
 
-    assert_eq!(
-        raw_task_progress.get("session_id"),
-        Some(&Value::String(session_id.clone()))
-    );
+    assert_eq!(event.session_id, session_id);
     assert_eq!(
         raw_task_progress.get("task_id"),
         Some(&Value::String(task_progress.task_id.clone()))
@@ -4174,25 +4171,29 @@ async fn handle_turn_with_runtime_records_verifying_task_progress_before_complet
         .iter()
         .filter(|event| event.event_kind == crate::task_progress::TASK_PROGRESS_EVENT_KIND)
         .map(|event| {
-            event.payload_json["task_progress"]
-                .as_object()
-                .expect("raw task progress payload")
+            (
+                event.session_id.as_str(),
+                event.payload_json["task_progress"]
+                    .as_object()
+                    .expect("raw task progress payload"),
+            )
         })
         .collect::<Vec<_>>();
     let canonical_task_id = raw_task_progress_events[0]
+        .1
         .get("task_id")
         .and_then(Value::as_str)
         .expect("canonical task id")
         .to_owned();
 
     assert!(
-        raw_task_progress_events.iter().all(|task_progress| {
-            task_progress.get("session_id") == Some(&Value::String(session_id.clone()))
-        }),
+        raw_task_progress_events
+            .iter()
+            .all(|(event_session_id, _)| *event_session_id == session_id),
         "every task-progress event should retain the backing session mapping"
     );
     assert!(
-        raw_task_progress_events.iter().all(|task_progress| {
+        raw_task_progress_events.iter().all(|(_, task_progress)| {
             task_progress.get("task_id") == Some(&Value::String(canonical_task_id.clone()))
         }),
         "status transitions should stay attached to one canonical task id"

--- a/crates/app/src/conversation/turn_coordinator/support.rs
+++ b/crates/app/src/conversation/turn_coordinator/support.rs
@@ -280,7 +280,7 @@ pub(super) fn active_task_progress_record(
         }],
         resume_recipe: Some(TaskResumeRecipeRecord {
             recommended_tool: "task_status".to_owned(),
-            session_id: session_id.to_owned(),
+            task_session_id: session_id.to_owned(),
             note: Some(
                 "Inspect task_status, task_wait, or task_history for durable task progress."
                     .to_owned(),
@@ -313,7 +313,7 @@ pub(super) fn verifying_task_progress_record(
         }],
         resume_recipe: Some(TaskResumeRecipeRecord {
             recommended_tool: "task_status".to_owned(),
-            session_id: session_id.to_owned(),
+            task_session_id: session_id.to_owned(),
             note: Some(
                 "Check task_status to see whether finalization verification has completed."
                     .to_owned(),
@@ -346,7 +346,7 @@ pub(super) fn waiting_task_progress_record(
         }],
         resume_recipe: Some(TaskResumeRecipeRecord {
             recommended_tool: "task_status".to_owned(),
-            session_id: session_id.to_owned(),
+            task_session_id: session_id.to_owned(),
             note: Some(
                 "Use task_status or the approval control path to resolve the waiting task."
                     .to_owned(),
@@ -389,7 +389,7 @@ pub(super) fn failed_task_progress_record(
         active_handles: Vec::new(),
         resume_recipe: Some(TaskResumeRecipeRecord {
             recommended_tool: "task_history".to_owned(),
-            session_id: session_id.to_owned(),
+            task_session_id: session_id.to_owned(),
             note: Some(
                 "Inspect recent task_history and task_status to diagnose the failed task."
                     .to_owned(),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -25,7 +25,7 @@ mod runtime_self_continuity;
 pub(crate) mod search_text;
 mod secrets;
 pub mod session;
-pub(crate) mod task_progress;
+pub mod task_progress;
 pub mod tools;
 pub(crate) mod trust;
 pub mod tui_surface;

--- a/crates/app/src/task_progress.rs
+++ b/crates/app/src/task_progress.rs
@@ -5,11 +5,11 @@ use serde_json::{Value, json};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::SessionRepository;
 
-pub(crate) const TASK_PROGRESS_EVENT_KIND: &str = "task_progress";
+pub const TASK_PROGRESS_EVENT_KIND: &str = "task_progress";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum TaskProgressStatus {
+pub enum TaskProgressStatus {
     #[default]
     Active,
     Waiting,
@@ -43,7 +43,7 @@ impl TaskProgressStatus {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum TaskVerificationState {
+pub enum TaskVerificationState {
     #[default]
     NotStarted,
     Pending,
@@ -65,7 +65,7 @@ impl TaskVerificationState {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
-pub(crate) struct TaskActiveHandleRecord {
+pub struct TaskActiveHandleRecord {
     pub handle_kind: String,
     pub handle_id: String,
     pub state: String,
@@ -75,9 +75,9 @@ pub(crate) struct TaskActiveHandleRecord {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct TaskResumeRecipeRecord {
+pub struct TaskResumeRecipeRecord {
     pub recommended_tool: String,
-    pub session_id: String,
+    pub task_session_id: String,
     pub note: Option<String>,
 }
 
@@ -85,7 +85,7 @@ pub(crate) struct TaskResumeRecipeRecord {
 impl TaskResumeRecipeRecord {
     #[must_use]
     pub fn task_session_id(&self) -> &str {
-        &self.session_id
+        &self.task_session_id
     }
 }
 
@@ -96,8 +96,8 @@ impl Serialize for TaskResumeRecipeRecord {
     {
         let mut map = serializer.serialize_map(Some(if self.note.is_some() { 4 } else { 3 }))?;
         map.serialize_entry("recommended_tool", &self.recommended_tool)?;
-        map.serialize_entry("task_session_id", &self.session_id)?;
-        map.serialize_entry("session_id", &self.session_id)?;
+        map.serialize_entry("task_session_id", &self.task_session_id)?;
+        map.serialize_entry("session_id", &self.task_session_id)?;
         if let Some(note) = &self.note {
             map.serialize_entry("note", note)?;
         }
@@ -120,18 +120,18 @@ impl<'de> Deserialize<'de> for TaskResumeRecipeRecord {
         }
 
         let raw = RawTaskResumeRecipeRecord::deserialize(deserializer)?;
-        let session_id = raw.task_session_id.or(raw.session_id).unwrap_or_default();
+        let task_session_id = raw.task_session_id.or(raw.session_id).unwrap_or_default();
 
         Ok(TaskResumeRecipeRecord {
             recommended_tool: raw.recommended_tool,
-            session_id,
+            task_session_id,
             note: raw.note,
         })
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TaskProgressRecord {
+pub struct TaskProgressRecord {
     pub task_id: String,
     pub owner_kind: String,
     pub status: TaskProgressStatus,
@@ -178,7 +178,6 @@ impl Serialize for TaskProgressRecord {
 
         let mut map = serializer.serialize_map(Some(entry_count))?;
         map.serialize_entry("task_id", &self.task_id)?;
-        map.serialize_entry("session_id", &self.task_id)?;
         map.serialize_entry("owner_kind", &self.owner_kind)?;
         map.serialize_entry("status", &self.status)?;
         if let Some(intent_summary) = &self.intent_summary {
@@ -233,7 +232,7 @@ impl<'de> Deserialize<'de> for TaskProgressRecord {
     }
 }
 
-pub(crate) fn task_progress_from_event_payload(payload: &Value) -> Option<TaskProgressRecord> {
+pub fn task_progress_from_event_payload(payload: &Value) -> Option<TaskProgressRecord> {
     let task_progress = payload
         .get("task_progress")
         .cloned()
@@ -241,10 +240,7 @@ pub(crate) fn task_progress_from_event_payload(payload: &Value) -> Option<TaskPr
     serde_json::from_value(task_progress).ok()
 }
 
-pub(crate) fn task_progress_event_payload(
-    source: &str,
-    task_progress: &TaskProgressRecord,
-) -> Value {
+pub fn task_progress_event_payload(source: &str, task_progress: &TaskProgressRecord) -> Value {
     json!({
         "source": source,
         "task_progress": task_progress,
@@ -253,7 +249,7 @@ pub(crate) fn task_progress_event_payload(
 
 #[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ResolvedTaskIdentity {
+pub struct ResolvedTaskIdentity {
     pub task_id: String,
     pub task_session_id: String,
 }
@@ -297,7 +293,7 @@ fn task_identity_from_delegate_payload(
 }
 
 #[cfg(feature = "memory-sqlite")]
-pub(crate) fn resolve_canonical_task_id_for_session(
+pub fn resolve_canonical_task_id_for_session(
     repo: &SessionRepository,
     session_id: &str,
 ) -> Option<String> {
@@ -333,7 +329,7 @@ pub(crate) fn resolve_task_identity_for_event(
 }
 
 #[cfg(feature = "memory-sqlite")]
-pub(crate) fn resolve_task_identity_for_session(
+pub fn resolve_task_identity_for_session(
     repo: &SessionRepository,
     session_id: &str,
 ) -> ResolvedTaskIdentity {
@@ -391,7 +387,7 @@ mod tests {
             }],
             resume_recipe: Some(TaskResumeRecipeRecord {
                 recommended_tool: "session_status".to_owned(),
-                session_id: "session-1".to_owned(),
+                task_session_id: "session-1".to_owned(),
                 note: Some("Inspect durable task progress.".to_owned()),
             }),
             updated_at: 123,
@@ -436,7 +432,7 @@ mod tests {
         assert_eq!(decoded.task_id, "legacy-session-1");
         let resume_recipe = decoded.resume_recipe.expect("legacy resume recipe");
         assert_eq!(resume_recipe.task_session_id(), "legacy-session-1");
-        assert_eq!(resume_recipe.session_id, "legacy-session-1");
+        assert_eq!(resume_recipe.task_session_id, "legacy-session-1");
     }
 
     #[test]
@@ -465,7 +461,7 @@ mod tests {
         assert_eq!(decoded.task_id, "task-123");
         let resume_recipe = decoded.resume_recipe.expect("canonical resume recipe");
         assert_eq!(resume_recipe.task_session_id(), "session-123");
-        assert_eq!(resume_recipe.session_id, "session-123");
+        assert_eq!(resume_recipe.task_session_id, "session-123");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -58,8 +58,9 @@ use session_definition_support::{
     session_tool_policy_clear_definition, session_tool_policy_set_definition,
     session_tool_policy_status_definition, session_unpin_head_definition, session_wait_definition,
     sessions_history_definition, sessions_list_definition, sessions_send_definition,
-    task_events_definition, task_history_definition, task_status_definition, task_wait_definition,
-    tasks_list_definition, tasks_search_definition,
+    task_cancel_definition, task_events_definition, task_history_definition,
+    task_recover_definition, task_status_definition, task_wait_definition, tasks_list_definition,
+    tasks_search_definition,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -623,6 +624,8 @@ fn declared_concurrency_class(tool_name: &str) -> ToolConcurrencyClass {
         | "task_wait"
         | "task_history"
         | "task_events"
+        | "task_cancel"
+        | "task_recover"
         | "tasks_list"
         | "tasks_search"
         | "sessions_history"
@@ -1231,6 +1234,34 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: task_events_definition,
         },
         ToolDescriptor {
+            name: "task_cancel",
+            provider_name: "task_cancel",
+            aliases: &[],
+            description: "Cancel a durable task using task-first identity while preserving runtime ownership truth",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: task_cancel_definition,
+        },
+        ToolDescriptor {
+            name: "task_recover",
+            provider_name: "task_recover",
+            aliases: &[],
+            description: "Recover a durable task using task-first identity while preserving runtime ownership truth",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: task_recover_definition,
+        },
+        ToolDescriptor {
             name: "tasks_list",
             provider_name: "tasks_list",
             aliases: &[],
@@ -1713,6 +1744,62 @@ fn build_tool_catalog() -> ToolCatalog {
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             concurrency_class: ToolConcurrencyClass::Unknown,
             provider_definition_builder: browser_open_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.snapshot",
+            provider_name: "browser_companion_snapshot",
+            aliases: &["browser_companion_snapshot"],
+            description: "Capture a managed browser snapshot for the current browser session",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: browser_extract_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.click",
+            provider_name: "browser_companion_click",
+            aliases: &["browser_companion_click"],
+            description: "Click a managed browser element within the current browser session",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: browser_click_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.type",
+            provider_name: "browser_companion_type",
+            aliases: &["browser_companion_type"],
+            description: "Type into a managed browser element within the current browser session",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: browser_click_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "browser.companion.wait",
+            provider_name: "browser_companion_wait",
+            aliases: &["browser_companion_wait"],
+            description: "Wait on a managed browser condition within the current browser session",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            concurrency_class: ToolConcurrencyClass::Unknown,
+            provider_definition_builder: browser_extract_definition,
         });
     }
 

--- a/crates/app/src/tools/catalog_metadata_support.rs
+++ b/crates/app/src/tools/catalog_metadata_support.rs
@@ -156,6 +156,10 @@ pub(super) fn tool_argument_hint(name: &str) -> &'static str {
         "browser.open" => "url:string,max_bytes?:integer",
         "browser.extract" => "session_id:string,mode?:string,selector?:string,limit?:integer",
         "browser.click" => "session_id:string,link_id:integer",
+        "browser.companion.snapshot" => "session_id:string,selector?:string",
+        "browser.companion.click" => "session_id:string,selector:string",
+        "browser.companion.type" => "session_id:string,selector:string,text:string",
+        "browser.companion.wait" => "session_id:string,condition:string,timeout_ms?:integer",
         "http.request" => {
             "url:string,method?:string,headers?:object,body?:string,content_type?:string,max_bytes?:integer"
         }
@@ -188,6 +192,7 @@ pub(super) fn tool_argument_hint(name: &str) -> &'static str {
         "task_status" => "task_id:string,task_ids?:string[]",
         "task_wait" | "task_history" => "task_id:string",
         "task_events" => "task_id:string,after_id?:integer,limit?:integer",
+        "task_cancel" | "task_recover" => "task_id:string,dry_run?:boolean",
         "tasks_list" => "limit?:integer,offset?:integer,task_state?:string,stable_only?:boolean",
         "tasks_search" => {
             "query:string,max_results?:integer,task_state?:string,stable_only?:boolean"
@@ -574,6 +579,18 @@ pub(super) fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'sta
             ("limit", "integer"),
         ],
         "browser.click" => &[("session_id", "string"), ("link_id", "integer")],
+        "browser.companion.snapshot" => &[("session_id", "string"), ("selector", "string")],
+        "browser.companion.click" => &[("session_id", "string"), ("selector", "string")],
+        "browser.companion.type" => &[
+            ("session_id", "string"),
+            ("selector", "string"),
+            ("text", "string"),
+        ],
+        "browser.companion.wait" => &[
+            ("session_id", "string"),
+            ("condition", "string"),
+            ("timeout_ms", "integer"),
+        ],
         "http.request" => &[
             ("url", "string"),
             ("method", "string"),
@@ -670,6 +687,7 @@ pub(super) fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'sta
             ("after_id", "integer"),
             ("limit", "integer"),
         ],
+        "task_cancel" | "task_recover" => &[("task_id", "string"), ("dry_run", "boolean")],
         "tasks_list" => &[
             ("limit", "integer"),
             ("offset", "integer"),
@@ -759,6 +777,10 @@ pub(super) fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "browser.open" => &["url"],
         "browser.extract" => &["session_id"],
         "browser.click" => &["session_id", "link_id"],
+        "browser.companion.snapshot" => &["session_id"],
+        "browser.companion.click" => &["session_id", "selector"],
+        "browser.companion.type" => &["session_id", "selector", "text"],
+        "browser.companion.wait" => &["session_id", "condition"],
         "http.request" => &["url"],
         "glob.search" => &["pattern"],
         "content.search" => &["query"],
@@ -769,7 +791,8 @@ pub(super) fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "delegate" | "delegate_async" => &["task"],
         "session_tool_policy_status" | "session_tool_policy_clear" => &[],
         "session_tool_policy_set" => &[],
-        "task_status" | "task_wait" | "task_history" | "task_events" => &["task_id"],
+        "task_status" | "task_wait" | "task_history" | "task_events" | "task_cancel"
+        | "task_recover" => &["task_id"],
         "tasks_list" => &[],
         "tasks_search" => &["query"],
         "session_continue" => &["session_id", "input"],
@@ -848,9 +871,13 @@ pub(super) fn tool_tags(name: &str) -> &'static [&'static str] {
         "skills.list" => &["skills", "list", "discover"],
         "skills.policy" => &["skills", "policy", "security"],
         "skills.remove" => &["skills", "remove", "uninstall"],
-        "browse" => &["browse", "page", "extract", "links"],
+        "browse" => &["browse", "page", "extract", "links", "automation"],
         "browser.open" | "browser.extract" => &["browser", "page", "read"],
         "browser.click" => &["browser", "page", "navigate"],
+        "browser.companion.snapshot" => &["browser", "managed", "snapshot"],
+        "browser.companion.click" => &["browser", "managed", "click"],
+        "browser.companion.type" => &["browser", "managed", "type"],
+        "browser.companion.wait" => &["browser", "managed", "wait"],
         "http.request" => &["http", "request", "web", "network", "external"],
         "glob.search" => &[
             "file",
@@ -886,6 +913,7 @@ pub(super) fn tool_tags(name: &str) -> &'static [&'static str] {
         }
         "task_status" | "task_wait" | "task_history" => &["task", "runtime", "history", "status"],
         "task_events" => &["task", "runtime", "events", "history", "status"],
+        "task_cancel" | "task_recover" => &["task", "runtime", "mutate", "status"],
         "tasks_list" => &["task", "runtime", "list", "status"],
         "tasks_search" => &["task", "runtime", "search", "status"],
         "session_continue" => &["session", "continue", "delegate", "child"],

--- a/crates/app/src/tools/catalog_session_definition_support.rs
+++ b/crates/app/src/tools/catalog_session_definition_support.rs
@@ -616,6 +616,56 @@ pub(super) fn task_events_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+pub(super) fn task_cancel_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Durable task identifier to cancel."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, return the planned cancellation action without mutating runtime state."
+                    }
+                },
+                "required": ["task_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+pub(super) fn task_recover_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Durable task identifier to recover."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When true, return the planned recovery action without mutating runtime state."
+                    }
+                },
+                "required": ["task_id"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 pub(super) fn tasks_list_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",

--- a/crates/app/src/tools/catalog_tests.rs
+++ b/crates/app/src/tools/catalog_tests.rs
@@ -698,6 +698,8 @@ fn autonomy_capability_action_classifies_representative_tool_families() {
         ("task_wait", CapabilityActionClass::ExecuteExisting),
         ("task_history", CapabilityActionClass::ExecuteExisting),
         ("task_events", CapabilityActionClass::ExecuteExisting),
+        ("task_cancel", CapabilityActionClass::ExecuteExisting),
+        ("task_recover", CapabilityActionClass::ExecuteExisting),
         ("tasks_list", CapabilityActionClass::ExecuteExisting),
         ("tasks_search", CapabilityActionClass::ExecuteExisting),
         ("session_recover", CapabilityActionClass::SessionMutation),

--- a/crates/app/src/tools/routing.rs
+++ b/crates/app/src/tools/routing.rs
@@ -142,8 +142,21 @@ fn route_direct_browser_tool_name_for_view(
     view: &ToolView,
 ) -> Result<&'static str, String> {
     let routed_tool_name = route_direct_browser_tool_name(payload)?;
-    let page_inspection_available = tool_surface::browser_page_inspection_available_in_view(view);
-    if page_inspection_available {
+    let browser_runtime_modes = tool_surface::direct_browser_runtime_modes_for_view(view);
+    let interactive_tool = matches!(
+        routed_tool_name,
+        "browser.companion.snapshot"
+            | "browser.companion.click"
+            | "browser.companion.type"
+            | "browser.companion.wait"
+    );
+    if interactive_tool {
+        if browser_runtime_modes.page_inspection_available {
+            return Ok(routed_tool_name);
+        }
+        return Err("managed browser automation is unavailable in this runtime".to_owned());
+    }
+    if browser_runtime_modes.page_inspection_available {
         return Ok(routed_tool_name);
     }
     Err("browser page inspection is unavailable in this runtime".to_owned())
@@ -433,17 +446,35 @@ pub(super) fn route_direct_browser_tool_name(payload: &Value) -> Result<&'static
     let has_text = payload_has_non_null_field(payload, "text");
     let has_condition = payload_has_non_null_field(payload, "condition");
     let has_timeout_ms = payload_has_non_null_field(payload, "timeout_ms");
+    let has_selector = payload_has_non_null_field(payload, "selector");
 
-    if matches!(
-        action,
-        Some("start" | "navigate" | "snapshot" | "wait" | "stop" | "type")
-    ) || has_text
-        || has_condition
-        || has_timeout_ms
-        || (has_session_id && has_url)
-    {
+    if matches!(action, Some("snapshot")) {
+        return Ok("browser.companion.snapshot");
+    }
+
+    if matches!(action, Some("wait")) || has_condition || has_timeout_ms {
+        return Ok("browser.companion.wait");
+    }
+
+    if matches!(action, Some("type")) || has_text {
+        return Ok("browser.companion.type");
+    }
+
+    if matches!(action, Some("start" | "navigate" | "stop")) {
         return Err(
-            "direct_browser_interactive_automation_unavailable: built-in browser only supports `open`, `extract`, and page-link `click`; use the `agent-browser` skill for richer browser automation".to_owned(),
+            "direct_browser_unknown_action: unsupported browser action for the direct browser surface"
+                .to_owned(),
+        );
+    }
+
+    if has_session_id && has_selector {
+        return Ok("browser.companion.click");
+    }
+
+    if has_session_id && has_url {
+        return Err(
+            "direct_browser_ambiguous: provide either a page session action or a navigation target, not both"
+                .to_owned(),
         );
     }
 
@@ -504,6 +535,8 @@ pub(crate) fn route_hidden_agent_tool_name(payload: &Value) -> Result<&'static s
             "tasks-search" => Ok("tasks_search"),
             "task-status" => Ok("task_status"),
             "task-wait" => Ok("task_wait"),
+            "task-cancel" => Ok("task_cancel"),
+            "task-recover" => Ok("task_recover"),
             "session-policy-status" => Ok("session_tool_policy_status"),
             "session-policy-set" => Ok("session_tool_policy_set"),
             "session-policy-clear" => Ok("session_tool_policy_clear"),
@@ -606,6 +639,12 @@ pub(crate) fn route_hidden_agent_tool_name(payload: &Value) -> Result<&'static s
     }
 
     if has_task_id || has_task_ids {
+        if has_dry_run {
+            return Err(
+                "hidden_agent_requires_operation: provide `operation` for task cancel/recover work"
+                    .to_owned(),
+            );
+        }
         if has_timeout_ms {
             return Ok("task_wait");
         }
@@ -702,6 +741,8 @@ pub(crate) fn hidden_operation_for_tool_name(raw: &str) -> Option<String> {
         "tasks_search" => Some("tasks-search".to_owned()),
         "task_status" => Some("task-status".to_owned()),
         "task_wait" => Some("task-wait".to_owned()),
+        "task_cancel" => Some("task-cancel".to_owned()),
+        "task_recover" => Some("task-recover".to_owned()),
         "session_tool_policy_status" => Some("session-policy-status".to_owned()),
         "session_tool_policy_set" => Some("session-policy-set".to_owned()),
         "session_tool_policy_clear" => Some("session-policy-clear".to_owned()),
@@ -834,7 +875,13 @@ fn routed_tool_display_name(routed_tool_name: &str) -> &str {
 fn display_inner_tool_name_for_logs(tool_name: &str) -> &str {
     if matches!(
         tool_name,
-        "browser.open" | "browser.extract" | "browser.click"
+        "browser.open"
+            | "browser.extract"
+            | "browser.click"
+            | "browser.companion.snapshot"
+            | "browser.companion.click"
+            | "browser.companion.type"
+            | "browser.companion.wait"
     ) {
         return "browse";
     }
@@ -882,7 +929,7 @@ mod tests {
             route_direct_tool_request(request, &runtime_config::ToolRuntimeConfig::default())
                 .expect_err("interactive browser automation should be unavailable");
 
-        assert!(error.contains("agent-browser"));
+        assert!(error.contains("managed browser automation is unavailable"));
         assert_eq!(
             unavailable_runtime_hint("browser.extract", &runtime_view),
             ""
@@ -928,14 +975,14 @@ mod tests {
     }
 
     #[test]
-    fn interactive_browser_payloads_surface_agent_browser_guidance() {
-        let error = route_direct_browser_tool_name(&json!({
+    fn interactive_browser_payloads_route_to_managed_browser_tools() {
+        let routed = route_direct_browser_tool_name(&json!({
             "session_id": "browser-1",
             "selector": "#submit",
             "text": "hello"
         }))
-        .expect_err("DOM interaction should not route through browse");
-        assert!(error.contains("agent-browser"));
+        .expect("DOM interaction should route through managed browser");
+        assert_eq!(routed, "browser.companion.type");
     }
 
     #[test]
@@ -960,6 +1007,18 @@ mod tests {
         .expect("task events payload should route");
 
         assert_eq!(routed, "task_events");
+    }
+
+    #[test]
+    fn hidden_operation_for_task_cancel_uses_task_cancel_alias() {
+        let operation = hidden_operation_for_tool_name("task_cancel").expect("task cancel alias");
+        assert_eq!(operation, "task-cancel");
+    }
+
+    #[test]
+    fn hidden_operation_for_task_recover_uses_task_recover_alias() {
+        let operation = hidden_operation_for_tool_name("task_recover").expect("task recover alias");
+        assert_eq!(operation, "task-recover");
     }
 
     #[test]

--- a/crates/app/src/tools/routing.rs
+++ b/crates/app/src/tools/routing.rs
@@ -142,7 +142,7 @@ fn route_direct_browser_tool_name_for_view(
     view: &ToolView,
 ) -> Result<&'static str, String> {
     let routed_tool_name = route_direct_browser_tool_name(payload)?;
-    let browser_runtime_modes = tool_surface::direct_browser_runtime_modes_for_view(view);
+    let page_inspection_available = tool_surface::browser_page_inspection_available_in_view(view);
     let interactive_tool = matches!(
         routed_tool_name,
         "browser.companion.snapshot"
@@ -151,12 +151,12 @@ fn route_direct_browser_tool_name_for_view(
             | "browser.companion.wait"
     );
     if interactive_tool {
-        if browser_runtime_modes.page_inspection_available {
+        if view.contains(routed_tool_name) {
             return Ok(routed_tool_name);
         }
         return Err("managed browser automation is unavailable in this runtime".to_owned());
     }
-    if browser_runtime_modes.page_inspection_available {
+    if page_inspection_available {
         return Ok(routed_tool_name);
     }
     Err("browser page inspection is unavailable in this runtime".to_owned())
@@ -921,13 +921,8 @@ mod tests {
             "selector": "#submit",
             "text": "hello"
         });
-        let request = loong_contracts::ToolCoreRequest {
-            tool_name: "browse".to_owned(),
-            payload,
-        };
-        let error =
-            route_direct_tool_request(request, &runtime_config::ToolRuntimeConfig::default())
-                .expect_err("interactive browser automation should be unavailable");
+        let error = route_direct_browser_tool_name_for_view(&payload, &runtime_view)
+            .expect_err("interactive browser automation should be unavailable");
 
         assert!(error.contains("managed browser automation is unavailable"));
         assert_eq!(

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -442,6 +442,10 @@ pub fn execute_session_tool_with_policies(
                 execute_task_history(payload, current_session_id, config, tool_config)
             }
             "task_events" => execute_task_events(payload, current_session_id, config, tool_config),
+            "task_cancel" => execute_task_cancel(payload, current_session_id, config, tool_config),
+            "task_recover" => {
+                execute_task_recover(payload, current_session_id, config, tool_config)
+            }
             "session_tool_policy_status" => {
                 execute_session_tool_policy_status(payload, current_session_id, config, tool_config)
             }
@@ -2368,6 +2372,37 @@ fn execute_session_recover(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn execute_task_recover(
+    payload: Value,
+    current_session_id: &str,
+    config: &SessionStoreConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_task_target_request(&payload, "task_id", None)?;
+    let target_task_id = legacy_single_task_id(&request.task_ids)?;
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let repo = SessionRepository::new(config)?;
+    let resolved_target =
+        resolve_task_target(&repo, current_session_id, target_task_id, tool_config)?;
+    let result = execute_session_recover_batch_result(
+        &resolved_target.owner_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        dry_run,
+    )?;
+    let mut payload = session_batch_result_json(result);
+    payload = rewrite_task_payload_aliases(payload, "task_recover");
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn execute_session_create_checkpoint(
     payload: Value,
     current_session_id: &str,
@@ -2647,6 +2682,37 @@ fn execute_session_cancel(
             request.target.session_ids.len(),
             results,
         ),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_task_cancel(
+    payload: Value,
+    current_session_id: &str,
+    config: &SessionStoreConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_task_target_request(&payload, "task_id", None)?;
+    let target_task_id = legacy_single_task_id(&request.task_ids)?;
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let repo = SessionRepository::new(config)?;
+    let resolved_target =
+        resolve_task_target(&repo, current_session_id, target_task_id, tool_config)?;
+    let result = execute_session_cancel_batch_result(
+        &resolved_target.owner_session_id,
+        current_session_id,
+        config,
+        tool_config,
+        dry_run,
+    )?;
+    let mut payload = session_batch_result_json(result);
+    payload = rewrite_task_payload_aliases(payload, "task_cancel");
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload,
     })
 }
 
@@ -3908,7 +3974,7 @@ fn recommended_resume_action(snapshot: &SessionInspectionSnapshot) -> Option<Val
     let task_progress = snapshot.workflow.task_progress.as_ref()?;
     let resume_recipe = task_progress.resume_recipe.as_ref()?;
     let tool_name = resume_recipe.recommended_tool.clone();
-    let session_id = resume_recipe.session_id.clone();
+    let session_id = resume_recipe.task_session_id.clone();
     let note = resume_recipe.note.clone();
     let requires_mutation = session_action_requires_mutation(tool_name.as_str());
     let task_status = task_progress.status.as_str().to_owned();
@@ -7920,7 +7986,7 @@ mod tests {
                     }],
                     resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
                         recommended_tool: "session_wait".to_owned(),
-                        session_id: "root-session".to_owned(),
+                        task_session_id: "root-session".to_owned(),
                         note: Some("Wait for durable task-progress transitions.".to_owned()),
                     }),
                     updated_at: 123,
@@ -8075,7 +8141,7 @@ mod tests {
                     active_handles: Vec::new(),
                     resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
                         recommended_tool: "session_status".to_owned(),
-                        session_id: "root-session".to_owned(),
+                        task_session_id: "root-session".to_owned(),
                         note: Some(
                             "Use session_status even after the recent window moves on.".to_owned(),
                         ),
@@ -8154,7 +8220,7 @@ mod tests {
                     active_handles: Vec::new(),
                     resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
                         recommended_tool: "task_wait".to_owned(),
-                        session_id: "task-owner".to_owned(),
+                        task_session_id: "task-owner".to_owned(),
                         note: Some("Wait on the task surface.".to_owned()),
                     }),
                     updated_at: 123,
@@ -8636,6 +8702,150 @@ mod tests {
         assert_eq!(second.payload["events"], json!([]));
         assert_eq!(second.payload["next_after_id"], next_after_id);
         assert_eq!(second.payload["task_session_count"], 2);
+    }
+
+    #[test]
+    fn task_recover_uses_canonical_task_id_to_recover_owner_session() {
+        let config = isolated_memory_config("task-recover-canonical");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "task-owner".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Task Owner".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create owner");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task_scope": {
+                    "task_id": "task-root",
+                },
+                "task_session_id": "task-owner",
+                "timeout_seconds": 1
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: crate::task_progress::TASK_PROGRESS_EVENT_KIND.to_owned(),
+            actor_session_id: Some("task-owner".to_owned()),
+            payload_json: crate::task_progress::task_progress_event_payload(
+                "unit_test",
+                &crate::task_progress::TaskProgressRecord {
+                    task_id: "task-root".to_owned(),
+                    owner_kind: "background_task_host".to_owned(),
+                    status: crate::task_progress::TaskProgressStatus::Blocked,
+                    intent_summary: Some("Recover overdue task".to_owned()),
+                    verification_state: Some(crate::task_progress::TaskVerificationState::Pending),
+                    active_handles: Vec::new(),
+                    resume_recipe: None,
+                    updated_at: 123,
+                },
+            ),
+        })
+        .expect("append task progress event");
+        repo.update_session_state("task-owner", SessionState::Ready, None)
+            .expect("keep ready state");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "task_recover".to_owned(),
+                payload: json!({
+                    "task_id": "task-root",
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("task_recover outcome");
+
+        assert_eq!(outcome.payload["task_id"], "task-root");
+        assert_eq!(outcome.payload["owner_session_id"], "task-owner");
+    }
+
+    #[test]
+    fn task_cancel_uses_canonical_task_id_to_cancel_owner_session() {
+        let config = isolated_memory_config("task-cancel-canonical");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "task-owner".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Task Owner".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create owner");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task_scope": {
+                    "task_id": "task-root",
+                },
+                "task_session_id": "task-owner",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: crate::task_progress::TASK_PROGRESS_EVENT_KIND.to_owned(),
+            actor_session_id: Some("task-owner".to_owned()),
+            payload_json: crate::task_progress::task_progress_event_payload(
+                "unit_test",
+                &crate::task_progress::TaskProgressRecord {
+                    task_id: "task-root".to_owned(),
+                    owner_kind: "background_task_host".to_owned(),
+                    status: crate::task_progress::TaskProgressStatus::Active,
+                    intent_summary: Some("Cancel queued task".to_owned()),
+                    verification_state: Some(
+                        crate::task_progress::TaskVerificationState::NotStarted,
+                    ),
+                    active_handles: Vec::new(),
+                    resume_recipe: None,
+                    updated_at: 123,
+                },
+            ),
+        })
+        .expect("append task progress event");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "task_cancel".to_owned(),
+                payload: json!({
+                    "task_id": "task-root",
+                    "dry_run": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("task_cancel outcome");
+
+        assert_eq!(outcome.payload["task_id"], "task-root");
+        assert_eq!(outcome.payload["owner_session_id"], "task-owner");
     }
 
     #[test]
@@ -9692,7 +9902,7 @@ mod tests {
                     active_handles: Vec::new(),
                     resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
                         recommended_tool: "session_wait".to_owned(),
-                        session_id: "root-session".to_owned(),
+                        task_session_id: "root-session".to_owned(),
                         note: Some("Wait for the terminal transition.".to_owned()),
                     }),
                     updated_at: 123,
@@ -11919,7 +12129,7 @@ mod tests {
                     }],
                     resume_recipe: Some(crate::task_progress::TaskResumeRecipeRecord {
                         recommended_tool: "task_status".to_owned(),
-                        session_id: "task-owner".to_owned(),
+                        task_session_id: "task-owner".to_owned(),
                         note: Some("Inspect task status for the approval gate.".to_owned()),
                     }),
                     updated_at: 123,

--- a/crates/app/src/tools/tool_app_runtime.rs
+++ b/crates/app/src/tools/tool_app_runtime.rs
@@ -50,6 +50,8 @@ fn execute_app_tool_dispatch(
         | "sessions_history"
         | "task_history"
         | "task_events"
+        | "task_cancel"
+        | "task_recover"
         | "session_heads"
         | "session_path"
         | "session_children"

--- a/crates/app/src/tools/tools_mod_tests.rs
+++ b/crates/app/src/tools/tools_mod_tests.rs
@@ -422,6 +422,8 @@ fn runtime_tool_view_hides_session_mutation_tools_when_explicitly_disabled() {
         "session_wait",
         "task_events",
         "task_history",
+        "task_cancel",
+        "task_recover",
         "task_status",
         "task_wait",
         "tasks_list",

--- a/crates/daemon/src/control_plane_server/mapping.rs
+++ b/crates/daemon/src/control_plane_server/mapping.rs
@@ -154,6 +154,7 @@ pub(super) fn map_session_workflow_binding(
     ControlPlaneSessionWorkflowBinding {
         session_id: binding.session_id,
         task_id: binding.task_id,
+        task_session_id: Some(binding.task_session_id),
         mode: binding.mode,
         execution_surface: binding.execution_surface,
         worktree,

--- a/crates/daemon/src/control_plane_server/mapping.rs
+++ b/crates/daemon/src/control_plane_server/mapping.rs
@@ -252,6 +252,8 @@ pub(super) fn map_task_summary(
 
     ControlPlaneTaskSummary {
         task_id: task.task_id,
+        task_session_id: task.task_session_id,
+        owner_session_id: task.owner_session_id,
         session_id: task.session_id,
         scope_session_id: task.scope_session_id,
         label,

--- a/crates/daemon/src/control_plane_server/tests.rs
+++ b/crates/daemon/src/control_plane_server/tests.rs
@@ -2194,6 +2194,8 @@ async fn task_list_returns_visible_background_tasks() {
     assert_eq!(tasks.returned_count, 1);
     let task = tasks.tasks.first().expect("task summary");
     assert_eq!(task.task_id, "child-session");
+    assert_eq!(task.task_session_id, "child-session");
+    assert_eq!(task.owner_session_id, "child-session");
     assert_eq!(task.workflow.workflow_id, "root-session");
     assert_eq!(
         task.workflow.task.as_deref(),
@@ -2244,6 +2246,8 @@ async fn task_read_returns_visible_background_task_detail() {
     let task: ControlPlaneTaskReadResponse = serde_json::from_slice(&body).expect("task read json");
     assert_eq!(task.current_session_id, "root-session");
     assert_eq!(task.task.task_id, "child-session");
+    assert_eq!(task.task.task_session_id, "child-session");
+    assert_eq!(task.task.owner_session_id, "child-session");
     assert_eq!(task.task.workflow.workflow_id, "root-session");
     assert_eq!(
         task.task

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -259,10 +259,20 @@ async fn execute_create_command(
         binding,
     )
     .await?;
-    let task_id = required_string_field(&queued.payload, "child_session_id", "tasks create")?;
-    let (task_detail, task_lookup_error) =
-        build_best_effort_task_detail(memory_config, tool_config, current_session_id, &task_id)
-            .await;
+    let task_session_id =
+        required_string_field(&queued.payload, "child_session_id", "tasks create")?;
+    let (task_detail, task_lookup_error) = build_best_effort_task_detail(
+        memory_config,
+        tool_config,
+        current_session_id,
+        &task_session_id,
+    )
+    .await;
+    let task_id = task_detail
+        .get("task_id")
+        .and_then(Value::as_str)
+        .unwrap_or(task_session_id.as_str())
+        .to_owned();
     let recipes = build_task_recipes(resolved_config_path, current_session_id, &task_id);
     let next_steps = build_task_next_steps();
     let payload = json!({
@@ -383,10 +393,10 @@ async fn execute_events_command(
     after_id: Option<i64>,
     limit: usize,
 ) -> CliResult<Value> {
-    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
+    let task_target = resolve_cli_task_target(memory_config, current_session_id, task_id)?;
     let event_limit = limit.clamp(1, 200);
     let payload = json!({
-        "session_id": task_id,
+        "task_id": task_target.task_id,
         "after_id": after_id,
         "limit": event_limit,
     });
@@ -394,7 +404,7 @@ async fn execute_events_command(
         memory_config,
         tool_config,
         current_session_id,
-        "session_events",
+        "task_events",
         payload,
     )?;
     let next_after_id = outcome
@@ -411,7 +421,7 @@ async fn execute_events_command(
         "command": "events",
         "config": resolved_config_path,
         "current_session_id": current_session_id,
-        "task_id": task_id,
+        "task_id": task_target.task_id,
         "after_id": after_id,
         "next_after_id": next_after_id,
         "events": events,
@@ -428,14 +438,14 @@ async fn execute_wait_command(
     after_id: Option<i64>,
     timeout_ms: u64,
 ) -> CliResult<Value> {
-    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id).await?;
+    let task_target = resolve_cli_task_target(memory_config, current_session_id, task_id)?;
     let payload = json!({
-        "session_id": task_id,
+        "task_id": task_target.task_id,
         "after_id": after_id,
         "timeout_ms": timeout_ms.clamp(1, 30_000),
     });
     let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
-    let outcome = mvp::tools::wait_for_session_with_config(
+    let outcome = mvp::tools::wait_for_task_with_config(
         payload,
         current_session_id,
         &session_store_config,
@@ -456,7 +466,7 @@ async fn execute_wait_command(
         "command": "wait",
         "config": resolved_config_path,
         "current_session_id": current_session_id,
-        "task_id": task_id,
+        "task_id": task_target.task_id,
         "wait_status": outcome.status,
         "after_id": after_id,
         "timeout_ms": timeout_ms.clamp(1, 30_000),
@@ -475,16 +485,19 @@ async fn execute_cancel_command(
     task_id: &str,
     dry_run: bool,
 ) -> CliResult<Value> {
-    validate_background_task_target(memory_config, tool_config, current_session_id, task_id)?;
+    let task_target = resolve_cli_task_target(memory_config, current_session_id, task_id)?;
+    let status_payload =
+        load_task_status_payload(memory_config, tool_config, current_session_id, &task_target)?;
+    ensure_background_task_status_payload(&status_payload, task_id)?;
     let payload = json!({
-        "session_id": task_id,
+        "task_id": task_target.task_id,
         "dry_run": dry_run,
     });
     let outcome = execute_app_tool_request(
         memory_config,
         tool_config,
         current_session_id,
-        "session_cancel",
+        "task_cancel",
         payload,
     )?;
     let (task, task_lookup_error) =
@@ -495,11 +508,13 @@ async fn execute_cancel_command(
         .as_ref()
         .and_then(|value| value.get("result"))
         .cloned()
+        .or_else(|| outcome.payload.get("result").cloned())
         .unwrap_or(Value::Null);
     let message = mutation_result
         .as_ref()
         .and_then(|value| value.get("message"))
         .cloned()
+        .or_else(|| outcome.payload.get("message").cloned())
         .unwrap_or(Value::Null);
     let action = outcome
         .payload
@@ -511,6 +526,7 @@ async fn execute_cancel_command(
                 .and_then(|value| value.get("action"))
                 .cloned()
         })
+        .or_else(|| outcome.payload.get("action").cloned())
         .unwrap_or(Value::Null);
     let output = json!({
         "command": "cancel",
@@ -534,16 +550,19 @@ async fn execute_recover_command(
     task_id: &str,
     dry_run: bool,
 ) -> CliResult<Value> {
-    validate_background_task_target(memory_config, tool_config, current_session_id, task_id)?;
+    let task_target = resolve_cli_task_target(memory_config, current_session_id, task_id)?;
+    let status_payload =
+        load_task_status_payload(memory_config, tool_config, current_session_id, &task_target)?;
+    ensure_background_task_status_payload(&status_payload, task_id)?;
     let payload = json!({
-        "session_id": task_id,
+        "task_id": task_target.task_id,
         "dry_run": dry_run,
     });
     let outcome = execute_app_tool_request(
         memory_config,
         tool_config,
         current_session_id,
-        "session_recover",
+        "task_recover",
         payload,
     )?;
     let (task, task_lookup_error) =
@@ -554,11 +573,13 @@ async fn execute_recover_command(
         .as_ref()
         .and_then(|value| value.get("result"))
         .cloned()
+        .or_else(|| outcome.payload.get("result").cloned())
         .unwrap_or(Value::Null);
     let message = mutation_result
         .as_ref()
         .and_then(|value| value.get("message"))
         .cloned()
+        .or_else(|| outcome.payload.get("message").cloned())
         .unwrap_or(Value::Null);
     let action = outcome
         .payload
@@ -570,6 +591,7 @@ async fn execute_recover_command(
                 .and_then(|value| value.get("action"))
                 .cloned()
         })
+        .or_else(|| outcome.payload.get("action").cloned())
         .unwrap_or(Value::Null);
     let output = json!({
         "command": "recover",
@@ -778,20 +800,21 @@ async fn build_task_detail(
     current_session_id: &str,
     task_id: &str,
 ) -> CliResult<Value> {
+    let task_target = resolve_cli_task_target(memory_config, current_session_id, task_id)?;
     let status_payload =
-        load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
+        load_task_status_payload(memory_config, tool_config, current_session_id, &task_target)?;
     ensure_background_task_status_payload(&status_payload, task_id)?;
     let (approvals_payload, approval_lookup_error) = load_best_effort_task_approvals_payload(
         memory_config,
         tool_config,
         current_session_id,
-        task_id,
+        &task_target,
     );
     let (tool_policy_payload, tool_policy_lookup_error) = load_best_effort_task_tool_policy_payload(
         memory_config,
         tool_config,
         current_session_id,
-        task_id,
+        &task_target,
     );
 
     let session = status_payload
@@ -871,21 +894,25 @@ async fn build_task_detail(
         &tool_policy,
         &recent_events,
     );
-    let prompt_frame =
-        crate::session_prompt_frame_cli::load_session_prompt_frame_payload(memory_config, task_id)
-            .await;
-    let safe_lane =
-        crate::session_runtime_truth_cli::load_session_safe_lane_payload(memory_config, task_id)
-            .await;
+    let prompt_frame = crate::session_prompt_frame_cli::load_session_prompt_frame_payload(
+        memory_config,
+        task_target.owner_session_id.as_str(),
+    )
+    .await;
+    let safe_lane = crate::session_runtime_truth_cli::load_session_safe_lane_payload(
+        memory_config,
+        task_target.owner_session_id.as_str(),
+    )
+    .await;
     let turn_checkpoint = crate::session_runtime_truth_cli::load_session_turn_checkpoint_payload(
         memory_config,
-        task_id,
+        task_target.owner_session_id.as_str(),
     )
     .await;
 
     let detail = compose_task_detail_payload(
         current_session_id,
-        task_id,
+        &task_target,
         session,
         delegate,
         label,
@@ -941,7 +968,8 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
     let task_status = unknown_task_status_payload();
     json!({
         "task_id": task_id,
-        "session_id": task_id,
+        "task_session_id": task_id,
+        "owner_session_id": task_id,
         "scope_session_id": current_session_id,
         "label": Value::Null,
         "session_state": Value::Null,
@@ -975,17 +1003,6 @@ fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
         "safe_lane": Value::Null,
         "turn_checkpoint": Value::Null,
     })
-}
-
-fn validate_background_task_target(
-    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
-    tool_config: &mvp::config::ToolConfig,
-    current_session_id: &str,
-    task_id: &str,
-) -> CliResult<()> {
-    let status_payload =
-        load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
-    ensure_background_task_status_payload(&status_payload, task_id)
 }
 
 fn ensure_background_task_status_payload(status_payload: &Value, task_id: &str) -> CliResult<()> {
@@ -1037,6 +1054,13 @@ fn parse_task_state_filter(raw_state: &str) -> CliResult<mvp::session::repositor
 struct TaskStatusSummary {
     is_background_task: bool,
     is_overdue: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedCliTaskTarget {
+    task_id: String,
+    owner_session_id: String,
+    task_session_id: String,
 }
 
 fn build_task_status_payload(
@@ -1315,16 +1339,16 @@ fn load_task_status_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
 ) -> CliResult<Value> {
     let payload = json!({
-        "session_id": task_id,
+        "task_id": task_target.task_id,
     });
     let outcome = execute_app_tool_request(
         memory_config,
         tool_config,
         current_session_id,
-        "session_status",
+        "task_status",
         payload,
     )?;
     Ok(outcome.payload)
@@ -1334,10 +1358,10 @@ fn load_task_approvals_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
 ) -> CliResult<Value> {
     let payload = json!({
-        "session_id": task_id,
+        "session_id": task_target.owner_session_id,
         "limit": 20,
     });
     let outcome = execute_app_tool_request(
@@ -1354,10 +1378,10 @@ fn load_best_effort_task_approvals_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
 ) -> (Value, Value) {
     let result =
-        load_task_approvals_payload(memory_config, tool_config, current_session_id, task_id);
+        load_task_approvals_payload(memory_config, tool_config, current_session_id, task_target);
     let fallback_payload = fallback_task_approvals_payload();
     best_effort_task_lookup_payload(result, fallback_payload)
 }
@@ -1366,10 +1390,10 @@ fn load_task_tool_policy_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
 ) -> CliResult<Value> {
     let payload = json!({
-        "session_id": task_id,
+        "session_id": task_target.owner_session_id,
     });
     let outcome = execute_app_tool_request(
         memory_config,
@@ -1385,10 +1409,10 @@ fn load_best_effort_task_tool_policy_payload(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
     tool_config: &mvp::config::ToolConfig,
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
 ) -> (Value, Value) {
     let result =
-        load_task_tool_policy_payload(memory_config, tool_config, current_session_id, task_id);
+        load_task_tool_policy_payload(memory_config, tool_config, current_session_id, task_target);
     let fallback_payload = Value::Null;
     best_effort_task_lookup_payload(result, fallback_payload)
 }
@@ -1415,7 +1439,7 @@ fn fallback_task_approvals_payload() -> Value {
 #[allow(clippy::too_many_arguments)]
 fn compose_task_detail_payload(
     current_session_id: &str,
-    task_id: &str,
+    task_target: &ResolvedCliTaskTarget,
     session: Value,
     delegate: Value,
     label: Value,
@@ -1447,8 +1471,9 @@ fn compose_task_detail_payload(
     turn_checkpoint: Value,
 ) -> Value {
     json!({
-        "task_id": task_id,
-        "session_id": task_id,
+        "task_id": task_target.task_id,
+        "task_session_id": task_target.task_session_id,
+        "owner_session_id": task_target.owner_session_id,
         "scope_session_id": current_session_id,
         "label": label,
         "session_state": session_state,
@@ -1481,6 +1506,54 @@ fn compose_task_detail_payload(
         "prompt_frame": prompt_frame,
         "safe_lane": safe_lane,
         "turn_checkpoint": turn_checkpoint,
+    })
+}
+
+fn resolve_cli_task_target(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    current_session_id: &str,
+    requested_task_id: &str,
+) -> CliResult<ResolvedCliTaskTarget> {
+    let session_store_config = mvp::session::store::SessionStoreConfig::from(memory_config);
+    let repo = mvp::session::repository::SessionRepository::new(&session_store_config)?;
+    let visible_sessions = repo.list_visible_sessions(current_session_id)?;
+
+    for session in &visible_sessions {
+        let task_identity =
+            mvp::task_progress::resolve_task_identity_for_session(&repo, &session.session_id);
+        if task_identity.task_id == requested_task_id {
+            return Ok(ResolvedCliTaskTarget {
+                task_id: task_identity.task_id,
+                owner_session_id: task_identity.task_session_id.clone(),
+                task_session_id: task_identity.task_session_id,
+            });
+        }
+    }
+
+    let fallback_session = repo
+        .load_session_summary_with_legacy_fallback(requested_task_id)?
+        .ok_or_else(|| format!("task_not_found: `{requested_task_id}`"))?;
+    if !visible_sessions
+        .iter()
+        .any(|session| session.session_id == fallback_session.session_id)
+    {
+        return Err(format!(
+            "visibility_denied: session `{}` is not visible from `{current_session_id}`",
+            fallback_session.session_id
+        ));
+    }
+
+    let task_identity =
+        mvp::task_progress::resolve_task_identity_for_session(&repo, &fallback_session.session_id);
+    let task_id = if task_identity.task_id.trim().is_empty() {
+        requested_task_id.to_owned()
+    } else {
+        task_identity.task_id
+    };
+    Ok(ResolvedCliTaskTarget {
+        task_id,
+        owner_session_id: fallback_session.session_id,
+        task_session_id: task_identity.task_session_id,
     })
 }
 
@@ -1568,7 +1641,7 @@ fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
     let mut lines = Vec::new();
     let sanitized_scope = crate::sessions_cli::sanitize_terminal_text(scope);
     lines.push(format!(
-        "background task queued in session `{sanitized_scope}`"
+        "background task queued from scope session `{sanitized_scope}`"
     ));
     lines.extend(render_task_detail_lines(task)?);
     append_task_lookup_error_line(payload, &mut lines);
@@ -1627,7 +1700,7 @@ fn render_tasks_list_text(payload: &Value) -> CliResult<String> {
     let mut lines = Vec::new();
     let sanitized_scope = crate::sessions_cli::sanitize_terminal_text(scope);
     lines.push(format!(
-        "visible background tasks from session `{sanitized_scope}`: {returned_count}/{matched_count}"
+        "visible background tasks from scope session `{sanitized_scope}`: {returned_count}/{matched_count}"
     ));
     if tasks.is_empty() {
         lines.push("No async background tasks are currently visible.".to_owned());
@@ -1902,6 +1975,14 @@ fn render_task_brief_line(task: &Value) -> CliResult<String> {
 
 fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
     let task_id = required_string_field(task, "task_id", "task detail")?;
+    let task_session_id = task
+        .get("task_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let owner_session_id = task
+        .get("owner_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
     let scope_session_id = task
         .get("scope_session_id")
         .and_then(Value::as_str)
@@ -2038,6 +2119,8 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
             .map_err(|error| format!("render runtime narrowing failed: {error}"))?
     };
     let sanitized_task_id = crate::sessions_cli::sanitize_terminal_text(task_id.as_str());
+    let sanitized_task_session_id = crate::sessions_cli::sanitize_terminal_text(task_session_id);
+    let sanitized_owner_session_id = crate::sessions_cli::sanitize_terminal_text(owner_session_id);
     let sanitized_scope_session_id = crate::sessions_cli::sanitize_terminal_text(scope_session_id);
     let sanitized_label = crate::sessions_cli::sanitize_terminal_text(label);
     let sanitized_last_error = crate::sessions_cli::sanitize_terminal_text(last_error);
@@ -2064,6 +2147,8 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
 
     let mut lines = Vec::new();
     lines.push(format!("task_id: {sanitized_task_id}"));
+    lines.push(format!("task_session_id: {sanitized_task_session_id}"));
+    lines.push(format!("owner_session_id: {sanitized_owner_session_id}"));
     lines.push(format!("scope_session_id: {sanitized_scope_session_id}"));
     lines.push(format!("label: {sanitized_label}"));
     lines.push(format!("task_status: {task_status_display}"));
@@ -2166,6 +2251,9 @@ fn render_string_array(values: &[Value]) -> String {
 mod tests {
     use super::*;
     use crate::mvp;
+    use mvp::session::repository::{
+        NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    };
 
     fn build_task_payload(
         session_state: &str,
@@ -2236,6 +2324,8 @@ mod tests {
 
         json!({
             "task_id": "delegate:task-1",
+            "task_session_id": "task-owner",
+            "owner_session_id": "task-owner",
             "scope_session_id": "ops-root",
             "label": "Release Check",
             "session_state": session_state,
@@ -2318,6 +2408,8 @@ mod tests {
         let joined = rendered.join("\n");
 
         assert!(joined.contains("task_status: approval_pending"));
+        assert!(joined.contains("task_session_id: task-owner"));
+        assert!(joined.contains("owner_session_id: task-owner"));
         assert!(joined.contains("task_blocked: true"));
         assert!(joined.contains("task_needs_attention: true"));
         assert!(joined.contains("task_next_action: resolve_request"));
@@ -2346,12 +2438,17 @@ mod tests {
         let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::default();
         let mut tool_config = mvp::config::ToolConfig::default();
         tool_config.sessions.enabled = false;
+        let task_target = ResolvedCliTaskTarget {
+            task_id: "delegate:task-1".to_owned(),
+            owner_session_id: "delegate-session-1".to_owned(),
+            task_session_id: "delegate-session-1".to_owned(),
+        };
 
         let (payload, lookup_error) = load_best_effort_task_approvals_payload(
             &memory_config,
             &tool_config,
             "ops-root",
-            "delegate:task-1",
+            &task_target,
         );
 
         assert_eq!(payload["matched_count"], 0);
@@ -2371,12 +2468,17 @@ mod tests {
         let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::default();
         let mut tool_config = mvp::config::ToolConfig::default();
         tool_config.sessions.enabled = false;
+        let task_target = ResolvedCliTaskTarget {
+            task_id: "delegate:task-1".to_owned(),
+            owner_session_id: "delegate-session-1".to_owned(),
+            task_session_id: "delegate-session-1".to_owned(),
+        };
 
         let (payload, lookup_error) = load_best_effort_task_tool_policy_payload(
             &memory_config,
             &tool_config,
             "ops-root",
-            "delegate:task-1",
+            &task_target,
         );
 
         assert!(
@@ -2427,7 +2529,11 @@ mod tests {
         });
         let detail = compose_task_detail_payload(
             "ops-root",
-            "delegate:task-1",
+            &ResolvedCliTaskTarget {
+                task_id: "delegate:task-1".to_owned(),
+                task_session_id: "delegate-session-1".to_owned(),
+                owner_session_id: "delegate-session-1".to_owned(),
+            },
             session.clone(),
             delegate.clone(),
             json!("Release Check"),
@@ -2462,6 +2568,8 @@ mod tests {
         assert_eq!(detail["session"], session);
         assert_eq!(detail["delegate"], delegate);
         assert_eq!(detail["task_id"], "delegate:task-1");
+        assert_eq!(detail["task_session_id"], "delegate-session-1");
+        assert_eq!(detail["owner_session_id"], "delegate-session-1");
         assert_eq!(detail["approval_lookup_error"], "approval lookup failed");
         assert_eq!(
             detail["tool_policy_lookup_error"],
@@ -2470,5 +2578,163 @@ mod tests {
         assert_eq!(detail["tool_policy"], Value::Null);
         assert_eq!(detail["approval"]["matched_count"], 0);
         assert_eq!(detail["terminal_outcome_state"], "missing");
+    }
+
+    fn isolated_memory_config(name: &str) -> mvp::session::store::SessionStoreConfig {
+        let root = std::env::temp_dir().join(format!(
+            "loong-tasks-cli-{name}-{}-{}",
+            std::process::id(),
+            current_unix_timestamp()
+        ));
+        let _ = std::fs::create_dir_all(&root);
+        mvp::session::store::SessionStoreConfig {
+            sqlite_path: Some(root.join("memory.sqlite3")),
+            ..mvp::session::store::SessionStoreConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_cancel_command_uses_canonical_task_identity() {
+        let store = isolated_memory_config("task-cancel");
+        let repo = SessionRepository::new(&store).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "task-owner".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Task Owner".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create task owner");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task_scope": { "task_id": "task-root" },
+                "task_session_id": "task-owner",
+                "timeout_seconds": 30
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: mvp::task_progress::TASK_PROGRESS_EVENT_KIND.to_owned(),
+            actor_session_id: Some("task-owner".to_owned()),
+            payload_json: mvp::task_progress::task_progress_event_payload(
+                "unit_test",
+                &mvp::task_progress::TaskProgressRecord {
+                    task_id: "task-root".to_owned(),
+                    owner_kind: "background_task_host".to_owned(),
+                    status: mvp::task_progress::TaskProgressStatus::Active,
+                    intent_summary: Some("Cancel queued task".to_owned()),
+                    verification_state: Some(mvp::task_progress::TaskVerificationState::NotStarted),
+                    active_handles: Vec::new(),
+                    resume_recipe: None,
+                    updated_at: 123,
+                },
+            ),
+        })
+        .expect("append task progress");
+        let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::for_sqlite_path(
+            store.sqlite_path.clone().expect("sqlite path"),
+        );
+        let tool_config = mvp::config::ToolConfig::default();
+        let payload = execute_cancel_command(
+            "/tmp/loong.toml",
+            "root-session",
+            &memory_config,
+            &tool_config,
+            "task-root",
+            true,
+        )
+        .await
+        .expect("cancel command");
+
+        assert_eq!(payload["task"]["task_id"], "task-root");
+        assert_eq!(payload["task"]["owner_session_id"], "task-owner");
+        assert_eq!(payload["action"]["kind"], "queued_async_cancelled");
+        assert_eq!(payload["dry_run"], true);
+    }
+
+    #[tokio::test]
+    async fn execute_recover_command_uses_canonical_task_identity() {
+        let store = isolated_memory_config("task-recover");
+        let repo = SessionRepository::new(&store).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "task-owner".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Task Owner".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create task owner");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task_scope": { "task_id": "task-root" },
+                "task_session_id": "task-owner",
+                "timeout_seconds": 1
+            }),
+        })
+        .expect("append queued event");
+        repo.append_event(NewSessionEvent {
+            session_id: "task-owner".to_owned(),
+            event_kind: mvp::task_progress::TASK_PROGRESS_EVENT_KIND.to_owned(),
+            actor_session_id: Some("task-owner".to_owned()),
+            payload_json: mvp::task_progress::task_progress_event_payload(
+                "unit_test",
+                &mvp::task_progress::TaskProgressRecord {
+                    task_id: "task-root".to_owned(),
+                    owner_kind: "background_task_host".to_owned(),
+                    status: mvp::task_progress::TaskProgressStatus::Blocked,
+                    intent_summary: Some("Recover overdue task".to_owned()),
+                    verification_state: Some(mvp::task_progress::TaskVerificationState::Pending),
+                    active_handles: Vec::new(),
+                    resume_recipe: None,
+                    updated_at: 123,
+                },
+            ),
+        })
+        .expect("append task progress");
+        let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig::for_sqlite_path(
+            store.sqlite_path.clone().expect("sqlite path"),
+        );
+        let tool_config = mvp::config::ToolConfig::default();
+        let payload = execute_recover_command(
+            "/tmp/loong.toml",
+            "root-session",
+            &memory_config,
+            &tool_config,
+            "task-root",
+            true,
+        )
+        .await
+        .expect("recover command");
+
+        assert_eq!(payload["task"]["task_id"], "task-root");
+        assert_eq!(payload["task"]["owner_session_id"], "task-owner");
+        assert!(
+            !payload["result"].is_null(),
+            "task recover should surface a mutation result"
+        );
+        assert_eq!(payload["dry_run"], true);
     }
 }

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -923,6 +923,9 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
     let task_id = execution.payload["task"]["task_id"]
         .as_str()
         .expect("task id");
+    let child_session_id = execution.payload["queued_outcome"]["child_session_id"]
+        .as_str()
+        .expect("queued child session id");
     let recipes = execution.payload["recipes"]
         .as_array()
         .expect("recipes array");
@@ -946,7 +949,15 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
         execution.payload["task"]["session"]["kind"],
         "delegate_child"
     );
-    assert!(task_id.starts_with("delegate:"));
+    assert_eq!(task_id, "ops-root");
+    assert_eq!(
+        execution.payload["task"]["task_session_id"],
+        execution.payload["queued_outcome"]["child_session_id"]
+    );
+    assert_eq!(
+        execution.payload["task"]["owner_session_id"],
+        execution.payload["queued_outcome"]["child_session_id"]
+    );
     assert_eq!(recipes.len(), 3);
     let task_started_immediately = task_status == "running";
     assert!(
@@ -990,7 +1001,7 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
         .expect("load root session")
         .expect("root session");
     let child_session = repo
-        .load_session(task_id)
+        .load_session(child_session_id)
         .expect("load child session")
         .expect("child session");
 
@@ -1110,11 +1121,11 @@ async fn execute_tasks_command_create_latest_session_selector_resolves_newest_re
     .await
     .expect("tasks create with latest selector should succeed");
 
-    let created_task_id = execution.payload["task"]["task_id"]
+    let created_task_session_id = execution.payload["queued_outcome"]["child_session_id"]
         .as_str()
-        .expect("created task id");
+        .expect("created task session id");
     let created_task = repo
-        .load_session(created_task_id)
+        .load_session(created_task_session_id)
         .expect("load created task session")
         .expect("created task session");
 
@@ -1277,11 +1288,8 @@ async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
 
     assert_eq!(events_execution.payload["command"], "events");
     assert_eq!(events_execution.payload["task_id"], "delegate:task-1");
-    assert_eq!(
-        events_execution.payload["events"][0]["event_kind"],
-        "delegate_queued"
-    );
-    assert!(next_after_id >= 1);
+    assert_eq!(events_execution.payload["events"], json!([]));
+    assert_eq!(next_after_id, 0);
 
     let wait_execution = loong_daemon::tasks_cli::execute_tasks_command(
         loong_daemon::tasks_cli::TasksCommandOptions {
@@ -1301,7 +1309,10 @@ async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
     assert_eq!(wait_execution.payload["command"], "wait");
     assert_eq!(wait_execution.payload["task_id"], "delegate:task-1");
     assert_eq!(wait_execution.payload["wait_status"], "timeout");
-    assert_eq!(wait_execution.payload["events"], json!([]));
+    assert_eq!(
+        wait_execution.payload["events"][0]["event_kind"],
+        "delegate_queued"
+    );
     assert_eq!(wait_execution.payload["task"]["task_id"], "delegate:task-1");
     assert_eq!(
         wait_execution.payload["task"]["task_status"]["status"],

--- a/crates/protocol/src/control_plane.rs
+++ b/crates/protocol/src/control_plane.rs
@@ -399,6 +399,8 @@ pub struct ControlPlaneSessionWorkflowBindingWorktree {
 pub struct ControlPlaneSessionWorkflowBinding {
     pub session_id: String,
     pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_session_id: Option<String>,
     pub mode: String,
     pub execution_surface: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/protocol/src/control_plane.rs
+++ b/crates/protocol/src/control_plane.rs
@@ -497,6 +497,8 @@ pub struct ControlPlaneSessionReadResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlPlaneTaskSummary {
     pub task_id: String,
+    pub task_session_id: String,
+    pub owner_session_id: String,
     pub session_id: String,
     pub scope_session_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/protocol/tests/protocol_transport.rs
+++ b/crates/protocol/tests/protocol_transport.rs
@@ -709,6 +709,7 @@ fn control_plane_session_read_response_roundtrips_through_json() {
                     binding: Some(ControlPlaneSessionWorkflowBinding {
                         session_id: "child-session".to_owned(),
                         task_id: "child-session".to_owned(),
+                        task_session_id: Some("child-session".to_owned()),
                         mode: "advisory_only".to_owned(),
                         execution_surface: "delegate.async".to_owned(),
                         worktree: Some(ControlPlaneSessionWorkflowBindingWorktree {
@@ -808,6 +809,8 @@ fn control_plane_task_read_response_roundtrips_through_json() {
         current_session_id: "root-session".to_owned(),
         task: ControlPlaneTaskSummary {
             task_id: "child-session".to_owned(),
+            task_session_id: "child-session".to_owned(),
+            owner_session_id: "child-session".to_owned(),
             session_id: "child-session".to_owned(),
             scope_session_id: "root-session".to_owned(),
             label: Some("Child".to_owned()),
@@ -832,6 +835,7 @@ fn control_plane_task_read_response_roundtrips_through_json() {
                 binding: Some(ControlPlaneSessionWorkflowBinding {
                     session_id: "child-session".to_owned(),
                     task_id: "child-session".to_owned(),
+                    task_session_id: Some("child-session".to_owned()),
                     mode: "advisory_only".to_owned(),
                     execution_surface: "delegate.async".to_owned(),
                     worktree: Some(ControlPlaneSessionWorkflowBindingWorktree {
@@ -864,6 +868,8 @@ fn control_plane_task_list_response_roundtrips_through_json() {
         returned_count: 1,
         tasks: vec![ControlPlaneTaskSummary {
             task_id: "child-session".to_owned(),
+            task_session_id: "child-session".to_owned(),
+            owner_session_id: "child-session".to_owned(),
             session_id: "child-session".to_owned(),
             scope_session_id: "root-session".to_owned(),
             label: Some("Child".to_owned()),

--- a/docs/product-specs/background-tasks.md
+++ b/docs/product-specs/background-tasks.md
@@ -8,29 +8,48 @@ to reason directly in raw session-runtime terms.
 
 ## Acceptance Criteria
 
-- [ ] Loong exposes a task-shaped operator surface for background delegated
+- [x] Loong exposes a task-shaped operator surface for background delegated
       work rather than requiring the operator to compose raw `delegate_async`
       and `session_*` calls manually.
-- [ ] The first slice supports:
+- [x] The first slice supports:
       create, list, inspect status, wait or follow, cancel, and recover for
       visible background tasks.
-- [ ] Task output surfaces approval-pending, blocked, failed, and recovered
+- [x] Task output surfaces approval-pending, blocked, failed, and recovered
       states explicitly.
-- [ ] Task output surfaces any session-scoped tool narrowing that materially
+- [x] Task output surfaces any session-scoped tool narrowing that materially
       affects what the delegated child may do.
-- [ ] `tasks create`, `tasks list`, `tasks status`, and `tasks wait` expose a
+- [x] `tasks create`, `tasks list`, `tasks status`, and `tasks wait` expose a
       derived `task_status.status`, `task_status.needs_attention`, and
       `task_status.next_action` summary instead of leaving operators to infer
       meaning only from raw session state and delegate phase.
-- [ ] The task surface remains truthful to the current runtime:
+- [x] The task surface remains truthful to the current runtime:
       background tasks are implemented as child sessions rather than a parallel
       scheduler-specific state model.
 - [ ] Product docs clearly distinguish this first-slice background task surface
       from future cron, heartbeat, or always-on daemon scheduling work.
 
-## Current Baseline
+## Current Contract
 
-The current runtime already ships the substrate for this surface:
+The current runtime ships a task-shaped operator contract on top of the existing
+async delegate substrate:
+
+- `tasks create`
+- `tasks list`
+- `tasks status`
+- `tasks events`
+- `tasks wait`
+- `tasks cancel`
+- `tasks recover`
+
+The contract is task-first:
+
+- `task_id` is the canonical task identity
+- `task_session_id` is the explicit runtime carrier for the current task lane
+- `owner_session_id` remains visible as runtime metadata where ownership and
+  lineage matter
+- `task_status` is the primary operator summary, not raw `session.state`
+
+The runtime substrate remains:
 
 - `delegate_async`
 - `session_status`
@@ -41,8 +60,21 @@ The current runtime already ships the substrate for this surface:
 - approval request tooling
 - session-scoped tool policy controls
 
-The missing part is the operator-facing product contract that turns those
-session primitives into a coherent task workflow.
+This means Loong keeps one truthful model:
+
+- background tasks are still child sessions at runtime
+- operators should primarily reason in task terms
+- session-oriented surfaces remain diagnostics and repair tools, not the primary
+  day-to-day contract for delegated background work
+
+## Remaining Product Work
+
+- keep tightening task identity so no public task-facing surface relies on
+  `session_id` as the primary visible identifier
+- keep aligning control-plane and other local product surfaces to the same
+  task-first wording and field contract
+- keep `tasks` as the primary operator path and `sessions` as the runtime
+  inspection path
 
 ## Out of Scope
 

--- a/site/use-loong/background-tasks.mdx
+++ b/site/use-loong/background-tasks.mdx
@@ -1,0 +1,99 @@
+---
+title: Background Tasks
+description: Use task-first commands for delegated async work without dropping into raw session internals.
+---
+
+# Background Tasks
+
+Use this page when you want Loong to launch background delegated work and keep
+the operator contract task-first.
+
+The current public contract is:
+
+- `loong tasks create`
+- `loong tasks list`
+- `loong tasks status`
+- `loong tasks events`
+- `loong tasks wait`
+- `loong tasks cancel`
+- `loong tasks recover`
+
+## Task-First Model
+
+Loong now treats delegated async work as a task-shaped operator surface.
+
+Three identifiers matter:
+
+- `task_id` is the durable task identity you should pass back to task commands
+- `task_session_id` is the current runtime carrier for that task lane
+- `owner_session_id` is runtime ownership metadata that stays visible for
+  inspection, follow-up, and repair
+
+This keeps one truthful model:
+
+- operators work through `tasks ...`
+- runtime ownership still uses child sessions underneath
+- `sessions ...` remains the inspection and repair path, not the normal
+  day-to-day task surface
+
+## What Task Status Means
+
+`tasks status` and `tasks wait` surface derived task state instead of forcing
+you to infer meaning from raw session fields.
+
+Current task-first summary fields include:
+
+- `task_status.status`
+- `task_status.needs_attention`
+- `task_status.next_action`
+- `task_status.signals`
+
+Use those fields as the primary operator truth for:
+
+- queued vs running work
+- approval-pending or blocked work
+- overdue or recoverable work
+- recovered, failed, or completed work
+- session-scoped tool narrowing that materially changes what the child may do
+
+## When To Use Tasks Vs Sessions
+
+Use `tasks ...` when:
+
+- you are following delegated async work as a product object
+- you need the next action for one task
+- you want task lineage, task events, or task recovery without reasoning in raw
+  session terms
+
+Use `sessions ...` when:
+
+- you are debugging runtime ownership directly
+- you need branch heads, raw history, or lower-level session tree detail
+- you are repairing runtime state outside the normal task workflow
+
+## Scope Of This First Slice
+
+Included today:
+
+- delegated background work implemented through child-session runtime lanes
+- task-first create, inspect, wait, follow, cancel, and recover flows
+
+Out of scope today:
+
+- cron
+- heartbeat jobs
+- daemon-owned always-on scheduling
+- distributed schedulers
+- web dashboards
+
+If you need longer-lived service ownership, use the gateway and supervision
+surfaces instead of treating background tasks as a scheduler product.
+
+## Continue Reading
+
+- Continue to [Tools And Memory](/use-loong/tools-and-memory) for the broader
+  governed capability story.
+- Continue to [Gateway And Supervision](/use-loong/gateway-and-supervision) for
+  longer-lived ownership models.
+- Continue to [Tool Surface](/use-loong/tool-surface) for the public visible-tool
+  contract.

--- a/site/use-loong/tools-and-memory.mdx
+++ b/site/use-loong/tools-and-memory.mdx
@@ -48,6 +48,7 @@ The current public profiles include:
 | If you want... | Start here |
 | --- | --- |
 | the visible-tool contract | [Tool Surface](/use-loong/tool-surface) |
+| task-first delegated async work | [Background Tasks](/use-loong/background-tasks) |
 | the operator path for installable skills | [Skills](/use-loong/skills) |
 | private-host, domain, or browser runtime troubleshooting | [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) |
 | continuity and profile selection | [Memory Profiles](/use-loong/memory-profiles) |
@@ -56,6 +57,7 @@ The current public profiles include:
 ## Where To Go Next
 
 - Continue to [Tool Surface](/use-loong/tool-surface) for the truthful visible-tool contract.
+- Continue to [Background Tasks](/use-loong/background-tasks) for the task-first delegated async work contract.
 - Continue to [Skills](/use-loong/skills) for install, policy, and external browser automation skill setup.
 - Continue to [Browser And Web Boundaries](/use-loong/browser-and-web-boundaries) for private-host, domain, and browser runtime troubleshooting.
 - Continue to [Memory Profiles](/use-loong/memory-profiles) for the public continuity contract.


### PR DESCRIPTION
## Summary

Make Loong's background task surfaces task-first across task identity, task tools, tasks CLI, control-plane task reads, and public docs.

Closes #1474

## What changed

- make `task_id` the canonical public task identity while surfacing `task_session_id` and `owner_session_id` explicitly
- keep backward-tolerant task-progress parsing while serializing the canonical shape
- route `tasks wait` and `tasks events` through task-first tools
- add first-class `task_cancel` and `task_recover` tools and wire `tasks cancel` / `tasks recover` to them
- extend control-plane task summaries with explicit task/session mapping metadata
- document the first-slice background-task contract and keep cron / heartbeat / service-owned scheduling out of scope

## Validation

- `cargo fmt --check`
- `cargo check -p loong`
- `cargo test -p loong-app tools::session::tests::task_`
- `cargo test -p loong tasks_cli::tests::`
- `cargo test -p loong control_plane_server::tests::task_`
- `cargo test -p loong-app tools::routing::tests::hidden_operation_for_task_`
- `cargo test -p loong-app tools::tests::capability_snapshot_with_config_uses_runtime_enabled_tool_view`
- `cargo test -p loong-app tools::catalog::tests::autonomy_capability_action_classifies_representative_tool_families`
