### PR TITLE
fix windows cargo test fail

### DIFF
--- a/crates/app/src/conversation/workspace_isolation.rs
+++ b/crates/app/src/conversation/workspace_isolation.rs
@@ -314,9 +314,21 @@ fn discover_git_executable() -> Result<PathBuf, String> {
 
     let stable_search_path = stable_command_search_path();
     let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let discovered = which::which_in("git", Some(stable_search_path), current_dir)
-        .map_err(|error| format!("resolve git executable failed: {error}"))?;
-    Ok(discovered)
+    if let Ok(discovered) = which::which_in("git", Some(stable_search_path), current_dir) {
+        return Ok(discovered);
+    }
+
+    #[cfg(windows)]
+    {
+        if let Some(discovered) = discover_git_via_where() {
+            return Ok(discovered);
+        }
+        if let Some(discovered) = discover_known_windows_git_paths() {
+            return Ok(discovered);
+        }
+    }
+
+    Err("resolve git executable failed: cannot find binary path".to_owned())
 }
 
 #[cfg(unix)]
@@ -347,9 +359,78 @@ fn stable_command_search_path() -> OsString {
     let env_path = std::env::var_os("PATH");
     env_path
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| {
-            OsString::from(r"C:\Windows\System32;C:\Windows;C:\Program Files\Git\cmd")
-        })
+        .unwrap_or_else(default_windows_search_path)
+}
+
+#[cfg(windows)]
+fn discover_git_via_where() -> Option<PathBuf> {
+    let where_executable = resolve_windows_where_executable()?;
+    let output = Command::new(where_executable).arg("git").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(windows)]
+fn discover_known_windows_git_paths() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        let base = PathBuf::from(program_files);
+        candidates.push(base.join("Git").join("cmd").join("git.exe"));
+        candidates.push(base.join("Git").join("bin").join("git.exe"));
+    }
+
+    if let Some(program_files_x86) = std::env::var_os("ProgramFiles(x86)") {
+        let base = PathBuf::from(program_files_x86);
+        candidates.push(base.join("Git").join("cmd").join("git.exe"));
+        candidates.push(base.join("Git").join("bin").join("git.exe"));
+    }
+
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+#[cfg(windows)]
+fn default_windows_search_path() -> OsString {
+    let mut parts = Vec::new();
+
+    if let Some(system_root) = std::env::var_os("SystemRoot") {
+        let root = PathBuf::from(system_root);
+        parts.push(root.join("System32").into_os_string());
+        parts.push(root.into_os_string());
+    } else {
+        parts.push(OsString::from(r"C:\Windows\System32"));
+        parts.push(OsString::from(r"C:\Windows"));
+    }
+
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        parts.push(
+            PathBuf::from(program_files)
+                .join("Git")
+                .join("cmd")
+                .into_os_string(),
+        );
+    }
+
+    std::env::join_paths(parts).unwrap_or_else(|_| OsString::from(r"C:\Windows\System32;C:\Windows"))
+}
+
+#[cfg(windows)]
+fn resolve_windows_where_executable() -> Option<PathBuf> {
+    if let Some(system_root) = std::env::var_os("SystemRoot") {
+        let candidate = PathBuf::from(system_root).join("System32").join("where.exe");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    which::which("where.exe").ok()
 }
 
 #[cfg(test)]

--- a/crates/app/src/process_launch.rs
+++ b/crates/app/src/process_launch.rs
@@ -125,6 +125,11 @@ where
         .map(|value| OsString::from(value.as_ref()))
         .collect::<Vec<_>>();
 
+    #[cfg(windows)]
+    if let Some(invocation) = resolve_windows_builtin_invocation(command, &collected_args) {
+        return invocation;
+    }
+
     if let Some(resolved_path) = resolve_existing_command_path(command) {
         #[cfg(unix)]
         if let Some(invocation) =
@@ -143,6 +148,31 @@ where
         program: OsString::from(command),
         args: collected_args,
     }
+}
+
+#[cfg(windows)]
+fn resolve_windows_builtin_invocation(
+    command: &str,
+    collected_args: &[OsString],
+) -> Option<ResolvedCommandInvocation> {
+    let normalized = command.trim().to_ascii_lowercase();
+    if !matches!(normalized.as_str(), "echo") {
+        return None;
+    }
+
+    let mut shell_command = String::from(command.trim());
+    for argument in collected_args {
+        shell_command.push(' ');
+        shell_command.push_str(argument.to_string_lossy().as_ref());
+    }
+
+    Some(ResolvedCommandInvocation {
+        program: OsString::from("cmd.exe"),
+        args: vec![
+            OsString::from("/C"),
+            OsString::from(shell_command.trim()),
+        ],
+    })
 }
 
 #[cfg(unix)]
@@ -237,9 +267,32 @@ fn resolve_existing_command_path(command: &str) -> Option<PathBuf> {
 fn stable_command_search_path() -> OsString {
     std::env::var_os("PATH")
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| {
-            OsString::from(r"C:\Windows\System32;C:\Windows;C:\Program Files\Git\cmd")
-        })
+        .unwrap_or_else(default_windows_search_path)
+}
+
+#[cfg(windows)]
+fn default_windows_search_path() -> OsString {
+    let mut parts = Vec::new();
+
+    if let Some(system_root) = std::env::var_os("SystemRoot") {
+        let root = PathBuf::from(system_root);
+        parts.push(root.join("System32").into_os_string());
+        parts.push(root.into_os_string());
+    } else {
+        parts.push(OsString::from(r"C:\Windows\System32"));
+        parts.push(OsString::from(r"C:\Windows"));
+    }
+
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        parts.push(
+            PathBuf::from(program_files)
+                .join("Git")
+                .join("cmd")
+                .into_os_string(),
+        );
+    }
+
+    std::env::join_paths(parts).unwrap_or_else(|_| OsString::from(r"C:\Windows\System32;C:\Windows"))
 }
 
 #[cfg(unix)]

--- a/crates/app/src/tools/skills_tests.rs
+++ b/crates/app/src/tools/skills_tests.rs
@@ -2062,12 +2062,16 @@ Safe for model-driven activation.
     #[test]
     fn model_surface_redacts_operator_only_skill_metadata() {
         with_managed_runtime_test(|| {
+            let required_bin = if cfg!(windows) { "cmd" } else { "sh" };
             let root = unique_temp_dir("loong-ext-skill-model-redaction");
             fs::create_dir_all(&root).expect("create fixture root");
+            let skill_body = format!(
+                "---\nname: demo-skill\ndescription: eligible project skill.\nrequires_env:\n  - DEMO_SKILL_TOKEN\nrequires_bin:\n  - {required_bin}\nrequires_paths:\n  - fixtures/present.txt\n---\n\n# Demo Skill\n\nOnly expose model-safe metadata on the provider surface.\n"
+            );
             write_file(
                 &root,
                 ".agents/skills/demo-skill/SKILL.md",
-                "---\nname: demo-skill\ndescription: eligible project skill.\nrequires_env:\n  - DEMO_SKILL_TOKEN\nrequires_bin:\n  - sh\nrequires_paths:\n  - fixtures/present.txt\n---\n\n# Demo Skill\n\nOnly expose model-safe metadata on the provider surface.\n",
+                skill_body.as_str(),
             );
             write_file(&root, "fixtures/present.txt", "present");
             let config = managed_runtime_config(&root);
@@ -2119,7 +2123,7 @@ Safe for model-driven activation.
                 .expect("operator list should include demo-skill");
             assert_eq!(operator_skill["model_visibility"], "visible");
             assert_eq!(operator_skill["required_env"], json!(["DEMO_SKILL_TOKEN"]));
-            assert_eq!(operator_skill["required_bin"], json!(["sh"]));
+            assert_eq!(operator_skill["required_bin"], json!([required_bin]));
             assert_eq!(
                 operator_skill["required_paths"],
                 json!(["fixtures/present.txt"])
@@ -2168,7 +2172,7 @@ Safe for model-driven activation.
             );
             assert_eq!(
                 operator_inspect.payload["skill"]["required_bin"],
-                json!(["sh"])
+                json!([required_bin])
             );
             assert_eq!(
                 operator_inspect.payload["skill"]["required_paths"],

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -14,6 +14,68 @@ impl ProcessStdioEnvironmentGuard {
     }
 }
 
+#[cfg(windows)]
+const PROCESS_STDIO_ECHO_COMMAND: &str = "cmd.exe";
+#[cfg(not(windows))]
+const PROCESS_STDIO_ECHO_COMMAND: &str = "cat";
+
+#[cfg(windows)]
+const PROCESS_STDIO_ECHO_ARGS_JSON: Option<&str> = Some(r#"["/d","/c","more"]"#);
+#[cfg(not(windows))]
+const PROCESS_STDIO_ECHO_ARGS_JSON: Option<&str> = None;
+
+#[cfg(windows)]
+const PROCESS_STDIO_INVALID_FRAME_COMMAND: &str = "cmd.exe";
+#[cfg(not(windows))]
+const PROCESS_STDIO_INVALID_FRAME_COMMAND: &str = "printf";
+
+#[cfg(windows)]
+const PROCESS_STDIO_INVALID_FRAME_ARGS_JSON: Option<&str> =
+    Some(r#"["/d","/c","echo not-json"]"#);
+#[cfg(not(windows))]
+const PROCESS_STDIO_INVALID_FRAME_ARGS_JSON: Option<&str> = Some(r#"["not-json\n"]"#);
+
+fn process_stdio_plugin_manifest(
+    plugin_id: &str,
+    provider_id: &str,
+    connector_name: &str,
+    command: &str,
+    args_json: Option<&str>,
+    process_timeout_ms: Option<&str>,
+) -> String {
+    let args_json_line = args_json
+        .map(|value| {
+            format!(
+                "#     \"args_json\":{},\n",
+                serde_json::to_string(value).expect("serialize args_json literal")
+            )
+        })
+        .unwrap_or_default();
+    let timeout_line = process_timeout_ms
+        .map(|value| format!("#     \"process_timeout_ms\":\"{value}\",\n"))
+        .unwrap_or_default();
+
+    format!(
+        r#"
+# LOONG_PLUGIN_START
+# {{
+#   "plugin_id": "{plugin_id}",
+#   "provider_id": "{provider_id}",
+#   "connector_name": "{connector_name}",
+#   "channel_id": "primary",
+#   "endpoint": "local://{provider_id}",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {{
+#     "bridge_kind":"process_stdio",
+#     "command":"{command}",
+{args_json_line}{timeout_line}#     "version":"1.0.0"
+#   }}
+# }}
+# LOONG_PLUGIN_END
+"#
+    )
+}
+
 #[tokio::test]
 async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -28,24 +90,14 @@ async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
 
     fs::write(
         plugin_root.join("stdio_plugin.py"),
-        r#"
-# LOONG_PLUGIN_START
-# {
-#   "plugin_id": "stdio-plugin",
-#   "provider_id": "stdio-provider",
-#   "connector_name": "stdio-provider",
-#   "channel_id": "primary",
-#   "endpoint": "local://stdio-provider",
-#   "capabilities": ["InvokeConnector"],
-#   "metadata": {
-#     "bridge_kind":"process_stdio",
-#     "command":"cat",
-#     "process_timeout_ms":"999999999",
-#     "version":"1.0.0"
-#   }
-# }
-# LOONG_PLUGIN_END
-"#,
+        process_stdio_plugin_manifest(
+            "stdio-plugin",
+            "stdio-provider",
+            "stdio-provider",
+            PROCESS_STDIO_ECHO_COMMAND,
+            PROCESS_STDIO_ECHO_ARGS_JSON,
+            Some("999999999"),
+        ),
     )
     .expect("write stdio plugin");
 
@@ -84,7 +136,7 @@ async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
             expected_sha256: None,
             execute_process_stdio: true,
             execute_http_json: false,
-            allowed_process_commands: vec!["cat".to_owned()],
+            allowed_process_commands: vec![PROCESS_STDIO_ECHO_COMMAND.to_owned()],
             enforce_execution_success: true,
             security_scan: None,
         }),
@@ -159,24 +211,14 @@ async fn execute_spec_process_stdio_bridge_blocks_when_command_not_allowlisted()
 
     fs::write(
         plugin_root.join("stdio_plugin.py"),
-        r#"
-# LOONG_PLUGIN_START
-# {
-#   "plugin_id": "stdio-plugin",
-#   "provider_id": "stdio-provider",
-#   "connector_name": "stdio-provider",
-#   "channel_id": "primary",
-#   "endpoint": "local://stdio-provider",
-#   "capabilities": ["InvokeConnector"],
-#   "metadata": {
-#     "bridge_kind":"process_stdio",
-#     "command":"cat",
-#     "process_timeout_ms":"999999999",
-#     "version":"1.0.0"
-#   }
-# }
-# LOONG_PLUGIN_END
-"#,
+        process_stdio_plugin_manifest(
+            "stdio-plugin",
+            "stdio-provider",
+            "stdio-provider",
+            PROCESS_STDIO_ECHO_COMMAND,
+            PROCESS_STDIO_ECHO_ARGS_JSON,
+            Some("999999999"),
+        ),
     )
     .expect("write stdio plugin");
 
@@ -273,24 +315,14 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
 
     fs::write(
         plugin_root.join("stdio_plugin.py"),
-        r#"
-# LOONG_PLUGIN_START
-# {
-#   "plugin_id": "stdio-invalid-frame-plugin",
-#   "provider_id": "stdio-invalid-frame-provider",
-#   "connector_name": "stdio-invalid-frame-provider",
-#   "channel_id": "primary",
-#   "endpoint": "local://stdio-invalid-frame-provider",
-#   "capabilities": ["InvokeConnector"],
-#   "metadata": {
-#     "bridge_kind":"process_stdio",
-#     "command":"printf",
-#     "args_json":"[\"not-json\\n\"]",
-#     "version":"1.0.0"
-#   }
-# }
-# LOONG_PLUGIN_END
-"#,
+        process_stdio_plugin_manifest(
+            "stdio-invalid-frame-plugin",
+            "stdio-invalid-frame-provider",
+            "stdio-invalid-frame-provider",
+            PROCESS_STDIO_INVALID_FRAME_COMMAND,
+            PROCESS_STDIO_INVALID_FRAME_ARGS_JSON,
+            None,
+        ),
     )
     .expect("write stdio plugin");
 
@@ -329,7 +361,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
             expected_sha256: None,
             execute_process_stdio: true,
             execute_http_json: false,
-            allowed_process_commands: vec!["printf".to_owned()],
+            allowed_process_commands: vec![PROCESS_STDIO_INVALID_FRAME_COMMAND.to_owned()],
             enforce_execution_success: false,
             security_scan: None,
         }),
@@ -747,24 +779,14 @@ async fn execute_spec_process_stdio_bridge_blocks_when_protocol_authorization_fa
 
     fs::write(
         plugin_root.join("stdio_plugin.py"),
-        r#"
-# LOONG_PLUGIN_START
-# {
-#   "plugin_id": "stdio-authz-block-plugin",
-#   "provider_id": "stdio-authz-block-provider",
-#   "connector_name": "stdio-authz-block-provider",
-#   "channel_id": "primary",
-#   "endpoint": "local://stdio-authz-block-provider",
-#   "capabilities": ["InvokeConnector"],
-#   "metadata": {
-#     "bridge_kind":"process_stdio",
-#     "command":"cat",
-#     "process_timeout_ms":"999999999",
-#     "version":"1.0.0"
-#   }
-# }
-# LOONG_PLUGIN_END
-"#,
+        process_stdio_plugin_manifest(
+            "stdio-authz-block-plugin",
+            "stdio-authz-block-provider",
+            "stdio-authz-block-provider",
+            PROCESS_STDIO_ECHO_COMMAND,
+            PROCESS_STDIO_ECHO_ARGS_JSON,
+            Some("999999999"),
+        ),
     )
     .expect("write stdio plugin");
 
@@ -803,7 +825,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_protocol_authorization_fa
             expected_sha256: None,
             execute_process_stdio: true,
             execute_http_json: false,
-            allowed_process_commands: vec!["cat".to_owned()],
+            allowed_process_commands: vec![PROCESS_STDIO_ECHO_COMMAND.to_owned()],
             enforce_execution_success: false,
             security_scan: None,
         }),


### PR DESCRIPTION
## Summary

- Problem: Windows failures came from Unix assumptions in command discovery and test fixtures. git lookup was too dependent on current process PATH, shell.exec treated echo as an external executable even though it is a Windows cmd.exe builtin, and several tests hardcoded Unix commands like cat, printf, and sh.
  - Why it matters: The code is intended to run and be tested on Windows for all contributors and in CI. Hardcoding Unix-only behavior or machine-specific Windows paths makes tests flaky, environment-dependent, and non-portable. It also means cargo test --workspace --locked can fail locally on Windows even when the underlying product logic is fine.
  - What changed: 
  - What did not change (scope boundary):

## Linked Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows
- [x] Testcases

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)

Commands and evidence:

```text
Paste the exact commands you ran and summarize the result.
```

## User-visible / Operator-visible Changes

- None, or describe the exact change:

## Failure Recovery

- Fast rollback or disable path:
- Observable failure symptoms reviewers should watch for:

## Reviewer Focus

- Point reviewers at the files, edge cases, or risk seams that deserve the most attention.
