### PR TITLE
feat(provider): add NEAR AI Cloud provider

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -631,6 +631,7 @@ mod tests {
                 "lm_studio",
                 "mistral",
                 "minimax",
+                "nearai",
                 "novita",
                 "nvidia",
                 "ollama",
@@ -680,6 +681,10 @@ mod tests {
             (
                 ProviderKind::Minimax,
                 "https://api.minimaxi.com/v1/chat/completions",
+            ),
+            (
+                ProviderKind::NearAi,
+                "https://cloud-api.near.ai/v1/chat/completions",
             ),
             (
                 ProviderKind::Ollama,
@@ -733,6 +738,7 @@ mod tests {
         let cases = vec![
             (ProviderKind::Kimi, Some("MOONSHOT_API_KEY")),
             (ProviderKind::Minimax, Some("MINIMAX_API_KEY")),
+            (ProviderKind::NearAi, Some("NEARAI_API_KEY")),
             (ProviderKind::Openai, Some("OPENAI_API_KEY")),
             (ProviderKind::OpencodeGo, Some("OPENCODE_API_KEY")),
             (ProviderKind::OpencodeZen, Some("OPENCODE_API_KEY")),
@@ -1356,6 +1362,7 @@ kind = "bailian_coding"
             ("bailian_coding_compatible", ProviderKind::BailianCoding),
             ("byteplus_compatible", ProviderKind::Byteplus),
             ("byteplus_coding_compatible", ProviderKind::ByteplusCoding),
+            ("near_ai_cloud", ProviderKind::NearAi),
             ("openai_custom", ProviderKind::Custom),
             (
                 "volcengine_coding_compatible",
@@ -1655,6 +1662,10 @@ kind = "volcengine_coding"
             (
                 ProviderKind::OpencodeZen,
                 "https://opencode.ai/zen/v1/models",
+            ),
+            (
+                ProviderKind::NearAi,
+                "https://cloud-api.near.ai/v1/model/list",
             ),
         ];
 
@@ -2407,6 +2418,10 @@ bot_token = { file = "/run/secrets/telegram" }
                 "https://api.kimi.com/coding/v1/models",
             ),
             (ProviderKind::Minimax, "https://api.minimaxi.com/v1/models"),
+            (
+                ProviderKind::NearAi,
+                "https://cloud-api.near.ai/v1/model/list",
+            ),
             (ProviderKind::Ollama, "http://127.0.0.1:11434/v1/models"),
             (ProviderKind::Openai, "https://api.openai.com/v1/models"),
             (

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -672,6 +672,15 @@ pub enum ProviderKind {
     Mistral,
     #[serde(alias = "minimax_compatible")]
     Minimax,
+    #[serde(
+        rename = "nearai",
+        alias = "near_ai",
+        alias = "near-ai",
+        alias = "nearai_compatible",
+        alias = "near_ai_cloud",
+        alias = "near-ai-cloud"
+    )]
+    NearAi,
     #[serde(alias = "novita_compatible")]
     Novita,
     #[serde(

--- a/crates/app/src/config/provider/catalog.rs
+++ b/crates/app/src/config/provider/catalog.rs
@@ -91,6 +91,7 @@ impl ProviderKind {
             ProviderKind::KimiCoding => "Kimi Coding",
             ProviderKind::Mistral => "Mistral",
             ProviderKind::Minimax => "MiniMax",
+            ProviderKind::NearAi => "NEAR AI Cloud",
             ProviderKind::Novita => "Novita",
             ProviderKind::Nvidia => "NVIDIA",
             ProviderKind::Llamacpp => "llama.cpp",
@@ -148,6 +149,7 @@ impl ProviderKind {
             lm_studio,
             mistral,
             minimax,
+            nearai,
             novita,
             nvidia,
             ollama,
@@ -196,6 +198,7 @@ impl ProviderKind {
             ProviderKind::LmStudio => lm_studio,
             ProviderKind::Mistral => mistral,
             ProviderKind::Minimax => minimax,
+            ProviderKind::NearAi => nearai,
             ProviderKind::Novita => novita,
             ProviderKind::Nvidia => nvidia,
             ProviderKind::Ollama => ollama,
@@ -273,7 +276,10 @@ impl ProviderKind {
 
     pub fn model_probe_auth_optional(self) -> bool {
         self.auth_optional()
-            || matches!(self, ProviderKind::Cerebras | ProviderKind::VercelAiGateway)
+            || matches!(
+                self,
+                ProviderKind::Cerebras | ProviderKind::NearAi | ProviderKind::VercelAiGateway
+            )
     }
 
     pub fn allowed_reasoning_efforts(self) -> Option<&'static [ReasoningEffort]> {
@@ -404,6 +410,7 @@ impl ProviderKind {
             | ProviderKind::LmStudio
             | ProviderKind::Mistral
             | ProviderKind::Novita
+            | ProviderKind::NearAi
             | ProviderKind::Nvidia
             | ProviderKind::Ollama
             | ProviderKind::Openai
@@ -694,7 +701,7 @@ pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
     None
 }
 
-const PROVIDER_KIND_ORDER: [ProviderKind; 45] = [
+const PROVIDER_KIND_ORDER: [ProviderKind; 46] = [
     ProviderKind::Anthropic,
     ProviderKind::BailianCoding,
     ProviderKind::Bedrock,
@@ -715,6 +722,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 45] = [
     ProviderKind::LmStudio,
     ProviderKind::Mistral,
     ProviderKind::Minimax,
+    ProviderKind::NearAi,
     ProviderKind::Novita,
     ProviderKind::Nvidia,
     ProviderKind::Ollama,
@@ -742,7 +750,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 45] = [
     ProviderKind::Zhipu,
 ];
 
-pub(super) const PROVIDER_PROFILES: [ProviderProfile; 45] = [
+pub(super) const PROVIDER_PROFILES: [ProviderProfile; 46] = [
     ProviderProfile {
         kind: ProviderKind::Anthropic,
         id: "anthropic",
@@ -1087,6 +1095,29 @@ pub(super) const PROVIDER_PROFILES: [ProviderProfile; 45] = [
         auth_scheme: ProviderAuthScheme::Bearer,
         default_headers: &[],
         default_api_key_env: Some("MINIMAX_API_KEY"),
+        api_key_env_aliases: &[],
+        default_user_agent: None,
+        default_oauth_access_token_env: None,
+        oauth_access_token_env_aliases: &[],
+        feature_family: ProviderFeatureFamily::OpenAiCompatible,
+    },
+    ProviderProfile {
+        kind: ProviderKind::NearAi,
+        id: "nearai",
+        aliases: &[
+            "near_ai",
+            "near-ai",
+            "nearai_compatible",
+            "near_ai_cloud",
+            "near-ai-cloud",
+        ],
+        base_url: "https://cloud-api.near.ai/v1",
+        chat_completions_path: "/chat/completions",
+        models_path: Some("/model/list"),
+        protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
+        auth_scheme: ProviderAuthScheme::Bearer,
+        default_headers: &[],
+        default_api_key_env: Some("NEARAI_API_KEY"),
         api_key_env_aliases: &[],
         default_user_agent: None,
         default_oauth_access_token_env: None,

--- a/crates/app/src/config/provider/tests.rs
+++ b/crates/app/src/config/provider/tests.rs
@@ -530,6 +530,28 @@ fn provider_descriptor_document_marks_auth_optional_profiles_without_required_en
 }
 
 #[test]
+fn provider_descriptor_document_preserves_nearai_contract_facts() {
+    let provider = ProviderConfig {
+        kind: ProviderKind::NearAi,
+        ..ProviderConfig::default()
+    };
+
+    let descriptor = provider.descriptor_document();
+    let encoded = encode_provider_descriptor(&descriptor);
+
+    assert_eq!(encoded["kind"], json!("nearai"));
+    assert_eq!(encoded["display_name"], json!("NEAR AI Cloud"));
+    assert_eq!(encoded["protocol_family"], json!("openai_chat_completions"));
+    assert_eq!(encoded["feature"]["family"], json!("openai_compatible"));
+    assert_eq!(encoded["auth"]["scheme"], json!("bearer"));
+    assert_eq!(
+        encoded["auth"]["default_api_key_env"],
+        json!("NEARAI_API_KEY")
+    );
+    assert_eq!(encoded["auth"]["model_probe_auth_optional"], json!(true));
+}
+
+#[test]
 fn provider_descriptor_document_prefers_dynamic_configuration_hint() {
     let provider = ProviderConfig {
         kind: ProviderKind::Custom,

--- a/crates/app/src/provider/catalog_query_runtime.rs
+++ b/crates/app/src/provider/catalog_query_runtime.rs
@@ -22,7 +22,7 @@ pub(super) async fn fetch_available_models_with_profiles(
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
     super::copilot_auth::ensure_provider_copilot_api_key(&config.provider).await?;
-    validate_provider_auth_readiness(config).await?;
+    validate_provider_model_catalog_auth_readiness(config).await?;
     let auth_context = super::transport::resolve_request_auth_context(&config.provider).await?;
     let headers = super::transport::build_request_headers_without_provider_auth(&config.provider)?;
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
@@ -74,7 +74,7 @@ pub(super) async fn fetch_model_catalog_with_profiles(
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
     super::copilot_auth::ensure_provider_copilot_api_key(&config.provider).await?;
-    validate_provider_auth_readiness(config).await?;
+    validate_provider_model_catalog_auth_readiness(config).await?;
     let auth_context = super::transport::resolve_request_auth_context(&config.provider).await?;
     let headers = super::transport::build_request_headers_without_provider_auth(&config.provider)?;
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);
@@ -118,4 +118,12 @@ pub(super) async fn fetch_model_catalog_with_profiles(
 
     Err(last_error
         .unwrap_or_else(|| "provider model-list unavailable for every auth profile".to_owned()))
+}
+
+async fn validate_provider_model_catalog_auth_readiness(config: &LoongConfig) -> CliResult<()> {
+    if config.provider.kind.model_probe_auth_optional() {
+        return Ok(());
+    }
+
+    validate_provider_auth_readiness(config).await
 }

--- a/crates/app/src/provider/contracts.rs
+++ b/crates/app/src/provider/contracts.rs
@@ -239,6 +239,11 @@ fn build_provider_runtime_contract(
     };
     let default_reasoning_field = match transport_mode {
         ProviderTransportMode::Responses => ReasoningField::ReasoningObject,
+        ProviderTransportMode::OpenAiChatCompletions
+            if matches!(provider.kind, ProviderKind::NearAi) =>
+        {
+            ReasoningField::Omit
+        }
         ProviderTransportMode::OpenAiChatCompletions | ProviderTransportMode::KimiApi => {
             ReasoningField::ReasoningEffort
         }

--- a/crates/app/src/provider/shape/model_catalog.rs
+++ b/crates/app/src/provider/shape/model_catalog.rs
@@ -113,7 +113,42 @@ fn model_is_default(value: &Value) -> bool {
 }
 
 fn model_display_name_from_value(value: &Value) -> Option<String> {
-    for key in ["display_name", "displayName", "modelName", "name"] {
+    first_model_text_from_keys(
+        value,
+        &[
+            "display_name",
+            "displayName",
+            "modelDisplayName",
+            "modelName",
+            "name",
+        ],
+    )
+    .or_else(|| {
+        model_metadata(value).and_then(|metadata| {
+            first_model_text_from_keys(
+                metadata,
+                &[
+                    "modelDisplayName",
+                    "display_name",
+                    "displayName",
+                    "modelName",
+                    "name",
+                ],
+            )
+        })
+    })
+}
+
+fn model_description_from_value(value: &Value) -> Option<String> {
+    first_model_text_from_keys(value, &["description", "modelDescription"]).or_else(|| {
+        model_metadata(value).and_then(|metadata| {
+            first_model_text_from_keys(metadata, &["modelDescription", "description"])
+        })
+    })
+}
+
+fn first_model_text_from_keys(value: &Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
         if let Some(text) = value.get(key).and_then(Value::as_str)
             && let Some(normalized) = normalize_text(text)
         {
@@ -123,15 +158,10 @@ fn model_display_name_from_value(value: &Value) -> Option<String> {
     None
 }
 
-fn model_description_from_value(value: &Value) -> Option<String> {
-    for key in ["description", "modelDescription"] {
-        if let Some(text) = value.get(key).and_then(Value::as_str)
-            && let Some(normalized) = normalize_text(text)
-        {
-            return Some(normalized);
-        }
-    }
-    None
+fn model_metadata(value: &Value) -> Option<&Value> {
+    value
+        .get("metadata")
+        .filter(|metadata| metadata.is_object())
 }
 
 fn parse_reasoning_effort_token(raw: &str) -> Option<ReasoningEffort> {
@@ -293,6 +323,10 @@ fn model_id_from_value(value: &Value) -> Option<String> {
 }
 
 fn model_is_known_non_chat_candidate(value: &Value) -> bool {
+    if model_id_is_known_non_chat_candidate(value) {
+        return true;
+    }
+
     if model_has_explicit_non_chat_endpoint_compatibility(value) {
         return true;
     }
@@ -309,7 +343,20 @@ fn model_is_known_non_chat_candidate(value: &Value) -> bool {
         return true;
     }
 
+    if model_has_explicit_audio_only_input_capability(value) {
+        return true;
+    }
+
     false
+}
+
+fn model_id_is_known_non_chat_candidate(value: &Value) -> bool {
+    let Some(id) = model_id_from_value(value) else {
+        return false;
+    };
+    let normalized = id.to_ascii_lowercase();
+
+    normalized.contains("privacy-filter") || normalized.contains("reranker")
 }
 
 fn model_has_explicit_non_chat_endpoint_compatibility(value: &Value) -> bool {
@@ -393,10 +440,8 @@ fn model_is_hidden(value: &Value) -> bool {
 }
 
 fn model_has_explicit_non_text_output_capability(value: &Value) -> bool {
-    let Some(output_modalities) = value
-        .get("output_modalities")
-        .or_else(|| value.get("outputModalities"))
-        .and_then(Value::as_array)
+    let Some(output_modalities) =
+        model_modality_array(value, "output_modalities", "outputModalities")
     else {
         return false;
     };
@@ -407,6 +452,44 @@ fn model_has_explicit_non_text_output_capability(value: &Value) -> bool {
         .map(|entry| entry.to_ascii_lowercase())
         .collect::<Vec<_>>();
     !modalities.is_empty() && !modalities.iter().any(|entry| entry == "text")
+}
+
+fn model_has_explicit_audio_only_input_capability(value: &Value) -> bool {
+    let Some(input_modalities) = model_modality_array(value, "input_modalities", "inputModalities")
+    else {
+        return false;
+    };
+
+    let modalities = input_modalities
+        .iter()
+        .filter_map(Value::as_str)
+        .map(|entry| entry.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    !modalities.is_empty()
+        && !modalities.iter().any(|entry| entry == "text")
+        && modalities.iter().any(|entry| entry == "audio")
+}
+
+fn model_modality_array<'a>(
+    value: &'a Value,
+    snake_key: &str,
+    camel_key: &str,
+) -> Option<&'a [Value]> {
+    value
+        .get(snake_key)
+        .or_else(|| value.get(camel_key))
+        .and_then(Value::as_array)
+        .or_else(|| {
+            model_metadata(value)
+                .and_then(|metadata| metadata.get("architecture"))
+                .and_then(|architecture| {
+                    architecture
+                        .get(snake_key)
+                        .or_else(|| architecture.get(camel_key))
+                        .and_then(Value::as_array)
+                })
+        })
+        .map(Vec::as_slice)
 }
 
 fn model_created_from_value(value: &Value) -> Option<i64> {
@@ -523,6 +606,64 @@ mod tests {
                 "amazon.nova-lite-v1:0",
                 "anthropic.claude-3-7-sonnet-20250219-v1:0"
             ]
+        );
+    }
+
+    #[test]
+    fn extract_model_catalog_entries_supports_nearai_catalog_metadata() {
+        let body = json!({
+            "models": [
+                {
+                    "modelId": "anthropic/claude-haiku-4-5",
+                    "metadata": {
+                        "modelDisplayName": "Claude Haiku 4.5",
+                        "modelDescription": "Fast hosted chat model.",
+                        "architecture": {
+                            "inputModalities": ["text", "image"],
+                            "outputModalities": ["text"]
+                        }
+                    }
+                },
+                {
+                    "modelId": "black-forest-labs/FLUX.2-klein-4B",
+                    "metadata": {
+                        "architecture": {
+                            "inputModalities": ["text"],
+                            "outputModalities": ["image"]
+                        }
+                    }
+                },
+                {
+                    "modelId": "Qwen/Qwen3-Embedding-0.6B",
+                    "metadata": {
+                        "architecture": {
+                            "inputModalities": ["text"],
+                            "outputModalities": ["embedding"]
+                        }
+                    }
+                },
+                {
+                    "modelId": "openai/whisper-large-v3",
+                    "metadata": {
+                        "architecture": {
+                            "inputModalities": ["audio"],
+                            "outputModalities": ["text"]
+                        }
+                    }
+                },
+                {"modelId": "Qwen/Qwen3-Reranker-0.6B"},
+                {"modelId": "openai/privacy-filter"}
+            ]
+        });
+
+        let entries = extract_model_catalog_entries(&body);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model, "anthropic/claude-haiku-4-5");
+        assert_eq!(entries[0].display_name.as_deref(), Some("Claude Haiku 4.5"));
+        assert_eq!(
+            entries[0].description.as_deref(),
+            Some("Fast hosted chat model.")
         );
     }
 

--- a/crates/app/src/provider/tests/mod.rs
+++ b/crates/app/src/provider/tests/mod.rs
@@ -1333,6 +1333,25 @@ fn completion_body_includes_reasoning_effort_when_configured() {
 }
 
 #[test]
+fn nearai_completion_body_omits_reasoning_effort_when_configured() {
+    let mut config = test_config(ProviderConfig {
+        kind: ProviderKind::NearAi,
+        ..ProviderConfig::default()
+    });
+    config.provider.reasoning_effort = Some(ReasoningEffort::High);
+
+    let body = build_completion_request_body(
+        &config,
+        &[],
+        "anthropic/claude-haiku-4-5",
+        CompletionPayloadMode::default_for(&config.provider),
+    );
+
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning").is_none());
+}
+
+#[test]
 fn responses_completion_body_uses_input_shape_and_responses_specific_fields() {
     let mut config = test_config(ProviderConfig {
         wire_api: crate::config::ProviderWireApi::Responses,

--- a/site/docs.json
+++ b/site/docs.json
@@ -53,6 +53,7 @@
               "use-loong/provider-guides/minimax",
               "use-loong/provider-guides/mistral",
               "use-loong/provider-guides/cohere",
+              "use-loong/provider-guides/nearai",
               "use-loong/provider-guides/xai",
               "use-loong/provider-guides/zai",
               "use-loong/provider-guides/zhipu",

--- a/site/use-loong/configuration-reference.mdx
+++ b/site/use-loong/configuration-reference.mdx
@@ -134,6 +134,7 @@ Configuration for the LLM provider.
 | `fireworks` | `fireworks_compatible` | `https://api.fireworks.ai` |
 | `mistral` | `mistral_compatible` | `https://api.mistral.ai` |
 | `minimax` | `minimax_compatible` | `https://api.minimaxi.com` |
+| `nearai` | `near_ai`, `near-ai`, `nearai_compatible`, `near_ai_cloud`, `near-ai-cloud` | `https://cloud-api.near.ai/v1` |
 | `gemini` | `google`, `google_gemini`, `gemini_compatible` | `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `bedrock` | `aws_bedrock`, `aws-bedrock` | `https://bedrock-runtime.<region>.amazonaws.com` |
 | `cohere` | `cohere_compatible` | `https://api.cohere.ai/compatibility` |

--- a/site/use-loong/provider-guides/index.mdx
+++ b/site/use-loong/provider-guides/index.mdx
@@ -5,7 +5,7 @@ description: One setup page per built-in Loong provider kind.
 
 # Provider Guides
 
-Loong currently ships 41 built-in provider kinds. This hub exists so the README and chooser pages can stay compact while every built-in provider still has a truthful setup page.
+Loong currently ships 42 built-in provider kinds. This hub exists so the README and chooser pages can stay compact while every built-in provider still has a truthful setup page.
 
 Use [Providers And Models](/use-loong/providers-and-models) when you are still choosing a lane. Use this hub when you already know the provider family and want the exact built-in contract, minimal config, and verification path.
 
@@ -44,6 +44,7 @@ Direct hosted provider families when your team already has a vendor choice and w
 | [MiniMax](/use-loong/provider-guides/minimax) | `minimax` | `MINIMAX_API_KEY` | reviewed fallback `MiniMax-M2.7` |
 | [Mistral](/use-loong/provider-guides/mistral) | `mistral` | `MISTRAL_API_KEY` | operator chooses model strategy |
 | [Cohere](/use-loong/provider-guides/cohere) | `cohere` | `COHERE_API_KEY` | operator chooses model strategy |
+| [NEAR AI Cloud](/use-loong/provider-guides/nearai) | `nearai` | `NEARAI_API_KEY` | operator chooses model strategy |
 | [xAI](/use-loong/provider-guides/xai) | `xai` | `XAI_API_KEY` | operator chooses model strategy |
 | [Z.ai](/use-loong/provider-guides/zai) | `zai` | `ZAI_API_KEY` | operator chooses model strategy |
 | [Zhipu](/use-loong/provider-guides/zhipu) | `zhipu` | `ZHIPUAI_API_KEY` | operator chooses model strategy |

--- a/site/use-loong/provider-guides/nearai.mdx
+++ b/site/use-loong/provider-guides/nearai.mdx
@@ -1,0 +1,62 @@
+---
+title: NEAR AI Cloud
+description: Configure the NEAR AI Cloud provider profile in Loong.
+---
+
+# NEAR AI Cloud
+
+Use this when your team wants NEAR AI Cloud TEE inference as an explicit OpenAI-compatible provider lane instead of routing it through a generic compatibility profile.
+
+## At A Glance
+
+| Field | Value |
+| --- | --- |
+| Built-in kind | `nearai` |
+| Provider group | Direct Hosted Providers |
+| Protocol family | `openai_chat_completions` |
+| Feature family | `openai_compatible` |
+| Auth scheme | `bearer` |
+| Credential envs | NEARAI_API_KEY |
+| Aliases | `near_ai`, `near-ai`, `nearai_compatible`, `near_ai_cloud`, `near-ai-cloud` |
+| Default base URL | `https://cloud-api.near.ai/v1` |
+| Request endpoint | `https://cloud-api.near.ai/v1/chat/completions` |
+| Models endpoint | `https://cloud-api.near.ai/v1/model/list` |
+
+## Minimal Config
+
+```toml
+active_provider = "nearai"
+
+[providers.nearai]
+kind = "nearai"
+api_key = { env = "NEARAI_API_KEY" }
+model = "auto"
+```
+
+## Verify It
+
+```bash
+loong doctor
+loong runtime models list
+loong ask --message "Say hello and name the active provider."
+```
+
+NEAR AI Cloud publishes a public model catalog, but chat requests still require `NEARAI_API_KEY`. If `runtime models list` is unreliable for this account or route, pin an explicit `provider.model` or add `preferred_models` instead of leaving recovery implicit.
+
+## Auth And Routing Contract
+
+| Contract | Value |
+| --- | --- |
+| Auth optional | no |
+| Model probe auth optional | yes |
+| Default API key env | `NEARAI_API_KEY` |
+| OAuth env | none |
+| Primary request route | `https://cloud-api.near.ai/v1/chat/completions` |
+| Primary model-catalog route | `https://cloud-api.near.ai/v1/model/list` |
+
+## Related Docs
+
+- Continue to [Providers And Models](/use-loong/providers-and-models) when you still need the broader chooser page.
+- Continue to [Provider Guides](/use-loong/provider-guides/index) for the full built-in provider matrix.
+- Continue to [Provider Recipes](/use-loong/provider-recipes) for representative rollout recipes.
+- Continue to [Configuration Patterns](/use-loong/configuration-patterns) for the shared provider-profile shape.

--- a/site/use-loong/provider-recipes.mdx
+++ b/site/use-loong/provider-recipes.mdx
@@ -34,7 +34,7 @@ should keep the broader hosted map legible too.
 | Family | Current built-in kinds | Use it when |
 | --- | --- | --- |
 | platform-first hosted | `volcengine`, `byteplus` | one managed hosted provider should own first value and you want a short reviewed path |
-| direct hosted general | `openai`, `anthropic`, `gemini`, `deepseek`, `minimax`, `mistral`, `cohere`, `xai`, `zai`, `zhipu`, `qwen`, `kimi`, `groq`, `fireworks`, `together`, `perplexity`, `qianfan`, `cerebras`, `nvidia`, `sambanova`, `novita`, `siliconflow`, `stepfun`, `venice` | your team already runs on a named hosted provider and you want that family to stay explicit |
+| direct hosted general | `openai`, `anthropic`, `gemini`, `deepseek`, `minimax`, `mistral`, `cohere`, `nearai`, `xai`, `zai`, `zhipu`, `qwen`, `kimi`, `groq`, `fireworks`, `together`, `perplexity`, `qianfan`, `cerebras`, `nvidia`, `sambanova`, `novita`, `siliconflow`, `stepfun`, `venice` | your team already runs on a named hosted provider and you want that family to stay explicit |
 | coding-specialized hosted | `volcengine_coding`, `byteplus_coding`, `kimi_coding`, `step_plan`, `bailian_coding` | coding traffic, pricing, or quota should stay on a deliberate lane |
 | gateway and platform routing | `openrouter`, `cloudflare_ai_gateway`, `vercel_ai_gateway`, `bedrock`, `custom` | a gateway, proxy, or managed route sits between Loong and the upstream models |
 | local and self-hosted | `ollama`, `lm_studio`, `llamacpp`, `vllm`, `sglang` | the model server boundary should stay operator-owned |
@@ -167,7 +167,7 @@ Representative direct-hosted variants:
 
 The broader direct-hosted catalog also includes `qwen`, `kimi`, `zai`, `groq`,
 `fireworks`, `together`, `perplexity`, `qianfan`, `cerebras`, `nvidia`,
-`sambanova`, `novita`, `siliconflow`, `stepfun`, and `venice`. Use the built-in
+`sambanova`, `novita`, `siliconflow`, `stepfun`, `nearai`, and `venice`. Use the built-in
 provider `kind`, then let `loong onboard` or `loong doctor` surface the exact
 default credential env and readiness hints for that family.
 

--- a/site/use-loong/providers-and-models.mdx
+++ b/site/use-loong/providers-and-models.mdx
@@ -29,7 +29,7 @@ playbook that matches the rollout shape.
 | If you need... | Start here | Why |
 | --- | --- | --- |
 | a common hosted first run with a short reviewed path | Volcengine or BytePlus | the main hosted fast path stays short without hiding the broader provider map |
-| a direct hosted provider your team already uses | OpenAI, Anthropic, Gemini, DeepSeek, MiniMax, Mistral, Cohere, xAI, Z.ai, Zhipu, Qwen, Kimi, Groq, Fireworks, Together, Perplexity, Qianfan, Cerebras, NVIDIA, SambaNova, Novita, SiliconFlow, StepFun, or Venice | built-in families stay explicit instead of being forced through `custom` |
+| a direct hosted provider your team already uses | OpenAI, Anthropic, Gemini, DeepSeek, MiniMax, Mistral, Cohere, NEAR AI Cloud, xAI, Z.ai, Zhipu, Qwen, Kimi, Groq, Fireworks, Together, Perplexity, Qianfan, Cerebras, NVIDIA, SambaNova, Novita, SiliconFlow, StepFun, or Venice | built-in families stay explicit instead of being forced through `custom` |
 | a separate coding lane for coding quota or billing | Volcengine Coding, BytePlus Coding, Kimi Coding, Step Plan, or Bailian Coding | coding traffic stays separate from the general hosted lane |
 | one proxy or compatibility endpoint in front of upstream models | gateway or custom endpoint recipes | route ownership stays visible instead of being mistaken for a first-party provider |
 | a local or self-hosted model server | Ollama, LM Studio, llama.cpp, vLLM, or SGLang | the server boundary and model inventory stay explicit |
@@ -103,7 +103,7 @@ A practical public grouping, inferred from the built-in provider kinds, is:
 | Family | Current built-in kinds | Use it when... |
 | --- | --- | --- |
 | platform-first hosted | Volcengine, BytePlus | you want a short first-run hosted lane that stays explicit in the docs |
-| direct hosted general | OpenAI, Anthropic, Gemini, DeepSeek, MiniMax, Mistral, Cohere, xAI, Z.ai, Zhipu, Qwen, Kimi, Groq, Fireworks, Together, Perplexity, Qianfan, Cerebras, NVIDIA, SambaNova, Novita, SiliconFlow, StepFun, Venice | your team already has a named hosted provider and you want that family to remain visible |
+| direct hosted general | OpenAI, Anthropic, Gemini, DeepSeek, MiniMax, Mistral, Cohere, NEAR AI Cloud, xAI, Z.ai, Zhipu, Qwen, Kimi, Groq, Fireworks, Together, Perplexity, Qianfan, Cerebras, NVIDIA, SambaNova, Novita, SiliconFlow, StepFun, Venice | your team already has a named hosted provider and you want that family to remain visible |
 | coding-specialized hosted | Volcengine Coding, BytePlus Coding, Kimi Coding, Step Plan, Bailian Coding | coding work, quota, or pricing should stay on an explicit lane |
 | gateway and platform routing | OpenRouter, Cloudflare AI Gateway, Vercel AI Gateway, Bedrock, Custom | a gateway, proxy, or managed route sits between Loong and the upstream models |
 | local and self-hosted | Ollama, LM Studio, llama.cpp, vLLM, SGLang | the model server boundary should stay operator-owned |
@@ -124,6 +124,7 @@ A practical public grouping, inferred from the built-in provider kinds, is:
 - MiniMax
 - Mistral
 - Cohere
+- NEAR AI Cloud
 - xAI
 - Z.ai
 - Zhipu


### PR DESCRIPTION
## Summary

- Problem: NEAR AI Cloud can be configured through a generic OpenAI-compatible profile, but Loong does not expose it as a first-class provider.
- Why it matters: users can keep NEAR AI Cloud TEE inference explicit in provider selection, docs, auth hints, and model discovery.
- What changed: added the `nearai` provider kind with `NEARAI_API_KEY`, `https://cloud-api.near.ai/v1`, chat completions routing, public model catalog routing, provider docs, and focused regression coverage.
- What did not change: no new feature flag, transport stack, or generated model catalog was added.

## Linked Issues

- Related # none

## Change Type

- [x] Feature
- [x] Documentation

## Touched Areas

- [x] Providers / routing
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `./scripts/cargo-local-toolchain.sh fmt --all -- --check`
- [x] `./scripts/cargo-local-toolchain.sh clippy -p loong-app --all-targets --all-features -- -D warnings`
- [x] Focused `loong-app` provider/config tests for NEAR AI, provider ordering, aliases, and model endpoint resolution
- [x] `scripts/check-docs.sh`
- [x] `git diff --check` and `git diff --cached --check`

Commands and evidence:

```text
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features nearai
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features provider_kinds_are_sorted_alphabetically
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features models_endpoint_resolution_for_supported_provider_profiles_is_stable
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features models_endpoint_resolution_for_supported_provider_profiles_includes_new_first_class_providers
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features provider_kind_keeps_new_provider_aliases
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features provider_profile_lookup_matches_kind
./scripts/cargo-local-toolchain.sh test -p loong-app --all-features provider_profile_aliases
```

Full workspace tests were not run locally; this change is limited to the provider descriptor, OpenAI-compatible payload defaults, model-catalog parsing, and public provider docs. `scripts/check-docs.sh` passed with existing non-blocking release artifact warnings.

## User-visible / Operator-visible Changes

- `nearai` is available as a built-in provider kind.
- The default API key env is `NEARAI_API_KEY`.
- The default request route is `https://cloud-api.near.ai/v1/chat/completions`.
- The default model catalog route is `https://cloud-api.near.ai/v1/model/list`.

## Failure Recovery

- Fast rollback or disable path: switch the active provider back to another configured profile or use `custom` with an explicit base URL.
- Observable failure symptoms reviewers should watch for: unexpected model catalog filtering or provider selection aliases not resolving to `nearai`.

## Reviewer Focus

- NEAR AI Cloud provider descriptor facts.
- Model catalog filtering for nested `metadata.architecture` modalities.
- Omission of unsupported reasoning fields for NEAR AI chat completion requests.
