### PR TITLE
refactor: reuse embedded json parsing in tool previews

### DIFF
--- a/crates/app/src/chat/chat_surface/message_list/message_list_tests.rs
+++ b/crates/app/src/chat/chat_surface/message_list/message_list_tests.rs
@@ -1535,6 +1535,12 @@ fn read_tool_request_json_parser_accepts_windows_escaped_paths() {
 }
 
 #[test]
+fn embedded_tool_json_parser_rejects_invalid_ranges_and_malformed_json() {
+    assert!(super::parse_embedded_json_value("args: } before {").is_none());
+    assert!(super::parse_embedded_json_value("args: {\"path\":").is_none());
+}
+
+#[test]
 fn read_tool_text_activity_renders_path_and_excerpt_card() {
     let mut list = MessageList::new();
     list.add_assistant_message(

--- a/crates/app/src/chat/chat_surface/message_list/tool_preview.rs
+++ b/crates/app/src/chat/chat_surface/message_list/tool_preview.rs
@@ -243,12 +243,7 @@ fn extract_tool_string_value(line: &str, keys: &[&str]) -> Option<String> {
 }
 
 fn extract_tool_string_value_from_json(line: &str, keys: &[&str]) -> Option<String> {
-    let start = line.find('{')?;
-    let end = line.rfind('}')?;
-    if end <= start {
-        return None;
-    }
-    let value = serde_json::from_str::<Value>(&line[start..=end]).ok()?;
+    let value = parse_embedded_json_value(line)?;
     first_string_field_recursive(&value, keys, 0)
 }
 
@@ -294,13 +289,17 @@ fn extract_glob_tool_summary(lines: &[String]) -> Option<String> {
 }
 
 fn extract_tool_command_from_json(line: &str) -> Option<String> {
+    let value = parse_embedded_json_value(line)?;
+    first_string_field_recursive(&value, &["cmd", "command", "script"], 0)
+}
+
+fn parse_embedded_json_value(line: &str) -> Option<Value> {
     let start = line.find('{')?;
     let end = line.rfind('}')?;
     if end <= start {
         return None;
     }
-    let value = serde_json::from_str::<Value>(&line[start..=end]).ok()?;
-    first_string_field_recursive(&value, &["cmd", "command", "script"], 0)
+    serde_json::from_str::<Value>(&line[start..=end]).ok()
 }
 
 fn first_string_field_recursive(value: &Value, keys: &[&str], depth: usize) -> Option<String> {
@@ -431,12 +430,7 @@ fn extract_read_tool_request(line: &str) -> Option<ReadToolRequest> {
 }
 
 fn extract_read_tool_request_from_json(line: &str) -> Option<ReadToolRequest> {
-    let start = line.find('{')?;
-    let end = line.rfind('}')?;
-    if end <= start {
-        return None;
-    }
-    let value = serde_json::from_str::<Value>(&line[start..=end]).ok()?;
+    let value = parse_embedded_json_value(line)?;
     let path = first_path_field(&value)?;
     Some(ReadToolRequest {
         path,
@@ -602,12 +596,7 @@ fn extract_tool_path(line: &str) -> Option<String> {
 }
 
 fn extract_tool_path_from_json(line: &str) -> Option<String> {
-    let start = line.find('{')?;
-    let end = line.rfind('}')?;
-    if end <= start {
-        return None;
-    }
-    let value = serde_json::from_str::<Value>(&line[start..=end]).ok()?;
+    let value = parse_embedded_json_value(line)?;
     first_path_field(&value)
 }
 
@@ -742,4 +731,3 @@ fn hex_value(byte: u8) -> Option<u8> {
         _ => None,
     }
 }
-


### PR DESCRIPTION
  ## Summary

  This is a small TUI clean code/refactor pass for tool preview parsing.

  The tool preview code had several places that repeated the same embedded JSON parsing flow:

  - find the first `{`
  - find the last `}`
  - reject invalid ranges
  - parse the slice with `serde_json::from_str`

  This PR extracts that repeated logic into a shared private helper, then reuses it across the JSON-
  backed tool preview extractors.

  ## Changes

  - Add `parse_embedded_json_value` for embedded JSON parsing in tool preview lines
  - Reuse the helper in:
    - `extract_tool_string_value_from_json`
    - `extract_tool_command_from_json`
    - `extract_read_tool_request_from_json`
    - `extract_tool_path_from_json`
  - Add regression coverage for invalid ranges and malformed JSON

  ## Verification

  - `cargo fmt --all -- --check`
  - `git diff --check`
  - `cargo test -p loong-app embedded_tool_json_parser_rejects_invalid_ranges_and_malformed_json -j 1`
  - `cargo test -p loong-app read_tool -j 1`
  - `cargo test -p loong-app tool_activity -j 1`
  - `cargo clippy -p loong-app --all-targets --all-features -- -D warnings`

  ## Notes

  I also tried `cargo test -p loong-app --no-default-features ...`, but `loong-app` currently does not
  compile without its default feature set because several modules depend on feature-gated channel/
  session pieces. That failure is unrelated to this change.
