### PR TITLE
chore(deploy/observability): migrate Jaeger to v2 unified image 2.19.0

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -14,7 +14,7 @@ flowchart LR
     subgraph server["Server"]
         C["OTel Collector"]
         CRT["server.crt + server.key\n(TLS)"]
-        J["Jaeger\nUI :16686"]
+        J["Jaeger v2\nUI :16686"]
     end
 
     L -- "OTLP/HTTPS\n:4318" --> C
@@ -67,7 +67,9 @@ This starts two containers:
 | Container | Ports | Role |
 |-----------|-------|------|
 | `otel-collector` | 4318 (HTTPS), 4317 (gRPC) | Receives traces from Loong, forwards to Jaeger |
-| `jaeger` | 16686 (HTTP) | Trace storage and web UI |
+| `jaeger` | 16686 (HTTP) | Trace storage and web UI (Jaeger v2 unified image) |
+
+Jaeger v2 uses a single `jaegertracing/jaeger` image; the OTLP receiver is enabled by default, so no extra environment variables are required.
 
 The Collector loads its TLS config from `otel-collector-config.yaml`, which references `server.crt` and `server.key` mounted into the container via `docker-compose.yml`.
 

--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     ports:
       - "4318:4318"
       - "4317:4317"
+    depends_on:
+      - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/jaeger:2.19.0
     ports:
       - "16686:16686"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true


### PR DESCRIPTION
## Summary

- **Problem:** The observability stack was using the legacy `jaegertracing/all-in-one:latest` image. Jaeger v1 components are deprecated and no longer released as of v2.14.0; the `latest` tag is also non-reproducible.
- **Why it matters:** Staying on v1 means we are on a deprecated image stream and pull an unpredictable version on every deploy. Pinning to v2 gives us a supported, reproducible deployment.
- **What changed:**
  - `deploy/observability/docker-compose.yml`: `jaegertracing/all-in-one:latest` → `jaegertracing/jaeger:2.19.0`
  - Removed `COLLECTOR_OTLP_ENABLED=true` (OTLP is enabled by default in Jaeger v2)
  - Added `depends_on: [jaeger]` to the OTel Collector service
  - `deploy/observability/README.md`: updated architecture diagram and added a note about the v2 unified image
  - `docs/design-docs/agent-observability-opentelemetry.md`: updated the standalone Jaeger run example to use v2
- **What did not change (scope boundary):** The OTel Collector config (`otel-collector-config.yaml`) and TLS setup are unchanged. The Collector still receives OTLP/HTTPS from Loong and forwards traces to Jaeger over OTLP/gRPC on port 4317.

## Linked Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check` (N/A — no Rust changes)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (N/A — no Rust changes)
- [ ] Rust tests match the touched packages / feature surface (N/A — no Rust changes)
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed

Commands and evidence:

```text
# Validate docker-compose syntax and service graph
cd deploy/observability && docker compose config
# → parsed successfully; jaeger service image is jaegertracing/jaeger:2.19.0

# Manual smoke test (local)
cd deploy/observability
./generate-certs.sh
docker compose up -d
# → both containers started; curl -k https://localhost:4318 returned 200 OK
# → Jaeger UI accessible at http://localhost:16686
```

## User-visible / Operator-visible Changes

- The Jaeger container image changes from `jaegertracing/all-in-one:latest` to `jaegertracing/jaeger:2.19.0`. End-user behavior is unchanged: Loong still exports to the Collector over OTLP/HTTPS, and traces are still viewable at `http://localhost:16686`.

## Failure Recovery

- **Fast rollback or disable path:** Revert this commit or change the image tag back to `jaegertracing/all-in-one:1.76.0` (last v1 release).
- **Observable failure symptoms reviewers should watch for:** Collector logs showing repeated connection failures to `jaeger:4317`; Jaeger UI returning 502/empty service list after startup.

## Reviewer Focus

- `deploy/observability/docker-compose.yml`: confirm image tag, removed env var, and `depends_on` ordering.
- `deploy/observability/README.md`: confirm the v2 note matches the actual deployment.
