### PR TITLE
refactor(observability): extract OTel reqwest client + exporter builder into standalone function

### DIFF
--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -377,6 +377,58 @@ fn endpoint_env_is_present(value: Option<&str>) -> bool {
     value.is_some_and(|entry| !entry.trim().is_empty())
 }
 
+fn build_otel_exporter() -> Option<SpanExporter> {
+    let mut client_builder = reqwest::Client::builder();
+
+    if let Ok(ca_path) = std::env::var("OTEL_CA_CERT_FILE") {
+        let pem = match std::fs::read(&ca_path) {
+            Ok(pem) => pem,
+            Err(e) => {
+                let mut stderr = io::stderr();
+                let _ = writeln!(
+                    stderr,
+                    "loong.daemon otel CA cert read failed ({ca_path}): {e}"
+                );
+                return None;
+            }
+        };
+        let ca = match reqwest::Certificate::from_pem(&pem) {
+            Ok(ca) => ca,
+            Err(e) => {
+                let mut stderr = io::stderr();
+                let _ = writeln!(
+                    stderr,
+                    "loong.daemon otel CA cert parse failed ({ca_path}): {e}"
+                );
+                return None;
+            }
+        };
+        client_builder = client_builder.add_root_certificate(ca);
+    }
+
+    let client = match client_builder.build() {
+        Ok(client) => client,
+        Err(e) => {
+            let mut stderr = io::stderr();
+            let _ = writeln!(stderr, "loong.daemon otel reqwest client build failed: {e}");
+            return None;
+        }
+    };
+
+    match SpanExporter::builder()
+        .with_http()
+        .with_http_client(client)
+        .build()
+    {
+        Ok(exporter) => Some(exporter),
+        Err(e) => {
+            let mut stderr = io::stderr();
+            let _ = writeln!(stderr, "loong.daemon otel exporter init failed: {e}");
+            None
+        }
+    }
+}
+
 pub fn init_otel() -> OtelGuard {
     if !otel_traces_export_is_enabled() {
         return OtelGuard { provider: None };
@@ -384,56 +436,8 @@ pub fn init_otel() -> OtelGuard {
 
     let service_name = std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "loong".to_owned());
 
-    let exporter = {
-        let mut client_builder = reqwest::Client::builder();
-
-        if let Ok(ca_path) = std::env::var("OTEL_CA_CERT_FILE") {
-            let pem = match std::fs::read(&ca_path) {
-                Ok(pem) => pem,
-                Err(e) => {
-                    let mut stderr = io::stderr();
-                    let _ = writeln!(
-                        stderr,
-                        "loong.daemon otel CA cert read failed ({ca_path}): {e}"
-                    );
-                    return OtelGuard { provider: None };
-                }
-            };
-            let ca = match reqwest::Certificate::from_pem(&pem) {
-                Ok(ca) => ca,
-                Err(e) => {
-                    let mut stderr = io::stderr();
-                    let _ = writeln!(
-                        stderr,
-                        "loong.daemon otel CA cert parse failed ({ca_path}): {e}"
-                    );
-                    return OtelGuard { provider: None };
-                }
-            };
-            client_builder = client_builder.add_root_certificate(ca);
-        }
-
-        let client = match client_builder.build() {
-            Ok(client) => client,
-            Err(e) => {
-                let mut stderr = io::stderr();
-                let _ = writeln!(stderr, "loong.daemon otel reqwest client build failed: {e}");
-                return OtelGuard { provider: None };
-            }
-        };
-
-        match SpanExporter::builder()
-            .with_http()
-            .with_http_client(client)
-            .build()
-        {
-            Ok(e) => e,
-            Err(e) => {
-                let mut stderr = io::stderr();
-                let _ = writeln!(stderr, "loong.daemon otel exporter init failed: {e}");
-                return OtelGuard { provider: None };
-            }
-        }
+    let Some(exporter) = build_otel_exporter() else {
+        return OtelGuard { provider: None };
     };
 
     let resource = Resource::builder()


### PR DESCRIPTION
## Summary

- **Problem:** `init_otel()` mixed exporter construction, tracer provider setup, global registration, and startup span creation in one function, making it harder to reason about error paths and test in isolation.
- **Why it matters:** The exporter creation block contained 4 distinct failure modes (CA file read, CA PEM parse, HTTP client build, exporter build), each duplicating the `io::stderr()` + `writeln!` + early return pattern. Extracting it eliminates the duplication and lowers cognitive load when reading the OTel init flow.
- **What changed:** Moved the `let exporter = { ... }` block into `build_otel_exporter() -> Option<SpanExporter>`; replaced the block with `let Some(exporter) = build_otel_exporter() else { return ... }`.
- **What did not change (scope boundary):** All behavior — error messages, env var keys (`OTEL_CA_CERT_FILE`), HTTP client config, exporter build parameters — is preserved identically. No test changes needed.

## Linked Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface
- [ ] If full workspace / all-features Rust tests were not run locally, explain why and cite CI evidence or a known baseline blocker
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
# Format
cargo fmt --all -- --check
# → exit 0

# Clippy (strict)
cargo clippy -p loong --all-targets --all-features -- -D warnings
# → exit 0, no warnings

# Unit + integration tests for the daemon crate
cargo test -p loong
# → 771 passed; 14 failed (all in control_plane_server / gateway::openai_compat / task_execution — pre-existing, unrelated to this change)

# Observability-specific tests
cargo test -p loong -- observability
# → 12 passed, 0 failed
```

## User-visible / Operator-visible Changes

- None. This is a pure internal refactor with no behavioral change.

## Failure Recovery

- **Fast rollback or disable path:** Revert the single commit on this branch.
- **Observable failure symptoms reviewers should watch for:** OTel span export failing to initialize at daemon startup — monitor stderr for `loong.daemon otel exporter init failed:` messages if `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

## Reviewer Focus

- `crates/daemon/src/observability.rs` — verify the extracted function signature (`build_otel_exporter() -> Option<SpanExporter>`) correctly preserves all four error-return paths and that `init_otel()` handles the `None` case with `OtelGuard { provider: None }`.
