### PR TITLE
refactor: name tui surface layout height parts

### DIFF
--- a/crates/app/src/chat/chat_surface/app/surface.rs
+++ b/crates/app/src/chat/chat_surface/app/surface.rs
@@ -5,7 +5,7 @@ pub struct RenderSectionHeights {
     spacer: u16,
     pending: u16,
     composer_separator: u16,
-    comsposer: u16,
+    composer: u16,
     palette_separator: u16,
     palette: u16,
     footer_separator: u16,
@@ -20,7 +20,7 @@ impl RenderSectionHeights {
             self.spacer,
             self.pending,
             self.composer_separator,
-            self.comsposer,
+            self.composer,
             self.palette_separator,
             self.palette,
             self.footer_separator,
@@ -86,6 +86,29 @@ impl RenderSections {
             footer_bottom_spacing,
         })
     }
+}
+
+const COMPOSER_SEPARATOR_HEIGHT: u16 = 1;
+const PALETTE_SEPARATOR_HEIGHT: u16 = 1;
+const FOOTER_SEPARATOR_HEIGHT: u16 = 1;
+const FOOTER_HEIGHT: u16 = 1;
+
+fn palette_band_height(palette_height: u16) -> u16 {
+    if palette_height > 0 {
+        PALETTE_SEPARATOR_HEIGHT + palette_height
+    } else {
+        0
+    }
+}
+
+fn bottom_band_height(interstitial_height: u16, composer_height: u16, palette_height: u16) -> u16 {
+    interstitial_height
+        + COMPOSER_SEPARATOR_HEIGHT
+        + composer_height
+        + palette_band_height(palette_height)
+        + FOOTER_SEPARATOR_HEIGHT
+        + FOOTER_HEIGHT
+        + FOOTER_BOTTOM_BREATHING_HEIGHT
 }
 
 impl App {
@@ -186,19 +209,9 @@ impl App {
                 size.width,
                 provisional_assistant_text.as_deref(),
             ) as u16;
-        // TODO: translate magic numbers
-        let bottom_band_height = interstitial_height
-            + 1
-            + composer_height
-            + if palette_height > 0 {
-                1 + palette_height
-            } else {
-                0
-            }
-            + 1
-            + 1
-            + FOOTER_BOTTOM_BREATHING_HEIGHT;
-        let available_transcript_height = size.height.saturating_sub(bottom_band_height).max(1);
+        let reserved_bottom_height =
+            bottom_band_height(interstitial_height, composer_height, palette_height);
+        let available_transcript_height = size.height.saturating_sub(reserved_bottom_height).max(1);
         let transcript_height = if self.message_list.messages.is_empty() {
             0
         } else {
@@ -209,12 +222,16 @@ impl App {
             transcript: transcript_height,
             spacer: 0,
             pending: interstitial_height,
-            composer_separator: 1,
-            comsposer: composer_height,
-            palette_separator: if palette_height > 0 { 1 } else { 0 },
+            composer_separator: COMPOSER_SEPARATOR_HEIGHT,
+            composer: composer_height,
+            palette_separator: if palette_height > 0 {
+                PALETTE_SEPARATOR_HEIGHT
+            } else {
+                0
+            },
             palette: palette_height,
-            footer_separator: 1,
-            footer: 1,
+            footer_separator: FOOTER_SEPARATOR_HEIGHT,
+            footer: FOOTER_HEIGHT,
             footer_bottom_spacing: FOOTER_BOTTOM_BREATHING_HEIGHT,
         }
     }
@@ -550,5 +567,16 @@ impl App {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bottom_band_height_includes_palette_separator_only_when_palette_is_visible() {
+        assert_eq!(bottom_band_height(3, 4, 0), 11);
+        assert_eq!(bottom_band_height(3, 4, 5), 17);
     }
 }


### PR DESCRIPTION
  ## Summary

  This PR is a small clean code/refactor pass for chat surface layout height calculation.

  The goal is to make the TUI surface rendering layout easier to read by replacing unnamed height
  literals with named constants and small helper functions.

  ## What Changed

  - Replaced repeated layout height literals with named constants:
    - `COMPOSER_SEPARATOR_HEIGHT`
    - `PALETTE_SEPARATOR_HEIGHT`
    - `FOOTER_SEPARATOR_HEIGHT`
    - `FOOTER_HEIGHT`
  - Extracted bottom layout height calculation into small pure helpers:
    - `palette_band_height`
    - `bottom_band_height`
  - Renamed the `RenderSectionHeights` field `comsposer` to `composer`.
  - Removed the old `TODO: translate magic numbers` comment by making the height parts explicit.
  - Added a focused regression test for palette-visible vs palette-hidden bottom band height
  calculation.

  ## Why

  `compute_render_section_heights` previously used several bare `1` values in one expression. Those
  values were correct, but the intent was not obvious.

  This refactor gives each fixed row a name and keeps the total reserved bottom height in one helper.

  ## Behavior / Compatibility

  This is intended to be behavior-preserving.

  It does not change render section order, transcript height behavior, composer height behavior,
  palette visibility behavior, footer rendering, or public chat surface APIs.

  ## Tests

  ```text
  rustfmt --check crates/app/src/chat/chat_surface/app/surface.rs
  git diff --check
  cargo test -p loong-app bottom_band_height_includes_palette_separator_only_when_palette_is_visible
  -j 1
  cargo test -p loong-app footer -j 1
  cargo clippy -p loong-app --all-targets --all-features -- -D warnings

  ## Notes for Reviewers

  The main review point is that bottom_band_height matches the old layout arithmetic while making each
  reserved row explicit.