### PR TITLE
refactor: simplify transcript scroll state transitions

### DIFF
--- a/crates/app/src/chat/chat_surface/transcript_scroll_state.rs
+++ b/crates/app/src/chat/chat_surface/transcript_scroll_state.rs
@@ -23,17 +23,13 @@ impl TranscriptScrollState {
     }
 
     pub(crate) fn reset(&mut self) {
-        self.offset_from_bottom = 0;
         self.last_scroll_start = 0;
-        self.follow_tail = true;
-        self.snap_on_next_render = true;
+        self.reset_to_tail(true);
     }
 
     pub(crate) fn reset_for_empty_render(&mut self) {
-        self.offset_from_bottom = 0;
         self.last_scroll_start = 0;
-        self.follow_tail = true;
-        self.snap_on_next_render = false;
+        self.reset_to_tail(false);
     }
 
     pub(crate) fn note_cache_invalidated(&mut self) {
@@ -80,8 +76,7 @@ impl TranscriptScrollState {
 
     #[cfg(test)]
     pub(crate) fn set_scroll_offset_for_test(&mut self, value: u16) {
-        self.offset_from_bottom = value;
-        self.follow_tail = value == 0;
+        self.set_offset_from_bottom(value);
     }
 
     #[cfg(test)]
@@ -95,39 +90,43 @@ impl TranscriptScrollState {
     }
 
     pub(crate) fn scroll_line_up(&mut self) {
-        self.offset_from_bottom = self.offset_from_bottom.saturating_add(1);
-        self.follow_tail = self.offset_from_bottom == 0;
-        self.snap_on_next_render = true;
+        self.apply_user_scroll_offset(self.offset_from_bottom.saturating_add(1));
     }
 
     pub(crate) fn scroll_line_down(&mut self) {
-        self.offset_from_bottom = self.offset_from_bottom.saturating_sub(1);
-        self.follow_tail = self.offset_from_bottom == 0;
-        self.snap_on_next_render = true;
+        self.apply_user_scroll_offset(self.offset_from_bottom.saturating_sub(1));
     }
 
     pub(crate) fn scroll_page_up(&mut self, step: u16) {
-        self.offset_from_bottom = self.offset_from_bottom.saturating_add(step);
-        self.follow_tail = self.offset_from_bottom == 0;
-        self.snap_on_next_render = true;
+        self.apply_user_scroll_offset(self.offset_from_bottom.saturating_add(step));
     }
 
     pub(crate) fn scroll_page_down(&mut self, step: u16) {
-        self.offset_from_bottom = self.offset_from_bottom.saturating_sub(step);
-        self.follow_tail = self.offset_from_bottom == 0;
-        self.snap_on_next_render = true;
+        self.apply_user_scroll_offset(self.offset_from_bottom.saturating_sub(step));
     }
 
     pub(crate) fn jump_home(&mut self) {
-        self.offset_from_bottom = u16::MAX;
-        self.follow_tail = false;
-        self.snap_on_next_render = true;
+        self.apply_user_scroll_offset(u16::MAX);
     }
 
     pub(crate) fn jump_end(&mut self) {
+        self.reset_to_tail(true);
+    }
+
+    fn reset_to_tail(&mut self, snap_on_next_render: bool) {
         self.offset_from_bottom = 0;
         self.follow_tail = true;
+        self.snap_on_next_render = snap_on_next_render;
+    }
+
+    fn apply_user_scroll_offset(&mut self, offset_from_bottom: u16) {
+        self.set_offset_from_bottom(offset_from_bottom);
         self.snap_on_next_render = true;
+    }
+
+    fn set_offset_from_bottom(&mut self, offset_from_bottom: u16) {
+        self.offset_from_bottom = offset_from_bottom;
+        self.follow_tail = offset_from_bottom == 0;
     }
 }
 
@@ -162,5 +161,32 @@ mod tests {
         state.apply_rendered_scroll_start(10, 10);
         assert_eq!(state.scroll_offset(), 0);
         assert!(state.follow_tail());
+    }
+
+    #[test]
+    fn prepare_for_appended_content_preserves_tail_following_state() {
+        let mut state = TranscriptScrollState::new();
+        state.apply_rendered_scroll_start(20, 12);
+        assert_eq!(state.scroll_offset(), 8);
+        assert!(!state.follow_tail());
+        assert!(!state.snap_on_next_render());
+
+        state.prepare_for_appended_content();
+
+        assert_eq!(state.scroll_offset(), 0);
+        assert!(!state.follow_tail());
+        assert!(!state.snap_on_next_render());
+
+        let mut state = TranscriptScrollState::new();
+        state.scroll_page_up(4);
+        assert_eq!(state.scroll_offset(), 4);
+        assert!(!state.follow_tail());
+        assert!(state.snap_on_next_render());
+
+        state.prepare_for_appended_content();
+
+        assert_eq!(state.scroll_offset(), 0);
+        assert!(!state.follow_tail());
+        assert!(state.snap_on_next_render());
     }
 }


### PR DESCRIPTION
  ## Summary

  This PR is a small clean code/refactor pass for transcript scroll state handling in the chat surface.

  It keeps the existing scroll behavior intact while making the state transitions easier to read and less error-prone.

  ## What Changed

  - Added small helper methods inside `TranscriptScrollState`:
    - `reset_to_tail`
    - `apply_user_scroll_offset`
    - `set_offset_from_bottom`
  - Reused those helpers across:
    - reset paths
    - line scroll
    - page scroll
    - home/end jumps
    - test-only scroll offset setup
  - Added regression coverage for `prepare_for_appended_content`.

  ## Why

  `TranscriptScrollState` manages a few fields that must stay consistent with each other:

  - `offset_from_bottom`
  - `last_scroll_start`
  - `follow_tail`
  - `snap_on_next_render`

  Before this change, several methods updated the same combinations of fields manually. That made it easy for future changes to accidentally update one field but forget another.

  This refactor groups the repeated state transitions by intent:

  - resetting to the tail
  - applying user-driven scroll offset changes
  - updating the offset/follow-tail invariant

  ## Behavior / Compatibility

  This is intended to be behavior-preserving.

  Important preserved behavior:

  - When the user is following the tail, reset/end-style actions still follow the latest content.
  - When the user scrolls up, `follow_tail` becomes false.
  - `prepare_for_appended_content` still preserves the current `follow_tail` and `snap_on_next_render`
  state while clearing `offset_from_bottom`.

  That last point is important: when new messages arrive while the user is scrolled up, the transcript
  should not jump to the bottom.

  ## Tests

  Validated locally:

  ```text
  cargo fmt --all -- --check
  cargo clippy --workspace --all-targets --all-features -- -D warnings
  cargo test -p loong-app transcript_scroll_state -j 1
  cargo test -p loong-app scroll -j 1

  Additional note:

  cargo test --workspace -j 1

  currently has unrelated daemon/gateway failures around missing CLI sessions in this local Windows
  environment. The focused transcript and scroll tests pass.

  ## Notes for Reviewers

  The main review point is the scroll state semantics around prepare_for_appended_content.

  This PR intentionally does not make appended content force follow_tail = true, because that would
  make the transcript jump when the user is reading older content.