### PR TITLE
fix: ctrl-h has been nomallized to backspace

### DIFF
--- a/crates/app/src/chat/chat_surface/input/adapter.rs
+++ b/crates/app/src/chat/chat_surface/input/adapter.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use crossterm::event::{self, Event};
 
-use super::{ChatInputEvent, ChatKeyEvent, ChatKeyEventKind, ChatMouseEvent};
+use super::{
+    ChatInputEvent, ChatKeyCode, ChatKeyEvent, ChatKeyEventKind, ChatKeyModifiers, ChatMouseEvent,
+};
 
 pub(crate) struct InputAdapter;
 
@@ -32,7 +34,7 @@ impl InputAdapter {
 fn normalize_crossterm_event(event: Event) -> Option<ChatInputEvent> {
     match event {
         Event::Key(key) => {
-            let key = ChatKeyEvent::from(key);
+            let key = normalize_key_event(ChatKeyEvent::from(key));
             match key.kind {
                 ChatKeyEventKind::Release => None,
                 ChatKeyEventKind::Press | ChatKeyEventKind::Repeat => {
@@ -46,4 +48,12 @@ fn normalize_crossterm_event(event: Event) -> Option<ChatInputEvent> {
         Event::FocusGained => Some(ChatInputEvent::FocusGained),
         Event::FocusLost => Some(ChatInputEvent::FocusLost),
     }
+}
+
+fn normalize_key_event(mut key: ChatKeyEvent) -> ChatKeyEvent {
+    if key.code == ChatKeyCode::Char('h') && key.modifiers.contains(ChatKeyModifiers::CONTROL) {
+        key.code = ChatKeyCode::Backspace;
+        key.modifiers = key.modifiers.without(ChatKeyModifiers::CONTROL);
+    }
+    key
 }

--- a/crates/app/src/chat/chat_surface/input/input_tests.rs
+++ b/crates/app/src/chat/chat_surface/input/input_tests.rs
@@ -27,6 +27,86 @@ fn normalize_keeps_press_key_events() {
 }
 
 #[test]
+fn normalize_legacy_ctrl_h_as_backspace() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Char('h'),
+        modifiers: KeyModifiers::CONTROL,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Key(ChatKeyEvent {
+            code: ChatKeyCode::Backspace,
+            modifiers: ChatKeyModifiers::NONE,
+            kind: ChatKeyEventKind::Press,
+            state: Default::default(),
+        }))
+    );
+}
+
+#[test]
+fn normalize_legacy_ctrl_h_preserves_non_control_modifiers() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Char('h'),
+        modifiers: KeyModifiers::CONTROL | KeyModifiers::ALT,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Key(ChatKeyEvent {
+            code: ChatKeyCode::Backspace,
+            modifiers: ChatKeyModifiers::ALT,
+            kind: ChatKeyEventKind::Press,
+            state: Default::default(),
+        }))
+    );
+}
+
+#[test]
+fn normalize_keeps_plain_h_as_character() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Char('h'),
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Key(ChatKeyEvent {
+            code: ChatKeyCode::Char('h'),
+            modifiers: ChatKeyModifiers::NONE,
+            kind: ChatKeyEventKind::Press,
+            state: Default::default(),
+        }))
+    );
+}
+
+#[test]
+fn normalize_keeps_direct_backspace() {
+    let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
+        code: KeyCode::Backspace,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }));
+
+    assert_eq!(
+        normalized,
+        Some(ChatInputEvent::Key(ChatKeyEvent {
+            code: ChatKeyCode::Backspace,
+            modifiers: ChatKeyModifiers::NONE,
+            kind: ChatKeyEventKind::Press,
+            state: Default::default(),
+        }))
+    );
+}
+
+#[test]
 fn normalize_keeps_repeat_key_events() {
     let normalized = InputAdapter::normalize_raw_event_for_test(Event::Key(KeyEvent {
         code: KeyCode::Left,

--- a/crates/app/src/chat/chat_surface/input/keyboard.rs
+++ b/crates/app/src/chat/chat_surface/input/keyboard.rs
@@ -105,6 +105,10 @@ impl ChatKeyModifiers {
     pub(crate) fn intersects(self, other: Self) -> bool {
         self.0.intersects(other.0)
     }
+
+    pub(crate) fn without(self, other: Self) -> Self {
+        Self(self.0.difference(other.0))
+    }
 }
 
 impl std::ops::BitOr for ChatKeyModifiers {


### PR DESCRIPTION
## Summary
- Problem:
  - Some Linux terminal environments emit Backspace as legacy `Ctrl-H` (`Char('h')` with `CONTROL`), causing the TUI input layer to treat it as a control-key event instead of Backspace.

- Why it matters:
  - Backspace is a core editing action in the chat input. When it is misread, Linux users can see broken or inconsistent text editing behavior.

- What changed:
  - Normalized `Ctrl-H` key events to `ChatKeyCode::Backspace` in the crossterm input adapter.
  - Removed only the `CONTROL` modifier during this normalization while preserving other modifiers such as `ALT`.
  - Added `ChatKeyModifiers::without`.
  - Added unit coverage for legacy `Ctrl-H`, modifier preservation, plain `h`, and direct Backspace behavior.

- What did not change (scope boundary):
  - No broader keyboard shortcut remapping.
  - No changes to mouse, paste, resize, focus, or key release handling.
  - No changes to terminal backend behavior outside the chat input normalization path.


## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows
- [x] TUI

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Rust tests match the touched packages / feature surface (for example `cargo test --workspace --locked`, `cargo test --workspace --all-features --locked`, `task verify`, `task verify:changed`, or equivalent exact commands documented below)


