### PR TITLE
normalize keyboard and mouse input handling in TUI surface

### DIFF
--- a/crates/app/src/chat/chat_surface/app.rs
+++ b/crates/app/src/chat/chat_surface/app.rs
@@ -1,6 +1,3 @@
-use crossterm::event::{
-    self, Event, KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
-};
 use crossterm::terminal::SetTitle;
 use ratatui::{
     Frame, Terminal,
@@ -43,6 +40,10 @@ use super::command_palette::{
 };
 use super::composer::Composer;
 use super::i18n::{I18nService, Language, SurfaceCopy, resolve_default_language};
+use super::input::{
+    ChatInputEvent, ChatKeyCode as KeyCode, ChatKeyEvent, ChatKeyModifiers as KeyModifiers,
+    ChatMouseButton as MouseButton, ChatMouseEvent, ChatMouseEventKind, InputAdapter,
+};
 use super::message_list::{MessageList, StartupEyeAnimation, StartupEyeFocus};
 use super::utils::*;
 

--- a/crates/app/src/chat/chat_surface/app/app_tests.rs
+++ b/crates/app/src/chat/chat_surface/app/app_tests.rs
@@ -9,6 +9,11 @@ use crate::chat::chat_surface::command_palette::{
 };
 use crate::chat::chat_surface::composer::Composer;
 use crate::chat::chat_surface::i18n::{I18nService, Language};
+use crate::chat::chat_surface::input::{
+    ChatKeyCode as KeyCode, ChatKeyEvent, ChatKeyEvent as KeyEvent, ChatKeyEventKind,
+    ChatKeyModifiers as KeyModifiers, ChatMouseButton as MouseButton, ChatMouseEvent as MouseEvent,
+    ChatMouseEventKind as MouseEventKind,
+};
 use crate::chat::chat_surface::message_list::{MessageList, StartupEyeAnimation, StartupEyeFocus};
 use crate::chat::chat_surface::utils::SURFACE_USER_MSG_BG;
 use crate::chat::{
@@ -16,7 +21,6 @@ use crate::chat::{
 };
 use crate::config::{LoongConfig, ProviderConfig, ProviderKind, ReasoningEffort};
 use crate::test_support::{ScopedEnv, unique_temp_dir};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{Terminal, backend::TestBackend, layout::Rect, style::Style};
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -1012,10 +1016,7 @@ fn typing_dollar_keeps_focus_in_composer_while_inline_skill_popup_filters() {
 
     assert!(
         app.composer
-            .handle_key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('$'),
-                KeyModifiers::NONE,
-            ))
+            .handle_key(KeyEvent::new(KeyCode::Char('$'), KeyModifiers::NONE))
             .is_none()
     );
     app.sync_inline_skill_popup();
@@ -1025,20 +1026,14 @@ fn typing_dollar_keeps_focus_in_composer_while_inline_skill_popup_filters() {
 
     assert!(
         app.composer
-            .handle_key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('d'),
-                KeyModifiers::NONE,
-            ))
+            .handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
             .is_none()
     );
     app.sync_inline_skill_popup();
 
     if let Some(action) = app
         .command_palette
-        .handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        ))
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
     {
         let _ = app.apply_palette_action(action);
     }
@@ -1052,10 +1047,7 @@ fn typing_dollar_without_available_skills_keeps_plain_text_without_popup() {
 
     assert!(
         app.composer
-            .handle_key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('$'),
-                KeyModifiers::NONE,
-            ))
+            .handle_key(KeyEvent::new(KeyCode::Char('$'), KeyModifiers::NONE))
             .is_none()
     );
     app.sync_inline_skill_popup();
@@ -1063,6 +1055,26 @@ fn typing_dollar_without_available_skills_keeps_plain_text_without_popup() {
     assert_eq!(app.focus, Focus::Composer);
     assert!(!app.inline_skill_popup_active);
     assert_eq!(app.composer.text(), "$");
+}
+
+#[test]
+fn release_key_events_do_not_change_app_state() {
+    let initial = blank_app();
+    let mut app = blank_app();
+
+    let handled = app.handle_inline_skill_popup_key(ChatKeyEvent::new_with_kind(
+        KeyCode::Char('a'),
+        KeyModifiers::NONE,
+        ChatKeyEventKind::Release,
+    ));
+
+    assert!(!handled);
+    assert_eq!(app.focus, initial.focus);
+    assert_eq!(app.composer.text(), initial.composer.text());
+    assert_eq!(
+        app.inline_skill_popup_active,
+        initial.inline_skill_popup_active
+    );
 }
 
 #[test]
@@ -1206,12 +1218,7 @@ fn tab_confirms_inline_skill_popup_through_shared_key_handler() {
     app.composer.set_input("$dem".to_owned());
     app.sync_inline_skill_popup();
 
-    assert!(
-        app.handle_inline_skill_popup_key(crossterm::event::KeyEvent::new(
-            KeyCode::Tab,
-            KeyModifiers::NONE,
-        ))
-    );
+    assert!(app.handle_inline_skill_popup_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)));
 
     assert_eq!(app.composer.text(), "$demo-skill ");
     assert_eq!(app.focus, Focus::Composer);
@@ -1224,10 +1231,9 @@ fn confirming_inline_skill_keeps_surrounding_text_stable() {
     app.command_palette = CommandPalette::new(Language::En, vec![skill("demo-skill")]);
     app.composer.set_input("please $dem now".to_owned());
     for _ in 0..4 {
-        let _ = app.composer.handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Left,
-            KeyModifiers::NONE,
-        ));
+        let _ = app
+            .composer
+            .handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
     }
     app.sync_inline_skill_popup();
 
@@ -1242,10 +1248,9 @@ fn confirming_inline_skill_works_with_cursor_inside_token_middle() {
     app.command_palette = CommandPalette::new(Language::En, vec![skill("demo-skill")]);
     app.composer.set_input("$demo now".to_owned());
     for _ in 0..4 {
-        let _ = app.composer.handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Left,
-            KeyModifiers::NONE,
-        ));
+        let _ = app
+            .composer
+            .handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
     }
     app.sync_inline_skill_popup();
 
@@ -1339,10 +1344,8 @@ fn footer_shows_follow_hint_when_transcript_is_off_tail() {
     }
 
     terminal.draw(|f| app.render(f)).expect("draw");
-    app.message_list.handle_key(crossterm::event::KeyEvent::new(
-        KeyCode::Up,
-        KeyModifiers::NONE,
-    ));
+    app.message_list
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
     terminal.draw(|f| app.render(f)).expect("draw off tail");
     let lines = buffer_lines(&terminal).join("\n");
 
@@ -1361,15 +1364,11 @@ fn footer_returns_to_status_line_when_tail_is_restored() {
     }
 
     terminal.draw(|f| app.render(f)).expect("draw");
-    app.message_list.handle_key(crossterm::event::KeyEvent::new(
-        KeyCode::Up,
-        KeyModifiers::NONE,
-    ));
+    app.message_list
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
     terminal.draw(|f| app.render(f)).expect("draw off tail");
-    app.message_list.handle_key(crossterm::event::KeyEvent::new(
-        KeyCode::End,
-        KeyModifiers::NONE,
-    ));
+    app.message_list
+        .handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
     terminal
         .draw(|f| app.render(f))
         .expect("draw tail restored");
@@ -1400,10 +1399,8 @@ fn mouse_scroll_over_palette_changes_selection_without_scrolling_transcript() {
     assert_eq!(app.message_list.scroll_offset_for_test(), 4);
     match app
         .command_palette
-        .handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        )) {
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+    {
         Some(CommandAction::RunCommand("/permissions")) => {}
         other => {
             panic!("expected palette mouse scroll to land on /permissions, got {other:?}")
@@ -1421,16 +1418,10 @@ fn slash_palette_open_and_sync_mirror_query_into_composer() {
 
     let _ = app
         .command_palette
-        .handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Char('m'),
-            KeyModifiers::NONE,
-        ));
+        .handle_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
     let _ = app
         .command_palette
-        .handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Char('o'),
-            KeyModifiers::NONE,
-        ));
+        .handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
     super::sync_slash_palette_composer(&mut app);
 
     assert_eq!(app.composer.text(), "/mo");
@@ -1763,10 +1754,8 @@ fn model_command_opens_selector_surface_instead_of_static_card() {
     assert_eq!(app.focus, Focus::CommandPalette);
     match app
         .command_palette
-        .handle_key(crossterm::event::KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        )) {
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+    {
         Some(CommandAction::OpenModelReasoning(entry))
             if entry.model == runtime.config.provider.model => {}
         other => panic!("expected /model to open model selector flow, got {other:?}"),
@@ -2777,18 +2766,22 @@ fn pending_signature_preview_budget_tracks_last_render_geometry() {
 
 #[test]
 fn transcript_navigation_key_helper_keeps_printable_keys_for_composer() {
-    assert!(super::is_transcript_navigation_key(
-        crossterm::event::KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE,)
-    ));
-    assert!(super::is_transcript_navigation_key(
-        crossterm::event::KeyEvent::new(KeyCode::Home, KeyModifiers::NONE,)
-    ));
-    assert!(!super::is_transcript_navigation_key(
-        crossterm::event::KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE,)
-    ));
-    assert!(!super::is_transcript_navigation_key(
-        crossterm::event::KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE,)
-    ));
+    assert!(super::is_transcript_navigation_key(KeyEvent::new(
+        KeyCode::PageDown,
+        KeyModifiers::NONE
+    )));
+    assert!(super::is_transcript_navigation_key(KeyEvent::new(
+        KeyCode::Home,
+        KeyModifiers::NONE
+    )));
+    assert!(!super::is_transcript_navigation_key(KeyEvent::new(
+        KeyCode::Char('j'),
+        KeyModifiers::NONE
+    )));
+    assert!(!super::is_transcript_navigation_key(KeyEvent::new(
+        KeyCode::Char(' '),
+        KeyModifiers::NONE
+    )));
 }
 
 #[test]
@@ -2798,7 +2791,7 @@ fn transcript_focus_text_keys_enter_composer_immediately() {
 
     let submitted = super::route_transcript_key_to_composer(
         &mut app,
-        crossterm::event::KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE),
     );
 
     assert!(submitted.is_none());
@@ -2839,7 +2832,7 @@ fn transcript_focus_enter_submits_existing_draft() {
 
     let submitted = super::route_transcript_key_to_composer(
         &mut app,
-        crossterm::event::KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
     );
 
     assert_eq!(submitted.as_deref(), Some("send me"));
@@ -2850,19 +2843,19 @@ fn transcript_focus_enter_submits_existing_draft() {
 #[test]
 fn transcript_focus_capture_helper_rejects_navigation_and_modified_keys() {
     assert!(super::should_focus_composer_for_transcript_key(
-        crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)
     ));
     assert!(super::should_focus_composer_for_transcript_key(
-        crossterm::event::KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)
     ));
     assert!(super::should_focus_composer_for_transcript_key(
-        crossterm::event::KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
     ));
     assert!(!super::should_focus_composer_for_transcript_key(
-        crossterm::event::KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)
     ));
     assert!(!super::should_focus_composer_for_transcript_key(
-        crossterm::event::KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL,)
+        KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL)
     ));
 }
 
@@ -2873,27 +2866,27 @@ fn composer_routes_arrow_and_page_scroll_even_with_a_draft() {
 
     assert!(super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::Up, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)
     ));
     assert!(super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::Down, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)
     ));
     assert!(super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)
     ));
     assert!(super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)
     ));
     assert!(!super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)
     ));
     assert!(!super::should_route_composer_key_to_transcript(
         &app,
-        crossterm::event::KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE,)
+        KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)
     ));
 }
 
@@ -3069,10 +3062,8 @@ fn off_tail_pending_resize_and_end_restore_tail_without_losing_state() {
     }
 
     terminal.draw(|f| app.render(f)).expect("draw");
-    app.message_list.handle_key(crossterm::event::KeyEvent::new(
-        KeyCode::Up,
-        KeyModifiers::NONE,
-    ));
+    app.message_list
+        .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
     app.pending_turn = true;
     app.turn_start = Some(std::time::Instant::now());
     if let Ok(mut live) = app.live_transcript.lock() {
@@ -3090,10 +3081,8 @@ fn off_tail_pending_resize_and_end_restore_tail_without_losing_state() {
     let resized_lines = buffer_lines(&terminal).join("\n");
     assert!(resized_lines.contains("PgDn / End"));
 
-    app.message_list.handle_key(crossterm::event::KeyEvent::new(
-        KeyCode::End,
-        KeyModifiers::NONE,
-    ));
+    app.message_list
+        .handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
     terminal.draw(|f| app.render(f)).expect("draw restored");
     let restored_lines = buffer_lines(&terminal).join("\n");
 

--- a/crates/app/src/chat/chat_surface/app/pending.rs
+++ b/crates/app/src/chat/chat_surface/app/pending.rs
@@ -144,7 +144,7 @@ fn dequeue_pending_steer(app: &mut App) -> bool {
     true
 }
 
-fn is_transcript_navigation_key(key: crossterm::event::KeyEvent) -> bool {
+fn is_transcript_navigation_key(key: ChatKeyEvent) -> bool {
     matches!(
         key.code,
         KeyCode::Up
@@ -156,7 +156,7 @@ fn is_transcript_navigation_key(key: crossterm::event::KeyEvent) -> bool {
     )
 }
 
-fn should_focus_composer_for_transcript_key(key: crossterm::event::KeyEvent) -> bool {
+fn should_focus_composer_for_transcript_key(key: ChatKeyEvent) -> bool {
     if key
         .modifiers
         .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
@@ -175,17 +175,14 @@ fn should_focus_composer_for_transcript_key(key: crossterm::event::KeyEvent) -> 
     )
 }
 
-fn route_transcript_key_to_composer(
-    app: &mut App,
-    key: crossterm::event::KeyEvent,
-) -> Option<String> {
+fn route_transcript_key_to_composer(app: &mut App, key: ChatKeyEvent) -> Option<String> {
     app.focus = Focus::Composer;
     let submitted = app.composer.handle_key(key);
     app.sync_inline_skill_popup();
     submitted
 }
 
-fn should_route_composer_key_to_transcript(app: &App, key: crossterm::event::KeyEvent) -> bool {
+fn should_route_composer_key_to_transcript(app: &App, key: ChatKeyEvent) -> bool {
     matches!(
         key.code,
         KeyCode::Up | KeyCode::Down | KeyCode::PageUp | KeyCode::PageDown

--- a/crates/app/src/chat/chat_surface/app/runtime.rs
+++ b/crates/app/src/chat/chat_surface/app/runtime.rs
@@ -212,6 +212,7 @@ pub async fn run_app<B: Backend>(
     let mut dirty = true;
     let mut last_resize_at: Option<std::time::Instant> = None;
     let mut pending_live_resize_rerender = false;
+    let mut input_adapter = InputAdapter::new();
 
     loop {
         if let Some(task) = startup_release_task.as_ref()
@@ -280,11 +281,9 @@ pub async fn run_app<B: Backend>(
             Duration::from_millis(250)
         };
 
-        if event::poll(poll_timeout).map_err(|e| format!("poll error: {}", e))? {
-            let event = event::read().map_err(|e| format!("read error: {}", e))?;
-
+        if let Some(event) = input_adapter.next_event(poll_timeout)? {
             match event {
-                Event::Key(key) => {
+                ChatInputEvent::Key(key) => {
                     if key.code == KeyCode::Char('c')
                         && key.modifiers.contains(KeyModifiers::CONTROL)
                     {
@@ -548,7 +547,7 @@ pub async fn run_app<B: Backend>(
                     }
                     dirty = true;
                 }
-                Event::Mouse(mouse_event) => {
+                ChatInputEvent::Mouse(mouse_event) => {
                     if let Some(command) = app.handle_mouse_event(mouse_event) {
                         if command == "/exit" {
                             clear_app_terminal_title(&mut app);
@@ -559,7 +558,7 @@ pub async fn run_app<B: Backend>(
                     }
                     dirty = true;
                 }
-                Event::Resize(width, height) => {
+                ChatInputEvent::Resize { width, height } => {
                     let new_size = ratatui::layout::Size::new(width, height);
                     if new_size.width == last_known_size.width
                         && new_size.height == last_known_size.height
@@ -586,15 +585,14 @@ pub async fn run_app<B: Backend>(
                     }
                     dirty = true;
                 }
-                Event::Paste(text) => {
+                ChatInputEvent::Paste(text) => {
                     paste_into_composer(&mut app, text.as_str());
                     dirty = true;
                 }
-                Event::FocusGained | Event::FocusLost => {}
+                ChatInputEvent::FocusGained | ChatInputEvent::FocusLost => {}
             }
         }
     }
     clear_app_terminal_title(&mut app);
     Ok(())
 }
-

--- a/crates/app/src/chat/chat_surface/app/state.rs
+++ b/crates/app/src/chat/chat_surface/app/state.rs
@@ -616,7 +616,7 @@ impl StartupOnboardingState {
             .unwrap_or(Language::En)
     }
 
-    fn handle_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
+    fn handle_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         match self.stage {
             StartupOnboardingStage::Language => self.handle_language_key(key),
             StartupOnboardingStage::Provider => self.handle_provider_key(key),
@@ -627,7 +627,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_language_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
+    fn handle_language_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Up {
             self.language_index = self.language_index.saturating_sub(1);
@@ -656,7 +656,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_provider_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
+    fn handle_provider_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Up {
             self.provider_index = self.provider_index.saturating_sub(1);
@@ -684,7 +684,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_skills_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
+    fn handle_skills_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Up {
             self.skill_cursor = self.skill_cursor.saturating_sub(1);
@@ -730,10 +730,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_setup_path_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-    ) -> StartupOnboardingAction {
+    fn handle_setup_path_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Up {
             self.setup_path_index = self.setup_path_index.saturating_sub(1);
@@ -773,10 +770,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_personalization_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-    ) -> StartupOnboardingAction {
+    fn handle_personalization_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Up {
             self.personalization_index = self.personalization_index.saturating_sub(1);
@@ -799,7 +793,7 @@ impl StartupOnboardingState {
         }
     }
 
-    fn handle_finish_key(&mut self, key: crossterm::event::KeyEvent) -> StartupOnboardingAction {
+    fn handle_finish_key(&mut self, key: ChatKeyEvent) -> StartupOnboardingAction {
         let code = key.code;
         if code == KeyCode::Enter {
             StartupOnboardingAction::Complete
@@ -875,4 +869,3 @@ pub struct App {
     title_pending_approval_count: usize,
     pub i18n: I18nService,
 }
-

--- a/crates/app/src/chat/chat_surface/app/surface.rs
+++ b/crates/app/src/chat/chat_surface/app/surface.rs
@@ -353,7 +353,7 @@ impl App {
         }
     }
 
-    fn handle_mouse_event(&mut self, mouse_event: MouseEvent) -> Option<String> {
+    fn handle_mouse_event(&mut self, mouse_event: ChatMouseEvent) -> Option<String> {
         if rect_contains_point(self.last_palette_area, mouse_event.column, mouse_event.row)
             && (matches!(self.focus, Focus::CommandPalette) || self.inline_skill_popup_active)
         {
@@ -364,7 +364,10 @@ impl App {
         }
 
         if rect_contains_point(self.last_composer_area, mouse_event.column, mouse_event.row) {
-            if matches!(mouse_event.kind, MouseEventKind::Down(MouseButton::Left)) {
+            if matches!(
+                mouse_event.kind,
+                ChatMouseEventKind::Down(MouseButton::Left)
+            ) {
                 self.focus = Focus::Composer;
                 self.sync_inline_skill_popup();
             }
@@ -378,9 +381,9 @@ impl App {
         ) {
             if matches!(
                 mouse_event.kind,
-                MouseEventKind::Down(MouseButton::Left)
-                    | MouseEventKind::Down(MouseButton::Right)
-                    | MouseEventKind::Down(MouseButton::Middle)
+                ChatMouseEventKind::Down(MouseButton::Left)
+                    | ChatMouseEventKind::Down(MouseButton::Right)
+                    | ChatMouseEventKind::Down(MouseButton::Middle)
             ) {
                 self.focus = Focus::MessageList;
                 self.sync_inline_skill_popup();
@@ -410,10 +413,7 @@ impl App {
     fn confirm_inline_skill_popup(&mut self) {
         if let Some(action) = self
             .command_palette
-            .handle_key(crossterm::event::KeyEvent::new(
-                KeyCode::Enter,
-                KeyModifiers::NONE,
-            ))
+            .handle_key(ChatKeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
         {
             let _ = self.apply_palette_action(action);
         } else {
@@ -421,7 +421,7 @@ impl App {
         }
     }
 
-    fn handle_inline_skill_popup_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+    fn handle_inline_skill_popup_key(&mut self, key: ChatKeyEvent) -> bool {
         if !self.inline_skill_popup_active {
             return false;
         }

--- a/crates/app/src/chat/chat_surface/command_palette.rs
+++ b/crates/app/src/chat/chat_surface/command_palette.rs
@@ -1,9 +1,12 @@
 use crate::chat::chat_surface::i18n::{I18nService, Language, SurfaceCopy};
+use crate::chat::chat_surface::input::{
+    ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatMouseButton as MouseButton,
+    ChatMouseEvent as MouseEvent, ChatMouseEventKind as MouseEventKind,
+};
 use crate::chat::chat_surface::scroll_state::ScrollState;
 use crate::chat::chat_surface::utils::*;
 use crate::config::{ProviderKind, ReasoningEffort};
 use crate::provider::ProviderModelCatalogEntry;
-use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -1940,11 +1943,13 @@ fn area_contains(area: Rect, column: u16, row: u16) -> bool {
 mod tests {
     use super::{CommandAction, CommandPalette, SettingsEntry, SettingsSurfaceFocus, SkillEntry};
     use crate::chat::chat_surface::i18n::Language;
+    use crate::chat::chat_surface::input::{
+        ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatKeyModifiers as KeyModifiers,
+        ChatMouseButton as MouseButton, ChatMouseEvent as MouseEvent,
+        ChatMouseEventKind as MouseEventKind,
+    };
     use crate::config::ReasoningEffort;
     use crate::provider::ProviderModelCatalogEntry;
-    use crossterm::event::{
-        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
-    };
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
     use ratatui::style::{Modifier, Style};

--- a/crates/app/src/chat/chat_surface/composer.rs
+++ b/crates/app/src/chat/chat_surface/composer.rs
@@ -1,5 +1,7 @@
 use super::utils::*;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crate::chat::chat_surface::input::{
+    ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatKeyModifiers as KeyModifiers,
+};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -397,7 +399,9 @@ fn highlight_composer_row(row: &str) -> Vec<Span<'static>> {
 #[cfg(test)]
 mod tests {
     use super::Composer;
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crate::chat::chat_surface::input::{
+        ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatKeyModifiers as KeyModifiers,
+    };
     use ratatui::layout::Rect;
 
     fn key(code: KeyCode) -> KeyEvent {

--- a/crates/app/src/chat/chat_surface/input/adapter.rs
+++ b/crates/app/src/chat/chat_surface/input/adapter.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+use crossterm::event::{self, Event};
+
+use super::{ChatInputEvent, ChatKeyEvent, ChatKeyEventKind, ChatMouseEvent};
+
+pub(crate) struct InputAdapter;
+
+impl InputAdapter {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    pub(crate) fn next_event(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<ChatInputEvent>, String> {
+        if !event::poll(timeout).map_err(|e| format!("poll error: {}", e))? {
+            return Ok(None);
+        }
+
+        let event = event::read().map_err(|e| format!("read error: {}", e))?;
+        Ok(normalize_crossterm_event(event))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn normalize_raw_event_for_test(event: Event) -> Option<ChatInputEvent> {
+        normalize_crossterm_event(event)
+    }
+}
+
+fn normalize_crossterm_event(event: Event) -> Option<ChatInputEvent> {
+    match event {
+        Event::Key(key) => {
+            let key = ChatKeyEvent::from(key);
+            match key.kind {
+                ChatKeyEventKind::Release => None,
+                ChatKeyEventKind::Press | ChatKeyEventKind::Repeat => {
+                    Some(ChatInputEvent::Key(key))
+                }
+            }
+        }
+        Event::Mouse(mouse) => Some(ChatInputEvent::Mouse(ChatMouseEvent::from(mouse))),
+        Event::Resize(width, height) => Some(ChatInputEvent::Resize { width, height }),
+        Event::Paste(text) => Some(ChatInputEvent::Paste(text)),
+        Event::FocusGained => Some(ChatInputEvent::FocusGained),
+        Event::FocusLost => Some(ChatInputEvent::FocusLost),
+    }
+}

--- a/crates/app/src/chat/chat_surface/input/event.rs
+++ b/crates/app/src/chat/chat_surface/input/event.rs
@@ -1,0 +1,11 @@
+use super::{ChatKeyEvent, ChatMouseEvent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChatInputEvent {
+    Key(ChatKeyEvent),
+    Mouse(ChatMouseEvent),
+    Resize { width: u16, height: u16 },
+    Paste(String),
+    FocusGained,
+    FocusLost,
+}

--- a/crates/app/src/chat/chat_surface/input/input_tests.rs
+++ b/crates/app/src/chat/chat_surface/input/input_tests.rs
@@ -1,0 +1,92 @@
+use super::{
+    ChatInputEvent, ChatKeyCode, ChatKeyEvent, ChatKeyEventKind, ChatKeyModifiers,
+    ChatMouseEventKind, InputAdapter,
+};
+use crossterm::event::{
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
+};
+
+#[test]
+fn normalize_keeps_press_key_events() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Char('a'),
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Key(ChatKeyEvent {
+            code: ChatKeyCode::Char('a'),
+            modifiers: ChatKeyModifiers::NONE,
+            kind: ChatKeyEventKind::Press,
+            state: Default::default(),
+        }))
+    );
+}
+
+#[test]
+fn normalize_keeps_repeat_key_events() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Left,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Repeat,
+        state: KeyEventState::NONE,
+    }));
+
+    let Some(ChatInputEvent::Key(key)) = normalized else {
+        panic!("expected key event");
+    };
+    assert_eq!(key.code, ChatKeyCode::Left);
+    assert_eq!(key.kind, ChatKeyEventKind::Repeat);
+}
+
+#[test]
+fn normalize_drops_release_key_events() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Enter,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Release,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(normalized, None);
+}
+
+#[test]
+fn normalize_passes_mouse_events_through() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 3,
+        row: 5,
+        modifiers: KeyModifiers::NONE,
+    }));
+
+    let Some(ChatInputEvent::Mouse(mouse)) = normalized else {
+        panic!("expected mouse event");
+    };
+    assert_eq!(mouse.kind, ChatMouseEventKind::ScrollDown);
+    assert_eq!(mouse.column, 3);
+    assert_eq!(mouse.row, 5);
+}
+
+#[test]
+fn resize_is_exposed_as_structured_chat_input_event() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Resize(80, 24));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Resize {
+            width: 80,
+            height: 24,
+        })
+    );
+}
+
+#[test]
+fn paste_is_exposed_as_structured_chat_input_event() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Paste("hello".to_owned()));
+
+    assert_eq!(normalized, Some(ChatInputEvent::Paste("hello".to_owned())));
+}

--- a/crates/app/src/chat/chat_surface/input/keyboard.rs
+++ b/crates/app/src/chat/chat_surface/input/keyboard.rs
@@ -1,0 +1,263 @@
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MediaKeyCode, ModifierKeyCode,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatMediaKeyCode {
+    Play,
+    Pause,
+    PlayPause,
+    Reverse,
+    Stop,
+    FastForward,
+    Rewind,
+    TrackNext,
+    TrackPrevious,
+    Record,
+    LowerVolume,
+    RaiseVolume,
+    MuteVolume,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatModifierKeyCode {
+    LeftShift,
+    LeftControl,
+    LeftAlt,
+    LeftSuper,
+    LeftHyper,
+    LeftMeta,
+    RightShift,
+    RightControl,
+    RightAlt,
+    RightSuper,
+    RightHyper,
+    RightMeta,
+    IsoLevel3Shift,
+    IsoLevel5Shift,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatKeyCode {
+    Backspace,
+    Enter,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    Tab,
+    BackTab,
+    Delete,
+    Insert,
+    F(u8),
+    Char(char),
+    Null,
+    Esc,
+    CapsLock,
+    ScrollLock,
+    NumLock,
+    PrintScreen,
+    Pause,
+    Menu,
+    KeypadBegin,
+    Media(ChatMediaKeyCode),
+    Modifier(ChatModifierKeyCode),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatKeyEventKind {
+    Press,
+    Repeat,
+    Release,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ChatKeyEventState(KeyEventState);
+
+impl ChatKeyEventState {
+    pub(crate) const NONE: Self = Self(KeyEventState::NONE);
+}
+
+impl Default for ChatKeyEventState {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ChatKeyModifiers(KeyModifiers);
+
+impl ChatKeyModifiers {
+    pub(crate) const SHIFT: Self = Self(KeyModifiers::SHIFT);
+    pub(crate) const CONTROL: Self = Self(KeyModifiers::CONTROL);
+    pub(crate) const ALT: Self = Self(KeyModifiers::ALT);
+    pub(crate) const SUPER: Self = Self(KeyModifiers::SUPER);
+    pub(crate) const NONE: Self = Self(KeyModifiers::NONE);
+
+    pub(crate) fn contains(self, other: Self) -> bool {
+        self.0.contains(other.0)
+    }
+
+    pub(crate) fn intersects(self, other: Self) -> bool {
+        self.0.intersects(other.0)
+    }
+}
+
+impl std::ops::BitOr for ChatKeyModifiers {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl Default for ChatKeyModifiers {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ChatKeyEvent {
+    pub(crate) code: ChatKeyCode,
+    pub(crate) modifiers: ChatKeyModifiers,
+    pub(crate) kind: ChatKeyEventKind,
+    pub(crate) state: ChatKeyEventState,
+}
+
+impl ChatKeyEvent {
+    pub(crate) fn new(code: ChatKeyCode, modifiers: ChatKeyModifiers) -> Self {
+        Self {
+            code,
+            modifiers,
+            kind: ChatKeyEventKind::Press,
+            state: ChatKeyEventState::NONE,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_kind(
+        code: ChatKeyCode,
+        modifiers: ChatKeyModifiers,
+        kind: ChatKeyEventKind,
+    ) -> Self {
+        Self {
+            code,
+            modifiers,
+            kind,
+            state: ChatKeyEventState::NONE,
+        }
+    }
+}
+
+impl From<KeyEventState> for ChatKeyEventState {
+    fn from(value: KeyEventState) -> Self {
+        Self(value)
+    }
+}
+
+impl From<KeyModifiers> for ChatKeyModifiers {
+    fn from(value: KeyModifiers) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MediaKeyCode> for ChatMediaKeyCode {
+    fn from(value: MediaKeyCode) -> Self {
+        match value {
+            MediaKeyCode::Play => Self::Play,
+            MediaKeyCode::Pause => Self::Pause,
+            MediaKeyCode::PlayPause => Self::PlayPause,
+            MediaKeyCode::Reverse => Self::Reverse,
+            MediaKeyCode::Stop => Self::Stop,
+            MediaKeyCode::FastForward => Self::FastForward,
+            MediaKeyCode::Rewind => Self::Rewind,
+            MediaKeyCode::TrackNext => Self::TrackNext,
+            MediaKeyCode::TrackPrevious => Self::TrackPrevious,
+            MediaKeyCode::Record => Self::Record,
+            MediaKeyCode::LowerVolume => Self::LowerVolume,
+            MediaKeyCode::RaiseVolume => Self::RaiseVolume,
+            MediaKeyCode::MuteVolume => Self::MuteVolume,
+        }
+    }
+}
+
+impl From<ModifierKeyCode> for ChatModifierKeyCode {
+    fn from(value: ModifierKeyCode) -> Self {
+        match value {
+            ModifierKeyCode::LeftShift => Self::LeftShift,
+            ModifierKeyCode::LeftControl => Self::LeftControl,
+            ModifierKeyCode::LeftAlt => Self::LeftAlt,
+            ModifierKeyCode::LeftSuper => Self::LeftSuper,
+            ModifierKeyCode::LeftHyper => Self::LeftHyper,
+            ModifierKeyCode::LeftMeta => Self::LeftMeta,
+            ModifierKeyCode::RightShift => Self::RightShift,
+            ModifierKeyCode::RightControl => Self::RightControl,
+            ModifierKeyCode::RightAlt => Self::RightAlt,
+            ModifierKeyCode::RightSuper => Self::RightSuper,
+            ModifierKeyCode::RightHyper => Self::RightHyper,
+            ModifierKeyCode::RightMeta => Self::RightMeta,
+            ModifierKeyCode::IsoLevel3Shift => Self::IsoLevel3Shift,
+            ModifierKeyCode::IsoLevel5Shift => Self::IsoLevel5Shift,
+        }
+    }
+}
+
+impl From<KeyCode> for ChatKeyCode {
+    fn from(value: KeyCode) -> Self {
+        match value {
+            KeyCode::Backspace => Self::Backspace,
+            KeyCode::Enter => Self::Enter,
+            KeyCode::Left => Self::Left,
+            KeyCode::Right => Self::Right,
+            KeyCode::Up => Self::Up,
+            KeyCode::Down => Self::Down,
+            KeyCode::Home => Self::Home,
+            KeyCode::End => Self::End,
+            KeyCode::PageUp => Self::PageUp,
+            KeyCode::PageDown => Self::PageDown,
+            KeyCode::Tab => Self::Tab,
+            KeyCode::BackTab => Self::BackTab,
+            KeyCode::Delete => Self::Delete,
+            KeyCode::Insert => Self::Insert,
+            KeyCode::F(value) => Self::F(value),
+            KeyCode::Char(value) => Self::Char(value),
+            KeyCode::Null => Self::Null,
+            KeyCode::Esc => Self::Esc,
+            KeyCode::CapsLock => Self::CapsLock,
+            KeyCode::ScrollLock => Self::ScrollLock,
+            KeyCode::NumLock => Self::NumLock,
+            KeyCode::PrintScreen => Self::PrintScreen,
+            KeyCode::Pause => Self::Pause,
+            KeyCode::Menu => Self::Menu,
+            KeyCode::KeypadBegin => Self::KeypadBegin,
+            KeyCode::Media(value) => Self::Media(value.into()),
+            KeyCode::Modifier(value) => Self::Modifier(value.into()),
+        }
+    }
+}
+
+impl From<KeyEventKind> for ChatKeyEventKind {
+    fn from(value: KeyEventKind) -> Self {
+        match value {
+            KeyEventKind::Press => Self::Press,
+            KeyEventKind::Repeat => Self::Repeat,
+            KeyEventKind::Release => Self::Release,
+        }
+    }
+}
+
+impl From<KeyEvent> for ChatKeyEvent {
+    fn from(value: KeyEvent) -> Self {
+        Self {
+            code: value.code.into(),
+            modifiers: value.modifiers.into(),
+            kind: value.kind.into(),
+            state: value.state.into(),
+        }
+    }
+}

--- a/crates/app/src/chat/chat_surface/input/mod.rs
+++ b/crates/app/src/chat/chat_surface/input/mod.rs
@@ -1,0 +1,13 @@
+mod adapter;
+mod event;
+mod keyboard;
+mod mouse;
+
+pub(crate) use adapter::InputAdapter;
+pub(crate) use event::ChatInputEvent;
+pub(crate) use keyboard::{ChatKeyCode, ChatKeyEvent, ChatKeyEventKind, ChatKeyModifiers};
+pub(crate) use mouse::{ChatMouseButton, ChatMouseEvent, ChatMouseEventKind};
+
+#[cfg(test)]
+#[path = "input_tests.rs"]
+mod tests;

--- a/crates/app/src/chat/chat_surface/input/mouse.rs
+++ b/crates/app/src/chat/chat_surface/input/mouse.rs
@@ -1,0 +1,66 @@
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+use super::ChatKeyModifiers;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatMouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChatMouseEventKind {
+    Down(ChatMouseButton),
+    Up(ChatMouseButton),
+    Drag(ChatMouseButton),
+    Moved,
+    ScrollDown,
+    ScrollUp,
+    ScrollLeft,
+    ScrollRight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ChatMouseEvent {
+    pub(crate) kind: ChatMouseEventKind,
+    pub(crate) column: u16,
+    pub(crate) row: u16,
+    pub(crate) modifiers: ChatKeyModifiers,
+}
+
+impl From<MouseButton> for ChatMouseButton {
+    fn from(value: MouseButton) -> Self {
+        match value {
+            MouseButton::Left => Self::Left,
+            MouseButton::Right => Self::Right,
+            MouseButton::Middle => Self::Middle,
+        }
+    }
+}
+
+impl From<MouseEventKind> for ChatMouseEventKind {
+    fn from(value: MouseEventKind) -> Self {
+        match value {
+            MouseEventKind::Down(button) => Self::Down(button.into()),
+            MouseEventKind::Up(button) => Self::Up(button.into()),
+            MouseEventKind::Drag(button) => Self::Drag(button.into()),
+            MouseEventKind::Moved => Self::Moved,
+            MouseEventKind::ScrollDown => Self::ScrollDown,
+            MouseEventKind::ScrollUp => Self::ScrollUp,
+            MouseEventKind::ScrollLeft => Self::ScrollLeft,
+            MouseEventKind::ScrollRight => Self::ScrollRight,
+        }
+    }
+}
+
+impl From<MouseEvent> for ChatMouseEvent {
+    fn from(value: MouseEvent) -> Self {
+        Self {
+            kind: value.kind.into(),
+            column: value.column,
+            row: value.row,
+            modifiers: value.modifiers.into(),
+        }
+    }
+}

--- a/crates/app/src/chat/chat_surface/message_list.rs
+++ b/crates/app/src/chat/chat_surface/message_list.rs
@@ -1,10 +1,13 @@
 use super::utils::*;
 use crate::chat::chat_surface::diff_viewer::render_diff_to_lines;
+use crate::chat::chat_surface::input::{
+    ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatKeyModifiers as KeyModifiers,
+    ChatMouseEvent, ChatMouseEventKind,
+};
 use crate::chat::chat_surface::markdown;
 use crate::chat::chat_surface::transcript_scroll_state::TranscriptScrollState;
 use crate::conversation::is_compacted_summary_content;
 use crate::tui_surface::TuiSectionSpec;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     Frame,
     layout::Rect,

--- a/crates/app/src/chat/chat_surface/message_list/core.rs
+++ b/crates/app/src/chat/chat_surface/message_list/core.rs
@@ -741,20 +741,16 @@ impl MessageList {
         }
     }
 
-    pub fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
+    pub fn handle_mouse(&mut self, mouse: ChatMouseEvent) {
         match mouse.kind {
-            crossterm::event::MouseEventKind::ScrollUp => {
-                self.scroll_state.scroll_page_up(self.mouse_step)
-            }
-            crossterm::event::MouseEventKind::ScrollDown => {
-                self.scroll_state.scroll_page_down(self.mouse_step)
-            }
-            crossterm::event::MouseEventKind::Down(_)
-            | crossterm::event::MouseEventKind::Up(_)
-            | crossterm::event::MouseEventKind::Drag(_)
-            | crossterm::event::MouseEventKind::Moved
-            | crossterm::event::MouseEventKind::ScrollLeft
-            | crossterm::event::MouseEventKind::ScrollRight => {}
+            ChatMouseEventKind::ScrollUp => self.scroll_state.scroll_page_up(self.mouse_step),
+            ChatMouseEventKind::ScrollDown => self.scroll_state.scroll_page_down(self.mouse_step),
+            ChatMouseEventKind::Down(_)
+            | ChatMouseEventKind::Up(_)
+            | ChatMouseEventKind::Drag(_)
+            | ChatMouseEventKind::Moved
+            | ChatMouseEventKind::ScrollLeft
+            | ChatMouseEventKind::ScrollRight => {}
         }
     }
 
@@ -1210,4 +1206,3 @@ fn content_renders_colored_block(role: &str, content: &MessageContent) -> bool {
         | MessageContent::StartupHeader { .. } => false,
     }
 }
-

--- a/crates/app/src/chat/chat_surface/message_list/message_list_tests.rs
+++ b/crates/app/src/chat/chat_surface/message_list/message_list_tests.rs
@@ -6,12 +6,15 @@ use super::{
     format_read_request_display, startup_logo_eye_frame_index, startup_logo_eye_style,
     startup_tip_render_state, startup_wordmark_eye_frame,
 };
+use crate::chat::chat_surface::input::{
+    ChatKeyCode as KeyCode, ChatKeyEvent as KeyEvent, ChatKeyModifiers as KeyModifiers,
+    ChatMouseEvent as MouseEvent, ChatMouseEventKind as MouseEventKind,
+};
 use crate::chat::chat_surface::utils::{
     SURFACE_ACCENT, SURFACE_DIM_GRAY, SURFACE_GRAY, SURFACE_GREEN, SURFACE_RED, SURFACE_TOOL_BG,
     SURFACE_USER_MSG_BG,
 };
 use crate::test_support::ScopedEnv;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{Terminal, backend::TestBackend, style::Color, text::Line};
 use std::time::Duration;
 

--- a/crates/app/src/chat/chat_surface/mod.rs
+++ b/crates/app/src/chat/chat_surface/mod.rs
@@ -3,6 +3,7 @@ pub mod command_palette;
 pub mod composer;
 pub mod diff_viewer;
 pub mod i18n;
+pub mod input;
 pub mod markdown;
 pub mod message_list;
 pub mod scroll_state;


### PR DESCRIPTION
## Summary

- Problem: On Windows, pressing a key once is recognized as two separate key operations. This happens because in the crossterm crate, a single physical key press generates two events: a press event and a release event. However, loong's TUI implementation treats both events as actual key presses.
- Why it matters: This makes loong's TUI unusable on Windows.
- What changed: I implemented an input adapter that converts platform-specific input events into loong's internal input event representation.
- What did not change (scope boundary):

## Linked Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows
- [x] TUI

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)

Commands and evidence:
<img width="1468" height="852" alt="image" src="https://github.com/user-attachments/assets/8f32e130-a2fd-4a87-b146-b2130305606e" />
These tesecases had been failed before my commit.
## User-visible / Operator-visible Changes

- None, or describe the exact change:

## Failure Recovery

- Fast rollback or disable path:
- Observable failure symptoms reviewers should watch for:

## Reviewer Focus

- Point reviewers at the files, edge cases, or risk seams that deserve the most attention.
